### PR TITLE
Fix IPv6 localhost detection in tracker script

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -33,7 +33,7 @@
 
 
   function trigger(eventName, options) {
-    if (/^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
+    if (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
     if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;
     if (plausible_ignore=="true") return warn('localStorage flag')
     {{#if exclusions}}


### PR DESCRIPTION
### Motivation

The tracker script has logic that disables itself for localhost addresses, and seems to want to handle literal IPv6 addresses but does not do so correctly.

This the default for a few development setups, see for instance: https://github.com/shellscape/webpack-plugin-serve#usage

Spec of literals in urls: https://datatracker.ietf.org/doc/html/rfc2732

Behaviour of literals in practice in javascript:
```js
> new URL('http://[::]:55555').hostname
'[::]'
> new URL('http://[0:0:0:0:0:0:0:1]').hostname
'[::1]'
> new URL('http://[::0000:0000]').hostname
'[::]'
```
Tested with current LTS node and in Firefox and Chromium. The browsers also redirect when a url in typed in the location bar.


### Changes

IPv6 literals in url hostnames follow RFC 2732 so are enclosed in brackets.

Browsers normalise so matching zeros is not required.

Allow `::` unspecified address as well as `::1`  loopback address.

Non-capturing groups not required when using `/.../.test()` method.

### Tests

Ideally would have some, there don't seem to be any for the tracker script?

### Changelog

Maybe needs an entry? You tell me.

### Documentation

This change does not need a documentation update.
