### PR TITLE
feat: add plausible_config and allowLocalhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
   `DATABASE_SOCKET_DIR` & `DATABASE_NAME` were added.
 - Time on Page metric available in detailed Top Pages report plausible/analytics#1007
 - Added `CLICKHOUSE_FLUSH_INTERVAL_MS` and `CLICKHOUSE_MAX_BUFFER_SIZE` configuration parameters
+- Added `plausible_config` event to save global options
+- Added `allowLocalhost` option to let plausible send localhost event in certain conditions
 
 ### Fixed
 - Fix weekly report time range plausible/analytics#951

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -17,7 +17,10 @@
   }
 
   function trigger(eventName, options) {
-    if (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
+    if (eventName === 'plausible_config') window.localStorage.plausible_config = JSON.stringify(options); return;
+    options = Object.assign(JSON.parse(window.localStorage.plausible_config || {}), options)
+    var allowLocalhost = options && options.allowLocalhost;
+    if (!allowLocalhost && (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(location.hostname) || location.protocol === 'file:')) return warn('localhost');
     if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;
     if (plausible_ignore=="true") return warn('localStorage flag')
     {{#if exclusions}}


### PR DESCRIPTION
The goal of this PR to allow users to send from localhost, In case needed, like in Cordova apps or Capacitor
Do to so, I had to add a plausible_config system is to save config across calls. 

I choose to implement it as `allowLocalhost` instead of @metmarkosaric suggestion `debug`, whitch is less opinionated, and define better what it does.

### Changes

I added plausible_config in window local storage, you can set it with `plausible('plausible_config', {allowLocalhost: true})`
Then each call to plausible will get data from locastorage and merge it with given options.
given options will override plausible_config.

Check the doc here: https://github.com/plausible/docs/pull/103

### Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

### Changelog
- [X ] Entry has been added to changelog
- [X] This PR does not make a user-facing change

### Documentation
- [ X] [Docs](https://github.com/plausible/docs) have been updated 
- [ ] This change does not need a documentation update
