### PR TITLE
feat: add variant local

### DIFF
--- a/lib/plausible_web/plugs/tracker.ex
+++ b/lib/plausible_web/plugs/tracker.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Tracker do
   use Agent
 
   custom_script_name = Application.get_env(:plausible, :custom_script_name)
-  base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-local"]
+  base_variants = ["hash", "outbound-links", "exclusions", "compat", "local"]
   base_filenames = ["plausible", custom_script_name]
 
   # Generates Power Set of all variants

--- a/lib/plausible_web/plugs/tracker.ex
+++ b/lib/plausible_web/plugs/tracker.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Tracker do
   use Agent
 
   custom_script_name = Application.get_env(:plausible, :custom_script_name)
-  base_variants = ["hash", "outbound-links", "exclusions", "compat"]
+  base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-localhost"]
   base_filenames = ["plausible", custom_script_name]
 
   # Generates Power Set of all variants

--- a/lib/plausible_web/plugs/tracker.ex
+++ b/lib/plausible_web/plugs/tracker.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Tracker do
   use Agent
 
   custom_script_name = Application.get_env(:plausible, :custom_script_name)
-  base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-localhost"]
+  base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-local"]
   base_filenames = ["plausible", custom_script_name]
 
   # Generates Power Set of all variants

--- a/tracker/compile.js
+++ b/tracker/compile.js
@@ -16,7 +16,7 @@ function compilefile(input, output, templateVars = {}) {
   fs.writeFileSync(output, result.code)
 }
 
-const base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-local"]
+const base_variants = ["hash", "outbound-links", "exclusions", "compat", "local"]
 const variants = [...g.clone.powerSet(base_variants)].filter(a => a.length > 0).map(a => a.sort());
 
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.js'))

--- a/tracker/compile.js
+++ b/tracker/compile.js
@@ -16,7 +16,7 @@ function compilefile(input, output, templateVars = {}) {
   fs.writeFileSync(output, result.code)
 }
 
-const base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-localhost"]
+const base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-local"]
 const variants = [...g.clone.powerSet(base_variants)].filter(a => a.length > 0).map(a => a.sort());
 
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.js'))

--- a/tracker/compile.js
+++ b/tracker/compile.js
@@ -16,7 +16,7 @@ function compilefile(input, output, templateVars = {}) {
   fs.writeFileSync(output, result.code)
 }
 
-const base_variants = ["hash", "outbound-links", "exclusions", "compat"]
+const base_variants = ["hash", "outbound-links", "exclusions", "compat", "allow-localhost"]
 const variants = [...g.clone.powerSet(base_variants)].filter(a => a.length > 0).map(a => a.sort());
 
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.js'))

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -33,7 +33,7 @@
 
 
   function trigger(eventName, options) {
-    {{#if !allow_localhost}}
+    {{#if !allow_local}}
     if (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
     {{/if}}
     if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -33,7 +33,9 @@
 
 
   function trigger(eventName, options) {
+    {{#if !allow_localhost}}
     if (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
+    {{/if}}
     if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;
     if (plausible_ignore=="true") return warn('localStorage flag')
     {{#if exclusions}}

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -33,7 +33,7 @@
 
 
   function trigger(eventName, options) {
-    {{#if !allow_local}}
+    {{#if !local}}
     if (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(location.hostname) || location.protocol === 'file:') return warn('localhost');
     {{/if}}
     if (window.phantom || window._phantom || window.__nightmare || window.navigator.webdriver || window.Cypress) return;


### PR DESCRIPTION
The goal of this PR is to allow users to send analytics from localhost.

In cases like Cordova apps or Capacitor, it's needed.

I added a new variant of plausible.js

I choose to implement it as `allow_local` instead of @metmarkosaric suggestion `debug`, whitch is less opinionated, and define better what it does.

### Changes

I added handlebar variable `allow_local` to `plausible.js`.
Then I updated builder script as mentioned here : 
https://github.com/plausible/analytics/pull/1125#issuecomment-860290491

Check the doc here: https://github.com/plausible/docs/pull/114

### Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

### Changelog
- [X ] Entry has been added to changelog
- [X] This PR does not make a user-facing change

### Documentation
- [ X] [Docs](https://github.com/plausible/docs) have been updated 
- [ ] This change does not need a documentation update
