### PR TITLE
Support multiple `data-domain` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New parameter `metrics` for the `/api/v1/stats/timeseries` endpoint plausible/analytics#952
 - CSV export now includes pageviews, bounce rate and visit duration in addition to visitors plausible/analytics#952
+- Send stats to multiple dashboards by configuring a comma-separated list of domains plausible/analytics#968
 
 ### Fixed
 - Fix weekly report time range plausible/analytics#951

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -38,6 +38,26 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.pathname == "/"
     end
 
+    test "can send to multiple dashboards by listing multiple domains", %{conn: conn} do
+      params = %{
+        name: "pageview",
+        url: "http://gigride.live/",
+        referrer: "http://m.facebook.com/",
+        domain: "test-domain1.com,test-domain2.com",
+        screen_width: 1440
+      }
+
+      conn =
+        conn
+        |> put_req_header("content-type", "text/plain")
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", Jason.encode!(params))
+
+      assert response(conn, 202) == ""
+      assert get_event("test-domain1.com")
+      assert get_event("test-domain2.com")
+    end
+
     test "www. is stripped from domain", %{conn: conn} do
       params = %{
         name: "custom event",


### PR DESCRIPTION
### Changes

Send stats to multiple dashboards by configuring the `data-domain` as a comma-separated list:

```html
<script async defer data-domain="test1.plausible.io,test2.plausible.io" src="https://plausible.io/js/plausible.js"></script>
```

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
