### PR TITLE
Add site switcher

### DIFF
--- a/assets/css/loader.css
+++ b/assets/css/loader.css
@@ -4,6 +4,11 @@
   animation: loaderFadein .2s ease-in;
 }
 
+.loading.sm {
+  width: 25px;
+  height: 25px;
+}
+
 .loading div {
   display: inline-block;
   width: 50px;
@@ -14,6 +19,12 @@
   animation: spin 1s ease-in-out infinite;
   -webkit-animation: spin 1s ease-in-out infinite;
 }
+
+.loading.sm div {
+  width: 25px;
+  height: 25px;
+}
+
 
 @keyframes spin {
   to { -webkit-transform: rotate(360deg); }

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -27,7 +27,7 @@ export default class Historical extends React.Component {
       <div className="mb-12">
         <div className="w-full sm:flex justify-between items-center">
           <div className="w-full flex items-center">
-            <SiteSwitcher site={this.props.site}  />
+            <SiteSwitcher site={this.props.site} loggedIn={this.props.loggedIn} />
             <CurrentVisitors timer={this.props.timer} site={this.props.site}  />
           </div>
           <Datepicker site={this.props.site} query={this.props.query} />

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Datepicker from './datepicker'
+import SiteSwitcher from './site-switcher'
 import Filters from './filters'
 import CurrentVisitors from './stats/current-visitors'
 import VisitorGraph from './stats/visitor-graph'
@@ -9,47 +10,6 @@ import Pages from './stats/pages'
 import Countries from './stats/countries'
 import Devices from './stats/devices'
 import Conversions from './stats/conversions'
-
-class SiteSwitcher extends React.Component {
-  constructor() {
-    super()
-    this.state = {open: false}
-  }
-
-  toggle() {
-    this.setState({open: !this.state.open})
-  }
-
-  render() {
-    const extraClass = this.state.open ? "transform opacity-100 scale-100 transition ease-in duration-75" : "transform opacity-0 scale-95 transition ease-out duration-100"
-
-    return (
-      <div className="relative inline-block text-left z-10 mr-8">
-        <button onClick={this.toggle.bind(this)} className="inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150" id="options-menu" aria-haspopup="true" aria-expanded="true">
-
-          <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} className="inline w-4 mr-2 align-middle" />
-          {this.props.site.domain}
-          <svg className="-mr-1 ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-          </svg>
-        </button>
-
-        <div className={'origin-top-left absolute left-0 mt-2 w-56 rounded-md shadow-lg ' + extraClass}>
-          <div className="rounded-md bg-white shadow-xs" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
-            <div className="py-1">
-              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">Settings</a>
-            </div>
-            <div className="border-t border-gray-100"></div>
-            <div className="py-1">
-              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">gigride.live</a>
-              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">did.app</a>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  }
-}
 
 export default class Historical extends React.Component {
   renderConversions() {

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -10,6 +10,47 @@ import Countries from './stats/countries'
 import Devices from './stats/devices'
 import Conversions from './stats/conversions'
 
+class SiteSwitcher extends React.Component {
+  constructor() {
+    super()
+    this.state = {open: false}
+  }
+
+  toggle() {
+    this.setState({open: !this.state.open})
+  }
+
+  render() {
+    const extraClass = this.state.open ? "transform opacity-100 scale-100 transition ease-in duration-75" : "transform opacity-0 scale-95 transition ease-out duration-100"
+
+    return (
+      <div className="relative inline-block text-left z-10 mr-8">
+        <button onClick={this.toggle.bind(this)} className="inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150" id="options-menu" aria-haspopup="true" aria-expanded="true">
+
+          <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} className="inline w-4 mr-2 align-middle" />
+          {this.props.site.domain}
+          <svg className="-mr-1 ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </button>
+
+        <div className={'origin-top-left absolute left-0 mt-2 w-56 rounded-md shadow-lg ' + extraClass}>
+          <div className="rounded-md bg-white shadow-xs" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
+            <div className="py-1">
+              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">Settings</a>
+            </div>
+            <div className="border-t border-gray-100"></div>
+            <div className="py-1">
+              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">gigride.live</a>
+              <a href="#" className="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">did.app</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
 export default class Historical extends React.Component {
   renderConversions() {
     if (this.props.site.hasGoals) {
@@ -26,7 +67,7 @@ export default class Historical extends React.Component {
       <div className="mb-12">
         <div className="w-full sm:flex justify-between items-center">
           <div className="w-full flex items-center">
-            <h2 className="text-left mr-8 font-semibold text-xl">Analytics for <a href={`http://${this.props.site.domain}`} target="_blank">{this.props.site.domain}</a></h2>
+            <SiteSwitcher site={this.props.site}  />
             <CurrentVisitors timer={this.props.timer} site={this.props.site}  />
           </div>
           <Datepicker site={this.props.site} query={this.props.query} />

--- a/assets/js/dashboard/index.js
+++ b/assets/js/dashboard/index.js
@@ -44,9 +44,9 @@ class Dashboard extends React.Component {
 
   render() {
     if (this.state.query.period === 'realtime') {
-      return <Realtime timer={this.state.timer} site={this.props.site} query={this.state.query} />
+      return <Realtime timer={this.state.timer} site={this.props.site} loggedIn={this.props.loggedIn} query={this.state.query} />
     } else {
-      return <Historical timer={this.state.timer} site={this.props.site} query={this.state.query} />
+      return <Historical timer={this.state.timer} site={this.props.site} loggedIn={this.props.loggedIn} query={this.state.query} />
     }
   }
 }

--- a/assets/js/dashboard/mount.js
+++ b/assets/js/dashboard/mount.js
@@ -14,9 +14,11 @@ if (container) {
     hasGoals: container.dataset.hasGoals === 'true'
   }
 
+  const loggedIn = container.dataset.loggedIn === 'true'
+
   const app = (
     <ErrorBoundary>
-      <Router site={site} />
+      <Router site={site} loggedIn={loggedIn} />
     </ErrorBoundary>
   )
 

--- a/assets/js/dashboard/realtime.js
+++ b/assets/js/dashboard/realtime.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Datepicker from './datepicker'
+import SiteSwitcher from './site-switcher'
 import Filters from './filters'
 import CurrentVisitors from './stats/current-visitors'
 import VisitorGraph from './stats/visitor-graph'
@@ -26,7 +27,7 @@ export default class Stats extends React.Component {
       <div className="mb-12">
         <div className="w-full sm:flex justify-between items-center">
           <div className="w-full flex items-center">
-            <h2 className="text-left mr-8 font-semibold text-xl">Analytics for <a href={`http://${this.props.site.domain}`} target="_blank">{this.props.site.domain}</a></h2>
+            <SiteSwitcher site={this.props.site} loggedIn={this.props.loggedIn} />
           </div>
           <Datepicker site={this.props.site} query={this.props.query} />
         </div>

--- a/assets/js/dashboard/router.js
+++ b/assets/js/dashboard/router.js
@@ -21,12 +21,12 @@ function ScrollToTop() {
   return null;
 }
 
-export default function Router({site}) {
+export default function Router({site, loggedIn}) {
   return (
     <BrowserRouter>
       <Route path="/:domain">
         <ScrollToTop />
-        <Dash site={site} />
+        <Dash site={site} loggedIn={loggedIn} />
         <Switch>
           <Route exact path="/:domain/referrers">
             <ReferrersModal site={site} />

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import Transition from "../transition.js";
+
+export default class SiteSwitcher extends React.Component {
+  constructor() {
+    super()
+    this.handleClick = this.handleClick.bind(this)
+    this.state = {
+      open: false,
+      sites: null,
+      error: null,
+      loading: true
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClick, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClick, false);
+  }
+
+  handleClick(e) {
+    if (this.dropDownNode && this.dropDownNode.contains(e.target)) return;
+    if (!this.state.open) return;
+
+    this.setState({open: false})
+  }
+
+  toggle() {
+    this.setState({open: !this.state.open})
+    if (!this.state.sites) {
+      fetch('/api/sites')
+        .then( response => {
+          if (!response.ok) { throw response }
+          return response.json()
+        })
+        .then((sites) => this.setState({loading: false, sites: sites}))
+        .catch((e) => this.setState({loading: false, error: e}))
+    }
+  }
+
+  renderSiteLink(domain) {
+    return (
+      <a href={`/${encodeURIComponent(domain)}`} key={domain} className="block truncate px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900">
+        <img src={`https://icons.duckduckgo.com/ip3/${domain}.ico`} className="inline w-4 mr-2 align-middle" />
+        <span>{domain}</span>
+      </a>
+    )
+  }
+
+  renderDropdown() {
+    if (this.state.loading) {
+      return <div className="px-4 py-6"><div className="loading sm mx-auto"><div></div></div></div>
+    } else if (this.state.error) {
+      return <div className="mx-auto px-4 py-6">Something went wrong, try again</div>
+    } else {
+      return (
+        <React.Fragment>
+          <div className="py-1">
+            <a href={`/${encodeURIComponent(this.props.site.domain)}/settings`} className="group flex items-center px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem">
+            <svg viewBox="0 0 20 20" fill="currentColor" className="mr-2 h-4 w-4 text-gray-500 group-hover:text-gray-600 group-focus:text-gray-500"><path d="M5 4a1 1 0 00-2 0v7.268a2 2 0 000 3.464V16a1 1 0 102 0v-1.268a2 2 0 000-3.464V4zM11 4a1 1 0 10-2 0v1.268a2 2 0 000 3.464V16a1 1 0 102 0V8.732a2 2 0 000-3.464V4zM16 3a1 1 0 011 1v7.268a2 2 0 010 3.464V16a1 1 0 11-2 0v-1.268a2 2 0 010-3.464V4a1 1 0 011-1z" /></svg>
+              Site settings
+            </a>
+          </div>
+          <div className="border-t border-gray-100"></div>
+          <div className="py-1">
+            { this.state.sites.map(this.renderSiteLink.bind(this)) }
+          </div>
+        </React.Fragment>
+      )
+    }
+  }
+
+  render() {
+    return (
+      <div className="relative inline-block text-left z-10 mr-8">
+        <button onClick={this.toggle.bind(this)} className="inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150" id="options-menu" aria-haspopup="true" aria-expanded="true">
+
+          <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} className="inline w-4 mr-2 align-middle" />
+          {this.props.site.domain}
+          <svg className="-mr-1 ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
+
+        <Transition
+          show={this.state.open}
+          enter="transition ease-out duration-100 transform"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="transition ease-in duration-75 transform"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+        >
+        <div className="origin-top-left absolute left-0 mt-2 w-64 rounded-md shadow-lg" ref={node => this.dropDownNode = node} >
+          <div className="rounded-md bg-white shadow-xs">
+            { this.renderDropdown() }
+          </div>
+        </div>
+        </Transition>
+      </div>
+    )
+  }
+}

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -29,7 +29,10 @@ export default class SiteSwitcher extends React.Component {
   }
 
   toggle() {
+    if (!this.props.loggedIn) return;
+
     this.setState({open: !this.state.open})
+
     if (!this.state.sites) {
       fetch('/api/sites')
         .then( response => {
@@ -74,16 +77,26 @@ export default class SiteSwitcher extends React.Component {
     }
   }
 
+  renderArrow() {
+    if (this.props.loggedIn) {
+      return (
+        <svg className="-mr-1 ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      )
+    }
+  }
+
   render() {
+    const hoverClass = this.props.loggedIn ? 'hover:text-gray-500' : 'cursor-default'
+
     return (
       <div className="relative inline-block text-left z-10 mr-8">
-        <button onClick={this.toggle.bind(this)} className="inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150" id="options-menu" aria-haspopup="true" aria-expanded="true">
+        <button onClick={this.toggle.bind(this)} className={`inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150 ${hoverClass}`}>
 
           <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} className="inline w-4 mr-2 align-middle" />
           {this.props.site.domain}
-          <svg className="-mr-1 ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
+          {this.renderArrow()}
         </button>
 
         <Transition

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -88,11 +88,11 @@ export default class SiteSwitcher extends React.Component {
   }
 
   render() {
-    const hoverClass = this.props.loggedIn ? 'hover:text-gray-500' : 'cursor-default'
+    const hoverClass = this.props.loggedIn ? 'hover:text-gray-500 focus:border-blue-300 focus:shadow-outline-blue ' : 'cursor-default'
 
     return (
       <div className="relative inline-block text-left z-10 mr-8">
-        <button onClick={this.toggle.bind(this)} className={`inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition ease-in-out duration-150 ${hoverClass}`}>
+        <button onClick={this.toggle.bind(this)} className={`inline-flex items-center text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 focus:outline-none transition ease-in-out duration-150 ${hoverClass}`}>
 
           <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} className="inline w-4 mr-2 align-middle" />
           {this.props.site.domain}

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -42,8 +42,9 @@ export default class SiteSwitcher extends React.Component {
   }
 
   renderSiteLink(domain) {
+    const extraClass = domain === this.props.site.domain ? 'font-medium text-gray-900' : 'hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900'
     return (
-      <a href={`/${encodeURIComponent(domain)}`} key={domain} className="block truncate px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900">
+      <a href={`/${encodeURIComponent(domain)}`} key={domain} className={`block truncate px-4 py-2 text-sm leading-5 text-gray-700 ${extraClass}`}>
         <img src={`https://icons.duckduckgo.com/ip3/${domain}.ico`} className="inline w-4 mr-2 align-middle" />
         <span>{domain}</span>
       </a>

--- a/assets/js/dashboard/stats/current-visitors.js
+++ b/assets/js/dashboard/stats/current-visitors.js
@@ -25,7 +25,7 @@ export default class CurrentVisitors extends React.Component {
     const { currentVisitors } = this.state;
     if (currentVisitors !== null) {
       return (
-        <Link to={`/${encodeURIComponent(this.props.site.domain)}?period=realtime`} className="block text-sm font-medium text-gray-500">
+        <Link to={`/${encodeURIComponent(this.props.site.domain)}?period=realtime`} className="block text-sm font-bold text-gray-500">
           <svg className="w-2 mr-2 fill-current text-green-500 inline" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <circle cx="8" cy="8" r="8"/>
           </svg>

--- a/assets/js/dashboard/stats/current-visitors.js
+++ b/assets/js/dashboard/stats/current-visitors.js
@@ -25,7 +25,7 @@ export default class CurrentVisitors extends React.Component {
     const { currentVisitors } = this.state;
     if (currentVisitors !== null) {
       return (
-        <Link to={`/${encodeURIComponent(this.props.site.domain)}?period=realtime`} className="block text-sm font-bold text-gray-500 mt-1">
+        <Link to={`/${encodeURIComponent(this.props.site.domain)}?period=realtime`} className="block text-sm font-medium text-gray-500">
           <svg className="w-2 mr-2 fill-current text-green-500 inline" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <circle cx="8" cy="8" r="8"/>
           </svg>

--- a/assets/js/transition.js
+++ b/assets/js/transition.js
@@ -1,0 +1,107 @@
+// https://gist.github.com/adamwathan/3b9f3ad1a285a2d1b482769aeb862467
+import { CSSTransition as ReactCSSTransition } from 'react-transition-group'
+import React, { useRef, useEffect, useContext } from 'react'
+
+const TransitionContext = React.createContext({
+  parent: {},
+})
+
+function useIsInitialRender() {
+  const isInitialRender = useRef(true)
+  useEffect(() => {
+    isInitialRender.current = false
+  }, [])
+  return isInitialRender.current
+}
+
+function CSSTransition({
+  show,
+  enter = '',
+  enterFrom = '',
+  enterTo = '',
+  leave = '',
+  leaveFrom = '',
+  leaveTo = '',
+  appear,
+  children,
+}) {
+  const enterClasses = enter.split(' ').filter((s) => s.length)
+  const enterFromClasses = enterFrom.split(' ').filter((s) => s.length)
+  const enterToClasses = enterTo.split(' ').filter((s) => s.length)
+  const leaveClasses = leave.split(' ').filter((s) => s.length)
+  const leaveFromClasses = leaveFrom.split(' ').filter((s) => s.length)
+  const leaveToClasses = leaveTo.split(' ').filter((s) => s.length)
+
+  function addClasses(node, classes) {
+    classes.length && node.classList.add(...classes)
+  }
+
+  function removeClasses(node, classes) {
+    classes.length && node.classList.remove(...classes)
+  }
+
+  return (
+    <ReactCSSTransition
+      appear={appear}
+      unmountOnExit
+      in={show}
+      addEndListener={(node, done) => {
+        node.addEventListener('transitionend', done, false)
+      }}
+      onEnter={(node) => {
+        addClasses(node, [...enterClasses, ...enterFromClasses])
+      }}
+      onEntering={(node) => {
+        removeClasses(node, enterFromClasses)
+        addClasses(node, enterToClasses)
+      }}
+      onEntered={(node) => {
+        removeClasses(node, [...enterToClasses, ...enterClasses])
+      }}
+      onExit={(node) => {
+        addClasses(node, [...leaveClasses, ...leaveFromClasses])
+      }}
+      onExiting={(node) => {
+        removeClasses(node, leaveFromClasses)
+        addClasses(node, leaveToClasses)
+      }}
+      onExited={(node) => {
+        removeClasses(node, [...leaveToClasses, ...leaveClasses])
+      }}
+    >
+      {children}
+    </ReactCSSTransition>
+  )
+}
+
+function Transition({ show, appear, ...rest }) {
+  const { parent } = useContext(TransitionContext)
+  const isInitialRender = useIsInitialRender()
+  const isChild = show === undefined
+
+  if (isChild) {
+    return (
+      <CSSTransition
+        appear={parent.appear || !parent.isInitialRender}
+        show={parent.show}
+        {...rest}
+      />
+    )
+  }
+
+  return (
+    <TransitionContext.Provider
+      value={{
+        parent: {
+          show,
+          isInitialRender,
+          appear,
+        },
+      }}
+    >
+      <CSSTransition appear={appear} show={show} {...rest} />
+    </TransitionContext.Provider>
+  )
+}
+
+export default Transition

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1356,7 +1356,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -2817,6 +2817,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw=="
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -2968,6 +2973,25 @@
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "requires": {
         "path-type": "^3.0.0"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "dom-serializer": {
@@ -4255,7 +4279,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         }
       }
@@ -6779,7 +6803,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "private": {
@@ -7005,6 +7029,17 @@
         "tiny-warning": "^1.0.0"
       }
     },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -7111,7 +7146,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -7752,7 +7787,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "stylehacks": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -28,6 +28,7 @@
     "react-flatpickr": "^3.10.0",
     "react-flip-move": "^3.0.4",
     "react-router-dom": "^5.1.2",
+    "react-transition-group": "^4.4.1",
     "tailwindcss": "^1.3.1",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "url-search-params-polyfill": "^7.0.1",

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -14,7 +14,8 @@ module.exports = {
     },
   },
   variants: {
-    textColor: ['responsive', 'hover', 'focus', 'group-hover']
+    textColor: ['responsive', 'hover', 'focus', 'group-hover'],
+    display: ['responsive', 'hover', 'focus', 'group-hover']
   },
   corePlugins: {},
   plugins: [

--- a/lib/plausible_web/controllers/api/internal_controller.ex
+++ b/lib/plausible_web/controllers/api/internal_controller.ex
@@ -10,4 +10,9 @@ defmodule PlausibleWeb.Api.InternalController do
       json(conn, "WAITING")
     end
   end
+
+  def sites(conn, _) do
+    user = Repo.preload(conn.assigns[:current_user], :sites)
+    json(conn, Enum.map(user.sites, &(&1.domain)))
+  end
 end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -68,6 +68,7 @@ defmodule PlausibleWeb.Router do
     post "/paddle/webhook", Api.PaddleController, :webhook
 
     get "/:domain/status", Api.InternalController, :domain_status
+    get "/sites", Api.InternalController, :sites
   end
 
   scope "/", PlausibleWeb do

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -5,7 +5,7 @@
     </div>
   <% end %>
   <div class="pt-6"></div>
-  <div id="stats-react-container" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>"></div>
+  <div id="stats-react-container" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>"></div>
   <div id="modal_root"></div>
   <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
     <div class="bg-gray-50">

--- a/test/plausible_web/controllers/api/internal_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller_test.exs
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
   use Plausible.Repo
   import Plausible.TestUtils
 
-  describe "GET /:domain/status" do
+  describe "GET /api/:domain/status" do
     setup [:create_user, :log_in]
 
     test "is WAITING when site has no pageviews", %{conn: conn, user: user} do
@@ -20,6 +20,18 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
       conn = get(conn, "/api/#{site.domain}/status")
 
       assert json_response(conn, 200) == "READY"
+    end
+  end
+
+  describe "GET /api/status" do
+    setup [:create_user, :log_in]
+
+    test "returns a list of site domains for the current user", %{conn: conn, user: user} do
+      site = insert(:site, members: [user])
+      site2 = insert(:site, members: [user])
+      conn = get(conn, "/api/sites")
+
+      assert json_response(conn, 200) == [site.domain, site2.domain]
     end
   end
 end


### PR DESCRIPTION
Adds a way to quickly navigate from one site's dashboard to another. Additionally, you can go to site settings straight from the dashboard, no need to navigate through /sites anymore.

Closes #103 
Closes #195 
Closes #155 