### PR TITLE
Add :ok return to CleanEmailVerificationCodes

### DIFF
--- a/lib/workers/clean_email_verification_codes.ex
+++ b/lib/workers/clean_email_verification_codes.ex
@@ -11,5 +11,7 @@ defmodule Plausible.Workers.CleanEmailVerificationCodes do
       ),
       set: [user_id: nil]
     )
+
+    :ok
   end
 end


### PR DESCRIPTION
### Changes

Same issue with 64a5b22e8c6ca7e6d1926bd283ffc7b567ff772e.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
