### PR TITLE
Prevent user id collisions in session tracking

### DIFF
--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -87,7 +87,7 @@ defmodule Plausible.TestUtils do
 
     events =
       Enum.map(events, fn event ->
-        Map.put(event, :session_id, sessions[event.user_id].session_id)
+        Map.put(event, :session_id, sessions[{event.domain, event.user_id}].session_id)
       end)
 
     Plausible.ClickhouseRepo.insert_all(


### PR DESCRIPTION
### Changes

We keep all active sessions in memory. Currently they are keyed with just `user_id` which has caused some collisions to happen. Basically, two different users on two different sites can end up affecting a single session in the database. This PR completely splits them so even if two users on different sites happen to get the same `user_id`, their session stats won't be mixed up.

There is still historical data that is wrong. I will probably rebuild the sessions table on the production server.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update