### PR TITLE
Fix shell scripts

### DIFF
--- a/.gitlab/build-scripts/docker-entrypoint.sh
+++ b/.gitlab/build-scripts/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-if [[ "$1" = 'run' ]]; then
+if [ "$1" = 'run' ]; then
       exec /app/bin/plausible start
 
-elif [[ "$1" = 'db' ]]; then
+elif [ "$1" = 'db' ]; then
       exec /app/"$2".sh
  else
       exec "$@"

--- a/.gitlab/build-scripts/docker.gitlab.sh
+++ b/.gitlab/build-scripts/docker.gitlab.sh
@@ -23,10 +23,10 @@ function docker_build_image() {
 
     /kaniko/executor \
       --cache=true \
-      --context ${CI_PROJECT_DIR} \
-      --dockerfile ${CI_PROJECT_DIR}/Dockerfile \
-      --destination ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}  \
-      --destination ${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}-latest  \
+      --context "${CI_PROJECT_DIR}" \
+      --dockerfile "${CI_PROJECT_DIR}"/Dockerfile \
+      --destination "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"  \
+      --destination "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}-latest"  \
       \
       "$@"
 

--- a/rel/overlays/createdb.sh
+++ b/rel/overlays/createdb.sh
@@ -2,6 +2,6 @@
 # Creates the database if needed
 
 
-BIN_DIR=`dirname "$0"`
+BIN_DIR=$(dirname "$0")
 
-${BIN_DIR}/bin/plausible eval Plausible.Release.createdb
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.createdb

--- a/rel/overlays/init-admin.sh
+++ b/rel/overlays/init-admin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Create an admin user
 
-BIN_DIR=`dirname "$0"`
+BIN_DIR=$(dirname "$0")
 
-${BIN_DIR}/bin/plausible eval Plausible.Release.init_admin
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.init_admin

--- a/rel/overlays/migrate.sh
+++ b/rel/overlays/migrate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # starts the db migration
 
-BIN_DIR=`dirname "$0"`
+BIN_DIR=$(dirname "$0")
 
-${BIN_DIR}/bin/plausible eval Plausible.Release.migrate
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.migrate

--- a/rel/overlays/rollback.sh
+++ b/rel/overlays/rollback.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-BIN_DIR=`dirname "$0"`
+BIN_DIR=$(dirname "$0")
 
-${BIN_DIR}/bin/plausible eval Plausible.Release.rollback
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.rollback

--- a/rel/overlays/seed.sh
+++ b/rel/overlays/seed.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-BIN_DIR=`dirname "$0"`
+BIN_DIR=$(dirname "$0")
 
-${BIN_DIR}/bin/plausible eval Plausible.Release.seed
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.seed


### PR DESCRIPTION
### Changes

There were various mistakes in the shell scripts, such as lack of quoting; they would break them immediately e.g. if `BIN_DIR` contained a space.

Pointed out by [`shellcheck`](https://www.shellcheck.net/).

### Tests

- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog

- [x] This PR does not make a user-facing change

### Documentation

- [x] This change does not need a documentation update
