### PR TITLE
Use auto generated copyright year

### DIFF
--- a/lib/plausible_web/templates/layout/focus.html.eex
+++ b/lib/plausible_web/templates/layout/focus.html.eex
@@ -23,7 +23,7 @@
     <%= @inner_content %>
 
     <p class="text-center text-gray-500 text-xs py-8">
-      ©2020 Plausible Analytics. All rights reserved.
+      ©<%= DateTime.utc_now().year() %> Plausible Analytics. All rights reserved.
     </p>
 
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>


### PR DESCRIPTION
### Changes
Uses DateTime to find out current year and use for copyright notice in the footer.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

While going through the templates I tried to fix https://github.com/plausible/analytics/issues/584, I'm not sure if it is an efficient solution. 