### PR TITLE
Add cities and regions to exported CSV data

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -74,6 +74,8 @@ defmodule PlausibleWeb.StatsController do
       {'entry_pages.csv', fn -> Api.StatsController.entry_pages(conn, params) end},
       {'exit_pages.csv', fn -> Api.StatsController.exit_pages(conn, limited_params) end},
       {'countries.csv', fn -> Api.StatsController.countries(conn, params) end},
+      {'regions.csv', fn -> Api.StatsController.regions(conn, params) end},
+      {'cities.csv', fn -> Api.StatsController.cities(conn, params) end},
       {'browsers.csv', fn -> Api.StatsController.browsers(conn, params) end},
       {'operating_systems.csv', fn -> Api.StatsController.operating_systems(conn, params) end},
       {'devices.csv', fn -> Api.StatsController.screen_sizes(conn, params) end},

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/cities.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/cities.csv
@@ -1,0 +1,1 @@
+name,conversions,conversion_rate

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/regions.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/regions.csv
@@ -1,0 +1,1 @@
+name,conversions,conversion_rate

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/cities.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/cities.csv
@@ -1,0 +1,2 @@
+name,visitors
+Tallinn,1

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/regions.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/regions.csv
@@ -1,0 +1,2 @@
+name,visitors
+Harjumaa,1

--- a/test/plausible_web/controllers/CSVs/30d/cities.csv
+++ b/test/plausible_web/controllers/CSVs/30d/cities.csv
@@ -1,0 +1,2 @@
+name,visitors
+Tallinn,1

--- a/test/plausible_web/controllers/CSVs/30d/regions.csv
+++ b/test/plausible_web/controllers/CSVs/30d/regions.csv
@@ -1,0 +1,2 @@
+name,visitors
+Harjumaa,1

--- a/test/plausible_web/controllers/CSVs/6m/cities.csv
+++ b/test/plausible_web/controllers/CSVs/6m/cities.csv
@@ -1,0 +1,2 @@
+name,visitors
+Tallinn,1

--- a/test/plausible_web/controllers/CSVs/6m/regions.csv
+++ b/test/plausible_web/controllers/CSVs/6m/regions.csv
@@ -1,0 +1,2 @@
+name,visitors
+Harjumaa,1

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -111,6 +111,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     populate_stats(site, [
       build(:pageview,
         country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
         pathname: "/",
         timestamp: Timex.shift(~N[2021-10-20 12:00:00], minutes: -1),
         referrer_source: "Google",
@@ -118,6 +120,8 @@ defmodule PlausibleWeb.StatsControllerTest do
       ),
       build(:pageview,
         country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
         pathname: "/some-other-page",
         timestamp: Timex.shift(~N[2021-10-20 12:00:00], minutes: -2),
         referrer_source: "Google",


### PR DESCRIPTION
### Changes

This includes the cities and regions data supported by #1449 in the CSV export.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog - not really needed if it's implied by #1449

### Documentation
- [x] This change does not need a documentation update
