### PR TITLE
Expose port 8000 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,5 @@ RUN chown -R plausibleuser:plausibleuser /app
 USER plausibleuser
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
+EXPOSE 8000
 CMD ["run"]


### PR DESCRIPTION
### Changes

Fixes #666
Re-implements #237 

This doesn't bind it to the host port by default, it's more a hint to tools which integrate with Docker directly.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
