### PR TITLE
Fix invisible text in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Capitalized date/time selection keybinds not working plausible/analytics#709
+- Invisible text on Google Search Console settings page in dark mode plausible/analytics#759
 
 ## [1.2] - 2021-01-26
 

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -47,7 +47,7 @@
       </div>
     <% end %>
   <% else %>
-    <div class="my-8 text-center text-lg">
+    <div class="my-8 text-center text-lg text-gray-900 dark:text-gray-200">
       <svg class="block mx-auto mb-4 w-6 h-6 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
       An extra step is needed to set up your Plausible Analytics Self Hosted for the Google Search Console integration.
       Find instructions <%= link("here", to: "https://plausible.io/docs/self-hosting-configuration#google-search-integration", class: "text-indigo-500") %>

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -47,10 +47,10 @@
       </div>
     <% end %>
   <% else %>
-    <div class="my-8 text-center text-lg text-gray-900 dark:text-gray-200">
+    <div class="my-8 text-center text-lg">
       <svg class="block mx-auto mb-4 w-6 h-6 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
-      An extra step is needed to set up your Plausible Analytics Self Hosted for the Google Search Console integration.
-      Find instructions <%= link("here", to: "https://plausible.io/docs/self-hosting-configuration#google-search-integration", class: "text-indigo-500") %>
+      <p class="text-gray-900 dark:text-gray-200">An extra step is needed to set up your Plausible Analytics Self Hosted for the Google Search Console integration.
+      Find instructions <%= link("here", to: "https://plausible.io/docs/self-hosting-configuration#google-search-integration", class: "text-indigo-500") %></p>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
### Changes

At the Site settings > Search Console, the notification text was invisible in dark mode.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
