### PR TITLE
Separate page metrics by hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Collect and display browser & OS versions plausible/analytics#397
 - Simple notifications around traffic spikes plausible/analytics#453
 - Dark theme option/system setting follow plausible/analytics#467
+- Separate pageview metrics by hostname#478
 
 ### Changed
 - Use alpine as base image to decrease Docker image size plausible/analytics#353

--- a/assets/js/dashboard/stats/pages.js
+++ b/assets/js/dashboard/stats/pages.js
@@ -48,7 +48,7 @@ export default class Pages extends React.Component {
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
-            <a target="_blank" href={'http://' + this.props.site.domain + page.name} className="hidden group-hover:block">
+            <a target="_blank" href={'http://' + page.name} className="hidden group-hover:block">
               <svg className="inline h-4 w-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -70,6 +70,22 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.hostname == "example.com"
     end
 
+    test "subdomain is preserved from hostname", %{conn: conn} do
+      params = %{
+        name: "pageview",
+        url: "http://blog.example.com/",
+        domain: "example.com"
+      }
+
+      conn
+      |> put_req_header("content-type", "text/plain")
+      |> post("/api/event", Jason.encode!(params))
+
+      pageview = get_event("example.com")
+
+      assert pageview.hostname == "blog.example.com"
+    end
+
     test "empty path defaults to /", %{conn: conn} do
       params = %{
         name: "pageview",
@@ -110,7 +126,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       conn
       |> put_req_header("content-type", "text/plain")
-      |> put_req_header("user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/85.0.4183.83 Safari/537.36")
+      |> put_req_header(
+        "user-agent",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/85.0.4183.83 Safari/537.36"
+      )
       |> post("/api/event", Jason.encode!(params))
 
       assert get_event("headless-chrome-test.com") == nil
@@ -396,10 +415,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       name: "Signup",
       url: "http://gigride.live/",
       domain: "custom-prop-test.com",
-      props: Jason.encode!(%{
-        bool_test: true,
-        number_test: 12
-      })
+      props:
+        Jason.encode!(%{
+          bool_test: true,
+          number_test: 12
+        })
     }
 
     conn
@@ -508,7 +528,8 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
   test "decodes URL pathname, fragment and search", %{conn: conn} do
     params = %{
       n: "pageview",
-      u: "https://test.com/%EF%BA%9D%EF%BB%AD%EF%BA%8E%EF%BA%8B%EF%BA%AF-%EF%BB%AE%EF%BB%A4%EF%BA%B3%EF%BA%8E%EF%BA%92%EF%BB%97%EF%BA%8E%EF%BA%97?utm_source=%25balle%25",
+      u:
+        "https://test.com/%EF%BA%9D%EF%BB%AD%EF%BA%8E%EF%BA%8B%EF%BA%AF-%EF%BB%AE%EF%BB%A4%EF%BA%B3%EF%BA%8E%EF%BA%92%EF%BB%97%EF%BA%8E%EF%BA%97?utm_source=%25balle%25",
       d: "url-decode-test.com",
       h: 1
     }

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -9,10 +9,11 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01")
 
       assert json_response(conn, 200) == [
-               %{"count" => 2, "pageviews" => 2, "name" => "/"},
-               %{"count" => 2, "pageviews" => 2, "name" => "/register"},
-               %{"count" => 1, "pageviews" => 1, "name" => "/contact"},
-               %{"count" => 1, "pageviews" => 1, "name" => "/irrelevant"}
+               %{"count" => 2, "pageviews" => 2, "name" => "test-site.com/"},
+               %{"count" => 1, "pageviews" => 1, "name" => "test-site.com/register"},
+               %{"count" => 1, "pageviews" => 1, "name" => "test-site.com/contact"},
+               %{"count" => 1, "pageviews" => 1, "name" => "blog.test-site.com/register"},
+               %{"count" => 1, "pageviews" => 1, "name" => "test-site.com/irrelevant"}
              ]
     end
 
@@ -28,25 +29,31 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "bounce_rate" => 33.0,
                  "count" => 2,
                  "pageviews" => 2,
-                 "name" => "/"
-               },
-               %{
-                 "bounce_rate" => nil,
-                 "count" => 2,
-                 "pageviews" => 2,
-                 "name" => "/register"
+                 "name" => "test-site.com/"
                },
                %{
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
-                 "name" => "/contact"
+                 "name" => "test-site.com/register"
                },
                %{
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
-                 "name" => "/irrelevant"
+                 "name" => "test-site.com/contact"
+               },
+               %{
+                 "bounce_rate" => nil,
+                 "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "blog.test-site.com/register"
+               },
+               %{
+                 "bounce_rate" => nil,
+                 "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "test-site.com/irrelevant"
                }
              ]
     end
@@ -55,8 +62,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=realtime")
 
       assert json_response(conn, 200) == [
-               %{"count" => 2, "name" => "/exit"},
-               %{"count" => 1, "name" => "/"}
+               %{"count" => 2, "name" => "test-site.com/exit"},
+               %{"count" => 1, "name" => "test-site.com/"}
              ]
     end
   end
@@ -68,7 +75,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/entry-pages?period=day&date=2019-01-01")
 
       assert json_response(conn, 200) == [
-               %{"count" => 3, "name" => "/"}
+               %{"count" => 3, "name" => "test-site.com/"}
              ]
     end
 
@@ -83,7 +90,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                %{
                  "bounce_rate" => 33.0,
                  "count" => 3,
-                 "name" => "/"
+                 "name" => "test-site.com/"
                }
              ]
     end

--- a/test/support/clickhouse_setup.ex
+++ b/test/support/clickhouse_setup.ex
@@ -7,6 +7,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/",
         country_code: "EE",
         browser: "Chrome",
@@ -22,6 +23,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/",
         country_code: "EE",
         browser: "Chrome",
@@ -36,6 +38,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/contact",
         country_code: "GB",
         browser: "Firefox",
@@ -44,10 +47,16 @@ defmodule Plausible.Test.ClickhouseSetup do
         referrer_source: "Bing",
         timestamp: ~N[2019-01-01 00:00:00]
       },
-      %{name: "pageview", domain: "test-site.com", timestamp: ~N[2019-01-31 00:00:00]},
+      %{
+        name: "pageview",
+        domain: "test-site.com",
+        hostname: "test-site.com",
+        timestamp: ~N[2019-01-31 00:00:00]
+      },
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 01:00:00],
         "meta.key": ["variant"],
@@ -56,6 +65,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 02:00:00],
         "meta.key": ["variant"],
@@ -64,6 +74,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_2_session_id,
         timestamp: ~N[2019-01-01 02:00:00],
         "meta.key": ["variant"],
@@ -73,6 +84,7 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/register",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
@@ -80,6 +92,7 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/register",
         domain: "test-site.com",
+        hostname: "blog.test-site.com",
         session_id: @conversion_2_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
@@ -87,24 +100,28 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/irrelevant",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer_source: "Google",
         timestamp: ~N[2019-02-01 01:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer_source: "Google",
         timestamp: ~N[2019-02-01 02:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/some-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 01:00:00]
@@ -112,6 +129,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/some-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 01:00:00]
@@ -119,32 +137,42 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/nonexistent-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 02:00:00]
       },
-      %{name: "pageview", domain: "test-site.com"},
+      %{name: "pageview", domain: "test-site.com", hostname: "test-site.com"},
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: Timex.now() |> Timex.shift(minutes: -3)
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: Timex.now() |> Timex.shift(minutes: -6)
       },
-      %{name: "pageview", domain: "tz-test.com", timestamp: ~N[2019-01-01 00:00:00]},
-      %{name: "pageview", domain: "public-site.io"},
+      %{
+        name: "pageview",
+        domain: "tz-test.com",
+        hostname: "tz-test.com",
+        timestamp: ~N[2019-01-01 00:00:00]
+      },
+      %{name: "pageview", domain: "public-site.io", hostname: "public-site.io"},
       %{
         name: "pageview",
         domain: "fetch-tweets-test.com",
+        hostname: "fetch-tweets-test.com",
         referrer: "t.co/a-link",
         referrer_source: "Twitter"
       },
       %{
         name: "pageview",
         domain: "fetch-tweets-test.com",
+        hostname: "fetch-tweets-test.com",
         referrer: "t.co/b-link",
         referrer_source: "Twitter",
         timestamp: Timex.now() |> Timex.shift(days: -5)
@@ -154,6 +182,7 @@ defmodule Plausible.Test.ClickhouseSetup do
     Plausible.TestUtils.create_sessions([
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "10words",
@@ -173,6 +202,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "10words",
@@ -186,6 +216,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Bing",
@@ -198,6 +229,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Google",
@@ -208,6 +240,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Google",
@@ -218,6 +251,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/some-link",
@@ -227,6 +261,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/some-link",
@@ -236,6 +271,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/nonexistent-link",
@@ -245,6 +281,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Bing",
@@ -254,6 +291,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/exit",
         referrer_source: "10words",
@@ -263,6 +301,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/exit",
         referrer_source: "10words",


### PR DESCRIPTION
Closes #160

### Changes

#### Goal

The issue I am aiming to solve is that some people (myself included) use subdomains, and want the data for the main site (e.g. j3rn.com) to also include data about the subdomains (e.g. blog.j3rn.com) such that they can have a holistic overview of an entire property.

#### Proposed Solution

I modified the "page" queries (top pages, entry pages, etc) to:
1. `GROUP BY` hostname
2. Combine the hostname and path to form the `name` field (whereas it was previously just the path).

This worked relatively well with the existing React code, and only a small change (outbound links) was needed.

I've tested this locally to my own satisfaction. I'm very open to feedback on any ways this can be improved!


Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update
