### PR TITLE
Validate domain format on site creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Ignore automated browsers (Phantom, Selenium, Headless Chrome, etc)
 - Display domain's favicon on the home page
 - Ignore consecutive pageviews on same pathname plausible/analytics#417
+- Validate domain format on site creation plausible/analytics#427
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -22,6 +22,7 @@ defmodule Plausible.Site do
     site
     |> cast(attrs, [:domain, :timezone])
     |> validate_required([:domain, :timezone])
+    |> validate_format(:domain, ~r/^[a-zA-z0-9\-\.\/\:]*$/, message: "only letters, numbers, slashes and period allowed")
     |> unique_constraint(:domain)
     |> clean_domain
   end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -52,6 +52,18 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html_response(conn, 200) =~ "can&#39;t be blank"
     end
 
+    test "only alphanumeric characters and slash allowed in domain", %{conn: conn} do
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "timezone" => "Europe/London",
+            "domain" => "!@£.com"
+          }
+        })
+
+      assert html_response(conn, 200) =~ "only letters, numbers, slashes and period allowed"
+    end
+
     test "renders form again when it is a duplicate domain", %{conn: conn} do
       insert(:site, domain: "example.com")
 


### PR DESCRIPTION
### Changes

Validates domain format before submitting to the database.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update
