### PR TITLE
Disable self-tracking with self hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Disable analytics tracking when running Cypress tests
 - CSV reports can be downloaded via shared links plausible/analytics#884
 - Fixes weekly/monthly email report delivery over SMTP plausible/analytics#889
+- Disable self-tracking with self hosting plausible/analytics#907
 
 ## [1.2] - 2021-01-26
 

--- a/lib/plausible_web/templates/layout/_tracking.html.eex
+++ b/lib/plausible_web/templates/layout/_tracking.html.eex
@@ -1,4 +1,4 @@
-<%= if !@conn.assigns[:skip_plausible_tracking] do %>
+<%= if !Application.get_env(:plausible, :is_selfhost) && !@conn.assigns[:skip_plausible_tracking] do %>
   <script async defer src="<%="#{plausible_url()}/js/plausible.js"%>"></script>
   <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 <% end %>


### PR DESCRIPTION
### Changes

Disables self-tracking when self hosted.

In my case, I was staring at mysterious entries for my website. It showed up because I hosted Plausible on a subdomain of my primary site (plausible.example.com) and it accidentally matched my site. This PR disables this, as probably no one self-hosting would want it.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
