### PR TITLE
Upgrade the GitHub Actions runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
 
     services:
       postgres:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2004
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Changes
Use BuildJet 4vCPU runners instead of the GitHub's built in. Should make all jobs go faster. 

Note: The CI jobs will fail until an admin authorizes BuildJet to be able to “install” the runners to the repo. This can be done in http://app.buildjet.com/onboarding

Thanks!

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update
