### PR TITLE
make tzdata dir configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,9 +15,7 @@ end
 base_url = URI.parse(base_url)
 
 if base_url.scheme not in ["http", "https"] do
-  raise "BASE_URL must start with `http` or `https`. Currently configured as `#{
-          System.get_env("BASE_URL")
-        }`"
+  raise "BASE_URL must start with `http` or `https`. Currently configured as `#{System.get_env("BASE_URL")}`"
 end
 
 secret_key_base =
@@ -303,3 +301,5 @@ config :logger, Sentry.LoggerBackend,
   capture_log_messages: true,
   level: :error,
   excluded_domains: []
+
+config :tzdata, :data_dir, System.get_env("TZDATA_DIR", "priv")


### PR DESCRIPTION
### Changes

tzdata will regularly update its data and write the result to a directory.
This will default to the priv directory.
This PR adds a way to configure it.
this enables the whole release to be read only.

### Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [X] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [X] This change does not need a documentation update
