### PR TITLE
Adds site switching keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Stats API [currently in beta] plausible/analytics#679
-- 30 day and 6 month keybindings (`3` and `6`, respectively) plausible/analytics#709
+- 30 day and 6 month keybindings (`T` and `S`, respectively) plausible/analytics#709
+- Site switching keybinds (1-9 for respective sites) plausible/analytics#735
 
 ### Fixed
 - Capitalized date/time selection keybinds not working plausible/analytics#709

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -100,7 +100,7 @@ class DatePicker extends React.Component {
 
     this.setState({open: false});
 
-    const keys = ['d', 'r', 'w', 'm', 'y', '3', '6'];
+    const keys = ['d', 'r', 'w', 'm', 'y', 't', 's'];
     const redirects = [{date: false, period: 'day'}, {period: 'realtime'}, {date: false, period: '7d'}, {date: false, period: 'month'}, {date: false, period: '12mo'}, {date: false, period: '30d'}, {date: false, period: '6mo'}];
 
     if (keys.includes(e.key.toLowerCase())) {

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -302,8 +302,8 @@ class DatePicker extends React.Component {
       'Last 7 days': 'W',
       'Month to Date': 'M',
       'Last 12 months': 'Y',
-      'Last 6 months': '6',
-      'Last 30 days': '3',
+      'Last 6 months': 'S',
+      'Last 30 days': 'T',
     };
 
     return (


### PR DESCRIPTION
### Changes

- Changes 30d keybind to `t` from `3`
- Changes 6mo keybind to `s` from `6`
- Adds dynamic keybinds 1-9 for sites 1-9

For now sites >9 don't have any keybindings, maybe in the future there can be a way to favorite/re-order the sites; but I figure most users won't need more than 9 for now, at least. 

### Tests
- [X] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Screenshots
![image](https://user-images.githubusercontent.com/19434157/108589968-beaea480-7326-11eb-897c-7a80e992d280.png)
![image](https://user-images.githubusercontent.com/19434157/108589970-bfdfd180-7326-11eb-8834-05726762d874.png)
![image](https://user-images.githubusercontent.com/19434157/108589990-db4adc80-7326-11eb-8b27-8e06bd5c08ad.png)

