### PR TITLE
Turn off form autocompletion for new shared links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - UI fix for details button overlapping content on mobile plausible/analytics#1114
 - UI fix for the main graph on mobile overlapping its tick items on both axis
 - UI fixes for text not showing properly in bars across multiple lines. This hides the totals on <768px and only shows the uniques and % to accommodate the goals text too.
+- Turn off autocomplete for name and password inputs in the _New shared link_ form.
 
 ### Removed
 - Removes AppSignal monitoring package

--- a/lib/plausible_web/templates/site/new_shared_link.html.eex
+++ b/lib/plausible_web/templates/site/new_shared_link.html.eex
@@ -5,14 +5,14 @@
   <div class="my-4">
     <%= label f, :name, "Name", class: "block text-sm font-medium text-gray-700 dark:text-gray-100" %>
     <div class="mt-1">
-      <%= text_input f, :name, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md", required: "required" %>
+      <%= text_input f, :name, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md", required: "required", autocomplete: "off" %>
       <%= error_tag f, :name %>
     </div>
   </div>
   <div class="my-4">
     <%= label f, :password, "Password (optional)", class: "block text-sm font-medium text-gray-700 dark:text-gray-100" %>
     <div class="mt-1">
-      <%= password_input f, :password, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md" %>
+      <%= password_input f, :password, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md", autocomplete: "off" %>
       <%= error_tag f, :password %>
       <p class="mt-2 text-sm text-gray-500">
         Password protection is optional. Please make sure you save it in a secure place. Once the link is created, we cannot reveal the password.


### PR DESCRIPTION
Many browsers autofill input fields based on their name, but here it makes no sense to use the user's `name` (email) or even `password` for the shared link.

### Changes

Turns off form autocompletion for `name` and `password` in the _New shared link_ form.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
