### PR TITLE
Expose a default port in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ RUN mix release plausible
 FROM debian:bullseye
 LABEL maintainer="tckb <tckb@tgrthi.me>"
 ENV LANG=C.UTF-8
-ENV PORT=8080
 
 RUN apt-get update && \
     apt-get install -y bash openssl --no-install-recommends&& \
@@ -83,5 +82,5 @@ COPY --from=buildcontainer /app/_build/prod/rel/plausible /app
 RUN chown -R plausibleuser:plausibleuser /app
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
-EXPOSE 8080
+EXPOSE 8000
 CMD ["run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN mix release plausible
 FROM debian:bullseye
 LABEL maintainer="tckb <tckb@tgrthi.me>"
 ENV LANG=C.UTF-8
+ENV PORT=8080
 
 RUN apt-get update && \
     apt-get install -y bash openssl --no-install-recommends&& \
@@ -82,4 +83,5 @@ COPY --from=buildcontainer /app/_build/prod/rel/plausible /app
 RUN chown -R plausibleuser:plausibleuser /app
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
+EXPOSE 8080
 CMD ["run"]

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -104,7 +104,7 @@ Following are the variables that can be used to configure the availability of th
 - SCHEME (*String*)
     - The scheme of the URL, either `http` or `https`. When using a reverse proxy with https, it'll be required to set this. _defaults to `http`_
 - PORT (*Number*)
-    - The port on which the server is available.
+    - The port on which the server is available (default `8000`).
 - SECRET_KEY_BASE (*String*)
     - An internal secret key used by [Phoenix Framework](https://www.phoenixframework.org/). Follow the [instructions](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Secret.html#content) to generate one.
 - ENVIRONMENT (*String*)


### PR DESCRIPTION
This allows tools like traefik to detect the running port correctly.