### PR TITLE
Expose tracker script as `index.js`

### DIFF
--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -37,6 +37,7 @@ defmodule PlausibleWeb.Router do
   end
 
   get "/js/plausible.js", PlausibleWeb.TrackerController, :plausible
+  get "/js/index.js", PlausibleWeb.TrackerController, :plausible
   get "/js/plausible.hash.js", PlausibleWeb.TrackerController, :plausible_hash
   get "/js/analytics.js", PlausibleWeb.TrackerController, :plausible
   get "/js/p.js", PlausibleWeb.TrackerController, :p


### PR DESCRIPTION
### Changes

This enables self-hosted applications to be compatible with the pattern for supporting custom domains.

Custom domains serve the script from `index.js`, which if directed to plausible itself, 404s.

https://plausible.io/js/index.js currently 404s, so this won't impact the production setup.

This also adds the slight benefit of allowing self hosted instances to use a completely disguised script URL.