### PR TITLE
Fix issue template formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,10 +11,10 @@ assignees: ''
 
 Please note that this tracker is only for bugs. Do not use the issue tracker for help or support. [Our docs](https://docs.plausible.io/) are a great place for most answers, but if you can’t find your answer there, you can [contact us](https://plausible.io/contact). Thanks!
 
-## Prerequisites 
+## Prerequisites
 - [ ] I have searched open and closed issues to make sure that the bug has not yet been reported.
 
-##Bug report
+## Bug report
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ Please note that this tracker is only for feature requests. Do not use the issue
 ## Prerequisites
 - [ ] I have searched open and closed issues to make sure that the feature has not yet been requested.
 
-##Feature request
+## Feature request
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
When rendered on GitHub, this isn't formatted as `h2` correctly.

![image](https://user-images.githubusercontent.com/6527489/88082984-62aa5480-cb7a-11ea-84d1-52e8d0e4e6e1.png)
