### PR TITLE
WIP: add lazy loading for dashboard

### DIFF
--- a/assets/js/dashboard/api.js
+++ b/assets/js/dashboard/api.js
@@ -3,6 +3,13 @@ import {formatISO} from './date'
 let abortController = new AbortController()
 let SHARED_LINK_AUTH = null
 
+class ApiError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 function serialize(obj) {
   var str = [];
   for (var p in obj)
@@ -44,7 +51,11 @@ export function get(url, query, ...extraQuery) {
   url = url + serializeQuery(query, extraQuery)
   return fetch(url, {signal: abortController.signal, headers: headers})
     .then( response => {
-      if (!response.ok) { throw response }
+      if (!response.ok) {
+        return response.json().then((msg) => {
+          throw new ApiError(msg.error)
+        })
+      }
       return response.json()
     })
 }

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -54,4 +54,4 @@ class Historical extends React.Component {
   }
 }
 
-export default withPinnedHeader(Historical, 'historical');
+export default withPinnedHeader(Historical, '#stats-container-top');

--- a/assets/js/dashboard/lazy-loader.js
+++ b/assets/js/dashboard/lazy-loader.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default class extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidMount() {
+    this.observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        this.props.onVisible && this.props.onVisible()
+        this.observer.unobserve(this.element);
+      }
+    }, {
+      threshold: 0
+    });
+
+    this.observer.observe(this.element);
+  }
+
+  componentWillUnmount() {
+    this.observer.unobserve(this.element);
+  }
+
+  render() {
+    return (
+      <div ref={(el) => this.element = el}>{this.props.children}</div>
+    );
+  }
+}

--- a/assets/js/dashboard/lazy-loader.js
+++ b/assets/js/dashboard/lazy-loader.js
@@ -24,7 +24,7 @@ export default class extends React.Component {
 
   render() {
     return (
-      <div ref={(el) => this.element = el}>{this.props.children}</div>
+      <div ref={(el) => this.element = el} className={this.props.className} style={this.props.style}>{this.props.children}</div>
     );
   }
 }

--- a/assets/js/dashboard/realtime.js
+++ b/assets/js/dashboard/realtime.js
@@ -54,4 +54,4 @@ class Realtime extends React.Component {
   }
 }
 
-export default withPinnedHeader(Realtime, 'realtime');
+export default withPinnedHeader(Realtime);

--- a/assets/js/dashboard/stats/conversions/index.js
+++ b/assets/js/dashboard/stats/conversions/index.js
@@ -6,14 +6,16 @@ import MoreLink from '../more-link'
 import PropBreakdown from './prop-breakdown'
 import numberFormatter from '../../number-formatter'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class Conversions extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchConversions()
   }
 
@@ -37,7 +39,7 @@ export default class Conversions extends React.Component {
       query.set('goal', goalName)
 
       return (
-        <Link to={{pathname: window.location.pathname, search: query.toString()}} style={{marginTop: '-26px'}} className="hover:underline block px-2">
+        <Link to={{pathname: window.location.pathname, search: query.toString()}} style={{marginTop: '-26px'}} className="block px-2 hover:underline">
           { goalName }
         </Link>
       )
@@ -50,14 +52,14 @@ export default class Conversions extends React.Component {
     return (
       <div className="my-2 text-sm" key={goal.name}>
         <div className="flex items-center justify-between my-2">
-          <div className="w-full h-8 relative dark:text-gray-300" style={{maxWidth: 'calc(100% - 16rem)'}}>
+          <div className="relative w-full h-8 dark:text-gray-300" style={{maxWidth: 'calc(100% - 16rem)'}}>
             <Bar count={goal.count} all={this.state.goals} bg="bg-red-50 dark:bg-gray-500 dark:bg-opacity-15" />
             {this.renderGoalText(goal.name)}
           </div>
           <div className="dark:text-gray-200">
-            <span className="font-medium inline-block w-20 text-right">{numberFormatter(goal.count)}</span>
-            <span className="font-medium inline-block w-20 text-right">{numberFormatter(goal.total_count)}</span>
-            <span className="font-medium inline-block w-20 text-right">{goal.conversion_rate}%</span>
+            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.count)}</span>
+            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.total_count)}</span>
+            <span className="inline-block w-20 font-medium text-right">{goal.conversion_rate}%</span>
           </div>
         </div>
         { renderProps && <PropBreakdown site={this.props.site} query={this.props.query} goal={goal} /> }
@@ -65,18 +67,14 @@ export default class Conversions extends React.Component {
     )
   }
 
-  render() {
+  renderInner() {
     if (this.state.loading) {
-      return (
-        <div className="w-full bg-white dark:bg-gray-825 shadow-xl rounded p-4" style={{height: '94px'}}>
-          <div className="loading my-2 mx-auto"><div></div></div>
-        </div>
-      )
+      return <div className="mx-auto my-2 loading"><div></div></div>
     } else if (this.state.goals) {
       return (
-        <div className="w-full bg-white dark:bg-gray-825 shadow-xl rounded p-4">
+        <React.Fragment>
           <h3 className="font-bold dark:text-gray-100">{this.props.title || "Goal Conversions"}</h3>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>Goal</span>
             <div className="text-right">
               <span className="inline-block w-20">Uniques</span>
@@ -86,8 +84,16 @@ export default class Conversions extends React.Component {
           </div>
 
           { this.state.goals.map(this.renderGoal.bind(this)) }
-        </div>
+        </React.Fragment>
       )
     }
+  }
+
+  render() {
+    return (
+      <LazyLoader className="w-full p-4 bg-white rounded shadow-xl dark:bg-gray-825" style={{minHeight: '94px'}} onVisible={this.onVisible}>
+        { this.renderInner() }
+      </LazyLoader>
+    )
   }
 }

--- a/assets/js/dashboard/stats/countries.js
+++ b/assets/js/dashboard/stats/countries.js
@@ -4,11 +4,13 @@ import { withRouter } from 'react-router-dom'
 
 import numberFormatter from '../number-formatter'
 import FadeIn from '../fade-in'
+import LazyLoader from '../lazy-loader'
 import Bar from './bar'
 import MoreLink from './more-link'
 import * as api from '../api'
 import { navigateToQuery } from '../query'
 import { withThemeConsumer } from '../theme-consumer-hoc';
+
 class Countries extends React.Component {
   constructor(props) {
     super(props)
@@ -16,9 +18,10 @@ class Countries extends React.Component {
     this.drawMap = this.drawMap.bind(this)
     this.getDataset = this.getDataset.bind(this)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchCountries().then(this.drawMap.bind(this))
     window.addEventListener('resize', this.resizeMap);
     if (this.props.timer) this.props.timer.onTick(this.updateCountries.bind(this))
@@ -127,7 +130,7 @@ class Countries extends React.Component {
       return (
         <React.Fragment>
           <h3 className="font-bold dark:text-gray-100">Countries</h3>
-          <div className="mt-6 mx-auto" style={{width: '100%', maxWidth: '475px', height: '320px'}} id="map-container"></div>
+          <div className="mx-auto mt-6" style={{width: '100%', maxWidth: '475px', height: '320px'}} id="map-container"></div>
           <MoreLink site={this.props.site} list={this.state.countries} endpoint="countries" />
         </React.Fragment>
       )
@@ -136,11 +139,13 @@ class Countries extends React.Component {
 
   render() {
     return (
-      <div className="stats-item relative bg-white dark:bg-gray-825 shadow-xl rounded p-4" style={{height: '436px'}}>
-        { this.state.loading && <div className="loading my-32 mx-auto"><div></div></div> }
-        <FadeIn show={!this.state.loading}>
-          { this.renderBody() }
-        </FadeIn>
+      <div className="relative p-4 bg-white rounded shadow-xl stats-item dark:bg-gray-825" style={{height: '436px'}}>
+        <LazyLoader onVisible={this.onVisible}>
+          { this.state.loading && <div className="mx-auto my-32 loading"><div></div></div> }
+          <FadeIn show={!this.state.loading}>
+            { this.renderBody() }
+          </FadeIn>
+        </LazyLoader>
       </div>
     )
   }

--- a/assets/js/dashboard/stats/devices/browsers.js
+++ b/assets/js/dashboard/stats/devices/browsers.js
@@ -5,14 +5,16 @@ import FadeIn from '../../fade-in'
 import numberFormatter from '../../number-formatter'
 import Bar from '../bar'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class Browsers extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchBrowsers()
     if (this.props.timer) this.props.timer.onTick(this.fetchBrowsers.bind(this))
   }
@@ -52,7 +54,7 @@ export default class Browsers extends React.Component {
             </Link>
           </span>
         </div>
-        <span className="font-medium dark:text-gray-200">{numberFormatter(browser.count)} <span className="inline-block text-xs w-8 text-right">({browser.percentage}%)</span></span>
+        <span className="font-medium dark:text-gray-200">{numberFormatter(browser.count)} <span className="inline-block w-8 text-xs text-right">({browser.percentage}%)</span></span>
       </div>
     )
   }
@@ -68,7 +70,7 @@ export default class Browsers extends React.Component {
     if (this.state.browsers && this.state.browsers.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>{ key }</span>
             <span>{ this.label() }</span>
           </div>
@@ -76,18 +78,18 @@ export default class Browsers extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     return (
-      <React.Fragment>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!this.state.loading}>
           { this.renderList() }
         </FadeIn>
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom'
 
+import LazyLoader from '../../lazy-loader'
 import Browsers from './browsers'
 import OperatingSystems from './operating-systems'
 import FadeIn from '../../fade-in'
@@ -20,19 +21,19 @@ const EXPLANATION = {
 function iconFor(screenSize) {
   if (screenSize === 'Mobile') {
     return (
-      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather -mt-px"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
+      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
     )
   } else if (screenSize === 'Tablet') {
     return (
-      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather -mt-px"><rect x="4" y="2" width="16" height="20" rx="2" ry="2" transform="rotate(180 12 12)"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
+      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="4" y="2" width="16" height="20" rx="2" ry="2" transform="rotate(180 12 12)"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
     )
   } else if (screenSize === 'Laptop') {
     return (
-      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather -mt-px"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
+      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
     )
   } else if (screenSize === 'Desktop') {
     return (
-      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather -mt-px"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+      <svg width="16px" height="16px" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
     )
   }
 }
@@ -41,9 +42,10 @@ class ScreenSizes extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchScreenSizes()
     if (this.props.timer) this.props.timer.onTick(this.fetchScreenSizes.bind(this))
   }
@@ -74,7 +76,7 @@ class ScreenSizes extends React.Component {
             </Link>
           </span>
         </div>
-        <span className="font-medium dark:text-gray-200">{numberFormatter(size.count)} <span className="inline-block text-xs w-8 text-right">({size.percentage}%)</span></span>
+        <span className="font-medium dark:text-gray-200">{numberFormatter(size.count)} <span className="inline-block w-8 text-xs text-right">({size.percentage}%)</span></span>
       </div>
     )
   }
@@ -87,7 +89,7 @@ class ScreenSizes extends React.Component {
     if (this.state.sizes && this.state.sizes.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500">
             <span>Screen size</span>
             <span>{ this.label() }</span>
           </div>
@@ -95,18 +97,18 @@ class ScreenSizes extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     return (
-      <React.Fragment>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!this.state.loading}>
           { this.renderList() }
         </FadeIn>
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }
@@ -142,21 +144,21 @@ export default class Devices extends React.Component {
     const isActive = this.state.mode === mode
 
     if (isActive) {
-      return <li className="inline-block h-5 text-indigo-700 dark:text-indigo-500 font-bold border-b-2 border-indigo-700 dark:border-indigo-500">{name}</li>
+      return <li className="inline-block h-5 font-bold text-indigo-700 border-b-2 border-indigo-700 dark:text-indigo-500 dark:border-indigo-500">{name}</li>
     } else {
-      return <li className="hover:text-indigo-600 cursor-pointer" onClick={this.setMode(mode)}>{name}</li>
+      return <li className="cursor-pointer hover:text-indigo-600" onClick={this.setMode(mode)}>{name}</li>
     }
   }
 
   render() {
     return (
       <div className="stats-item">
-        <div className="bg-white dark:bg-gray-825 shadow-xl rounded p-4 relative" style={{height: '436px'}}>
+        <div className="relative p-4 bg-white rounded shadow-xl dark:bg-gray-825" style={{height: '436px'}}>
 
-          <div className="w-full flex justify-between">
+          <div className="flex justify-between w-full">
             <h3 className="font-bold dark:text-gray-100">Devices</h3>
 
-            <ul className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
+            <ul className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
               { this.renderPill('Size', 'size') }
               { this.renderPill('Browser', 'browser') }
               { this.renderPill('OS', 'os') }

--- a/assets/js/dashboard/stats/devices/operating-systems.js
+++ b/assets/js/dashboard/stats/devices/operating-systems.js
@@ -5,14 +5,16 @@ import FadeIn from '../../fade-in'
 import numberFormatter from '../../number-formatter'
 import Bar from '../bar'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class OperatingSystems extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchOperatingSystems()
     if (this.props.timer) this.props.timer.onTick(this.fetchOperatingSystems.bind(this))
   }
@@ -52,7 +54,7 @@ export default class OperatingSystems extends React.Component {
             </Link>
           </span>
         </div>
-        <span className="font-medium dark:text-gray-200">{numberFormatter(os.count)} <span className="inline-block text-xs w-8 text-right">({os.percentage}%)</span></span>
+        <span className="font-medium dark:text-gray-200">{numberFormatter(os.count)} <span className="inline-block w-8 text-xs text-right">({os.percentage}%)</span></span>
       </div>
     )
   }
@@ -67,7 +69,7 @@ export default class OperatingSystems extends React.Component {
     if (this.state.operatingSystems && this.state.operatingSystems.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>{ key }</span>
             <span>{ this.label() }</span>
           </div>
@@ -75,18 +77,18 @@ export default class OperatingSystems extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     return (
-      <React.Fragment>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!this.state.loading}>
           { this.renderList() }
         </FadeIn>
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/pages/entry-pages.js
+++ b/assets/js/dashboard/stats/pages/entry-pages.js
@@ -8,14 +8,16 @@ import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
 import { eventName } from '../../query'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class EntryPages extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchPages()
     if (this.props.timer) this.props.timer.onTick(this.fetchPages.bind(this))
   }
@@ -43,7 +45,7 @@ export default class EntryPages extends React.Component {
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
             <a target="_blank" href={'http://' + this.props.site.domain + page.name} className="hidden group-hover:block">
-              <svg className="inline h-4 w-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
+              <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>
         </div>
@@ -56,7 +58,7 @@ export default class EntryPages extends React.Component {
     if (this.state.pages && this.state.pages.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>Page url</span>
             <span>Unique Entrances</span>
           </div>
@@ -67,20 +69,20 @@ export default class EntryPages extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     const { loading } = this.state;
     return (
-      <React.Fragment>
-        { loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!loading}>
           { this.renderList() }
         </FadeIn>
         {!loading && <MoreLink site={this.props.site} list={this.state.pages} endpoint="entry-pages" />}
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/pages/exit-pages.js
+++ b/assets/js/dashboard/stats/pages/exit-pages.js
@@ -8,14 +8,16 @@ import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
 import { eventName } from '../../query'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class ExitPages extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchPages()
     if (this.props.timer) this.props.timer.onTick(this.fetchPages.bind(this))
   }
@@ -43,7 +45,7 @@ export default class ExitPages extends React.Component {
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
             <a target="_blank" href={'http://' + this.props.site.domain + page.name} className="hidden group-hover:block">
-              <svg className="inline h-4 w-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
+              <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>
         </div>
@@ -56,7 +58,7 @@ export default class ExitPages extends React.Component {
     if (this.state.pages && this.state.pages.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>Page url</span>
             <span>Unique Exits</span>
           </div>
@@ -67,20 +69,20 @@ export default class ExitPages extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     const { loading } = this.state;
     return (
-      <React.Fragment>
-        { loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!loading}>
           { this.renderList() }
         </FadeIn>
         {!loading && <MoreLink site={this.props.site} list={this.state.pages} endpoint="exit-pages" />}
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/pages/pages.js
+++ b/assets/js/dashboard/stats/pages/pages.js
@@ -8,14 +8,16 @@ import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
 import { eventName } from '../../query'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 export default class Visits extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchPages()
     if (this.props.timer) this.props.timer.onTick(this.fetchPages.bind(this))
   }
@@ -45,7 +47,7 @@ export default class Visits extends React.Component {
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
             <a target="_blank" href={externalLink} className="hidden group-hover:block">
-              <svg className="inline h-4 w-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
+              <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>
         </div>
@@ -67,7 +69,7 @@ export default class Visits extends React.Component {
     if (this.state.pages && this.state.pages.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>Page url</span>
             <span>{ this.label() }</span>
           </div>
@@ -78,20 +80,20 @@ export default class Visits extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   render() {
     const { loading } = this.state;
     return (
-      <React.Fragment>
-        { loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+      <LazyLoader onVisible={this.onVisible}>
+        { loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!loading}>
           { this.renderList() }
         </FadeIn>
         {!loading && <MoreLink site={this.props.site} list={this.state.pages} endpoint="pages" />}
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -7,6 +7,7 @@ import Bar from '../bar'
 import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 function LinkOption(props) {
   if (props.disabled) {
@@ -21,9 +22,10 @@ export default class Referrers extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchReferrers()
     if (this.props.timer) this.props.timer.onTick(this.fetchReferrers.bind(this))
   }
@@ -57,7 +59,7 @@ export default class Referrers extends React.Component {
     if (this.props.query.filters.source && this.props.query.filters.source !== 'Google' && referrer.name !== 'Direct / None') {
       return (
         <a target="_blank" href={'//' + referrer.name} className="hidden group-hover:block">
-          <svg className="inline h-4 w-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
+          <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
         </a>
       )
     }
@@ -74,7 +76,7 @@ export default class Referrers extends React.Component {
           <Bar count={referrer.count} all={this.state.referrers} bg="bg-blue-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group" style={{marginTop: '-26px'}} >
             <LinkOption className="block truncate dark:text-gray-300" to={{search: query.toString()}} disabled={referrer.name === 'Direct / None'}>
-              <img src={`https://icons.duckduckgo.com/ip3/${referrer.url}.ico`} referrerPolicy="no-referrer" className="inline h-4 w-4 mr-2 align-middle -mt-px" />
+              <img src={`https://icons.duckduckgo.com/ip3/${referrer.url}.ico`} referrerPolicy="no-referrer" className="inline w-4 h-4 mr-2 -mt-px align-middle" />
               { referrer.name }
             </LinkOption>
             { this.renderExternalLink(referrer) }
@@ -93,7 +95,7 @@ export default class Referrers extends React.Component {
     if (this.state.referrers.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>Referrer</span>
             <span>{ this.label() }</span>
           </div>
@@ -104,7 +106,7 @@ export default class Referrers extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
@@ -122,12 +124,14 @@ export default class Referrers extends React.Component {
 
   render() {
     return (
-      <div className="stats-item relative bg-white dark:bg-gray-825 shadow-xl rounded p-4" style={{height: '436px'}}>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
-        <FadeIn show={!this.state.loading}>
-          { this.renderContent() }
-        </FadeIn>
-      </div>
+      <LazyLoader>
+        <div className="relative p-4 bg-white rounded shadow-xl stats-item dark:bg-gray-825" style={{height: '436px'}}>
+          { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
+          <FadeIn show={!this.state.loading}>
+            { this.renderContent() }
+          </FadeIn>
+        </div>
+      </LazyLoader>
     )
   }
 }

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -7,14 +7,16 @@ import Bar from '../bar'
 import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
 import * as api from '../../api'
+import LazyLoader from '../../lazy-loader'
 
 class AllSources extends React.Component {
   constructor(props) {
     super(props)
+    this.onVisible = this.onVisible.bind(this)
     this.state = {loading: true}
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchReferrers()
     if (this.props.timer) this.props.timer.onTick(this.fetchReferrers.bind(this))
   }
@@ -45,7 +47,7 @@ class AllSources extends React.Component {
           <Bar count={referrer.count} all={this.state.referrers} bg="bg-blue-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link className="block truncate hover:underline" to={{search: query.toString()}}>
-              <img src={`https://icons.duckduckgo.com/ip3/${referrer.url}.ico`} referrerPolicy="no-referrer" className="inline h-4 w-4 mr-2 align-middle -mt-px" />
+              <img src={`https://icons.duckduckgo.com/ip3/${referrer.url}.ico`} referrerPolicy="no-referrer" className="inline w-4 h-4 mr-2 -mt-px align-middle" />
               { referrer.name }
             </Link>
           </span>
@@ -63,7 +65,7 @@ class AllSources extends React.Component {
     if (this.state.referrers && this.state.referrers.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500">
             <span>Source</span>
             <span>{this.label()}</span>
           </div>
@@ -75,28 +77,28 @@ class AllSources extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44">No data yet</div>
     }
   }
 
   renderContent() {
     return (
-      <React.Fragment>
-        <div className="w-full flex justify-between">
+      <LazyLoader onVisible={this.onVisible}>
+        <div id="sources" className="flex justify-between w-full">
           <h3 className="font-bold dark:text-gray-100">Top Sources</h3>
           { this.props.renderTabs() }
         </div>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+        { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!this.state.loading}>
           { this.renderList() }
         </FadeIn>
-      </React.Fragment>
+      </LazyLoader>
     )
   }
 
   render() {
     return (
-      <div className="stats-item relative bg-white dark:bg-gray-825 shadow-xl rounded p-4" style={{height: '436px'}}>
+      <div className="relative p-4 bg-white rounded shadow-xl stats-item dark:bg-gray-825" style={{height: '436px'}}>
           { this.renderContent() }
       </div>
     )
@@ -164,7 +166,7 @@ class UTMSources extends React.Component {
     if (this.state.referrers && this.state.referrers.length > 0) {
       return (
         <React.Fragment>
-          <div className="flex items-center mt-3 mb-2 justify-between text-gray-500 dark:text-gray-400 text-xs font-bold tracking-wide">
+          <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
             <span>{UTM_TAGS[this.props.tab].label}</span>
             <span>{this.label()}</span>
           </div>
@@ -176,18 +178,18 @@ class UTMSources extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="text-center mt-44 font-medium text-gray-500 dark:text-gray-400">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 
   renderContent() {
     return (
       <React.Fragment>
-        <div className="w-full flex justify-between">
+        <div className="flex justify-between w-full">
           <h3 className="font-bold dark:text-gray-100">Top sources</h3>
           { this.props.renderTabs() }
         </div>
-        { this.state.loading && <div className="loading mt-44 mx-auto"><div></div></div> }
+        { this.state.loading && <div className="mx-auto loading mt-44"><div></div></div> }
         <FadeIn show={!this.state.loading}>
           { this.renderList() }
         </FadeIn>
@@ -197,7 +199,7 @@ class UTMSources extends React.Component {
 
   render() {
     return (
-      <div className="stats-item relative bg-white dark:bg-gray-825 shadow-xl rounded p-4" style={{height: '436px'}}>
+      <div className="relative p-4 bg-white rounded shadow-xl stats-item dark:bg-gray-825" style={{height: '436px'}}>
         { this.renderContent() }
       </div>
     )
@@ -225,7 +227,7 @@ export default class SourceList extends React.Component {
     const activeClass = 'inline-block h-5 text-indigo-700 dark:text-indigo-500 font-bold border-b-2 border-indigo-700 dark:border-indigo-500'
     const defaultClass = 'hover:text-indigo-600 cursor-pointer'
     return (
-      <ul className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
+      <ul className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
         <li className={this.state.tab === 'all' ? activeClass : defaultClass} onClick={this.setTab('all')}>All</li>
         <li className={this.state.tab === 'utm_medium' ? activeClass : defaultClass} onClick={this.setTab('utm_medium')}>Medium</li>
         <li className={this.state.tab === 'utm_source' ? activeClass : defaultClass} onClick={this.setTab('utm_source')}>Source</li>

--- a/assets/js/dashboard/stats/visitor-graph.js
+++ b/assets/js/dashboard/stats/visitor-graph.js
@@ -5,6 +5,7 @@ import { eventName, navigateToQuery } from '../query'
 import numberFormatter, {durationFormatter} from '../number-formatter'
 import * as api from '../api'
 import {ThemeContext} from '../theme-context'
+import LazyLoader from '../lazy-loader'
 
 function buildDataSet(plot, present_index, ctx, label) {
   var gradient = ctx.createLinearGradient(0, 0, 0, 300);
@@ -305,7 +306,7 @@ class LineGraph extends React.Component {
       return (
         <div tooltip={`Stats based on a ${samplePercent}% sample of all visitors`} className="absolute cursor-pointer -top-20 right-8">
           <svg className="w-4 h-4 text-gray-300 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
       )
@@ -336,9 +337,10 @@ export default class VisitorGraph extends React.Component {
   constructor(props) {
     super(props)
     this.state = {loading: true}
+    this.onVisible = this.onVisible.bind(this)
   }
 
-  componentDidMount() {
+  onVisible() {
     this.fetchGraphData()
     if (this.props.timer) this.props.timer.onTick(this.fetchGraphData.bind(this))
   }
@@ -372,10 +374,12 @@ export default class VisitorGraph extends React.Component {
 
   render() {
     return (
-      <div className="relative w-full mt-2 bg-white rounded shadow-xl dark:bg-gray-825 main-graph">
-        { this.state.loading && <div className="graph-inner"><div className="pt-24 mx-auto loading sm:pt-32 md:pt-48"><div></div></div></div> }
-        { this.renderInner() }
-      </div>
+      <LazyLoader onVisible={this.onVisible}>
+        <div className="relative w-full mt-2 bg-white rounded shadow-xl dark:bg-gray-825 main-graph">
+          { this.state.loading && <div className="graph-inner"><div className="pt-24 mx-auto loading sm:pt-32 md:pt-48"><div></div></div></div> }
+          { this.renderInner() }
+        </div>
+      </LazyLoader>
     )
   }
 }

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1,6 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController do
   use PlausibleWeb, :controller
   use Plausible.Repo
+  use Plug.ErrorHandler
   alias Plausible.Stats.Clickhouse, as: Stats
   alias Plausible.Stats.Query
 
@@ -335,4 +336,8 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp google_api(), do: Application.fetch_env!(:plausible, :google_api)
+
+  def handle_errors(conn, %{kind: kind, reason: reason}) do
+    json(conn, %{error: Exception.format_banner(kind, reason)})
+  end
 end


### PR DESCRIPTION
### Changes

I noticed that a lot of queries to CH run considerably faster when run in isolation vs when loading the whole dashboard. When loading the dashboard, we fire about 10 separate queries to Clickhouse. I believe all these concurrent queries are competing for CPU and RAM resources.

By loading only the data that is visible in the user's viewport, we can reduce the number of concurrent queries which should free up resources for the queries that are most important (i.e. visible part of the dashboard)

Thanks @Vigasaurus for the work on sticky header. I'm taking the InteractionObserver code as base for the LazyLoader.

### Tests
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
