### PR TITLE
Add weekday to the visitor graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Ability to add event metadata plausible/analytics#381
+- Display weekday on the visitor graph plausible/analytics#175
 
 ### Changed
 - Use alpine as base image to decrease Docker image size plausible/analytics#353

--- a/assets/js/dashboard/stats/visitor-graph.js
+++ b/assets/js/dashboard/stats/visitor-graph.js
@@ -53,6 +53,14 @@ const MONTHS = [
   "November", "December"
 ]
 
+const MONTHS_ABBREV = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+]
+
+const DAYS_ABBREV = [
+  "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+]
+
 function dateFormatter(interval, longForm) {
   return function(isoDate) {
     let date = new Date(isoDate)
@@ -60,7 +68,10 @@ function dateFormatter(interval, longForm) {
     if (interval === 'month') {
       return MONTHS[date.getUTCMonth()];
     } else if (interval === 'date') {
-      return date.getUTCDate() + ' ' + MONTHS[date.getUTCMonth()];
+      var day = DAYS_ABBREV[date.getUTCDay()];
+      var date_ = date.getUTCDate();
+      var month = MONTHS_ABBREV[date.getUTCMonth()];
+      return day + ', ' + date_ + ' ' + month;
     } else if (interval === 'hour') {
       const parts = isoDate.split(/[^0-9]/);
       date = new Date(parts[0],parts[1]-1,parts[2],parts[3],parts[4],parts[5])


### PR DESCRIPTION

Closes #175.

### Changes

Abbreviate both weekday and month in order to keep horizontal spacing roughly the same as it's been.

### Tests
- [x] This PR does not require tests - I skimmed the test suite and didn't find any FE tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) ~have been~ *need to be* updated - **TODO** need a new screenshot, once live on https://plausible.io/plausible.io
