### PR TITLE
Group pages by hostname and pathname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New parameter `metrics` for the `/api/v1/stats/timeseries` endpoint plausible/analytics#952
 - CSV export now includes pageviews, bounce rate and visit duration in addition to visitors plausible/analytics#952
+- Page views are now grouped by hostname and pathname on the dashboard.
 
 ### Fixed
 - Fix weekly report time range plausible/analytics#951

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom'
-import { countFilters, navigateToQuery, removeQueryParam } from './query'
+import { countFilters, navigateToQuery, parsePageAttributes, removeQueryParam } from './query'
 import Datamap from 'datamaps'
 import Transition from "../transition.js";
 
@@ -148,7 +148,8 @@ class Filters extends React.Component {
       return <span className="inline-block max-w-2xs md:max-w-xs truncate">Country: <b>{selectedCountry.properties.name}</b></span>
     }
     if (key === "page") {
-      return <span className="inline-block max-w-2xs md:max-w-xs truncate">Page: <b>{value}</b></span>
+      const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: value})
+      return <span className="inline-block max-w-2xs md:max-w-xs truncate">Page: <b>{pageLabel}</b> {subdomain && <span className="bg-gray-600 px-1 rounded-md">{subdomain}</span>}</span>
     }
     if (key === "entry_page") {
       return <span className="inline-block max-w-2xs md:max-w-xs truncate">Entry Page: <b>{value}</b></span>

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -148,8 +148,8 @@ class Filters extends React.Component {
       return <span className="inline-block max-w-2xs md:max-w-xs truncate">Country: <b>{selectedCountry.properties.name}</b></span>
     }
     if (key === "page") {
-      const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: value})
-      return <span className="inline-block max-w-2xs md:max-w-xs truncate">Page: <b>{pageLabel}</b> {subdomain && <span className="bg-gray-600 px-1 rounded-md">{subdomain}</span>}</span>
+      const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: value})
+      return <span className="inline-block max-w-2xs md:max-w-xs truncate">Page: <b>{pathname}</b> {label && <span className="bg-gray-600 px-1 rounded-md">{label}</span>}</span>
     }
     if (key === "entry_page") {
       return <span className="inline-block max-w-2xs md:max-w-xs truncate">Entry Page: <b>{value}</b></span>

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -34,7 +34,7 @@ class Historical extends React.Component {
             <div className="flex items-center w-full mb-2 sm:mb-0">
               <SiteSwitcher site={this.props.site} loggedIn={this.props.loggedIn} />
               <CurrentVisitors timer={this.props.timer} site={this.props.site} query={this.props.query} />
-              <Filters query={this.props.query} history={this.props.history} />
+              <Filters query={this.props.query} history={this.props.history} site={this.props.site} />
             </div>
             <Datepicker site={this.props.site} query={this.props.query} />
           </div>

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -161,14 +161,13 @@ export function eventName(query) {
 
 export function parsePageAttributes({domain, pageName}) {
   const {hostname, pathname} = new URL(`https://${pageName}`)
-  let pageLabel = pathname;
-  let subdomain;
+  let label;
   if(hostname.includes(domain)){
     if(hostname !== domain){
-      subdomain = hostname.replace(`.${domain}`, "")
+      label = hostname.replace(`.${domain}`, "")
     }
   } else {
-    pageLabel = hostname + pathname
+    label = hostname
   }
-  return {pageLabel, subdomain}
+  return {pathname, label}
 }

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -158,3 +158,17 @@ export function eventName(query) {
   }
   return 'pageviews'
 }
+
+export function parsePageAttributes({domain, pageName}) {
+  const {hostname, pathname} = new URL(`https://${pageName}`)
+  let pageLabel = pathname;
+  let subdomain;
+  if(hostname.includes(domain)){
+    if(hostname !== domain){
+      subdomain = hostname.replace(`.${domain}`, "")
+    }
+  } else {
+    pageLabel = hostname + pathname
+  }
+  return {pageLabel, subdomain}
+}

--- a/assets/js/dashboard/realtime.js
+++ b/assets/js/dashboard/realtime.js
@@ -33,7 +33,7 @@ class Realtime extends React.Component {
           <div className="items-center justify-between w-full sm:flex">
             <div className="flex items-center w-full mb-2 sm:mb-0">
               <SiteSwitcher site={this.props.site} loggedIn={this.props.loggedIn} />
-              <Filters query={this.props.query} history={this.props.history} />
+              <Filters query={this.props.query} history={this.props.history} site={this.props.site} />
             </div>
             <Datepicker site={this.props.site} query={this.props.query} />
           </div>

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -49,13 +49,13 @@ class EntryPagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('entry_page', page.name)
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {label, pathname} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <tr className="text-sm dark:text-gray-200" key={page.name}>
+      <tr className="text-sm dark:text-gray-200" key={pathname + label}>
         <td className="p-2">
           <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
-            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+            {pathname} {label && <div className="bg-gray-600 px-1 rounded-md ml-2">{label}</div>}
           </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom'
 import Modal from './modal'
 import * as api from '../../api'
 import numberFormatter, { durationFormatter } from '../../number-formatter'
-import {parseQuery} from '../../query'
+import {parseQuery, parsePageAttributes} from '../../query'
 
 class EntryPagesModal extends React.Component {
   constructor(props) {
@@ -49,11 +49,14 @@ class EntryPagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('entry_page', page.name)
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
         <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
+          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
+            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+          </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.entries)}</td>

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom'
 import Modal from './modal'
 import * as api from '../../api'
 import numberFormatter from '../../number-formatter'
-import {parseQuery} from '../../query'
+import {parseQuery, parsePageAttributes} from '../../query'
 
 class ExitPagesModal extends React.Component {
   constructor(props) {
@@ -45,11 +45,14 @@ class ExitPagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('exit_page', page.name)
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
         <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
+          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
+            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+          </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.exits)}</td>

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -45,13 +45,13 @@ class ExitPagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('exit_page', page.name)
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <tr className="text-sm dark:text-gray-200" key={page.name}>
+      <tr className="text-sm dark:text-gray-200" key={pathname + label}>
         <td className="p-2">
           <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
-            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+            {pathname} {label && <div className="bg-gray-600 px-1 rounded-md ml-2">{label}</div>}
           </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom'
 import Modal from './modal'
 import * as api from '../../api'
 import numberFormatter from '../../number-formatter'
-import {parseQuery} from '../../query'
+import {parseQuery, parsePageAttributes} from '../../query'
 
 class PagesModal extends React.Component {
   constructor(props) {
@@ -61,11 +61,14 @@ class PagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('page', page.name)
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
         <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
+          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
+            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+          </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -61,13 +61,13 @@ class PagesModal extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('page', page.name)
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <tr className="text-sm dark:text-gray-200" key={page.name}>
+      <tr className="text-sm dark:text-gray-200" key={pathname + label}>
         <td className="p-2">
           <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline flex">
-            {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md ml-2">{subdomain}</div>}
+            {pathname} {label && <div className="bg-gray-600 px-1 rounded-md ml-2">{label}</div>}
           </Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>

--- a/assets/js/dashboard/stats/pages/entry-pages.js
+++ b/assets/js/dashboard/stats/pages/entry-pages.js
@@ -38,15 +38,15 @@ export default class EntryPages extends React.Component {
     const query = new URLSearchParams(window.location.search)
     query.set('entry_page', page.name)
     const externalLink = 'https://' + page.name
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pathname + label}>
         <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
-              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+              {pathname} {label && <div className="bg-gray-600 px-1 rounded-md  ml-2">{label}</div>}
             </Link>
             <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>

--- a/assets/js/dashboard/stats/pages/entry-pages.js
+++ b/assets/js/dashboard/stats/pages/entry-pages.js
@@ -6,7 +6,7 @@ import FadeIn from '../../fade-in'
 import Bar from '../bar'
 import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
-import { eventName } from '../../query'
+import { eventName, parsePageAttributes } from '../../query'
 import * as api from '../../api'
 import LazyLoader from '../../lazy-loader'
 
@@ -37,14 +37,18 @@ export default class EntryPages extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('entry_page', page.name)
+    const externalLink = 'https://' + page.name
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={page.name}>
-        <div className="w-full h-8 truncate" style={{maxWidth: 'calc(100% - 4rem)'}}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
+        <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
-            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
-            <a target="_blank" href={'http://' + this.props.site.domain + page.name} className="hidden group-hover:block">
+            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
+              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+            </Link>
+            <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>

--- a/assets/js/dashboard/stats/pages/exit-pages.js
+++ b/assets/js/dashboard/stats/pages/exit-pages.js
@@ -6,7 +6,7 @@ import FadeIn from '../../fade-in'
 import Bar from '../bar'
 import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
-import { eventName } from '../../query'
+import { eventName, parsePageAttributes } from '../../query'
 import * as api from '../../api'
 import LazyLoader from '../../lazy-loader'
 
@@ -37,14 +37,18 @@ export default class ExitPages extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('exit_page', page.name)
+    const externalLink = 'https://' + page.name
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={page.name}>
-        <div className="w-full h-8 truncate" style={{maxWidth: 'calc(100% - 4rem)'}}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
+        <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
-            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline">{page.name}</Link>
-            <a target="_blank" href={'http://' + this.props.site.domain + page.name} className="hidden group-hover:block">
+            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
+              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+            </Link>
+            <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>
           </span>

--- a/assets/js/dashboard/stats/pages/exit-pages.js
+++ b/assets/js/dashboard/stats/pages/exit-pages.js
@@ -38,15 +38,15 @@ export default class ExitPages extends React.Component {
     const query = new URLSearchParams(window.location.search)
     query.set('exit_page', page.name)
     const externalLink = 'https://' + page.name
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pathname + label}>
         <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
-              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+              {pathname} {label && <div className="bg-gray-600 px-1 rounded-md  ml-2">{label}</div>}
             </Link>
             <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>

--- a/assets/js/dashboard/stats/pages/pages.js
+++ b/assets/js/dashboard/stats/pages/pages.js
@@ -38,15 +38,15 @@ export default class Visits extends React.Component {
     const query = new URLSearchParams(window.location.search)
     query.set('page', page.name)
     const externalLink = 'https://' + page.name
-    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
+    const {pathname, label} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pathname + pathname}>
         <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
             <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
-              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+              {pathname} {label && <div className="bg-gray-600 px-1 rounded-md  ml-2">{label}</div>}
             </Link>
             <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>

--- a/assets/js/dashboard/stats/pages/pages.js
+++ b/assets/js/dashboard/stats/pages/pages.js
@@ -6,7 +6,7 @@ import FadeIn from '../../fade-in'
 import Bar from '../bar'
 import MoreLink from '../more-link'
 import numberFormatter from '../../number-formatter'
-import { eventName } from '../../query'
+import { eventName, parsePageAttributes } from '../../query'
 import * as api from '../../api'
 import LazyLoader from '../../lazy-loader'
 
@@ -37,15 +37,17 @@ export default class Visits extends React.Component {
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     query.set('page', page.name)
-    const domain = new URL('https://' + this.props.site.domain)
-    const externalLink = 'https://' + domain.host  + page.name
+    const externalLink = 'https://' + page.name
+    const {pageLabel, subdomain} = parsePageAttributes({domain: this.props.site.domain, pageName: page.name})
 
     return (
-      <div className="flex items-center justify-between my-1 text-sm" key={page.name}>
+      <div className="flex items-center justify-between my-1 text-sm" key={pageLabel + subdomain}>
         <div className="w-full h-8" style={{maxWidth: 'calc(100% - 4rem)'}}>
           <Bar count={page.count} all={this.state.pages} bg="bg-orange-50 dark:bg-gray-500 dark:bg-opacity-15" />
           <span className="flex px-2 group dark:text-gray-300" style={{marginTop: '-26px'}} >
-            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate">{page.name}</Link>
+            <Link to={{pathname: window.location.pathname, search: query.toString()}} className="block hover:underline truncate flex">
+              {pageLabel} {subdomain && <div className="bg-gray-600 px-1 rounded-md  ml-2">{subdomain}</div>}
+            </Link>
             <a target="_blank" href={externalLink} className="hidden group-hover:block">
               <svg className="inline w-4 h-4 ml-1 -mt-1 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
             </a>

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -519,12 +519,13 @@ defmodule Plausible.Stats.Clickhouse do
     q =
       from(
         s in base_session_query(site, query),
+        group_by: s.hostname,
         group_by: s.entry_page,
         order_by: [desc: uniq(s.user_id)],
         limit: ^limit,
         offset: ^offset,
         select: %{
-          name: s.entry_page,
+          name: fragment("concat(?, ?) as name", s.hostname, s.entry_page),
           count: uniq(s.user_id),
           entries: uniq(s.session_id),
           visit_duration: visit_duration()
@@ -541,13 +542,14 @@ defmodule Plausible.Stats.Clickhouse do
     q =
       from(
         s in base_session_query(site, query),
+        group_by: s.hostname,
         group_by: s.exit_page,
         order_by: [desc: uniq(s.user_id)],
         limit: ^limit,
         offset: ^offset,
         where: s.exit_page != "",
         select: %{
-          name: s.exit_page,
+          name: fragment("concat(?, ?) as name", s.hostname, s.exit_page),
           count: uniq(s.user_id),
           exits: uniq(s.session_id)
         }
@@ -592,12 +594,13 @@ defmodule Plausible.Stats.Clickhouse do
 
     ClickhouseRepo.all(
       from s in q,
+        group_by: s.hostname,
         group_by: s.exit_page,
         order_by: [desc: uniq(s.user_id)],
         limit: ^limit,
         offset: ^offset,
         select: %{
-          name: s.exit_page,
+          name: fragment("concat(?, ?) as name", s.hostname, s.exit_page),
           count: uniq(s.user_id)
         }
     )
@@ -609,12 +612,13 @@ defmodule Plausible.Stats.Clickhouse do
     q =
       from(
         e in base_query_w_sessions(site, query),
+        group_by: e.hostname,
         group_by: e.pathname,
         order_by: [desc: uniq(e.user_id)],
         limit: ^limit,
         offset: ^offset,
         select: %{
-          name: e.pathname,
+          name: fragment("concat(?, ?) as name", e.hostname, e.pathname),
           count: uniq(e.user_id),
           pageviews: total()
         }
@@ -636,10 +640,11 @@ defmodule Plausible.Stats.Clickhouse do
     ClickhouseRepo.all(
       from s in q,
         group_by: s.entry_page,
+        group_by: s.hostname,
         order_by: [desc: total()],
         limit: 100,
         select: %{
-          entry_page: s.entry_page,
+          entry_page: fragment("concat(?, ?)", s.hostname, s.entry_page),
           total: total(),
           bounce_rate: bounce_rate()
         }

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -9,10 +9,10 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01")
 
       assert json_response(conn, 200) == [
-               %{"count" => 3, "pageviews" => 3, "name" => "/"},
-               %{"count" => 2, "pageviews" => 2, "name" => "/register"},
-               %{"count" => 1, "pageviews" => 1, "name" => "/contact"},
-               %{"count" => 1, "pageviews" => 1, "name" => "/irrelevant"}
+               %{"count" => 3, "pageviews" => 3, "name" => "test-site.com/"},
+               %{"count" => 2, "pageviews" => 2, "name" => "test-site.com/register"},
+               %{"count" => 1, "pageviews" => 1, "name" => "test-site.com/contact"},
+               %{"count" => 1, "pageviews" => 1, "name" => "test-site.com/irrelevant"}
              ]
     end
 
@@ -28,25 +28,25 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "bounce_rate" => 33.0,
                  "count" => 3,
                  "pageviews" => 3,
-                 "name" => "/"
+                 "name" => "test-site.com/"
                },
                %{
                  "bounce_rate" => nil,
                  "count" => 2,
                  "pageviews" => 2,
-                 "name" => "/register"
+                 "name" => "test-site.com/register"
                },
                %{
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
-                 "name" => "/contact"
+                 "name" => "test-site.com/contact"
                },
                %{
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
-                 "name" => "/irrelevant"
+                 "name" => "test-site.com/irrelevant"
                }
              ]
     end
@@ -55,8 +55,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=realtime")
 
       assert json_response(conn, 200) == [
-               %{"count" => 2, "name" => "/exit"},
-               %{"count" => 1, "name" => "/"}
+               %{"count" => 2, "name" => "test-site.com/exit"},
+               %{"count" => 1, "name" => "test-site.com/"}
              ]
     end
   end
@@ -71,7 +71,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                %{
                  "count" => 3,
                  "entries" => 3,
-                 "name" => "/",
+                 "name" => "test-site.com/",
                  "visit_duration" => 67
                }
              ]
@@ -89,7 +89,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visit_duration" => 67,
                  "count" => 3,
                  "entries" => 3,
-                 "name" => "/"
+                 "name" => "test-site.com/"
                }
              ]
     end
@@ -102,7 +102,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/exit-pages?period=day&date=2019-01-01")
 
       assert json_response(conn, 200) == [
-               %{"count" => 3, "exits" => 3, "name" => "/", "exit_rate" => 100.0}
+               %{"count" => 3, "exits" => 3, "name" => "test-site.com/", "exit_rate" => 100.0}
              ]
     end
   end

--- a/test/support/clickhouse_setup.ex
+++ b/test/support/clickhouse_setup.ex
@@ -7,6 +7,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/",
         country_code: "EE",
         browser: "Chrome",
@@ -22,6 +23,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/",
         country_code: "EE",
         browser: "Chrome",
@@ -36,6 +38,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/",
         country_code: "US",
         browser: "Chrome",
@@ -50,6 +53,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         pathname: "/contact",
         country_code: "GB",
         browser: "Firefox",
@@ -58,10 +62,11 @@ defmodule Plausible.Test.ClickhouseSetup do
         referrer_source: "Bing",
         timestamp: ~N[2019-01-01 00:00:00]
       },
-      %{name: "pageview", domain: "test-site.com", timestamp: ~N[2019-01-31 00:00:00]},
+      %{name: "pageview", domain: "test-site.com", hostname: "test-site.com", timestamp: ~N[2019-01-31 00:00:00]},
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 01:00:00],
         "meta.key": ["variant"],
@@ -70,6 +75,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 02:00:00],
         "meta.key": ["variant"],
@@ -78,6 +84,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "Signup",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_2_session_id,
         timestamp: ~N[2019-01-01 02:00:00],
         "meta.key": ["variant"],
@@ -87,6 +94,7 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/register",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
@@ -94,6 +102,7 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/register",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_2_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
@@ -101,24 +110,28 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/irrelevant",
         domain: "test-site.com",
+        hostname: "test-site.com",
         session_id: @conversion_1_session_id,
         timestamp: ~N[2019-01-01 23:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer_source: "Google",
         timestamp: ~N[2019-02-01 01:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer_source: "Google",
         timestamp: ~N[2019-02-01 02:00:00]
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/some-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 01:00:00]
@@ -126,6 +139,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/some-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 01:00:00]
@@ -133,32 +147,37 @@ defmodule Plausible.Test.ClickhouseSetup do
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         referrer: "t.co/nonexistent-link",
         referrer_source: "Twitter",
         timestamp: ~N[2019-03-01 02:00:00]
       },
-      %{name: "pageview", domain: "test-site.com"},
+      %{name: "pageview", domain: "test-site.com", hostname: "test-site.com",},
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: Timex.now() |> Timex.shift(minutes: -3)
       },
       %{
         name: "pageview",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: Timex.now() |> Timex.shift(minutes: -6)
       },
-      %{name: "pageview", domain: "tz-test.com", timestamp: ~N[2019-01-01 00:00:00]},
-      %{name: "pageview", domain: "public-site.io"},
+      %{name: "pageview", domain: "tz-test.com", hostname: "tz-test.com", timestamp: ~N[2019-01-01 00:00:00]},
+      %{name: "pageview", domain: "public-site.io", hostname: "public-site.io",},
       %{
         name: "pageview",
         domain: "fetch-tweets-test.com",
+        hostname: "fetch-tweets-test.com",
         referrer: "t.co/a-link",
         referrer_source: "Twitter"
       },
       %{
         name: "pageview",
         domain: "fetch-tweets-test.com",
+        hostname: "fetch-tweets-test.com",
         referrer: "t.co/b-link",
         referrer_source: "Twitter",
         timestamp: Timex.now() |> Timex.shift(days: -5)
@@ -167,48 +186,56 @@ defmodule Plausible.Test.ClickhouseSetup do
         name: "pageview",
         pathname: "/register",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/signup/new",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/billing/success",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/reg",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/signup/new/2",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/signup/new/3",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       },
       %{
         name: "pageview",
         pathname: "/billing/upgrade/success",
         domain: "test-site.com",
+        hostname: "test-site.com",
         timestamp: ~N[2019-07-01 23:00:00]
       }
     ])
@@ -216,6 +243,7 @@ defmodule Plausible.Test.ClickhouseSetup do
     Plausible.TestUtils.create_sessions([
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "10words",
@@ -235,6 +263,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "10words",
@@ -248,6 +277,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Bing",
@@ -260,6 +290,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Google",
@@ -270,6 +301,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Google",
@@ -280,6 +312,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/some-link",
@@ -289,6 +322,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/some-link",
@@ -298,6 +332,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer: "t.co/nonexistent-link",
@@ -307,6 +342,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/",
         referrer_source: "Bing",
@@ -316,6 +352,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/exit",
         referrer_source: "10words",
@@ -325,6 +362,7 @@ defmodule Plausible.Test.ClickhouseSetup do
       },
       %{
         domain: "test-site.com",
+        hostname: "test-site.com",
         entry_page: "/",
         exit_page: "/exit",
         referrer_source: "10words",


### PR DESCRIPTION
### Changes
Display pages by taking into account the hostname.

The label is formatted by following these rules:
- If page view is from the exact same configured domain: show only the pathname
- If page view is from a subdomain of the configured domain: show the pathname with subdomain as a tag label next to it (displayed here with parentheses)
- If page view is from a completely different domain: display the entire domain + pathname


<img width="505" alt="CleanShot 2021-04-25 at 11 42 10@2x" src="https://user-images.githubusercontent.com/16015833/115988899-e8e94080-a5bb-11eb-9301-ad93a8174e7b.png">

Filtering has also been adapted.

This is a result of the discussion in #478

### Tests
- [x] Automated tests have been adapted

### Changelog
- [x] Entry has been added to the changelog

### Documentation
- [x] This change does not need a documentation update
