### PR TITLE
Prevent leaving apk cache in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM alpine:3.13.3
 LABEL maintainer="tckb <tckb@tgrthi.me>"
 ENV LANG=C.UTF-8
 
-RUN apk update && apk upgrade
+RUN apk upgrade --no-cache
 
 RUN apk add --no-cache openssl ncurses libstdc++ libgcc
 


### PR DESCRIPTION
### Changes

Use `--no-cache` with `apk upgrade` instead of additional `apk update`, kind of best practice for the Docker image to be released.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests (A simple Docker image build will be good enough to test the change)

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
