### PR TITLE
Add HCaptcha support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -184,6 +184,10 @@ config :plausible, :custom_domain_server,
 config :plausible, PlausibleWeb.Firewall,
   blocklist: System.get_env("IP_BLOCKLIST", "") |> String.split(",") |> Enum.map(&String.trim/1)
 
+config :plausible, :hcaptcha,
+  sitekey: System.get_env("HCAPTCHA_SITEKEY"),
+  secret: System.get_env("HCAPTCHA_SECRET")
+
 config :geolix,
   databases: [
     %{

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -53,6 +53,9 @@ custom_domain_server_user = System.get_env("CUSTOM_DOMAIN_SERVER_USER")
 custom_domain_server_password = System.get_env("CUSTOM_DOMAIN_SERVER_PASSWORD")
 geolite2_country_db = System.get_env("GEOLITE2_COUNTRY_DB")
 disable_auth = String.to_existing_atom(System.get_env("DISABLE_AUTH", "false"))
+hcaptcha_sitekey = System.get_env("HCAPTCHA_SITEKEY")
+hcaptcha_secret = System.get_env("HCAPTCHA_SECRET")
+
 
 config :plausible,
   admin_user: admin_user,
@@ -186,6 +189,10 @@ config :plausible, Oban,
   repo: Plausible.Repo,
   queues: if(cron_enabled, do: base_queues ++ extra_queues, else: base_queues),
   crontab: if(cron_enabled, do: base_cron ++ extra_cron, else: base_cron)
+
+config :plausible, :hcaptcha,
+  sitekey: hcaptcha_sitekey,
+  secret: hcaptcha_secret
 
 config :ref_inspector,
   init: {Plausible.Release, :configure_ref_inspector}

--- a/config/test.exs
+++ b/config/test.exs
@@ -54,4 +54,5 @@ config :geolix,
   ]
 
 config :plausible,
-  session_timeout: 0
+  session_timeout: 0,
+  environment: System.get_env("ENVIRONMENT", "test")

--- a/lib/plausible_web/captcha.ex
+++ b/lib/plausible_web/captcha.ex
@@ -1,0 +1,27 @@
+defmodule PlausibleWeb.Captcha do
+  @verify_endpoint "https://hcaptcha.com/siteverify"
+
+  def enabled? do
+    !!sitekey()
+  end
+
+  def sitekey() do
+    Application.get_env(:plausible, :hcaptcha, [])
+    |> Keyword.fetch!(:sitekey)
+  end
+
+  def verify(token) do
+    if enabled?() do
+      res = HTTPoison.post!(@verify_endpoint, {:form, [{"response", token}, {"secret", secret()}]})
+      json = Jason.decode!(res.body)
+      json["success"]
+    else
+      true
+    end
+  end
+
+  defp secret() do
+    Application.get_env(:plausible, :hcaptcha, [])
+    |> Keyword.fetch!(:secret)
+  end
+end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -95,9 +95,8 @@ defmodule PlausibleWeb.AuthController do
     )
   end
 
-  def password_reset_request(conn, %{"email" => email, "h-captcha-response" => captcha_token}) do
-
-    if PlausibleWeb.Captcha.verify(captcha_token) do
+  def password_reset_request(conn, %{"email" => email} = params) do
+    if PlausibleWeb.Captcha.verify(params["h-captcha-response"]) do
       user = Repo.get_by(Plausible.Auth.User, email: email)
 
       if user do

--- a/lib/plausible_web/templates/auth/password_reset_request_form.html.eex
+++ b/lib/plausible_web/templates/auth/password_reset_request_form.html.eex
@@ -7,5 +7,16 @@
   <%= if @conn.assigns[:error] do %>
     <div class="text-red-500 text-xs italic my-2"><%= @conn.assigns[:error] %></div>
   <% end %>
+
+  <%= if PlausibleWeb.Captcha.enabled?() do %>
+    <div class="mt-4">
+      <div class="h-captcha" data-sitekey="<%= PlausibleWeb.Captcha.sitekey() %>"></div>
+      <%= if assigns[:captcha_error] do %>
+        <div class="text-red-500 text-xs italic mt-3"><%= @captcha_error %></div>
+      <% end %>
+      <script src="https://hcaptcha.com/1/api.js" async defer></script>
+    </div>
+  <% end %>
+
   <%= submit "Send reset link →", class: "button mt-4 w-full" %>
 <% end %>

--- a/lib/plausible_web/templates/auth/register_form.html.eex
+++ b/lib/plausible_web/templates/auth/register_form.html.eex
@@ -19,6 +19,16 @@
         <%= error_tag f, :email %>
       </div>
 
+      <%= if PlausibleWeb.Captcha.enabled?() do %>
+        <div class="mt-4">
+          <div class="h-captcha" data-sitekey="<%= PlausibleWeb.Captcha.sitekey() %>"></div>
+          <%= if assigns[:captcha_error] do %>
+            <div class="text-red-500 text-xs italic mt-3"><%= @captcha_error %></div>
+          <% end %>
+          <script src="https://hcaptcha.com/1/api.js" async defer></script>
+        </div>
+      <% end %>
+
       <%= submit "Start my free trial →", class: "button mt-4 w-full" %>
 
       <p class="text-center text-gray-600 text-xs mt-4">


### PR DESCRIPTION
Adds optional captcha support on:
* Register page
* Forgot password page

Both of these forms send an email to the specified address so we want to exclude bots from spamming people and lowering our email reputation.