### PR TITLE
Make /sites live update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 ## [1.2] - Unreleased
 
 ### Added
+
 - Ability to add event metadata plausible/analytics#381
-- Add tracker module to automatically track outbound links  plausible/analytics#389
+- Add tracker module to automatically track outbound links plausible/analytics#389
 - Display weekday on the visitor graph plausible/analytics#175
 - Collect and display browser & OS versions plausible/analytics#397
 - Simple notifications around traffic spikes plausible/analytics#453
@@ -16,8 +18,10 @@ All notable changes to this project will be documented in this file.
 - Escape keyboard shortcut to clear all filters plausible/analytics#625
 - Tracking exclusions, see our documentation [here](https://docs.plausible.io/excluding) and [here](https://docs.plausible.io/excluding-pages) for details plausible/analytics#489
 - Keybindings for selecting dates/ranges plausible/analytics#630
+- Live update stats in /sites and allow changing period
 
 ### Changed
+
 - Use alpine as base image to decrease Docker image size plausible/analytics#353
 - Ignore automated browsers (Phantom, Selenium, Headless Chrome, etc)
 - Display domain's favicon on the home page
@@ -34,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Changed caret/chevron color in datepicker and filters dropdown
 
 ### Fixed
+
 - Do not error when activating an already activated account plausible/analytics#370
 - Ignore arrow keys when modifier keys are pressed plausible/analytics#363
 - Show correct stats when goal filter is combined with source plausible/analytics#374
@@ -47,20 +52,24 @@ All notable changes to this project will be documented in this file.
 - Various UI/UX issues plausible/analytics#503
 
 ### Security
+
 - Do not run the plausible Docker container as root plausible/analytics#362
 
 ## [1.1.1] - 2020-10-14
 
 ### Fixed
+
 - Revert Dockerfile change that introduced a regression
 
 ## [1.1.0] - 2020-10-14
 
 ### Added
+
 - Linkify top pages [plausible/analytics#91](https://github.com/plausible/analytics/issues/91)
-- Filter by country, screen size, browser and operating system  [plausible/analytics#303](https://github.com/plausible/analytics/issues/303)
+- Filter by country, screen size, browser and operating system [plausible/analytics#303](https://github.com/plausible/analytics/issues/303)
 
 ### Fixed
+
 - Fix issue with creating a PostgreSQL database when `?ssl=true` [plausible/analytics#347](https://github.com/plausible/analytics/issues/347)
 - Do no disclose current URL to DuckDuckGo's favicon service [plausible/analytics#343](https://github.com/plausible/analytics/issues/343)
 - Updated UAInspector database to detect newer devices [plausible/analytics#309](https://github.com/plausible/analytics/issues/309)
@@ -68,9 +77,11 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0] - 2020-10-06
 
 ### Added
+
 - Collect and present link tags (`utm_medium`, `utm_source`, `utm_campaign`) in the dashboard
 
 ### Changed
+
 - Replace configuration parameters `CLICKHOUSE_DATABASE_{HOST,NAME,USER,PASSWORD}` with a single `CLICKHOUSE_DATABASE_URL` [plausible/analytics#317](https://github.com/plausible/analytics/pull/317)
 - Disable subscriptions by default
 - Remove `CLICKHOUSE_DATABASE_POOLSIZE`, `DATABASE_POOLSIZE` and `DATABASE_TLS_ENABLED` parameters. Use query parameters in `CLICKHOUSE_DATABASE_URL` and `DATABASE_URL` instead.

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -3,7 +3,23 @@
     <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
       My sites
     </h2>
-    <a href="/sites/new" class="button my-2 sm:my-0 w-auto">+ Add a website</a>
+    <ul class="flex">
+      <li class="relative mr-6">
+        <%# <div data-dropdown-trigger class="rounded bg-white dark:bg-gray-800 shadow px-4 pr-3 py-2 leading-tight cursor-pointer text-sm font-medium text-gray-800 dark:text-gray-200flex items-center hover:bg-gray-200 dark:hover:bg-gray-900 rounded m-1 p-1 cursor-pointer dark:text-gray-100"> %>
+        <div data-dropdown-trigger class="rounded bg-white shadow px-4 py-2 cursor-pointer text-sm font-medium flex items-center hover:bg-gray-200 dark:hover:bg-gray-900 dark:bg-gray-800 text-gray-800 dark:text-gray-200">
+          <span class="pl-2 mr-2"><%= elem(@period, 1) %></span>
+          <svg class="text-indigo-500 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </div>
+
+        <div data-dropdown style="top: 42px; right: 0px; width: 185px;" class="dropdown-content hidden absolute right-0 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-500 rounded shadow-md z-10">
+          <%= for {key, name} <- @periods do %>
+            <%= link(name, to: "/sites?period=#{key}", class: "block py-2 px-2 border-b border-gray-300 dark:border-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 dark:text-gray-100") %>
+          <% end %>
+        </div>
+      </li>
+
+      <li><a href="/sites/new" class="button my-2 sm:my-0 w-auto">+ Add a website</a></li>
+    </ul>
   </div>
 
   <ul class="my-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -23,8 +39,8 @@
             </div>
             <div class="pl-8 mt-2 flex items-center justify-between">
               <span class="text-gray-600 dark:text-gray-400 text-sm truncate">
-                <span class="text-gray-800 dark:text-gray-200">
-                  <b><%= PlausibleWeb.StatsView.large_number_format(Map.get(@visitors, site.domain, 0)) %></b> visitor<%= if Map.get(@visitors, site.domain, 0) != 1 do %>s<% end %> in last 24h
+                <span class="visitors-row text-gray-800 dark:text-gray-200">
+                  <b><%= PlausibleWeb.StatsView.large_number_format(Map.get(@visitors, site.domain, 0)) %></b> visitor<%= if Map.get(@visitors, site.domain, 0) != 1 do %>s<% end %> in last <%= elem(@period, 0) %>
                 </span>
               </span>
             </div>
@@ -37,4 +53,15 @@
       </div>
     <% end %>
   </ul>
+  <script>
+    setInterval(function(){
+      document.querySelectorAll(".visitors-row").forEach(async el => {
+        const domain = el.closest('a').getAttribute('href')
+        const request = await fetch(`/api/stats${domain}/main-graph?period=<%= elem(@period, 0) %>`)
+        const json = await request.json()
+        const visitors = json.top_stats[0].count
+        el.innerHTML = `<b>${visitors}</b> visitor${visitors === 1 ? '' : 's'} in last <%=elem(@period, 0) %>`
+      })
+    }, 30000)
+  </script>
 </div>


### PR DESCRIPTION
### Changes

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Changes

- stats update every 30 sec
- user can change period shown

![image](https://user-images.githubusercontent.com/2750622/106631941-87e23b80-657d-11eb-8111-8fe325f4faa4.png)

I had assumed the stats update all along :)

### Problems

I understand the *real* solution would be to Reactify the whole thing, but it was a little too many things to bite off at once (even though I got half way with React).

### Areas to check by reviewer

- Is using session for storing period okay?
- **It's hard to test with no data. Does the dropdown and periods actually work?**
- At the end of the template is a raw `<script>` - is that ok?