### PR TITLE
Fix conversions metrics

### DIFF
--- a/assets/js/dashboard/stats/conversions/index.js
+++ b/assets/js/dashboard/stats/conversions/index.js
@@ -79,16 +79,17 @@ export default class Conversions extends React.Component {
       <div className="my-2 text-sm" key={goal.name}>
         <div className="flex items-center justify-between my-2">
           <Bar
-            count={goal.visitors}
+            count={goal.unique_conversions}
             all={this.state.goals}
             bg="bg-red-50 dark:bg-gray-500 dark:bg-opacity-15"
             maxWidthDeduction={this.getBarMaxWidth()}
+            plot="unique_conversions"
           >
             {this.renderGoalText(goal.name)}
           </Bar>
           <div className="dark:text-gray-200">
-            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.visitors)}</span>
-            {viewport > MOBILE_UPPER_WIDTH && <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.total_count)}</span>}
+            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.unique_conversions)}</span>
+            {viewport > MOBILE_UPPER_WIDTH && <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.total_conversions)}</span>}
             <span className="inline-block w-20 font-medium text-right">{goal.conversion_rate}%</span>
           </div>
         </div>

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -580,13 +580,13 @@ defmodule PlausibleWeb.Api.StatsController do
       Stats.breakdown(site, query, "event:goal", ["visitors", "events"], {100, 1})
       |> transform_keys(%{
         "goal" => "name",
-        "count" => "unique_conversions",
+        "visitors" => "unique_conversions",
         "events" => "total_conversions"
       })
       |> Enum.map(fn goal ->
         goal
         |> Map.put(:prop_names, prop_names[goal["name"]])
-        |> Map.put(:conversion_rate, calculate_cr(total_visitors, goal["visitors"]))
+        |> Map.put(:conversion_rate, calculate_cr(total_visitors, goal["unique_conversions"]))
       end)
 
     if params["csv"] do

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -35,14 +35,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "visitors" => 2,
+                 "unique_conversions" => 2,
                  "total_conversions" => 3,
                  "prop_names" => nil,
                  "conversion_rate" => 50
                },
                %{
                  "name" => "Visit /register",
-                 "visitors" => 2,
+                 "unique_conversions" => 2,
                  "total_conversions" => 2,
                  "prop_names" => nil,
                  "conversion_rate" => 50
@@ -78,7 +78,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "visitors" => 2,
+                 "unique_conversions" => 2,
                  "total_conversions" => 2,
                  "prop_names" => ["variant"],
                  "conversion_rate" => 50
@@ -215,56 +215,56 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "conversion_rate" => 100.0,
-                 "visitors" => 8,
+                 "unique_conversions" => 8,
                  "name" => "Visit /**",
                  "total_conversions" => 8,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 37.5,
-                 "visitors" => 3,
+                 "unique_conversions" => 3,
                  "name" => "Visit /*",
                  "total_conversions" => 3,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 37.5,
-                 "visitors" => 3,
+                 "unique_conversions" => 3,
                  "name" => "Visit /signup/**",
                  "total_conversions" => 3,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 25.0,
-                 "visitors" => 2,
+                 "unique_conversions" => 2,
                  "name" => "Visit /billing**/success",
                  "total_conversions" => 2,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 25.0,
-                 "visitors" => 2,
+                 "unique_conversions" => 2,
                  "name" => "Visit /reg*",
                  "total_conversions" => 2,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 12.5,
-                 "visitors" => 1,
+                 "unique_conversions" => 1,
                  "name" => "Visit /billing*/success",
                  "total_conversions" => 1,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 12.5,
-                 "visitors" => 1,
+                 "unique_conversions" => 1,
                  "name" => "Visit /register",
                  "total_conversions" => 1,
                  "prop_names" => nil
                },
                %{
                  "conversion_rate" => 12.5,
-                 "visitors" => 1,
+                 "unique_conversions" => 1,
                  "name" => "Visit /signup/*",
                  "total_conversions" => 1,
                  "prop_names" => nil


### PR DESCRIPTION
f576fa2 should have updated the conversion metric names so that
`unique_conversions` and `total_conversions` are the two metrics
returned by the conversions API. This updates those so that the CSV
export outputs the correct data.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update
