### PR TITLE
Added parameters for Clickhouse flush interval and max buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - CSV export now includes pageviews, bounce rate and visit duration in addition to visitors plausible/analytics#952
 - Send stats to multiple dashboards by configuring a comma-separated list of domains plausible/analytics#968
 - Time on Page metric available in detailed Top Pages report plausible/analytics#1007
+- Added `CLICKHOUSE_FLUSH_INTERVAL_MS` and `CLICKHOUSE_MAX_BUFFER_SIZE` configuration parameters
 
 ### Fixed
 - Fix weekly report time range plausible/analytics#951

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -50,6 +50,9 @@ app_version = System.get_env("APP_VERSION", "0.0.1")
 ch_db_url =
   System.get_env("CLICKHOUSE_DATABASE_URL", "http://plausible_events_db:8123/plausible_events_db")
 
+{ch_flush_interval_ms, ""} = Integer.parse(System.get_env("CLICKHOUSE_FLUSH_INTERVAL_MS", "5000"))
+{ch_max_buffer_size, ""} = Integer.parse(System.get_env("CLICKHOUSE_MAX_BUFFER_SIZE", "10000"))
+
 ### Mandatory params End
 
 sentry_dsn = System.get_env("SENTRY_DSN")
@@ -130,7 +133,9 @@ config :plausible, Plausible.ClickhouseRepo,
   loggers: [Ecto.LogEntry],
   queue_target: 500,
   queue_interval: 2000,
-  url: ch_db_url
+  url: ch_db_url,
+  flush_interval_ms: ch_flush_interval_ms,
+  max_buffer_size: ch_max_buffer_size
 
 case mailer_adapter do
   "Bamboo.PostmarkAdapter" ->


### PR DESCRIPTION
### Changes

Currently, both "flush interval" and "max buffer size" are hard-coded to relatively small values.
This may cause an unnecessarily high load on the Clickhouse instance.
It makes sense to make those configurable.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

Docs haven't been updated, but if you're okay with this PR, I'll open a PR there.