### PR TITLE
URL Decode pathnames and sources

### DIFF
--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -398,6 +398,25 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     assert pageview["country_code"] == "US"
   end
 
+    test "URL and source are decoded", %{conn: conn} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/opportunity/category/%D8%AC%D9%88%D8%A7%D8%A6%D8%B2-%D9%88%D9%85%D8%B3%D8%A7%D8%A8%D9%82%D8%A7%D8%AA",
+        source: "Hello%20World",
+        domain: "external-controller-test-21.com"
+      }
+
+      conn
+      |> put_req_header("content-type", "text/plain")
+      |> post("/api/event", Jason.encode!(params))
+
+      pageview = get_event("external-controller-test-21.com")
+
+      assert pageview["pathname"] == "/opportunity/category/جوائز-ومسابقات"
+      assert pageview["referrer_source"] == "Hello World"
+    end
+
+
   test "responds 400 when required fields are missing", %{conn: conn} do
     params = %{}
 


### PR DESCRIPTION
This change will decode URL pathnames and sources going forward

Closes #229 

NB: We don't have automated migrations for Clickhouse in place yet. If you're self-hosting and want to change your historical data, run the following commands:

```
ALTER TABLE events UPDATE pathname=decodeURLComponent(pathname), referrer_source=decodeURLComponent(referrer_source) WHERE 1;
```
```
ALTER TABLE sessions UPDATE entry_page=decodeURLComponent(entry_page), exit_page=decodeURLComponent(exit_page), referrer_source=decodeURLComponent(referrer_source) WHERE 1;
```