### PR TITLE
Adds proper dark styles for API key issuance page

### DIFF
--- a/lib/plausible_web/templates/auth/new_api_key.html.eex
+++ b/lib/plausible_web/templates/auth/new_api_key.html.eex
@@ -1,20 +1,20 @@
 <%= form_for @changeset, "/settings/api-keys", [class: "w-full max-w-md mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mt-8"], fn f -> %>
   <h1 class="text-xl font-black dark:text-gray-100">Create new API key</h1>
   <div class="my-4 mt-8">
-    <%= label f, :name, class: "block text-sm font-medium text-gray-700" %>
+    <%= label f, :name, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <div class="mt-1">
-      <%= text_input f, :name, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md" %>
+      <%= text_input f, :name, class: "dark:bg-gray-900 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 dark:text-gray-300 dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500 rounded-md", placeholder: "Development" %>
     </div>
     <%= error_tag f, :name %>
   </div>
   <div class="my-4">
-    <%= label f, :key, class: "block text-sm font-medium text-gray-700" %>
+    <%= label f, :key, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <div class="relative mt-1">
-      <%= text_input f, :key, id: "key-input", class: "shadow-sm  bg-gray-50 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md pr-16", readonly: "readonly" %>
+      <%= text_input f, :key, id: "key-input", class: "dark:text-gray-300 shadow-sm bg-gray-50 dark:bg-gray-850 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md pr-16", readonly: "readonly" %>
         <a onclick="var textarea = document.getElementById('key-input'); textarea.focus(); textarea.select(); document.execCommand('copy');" href="javascript:void(0)" class="absolute flex items-center text-xs font-medium text-indigo-600 no-underline hover:underline"  style="top: 12px; right: 12px;">
-          <svg class="pr-1 text-indigo-600" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>COPY
+          <svg class="pr-1 text-indigo-600 dark:text-indigo-500" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>COPY
         </a>
-      <p class="mt-1 text-xs text-gray-500">Make sure to store the key in a secure place. Once created, we will not be able to show it again.</p>
+      <p class="mt-1 text-xs text-gray-500 dark:text-gray-200">Make sure to store the key in a secure place. Once created, we will not be able to show it again.</p>
     </div>
   </div>
   <%= submit "Continue", class: "button mt-4 w-full" %>


### PR DESCRIPTION
### Changes

Before: 
![image](https://user-images.githubusercontent.com/19434157/109545586-a9f0b000-7a8e-11eb-9232-3b6a5ae000e7.png)

After: 
![image](https://user-images.githubusercontent.com/19434157/109545596-ac530a00-7a8e-11eb-810f-7f140cc64458.png)

(I did add the placeholder there because it was missing, do let me know if you don't want it/want it to be different)

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update
