### PR TITLE
Replace "async defer" by "defer" in sniplet for dashboard

### DIFF
--- a/lib/plausible_web/views/site_view.ex
+++ b/lib/plausible_web/views/site_view.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.SiteView do
       end
 
     """
-    <script async defer data-domain="#{site.domain}" src="#{tracker}"></script>
+    <script defer data-domain="#{site.domain}" src="#{tracker}"></script>
     """
   end
 end


### PR DESCRIPTION
### Changes

Replace `async defer` by `defer` in sniplet from dashboard.

There is 

### Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [X] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update
