### PR TITLE
Fix typo with "succesfully"

### DIFF
--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -313,7 +313,7 @@ defmodule PlausibleWeb.AuthController do
     case Repo.update(changes) do
       {:ok, _user} ->
         conn
-        |> put_flash(:success, "Account settings saved succesfully")
+        |> put_flash(:success, "Account settings saved successfully")
         |> redirect(to: "/settings")
 
       {:error, changeset} ->

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -120,7 +120,7 @@ defmodule PlausibleWeb.SiteController do
     case Plausible.Goals.create(site, goal) do
       {:ok, _} ->
         conn
-        |> put_flash(:success, "Goal created succesfully")
+        |> put_flash(:success, "Goal created successfully")
         |> redirect(to: "/#{URI.encode_www_form(site.domain)}/settings/goals")
 
       {:error, changeset} ->
@@ -138,7 +138,7 @@ defmodule PlausibleWeb.SiteController do
     Plausible.Goals.delete(goal_id)
 
     conn
-    |> put_flash(:success, "Goal deleted succesfully")
+    |> put_flash(:success, "Goal deleted successfully")
     |> redirect(to: "/#{URI.encode_www_form(website)}/settings/goals")
   end
 
@@ -252,7 +252,7 @@ defmodule PlausibleWeb.SiteController do
     |> Repo.update!()
 
     conn
-    |> put_flash(:success, "Google integration saved succesfully")
+    |> put_flash(:success, "Google integration saved successfully")
     |> redirect(to: "/#{URI.encode_www_form(site.domain)}/settings/search-console")
   end
 
@@ -303,7 +303,7 @@ defmodule PlausibleWeb.SiteController do
     Plausible.ClickhouseRepo.clear_stats_for(site.domain)
 
     conn
-    |> put_flash(:success, "Site deleted succesfully along with all pageviews")
+    |> put_flash(:success, "Site deleted successfully along with all pageviews")
     |> redirect(to: "/sites")
   end
 
@@ -615,7 +615,7 @@ defmodule PlausibleWeb.SiteController do
     Repo.delete!(site.custom_domain)
 
     conn
-    |> put_flash(:success, "Custom domain deleted succesfully")
+    |> put_flash(:success, "Custom domain deleted successfully")
     |> redirect(to: "/#{URI.encode_www_form(site.domain)}/settings/custom-domain")
   end
 

--- a/lib/plausible_web/templates/billing/upgrade_success.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade_success.html.eex
@@ -1,7 +1,7 @@
 <div class="w-full max-w-lg px-4 mt-4 mx-auto">
   <div x-data="{volume: '10k', billingCycle: 'monthly'}" class="flex-1 bg-white dark:bg-gray-800 shadow-md rounded px-8 py-4 mb-4 mt-8">
     <div class="w-full pt-2 text-xl font-bold dark:text-gray-100">
-      Subscription created succesfully
+      Subscription created successfully
     </div>
 
     <div class="w-full text-gray-500 dark:text-gray-200 text-sm py-4">

--- a/test/plausible_web/controllers/billing_controller_test.exs
+++ b/test/plausible_web/controllers/billing_controller_test.exs
@@ -40,7 +40,7 @@ defmodule PlausibleWeb.BillingControllerTest do
     test "shows success page after user subscribes", %{conn: conn} do
       conn = get(conn, "/billing/upgrade-success")
 
-      assert html_response(conn, 200) =~ "Subscription created succesfully"
+      assert html_response(conn, 200) =~ "Subscription created successfully"
     end
   end
 end


### PR DESCRIPTION
### Changes

Changed instances of "succesfully" to "successfully". This was bugging me 😅 

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update
