### PR TITLE
Fixes text overflow on long site urls in site switcher

### DIFF
--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -73,7 +73,7 @@ export default class SiteSwitcher extends React.Component {
       <a href={domain === this.props.site.domain ? null : `/${encodeURIComponent(domain)}`} key={domain} className={`flex items-center justify-between truncate px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 ${extraClass}`}>
         <span>
           <img src={`https://icons.duckduckgo.com/ip3/${domain}.ico`} referrerPolicy="no-referrer" className="inline w-4 mr-2 align-middle" />
-          <span>{domain}</span>
+          <span class="truncate inline-block align-middle max-w-3xs pr-2">{domain}</span>
         </span>
         {index < 9 && <span>{index+1}</span>}
       </a>

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -31,6 +31,7 @@ module.exports = {
       },
       maxWidth: {
         '2xs': '16rem',
+        '3xs': '12rem',
       }
     },
   },


### PR DESCRIPTION
### Changes

Pretty straightforward. 

Before:
![image](https://user-images.githubusercontent.com/19434157/108958559-c200a380-7638-11eb-8a89-fbe68483e3b5.png)
After:
![image](https://user-images.githubusercontent.com/19434157/108958564-c331d080-7638-11eb-9446-f8054f038b99.png)


### Tests
- [X] This PR does not require tests

### Changelog
- Minor

### Documentation
- [X] This change does not need a documentation update
