### PR TITLE
Add "events" metric to public breakdown endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - API route `PUT /api/v1/sites/goals` with form params `site_id`, `event_name` and/or `page_path`, and `goal_type` with supported types `event` and `page`
 - API route `DELETE /api/v1/sites/goals/:goal_id` with form params `site_id`
+- The public breakdown endpoint can be queried with the "events" metric
 
 ### Added
 - Data exported via the download button will contain CSV data for all visible graps in a zip file.

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -88,7 +88,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   defp event_only_property?("event:props:" <> _), do: true
   defp event_only_property?(_), do: false
 
-  @event_metrics ["visitors", "pageviews"]
+  @event_metrics ["visitors", "pageviews", "events"]
   @session_metrics ["visits", "bounce_rate", "visit_duration"]
   defp parse_metrics(params, property, query) do
     metrics =


### PR DESCRIPTION
### Changes

Add "events" metric to public breakdown endpoint

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated
