### PR TITLE
Adds "Load More" functionality to pages modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Collect and display browser & OS versions plausible/analytics#397
 - Simple notifications around traffic spikes plausible/analytics#453
 - Dark theme option/system setting follow plausible/analytics#467
+- "Load More" capability to pages modal plausible/analytics#480
 
 ### Changed
 - Use alpine as base image to decrease Docker image size plausible/analytics#353

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -212,8 +212,9 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site.timezone, params)
     include = if params["include"], do: String.split(params["include"], ","), else: []
     limit = if params["limit"], do: String.to_integer(params["limit"])
+    page = if params["page"], do: String.to_integer(params["page"])
 
-    json(conn, Stats.top_pages(site, query, limit || 9, include))
+    json(conn, Stats.top_pages(site, query, limit || 9, page || 1, include))
   end
 
   def entry_pages(conn, params) do
@@ -221,8 +222,9 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site.timezone, params)
     include = if params["include"], do: String.split(params["include"], ","), else: []
     limit = if params["limit"], do: String.to_integer(params["limit"])
+    page = if params["page"], do: String.to_integer(params["page"])
 
-    json(conn, Stats.entry_pages(site, query, limit || 9, include))
+    json(conn, Stats.entry_pages(site, query, limit || 9, page || 1, include))
   end
 
   def countries(conn, params) do

--- a/lib/workers/send_email_report.ex
+++ b/lib/workers/send_email_report.ex
@@ -56,7 +56,7 @@ defmodule Plausible.Workers.SendEmailReport do
     prev_bounce_rate = Stats.bounce_rate(site, Query.shift_back(query))
     change_bounce_rate = if prev_bounce_rate > 0, do: bounce_rate - prev_bounce_rate
     referrers = Stats.top_sources(site, query, 5, 1, [])
-    pages = Stats.top_pages(site, query, 5, [])
+    pages = Stats.top_pages(site, query, 5, 1, [])
     user = Plausible.Auth.find_user_by(email: email)
     login_link = user && Plausible.Sites.is_owner?(user.id, site)
 


### PR DESCRIPTION
### Changes

Adds "Load More" capability to pages modal - both top-pages and entry-pages. Allows for a user to get all the way to all pages, not just the top 100. 

Fixed #429 

For clarity: I was running into an issue with this setup where I would receive all `n` pages as expected, but I'd also consistently get a seemingly random `n+1` page sent, which was a complete duplicate of a previously sent entry. I suspect it was just an issue with how I was generating data, as even without my changes it was appearing in my local if I bumped the limit on the pages API call (and not the live demo or my self-hosted instance). But I figured I'd mention it in case you could see any code reason for that happening. 

### Tests
- [X] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update
