### PR TITLE
Fix overly-sticky date in query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Show correct stats when goal filter is combined with source plausible/analytics#374
 - Going back in history now correctly resets the period filter plausible/analytics#408
 - Fix URL decoding in query parameters plausible/analytics#416
+- Fix overly-sticky date in query parameters plausible/analytics/#439
 
 ### Security
 - Do not run the plausible Docker container as root plausible/analytics#362

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -45,6 +45,7 @@ export function parseQuery(querystring, site) {
 
 function generateQueryString(data) {
   const query = new URLSearchParams(window.location.search)
+  query.delete("date");
   Object.keys(data).forEach(key => {
     if (!data[key]) {
       query.delete(key)


### PR DESCRIPTION
### Changes

The date param was sticking around even when not specified
resulting in Last Month -> This Month still having last month's
date.

Fixes #439

### Tests
- [ ] Automated tests have been added
Frontend doesn't have a test framework

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
