### PR TITLE
Fix weekly report time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.3] - Unreleased
+## Unreleased
+
+### Fixed
+- Fix weekly report time range plausible/analytics#951
+
+
+## [1.3] - 2021-04-14
 
 ### Added
 - Stats API [currently in beta] plausible/analytics#679

--- a/lib/plausible_web/templates/email/weekly_report.html.eex
+++ b/lib/plausible_web/templates/email/weekly_report.html.eex
@@ -223,7 +223,7 @@ body {
                         <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 5px; padding-left: 5px; padding-top: 0px; padding-bottom: 5px; font-family: Arial, sans-serif"><![endif]-->
                         <div style="color:#555555;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;line-height:120%;padding-top:0px;padding-right:5px;padding-bottom:5px;padding-left:5px;">
                           <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 14px; color: #555555;">
-                            <p style="font-size: 12px; line-height: 24px; text-align: left; margin: 0;"><span style="font-size: 20px;"><strong><span style="line-height: 24px; font-size: 20px;"><%= PlausibleWeb.StatsView.large_number_format(@unique_visitors) %></span></strong></span></p>
+                            <p style="font-size: 12px; line-height: 24px; text-align: left; margin: 0;"><span style="font-size: 20px;"><strong><span id="visitors" style="line-height: 24px; font-size: 20px;"><%= PlausibleWeb.StatsView.large_number_format(@unique_visitors) %></span></strong></span></p>
                           </div>
                         </div>
                         <!--[if mso]></td></tr></table><![endif]-->

--- a/lib/workers/send_email_report.ex
+++ b/lib/workers/send_email_report.ex
@@ -7,7 +7,9 @@ defmodule Plausible.Workers.SendEmailReport do
   @impl Oban.Worker
   def perform(%{"interval" => "weekly", "site_id" => site_id}, _job) do
     site = Repo.get(Plausible.Site, site_id) |> Repo.preload(:weekly_report)
-    query = Query.from(site.timezone, %{"period" => "7d"})
+    today = Timex.now(site.timezone) |> DateTime.to_date()
+    date = Timex.shift(today, weeks: -1) |> Timex.end_of_week() |> Date.to_iso8601()
+    query = Query.from(site.timezone, %{"period" => "7d", "date" => date})
 
     for email <- site.weekly_report.recipients do
       unsubscribe_link =

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -1,7 +1,9 @@
 defmodule Plausible.Workers.SendEmailReportTest do
+  import Plausible.TestUtils
   use Plausible.DataCase
   use Bamboo.Test
   alias Plausible.Workers.SendEmailReport
+  alias Timex.Timezone
 
   defp perform(args) do
     SendEmailReport.new(args) |> Oban.insert!()
@@ -24,6 +26,43 @@ defmodule Plausible.Workers.SendEmailReportTest do
         subject: "Weekly report for #{site.domain}",
         to: [nil: "user2@email.com"]
       )
+    end
+
+    test "calculates timezone correctly" do
+      site = insert(:site, timezone: "US/Eastern")
+      insert(:weekly_report, site: site, recipients: ["user@email.com"])
+
+      now = Timex.now(site.timezone)
+      last_monday = Timex.shift(now, weeks: -1) |> Timex.beginning_of_week()
+      last_sunday = Timex.shift(now, weeks: -1) |> Timex.end_of_week()
+      sunday_before_last = Timex.shift(last_monday, minutes: -1)
+      this_monday = Timex.beginning_of_week(now)
+
+      create_pageviews([
+        # Sunday before last, not counted
+        %{domain: site.domain, timestamp: Timezone.convert(sunday_before_last, "UTC")},
+        # Sunday before last, not counted
+        %{domain: site.domain, timestamp: Timezone.convert(sunday_before_last, "UTC")},
+        # Last monday, counted
+        %{domain: site.domain, timestamp: Timezone.convert(last_monday, "UTC")},
+        # Last sunday, counted
+        %{domain: site.domain, timestamp: Timezone.convert(last_sunday, "UTC")},
+        # This monday, not counted
+        %{domain: site.domain, timestamp: Timezone.convert(this_monday, "UTC")},
+        # This monday, not counted
+        %{domain: site.domain, timestamp: Timezone.convert(this_monday, "UTC")}
+      ])
+
+      perform(%{"site_id" => site.id, "interval" => "weekly"})
+
+      assert_delivered_email_matches(%{
+        to: [nil: "user@email.com"],
+        html_body: html_body
+      })
+
+      # Should find 2 visiors
+      assert html_body =~
+               ~s(<span id="visitors" style="line-height: 24px; font-size: 20px;">2</span>)
     end
   end
 


### PR DESCRIPTION
### Changes

Bug: weekly reports are sent out on Monday. The time range that stats are calculated for are using the `Query.from(%{"period" => "7d"})` which is problematic because:
* The resulting date range is last Tuesday -> this Monday
* Stats for 'this Monday' are incomplete, so sending a report is for that is wrong

The correct date range is 'last monday' -> 'last sunday'. The stats for that range are complete and that's what most people consider a 'week'.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update