### PR TITLE
Use a working postgres version for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   plausible_db:
     container_name: plausible_db
-    image: postgres:9.4
+    image: postgres:12
     command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
     volumes:
       - db-data:/var/lib/postgresql/data


### PR DESCRIPTION
As stated in #71, the docker-compose example does not work with postgres `9.4` but with `12` this pr updates the default version to `12`.