### PR TITLE
Add documentation to Dockerfile about exposed port 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,5 @@ COPY --from=buildcontainer /app/_build/prod/rel/plausible /app
 RUN chown -R plausibleuser:plausibleuser /app
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
+EXPOSE 8080
 CMD ["run"]


### PR DESCRIPTION
This information is helpfull to users of the Docker image from Dockerhub when defining containers port mapping. 

It is also used by some automatic scripting like for example docker-gen (https://github.com/jwilder/docker-gen)
