### PR TITLE
Adds time on page as a top stat when a page filter is active

### DIFF
--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -691,7 +691,7 @@ defmodule Plausible.Stats.Clickhouse do
     |> Enum.into(%{})
   end
 
-  defp page_times_by_page_url(site, query, page_list) do
+  def page_times_by_page_url(site, query, page_list) do
     q =
       from(
         e in base_query_w_sessions(site, %Query{
@@ -725,7 +725,10 @@ defmodule Plausible.Stats.Clickhouse do
         FROM (#{base_query_raw}))
       WHERE s=s2 AND p IN tuple(?)
       GROUP BY p,p2,s)
-    GROUP BY p" |> ClickhouseRepo.query(base_query_raw_params ++ [page_list ++ ["/"]])
+    GROUP BY p"
+    |> ClickhouseRepo.query(
+      base_query_raw_params ++ [(Enum.count(page_list) > 0 && page_list) || ["/"]]
+    )
   end
 
   defp add_percentages(stat_list) do

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -104,6 +104,53 @@ defmodule PlausibleWeb.Api.StatsController do
         }
       end
 
+    time_on_page =
+      if query.filters["page"] do
+        IO.inspect(
+          [{success, duration}, {prev_success, prev_duration}] =
+            Task.yield_many(
+              [
+                Task.async(fn ->
+                  {:ok, page_times} =
+                    Stats.page_times_by_page_url(site, query, [query.filters["page"]])
+
+                  page_times
+                end),
+                Task.async(fn ->
+                  {:ok, page_times} =
+                    Stats.page_times_by_page_url(site, prev_query, [query.filters["page"]])
+
+                  page_times
+                end)
+              ],
+              5000
+            )
+            |> Enum.map(fn {task, response} ->
+              case response do
+                nil ->
+                  Task.shutdown(task, :brutal_kill)
+                  {nil, nil}
+
+                {:ok, page_times} ->
+                  result = Enum.at(page_times.rows, 0)
+                  result = if result, do: Enum.at(result, 1), else: nil
+                  if result, do: {:ok, round(result)}, else: {:ok, 0}
+
+                _ ->
+                  response
+              end
+            end)
+        )
+
+        if success == :ok && prev_success == :ok do
+          %{
+            name: "Time on Page",
+            duration: duration,
+            change: percent_change(prev_duration, duration)
+          }
+        end
+      end
+
     stats =
       [
         %{
@@ -117,7 +164,8 @@ defmodule PlausibleWeb.Api.StatsController do
           change: percent_change(prev_pageviews, pageviews)
         },
         %{name: "Bounce rate", percentage: bounce_rate, change: change_bounce_rate},
-        visit_duration
+        visit_duration,
+        time_on_page
       ]
       |> Enum.filter(& &1)
 


### PR DESCRIPTION
### Changes

As per https://github.com/plausible/analytics/pull/1007#issuecomment-843234020

*Notes*:
- I used the same setup as the bounce+time on page async, but with the current and previous query for the rate of change calculation. 
- In the above setup, I reduced the timeout to 5 seconds in this version, since I figure waiting longer for the top graph just for the one stat is probably not the best UX, so if it takes more than 5 seconds, it'll return the entire graph and all top stats except the time on page (it's just not present). 

### Tests
- [X] This PR does not require tests

### Changelog
It's bundled with regular time on page, nbd

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Screenshots
![image](https://user-images.githubusercontent.com/19434157/118698594-367d5580-b7d6-11eb-89d0-877918202816.png)


