### PR TITLE
Fix NaN issue in percent_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Fix overly-sticky from and to in query parameters plausible/analytics#495
 - Adds support for single-day date selection plausible/analytics#495
 - Goal conversion rate in realtime view is now accurate plausible/analytics#500
+- Fix NaN issue when today's and yesterday's numbers are same plausible/analytics#510
 
 ### Security
 - Do not run the plausible Docker container as root plausible/analytics#362

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -119,10 +119,7 @@ defmodule PlausibleWeb.Api.StatsController do
       old_count == 0 and new_count > 0 ->
         100
 
-      old_count == 0 and new_count == 0 ->
-        0
-
-      old_count - new_count == 0 ->
+      (old_count - new_count) == 0 ->
         0
 
       true ->

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -122,6 +122,9 @@ defmodule PlausibleWeb.Api.StatsController do
       old_count == 0 and new_count == 0 ->
         0
 
+      old_count - new_count == 0 ->
+        0
+
       true ->
         round((new_count - old_count) / old_count * 100)
     end


### PR DESCRIPTION
### Changes

Hello! Today, I saw that if there is no change in unique visitors (and probably also for the other ones), instead of showing `0`, the app shows `NaN`. This PR fixes this issue.

<img width="462" alt="Screenshot 2020-12-24 at 16 28 53" src="https://user-images.githubusercontent.com/8930176/103098538-63548480-460b-11eb-8987-f1e4cbc7e7bb.png">


### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
