### PR TITLE
Adds Time on Page metric to Top Pages report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - New parameter `metrics` for the `/api/v1/stats/timeseries` endpoint plausible/analytics#952
 - CSV export now includes pageviews, bounce rate and visit duration in addition to visitors plausible/analytics#952
 - Send stats to multiple dashboards by configuring a comma-separated list of domains plausible/analytics#968
+- Time on Page metric available in detailed Top Pages report plausible/analytics#1007
 
 ### Fixed
 - Fix weekly report time range plausible/analytics#951

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -27,14 +27,8 @@ class PagesModal extends React.Component {
     const detailed = this.showExtra()
     const {query, page, pages} = this.state;
 
-    const {filters} = query
-    if (filters.source || filters.referrer) {
-      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/entry-pages`, query, {limit: 100, page, detailed})
-        .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
-    } else {
-      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, {limit: 100, page, detailed})
-        .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
-    }
+    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, {limit: 100, page, detailed})
+      .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
   }
 
   loadMore() {
@@ -80,11 +74,6 @@ class PagesModal extends React.Component {
     return this.state.query.period === 'realtime' ? 'Current visitors' : 'Visitors'
   }
 
-  title() {
-    const {filters} = this.state.query
-    return (filters.source || filters.referrer) ? 'Entry Pages' : 'Top Pages'
-  }
-
   renderLoading() {
     if (this.state.loading) {
       return <div className="loading my-16 mx-auto"><div></div></div>
@@ -103,7 +92,7 @@ class PagesModal extends React.Component {
     if (this.state.pages) {
       return (
         <React.Fragment>
-          <h1 className="text-xl font-bold dark:text-gray-100">{this.title()}</h1>
+          <h1 className="text-xl font-bold dark:text-gray-100">Top Pages</h1>
 
           <div className="my-4 border-b border-gray-300"></div>
           <main className="modal__content">

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -24,15 +24,15 @@ class PagesModal extends React.Component {
   }
 
   loadPages() {
-    const include = [this.showBounceRate() && 'bounce_rate', this.showTimeOnPage() && 'time_on_page'].filter(i =>i).join(',')
+    const detailed = this.showExtra()
     const {query, page, pages} = this.state;
 
     const {filters} = query
     if (filters.source || filters.referrer) {
-      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/entry-pages`, query, {limit: 100, page, include})
+      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/entry-pages`, query, {limit: 100, page, detailed})
         .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
     } else {
-      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, {limit: 100, page, include})
+      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, {limit: 100, page, detailed})
         .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
     }
   }
@@ -41,11 +41,7 @@ class PagesModal extends React.Component {
     this.setState({loading: true, page: this.state.page + 1}, this.loadPages.bind(this))
   }
 
-  showBounceRate() {
-    return this.state.query.period !== 'realtime' && !this.state.query.filters.goal
-  }
-
-  showTimeOnPage() {
+  showExtra() {
     return this.state.query.period !== 'realtime' && !this.state.query.filters.goal
   }
 
@@ -74,8 +70,8 @@ class PagesModal extends React.Component {
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }
-        {this.showBounceRate() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
-        {this.showTimeOnPage() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td> }
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td> }
       </tr>
     )
   }
@@ -117,8 +113,8 @@ class PagesModal extends React.Component {
                   <th className="p-2 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="left">Page url</th>
                   <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">{ this.label() }</th>
                   {this.showPageviews() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Pageviews</th>}
-                  {this.showBounceRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th>}
-                  {this.showTimeOnPage() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Time on Page</th>}
+                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th>}
+                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Time on Page</th>}
                 </tr>
               </thead>
               <tbody>

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom'
 
 import Modal from './modal'
 import * as api from '../../api'
-import numberFormatter from '../../number-formatter'
+import numberFormatter, {durationFormatter} from '../../number-formatter'
 import {parseQuery} from '../../query'
 
 class PagesModal extends React.Component {
@@ -24,7 +24,7 @@ class PagesModal extends React.Component {
   }
 
   loadPages() {
-    const include = this.showBounceRate() ? 'bounce_rate' : null
+    const include = [this.showBounceRate() && 'bounce_rate', this.showTimeOnPage() && 'time_on_page'].filter(i =>i).join(',')
     const {query, page, pages} = this.state;
 
     const {filters} = query
@@ -45,6 +45,10 @@ class PagesModal extends React.Component {
     return this.state.query.period !== 'realtime' && !this.state.query.filters.goal
   }
 
+  showTimeOnPage() {
+    return this.state.query.period !== 'realtime' && !this.state.query.filters.goal
+  }
+
   showPageviews() {
     const {filters} = this.state.query
     return this.state.query.period !== 'realtime' && !(filters.goal || filters.source || filters.referrer)
@@ -60,6 +64,7 @@ class PagesModal extends React.Component {
 
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
+    const timeOnPage = page['time_on_page'] ? durationFormatter(page['time_on_page']) : '-';
     query.set('page', page.name)
 
     return (
@@ -70,6 +75,7 @@ class PagesModal extends React.Component {
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }
         {this.showBounceRate() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
+        {this.showTimeOnPage() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td> }
       </tr>
     )
   }
@@ -112,6 +118,7 @@ class PagesModal extends React.Component {
                   <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">{ this.label() }</th>
                   {this.showPageviews() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Pageviews</th>}
                   {this.showBounceRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th>}
+                  {this.showTimeOnPage() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Time on Page</th>}
                 </tr>
               </thead>
               <tbody>

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -17,9 +17,9 @@ class ReferrerDrilldownModal extends React.Component {
   }
 
   componentDidMount() {
-    const include = this.showExtra() ? 'bounce_rate,visit_duration' : null
+    const detailed = this.showExtra()
 
-    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/referrers/${this.props.match.params.referrer}`, this.state.query, {limit: 100, include: include})
+    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/referrers/${this.props.match.params.referrer}`, this.state.query, {limit: 100, detailed})
       .then((res) => this.setState({loading: false, referrers: res.referrers, totalVisitors: res.total_visitors}))
   }
 

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -31,8 +31,8 @@ class SourcesModal extends React.Component {
     const {site} = this.props
     const {query, page, sources} = this.state
 
-    const include = this.showExtra() ? 'bounce_rate,visit_duration' : null
-    api.get(`/api/stats/${encodeURIComponent(site.domain)}/${this.currentFilter()}`, query, {limit: 100, page: page, include: include, show_noref: true})
+    const detailed = this.showExtra()
+    api.get(`/api/stats/${encodeURIComponent(site.domain)}/${this.currentFilter()}`, query, {limit: 100, page, detailed, show_noref: true})
       .then((res) => this.setState({loading: false, sources: sources.concat(res), moreResultsAvailable: res.length === 100}))
   }
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -693,7 +693,7 @@ defmodule Plausible.Stats.Clickhouse do
 
   defp page_times_by_page_url(site, query, page_list) do
     q =
-      from(e in base_query(site, query),
+      from(e in base_query_w_sessions(site, %Query{query | filters: Map.delete(query.filters, "page")}),
         select: {
           fragment("? as p", e.pathname),
           fragment("? as t", e.timestamp),

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -631,11 +631,23 @@ defmodule Plausible.Stats.Clickhouse do
       end
 
     if "time_on_page" in include do
-      {:ok, page_times} =
-        page_times_by_page_url(site, query, Enum.map(pages, fn p -> p.name end))
+      {:ok, page_times} = page_times_by_page_url(site, query, Enum.map(pages, fn p -> p.name end))
 
       page_times = page_times.rows |> Enum.map(fn [a, b] -> {a, b} end) |> Enum.into(%{})
-      Enum.map(pages, fn url -> time=page_times[url[:name]];  Map.put(url, :time_on_page, if time do round(time) else nil end) end)
+
+      Enum.map(pages, fn url ->
+        time = page_times[url[:name]]
+
+        Map.put(
+          url,
+          :time_on_page,
+          if time do
+            round(time)
+          else
+            nil
+          end
+        )
+      end)
     else
       pages
     end

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -697,7 +697,7 @@ defmodule Plausible.Stats.Clickhouse do
         FROM (#{base_query_raw}))
       WHERE s=s2 AND p IN tuple(?)
       GROUP BY p,p2,s)
-    GROUP BY p" |> ClickhouseRepo.query(base_query_raw_params ++ [page_list])
+    GROUP BY p" |> ClickhouseRepo.query(base_query_raw_params ++ [page_list ++ ["/"]])
   end
 
   defp add_percentages(stat_list) do

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -693,7 +693,11 @@ defmodule Plausible.Stats.Clickhouse do
 
   defp page_times_by_page_url(site, query, page_list) do
     q =
-      from(e in base_query_w_sessions(site, %Query{query | filters: Map.delete(query.filters, "page")}),
+      from(
+        e in base_query_w_sessions(site, %Query{
+          query
+          | filters: Map.delete(query.filters, "page")
+        }),
         select: {
           fragment("? as p", e.pathname),
           fragment("? as t", e.timestamp),

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -635,7 +635,7 @@ defmodule Plausible.Stats.Clickhouse do
         page_times_by_page_url(site, query, Enum.map(pages, fn p -> p.name end))
 
       page_times = page_times.rows |> Enum.map(fn [a, b] -> {a, b} end) |> Enum.into(%{})
-      Enum.map(pages, fn url -> time=page_times[url[:name]]; if time do Map.put(url, :time_on_page, round(time)) else url end end)
+      Enum.map(pages, fn url -> time=page_times[url[:name]];  Map.put(url, :time_on_page, if time do round(time) else nil end) end)
     else
       pages
     end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -140,7 +140,7 @@ defmodule PlausibleWeb.Api.StatsController do
   def sources(conn, params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include_details = params["detailed"]=="true"
+    include_details = params["detailed"] == "true"
     limit = if params["limit"], do: String.to_integer(params["limit"])
     page = if params["page"], do: String.to_integer(params["page"])
     show_noref = params["show_noref"] == "true"
@@ -203,7 +203,7 @@ defmodule PlausibleWeb.Api.StatsController do
   def referrer_drilldown(conn, %{"referrer" => referrer} = params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include_details = params["detailed"]=="true"
+    include_details = params["detailed"] == "true"
     limit = params["limit"] || 9
 
     referrers = Stats.referrer_drilldown(site, query, referrer, include_details, limit)
@@ -223,7 +223,7 @@ defmodule PlausibleWeb.Api.StatsController do
   def pages(conn, params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include_details = params["detailed"]=="true"
+    include_details = params["detailed"] == "true"
     limit = if params["limit"], do: String.to_integer(params["limit"])
     page = if params["page"], do: String.to_integer(params["page"])
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -140,11 +140,11 @@ defmodule PlausibleWeb.Api.StatsController do
   def sources(conn, params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include = if params["include"], do: String.split(params["include"], ","), else: []
+    include_details = params["detailed"]=="true"
     limit = if params["limit"], do: String.to_integer(params["limit"])
     page = if params["page"], do: String.to_integer(params["page"])
     show_noref = params["show_noref"] == "true"
-    json(conn, Stats.top_sources(site, query, limit || 9, page || 1, show_noref, include))
+    json(conn, Stats.top_sources(site, query, limit || 9, page || 1, show_noref, include_details))
   end
 
   def utm_mediums(conn, params) do
@@ -203,10 +203,10 @@ defmodule PlausibleWeb.Api.StatsController do
   def referrer_drilldown(conn, %{"referrer" => referrer} = params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include = if params["include"], do: String.split(params["include"], ","), else: []
+    include_details = params["detailed"]=="true"
     limit = params["limit"] || 9
 
-    referrers = Stats.referrer_drilldown(site, query, referrer, include, limit)
+    referrers = Stats.referrer_drilldown(site, query, referrer, include_details, limit)
     {_, total_visitors} = Stats.pageviews_and_visitors(site, query)
     json(conn, %{referrers: referrers, total_visitors: total_visitors})
   end
@@ -223,11 +223,11 @@ defmodule PlausibleWeb.Api.StatsController do
   def pages(conn, params) do
     site = conn.assigns[:site]
     query = Query.from(site.timezone, params)
-    include = if params["include"], do: String.split(params["include"], ","), else: []
+    include_details = params["detailed"]=="true"
     limit = if params["limit"], do: String.to_integer(params["limit"])
     page = if params["page"], do: String.to_integer(params["page"])
 
-    json(conn, Stats.top_pages(site, query, limit || 9, page || 1, include))
+    json(conn, Stats.top_pages(site, query, limit || 9, page || 1, include_details))
   end
 
   def entry_pages(conn, params) do

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -51,6 +51,41 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    test "calculates time on page for pages", %{conn: conn, site: site} do
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&include=time_on_page"
+        )
+
+      assert json_response(conn, 200) == [
+               %{
+                 "time_on_page" => 82800,
+                 "count" => 3,
+                 "pageviews" => 3,
+                 "name" => "/"
+               },
+               %{
+                "time_on_page" => nil,
+                 "count" => 2,
+                 "pageviews" => 2,
+                 "name" => "/register"
+               },
+               %{
+                "time_on_page" => nil,
+                "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "/contact"
+               },
+               %{
+                 "time_on_page" => 0,
+                 "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "/irrelevant"
+               }
+             ]
+    end
+
     test "returns top pages in realtime report", %{conn: conn, site: site} do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=realtime")
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -51,41 +51,6 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
-    test "calculates time on page for pages", %{conn: conn, site: site} do
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&include=time_on_page"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "time_on_page" => 82800,
-                 "count" => 3,
-                 "pageviews" => 3,
-                 "name" => "/"
-               },
-               %{
-                 "time_on_page" => nil,
-                 "count" => 2,
-                 "pageviews" => 2,
-                 "name" => "/register"
-               },
-               %{
-                 "time_on_page" => nil,
-                 "count" => 1,
-                 "pageviews" => 1,
-                 "name" => "/contact"
-               },
-               %{
-                 "time_on_page" => 0,
-                 "count" => 1,
-                 "pageviews" => 1,
-                 "name" => "/irrelevant"
-               }
-             ]
-    end
-
     test "returns top pages in realtime report", %{conn: conn, site: site} do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=realtime")
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -66,14 +66,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/"
                },
                %{
-                "time_on_page" => nil,
+                 "time_on_page" => nil,
                  "count" => 2,
                  "pageviews" => 2,
                  "name" => "/register"
                },
                %{
-                "time_on_page" => nil,
-                "count" => 1,
+                 "time_on_page" => nil,
+                 "count" => 1,
                  "pageviews" => 1,
                  "name" => "/contact"
                },

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -51,6 +51,41 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    test "calculates time on page for pages", %{conn: conn, site: site} do
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&include=time_on_page"
+        )
+
+      assert json_response(conn, 200) == [
+               %{
+                 "time_on_page" => 82800,
+                 "count" => 3,
+                 "pageviews" => 3,
+                 "name" => "/"
+               },
+               %{
+                 "time_on_page" => 1,
+                 "count" => 2,
+                 "pageviews" => 2,
+                 "name" => "/register"
+               },
+               %{
+                 "time_on_page" => nil,
+                 "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "/contact"
+               },
+               %{
+                 "time_on_page" => nil,
+                 "count" => 1,
+                 "pageviews" => 1,
+                 "name" => "/irrelevant"
+               }
+             ]
+    end
+
     test "returns top pages in realtime report", %{conn: conn, site: site} do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=realtime")
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -16,69 +16,38 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
-    test "calculates bounce rate for pages", %{conn: conn, site: site} do
+    test "calculates bounce rate and time on page for pages", %{conn: conn, site: site} do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&include=bounce_rate"
+          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&detailed=true"
         )
 
       assert json_response(conn, 200) == [
                %{
+                "time_on_page" => 82800,
                  "bounce_rate" => 33.0,
                  "count" => 3,
                  "pageviews" => 3,
                  "name" => "/"
                },
                %{
+                "time_on_page" => 1,
                  "bounce_rate" => nil,
                  "count" => 2,
                  "pageviews" => 2,
                  "name" => "/register"
                },
                %{
+                "time_on_page" => nil,
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
                  "name" => "/contact"
                },
                %{
+                "time_on_page" => nil,
                  "bounce_rate" => nil,
-                 "count" => 1,
-                 "pageviews" => 1,
-                 "name" => "/irrelevant"
-               }
-             ]
-    end
-
-    test "calculates time on page for pages", %{conn: conn, site: site} do
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/pages?period=day&date=2019-01-01&include=time_on_page"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "time_on_page" => 82800,
-                 "count" => 3,
-                 "pageviews" => 3,
-                 "name" => "/"
-               },
-               %{
-                 "time_on_page" => 1,
-                 "count" => 2,
-                 "pageviews" => 2,
-                 "name" => "/register"
-               },
-               %{
-                 "time_on_page" => nil,
-                 "count" => 1,
-                 "pageviews" => 1,
-                 "name" => "/contact"
-               },
-               %{
-                 "time_on_page" => nil,
                  "count" => 1,
                  "pageviews" => 1,
                  "name" => "/irrelevant"

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -25,28 +25,28 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                "time_on_page" => 82800,
+                 "time_on_page" => 82800,
                  "bounce_rate" => 33.0,
                  "count" => 3,
                  "pageviews" => 3,
                  "name" => "/"
                },
                %{
-                "time_on_page" => 1,
+                 "time_on_page" => 1,
                  "bounce_rate" => nil,
                  "count" => 2,
                  "pageviews" => 2,
                  "name" => "/register"
                },
                %{
-                "time_on_page" => nil,
+                 "time_on_page" => nil,
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,
                  "name" => "/contact"
                },
                %{
-                "time_on_page" => nil,
+                 "time_on_page" => nil,
                  "bounce_rate" => nil,
                  "count" => 1,
                  "pageviews" => 1,

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2019-01-01&include=bounce_rate,visit_duration"
+          "/api/stats/#{site.domain}/sources?period=day&date=2019-01-01&detailed=true"
         )
 
       assert json_response(conn, 200) == [
@@ -143,7 +143,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           conn,
           "/api/stats/#{site.domain}/referrers/10words?period=day&date=2019-01-01&filters=#{
             filters
-          }&include=bounce_rate,visit_duration"
+          }&detailed=true"
         )
 
       assert json_response(conn, 200) == %{

--- a/test/support/clickhouse_setup.ex
+++ b/test/support/clickhouse_setup.ex
@@ -102,7 +102,7 @@ defmodule Plausible.Test.ClickhouseSetup do
         pathname: "/irrelevant",
         domain: "test-site.com",
         session_id: @conversion_1_session_id,
-        timestamp: ~N[2019-01-01 23:00:00]
+        timestamp: ~N[2019-01-01 23:00:01]
       },
       %{
         name: "pageview",


### PR DESCRIPTION
### Changes

Title. 

Couple of things here to discuss though - 

1. Yes, adding this 4th column of data to the Top Pages report isn't great for the already rough mobile UI - but I figured I'd leave that to #972 to resolve instead of me causing unnecessary conflicts
2. Currently I've just set up the naive approach to time on page (where we can't compute the time for the exit page of a session) - but if you want, I could add the better method in the form of a beacon and creating a new type of event, `exit`, such that it won't count as a pageview, and will always end a session. (There is another thing to discuss here on if you think using the visibility change method for ending sessions is appropriate - as this can have false positives with users swapping tabs) lmk what you think. 
3. This query isn't exactly super fast, but I'm not sure if that's just my amount of data vs the speed of my dev environment, so this may need some testing with some of the larger data sets. (I was getting about 1.5ish seconds to load the 100 top pages with time on page for a period with 2M pageviews) 
4. I have a couple of other code-based/style questions, but I'll put those in line-comments

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Screenshots
![image](https://user-images.githubusercontent.com/19434157/117526741-a0069400-af8c-11eb-9e22-34757fb81601.png)
