### PR TITLE
Fix for GeoIP container not starting when deploying Plausible

### DIFF
--- a/docker-compose-geoip.yml
+++ b/docker-compose-geoip.yml
@@ -67,10 +67,10 @@ services:
     env_file:
       - plausible-variables.sample.env
     # only if you use the geioip container
+    environment:
+      - GEOLITE2_COUNTRY_DB=/geoip/GeoLite2-Country.mmdb
     volumes:
       - geoip:/geoip:ro
-    environment:
-      -
 
   setup:
     build:
@@ -80,9 +80,11 @@ services:
     depends_on:
       - plausible_db
       - plausible_events_db
+      - geoip
     links:
       - plausible_db
       - plausible_events_db
+      - geoip
     env_file:
       - plausible-variables.sample.env
 

--- a/docker-compose-geoip.yml
+++ b/docker-compose-geoip.yml
@@ -36,6 +36,8 @@ services:
   # this requires an account at maxmind.com (https://www.maxmind.com/en/geolite2/signup)
   geoip:
     image: maxmindinc/geoipupdate
+    ports:
+      - 1080:1080
     environment:
       - GEOIPUPDATE_ACCOUNT_ID=<your-account-id>
       - GEOIPUPDATE_LICENSE_KEY=<your-license-key>
@@ -53,12 +55,14 @@ services:
     depends_on:
       - plausible_db
       - plausible_events_db
+      - geoip
       - fake_smtp
     ports:
       - 80:8080
     links:
       - plausible_db
       - plausible_events_db
+      - geoip
       - fake_smtp
     env_file:
       - plausible-variables.sample.env


### PR DESCRIPTION
I was facing an issue with the GeoIP container not starting when deploying Plausible and so countries would not show up on the map. I have updated the **docker-compose-geoip.yml** file accordingly and have also added the default port number 1080(documented on maxmind/geoupdate's Docker Hub). Henceforth, it got fixed. Hope this helps. Thank you for Plausible!