### PR TITLE
Stats API improvements

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -31,7 +31,9 @@ defmodule Plausible.Stats.Aggregate do
   end
 
   defp select_event_metric("pageviews", q) do
-    from(e in q, select_merge: %{pageviews: fragment("count(*)")})
+    from(e in q,
+      select_merge: %{pageviews: fragment("countIf(? = 'pageview')", e.name)}
+    )
   end
 
   defp select_event_metric("visitors", q) do

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Stats.Aggregate do
       Task.await(session_task)
     )
     |> Enum.map(fn {metric, value} ->
-      {metric, %{value: value}}
+      {metric, %{value: value || 0}}
     end)
     |> Enum.into(%{})
   end

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -54,6 +54,14 @@ defmodule Plausible.Stats.Base do
         q
       end
 
+    q =
+      if query.filters["event:name"] do
+        name = query.filters["event:name"]
+        from(e in q, where: e.name == ^name)
+      else
+        q
+      end
+
     if query.filters["props"] do
       [{key, val}] = query.filters["props"] |> Enum.into([])
 

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -62,25 +62,27 @@ defmodule Plausible.Stats.Base do
         q
       end
 
-    if query.filters["props"] do
-      [{key, val}] = query.filters["props"] |> Enum.into([])
+    Enum.reduce(query.filters, q, fn {filter_key, filter_value}, query ->
+      case filter_key do
+        "event:props:" <> prop_name ->
+          if filter_value == "(none)" do
+            from(
+              e in query,
+              where: fragment("not has(meta.key, ?)", ^prop_name)
+            )
+          else
+            from(
+              e in query,
+              inner_lateral_join: meta in "meta",
+              as: :meta,
+              where: meta.key == ^prop_name and meta.value == ^filter_value
+            )
+          end
 
-      if val == "(none)" do
-        from(
-          e in q,
-          where: fragment("not has(meta.key, ?)", ^key)
-        )
-      else
-        from(
-          e in q,
-          inner_lateral_join: meta in fragment("meta as m"),
-          as: :meta,
-          where: meta.key == ^key and meta.value == ^val
-        )
+        _ ->
+          query
       end
-    else
-      q
-    end
+    end)
   end
 
   def query_sessions(site, query) do

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -1,6 +1,7 @@
 defmodule Plausible.Stats.Breakdown do
   use Plausible.ClickhouseRepo
   import Plausible.Stats.Base
+  @no_ref "Direct / None"
 
   @event_metrics ["visitors", "pageviews"]
   @session_metrics ["bounce_rate", "visit_duration"]
@@ -71,7 +72,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.referrer_source,
-      select_merge: %{source: s.referrer_source}
+      select_merge: %{
+        source: fragment("if(empty(?), ?, ?)", s.referrer_source, @no_ref, s.referrer_source)
+      }
     )
   end
 
@@ -95,7 +98,7 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.referrer,
-      select_merge: %{referrer: s.referrer}
+      select_merge: %{referrer: fragment("if(empty(?), ?, ?)", s.referrer, @no_ref, s.referrer)}
     )
   end
 
@@ -103,7 +106,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.utm_medium,
-      select_merge: %{utm_medium: s.utm_medium}
+      select_merge: %{
+        utm_medium: fragment("if(empty(?), ?, ?)", s.utm_medium, @no_ref, s.utm_medium)
+      }
     )
   end
 
@@ -111,7 +116,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.utm_source,
-      select_merge: %{utm_source: s.utm_source}
+      select_merge: %{
+        utm_source: fragment("if(empty(?), ?, ?)", s.utm_source, @no_ref, s.utm_source)
+      }
     )
   end
 
@@ -119,7 +126,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.utm_campaign,
-      select_merge: %{utm_campaign: s.utm_campaign}
+      select_merge: %{
+        utm_campaign: fragment("if(empty(?), ?, ?)", s.utm_campaign, @no_ref, s.utm_campaign)
+      }
     )
   end
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -85,6 +85,17 @@ defmodule Plausible.Stats.Breakdown do
 
   defp do_group_by(
          %Ecto.Query{from: %Ecto.Query.FromExpr{source: {"events", _}}} = q,
+         "event:name"
+       ) do
+    from(
+      e in q,
+      group_by: e.name,
+      select_merge: %{name: e.name}
+    )
+  end
+
+  defp do_group_by(
+         %Ecto.Query{from: %Ecto.Query.FromExpr{source: {"events", _}}} = q,
          "event:page"
        ) do
     from(

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -148,8 +148,8 @@ defmodule Plausible.Stats.Query do
     }
   end
 
-  def from(tz, _) do
-    __MODULE__.from(tz, %{"period" => "30d"})
+  def from(tz, params) do
+    __MODULE__.from(tz, Map.merge(params, %{"period" => "30d"}))
   end
 
   defp today(tz) do

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -43,12 +43,7 @@ defmodule Plausible.Stats.Query do
   end
 
   def from(tz, %{"period" => "day"} = params) do
-    date =
-      if params["date"] do
-        Date.from_iso8601!(params["date"])
-      else
-        today(tz)
-      end
+    date = parse_single_date(tz, params)
 
     %__MODULE__{
       period: "day",
@@ -59,8 +54,8 @@ defmodule Plausible.Stats.Query do
   end
 
   def from(tz, %{"period" => "7d"} = params) do
-    end_date = today(tz)
-    start_date = end_date |> Timex.shift(days: -7)
+    end_date = parse_single_date(tz, params)
+    start_date = end_date |> Timex.shift(days: -6)
 
     %__MODULE__{
       period: "7d",
@@ -71,7 +66,7 @@ defmodule Plausible.Stats.Query do
   end
 
   def from(tz, %{"period" => "30d"} = params) do
-    end_date = today(tz)
+    end_date = parse_single_date(tz, params)
     start_date = end_date |> Timex.shift(days: -30)
 
     %__MODULE__{
@@ -83,12 +78,7 @@ defmodule Plausible.Stats.Query do
   end
 
   def from(tz, %{"period" => "month"} = params) do
-    date =
-      if params["date"] do
-        Date.from_iso8601!(params["date"])
-      else
-        today(tz)
-      end
+    date = parse_single_date(tz, params)
 
     start_date = Timex.beginning_of_month(date)
     end_date = Timex.end_of_month(date)
@@ -103,10 +93,7 @@ defmodule Plausible.Stats.Query do
 
   def from(tz, %{"period" => "6mo"} = params) do
     end_date =
-      case params["date"] do
-        nil -> today(tz)
-        date -> Date.from_iso8601!(date)
-      end
+      parse_single_date(tz, params)
       |> Timex.end_of_month()
 
     start_date =
@@ -123,10 +110,7 @@ defmodule Plausible.Stats.Query do
 
   def from(tz, %{"period" => "12mo"} = params) do
     end_date =
-      case params["date"] do
-        nil -> today(tz)
-        date -> Date.from_iso8601!(date)
-      end
+      parse_single_date(tz, params)
       |> Timex.end_of_month()
 
     start_date =
@@ -170,6 +154,14 @@ defmodule Plausible.Stats.Query do
 
   defp today(tz) do
     Timex.now(tz) |> Timex.to_date()
+  end
+
+  defp parse_single_date(tz, params) do
+    case params["date"] do
+      "today" -> Timex.now(tz) |> Timex.to_date()
+      date when is_binary(date) -> Date.from_iso8601!(date)
+      _ -> Timex.now(tz) |> Timex.to_date()
+    end
   end
 
   defp parse_filters(%{"filters" => filters}) when is_binary(filters) do

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
         |> String.split(",")
         |> Enum.map(&String.trim/1)
 
-      result =
+      results =
         if params["compare"] == "previous_period" do
           prev_query = Query.shift_back(query, site)
 
@@ -46,7 +46,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
           Plausible.Stats.aggregate(site, query, metrics)
         end
 
-      json(conn, result)
+      json(conn, %{"results" => results})
     else
       {:error, msg} ->
         conn

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -182,10 +182,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200) == %{
-               "pageviews" => %{"value" => 3, "change" => 200},
-               "visitors" => %{"value" => 2, "change" => 100},
-               "bounce_rate" => %{"value" => 50, "change" => -50},
-               "visit_duration" => %{"value" => 750, "change" => 100}
+               "pageviews" => %{"value" => 4, "change" => 100},
+               "visitors" => %{"value" => 3, "change" => 100},
+               "bounce_rate" => %{"value" => 100, "change" => 100},
+               "visit_duration" => %{"value" => 0, "change" => 0}
              }
     end
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         "metrics" => "pageviews"
       })
 
-    assert json_response(conn, 200) == %{
+    assert json_response(conn, 200)["results"] == %{
              "pageviews" => %{"value" => 3}
            }
   end
@@ -114,7 +114,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         "metrics" => "pageviews,visitors,bounce_rate,visit_duration"
       })
 
-    assert json_response(conn, 200) == %{
+    assert json_response(conn, 200)["results"] == %{
              "pageviews" => %{"value" => 3},
              "visitors" => %{"value" => 2},
              "bounce_rate" => %{"value" => 50},
@@ -148,7 +148,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "compare" => "previous_period"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 3, "change" => 200},
                "visitors" => %{"value" => 2, "change" => 100},
                "bounce_rate" => %{"value" => 50, "change" => -50},
@@ -181,7 +181,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "compare" => "previous_period"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 4, "change" => 100},
                "visitors" => %{"value" => 3, "change" => 100},
                "bounce_rate" => %{"value" => 100, "change" => 100},
@@ -216,7 +216,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:source==Google"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -252,7 +252,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:source==Direct / None"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -285,7 +285,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:referrer==https://facebook.com"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -318,7 +318,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:utm_medium==social"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -351,7 +351,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:utm_source==Twitter"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -384,7 +384,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:utm_campaign==profile"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -417,7 +417,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:device==Desktop"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -450,7 +450,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:browser==Chrome"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -484,7 +484,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:browser_version==56"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -517,7 +517,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:os==Mac"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -550,7 +550,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:os_version==10.5"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -583,7 +583,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "visit:country==EE"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},
@@ -624,7 +624,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "event:page==/blogpost"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 2},
                "bounce_rate" => %{"value" => 50},
@@ -663,7 +663,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "filters" => "event:page==/blogpost;visit:country==EE"
         })
 
-      assert json_response(conn, 200) == %{
+      assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 1},
                "visitors" => %{"value" => 1},
                "bounce_rate" => %{"value" => 0},

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -57,6 +57,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                  "Session metric `bounce_rate` cannot be queried for breakdown by `event:name`."
              }
     end
+
+    test "session metrics cannot be used with event:name filter", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "property" => "event:page",
+          "filters" => "event:name==Signup",
+          "metrics" => "visitors,bounce_rate",
+          "site_id" => site.domain
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Session metric `bounce_rate` cannot be queried when using a filter on `event:name`."
+             }
+    end
   end
 
   test "breakdown by visit:source", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        referrer_source: "Twitter",
+        referrer_source: "",
         domain: site.domain,
         timestamp: ~N[2021-01-01 00:00:00]
       )
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"source" => "Google", "visitors" => 2},
-               %{"source" => "Twitter", "visitors" => 1}
+               %{"source" => "Direct / None", "visitors" => 1}
              ]
            }
   end
@@ -102,7 +102,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        referrer: "https://ref2.com",
+        referrer: "",
         domain: site.domain,
         timestamp: ~N[2021-01-01 00:00:00]
       )
@@ -119,7 +119,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"referrer" => "https://ref.com", "visitors" => 2},
-               %{"referrer" => "https://ref2.com", "visitors" => 1}
+               %{"referrer" => "Direct / None", "visitors" => 1}
              ]
            }
   end
@@ -137,7 +137,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_medium: "Social",
+        utm_medium: "",
         domain: site.domain,
         timestamp: ~N[2021-01-01 00:00:00]
       )
@@ -154,7 +154,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"utm_medium" => "Search", "visitors" => 2},
-               %{"utm_medium" => "Social", "visitors" => 1}
+               %{"utm_medium" => "Direct / None", "visitors" => 1}
              ]
            }
   end
@@ -172,7 +172,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_source: "Twitter",
+        utm_source: "",
         domain: site.domain,
         timestamp: ~N[2021-01-01 00:00:00]
       )
@@ -189,7 +189,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"utm_source" => "Google", "visitors" => 2},
-               %{"utm_source" => "Twitter", "visitors" => 1}
+               %{"utm_source" => "Direct / None", "visitors" => 1}
              ]
            }
   end
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_campaign: "profile",
+        utm_campaign: "",
         domain: site.domain,
         timestamp: ~N[2021-01-01 00:00:00]
       )
@@ -224,7 +224,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"utm_campaign" => "ads", "visitors" => 2},
-               %{"utm_campaign" => "profile", "visitors" => 1}
+               %{"utm_campaign" => "Direct / None", "visitors" => 1}
              ]
            }
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -90,6 +90,32 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
            }
   end
 
+  test "shows last 7 days of visitors", %{conn: conn, site: site} do
+    populate_stats([
+      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-07 23:59:00])
+    ])
+
+    conn =
+      get(conn, "/api/v1/stats/timeseries", %{
+        "site_id" => site.domain,
+        "period" => "7d",
+        "date" => "2021-01-07"
+      })
+
+    assert json_response(conn, 200) == %{
+             "results" => [
+               %{"date" => "2021-01-01", "visitors" => 1},
+               %{"date" => "2021-01-02", "visitors" => 0},
+               %{"date" => "2021-01-03", "visitors" => 0},
+               %{"date" => "2021-01-04", "visitors" => 0},
+               %{"date" => "2021-01-05", "visitors" => 0},
+               %{"date" => "2021-01-06", "visitors" => 0},
+               %{"date" => "2021-01-07", "visitors" => 1}
+             ]
+           }
+  end
+
   test "shows last 6 months of visitors", %{conn: conn, site: site} do
     populate_stats([
       build(:pageview, domain: site.domain, timestamp: ~N[2020-12-31 00:00:00]),

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -511,5 +511,27 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       res = json_response(conn, 200)["results"]
       assert List.first(res) == %{"date" => "2021-01-01", "visitors" => 2}
     end
+
+    test "can filter by event:name", %{conn: conn, site: site} do
+      populate_stats([
+        build(:event,
+          name: "Signup",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "month",
+          "date" => "2021-01-01",
+          "filters" => "event:name==Signup"
+        })
+
+      res = json_response(conn, 200)
+      assert List.first(res["results"]) == %{"date" => "2021-01-01", "visitors" => 1}
+    end
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -47,6 +47,49 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     end
   end
 
+  test "shows hourly data for a certain date", %{conn: conn, site: site} do
+    populate_stats([
+      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 23:59:00])
+    ])
+
+    conn =
+      get(conn, "/api/v1/stats/timeseries", %{
+        "site_id" => site.domain,
+        "period" => "day",
+        "date" => "2021-01-01"
+      })
+
+    assert json_response(conn, 200) == %{
+             "results" => [
+               %{"date" => "2021-01-01 00:00:00", "visitors" => 1},
+               %{"date" => "2021-01-01 01:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 02:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 03:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 04:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 05:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 06:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 07:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 08:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 09:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 10:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 11:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 12:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 13:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 14:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 15:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 16:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 17:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 18:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 19:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 20:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 21:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 22:00:00", "visitors" => 0},
+               %{"date" => "2021-01-01 23:00:00", "visitors" => 1}
+             ]
+           }
+  end
+
   test "shows last 6 months of visitors", %{conn: conn, site: site} do
     populate_stats([
       build(:pageview, domain: site.domain, timestamp: ~N[2020-12-31 00:00:00]),

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -69,7 +69,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       conn = get(conn, "/api/stats/#{site.domain}/main-graph?period=7d")
       assert %{"labels" => labels} = json_response(conn, 200)
 
-      {:ok, first} = Timex.today() |> Timex.shift(days: -7) |> Timex.format("{ISOdate}")
+      {:ok, first} = Timex.today() |> Timex.shift(days: -6) |> Timex.format("{ISOdate}")
       {:ok, last} = Timex.today() |> Timex.format("{ISOdate}")
       assert List.first(labels) == first
       assert List.last(labels) == last


### PR DESCRIPTION
### Changes

Hopefully the last round of improvements to the stats API before calling it stable.

- [x] Implement timeseries endpoin for a single day with hourly interval. Fixes #797
- [x] Fix aggregate endpoint comparison with previous period. Fixes  #792
- [x] :warning: BREAKING: Return '(Direct / None)' instead of empty string for missing source, referrer, utm params
- [x] Make sure client can filter on `(Direct / None)`
- [x] Fix/Align breakdown query with current queries in the UI. Fixes https://github.com/plausible/analytics/discussions/829
- [x] :warning: BREAKING: Show correct number of days in 7d and 30d periods (currently it's off by one, 8 days returned for 7 day period etc)
- [x] Should the API use ALPHA-2 country codes or full country names? Support both?
  - [x]  Decision: Keep using ALPHA-2. In the future we can add `country_name` to return the full name
- [x] :warning: BREAKING: Wrap results of the `aggregate` endpoint in `{"results": ..}` for consistency with other endpoints
- [x] Add event name as a dimension for filtering and breakdowns
- [x] Add custom props as dimensions for filtering and breakdowns

### Tests
- [x] Automated tests have been added

### Changelog
- [x] We haven't released the API as stable yet so it's part of the existing entry in the changelog

### Documentation
- [x] Will update docs when it goes live