### PR TITLE
Link to docs site rather than current instance

### DIFF
--- a/lib/plausible_web/templates/site/settings.html.eex
+++ b/lib/plausible_web/templates/site/settings.html.eex
@@ -116,7 +116,7 @@
             </p>
           <% else %>
             <p class="text-gray-700 mt-6">
-            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://docs.#{base_domain()}/google-search-console-integration", class: "text-indigo-500") %> on Search Console first.
+            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://docs.plausible.io/google-search-console-integration", class: "text-indigo-500") %> on Search Console first.
             </p>
           <% end %>
 
@@ -140,7 +140,8 @@
       <%= button("Continue with Google", to: Plausible.Google.Api.authorize_url(@site.id), class: "button mt-4") %>
 
       <div class="text-gray-700 mt-8">
-        NB: You also need to set up your site on <%= link("Google Search Console", to: "https://search.google.com/search-console/about") %> for the integration to work. <%= link("Read the docs", to: "https://docs.#{base_domain()}/google-search-console-integration", class: "text-indigo-500") %>
+        NB: You also need to set up your site on <%= link("Google Search Console", to: "https://search.google.com/search-console/about") %> for the integration to work. <%= link("Read the docs", to: "https://
+          plausible.io/google-search-console-integration", class: "text-indigo-500") %>
       </div>
     <% end %>
 </div>

--- a/lib/plausible_web/templates/site/settings.html.eex
+++ b/lib/plausible_web/templates/site/settings.html.eex
@@ -140,8 +140,7 @@
       <%= button("Continue with Google", to: Plausible.Google.Api.authorize_url(@site.id), class: "button mt-4") %>
 
       <div class="text-gray-700 mt-8">
-        NB: You also need to set up your site on <%= link("Google Search Console", to: "https://search.google.com/search-console/about") %> for the integration to work. <%= link("Read the docs", to: "https://
-          plausible.io/google-search-console-integration", class: "text-indigo-500") %>
+        NB: You also need to set up your site on <%= link("Google Search Console", to: "https://search.google.com/search-console/about") %> for the integration to work. <%= link("Read the docs", to: "https://docs.plausible.io/google-search-console-integration", class: "text-indigo-500") %>
       </div>
     <% end %>
 </div>


### PR DESCRIPTION
### Changes

Self-hosted instances don't serve the docs site anymore, correctly.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
