### PR TITLE
Change Docker volume used by Clickhouse to a local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ plausible-*.tar
 # If NPM crashes, it generates a log, let's ignore it too.
 npm-debug.log
 
+# If running Clickhouse through the Makefile, its data is written here
+/.clickhouse_db_vol/
+
 # The directory NPM downloads your dependencies sources to.
 /assets/node_modules/
 /tracker/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 clickhouse:
-	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$HOME/clickhouse_db_vol:/var/lib/clickhouse yandex/clickhouse-server
+	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse yandex/clickhouse-server
 
 postgres:
 	docker run --detach -e POSTGRES_PASSWORD="postgres" -p 5432:5432 postgres


### PR DESCRIPTION
## Changes

Just a quick update for an issue that I noticed after submitting #403 (darn you and your quick merging ;) ). Previously the Clickhouse container would use a volume mounted in the users home directory, if created using the Makefile. Polluting the home directory is no bueno, so this moves the directory into the current directory, and makes it hidden by default. It also adds said directory to `.gitignore`.

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update
