### PR TITLE
Create the admin user as a separate command

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -35,13 +35,13 @@ The repo supplies with a [Docker Compose](./docker-compose.yml) file and the sam
     docker-compose down
     ```
 
-- After the setup, you can start plausible as -- 
+- After the setup, you can start plausible as --
     ```bash
-    docker-compose up -d plausible 
+    docker-compose up -d plausible
     ```
-     after a successful startup (can take upto 5 mins), `plausible` is available at port `80`, navigate to [`http://localhost`](http://localhost). 
- 
-- stopping plausible --  
+     after a successful startup (can take upto 5 mins), `plausible` is available at port `80`, navigate to [`http://localhost`](http://localhost).
+
+- stopping plausible --
     ```bash
     docker-compose down
     ```
@@ -51,12 +51,12 @@ The repo supplies with a [Docker Compose](./docker-compose.yml) file and the sam
     docker volume rm plausible_event-data -f
     docker volume rm plausible_db-data -f
     ```
-Note: 
+Note:
 - #1 you need to stop plausible and restart plausible  if you change the environment variables.
 - #2 With docker-compose, you need to remove the existing container and rebuild if you want your changes need to be reflected:
     ```bash
     docker rmi -f  plausible_plausible:latest
-    docker-compose up -d plausible 
+    docker-compose up -d plausible
     ```
 ### Non-docker building
 It is possible to create a release artifact by running a release.
@@ -78,6 +78,7 @@ After the release, these are available under  `_build/prod/rel/plausible` --
 
 ```bash
 _build/prod/rel/plausible/createdb.sh
+_build/prod/rel/plausible/init-admin.sh
 _build/prod/rel/plausible/migrate.sh
 _build/prod/rel/plausible/rollback.sh
 _build/prod/rel/plausible/seed.sh
@@ -87,6 +88,7 @@ the same is available in the docker images as follows --
 
 ```bash
 docker run plausible:master-12add db createdb
+docker run plausible:master-12add db init-admin
 docker run plausible:master-12add db migrate
 docker run plausible:master-12add db rollback
 docker run plausible:master-12add db seed
@@ -120,7 +122,7 @@ Following are the variables that can be used to configure the availability of th
   - Disables changing of subscription and removes the trial notice banner (use with caution!) _defaults to `false`_
 
 ### Default User Generation
-For self-hosting, a default user is generated during the [Database Migration](#Database Migration) to access Plausible. To be noted that, a default user is a user whose trial period expires in 100 Years ;).
+For self-hosting, a default user can be generated using the `db init-admin` command. To be noted that, a default user is a user whose trial period expires in 100 Years ;).
 It is *highly* recommended that you configure these parameters.
 
 - ADMIN_USER_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: sh -c "sleep 10 && /entrypoint.sh run"
+    command: sh -c "sleep 10 && /entrypoint.sh db migrate && /entrypoint.sh run"
     depends_on:
       - plausible_db
       - plausible_events_db
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate"
+    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin"
     depends_on:
       - plausible_db
       - plausible_events_db

--- a/lib/plausible_release.ex
+++ b/lib/plausible_release.ex
@@ -36,7 +36,6 @@ defmodule Plausible.Release do
   def migrate do
     prepare()
     Enum.each(repos(), &run_migrations_for/1)
-    init_admin()
     prepare_clickhouse()
     run_migrations_for_ch()
     IO.puts("Migrations successful!")

--- a/rel/overlays/init-admin.sh
+++ b/rel/overlays/init-admin.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Create an admin user
+
+BIN_DIR=`dirname "$0"`
+
+${BIN_DIR}/bin/plausible eval Plausible.Release.init_admin


### PR DESCRIPTION
This means the migrations can always be run on startup, meaning the database won't get out of sync with the running application. It also means users who don't set the credential variables in their compose files don't keep creating admin users every time the application starts.

I'm hoping at some point we can get to a point where the `setup` container isn't necessary, which is how i've setup plausible myself, but that'll come as a later PR.

Looks like the diff is a bit noisy due to trailing space cleanup, sorry!