### PR TITLE
Validate API query params

### DIFF
--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -11,53 +11,70 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def aggregate(conn, params) do
-    site = conn.assigns[:site]
-    query = Query.from(site.timezone, params)
+    with :ok <- validate_date(params),
+         :ok <- validate_period(params),
+         :ok <- validate_metrics(params) do
+      site = conn.assigns[:site]
+      query = Query.from(site.timezone, params)
 
-    metrics =
-      params["metrics"]
-      |> String.split(",")
-      |> Enum.map(&String.trim/1)
+      metrics =
+        params["metrics"]
+        |> String.split(",")
+        |> Enum.map(&String.trim/1)
 
-    result =
-      if params["compare"] == "previous_period" do
-        prev_query = Query.shift_back(query)
+      result =
+        if params["compare"] == "previous_period" do
+          prev_query = Query.shift_back(query)
 
-        [prev_result, curr_result] =
-          Task.await_many([
-            Task.async(fn -> Plausible.Stats.aggregate(site, prev_query, metrics) end),
-            Task.async(fn -> Plausible.Stats.aggregate(site, query, metrics) end)
-          ])
+          [prev_result, curr_result] =
+            Task.await_many([
+              Task.async(fn -> Plausible.Stats.aggregate(site, prev_query, metrics) end),
+              Task.async(fn -> Plausible.Stats.aggregate(site, query, metrics) end)
+            ])
 
-        Enum.map(curr_result, fn {metric, %{value: current_val}} ->
-          %{value: prev_val} = prev_result[metric]
+          Enum.map(curr_result, fn {metric, %{value: current_val}} ->
+            %{value: prev_val} = prev_result[metric]
 
-          {metric,
-           %{
-             value: current_val,
-             change: percent_change(prev_val, current_val)
-           }}
-        end)
-        |> Enum.into(%{})
-      else
-        Plausible.Stats.aggregate(site, query, metrics)
-      end
+            {metric,
+             %{
+               value: current_val,
+               change: percent_change(prev_val, current_val)
+             }}
+          end)
+          |> Enum.into(%{})
+        else
+          Plausible.Stats.aggregate(site, query, metrics)
+        end
 
-    json(conn, result)
+      json(conn, result)
+    else
+      {:error, msg} ->
+        conn
+        |> put_status(400)
+        |> json(%{error: msg})
+    end
   end
 
   def timeseries(conn, params) do
-    site = conn.assigns[:site]
-    query = Query.from(site.timezone, params)
+    with :ok <- validate_date(params),
+         :ok <- validate_period(params) do
+      site = conn.assigns[:site]
+      query = Query.from(site.timezone, params)
 
-    {plot, labels} = Plausible.Stats.timeseries(site, query)
+      {plot, labels} = Plausible.Stats.timeseries(site, query)
 
-    graph =
-      Enum.zip(labels, plot)
-      |> Enum.map(fn {label, val} -> %{date: label, value: val} end)
-      |> Enum.into([])
+      graph =
+        Enum.zip(labels, plot)
+        |> Enum.map(fn {label, val} -> %{date: label, value: val} end)
+        |> Enum.into([])
 
-    json(conn, graph)
+      json(conn, graph)
+    else
+      {:error, msg} ->
+        conn
+        |> put_status(400)
+        |> json(%{error: msg})
+    end
   end
 
   def handle_errors(conn, %{kind: kind, reason: reason}) do
@@ -76,4 +93,51 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
         round((new_count - old_count) / old_count * 100)
     end
   end
+
+  defp validate_date(%{"date" => date}) do
+    case Date.from_iso8601(date) do
+      {:ok, _date} ->
+        :ok
+
+      {:error, msg} ->
+        {:error,
+         "Error parsing `date` parameter: #{msg}. Please specify a valid date in ISO-8601 format."}
+    end
+  end
+
+  defp validate_date(_), do: :ok
+
+  defp validate_period(%{"period" => period}) do
+    if period in ["day", "7d", "30d", "month", "6mo", "12mo", "custom"] do
+      :ok
+    else
+      {:error,
+       "Error parsing `period` parameter: invalid period `#{period}`. Please find accepted values in our docs: https://plausible.io/docs/stats-api#time-periods"}
+    end
+  end
+
+  defp validate_period(_), do: :ok
+
+  @valid_metrics ["pageviews", "visitors", "bounce_rate", "visit_duration"]
+  @valid_metrics_str Enum.map(@valid_metrics, &("`" <> &1 <> "`")) |> Enum.join(", ")
+
+  defp validate_metrics(%{"metrics" => metrics_str}) do
+    metrics =
+      metrics_str
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+
+    bad_metric = Enum.find(metrics, fn metric -> metric not in @valid_metrics end)
+
+    if bad_metric do
+      {:error,
+       "Error parsing `metrics` parameter: invalid metric `#{bad_metric}`. Valid metrics are #{
+         @valid_metrics_str
+       }"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_metrics(_), do: :ok
 end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -57,7 +57,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   def timeseries(conn, params) do
     with :ok <- validate_date(params),
-         :ok <- validate_period(params) do
+         :ok <- validate_period(params),
+         :ok <- validate_interval(params) do
       site = conn.assigns[:site]
       query = Query.from(site.timezone, params)
 
@@ -140,4 +141,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_metrics(_), do: :ok
+
+  @valid_intervals ["date", "month"]
+  @valid_intervals_str Enum.map(@valid_intervals, &("`" <> &1 <> "`")) |> Enum.join(", ")
+
+  defp validate_interval(%{"interval" => interval}) do
+    if interval in @valid_intervals do
+      :ok
+    else
+      {:error,
+       "Error parsing `interval` parameter: invalid interval `#{interval}`. Valid intervals are #{
+         @valid_intervals_str
+       }"}
+    end
+  end
+
+  defp validate_interval(_), do: :ok
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -31,6 +31,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                  "Error parsing `period` parameter: invalid period `aosuhsacp`. Please find accepted values in our docs: https://plausible.io/docs/stats-api#time-periods"
              }
     end
+
+    test "validates that interval is `date` or `month`", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "12mo",
+          "interval" => "alskd"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Error parsing `interval` parameter: invalid interval `alskd`. Valid intervals are `date`, `month`"
+             }
+    end
   end
 
   test "shows last 6 months of visitors", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -4,6 +4,35 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
 
+  describe "param validation" do
+    test "validates that date can be parsed", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "6mo",
+          "date" => "2021-dkjbAS"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Error parsing `date` parameter: invalid_format. Please specify a valid date in ISO-8601 format."
+             }
+    end
+
+    test "validates that period can be parsed", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "aosuhsacp"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Error parsing `period` parameter: invalid period `aosuhsacp`. Please find accepted values in our docs: https://plausible.io/docs/stats-api#time-periods"
+             }
+    end
+  end
+
   test "shows last 6 months of visitors", %{conn: conn, site: site} do
     populate_stats([
       build(:pageview, domain: site.domain, timestamp: ~N[2020-12-31 00:00:00]),


### PR DESCRIPTION
### Changes

Add validations for `date`, `period` and `metrics` variables


### Tests
- [x] Automated tests have been added

### Documentation
- [x] This change does not need a documentation update
