### PR TITLE
Stop analytics tracking if running under Cypress tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Capitalized date/time selection keybinds not working plausible/analytics#709
 - Invisible text on Google Search Console settings page in dark mode plausible/analytics#759
+- Disable analytics tracking when running Cypress tests
 
 ## [1.2] - 2021-01-26
 

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -18,7 +18,7 @@
 
   function trigger(eventName, options) {
     if (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
-    if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver) return;
+    if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;
     if (plausible_ignore=="true") return warn('localStorage flag')
     {{#if exclusionMode}}
     if (excludedPaths)


### PR DESCRIPTION
I'm using [Cypress](https://www.cypress.io/) to run end-to-end tests on my website locally, and I'm using Plausible Analytics on that website.

At the time, the website in question wasn't advertised anywhere, it was not indexed by Google, and it didn't have any visitors.
After introducing some Cypress tests, my visitor numbers spiked in a way that I just don't see realistically happening.

Putting one and one together, I think the cause was because Plausible tracked events when being run by Cypress. The existing methods of checking if we're running inside an end-to-end test didn't work because Cypress takes a different approach to running end-to-end tests and doesn't use webdrivers.

### Changes
- Detect if we're running under Cypress. If we are, stop tracking. [See here for the official Cypress documentation](https://docs.cypress.io/faq/questions/using-cypress-faq.html#Is-there-any-way-to-detect-if-my-app-is-running-under-Cypress).

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
