### PR TITLE
Don't enforce longer SECRET_KEY_BASE than Phoenix

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,8 +28,8 @@ case secret_key_base do
   nil ->
     raise "SECRET_KEY_BASE configuration option is required. See https://plausible.io/docs/self-hosting-configuration#server"
 
-  key when byte_size(key) < 64 ->
-    raise "SECRET_KEY_BASE must be at least 64 bytes long. See https://plausible.io/docs/self-hosting-configuration#server"
+  key when byte_size(key) < 32 ->
+    raise "SECRET_KEY_BASE must be at least 32 bytes long. See https://plausible.io/docs/self-hosting-configuration#server"
 
   _ ->
     nil


### PR DESCRIPTION
Phoenix only requires SECRET_KEY_BASE to be longer than 32 characters. 32 characters even with hex encoding is 128 bits of entropy which is more than enough. Some secret generation tools only generate 32 characters/128 bits by default which makes this relatively arbitrary limit annoying. Let's change it to what Phoenix requires.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
