### PR TITLE
Fixes page names truncate in pages modal in dashboard

### DIFF
--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -60,7 +60,7 @@ class PagesModal extends React.Component {
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
         <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
+          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline block truncate">{page.name}</Link>
         </td>
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.count)}</td>
         {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }


### PR DESCRIPTION
### Changes

This change fixes content overflow in pages modal in dashboard

Based on this code example:
https://github.com/plausible/analytics/blob/f179b253b43dc199871609b4eaebe7bbacf3237a/assets/js/dashboard/stats/pages/entry-pages.js#L50-L55

Visualized difference: 

#### Before: 

![image](https://user-images.githubusercontent.com/11247988/130852711-88e6da06-6011-44c5-8f23-4fe1c93c23a7.png)

#### After:

![image](https://user-images.githubusercontent.com/11247988/130852788-6a4a3700-7b95-43b3-ac99-d301b39d356e.png)


### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update
