### PR TITLE
fix: low contrast text in dark mode

### DIFF
--- a/assets/js/dashboard/stats/sources/search-terms.js
+++ b/assets/js/dashboard/stats/sources/search-terms.js
@@ -87,7 +87,7 @@ export default class SearchTerms extends React.Component {
           <RocketIcon />
           <div>Could not find any search terms for this period</div>
           <div>Google Search Console data is sampled and delayed by 24-36h</div>
-          <div>Read more on <a href="https://docs.plausible.io/google-search-console-integration/#i-dont-see-google-search-query-data-in-my-dashboard" target="_blank" className="hover:underline text-indigo-700">our documentation</a></div>
+          <div>Read more on <a href="https://docs.plausible.io/google-search-console-integration/#i-dont-see-google-search-query-data-in-my-dashboard" target="_blank" className="hover:underline text-indigo-700 dark:text-indigo-500">our documentation</a></div>
         </div>
       )
     }


### PR DESCRIPTION
### Changes

Change color of link in dark mode because of low contrast.

before:
![link with low contrast](https://user-images.githubusercontent.com/24668338/102697989-8a413e00-423a-11eb-8a8a-993a6a014619.png)

after:
![link with enough contrast](https://user-images.githubusercontent.com/24668338/102697984-7d244f00-423a-11eb-94e6-9f58372481ad.png)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change (it is a user-facing change but it is not worth adding imo)

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
