### PR TITLE
Clean up deprecated option DISABLE_SUBSCRIPTION

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -2,7 +2,6 @@ BASE_URL=http://localhost:8000
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_dev
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_dev
 SECRET_KEY_BASE=/njrhntbycvastyvtk1zycwfm981vpo/0xrvwjjvemdakc/vsvbrevlwsc6u8rcg
-DISABLE_SUBSCRIPTION=false
 ENVIRONMENT=dev
 MAILER_ADAPTER=Bamboo.LocalAdapter
 LOG_LEVEL=debug


### PR DESCRIPTION
### Changes
DISABLE_SUBSCRIPTION was removed in commit e873d790e5117f08102e28be1f7f1926ec35d877.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update
