### PR TITLE
Embeddable dashboard

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,7 @@ jobs:
         uses: marocchino/tool-versions-action@v1
         id: versions
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           elixir-version: ${{steps.versions.outputs.elixir}}
           otp-version: ${{ steps.versions.outputs.erlang}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - 30 day and 6 month keybindings (`T` and `S`, respectively) plausible/analytics#709
 - Site switching keybinds (1-9 for respective sites) plausible/analytics#735
 - Glob (wildcard) based pageview goals plausible/analytics#750
+- Support for embedding shared links in an iframe plausible/analytics#812
 
 ### Fixed
 - Capitalized date/time selection keybinds not working plausible/analytics#709

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,19 +8,19 @@
 @import "flatpickr.css";
 
 .button {
-  @apply bg-indigo-600 border border-transparent rounded-md py-2 px-4 inline-flex justify-center text-sm leading-5 font-medium text-white transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500;
+  @apply inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md leading-5 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500;
 }
 
 .button-outline {
-  @apply bg-transparent border border-indigo-600 text-indigo-600;
+  @apply text-indigo-600 bg-transparent border border-indigo-600;
 }
 
 .button-sm {
-  @apply text-sm py-2 px-4;
+  @apply px-4 py-2 text-sm;
 }
 
 .button-md {
-  @apply py-2 px-4;
+  @apply px-4 py-2;
 }
 
 html {
@@ -38,7 +38,7 @@ button:disabled {
 }
 
 blockquote {
-  @apply my-4 py-2 px-4 border-l-4 border-gray-500;
+  @apply px-4 py-2 my-4 border-l-4 border-gray-500;
 }
 
 @screen xl {
@@ -273,11 +273,12 @@ blockquote {
 }
 
 .fullwidth-shadow::before {
-  @apply h-full absolute top-0 bg-gray-50 w-screen dark:bg-gray-850;
+  @apply absolute top-0 w-screen h-full;
   box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.06);
   content: "";
   z-index: -1;
   left: calc(-1 * calc(50vw - 50%));
+  background-color: inherit;
 }
 
 .dark .fullwidth-shadow::before {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -90,3 +90,15 @@ function showChangelogNotification(el) {
     })
   }
 }
+
+const embedButton = document.getElementById('generate-embed')
+
+if (embedButton) {
+  embedButton.addEventListener('click', function(e) {
+    const embedCode = document.getElementById('embed-code')
+    const embedLink = new URL(document.getElementById('embed-link').value)
+    embedLink.searchParams.set('embed', 'true')
+
+    embedCode.value = `<iframe id="plausible-embed" src="${embedLink.toString()}" width="100%" height="1700px" scrolling="no"></iframe>`
+  })
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -96,9 +96,20 @@ const embedButton = document.getElementById('generate-embed')
 if (embedButton) {
   embedButton.addEventListener('click', function(e) {
     const embedCode = document.getElementById('embed-code')
-    const embedLink = new URL(document.getElementById('embed-link').value)
-    embedLink.searchParams.set('embed', 'true')
+    const theme = document.getElementById('theme').value.toLowerCase()
+    const background = document.getElementById('background').value
 
-    embedCode.value = `<iframe id="plausible-embed" src="${embedLink.toString()}" width="100%" height="1700px" scrolling="no"></iframe>`
+    try {
+      const embedLink = new URL(document.getElementById('embed-link').value)
+      embedLink.searchParams.set('embed', 'true')
+      embedLink.searchParams.set('theme', theme)
+      if (background) {
+        embedLink.searchParams.set('background', background)
+      }
+
+      embedCode.value = `<iframe id="plausible-embed" src="${embedLink.toString()}" width="100%" height="1700px" scrolling="no"></iframe>`
+    } catch (e) {
+      embedCode.value = 'ERROR: Please enter a valid URL in the shared link field'
+    }
   })
 }

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -16,7 +16,7 @@ class Historical extends React.Component {
   renderConversions() {
     if (this.props.site.hasGoals) {
       return (
-        <div className="w-full block md:flex items-start justify-between mt-6">
+        <div className="items-start justify-between block w-full mt-6 md:flex">
           <Conversions site={this.props.site} query={this.props.query} />
         </div>
       )
@@ -24,12 +24,13 @@ class Historical extends React.Component {
   }
 
   render() {
+    const extraStyle = this.props.site.background ? {backgroundColor: this.props.site.background} : {}
     return (
       <div className="mb-12">
         <div id="stats-container-top"></div>
-        <div className={`sticky top-0 bg-gray-50 dark:bg-gray-850 sm:py-3 py-1 z-9 ${this.props.stuck ? 'z-10 fullwidth-shadow' : ''}`}>
-          <div className="w-full sm:flex items-center">
-            <div className="w-full flex items-center mb-2 sm:mb-0">
+        <div className={`sticky top-0 bg-gray-50 dark:bg-gray-850 sm:py-3 py-1 z-9 ${this.props.stuck ? 'z-10 fullwidth-shadow' : ''}`} style={extraStyle}>
+          <div className="items-center w-full sm:flex">
+            <div className="flex items-center w-full mb-2 sm:mb-0">
               <SiteSwitcher site={this.props.site} loggedIn={this.props.loggedIn} />
               <CurrentVisitors timer={this.props.timer} site={this.props.site} query={this.props.query} />
               <Filters query={this.props.query} history={this.props.history} />
@@ -38,11 +39,11 @@ class Historical extends React.Component {
           </div>
         </div>
         <VisitorGraph site={this.props.site} query={this.props.query} />
-        <div className="w-full block md:flex items-start justify-between">
+        <div className="items-start justify-between block w-full md:flex">
           <Sources site={this.props.site} query={this.props.query} />
           <Pages site={this.props.site} query={this.props.query} />
         </div>
-        <div className="w-full block md:flex items-start justify-between">
+        <div className="items-start justify-between block w-full md:flex">
           <Countries site={this.props.site} query={this.props.query} />
           <Devices site={this.props.site} query={this.props.query} />
         </div>

--- a/assets/js/dashboard/mount.js
+++ b/assets/js/dashboard/mount.js
@@ -13,7 +13,8 @@ if (container) {
     domain: container.dataset.domain,
     offset: container.dataset.offset,
     hasGoals: container.dataset.hasGoals === 'true',
-    insertedAt: container.dataset.insertedAt
+    insertedAt: container.dataset.insertedAt,
+    background: container.dataset.background
   }
 
   const loggedIn = container.dataset.loggedIn === 'true'

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -74,6 +74,7 @@ defmodule PlausibleWeb.StatsController do
           _e ->
             conn
             |> assign(:skip_plausible_tracking, true)
+            |> delete_resp_header("x-frame-options")
             |> render("shared_link_password.html",
               link: shared_link,
               layout: {PlausibleWeb.LayoutView, "focus.html"}
@@ -112,6 +113,7 @@ defmodule PlausibleWeb.StatsController do
       else
         conn
         |> assign(:skip_plausible_tracking, true)
+        |> delete_resp_header("x-frame-options")
         |> render("shared_link_password.html",
           link: shared_link,
           error: "Incorrect password. Please try again.",
@@ -127,13 +129,17 @@ defmodule PlausibleWeb.StatsController do
     conn
     |> assign(:skip_plausible_tracking, true)
     |> put_resp_header("x-robots-tag", "noindex")
+    |> delete_resp_header("x-frame-options")
     |> render("stats.html",
       site: shared_link.site,
       has_goals: Plausible.Sites.has_goals?(shared_link.site),
       title: "Plausible · " <> shared_link.site.domain,
       offer_email_report: false,
       demo: false,
-      shared_link_auth: shared_link.slug
+      shared_link_auth: shared_link.slug,
+      embedded: conn.params["embed"] == "true",
+      theme: conn.params["theme"],
+      background: conn.params["background"]
     )
   end
 

--- a/lib/plausible_web/templates/layout/_embedded_footer.html.eex
+++ b/lib/plausible_web/templates/layout/_embedded_footer.html.eex
@@ -1,0 +1,13 @@
+<div class="mt-4 bg-gray-800 dark:bg-gray-800">
+  <div class="container px-4 py-2 sm:px-6 lg:px-8">
+    <div class="xl:grid xl:grid-cols-3 xl:gap-8">
+      <div class="col-start-2 xl:my-0">
+        <a href="https://plausible.io" class="text-center">
+          <span class="text-xs text-gray-100">Powered by</span>
+          <img src="/images/icon/plausible_logo_sm.png" class="inline-block w-4 ml-1" />
+          <span class="text-xs font-semibold tracking-wider text-gray-300 leading-5">Plausible Analytics</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/plausible_web/templates/layout/_footer.html.eex
+++ b/lib/plausible_web/templates/layout/_footer.html.eex
@@ -1,12 +1,12 @@
-<div class="bg-gray-800 dark:bg-gray-800 mt-12">
-  <div class="container py-12 px-4 sm:px-6 lg:py-16 lg:px-8">
+<div class="mt-24 bg-gray-800 dark:bg-gray-800">
+  <div class="container px-4 py-12 sm:px-6 lg:py-16 lg:px-8">
     <div class="xl:grid xl:grid-cols-3 xl:gap-8">
       <div class="my-8 xl:my-0">
-        <h4 class="leading-5 font-semibold tracking-wider text-gray-300">
+        <h4 class="font-semibold tracking-wider text-gray-300 leading-5">
           <img src="/images/icon/plausible_logo_sm.png" class="inline-block w-6 mr-1" />
           Plausible Analytics
         </h4>
-        <p class="mt-4 text-gray-400 text-base leading-6">
+        <p class="mt-4 text-base text-gray-400 leading-6">
         <%= if !Application.get_env(:plausible, :is_selfhost) do %>
           Made and hosted in the EU <span class="text-lg">🇪🇺</span><br />
         <% end %>
@@ -15,8 +15,8 @@
         </p>
         <%= if Application.get_env(:plausible, :is_selfhost) do %>
           <div class="mt-4">
-            <a href="https://github.com/sponsors/plausible" class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-gray-50 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2  focus:ring-gray-500">
-              <svg class="-ml-1 mr-2 w-5 h-5 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path></svg>
+            <a href="https://github.com/sponsors/plausible" class="inline-flex items-center px-4 py-2 text-sm font-medium bg-gray-700 border border-transparent shadow-sm rounded-md text-gray-50 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500">
+              <svg class="w-5 h-5 mr-2 -ml-1 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path></svg>
               Sponsor @plausible
             </a>
           </div>
@@ -25,44 +25,44 @@
       <div class="grid grid-cols-2 gap-8 xl:col-span-2">
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+            <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Why Plausible?
             </h4>
             <ul class="mt-4">
               <li>
-                <a href="https://plausible.io/simple-web-analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/simple-web-analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   Simple metrics
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/lightweight-web-analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/lightweight-web-analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   Lightweight script
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/privacy-focused-web-analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/privacy-focused-web-analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   Privacy focused
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/open-source-website-analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/open-source-website-analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   Open source
                 </a>
               </li>
             </ul>
           </div>
           <div class="mt-12 md:mt-0">
-            <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+            <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Comparisons
             </h4>
             <ul class="mt-4">
               <li>
-                <a href="https://plausible.io/vs-google-analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/vs-google-analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   vs Google Analytics
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/vs-matomo" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/vs-matomo" class="text-base text-gray-300 leading-6 hover:text-white">
                   vs Matomo
                 </a>
               </li>
@@ -72,74 +72,74 @@
         </div>
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div class="mt-12 md:mt-0">
-            <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+            <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Community
             </h4>
             <ul class="mt-4">
               <li>
-                <a href="https://plausible.io/blog" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/blog" class="text-base text-gray-300 leading-6 hover:text-white">
                   Blog
                 </a>
               </li>
             <li class="mt-4">
-                <a target="_blank" href="https://docs.plausible.io/" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a target="_blank" href="https://docs.plausible.io/" class="text-base text-gray-300 leading-6 hover:text-white">
                   Documentation
                 </a>
               </li>
               <li class="mt-4">
-                <a target="_blank" href="https://github.com/plausible/analytics" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a target="_blank" href="https://github.com/plausible/analytics" class="text-base text-gray-300 leading-6 hover:text-white">
                   GitHub
                 </a>
               </li>
               <li class="mt-4">
-                <a target="_blank" href="https://plausible.io/forum" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a target="_blank" href="https://plausible.io/forum" class="text-base text-gray-300 leading-6 hover:text-white">
                   Forum
                 </a>
               </li>
               <li class="mt-4">
-                <a target="_blank" href="https://twitter.com/plausiblehq" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a target="_blank" href="https://twitter.com/plausiblehq" class="text-base text-gray-300 leading-6 hover:text-white">
                   Twitter
                 </a>
               </li>
               <li class="mt-4">
-                <a target="_blank" href="https://fosstodon.org/@plausible" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a target="_blank" href="https://fosstodon.org/@plausible" class="text-base text-gray-300 leading-6 hover:text-white">
                   Mastodon
                 </a>
               </li>
             </ul>
           </div>
           <div>
-            <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+            <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Company
             </h4>
             <ul class="mt-4">
               <li class="mt-4">
-                <a href="https://plausible.io/about" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/about" class="text-base text-gray-300 leading-6 hover:text-white">
                   About
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/status" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/status" class="text-base text-gray-300 leading-6 hover:text-white">
                   Status
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/contact" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/contact" class="text-base text-gray-300 leading-6 hover:text-white">
                   Contact
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/privacy" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/privacy" class="text-base text-gray-300 leading-6 hover:text-white">
                   Privacy
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/data-policy" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/data-policy" class="text-base text-gray-300 leading-6 hover:text-white">
                   Data policy
                 </a>
               </li>
               <li class="mt-4">
-                <a href="https://plausible.io/imprint" class="text-base leading-6 text-gray-300 hover:text-white">
+                <a href="https://plausible.io/imprint" class="text-base text-gray-300 leading-6 hover:text-white">
                   Imprint
                 </a>
               </li>

--- a/lib/plausible_web/templates/layout/_header.html.eex
+++ b/lib/plausible_web/templates/layout/_header.html.eex
@@ -1,0 +1,81 @@
+<nav class="relative z-10 py-8">
+  <div class="container">
+    <nav class="relative flex items-center justify-between sm:h-10 md:justify-center">
+      <div class="flex items-center flex-1 md:absolute md:inset-y-0 md:left-0">
+        <div class="flex items-center justify-between">
+          <a href="<%= home_dest(@conn) %>">
+            <%= img_tag(PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_logo_dark.png"), class: "h-8 w-auto sm:h-10 -mt-2 hidden dark:inline", alt: "Plausible logo")%>
+            <%= img_tag(PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_logo.png"), class: "h-8 w-auto sm:h-10 -mt-2 inline dark:hidden", alt: "Plausible logo") %>
+          </a>
+        </div>
+      </div>
+      <div class="absolute inset-y-0 right-0 flex items-center justify-end">
+        <%= cond do %>
+          <% @conn.assigns[:current_user] -> %>
+            <ul class="flex">
+              <%= if Application.get_env(:plausible, :is_selfhost) do %>
+                <li class="hidden mr-6 sm:block">
+                  <%= link(to: "https://github.com/plausible/analytics", class: "font-bold rounded m-1 ml-0 p-1 hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100", style: "line-height: 40px;", target: "_blank") do %>
+                    <svg class="inline w-4 h-4 mr-px -mt-1" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub icon</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                    Repo
+                  <% end %>
+                </li>
+              <% end %>
+              <%= if !Application.get_env(:plausible, :is_selfhost) && @conn.assigns[:current_user].subscription == nil  do %>
+                <li class="hidden mr-6 sm:block">
+                  <%= link(trial_notificaton(@conn.assigns[:current_user]), to: "/settings", class: "font-bold text-orange-900 dark:text-yellow-900 rounded p-2 bg-orange-200 dark:bg-yellow-100", style: "line-height: 40px;") %>
+                </li>
+              <% else %>
+                <li class="hidden mr-6 sm:block">
+                  <%= link("Docs", to: "https://docs.plausible.io", class: "font-bold rounded m-1 p-1 hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100", style: "line-height: 40px;", target: "_blank") %>
+                </li>
+              <% end %>
+              <li>
+                <div class="relative font-bold rounded">
+                  <div data-dropdown-trigger class="flex items-center p-1 m-1 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100">
+                    <span class="pl-2 mr-2"><%= @conn.assigns[:current_user].name || @conn.assigns[:current_user].email %></span>
+                    <svg style="height: 18px; transform: translateY(2px); fill: #606f7b;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 512 640" enable-background="new 0 0 512 512" xml:space="preserve"><g><circle cx="256" cy="52.8" r="50.8"/><circle cx="256" cy="256" r="50.8"/><circle cx="256" cy="459.2" r="50.8"/></g></svg>
+                  </div>
+
+                  <div data-dropdown style="top: 42px; right: 0px; width: 185px;" class="absolute right-0 z-10 hidden bg-white border border-gray-300 rounded shadow-md dropdown-content dark:bg-gray-800 dark:border-gray-500">
+                    <%= link("Settings", to: "/settings", class: "block py-2 px-2 border-b border-gray-300 dark:border-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 dark:text-gray-100") %>
+                    <%= link("Log out", to: "/logout", method: :post, class: "block py-2 px-2 hover:bg-gray-100 dark:hover:bg-gray-900 dark:text-gray-100") %>
+                  </div>
+                </div>
+              </li>
+              <%= if @conn.assigns[:current_user] && !Application.get_env(:plausible, :is_selfhost) do  %>
+                <li id="changelog-notification" class="relative py-2"></li>
+              <% end %>
+            </ul>
+            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_authentication) -> %>
+              <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
+                <li>
+                    <div class="inline-flex ml-6 rounded shadow">
+                      <a href="/" class="inline-flex items-center justify-center px-5 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">My Sites</a>
+                    </div>
+                </li>
+              </ul>
+            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) -> %>
+              <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
+                <li>
+                    <div class="inline-flex">
+                      <a href="/login" class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">Login</a>
+                    </div>
+                </li>
+              </ul>
+            <%  true -> %>
+              <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
+                <li>
+                    <div class="inline-flex">
+                      <a href="/login" class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">Login</a>
+                    </div>
+                    <div class="inline-flex ml-6 rounded shadow">
+                      <a href="/register" class="inline-flex items-center justify-center px-5 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">Sign up</a>
+                    </div>
+                </li>
+              </ul>
+        <% end %>
+      </div>
+    </nav>
+  </div>
+</nav>

--- a/lib/plausible_web/templates/layout/_notice.html.eex
+++ b/lib/plausible_web/templates/layout/_notice.html.eex
@@ -1,0 +1,47 @@
+<%= if @conn.private[:phoenix_flash] do %>
+  <%= render("_flash.html", assigns) %>
+<% end %>
+
+<%= if @conn.assigns[:current_user] && @conn.assigns[:current_user].subscription && @conn.assigns[:current_user].subscription.status == "past_due" do %>
+  <div class="container">
+    <div class="p-2 bg-yellow-100 rounded-lg sm:p-3">
+      <div class="flex flex-wrap items-center justify-between">
+        <div class="flex items-center flex-1 w-0">
+          <svg class="w-6 h-6 text-yellow-800" viewBox="0 0 24 24" stroke="currentColor" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <p class="ml-3 font-medium text-yellow-800">
+          Your latest payment failed. Please provide valid payment details to keep using Plausible.
+          </p>
+        </div>
+        <div class="flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto">
+          <div class="rounded-md shadow-sm">
+            <%= link("Update billing info", to: @conn.assigns[:current_user].subscription.update_url, class: "flex items-center justify-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:ring transition ease-in-out duration-150") %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<%= if @conn.assigns[:current_user] && @conn.assigns[:current_user].subscription && @conn.assigns[:current_user].subscription.status == "paused" do %>
+  <div class="container">
+    <div class="p-2 bg-red-100 rounded-lg sm:p-3">
+      <div class="flex flex-wrap items-center justify-between">
+        <div class="flex items-center flex-1 w-0">
+          <svg class="w-6 h-6 text-red-800" viewBox="0 0 24 24" stroke="currentColor" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <p class="ml-3 font-medium text-red-800">
+          Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.
+          </p>
+        </div>
+        <div class="flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto">
+          <div class="rounded-md shadow-sm">
+            <%= link("Update billing info", to: @conn.assigns[:current_user].subscription.update_url, class: "flex items-center justify-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:ring transition ease-in-out duration-150") %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -10,143 +10,23 @@
     <title><%= assigns[:title] || "Plausible · Simple, privacy-friendly alternative to Google Analytics" %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
     <%= render("_tracking.html", assigns) %>
-    <script type="text/javascript" data-pref="<%= @conn.assigns[:current_user] && @conn.assigns[:current_user].theme %>" src="<%= Routes.static_path(@conn, "/js/applyTheme.js") %>"></script>
+    <script type="text/javascript" data-pref="<%= @conn.assigns[:theme] || (@conn.assigns[:current_user] && @conn.assigns[:current_user].theme) %>" src="<%= Routes.static_path(@conn, "/js/applyTheme.js") %>"></script>
   </head>
-  <body class="flex flex-col h-full bg-gray-50 dark:bg-gray-850">
-    <nav class="relative z-10 py-8">
-      <div class="container">
-        <nav class="relative flex items-center justify-between sm:h-10 md:justify-center">
-          <div class="flex items-center flex-1 md:absolute md:inset-y-0 md:left-0">
-            <div class="flex items-center justify-between">
-              <a href="<%= home_dest(@conn) %>">
-                <%= img_tag(PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_logo_dark.png"), class: "h-8 w-auto sm:h-10 -mt-2 hidden dark:inline", alt: "Plausible logo")%>
-                <%= img_tag(PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_logo.png"), class: "h-8 w-auto sm:h-10 -mt-2 inline dark:hidden", alt: "Plausible logo") %>
-              </a>
-            </div>
-          </div>
-          <div class="absolute inset-y-0 right-0 flex items-center justify-end">
-            <%= cond do %>
-              <% @conn.assigns[:current_user] -> %>
-                <ul class="flex">
-                  <%= if Application.get_env(:plausible, :is_selfhost) do %>
-                    <li class="hidden mr-6 sm:block">
-                      <%= link(to: "https://github.com/plausible/analytics", class: "font-bold rounded m-1 ml-0 p-1 hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100", style: "line-height: 40px;", target: "_blank") do %>
-                        <svg class="inline w-4 h-4 mr-px -mt-1" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub icon</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                        Repo
-                      <% end %>
-                    </li>
-                  <% end %>
-                  <%= if !Application.get_env(:plausible, :is_selfhost) && @conn.assigns[:current_user].subscription == nil  do %>
-                    <li class="hidden mr-6 sm:block">
-                      <%= link(trial_notificaton(@conn.assigns[:current_user]), to: "/settings", class: "font-bold text-orange-900 dark:text-yellow-900 rounded p-2 bg-orange-200 dark:bg-yellow-100", style: "line-height: 40px;") %>
-                    </li>
-                  <% else %>
-                    <li class="hidden mr-6 sm:block">
-                      <%= link("Docs", to: "https://docs.plausible.io", class: "font-bold rounded m-1 p-1 hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100", style: "line-height: 40px;", target: "_blank") %>
-                    </li>
-                  <% end %>
-                  <li>
-                    <div class="relative font-bold rounded">
-                      <div data-dropdown-trigger class="flex items-center p-1 m-1 rounded cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-900 dark:text-gray-100">
-                        <span class="pl-2 mr-2"><%= @conn.assigns[:current_user].name || @conn.assigns[:current_user].email %></span>
-                        <svg style="height: 18px; transform: translateY(2px); fill: #606f7b;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 512 640" enable-background="new 0 0 512 512" xml:space="preserve"><g><circle cx="256" cy="52.8" r="50.8"/><circle cx="256" cy="256" r="50.8"/><circle cx="256" cy="459.2" r="50.8"/></g></svg>
-                      </div>
-
-                      <div data-dropdown style="top: 42px; right: 0px; width: 185px;" class="absolute right-0 z-10 hidden bg-white border border-gray-300 rounded shadow-md dropdown-content dark:bg-gray-800 dark:border-gray-500">
-                        <%= link("Settings", to: "/settings", class: "block py-2 px-2 border-b border-gray-300 dark:border-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900 dark:text-gray-100") %>
-                        <%= link("Log out", to: "/logout", method: :post, class: "block py-2 px-2 hover:bg-gray-100 dark:hover:bg-gray-900 dark:text-gray-100") %>
-                      </div>
-                    </div>
-                  </li>
-                  <%= if @conn.assigns[:current_user] && !Application.get_env(:plausible, :is_selfhost) do  %>
-                    <li id="changelog-notification" class="relative py-2"></li>
-                  <% end %>
-                </ul>
-                <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_authentication) -> %>
-                  <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
-                    <li>
-                        <div class="inline-flex ml-6 rounded shadow">
-                          <a href="/" class="inline-flex items-center justify-center px-5 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">My Sites</a>
-                        </div>
-                    </li>
-                  </ul>
-                <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) -> %>
-                  <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
-                    <li>
-                        <div class="inline-flex">
-                          <a href="/login" class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">Login</a>
-                        </div>
-                    </li>
-                  </ul>
-                <%  true -> %>
-                  <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
-                    <li>
-                        <div class="inline-flex">
-                          <a href="/login" class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out">Login</a>
-                        </div>
-                        <div class="inline-flex ml-6 rounded shadow">
-                          <a href="/register" class="inline-flex items-center justify-center px-5 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">Sign up</a>
-                        </div>
-                    </li>
-                  </ul>
-            <% end %>
-          </div>
-        </nav>
-      </div>
-    </nav>
-
-    <%= if @conn.private[:phoenix_flash] do %>
-      <%= render("_flash.html", assigns) %>
-    <% end %>
-
-    <%= if @conn.assigns[:current_user] && @conn.assigns[:current_user].subscription && @conn.assigns[:current_user].subscription.status == "past_due" do %>
-      <div class="container">
-        <div class="p-2 bg-yellow-100 rounded-lg sm:p-3">
-          <div class="flex flex-wrap items-center justify-between">
-            <div class="flex items-center flex-1 w-0">
-              <svg class="w-6 h-6 text-yellow-800" viewBox="0 0 24 24" stroke="currentColor" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-              <p class="ml-3 font-medium text-yellow-800">
-              Your latest payment failed. Please provide valid payment details to keep using Plausible.
-              </p>
-            </div>
-            <div class="flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto">
-              <div class="rounded-md shadow-sm">
-                <%= link("Update billing info", to: @conn.assigns[:current_user].subscription.update_url, class: "flex items-center justify-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:ring transition ease-in-out duration-150") %>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    <% end %>
-
-    <%= if @conn.assigns[:current_user] && @conn.assigns[:current_user].subscription && @conn.assigns[:current_user].subscription.status == "paused" do %>
-      <div class="container">
-        <div class="p-2 bg-red-100 rounded-lg sm:p-3">
-          <div class="flex flex-wrap items-center justify-between">
-            <div class="flex items-center flex-1 w-0">
-              <svg class="w-6 h-6 text-red-800" viewBox="0 0 24 24" stroke="currentColor" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-              <p class="ml-3 font-medium text-red-800">
-              Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.
-              </p>
-            </div>
-            <div class="flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto">
-              <div class="rounded-md shadow-sm">
-                <%= link("Update billing info", to: @conn.assigns[:current_user].subscription.update_url, class: "flex items-center justify-center px-4 py-2 border border-transparent text-sm leading-5 font-medium rounded-md text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:ring transition ease-in-out duration-150") %>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+  <body class="flex flex-col h-full bg-gray-50 dark:bg-gray-850" style="<%= if @conn.assigns[:background], do: "background-color: " <> @conn.assigns[:background] %>">
+    <%= if !@conn.assigns[:embedded] do %>
+      <%= render("_header.html", assigns) %>
+      <%= render("_notice.html", assigns) %>
     <% end %>
 
     <main class="flex-1">
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
     </main>
-    <%= render("_footer.html", assigns) %>
+
+    <%= if @conn.assigns[:embedded] do %>
+      <%= render("_embedded_footer.html", assigns) %>
+    <% else %>
+      <%= render("_footer.html", assigns) %>
+    <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/lib/plausible_web/templates/site/settings_visibility.html.eex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.eex
@@ -1,43 +1,43 @@
-<div class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
+<div class="px-4 py-6 bg-white shadow dark:bg-gray-800 sm:rounded-md sm:overflow-hidden sm:p-6">
   <header class="relative">
-    <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Public dashboard</h2>
-    <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Share your stats publicly or keep them private</p>
+    <h2 class="text-lg font-medium text-gray-900 leading-6 dark:text-gray-100">Public dashboard</h2>
+    <p class="mt-1 text-sm text-gray-500 leading-5 dark:text-gray-200">Share your stats publicly or keep them private</p>
     <%= link(to: "https://docs.plausible.io/visibility", target: "_blank") do %>
-      <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+      <svg class="absolute top-0 right-0 w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>
 
 	<%= if @site.public do %>
-		<div class="flex items-center space-x-3 mt-4">
+		<div class="flex items-center mt-4 space-x-3">
 			<%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/make-private", method: "POST", class: "bg-indigo-600 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring") do %>
-				<span class="translate-x-5 inline-block h-5 w-5 rounded-full bg-white dark:bg-gray-800 shadow transform transition ease-in-out duration-200"></span>
+				<span class="inline-block w-5 h-5 bg-white rounded-full shadow translate-x-5 dark:bg-gray-800 transform transition ease-in-out duration-200"></span>
 			<% end %>
-			<span class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">Make stats publicly available on <a href="<%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%>" class="text-indigo-500"><%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%></a></span>
+			<span class="text-sm font-medium text-gray-900 leading-5 dark:text-gray-100">Make stats publicly available on <a href="<%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%>" class="text-indigo-500"><%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%></a></span>
 		</div>
 	<% else %>
-		<div class="flex items-center space-x-3 mt-4">
+		<div class="flex items-center mt-4 space-x-3">
 			<%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/make-public", method: "POST", class: "bg-gray-200 dark:bg-gray-700 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring") do %>
-				<span class="translate-x-0 inline-block h-5 w-5 rounded-full bg-white dark:bg-gray-800 shadow transform transition ease-in-out duration-200"></span>
+				<span class="inline-block w-5 h-5 bg-white rounded-full shadow translate-x-0 dark:bg-gray-800 transform transition ease-in-out duration-200"></span>
 			<% end %>
-			<span class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">Make stats publicly available on <a href="<%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%>" class="text-indigo-500"><%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%></a></span>
+			<span class="text-sm font-medium text-gray-900 leading-5 dark:text-gray-100">Make stats publicly available on <a href="<%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%>" class="text-indigo-500"><%= plausible_url() <> "/" <> URI.encode_www_form(@site.domain)%></a></span>
 		</div>
 	<% end %>
 </div>
 
-<div class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
+<div class="px-4 py-6 bg-white shadow dark:bg-gray-800 sm:rounded-md sm:overflow-hidden sm:p-6">
   <header class="relative">
-    <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Shared links</h2>
-    <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">You can share your stats privately by generating a shared link. The links are impossible to guess and you can add password protection for extra security.</p>
+    <h2 class="text-lg font-medium text-gray-900 leading-6 dark:text-gray-100">Shared links</h2>
+    <p class="mt-1 text-sm text-gray-500 leading-5 dark:text-gray-200">You can share your stats privately by generating a shared link. The links are impossible to guess and you can add password protection for extra security.</p>
     <%= link(to: "https://docs.plausible.io/shared-links", target: "_blank") do %>
-      <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+      <svg class="absolute top-0 right-0 w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>
 
   <div class="mt-6">
     <%= for link <- @shared_links do %>
-      <div class="flex relative w-full max-w-xl mt-2 text-sm">
-        <input type="text" id="<%= link.slug %>" readonly="readonly" value="<%= shared_link_dest(@site, link) %>" class="transition bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded rounded-r-none w-full p-2 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-gray-300 dark:focus:border-gray-500" />
-        <button onclick="var input = document.getElementById('<%= link.slug %>'); input.focus(); input.select(); document.execCommand('copy');" href="javascript:void(0)" class="py-2 px-4 bg-gray-200 dark:bg-gray-850 text-indigo-800 dark:text-indigo-500 rounded-none border-r border-gray-300 dark:border-gray-500 hover:bg-gray-300 dark:hover:bg-gray-825">
+      <div class="relative flex w-full max-w-xl mt-2 text-sm">
+        <input type="text" id="<%= link.slug %>" readonly="readonly" value="<%= shared_link_dest(@site, link) %>" class="w-full p-2 text-gray-700 bg-gray-100 border border-transparent rounded rounded-r-none outline-none appearance-none transition dark:bg-gray-900 dark:text-gray-300 focus:outline-none focus:border-gray-300 dark:focus:border-gray-500" />
+        <button onclick="var input = document.getElementById('<%= link.slug %>'); input.focus(); input.select(); document.execCommand('copy');" href="javascript:void(0)" class="px-4 py-2 text-indigo-800 bg-gray-200 border-r border-gray-300 rounded-none dark:bg-gray-850 dark:text-indigo-500 dark:border-gray-500 hover:bg-gray-300 dark:hover:bg-gray-825">
           <svg class="feather-sm" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
         </button>
         <%= button(to: "/sites/#{URI.encode_www_form(@site.domain)}/shared-links/#{link.slug}", method: :delete, class: "py-2 px-4 bg-gray-200 dark:bg-gray-850 text-red-600 dark:text-red-500 rounded-l-none hover:bg-gray-300 dark:hover:bg-gray-825", data: [confirm: "Are you sure you want to delete this shared link? The stats will not be accessible with this link anymore."]) do %>
@@ -50,3 +50,39 @@
   </div>
 </div>
 
+<div class="px-4 py-6 bg-white shadow dark:bg-gray-800 sm:rounded-md sm:overflow-hidden sm:p-6">
+  <header class="relative">
+    <h2 class="text-lg font-medium text-gray-900 leading-6 dark:text-gray-100">Embed dashboard</h2>
+    <p class="mt-1 text-sm text-gray-500 leading-5 dark:text-gray-200">You can use shared links to embed your stats in any other webpage using an <code>iframe</code>. Copy & paste a shared link into the form below to generate the embed code.</p>
+    <%= link(to: "https://docs.plausible.io/visibility", target: "_blank") do %>
+      <svg class="absolute top-0 right-0 w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+    <% end %>
+  </header>
+
+  <div class="mt-6">
+    <div class="max-w-xl">
+      <label for="embed-link" class="block text-sm font-medium text-gray-700">Enter shared link</label>
+      <div class="flex mt-1 rounded-md shadow-sm">
+        <div class="relative flex items-stretch flex-grow focus-within:z-10">
+          <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+            <svg class="w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"></path></svg>
+          </div>
+          <input type="text" name="embed-link" id="embed-link" onclick="this.select()" class="block w-full pl-10 border-gray-300 rounded-none focus:ring-indigo-500 focus:border-indigo-500 rounded-l-md sm:text-sm">
+        </div>
+        <button id="generate-embed" class="rounded-l-none button">Generate embed code</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <div class="max-w-xl">
+      <label for="embed-code" class="block text-sm font-medium text-gray-700">Embed code</label>
+      <div class="relative mt-1">
+        <textarea id="embed-code" name="embed-code" rows="3" readonly="readonly" onclick="this.select()" class="block w-full max-w-xl border-gray-300 resize-none shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"></textarea>
+        <a onclick="var textarea = document.getElementById('embed-code'); textarea.focus(); textarea.select(); document.execCommand('copy');" href="javascript:void(0)" class="text-sm text-indigo-500 no-underline hover:underline">
+          <svg class="absolute text-indigo-800" style="top: 12px; right: 12px;" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/plausible_web/templates/site/settings_visibility.html.eex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.eex
@@ -59,24 +59,37 @@
     <% end %>
   </header>
 
-  <div class="mt-6">
-    <div class="max-w-xl">
+  <div class="max-w-xl mt-4">
+    <div>
       <label for="embed-link" class="block text-sm font-medium text-gray-700">Enter shared link</label>
-      <div class="flex mt-1 rounded-md shadow-sm">
-        <div class="relative flex items-stretch flex-grow focus-within:z-10">
-          <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-            <svg class="w-5 h-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd"></path></svg>
-          </div>
-          <input type="text" name="embed-link" id="embed-link" onclick="this.select()" class="block w-full pl-10 border-gray-300 rounded-none focus:ring-indigo-500 focus:border-indigo-500 rounded-l-md sm:text-sm">
-        </div>
-        <button id="generate-embed" class="rounded-l-none button">Generate embed code</button>
+      <div class="mt-1">
+        <input type="text" name="embed-link" id="embed-link" onclick="this.select()" class="block w-full border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+      </div>
+    </div>
+
+    <div class="mt-2">
+      <label for="theme" class="block text-sm font-medium text-gray-700">Select theme</label>
+      <select id="theme" name="theme" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+        <option selected>Light</option>
+        <option>Dark</option>
+        <option>System</option>
+      </select>
+    </div>
+
+    <div class="mt-2">
+      <label for="background" class="block text-sm font-medium text-gray-700">Custom background colour (optional)</label>
+      <div class="mt-1">
+        <input type="text" name="background" id="background" class="block w-full border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md" placeholder="#F9FAFB">
       </div>
     </div>
   </div>
 
-  <div class="mt-6">
+  <button id="generate-embed" class="my-4 button">Generate embed code 👇</button>
+
+  <div class="mt-2">
     <div class="max-w-xl">
       <label for="embed-code" class="block text-sm font-medium text-gray-700">Embed code</label>
+
       <div class="relative mt-1">
         <textarea id="embed-code" name="embed-code" rows="3" readonly="readonly" onclick="this.select()" class="block w-full max-w-xl border-gray-300 resize-none shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"></textarea>
         <a onclick="var textarea = document.getElementById('embed-code'); textarea.focus(); textarea.select(); document.execCommand('copy');" href="javascript:void(0)" class="text-sm text-indigo-500 no-underline hover:underline">

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -1,28 +1,28 @@
-<div class="container pb-24" data-site-domain="<%= @site.domain %>">
+<div class="container" data-site-domain="<%= @site.domain %>">
   <%= if @offer_email_report do %>
-    <div class="text-center bg-blue-200 text-blue-900 text-sm font-bold px-4 w-full rounded transition" style="top: 91px" role="alert">
+    <div class="w-full px-4 text-sm font-bold text-center text-blue-900 bg-blue-200 rounded transition" style="top: 91px" role="alert">
       <%= link("Click here to enable weekly email reports →", to: "/#{URI.encode_www_form(@site.domain)}/settings/email-reports", class: "py-2 block") %>
     </div>
   <% end %>
   <div class="pt-6"></div>
-  <div id="stats-react-container" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>" data-inserted-at="<%= @site.inserted_at %>" data-shared-link-auth="<%= assigns[:shared_link_auth] %>"></div>
+<div id="stats-react-container" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>" data-inserted-at="<%= @site.inserted_at %>" data-shared-link-auth="<%= assigns[:shared_link_auth] %>" data-background="<%= @conn.assigns[:background] %>"></div>
   <div id="modal_root"></div>
   <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
     <div class="bg-gray-50 dark:bg-gray-850">
       <div class="py-12 lg:py-16 lg:flex lg:items-center lg:justify-between">
-        <h2 class="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 dark:text-gray-100">
+        <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 leading-9 sm:text-4xl sm:leading-10 dark:text-gray-100">
           Want these stats for your website?
           <br />
           <span class="text-indigo-600">Start your free trial today.</span>
         </h2>
-        <div class="mt-8 flex lg:flex-shrink-0 lg:mt-0">
-          <div class="inline-flex rounded-md shadow">
-            <a href="/register" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">
+        <div class="flex mt-8 lg:flex-shrink-0 lg:mt-0">
+          <div class="inline-flex shadow rounded-md">
+            <a href="/register" class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">
               Get started
             </a>
           </div>
-          <div class="ml-3 inline-flex rounded-md shadow">
-            <a href="/" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base leading-6 font-medium rounded-md text-indigo-600 dark:text-gray-100 bg-white dark:bg-gray-800 hover:text-indigo-500 dark:hover:text-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">
+          <div class="inline-flex ml-3 shadow rounded-md">
+            <a href="/" class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-indigo-600 bg-white border border-transparent leading-6 rounded-md dark:text-gray-100 dark:bg-gray-800 hover:text-indigo-500 dark:hover:text-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out">
               Learn more
             </a>
           </div>

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -70,6 +70,16 @@ defmodule PlausibleWeb.StatsControllerTest do
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
       assert html_response(conn, 200) =~ "stats-react-container"
     end
+
+    test "returns page with X-Frame-Options disabled so it can be embedded in an iframe", %{
+      conn: conn
+    } do
+      site = insert(:site, domain: "test-site.com")
+      link = insert(:shared_link, site: site)
+
+      conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
+      assert Plug.Conn.get_resp_header(conn, "x-frame-options") == []
+    end
   end
 
   describe "POST /share/:slug/authenticate" do


### PR DESCRIPTION
### Changes

New branch for embed mode based on #772. Mostly the same feature, thanks a lot @aymanterra @bradkane for your research and contributions on this. I'll see if I can add you as addition authors for the commit when I merge it.

The main change from the original PR is that the embed mode is done with no configuration or persistence on the server side. Shared links will always remove `X-Frame-Options` header and set `SameSite: None; secure` for cookies. This relaxed security is only applied to shared links, the rest of the application still uses secure browser headers and restricts cookie domain.

Since shared links are read-only, and specifically meant for sharing stats outside of Plausible, I don't think it introduces any security issues. Happy to be convinced otherwise.

TODO:
- [x] Theming for light/dark mode. Allow the parent page to specify which theme should be used.
- [x] Allow passing in the background color for the dashboard. Make sure `transparent` works.

EDIT: transparent backgound does work but the header looks a bit weird. Maybe transparent cannot work due to the sticky header we have.

I think this should be enough for a first release. We can add more elaborate external CSS theming in the future if there's demand.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
