### PR TITLE
Simple notifications around traffic spikes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add tracker module to automatically track outbound links  plausible/analytics#389
 - Display weekday on the visitor graph plausible/analytics#175
 - Collect and display browser & OS versions plausible/analytics#397
+- Simple notifications around traffic spikes plausible/analytics#453
 
 ### Changed
 - Use alpine as base image to decrease Docker image size plausible/analytics#353

--- a/config/config.exs
+++ b/config/config.exs
@@ -118,7 +118,9 @@ extra_cron = [
   # Daily at midday
   {"0 12 * * *", Plausible.Workers.SendCheckStatsEmails},
   # Every 10 minutes
-  {"*/10 * * * *", Plausible.Workers.ProvisionSslCertificates}
+  {"*/10 * * * *", Plausible.Workers.ProvisionSslCertificates},
+  # Every 15 minutes
+  {"*/15 * * * *", Plausible.Workers.SpikeNotifier}
 ]
 
 base_queues = [rotate_salts: 1]
@@ -130,7 +132,8 @@ extra_queues = [
   site_setup_emails: 1,
   trial_notification_emails: 1,
   schedule_email_reports: 1,
-  send_email_reports: 1
+  send_email_reports: 1,
+  spike_notifications: 1
 ]
 
 config :plausible, Oban,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -157,7 +157,9 @@ extra_cron = [
   # Daily at midday
   {"0 12 * * *", Plausible.Workers.SendCheckStatsEmails},
   # Every 10 minutes
-  {"*/10 * * * *", Plausible.Workers.ProvisionSslCertificates}
+  {"*/10 * * * *", Plausible.Workers.ProvisionSslCertificates},
+  # Every 15 minutes
+  {"*/15 * * * *", Plausible.Workers.SpikeNotifier}
 ]
 
 base_queues = [rotate_salts: 1]
@@ -169,7 +171,8 @@ extra_queues = [
   site_setup_emails: 1,
   trial_notification_emails: 1,
   schedule_email_reports: 1,
-  send_email_reports: 1
+  send_email_reports: 1,
+  spike_notifications: 1
 ]
 
 config :plausible, Oban,

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -14,6 +14,7 @@ defmodule Plausible.Site do
     has_one :weekly_report, Plausible.Site.WeeklyReport
     has_one :monthly_report, Plausible.Site.MonthlyReport
     has_one :custom_domain, Plausible.Site.CustomDomain
+    has_one :spike_notification, Plausible.Site.SpikeNotification
 
     timestamps()
   end

--- a/lib/plausible/site/spike_notification.ex
+++ b/lib/plausible/site/spike_notification.ex
@@ -11,25 +11,8 @@ defmodule Plausible.Site.SpikeNotification do
     timestamps()
   end
 
-  def changeset(settings, attrs \\ %{}) do
-    settings
-    |> cast(attrs, [:site_id, :recipients])
-    |> validate_required([:site_id, :recipients])
-    |> unique_constraint(:site)
-  end
-
   def was_sent(schema) do
     schema
     |> change(last_sent: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
-  end
-
-  def add_recipient(report, recipient) do
-    report
-    |> change(recipients: report.recipients ++ [recipient])
-  end
-
-  def remove_recipient(report, recipient) do
-    report
-    |> change(recipients: List.delete(report.recipients, recipient))
   end
 end

--- a/lib/plausible/site/spike_notification.ex
+++ b/lib/plausible/site/spike_notification.ex
@@ -11,6 +11,23 @@ defmodule Plausible.Site.SpikeNotification do
     timestamps()
   end
 
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:site_id, :recipients, :threshold])
+    |> validate_required([:site_id, :recipients, :threshold])
+    |> unique_constraint(:site)
+  end
+
+  def add_recipient(schema, recipient) do
+    schema
+    |> change(recipients: schema.recipients ++ [recipient])
+  end
+
+  def remove_recipient(schema, recipient) do
+    schema
+    |> change(recipients: List.delete(schema.recipients, recipient))
+  end
+
   def was_sent(schema) do
     schema
     |> change(last_sent: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))

--- a/lib/plausible/site/spike_notification.ex
+++ b/lib/plausible/site/spike_notification.ex
@@ -18,6 +18,11 @@ defmodule Plausible.Site.SpikeNotification do
     |> unique_constraint(:site)
   end
 
+  def was_sent(schema) do
+    schema
+    |> change(last_sent: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
+  end
+
   def add_recipient(report, recipient) do
     report
     |> change(recipients: report.recipients ++ [recipient])

--- a/lib/plausible/site/spike_notification.ex
+++ b/lib/plausible/site/spike_notification.ex
@@ -1,0 +1,30 @@
+defmodule Plausible.Site.SpikeNotification do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "spike_notifications" do
+    field :recipients, {:array, :string}
+    field :threshold, :integer
+    field :last_sent, :naive_datetime
+    belongs_to :site, Plausible.Site
+
+    timestamps()
+  end
+
+  def changeset(settings, attrs \\ %{}) do
+    settings
+    |> cast(attrs, [:site_id, :recipients])
+    |> validate_required([:site_id, :recipients])
+    |> unique_constraint(:site)
+  end
+
+  def add_recipient(report, recipient) do
+    report
+    |> change(recipients: report.recipients ++ [recipient])
+  end
+
+  def remove_recipient(report, recipient) do
+    report
+    |> change(recipients: List.delete(report.recipients, recipient))
+  end
+end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -93,12 +93,12 @@ defmodule PlausibleWeb.Email do
     |> render("weekly_report.html", Keyword.put(assigns, :site, site))
   end
 
-  def spike_notification(email, site, current_visitors) do
+  def spike_notification(email, site, current_visitors, sources, dashboard_link) do
     base_email()
     |> to(email)
     |> tag("spike-notification")
     |> subject("Traffic spike on #{site.domain}")
-    |> render("spike_notification.html", %{current_visitors: current_visitors})
+    |> render("spike_notification.html", %{site: site, current_visitors: current_visitors, sources: sources, link: dashboard_link})
   end
 
   def cancellation_email(user) do

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -13,7 +13,6 @@ defmodule PlausibleWeb.Email do
     |> subject("Activate your Plausible free trial")
     |> render("activation_email.html", name: user.name, link: link)
   end
-
   def welcome_email(user) do
     base_email()
     |> to(user)
@@ -92,6 +91,14 @@ defmodule PlausibleWeb.Email do
     |> tag("weekly-report")
     |> subject("#{assigns[:name]} report for #{site.domain}")
     |> render("weekly_report.html", Keyword.put(assigns, :site, site))
+  end
+
+  def spike_notification(email, site, current_visitors) do
+    base_email()
+    |> to(email)
+    |> tag("spike-notification")
+    |> subject("Traffic spike on #{site.domain}")
+    |> render("spike_notification.html", %{current_visitors: current_visitors})
   end
 
   def cancellation_email(user) do

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -130,6 +130,17 @@ defmodule PlausibleWeb.Router do
            SiteController,
            :remove_monthly_report_recipient
 
+    post "/sites/:website/spike-notification/enable", SiteController, :enable_spike_notification
+    post "/sites/:website/spike-notification/disable", SiteController, :disable_spike_notification
+    put "/sites/:website/spike-notification", SiteController, :update_spike_notification
+    post "/sites/:website/spike-notification/recipients",
+         SiteController,
+         :add_spike_notification_recipient
+
+    delete "/sites/:website/spike-notification/recipients/:recipient",
+           SiteController,
+           :remove_spike_notification_recipient
+
     get "/sites/:website/shared-links/new", SiteController, :new_shared_link
     post "/sites/:website/shared-links", SiteController, :create_shared_link
     delete "/sites/:website/shared-links/:slug", SiteController, :delete_shared_link

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -1,0 +1,1 @@
+Yours site has <%= @current_visitors %> visitors. Nice!

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -1,1 +1,25 @@
-Yours site has <%= @current_visitors %> visitors. Nice!
+There are currently <%= @current_visitors %> visitors on <%= @site.domain %>.
+<br />
+<br />
+The top 3 sources for current visitors:<br />
+<table cellpadding="0" cellspacing="0" width="640" align="center" border="1">
+<tr>
+<td>
+<table cellpadding="0" cellspacing="0" width="640" align="left" border="1">
+  <%= for %{"name" => source, "count" => visitors} <- @sources do %>
+    <tr>
+      <td><%= source %><td>
+      <td><%= visitors %></td>
+    </tr>
+  <% end %>
+</table>
+</td>
+</tr>
+</table>
+<%= if @link do %>
+  View dashboard: @link
+<% end %>
+<br /><br />
+--
+<br /><br />
+<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -1,25 +1,11 @@
 There are currently <%= @current_visitors %> visitors on <%= link(@site.domain, to: "https://" <> @site.domain) %>.
-<br />
-<br />
 <%= if Enum.count(@sources) > 0 do %>
+  <br />
+  <br />
   The top 3 sources for current visitors:<br />
-
-  <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 400px;">
-      <thead>
-        <tr>
-          <th scope="col"><b>Page</b></th>
-          <th scope="col"><b>Visitors</b></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= for %{"name" => source, "count" => visitors} <- @sources do %>
-          <tr>
-            <td valign="top"><%= source %></td>
-            <td valign="top"><%= visitors %></td>
-          </tr>
-        <% end %>
-      </tbody>
-  </table>
+  <%= for %{name: source, count: visitors} <- @sources do %>
+    <%= source %> - <%= visitors %> visitors<br />
+  <% end %>
 <% end %>
 
 <%= if @link do %>

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -1,23 +1,28 @@
-There are currently <%= @current_visitors %> visitors on <%= @site.domain %>.
+There are currently <%= @current_visitors %> visitors on <%= link(@site.domain, to: "https://" <> @site.domain) %>.
 <br />
 <br />
 The top 3 sources for current visitors:<br />
-<table cellpadding="0" cellspacing="0" width="640" align="center" border="1">
-<tr>
-<td>
-<table cellpadding="0" cellspacing="0" width="640" align="left" border="1">
-  <%= for %{"name" => source, "count" => visitors} <- @sources do %>
-    <tr>
-      <td><%= source %><td>
-      <td><%= visitors %></td>
-    </tr>
-  <% end %>
+
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width: 400px;">
+    <thead>
+      <tr>
+        <th scope="col"><b>Page</b></th>
+        <th scope="col"><b>Visitors</b></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= for %{"name" => source, "count" => visitors} <- @sources do %>
+        <tr>
+          <td valign="top"><%= source %></td>
+          <td valign="top"><%= visitors %></td>
+        </tr>
+      <% end %>
+    </tbody>
 </table>
-</td>
-</tr>
-</table>
+
 <%= if @link do %>
-  View dashboard: @link
+<br /><br />
+View dashboard: @link
 <% end %>
 <br /><br />
 --

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -1,24 +1,26 @@
 There are currently <%= @current_visitors %> visitors on <%= link(@site.domain, to: "https://" <> @site.domain) %>.
 <br />
 <br />
-The top 3 sources for current visitors:<br />
+<%= if Enum.count(@sources) > 0 do %>
+  The top 3 sources for current visitors:<br />
 
-<table width="100%" cellpadding="0" cellspacing="0" style="max-width: 400px;">
-    <thead>
-      <tr>
-        <th scope="col"><b>Page</b></th>
-        <th scope="col"><b>Visitors</b></th>
-      </tr>
-    </thead>
-    <tbody>
-      <%= for %{"name" => source, "count" => visitors} <- @sources do %>
+  <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 400px;">
+      <thead>
         <tr>
-          <td valign="top"><%= source %></td>
-          <td valign="top"><%= visitors %></td>
+          <th scope="col"><b>Page</b></th>
+          <th scope="col"><b>Visitors</b></th>
         </tr>
-      <% end %>
-    </tbody>
-</table>
+      </thead>
+      <tbody>
+        <%= for %{"name" => source, "count" => visitors} <- @sources do %>
+          <tr>
+            <td valign="top"><%= source %></td>
+            <td valign="top"><%= visitors %></td>
+          </tr>
+        <% end %>
+      </tbody>
+  </table>
+<% end %>
 
 <%= if @link do %>
 <br /><br />

--- a/lib/plausible_web/templates/site/settings_email_reports.html.eex
+++ b/lib/plausible_web/templates/site/settings_email_reports.html.eex
@@ -109,3 +109,83 @@
     </div>
   <% end %>
 </div>
+
+<div class="shadow bg-white sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
+  <header class="relative">
+    <h2 class="text-lg leading-6 font-medium text-gray-900">Traffic spike notifications</h2>
+    <p class="mt-1 text-sm leading-5 text-gray-500">Get notified when your site has unusually high number of current visitors</p>
+    <%= link(to: "https://docs.plausible.io/email-reports/", target: "_blank") do %>
+      <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+    <% end %>
+  </header>
+
+  <div class="my-8 flex items-center">
+    <%= if @spike_notification do %>
+      <%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/spike-notification/disable", method: :post, class: "bg-indigo-600 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring") do %>
+        <span class="translate-x-5 inline-block h-5 w-5 rounded-full bg-white shadow transform transition ease-in-out duration-200"></span>
+      <% end %>
+    <% else %>
+      <%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/spike-notification/enable", method: :post, class: "bg-gray-200 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring") do %>
+				<span class="translate-x-0 inline-block h-5 w-5 rounded-full bg-white shadow transform transition ease-in-out duration-200"></span>
+      <% end %>
+    <% end %>
+    <span class="ml-2">Send notifications of traffic spikes</span>
+  </div>
+
+  <%= if @spike_notification do %>
+    <div class="text-sm text-gray-700 mt-6">
+
+      <%= form_for Plausible.Site.SpikeNotification.changeset(@spike_notification, %{}), "/sites/#{URI.encode_www_form(@site.domain)}/spike-notification", fn f -> %>
+        <h4 class="font-bold my-2">Current visitor threshold</h4>
+        <div class="mt-1 flex rounded-md shadow-sm max-w-md">
+          <div class="relative flex items-stretch flex-grow focus-within:z-10">
+            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <!-- Heroicon name: users -->
+              <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
+              </svg>
+            </div>
+            <%= number_input f, :threshold, class: "focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md pl-10 sm:text-sm border-gray-300" %>
+          </div>
+          <button class="-ml-px relative button rounded-l-none">
+            <span>Save threshold</span>
+          </button>
+        </div>
+    <% end %>
+      <h4 class="font-bold mt-6">Notification recipients</h4>
+      <%= for recipient <- @spike_notification.recipients do %>
+        <div class="p-2 pl-3 flex justify-between bg-gray-100 rounded my-2 max-w-md">
+          <span>
+            <svg class="h-5 w-5 text-gray-400 inline mr-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+              <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+            </svg><%= recipient %>
+          </span>
+          <%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/spike-notification/recipients/#{recipient}", method: :delete) do %>
+            <svg class="w-4 h-4 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+          <% end %>
+        </div>
+      <% end %>
+      <%= form_for @conn, "/sites/#{URI.encode_www_form(@site.domain)}/spike-notification/recipients", fn f -> %>
+        <div class="max-w-md mt-4">
+          <div class="mt-1 flex rounded-md shadow-sm">
+            <div class="relative flex items-stretch flex-grow focus-within:z-10">
+              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                  <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                </svg>
+              </div>
+              <%= email_input f, :recipient, class: "focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md pl-10 sm:text-sm border-gray-300", placeholder: "recipient@example.com" %>
+            </div>
+
+            <%= submit class: "-ml-px relative button rounded-l-none" do %>
+              <svg class="w-5 h-5 mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"></path></svg>
+              <span>Add recipient</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -17,7 +17,7 @@ defmodule Plausible.Workers.SpikeNotifier do
     for notification <- notifications do
       query = Query.from(notification.site.timezone, %{"period" => "realtime"})
       current_visitors = clickhouse.current_visitors(notification.site, query)
-      sources = clickhouse.top_sources(notification.site, query, 3, 1)
+      sources = clickhouse.top_sources(notification.site, query, 3, 1, true)
       notify(notification, current_visitors, sources)
     end
   end

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -1,0 +1,39 @@
+defmodule Plausible.Workers.SpikeNotifier do
+  use Plausible.Repo
+  alias Plausible.Stats.Query
+  use Oban.Worker, queue: :spike_notifications
+  @at_most_every "12 hours"
+
+  @impl Oban.Worker
+  def perform(_args, _job, clickhouse \\ Plausible.Stats.Clickhouse) do
+    notifications = Repo.all(
+      from sn in Plausible.Site.SpikeNotification,
+      where: is_nil(sn.last_sent),
+      or_where: sn.last_sent < fragment("now() - INTERVAL ?", @at_most_every)
+    )
+
+    for notification <- notifications do
+      notification = Repo.preload(notification, :site)
+      query = Query.from(notification.site.timezone, %{"period" => "realtime"})
+      current_visitors = clickhouse.current_visitors(notification.site, query)
+      notify(notification, current_visitors)
+    end
+  end
+
+  def notify(notification, current_visitors) do
+    if current_visitors >= notification.threshold do
+      for recipient <- notification.recipients do
+        send_notification(recipient, notification.site, current_visitors)
+      end
+    end
+  end
+
+  defp send_notification(recipient, site, current_visitors) do
+    template = PlausibleWeb.Email.spike_notification(recipient, site, current_visitors)
+    try do
+      Plausible.Mailer.send_email(template)
+    rescue
+      _ -> nil
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -90,7 +90,8 @@ defmodule Plausible.MixProject do
       {:sshex, "2.2.1"},
       {:geolix, "~> 1.0"},
       {:clickhouse_ecto, git: "https://github.com/plausible/clickhouse_ecto.git"},
-      {:geolix_adapter_mmdb2, "~> 0.5.0"}
+      {:geolix_adapter_mmdb2, "~> 0.5.0"},
+      {:mix_test_watch, "~> 1.0", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -44,6 +44,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm", "6cbe761d6a0ca5a31a0931bf4c63204bceb64538e664a8ecf784a9a6f3b875f1"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
   "mmdb2_decoder": {:hex, :mmdb2_decoder, "3.0.0", "54828676a36e75e9a25bc9a0bb0598d4c7fcc767bf0b40674850b22e05b7b6cc", [:mix], [], "hexpm", "359dc9242915538d1dceb9f6d96c72201dca76ce62e49d22e2ed1e86f20bea8e"},
   "nanoid": {:hex, :nanoid, "2.0.2", "f3f7b4bf103ab6667f22beb00b6315825ee3f30100dd2c93d534e5c02164e857", [:mix], [], "hexpm", "3095cb1fac7bbc78843a8ccd99f1af375d0da1d3ebaa8552e846b73438c0c44f"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm", "9374f4302045321874cccdc57eb975893643bd69c3b22bf1312dab5f06e5788e"},

--- a/priv/repo/migrations/20201208173543_add_spike_notifications.exs
+++ b/priv/repo/migrations/20201208173543_add_spike_notifications.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Repo.Migrations.AddSpikeNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:spike_notifications) do
+      add :site_id, references(:sites), null: false
+      add :threshold, :integer, null: false
+      add :last_sent, :naive_datetime
+      add :recipients, {:array, :citext}, null: false, default: []
+
+      timestamps()
+    end
+  end
+end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -393,7 +393,7 @@ defmodule PlausibleWeb.SiteControllerTest do
   describe "PUT /sites/:website/spike-notification" do
     setup [:create_user, :log_in, :create_site]
 
-    test "updates spike notification threshold", %{conn: conn, site: site, user: user} do
+    test "updates spike notification threshold", %{conn: conn, site: site} do
       insert(:spike_notification, site: site, threshold: 10)
       put(conn, "/sites/#{site.domain}/spike-notification", %{"spike_notification" => %{"threshold" => "15"}})
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -367,6 +367,67 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
+  describe "POST /sites/:website/spike-notification/enable" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "creates a spike notification record with the user email", %{conn: conn, site: site, user: user} do
+      post(conn, "/sites/#{site.domain}/spike-notification/enable")
+
+      notification = Repo.get_by(Plausible.Site.SpikeNotification, site_id: site.id)
+      assert notification.recipients == [user.email]
+    end
+  end
+
+  describe "POST /sites/:website/spike-notification/disable" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "deletes the spike notification record", %{conn: conn, site: site} do
+      insert(:spike_notification, site: site)
+
+      post(conn, "/sites/#{site.domain}/spike-notification/disable")
+
+      refute Repo.get_by(Plausible.Site.SpikeNotification, site_id: site.id)
+    end
+  end
+
+  describe "PUT /sites/:website/spike-notification" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "updates spike notification threshold", %{conn: conn, site: site, user: user} do
+      insert(:spike_notification, site: site, threshold: 10)
+      put(conn, "/sites/#{site.domain}/spike-notification", %{"spike_notification" => %{"threshold" => "15"}})
+
+      notification = Repo.get_by(Plausible.Site.SpikeNotification, site_id: site.id)
+      assert notification.threshold == 15
+    end
+  end
+
+  describe "POST /sites/:website/spike-notification/recipients" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "adds a recipient to the spike notification", %{conn: conn, site: site} do
+      insert(:spike_notification, site: site)
+
+      post(conn, "/sites/#{site.domain}/spike-notification/recipients", recipient: "user@email.com")
+
+      report = Repo.get_by(Plausible.Site.SpikeNotification, site_id: site.id)
+      assert report.recipients == ["user@email.com"]
+    end
+  end
+
+  describe "DELETE /sites/:website/spike-notification/recipients/:recipient" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "removes a recipient from the spike notification", %{conn: conn, site: site} do
+      insert(:spike_notification, site: site, recipients: ["recipient@email.com"])
+
+      delete(conn, "/sites/#{site.domain}/spike-notification/recipients/recipient@email.com")
+
+      report = Repo.get_by(Plausible.Site.SpikeNotification, site_id: site.id)
+      assert report.recipients == []
+    end
+  end
+
   describe "GET /sites/:website/shared-links/new" do
     setup [:create_user, :log_in, :create_site]
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,7 +21,9 @@ defmodule Plausible.Factory do
   end
 
   def spike_notification_factory do
-    %Plausible.Site.SpikeNotification{}
+    %Plausible.Site.SpikeNotification{
+      threshold: 10
+    }
   end
 
   def site_factory do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,6 +20,10 @@ defmodule Plausible.Factory do
     merge_attributes(user, attrs)
   end
 
+  def spike_notification_factory do
+    %Plausible.Site.SpikeNotification{}
+  end
+
   def site_factory do
     domain = sequence(:domain, &"example-#{&1}.com")
 

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -9,7 +9,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
 
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 5 end)
-                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 
     assert_no_emails_delivered()
@@ -20,7 +20,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
 
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 
     assert_email_delivered_with(
@@ -38,7 +38,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     site = insert(:site)
     insert(:spike_notification, site: site, threshold: 10, recipients: ["uku@example.com"])
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -1,0 +1,44 @@
+defmodule Plausible.Workers.SpikeNotifierTest do
+  use Plausible.DataCase
+  use Bamboo.Test
+  import Double
+  alias Plausible.Workers.SpikeNotifier
+
+  test "does not notify anyone if current visitors does not exceed notification threshold" do
+    site = insert(:site)
+    insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
+
+    clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 5 end)
+    SpikeNotifier.perform(nil, nil, clickhouse_stub)
+
+    assert_no_emails_delivered()
+  end
+
+  test "notifies all recipients when traffic is higher than configured threshold" do
+    site = insert(:site)
+    insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
+
+    clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
+    SpikeNotifier.perform(nil, nil, clickhouse_stub)
+
+    assert_email_delivered_with(
+      subject: "Traffic spike on #{site.domain}",
+      to: [nil: "jerod@example.com"]
+    )
+
+    assert_email_delivered_with(
+      subject: "Traffic spike on #{site.domain}",
+      to: [nil: "uku@example.com"]
+    )
+  end
+
+  test "does not notify anyone if a notification already went out in the last 12 hours" do
+    site = insert(:site)
+    insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"], last_sent: Timex.now())
+
+    clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
+    SpikeNotifier.perform(nil, nil, clickhouse_stub)
+
+    assert_no_emails_delivered()
+  end
+end

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -9,6 +9,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
 
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 5 end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 
     assert_no_emails_delivered()
@@ -19,6 +20,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     insert(:spike_notification, site: site, threshold: 10, recipients: ["jerod@example.com", "uku@example.com"])
 
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 
     assert_email_delivered_with(
@@ -36,6 +38,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
     site = insert(:site)
     insert(:spike_notification, site: site, threshold: 10, recipients: ["uku@example.com"])
     clickhouse_stub = stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
+                      |> stub(:top_sources, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, nil, clickhouse_stub)
 


### PR DESCRIPTION
Co-authored-by: Jerod Santo <jerod@changelog.com>
Streamed live at https://www.youtube.com/watch?v=dPMn2xQ7DDk
 Simple notifications around traffic spikes #172 

### Changes

Adds a background worker to send notifications for traffic spikes. The behaviour is pretty simple:
* Background worker runs every 15 minutes
* If the current visitors number on the site is higher than configured threshold, sends an email to all recipients
* Any further notifications are suppressed for 12 hours. 

TODO:
- [x] Settings UI to configure the notification
- [x] Manual testing

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog
