### PR TITLE
Change datepicker caret from pink to indigo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - My sites now show settings cog at all times on smaller screens plausible/analytics#497
 - Background jobs are enabled by default for self-hosted installations plausible/analytics#603
 - All new users on self-hosted installations have a never-ending trial plausible/analytics#603
+- Changed caret/chevron color in datepicker dropwdown
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 - My sites now show settings cog at all times on smaller screens plausible/analytics#497
 - Background jobs are enabled by default for self-hosted installations plausible/analytics#603
 - All new users on self-hosted installations have a never-ending trial plausible/analytics#603
-- Changed caret/chevron color in datepicker dropwdown
+- Changed caret/chevron color in datepicker dropdown
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 - My sites now show settings cog at all times on smaller screens plausible/analytics#497
 - Background jobs are enabled by default for self-hosted installations plausible/analytics#603
 - All new users on self-hosted installations have a never-ending trial plausible/analytics#603
-- Changed caret/chevron color in datepicker dropdown
+- Changed caret/chevron color in datepicker and filters dropdown
 
 ### Fixed
 - Do not error when activating an already activated account plausible/analytics#370

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -239,7 +239,7 @@ class DatePicker extends React.Component {
         >
           <span className="mr-2">{this.timeFrameText()}</span>
           <svg
-            className="text-pink-500 h-4 w-4"
+            className="text-indigo-500 h-4 w-4"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -199,7 +199,7 @@ class Filters extends React.Component {
         <div className="relative" style={{ height: '35.5px', width: '100px' }}>
           <div onClick={() => this.setState((state) => ({ dropdownOpen: !state.dropdownOpen }))} className="flex items-center justify-between rounded bg-white dark:bg-gray-800 shadow px-4 pr-3 py-2 leading-tight cursor-pointer text-sm font-medium text-gray-800 dark:text-gray-200 h-full">
             <span className="mr-2">Filters</span>
-            <svg className="text-pink-500 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg className="text-indigo-500 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="6 9 12 15 18 9"></polyline>
             </svg>
           </div>


### PR DESCRIPTION
### Changes

I couldn't understand why the dropdown caret/chevron was pink. It actually looks more red on my screen and I thought I had an error on the datepicker. Changed to indigo to match the rest of the theme. Appreciate this might be a preference thing, so feel free to ignore.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] This change does not need a documentation update
