### PR TITLE
Allows middle-click and ctrl+click outbound clicks to properly open as user intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Improve settings UX and design plausible/analytics#412
 - Improve site listing UX and design plausible/analytics#438
 - Improve onboarding UX and design plausible/analytics#441
+- Allows outbound link tracking script to use new tab redirection plausible/analytics#494
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -70,10 +70,9 @@
 
         // Delay navigation so that Plausible is notified of the click
         if(!link.target || link.target.match(/^_(self|parent|top)$/i)) {
-          if (middle || event.ctrlKey || event.metaKey || event.shiftKey) window.open(link.href)
-          else {
+          if (!(event.ctrlKey || event.metaKey || event.shiftKey) && click) {
             setTimeout(function() {
-              if (click) location.href = link.href;
+              location.href = link.href;
             }, 150);
             event.preventDefault();
           }

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -58,21 +58,25 @@
   {{#if outboundLinks}}
   function handleOutbound(event) {
     var link = event.target;
+    var middle = event.type == "auxclick" && event.which == 2;
+    var click = event.type == "click";
       while(link && (typeof link.tagName == 'undefined' || link.tagName.toLowerCase() != 'a' || !link.href)) {
         link = link.parentNode
       }
 
       if (link && link.href && link.host && link.host !== location.host) {
-        if ((event.type == "auxclick" && event.which == 2) || event.type == "click")
+        if (middle || click)
         plausible('Outbound Link: Click', {props: {url: link.href}})
 
         // Delay navigation so that Plausible is notified of the click
         if(!link.target || link.target.match(/^_(self|parent|top)$/i)) {
-          setTimeout(function() {
-            if ((event.type == "auxclick" && event.which == 2) || event.ctrlKey || event.metaKey || event.shiftKey) window.open(link.href)
-            else if (event.type == "click") location.href = link.href;
-          }, 150);
-          event.preventDefault();
+          if (middle || event.ctrlKey || event.metaKey || event.shiftKey) window.open(link.href)
+          else {
+            setTimeout(function() {
+              if (click) location.href = link.href;
+            }, 150);
+            event.preventDefault();
+          }
         }
       }
   }

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -56,23 +56,30 @@
   }
 
   {{#if outboundLinks}}
-  function registerOutboundLinkEvents() {
-    document.addEventListener('click', function (event) {
-      var link = event.target;
+  function handleOutbound(event) {
+    var link = event.target;
       while(link && (typeof link.tagName == 'undefined' || link.tagName.toLowerCase() != 'a' || !link.href)) {
         link = link.parentNode
       }
 
       if (link && link.href && link.host && link.host !== location.host) {
+        if ((event.type == "auxclick" && event.which == 2) || event.type == "click")
         plausible('Outbound Link: Click', {props: {url: link.href}})
 
         // Delay navigation so that Plausible is notified of the click
         if(!link.target || link.target.match(/^_(self|parent|top)$/i)) {
-          setTimeout(function() { location.href = link.href; }, 150);
+          setTimeout(function() {
+            if ((event.type == "auxclick" && event.which == 2) || event.ctrlKey || event.metaKey || event.shiftKey) window.open(link.href)
+            else if (event.type == "click") location.href = link.href;
+          }, 150);
           event.preventDefault();
         }
       }
-    })
+  }
+
+  function registerOutboundLinkEvents() {
+    document.addEventListener('click', handleOutbound)
+    document.addEventListener('auxclick', handleOutbound)
   }
   {{/if}}
 


### PR DESCRIPTION
### Changes

Allows middle clicks or ctrl+click, cmd+click, shift+click to track to plausible, and open in a new tab if requested, instead of always redirecting the current tab. 

Fixes #451 

This will almost certainly cause conflicts with #489 in the compiled script, so I didn't push them in this PR at all. Once both are merged we can re-compile the merged version. 

### Tests
- [X] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update
