### PR TITLE
Add Cross-Origin-Resource-Policy header to script

### DIFF
--- a/lib/plausible_web/plugs/tracker.ex
+++ b/lib/plausible_web/plugs/tracker.ex
@@ -47,6 +47,7 @@ defmodule PlausibleWeb.Tracker do
     conn
     |> put_resp_header("cache-control", "max-age=#{@max_age},public")
     |> put_resp_header("content-type", "application/javascript")
+    |> put_resp_header("cross-origin-resource-policy", "cross-origin")
     |> send_resp(200, file)
     |> halt()
   end


### PR DESCRIPTION
Hey Plausible devs,

I am trying to embed the `plausible.js` onto a page that has the [`require-corp`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) header set, which means that for every resource that is loaded they must be clearly marked as cross-origin OK.

The tracker script response currently doesn't have that header set, so I can't load it right now. This would solve that.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change
Note: if anything, it's more permissive.

### Documentation
- [x] This change does not need a documentation update
