### PR TITLE
Sort screen sizes by count

### DIFF
--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -452,7 +452,7 @@ defmodule Plausible.Stats.Clickhouse do
       from e in base_query(site, query),
         select: {fragment("? as name", e.screen_size), fragment("uniq(user_id) as count")},
         group_by: e.screen_size,
-        where: e.screen_size != ""
+        where: e.screen_size != "",
         order_by: [desc: fragment("count")]
     )
     |> add_percentages

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -447,20 +447,14 @@ defmodule Plausible.Stats.Clickhouse do
     end)
   end
 
-  @available_screen_sizes ["Desktop", "Laptop", "Tablet", "Mobile"]
-
   def top_screen_sizes(site, query) do
     Clickhouse.all(
       from e in base_query(site, query),
         select: {fragment("? as name", e.screen_size), fragment("uniq(user_id) as count")},
         group_by: e.screen_size,
         where: e.screen_size != ""
+        order_by: [desc: fragment("count")]
     )
-    |> Enum.sort(fn %{"name" => screen_size1}, %{"name" => screen_size2} ->
-      index1 = Enum.find_index(@available_screen_sizes, fn s -> s == screen_size1 end)
-      index2 = Enum.find_index(@available_screen_sizes, fn s -> s == screen_size2 end)
-      index2 > index1
-    end)
     |> add_percentages
   end
 


### PR DESCRIPTION
Sorting by a fixed list does make quick referencing slightly easier, but having them ordered looks much nicer, as the other tabs are also ordered.

This may also come with a performance boost, as the ordering is being handed by Clickhouse.