### PR TITLE
Fix hashmode when using plausible's script with hash and outbound-links at the same time

### DIFF
--- a/tracker/compile.js
+++ b/tracker/compile.js
@@ -18,6 +18,6 @@ function compilefile(input, output, templateVars = {}) {
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.js'))
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.hash.js'), {hashMode: true})
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.outbound-links.js'), {outboundLinks: true})
-compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.hash.outbound-links.js'), {hash: true, outboundLinks: true})
+compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.hash.outbound-links.js'), {hashMode: true, outboundLinks: true})
 compilefile(relPath('src/p.js'), relPath('../priv/tracker/js/p.js'))
 fs.copyFileSync(relPath('../priv/tracker/js/plausible.js'), relPath('../priv/tracker/js/analytics.js'))


### PR DESCRIPTION
### Changes

Fixes a typo on the tracker script compiler.

Resolves #401 

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
