### PR TITLE
UI fix: footer alignment on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - Region and city-level geolocation plausible/analytics#1449
 - The `u` option can now be used in the `manual` extension to specify a URL when triggering events.
 
+### Fixed
+
+- UI fix to align footer columns
+
 ## v1.4.1
 
 ### Fixed

--- a/lib/plausible_web/templates/layout/_footer.html.eex
+++ b/lib/plausible_web/templates/layout/_footer.html.eex
@@ -51,7 +51,7 @@
               </li>
             </ul>
           </div>
-          <div class="mt-12 md:mt-0">
+          <div class="mt-32 md:mt-0">
             <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Comparisons
             </h4>
@@ -68,10 +68,9 @@
               </li>
             </ul>
           </div>
-
         </div>
         <div class="md:grid md:grid-cols-2 md:gap-8">
-          <div class="mt-12 md:mt-0">
+          <div>
             <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Community
             </h4>
@@ -108,7 +107,7 @@
               </li>
             </ul>
           </div>
-          <div>
+          <div class="mt-12 md:mt-0">
             <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Company
             </h4>


### PR DESCRIPTION
### Changes

This fixes the issue raised in https://github.com/plausible/analytics/issues/1272, specifically:

> footer menus need to be aligned properly

I have opted for a bit of a hacky approach as far as the alignment for the "Comparisons" column goes (`mt-32`). If that is unwarranted, let me know please.

#### Tested with

- Firefox 94
- Edge 96
- Chromium 96

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update
