### PR TITLE
Fix reading config from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - UI fixes for text not showing properly in bars across multiple lines. This hides the totals on <768px and only shows the uniques and % to accommodate the goals text too. Larger screens still truncate as usual.
 - Turn off autocomplete for name and password inputs in the _New shared link_ form.
 - Details modals are now responsive and take up less horizontal space on smaller screens to make it easier to scroll.
+- Fix reading config from file
 
 ### Removed
 - Removes AppSignal monitoring package

--- a/lib/plausible/helpers/config.ex
+++ b/lib/plausible/helpers/config.ex
@@ -3,7 +3,7 @@ defmodule Plausible.ConfigHelpers do
     var_path = Path.join(config_dir, var_name)
 
     if File.exists?(var_path) do
-      File.read(var_path)
+      File.read!(var_path)
     else
       System.get_env(var_name, default)
     end


### PR DESCRIPTION
### Changes

This change fixes an error I'm experiencing when using secret files (instead of ENV vars) for config. 

- Here's a related discussion: https://github.com/plausible/analytics/discussions/1311
- Here's where I discovered a potential fix: https://github.com/plausible/analytics/issues/1105#issuecomment-915813670

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update
