### PR TITLE
Add page after upgrading to paid plan

### DIFF
--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -76,9 +76,7 @@ defmodule PlausibleWeb.BillingController do
     )
   end
 
-  def success(conn, _params) do
-    conn
-    |> put_flash(:success, "Subscription created successfully")
-    |> redirect(to: "/settings")
+  def upgrade_success(conn, _params) do
+    render(conn, "upgrade_success.html", layout: {PlausibleWeb.LayoutView, "focus.html"})
   end
 end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -103,7 +103,7 @@ defmodule PlausibleWeb.Router do
     get "/billing/change-plan/preview/:plan_id", BillingController, :change_plan_preview
     post "/billing/change-plan/:new_plan_id", BillingController, :change_plan
     get "/billing/upgrade", BillingController, :upgrade
-    get "/billing/success", BillingController, :success
+    get "/billing/upgrade-success", BillingController, :upgrade_success
 
     get "/sites", SiteController, :index
     get "/sites/new", SiteController, :new

--- a/lib/plausible_web/templates/billing/upgrade.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade.html.eex
@@ -102,7 +102,7 @@
       <div class="text-right mt-6">
         <div class="mb-4 text-sm font-medium">Due today: <b x-text="window.plans[billingCycle][planSize].due_now">$6</b></div>
         <span class="inline-flex rounded-md shadow-sm">
-          <button type="button" data-theme="none" :data-product="window.plans[billingCycle][planSize].product_id" data-email="<%= @conn.assigns[:current_user].email %>" data-disable-logout="true" data-passthrough="<%= @conn.assigns[:current_user].id %>" data-success="/billing/success" class="paddle_button inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150">
+          <button type="button" data-theme="none" :data-product="window.plans[billingCycle][planSize].product_id" data-email="<%= @conn.assigns[:current_user].email %>" data-disable-logout="true" data-passthrough="<%= @conn.assigns[:current_user].id %>" data-success="/billing/upgrade-success" class="paddle_button inline-flex items-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150">
             <svg fill="currentColor" viewBox="0 0 20 20" class="w-4 h-4 inline mr-2"><path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"></path></svg>
             Pay securely via Paddle
           </button>

--- a/lib/plausible_web/templates/billing/upgrade_success.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade_success.html.eex
@@ -1,0 +1,18 @@
+<div class="w-full max-w-lg px-4 mt-4 mx-auto">
+  <div x-data="{volume: '10k', billingCycle: 'monthly'}" class="flex-1 bg-white shadow-md rounded px-8 py-4 mb-4 mt-8">
+    <div class="w-full pt-2 text-xl font-bold">
+      Subscription created succesfully
+    </div>
+
+    <div class="w-full text-gray-500 text-sm py-4">
+      Thank you for upgrading your subscription. You will be redirected to your
+      account within 5 seconds.
+    </div>
+
+    <div class="loading my-12 mx-auto"><div></div></div>
+
+    <script>
+      setTimeout(function() {window.location='/settings'}, 3500);
+    </script>
+  </div>
+</div>

--- a/test/plausible_web/controllers/billing_controller_test.exs
+++ b/test/plausible_web/controllers/billing_controller_test.exs
@@ -33,4 +33,14 @@ defmodule PlausibleWeb.BillingControllerTest do
       assert subscription.next_bill_amount == "6.00"
     end
   end
+
+  describe "GET /billing/upgrade-success" do
+    setup [:create_user, :log_in]
+
+    test "shows success page after user subscribes", %{conn: conn} do
+      conn = get(conn, "/billing/upgrade-success")
+
+      assert html_response(conn, 200) =~ "Subscription created succesfully"
+    end
+  end
 end


### PR DESCRIPTION
When users upgrade, our database isn't synced up to Paddle immediately. This makes it look like subscribing was unsuccessful because the settings page shows they still have an expired free trial.

I've added an intermediate page to thank the user for upgrading and to allow 3-4 seconds for the Paddle webhook to come through.