### PR TITLE
#332: Refactor stats controller

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -5,38 +5,38 @@ defmodule PlausibleWeb.StatsController do
   alias Plausible.Stats.Query
 
   plug PlausibleWeb.AuthorizeStatsPlug when action in [:stats, :csv_export]
+  plug PlausibleWeb.UpgradeBillingPlug when action in [:stats]
 
   def base_domain() do
     PlausibleWeb.Endpoint.host()
   end
 
-  def stats(conn, _params) do
-    site = conn.assigns[:site]
-    user = conn.assigns[:current_user]
+  def stats(%{assigns: %{site: site, has_pageviews: true}} = conn, _params) do
+    demo = site.domain == base_domain()
+    offer_email_report = get_session(conn, site.domain <> "_offer_email_report")
 
-    if user && Plausible.Billing.needs_to_upgrade?(conn.assigns[:current_user]) do
-      redirect(conn, to: "/settings")
+    conn
+    |> assign(:skip_plausible_tracking, !demo)
+    |> remove_email_report_banner(site)
+    |> put_resp_header("x-robots-tag", "noindex")
+    |> render("stats.html",
+      site: site,
+      has_goals: Plausible.Sites.has_goals?(site),
+      title: "Plausible · " <> site.domain,
+      offer_email_report: offer_email_report,
+      demo: demo
+    )
+  end
+
+  def stats(%{assigns: %{site: site}} = conn, params) do
+    if Stats.has_pageviews?(site) do
+      conn
+      |> assign(:has_pageviews, true)
+      |> stats(params)
     else
-      if Stats.has_pageviews?(site) do
-        demo = site.domain == base_domain()
-        offer_email_report = get_session(conn, site.domain <> "_offer_email_report")
-
-        conn
-        |> assign(:skip_plausible_tracking, !demo)
-        |> remove_email_report_banner(site)
-        |> put_resp_header("x-robots-tag", "noindex")
-        |> render("stats.html",
-          site: site,
-          has_goals: Plausible.Sites.has_goals?(site),
-          title: "Plausible · " <> site.domain,
-          offer_email_report: offer_email_report,
-          demo: demo
-        )
-      else
-        conn
-        |> assign(:skip_plausible_tracking, true)
-        |> render("waiting_first_pageview.html", site: site)
-      end
+      conn
+      |> assign(:skip_plausible_tracking, true)
+      |> render("waiting_first_pageview.html", site: site)
     end
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -11,28 +11,22 @@ defmodule PlausibleWeb.StatsController do
     PlausibleWeb.Endpoint.host()
   end
 
-  def stats(%{assigns: %{site: site, has_pageviews: true}} = conn, _params) do
-    demo = site.domain == base_domain()
-    offer_email_report = get_session(conn, site.domain <> "_offer_email_report")
-
-    conn
-    |> assign(:skip_plausible_tracking, !demo)
-    |> remove_email_report_banner(site)
-    |> put_resp_header("x-robots-tag", "noindex")
-    |> render("stats.html",
-      site: site,
-      has_goals: Plausible.Sites.has_goals?(site),
-      title: "Plausible · " <> site.domain,
-      offer_email_report: offer_email_report,
-      demo: demo
-    )
-  end
-
-  def stats(%{assigns: %{site: site}} = conn, params) do
+  def stats(%{assigns: %{site: site}} = conn, _params) do
     if Stats.has_pageviews?(site) do
+      demo = site.domain == base_domain()
+      offer_email_report = get_session(conn, site.domain <> "_offer_email_report")
+
       conn
-      |> assign(:has_pageviews, true)
-      |> stats(params)
+      |> assign(:skip_plausible_tracking, !demo)
+      |> remove_email_report_banner(site)
+      |> put_resp_header("x-robots-tag", "noindex")
+      |> render("stats.html",
+        site: site,
+        has_goals: Plausible.Sites.has_goals?(site),
+        title: "Plausible · " <> site.domain,
+        offer_email_report: offer_email_report,
+        demo: demo
+      )
     else
       conn
       |> assign(:skip_plausible_tracking, true)

--- a/lib/plausible_web/plugs/upgrade_billing_plug.ex
+++ b/lib/plausible_web/plugs/upgrade_billing_plug.ex
@@ -1,0 +1,19 @@
+defmodule PlausibleWeb.UpgradeBillingPlug do
+  import Phoenix.Controller
+  use Plausible.Repo
+
+  def init(options) do
+    options
+  end
+
+  def call(conn, _opts) do
+    user = conn.assigns[:current_user]
+
+    if user && Plausible.Billing.needs_to_upgrade?(conn.assigns[:current_user]) do
+      conn
+      |> redirect(to: "/settings")
+    else
+      conn
+    end
+  end
+end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -11,6 +11,13 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert html_response(conn, 200) =~ "stats-react-container"
     end
 
+    test "public site - shows waiting for first pageview", %{conn: conn} do
+      insert(:site, domain: "some-other-public-site.io", public: true)
+
+      conn = get(conn, "/some-other-public-site.io")
+      assert html_response(conn, 200) =~ "Need to see the snippet again?"
+    end
+
     test "can not view stats of a private website", %{conn: conn} do
       conn = get(conn, "/test-site.com")
       assert html_response(conn, 404) =~ "There&#39;s nothing here"


### PR DESCRIPTION
Addresses the code refactoring opportunities addressed in #332. 

NOTE: I had to change my original idea a bit, since, of course Elixir does not support early returns. The preferred way here is to introduce multiple overloading functions and choose the right one with pattern matching.

@ukutaht at the end, It's a matter of taste and code style. I leave the final decision to you. Please, keep in mind that while I added one test to guarantee that the conditions are satisfied, I would still love to see being tested in some sort of integration environment.

Cheers!  
