### PR TITLE
Stats API: Support IN filter expression

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -71,9 +71,7 @@ defmodule Plausible.Stats.Breakdown do
   end
 
   defp filter_converted_sessions(db_query, site, query) do
-    event = query.filters["event:name"]
-
-    if is_binary(event) do
+    if query.filters["event:name"] do
       converted_sessions =
         from(e in query_events(site, query),
           select: %{session_id: fragment("DISTINCT ?", e.session_id)}

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -182,9 +182,14 @@ defmodule Plausible.Stats.Query do
   end
 
   defp parse_single_filter(str) do
-    String.trim(str)
-    |> String.split("==")
-    |> Enum.map(&String.trim/1)
-    |> List.to_tuple()
+    [key, val] =
+      String.trim(str)
+      |> String.split("==")
+      |> Enum.map(&String.trim/1)
+
+    case String.split(val, "|") do
+      [single_value] -> {key, {:is, single_value}}
+      list -> {key, {:member, list}}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Plausible.MixProject do
       {:oban, "~> 2.0"},
       {:sshex, "2.2.1"},
       {:geolix, "~> 1.0"},
-      {:clickhouse_ecto, path: "/home/uku/plausible/clickhouse_ecto"},
+      {:clickhouse_ecto, git: "https://github.com/plausible/clickhouse_ecto.git"},
       {:geolix_adapter_mmdb2, "~> 0.5.0"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:cachex, "~> 3.3"},

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Plausible.MixProject do
       {:oban, "~> 2.0"},
       {:sshex, "2.2.1"},
       {:geolix, "~> 1.0"},
-      {:clickhouse_ecto, git: "https://github.com/plausible/clickhouse_ecto.git"},
+      {:clickhouse_ecto, path: "/home/uku/plausible/clickhouse_ecto"},
       {:geolix_adapter_mmdb2, "~> 0.5.0"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:cachex, "~> 3.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "cachex": {:hex, :cachex, "3.3.0", "6f2ebb8f27491fe39121bd207c78badc499214d76c695658b19d6079beeca5c2", [:mix], [{:eternal, "~> 1.2", [hex: :eternal, repo: "hexpm", optional: false]}, {:jumper, "~> 1.0", [hex: :jumper, repo: "hexpm", optional: false]}, {:sleeplocks, "~> 1.1", [hex: :sleeplocks, repo: "hexpm", optional: false]}, {:unsafe, "~> 1.0", [hex: :unsafe, repo: "hexpm", optional: false]}], "hexpm", "d90e5ee1dde14cef33f6b187af4335b88748b72b30c038969176cd4e6ccc31a1"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},
-  "clickhouse_ecto": {:git, "https://github.com/plausible/clickhouse_ecto.git", "1969f14ecef7c357b2bd8bdc3e566234269de58c", []},
+  "clickhouse_ecto": {:git, "https://github.com/plausible/clickhouse_ecto.git", "07adb8da725346e4de6d376069192e9942fe7a5b", []},
   "clickhousex": {:git, "https://github.com/plausible/clickhousex", "0832dd4b1af1f0eba1d1018c231bf0d8d281f031", []},
   "combination": {:hex, :combination, "0.0.3", "746aedca63d833293ec6e835aa1f34974868829b1486b1e1cb0685f0b2ae1f41", [:mix], [], "hexpm", "72b099f463df42ef7dc6371d250c7070b57b6c5902853f69deb894f79eda18ca"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -776,6 +776,175 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                ]
              }
     end
+
+    test "IN filter for event:page", %{conn: conn, site: site} do
+      populate_stats([
+        build(:pageview,
+          pathname: "/ignore",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/important-page",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:page",
+          "filters" => "event:page == /plausible.io|/important-page"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"page" => "/plausible.io", "visitors" => 2},
+                 %{"page" => "/important-page", "visitors" => 1}
+               ]
+             }
+    end
+
+    test "IN filter for visit:browser", %{conn: conn, site: site} do
+      populate_stats([
+        build(:pageview,
+          pathname: "/ignore",
+          browser: "Firefox",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          browser: "Chrome",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          browser: "Safari",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/important-page",
+          browser: "Safari",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:page",
+          "filters" => "visit:browser == Chrome|Safari"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"page" => "/plausible.io", "visitors" => 2},
+                 %{"page" => "/important-page", "visitors" => 1}
+               ]
+             }
+    end
+
+    test "IN filter for visit:entry_page", %{conn: conn, site: site} do
+      populate_stats([
+        build(:pageview,
+          pathname: "/ignore",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/plausible.io",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/important-page",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:page",
+          "filters" => "event:page == /plausible.io|/important-page",
+          "metrics" => "bounce_rate"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"page" => "/plausible.io", "bounce_rate" => 100},
+                 %{"page" => "/important-page", "bounce_rate" => 100}
+               ]
+             }
+    end
+
+    test "IN filter for event:name", %{conn: conn, site: site} do
+      populate_stats([
+        build(:event,
+          name: "Signup",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Signup",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Login",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Irrelevant",
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:name",
+          "filters" => "event:name == Signup|Login"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"name" => "Signup", "visitors" => 2},
+                 %{"name" => "Login", "visitors" => 1}
+               ]
+             }
+    end
   end
 
   describe "pagination" do


### PR DESCRIPTION
### Changes

Adds a new `|` syntax to specify an `IN` or `MEMBER` operator in the API filter expressions. Here's how it looks like:

```
event:page == /plausible.io|/register
```

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### TODO
- [ ] Push changes to `clickhouse_ecto` to make this one work