### PR TITLE
Do not error when activating an account that already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2020-10-14
+
+### Fixed
+- Do not error when activating an already activated account plausible/analytics#370
+
 ## [1.1.1] - 2020-10-14
 
 ### Fixed

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -56,13 +56,13 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert redirected_to(conn) == "/password"
     end
 
-    test "shows error when user with that email already exists", %{conn: conn} do
+    test "redirects existing user to create a password", %{conn: conn} do
       token = Plausible.Auth.Token.sign_activation("Jane Doe", "user@example.com")
 
       conn = get(conn, "/claim-activation?token=#{token}")
       conn = get(conn, "/claim-activation?token=#{token}")
 
-      assert conn.status == 400
+      assert redirected_to(conn) == "/password"
     end
   end
 


### PR DESCRIPTION
### Changes

When clicking on an activation link that is still valid but the user has already been created should not show an error. Instead, take the user to set password page instead.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
