### PR TITLE
Traffic spike docs link in Site Settings leads to the wrong docs page

### DIFF
--- a/lib/plausible_web/templates/site/settings_email_reports.html.eex
+++ b/lib/plausible_web/templates/site/settings_email_reports.html.eex
@@ -2,7 +2,7 @@
   <header class="relative">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Email reports</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Send weekly/monthly analytics reports to as many addresses as you wish</p>
-    <%= link(to: "https://docs.plausible.io/email-reports/", target: "_blank", rel: "noferrer") do %>
+    <%= link(to: "https://plausible.io/docs/email-reports", target: "_blank", rel: "noferrer") do %>
       <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>
@@ -114,7 +114,7 @@
   <header class="relative">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Traffic spike notifications</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Get notified when your site has unusually high number of current visitors</p>
-    <%= link(to: "https://docs.plausible.io/email-reports/", target: "_blank", rel: "noreferrer") do %>
+    <%= link(to: "https://plausible.io/docs/traffic-spikes", target: "_blank", rel: "noreferrer") do %>
       <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>


### PR DESCRIPTION
In "Email Reports" in Site Settings, the little "i" icon for "Traffic spike notifications" leads to https://docs.plausible.io/email-reports/ rather than to https://plausible.io/docs/traffic-spikes. Someone reported on Twitter so I thought I may be able to fix it myself! :)