### PR TITLE
Start all apps when creating DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Linkify top pages [plausible/analytics#91](https://github.com/plausible/analytics/issues/91)
 
+### Fixed
+- Fix issue with creating a PostgreSQL database when `?ssl=true` [plausible/analytics#347](https://github.com/plausible/analytics/issues/347)
+
 ## [1.0.0] - 2020-10-06
 
 ### Added

--- a/lib/plausible_release.ex
+++ b/lib/plausible_release.ex
@@ -50,7 +50,7 @@ defmodule Plausible.Release do
   end
 
   def createdb do
-    :ok = Application.load(@app)
+    prepare()
 
     for repo <- repos() do
       :ok = ensure_repo_created(repo)


### PR DESCRIPTION
### Changes

Starts all apps including `:ssl` when creating DB. This fixes Postgres connection when `?ssl=true`

Fixes #347

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
