### PR TITLE
Specify clickhouse and postgres versions for local development.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 clickhouse:
-	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse yandex/clickhouse-server
+	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse yandex/clickhouse-server:21.3.2.5
 
 postgres:
-	docker run --detach -e POSTGRES_PASSWORD="postgres" -p 5432:5432 postgres
+	docker run --detach -e POSTGRES_PASSWORD="postgres" -p 5432:5432 postgres:12
 
 dummy_event:
 	curl 'http://localhost:8000/api/event' \


### PR DESCRIPTION
### Changes

This PR solves #1017. The only change is to specify clickhouse and postgres versions for local development in the `Makefile`, bringing it in line with the hosting repo.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
