### PR TITLE
Display domain's favicon on the home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Use alpine as base image to decrease Docker image size plausible/analytics#353
 - Ignore automated browsers (Phantom, Selenium, Headless Chrome, etc)
+- Display domain's favicon on the home page
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -8,7 +8,8 @@
     <div class="overflow-hidden bg-white rounded max-w-xl w-full shadow-md leading-normal">
       <%= for site <- @sites do %>
         <div class="w-full relative">
-          <a href="/<%= URI.encode_www_form(site.domain) %>" class="block hover:bg-gray-100 group p-4 border-b no-underline flex justify-between transition">
+          <a href="/<%= URI.encode_www_form(site.domain) %>" class="block hover:bg-gray-100 group p-4 border-b no-underline flex justify-between transition items-center">
+            <img src="https://icons.duckduckgo.com/ip3/<%= site.domain %>.ico" referrerpolicy="no-referrer" class="inline mb-1 mr-2 w-4">
             <p class="w-full font-bold text-lg mb-1 text-gray-800"><%= site.domain %></p>
           </a>
           <%= link(to: "/#{URI.encode_www_form(site.domain)}/settings", class: "flex absolute hover:bg-gray-100 transition rounded py-2 px-5", style: "top: 12px; right: 6px;") do %>


### PR DESCRIPTION
### Changes

Everywhere that the user's site list is displayed, the site domains are accompanied by their respective favicons:

![CleanShot 2020-11-10 at 15 54 11@2x](https://user-images.githubusercontent.com/19658460/98718755-9c8fa880-236d-11eb-9562-c9cd66cfde00.png)

That is, however, not true for the home page, which only displays the domain names:

<img width="690" alt="CleanShot 2020-11-10 at 15 59 50@2x" src="https://user-images.githubusercontent.com/19658460/98718894-c9dc5680-236d-11eb-8efb-1d688993d9b0.png">

This PR attempts to make the design more consistent by adding the favicons to the home page:
<img width="726" alt="CleanShot 2020-11-10 at 15 52 30@2x" src="https://user-images.githubusercontent.com/19658460/98719060-0445f380-236e-11eb-9aac-7cd8efba9e04.png">


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
