### PR TITLE
Update container image to run as non root

### DIFF
--- a/.gitlab/build-scripts/docker-entrypoint.sh
+++ b/.gitlab/build-scripts/docker-entrypoint.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 set -e
 
-chmod a+x /app/*.sh
-
 if [[ "$1" = 'run' ]]; then
-      exec gosu plausibleuser /app/bin/plausible start
+      /app/bin/plausible start
 
 elif [[ "$1" = 'db' ]]; then
-      exec gosu plausibleuser /app/"$2".sh
- else
-      exec "$@"
-
+      /app/"$2".sh
 fi
 
 exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ FROM elixir:1.10.3 as buildcontainer
 
 # preparation
 ARG APP_VER=0.0.1
-ENV GOSU_VERSION 1.11
 ENV MIX_ENV=prod
 ENV NODE_ENV=production
 ENV APP_VERSION=$APP_VER
@@ -22,20 +21,6 @@ RUN apt-get update  && \
 
 RUN apt-get install -y --no-install-recommends ca-certificates wget \
     && apt-get install -y --install-recommends gnupg2 dirmngr
-
-# grab gosu for easy step-down from root
-RUN set -x \
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && command -v gpgconf && gpgconf --kill all || : \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version \
-    && gosu nobody true
 
 COPY mix.exs ./
 COPY mix.lock ./
@@ -82,9 +67,9 @@ COPY .gitlab/build-scripts/docker-entrypoint.sh /entrypoint.sh
 RUN chmod a+x /entrypoint.sh && \
     useradd -d /app -u 1000 -s /bin/bash -m plausibleuser
 
-COPY --from=buildcontainer /usr/local/bin/gosu /usr/local/bin/gosu
 COPY --from=buildcontainer /app/_build/prod/rel/plausible /app
 RUN chown -R plausibleuser:plausibleuser /app
+USER plausibleuser
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["run"]


### PR DESCRIPTION
# Goal

This PR removes extra dependencies in the container image to run as a non-root user, instead defaulting all processes to run as root from the entrypoint.
This is important, as an _exec_'s into the container image will not run as root, unlike currently.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
