### PR TITLE
Enable Pull Dog

### DIFF
--- a/pull-dog.json
+++ b/pull-dog.json
@@ -1,0 +1,3 @@
+{
+  "dockerComposeYmlFilePaths": ["docker-compose.yml"]
+}


### PR DESCRIPTION
Hey Plausible! 

I'm a [big fan](https://plausible.io/dogger.io) and a [fellow indie hacker](https://www.indiehackers.com/product/dogger) from Denmark. I love the product you're building and the transparency you have was the main inspiration for also [open-sourcing my product](https://github.com/dogger) and sharing everything.

Now, I noticed you are using Docker Compose to bring up a test-instance of your whole system. [Pull Dog](https://dogger.io) (my product) is a GitHub app that can take your `docker-compose.yml` file, and automatically provision a brand new test environment from it, for every open pull request you have or make in the future.

I thought that could be useful to you, so I actually made a [fork of your repository](https://github.com/ffMathy/analytics) where it's enabled. See this PR to see it in action: https://github.com/ffMathy/analytics/pull/2

This makes it easier for you guys to test things before shipping it into production, and there's a free plan available! The [Portainer project](https://github.com/portainer/portainer/pulls) (15k stars on GitHub, 2 billion downloads on Docker Hub) is currently using it for all of their pull requests, and are happy with it.

Enabling it is as simple as [installing the GitHub app](https://github.com/apps/pull-dog) to this repo, and merging this PR. Then when pull requests are opened, a test environment is created, and destroyed again when the pull request closes.

What do you think? By the way, this is a personal PR - no bots or automation (or cold marketing) was involved in the making of this issue/PR. It's from the heart.

Oh, and no matter if you enable it or not, I'll keep promoting Plausible on Indie Hackers and to everyone I know - simply because it's awesome.