### PR TITLE
Fixes couple of Flatpickr related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
 - Fix URL decoding in query parameters plausible/analytics#416
 - Fix overly-sticky date in query parameters plausible/analytics/#439
 - Prevent picking dates before site insertion plausible/analtics#446
+- Fix overly-sticky from and to in query parameters plausible/analytics#495
+- Adds support for single-day date selection plausible/analytics#495
 
 ### Security
 - Do not run the plausible Docker container as root plausible/analytics#362

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -223,16 +223,29 @@ class DatePicker extends React.Component {
   setCustomDate(dates) {
     if (dates.length === 2) {
       const [from, to] = dates
-      navigateToQuery(
-        this.props.history,
-        this.props.query,
-        {
-          period: 'custom',
-          date: false,
-          from: formatISO(from),
-          to: formatISO(to),
-        }
-      )
+      if (formatISO(from) === formatISO(to)) {
+        navigateToQuery(
+          this.props.history,
+          this.props.query,
+          {
+            period: 'day',
+            date: formatISO(from),
+            from: false,
+            to: false,
+          }
+        )
+      } else {
+        navigateToQuery(
+          this.props.history,
+          this.props.query,
+          {
+            period: 'custom',
+            date: false,
+            from: formatISO(from),
+            to: formatISO(to),
+          }
+        )
+      }
       this.close()
     }
   }

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -46,6 +46,8 @@ export function parseQuery(querystring, site) {
 function generateQueryString(data) {
   const query = new URLSearchParams(window.location.search)
   query.delete("date");
+  query.delete("from");
+  query.delete("to");
   Object.keys(data).forEach(key => {
     if (!data[key]) {
       query.delete(key)


### PR DESCRIPTION
### Changes

- Ensures that selecting the same day for both entries in Flatpickr doesn't result in an empty graph, and instead changes to "day" view for the single day selected. 
- Does the same as #470 but for `from` and `to` params, which persist when moving from a custom date range to any other period

Fixes #466 

### Tests
- [X] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update
