### PR TITLE
Added SCHEME to HOSTING.md

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -85,6 +85,8 @@ Following are the variables that can be used to configure the availability of th
 
 - HOST (*String*)
     - The hosting address of the server. For running on local system, this can be set to **localhost**. In production systems, this can be your ingress host.
+- SCHEME (*String*)
+    - The scheme of the URL, either `http` or `https`. When using a reverse proxy with https, it'll be required to set this. _defaults to `http`_
 - PORT (*Number*)
     - The port on which the server is available.
 - SECRET_KEY_BASE (*String*)


### PR DESCRIPTION
Not being documented caused some confusion for me. The tracker link had references to http links so events weren't being sent because https sites aren't allowed to use http links.