### PR TITLE
Add public events endpoint to retrieve all defined goals with their properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - API route `PUT /api/v1/sites/goals` with form params `site_id`, `event_name` and/or `page_path`, and `goal_type` with supported types `event` and `page`
 - API route `DELETE /api/v1/sites/goals/:goal_id` with form params `site_id`
 - The public breakdown endpoint can be queried with the "events" metric
+- Add new endpoint `/api/v1/events` to retrieve all defined goals/events with their properties
+- Add new endpoint `/api/v1/events/:event_id/properties` to retrieve all properties for a single goal/event
 
 ### Added
 - Data exported via the download button will contain CSV data for all visible graps in a zip file.

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Auth.ApiKey do
   @optional [:key, :scopes, :hourly_request_limit]
   schema "api_keys" do
     field :name, :string
-    field :scopes, {:array, :string}, default: ["stats:read:*"]
+    field :scopes, {:array, :string}, default: ["stats:read:*", "events:read:*"]
     field :hourly_request_limit, :integer, default: 600
 
     field :key, :string, virtual: true

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -30,7 +30,13 @@ defmodule Plausible.Auth.ApiKeyAdmin do
       key: %{create: :readonly, update: :hidden, help_text: @plaintext_key_help},
       key_prefix: %{create: :hidden, update: :readonly},
       hourly_request_limit: %{default: 1000},
-      scope: %{choices: [{"Stats API", ["stats:read:*"]}, {"Sites API", ["sites:provision:*"]}]},
+      scope: %{
+        choices: [
+          {"Stats API", ["stats:read:*"]},
+          {"Events API", ["events:read:*"]},
+          {"Sites API", ["sites:provision:*"]}
+        ]
+      },
       user_id: nil
     ]
   end

--- a/lib/plausible/event/props.ex
+++ b/lib/plausible/event/props.ex
@@ -1,0 +1,42 @@
+defmodule Plausible.Event.Props do
+  use Plausible.Repo
+  use Plausible.ClickhouseRepo
+
+  def props(site) do
+    Repo.all(from g in Plausible.Goal, where: g.domain == ^site.domain)
+    |> Enum.map(fn evt ->
+      %{
+        id: evt.id,
+        name: if(evt.event_name, do: evt.event_name, else: "Visit #{evt.page_path}"),
+        event_type: if(evt.event_name, do: "custom", else: "pageview"),
+        props: properties_for_event(site, evt.event_name)
+      }
+    end)
+  end
+
+  def props(site, event_name) do
+    properties_for_event(site, event_name)
+  end
+
+  def properties_for_event(site, event_name) do
+    q =
+      from(
+        e in "events",
+        inner_lateral_join: meta in fragment("meta as m"),
+        select: meta.key,
+        distinct: true,
+        where: e.domain == ^site.domain
+      )
+
+    q =
+      case event_name do
+        nil ->
+          from(e in q, where: is_nil(e.name))
+
+        _ ->
+          from(e in q, where: e.name == ^event_name)
+      end
+
+    Enum.map(ClickhouseRepo.all(q), fn x -> x end)
+  end
+end

--- a/lib/plausible_web/controllers/api/external_events_controller.ex
+++ b/lib/plausible_web/controllers/api/external_events_controller.ex
@@ -1,0 +1,43 @@
+defmodule PlausibleWeb.Api.ExternalEventsController do
+  use PlausibleWeb, :controller
+  use Plausible.Repo
+  use Plug.ErrorHandler
+  alias PlausibleWeb.Api.Helpers, as: H
+  alias Plausible.Event.Props, as: EventProps
+
+  def list(conn, _params) do
+    site = conn.assigns[:site]
+    json(conn, EventProps.props(site))
+  end
+
+  def properties(conn, params) do
+    site = conn.assigns[:site]
+
+    with {:ok, event_id} <- expect_param_key(params, "event_id") do
+      event = Repo.get_by(Plausible.Goal, id: event_id, domain: site.domain)
+
+      if event do
+        json(conn, EventProps.props(site, event.event_name))
+      else
+        H.not_found(conn, "Event could not be found")
+      end
+    else
+      {:missing, "event_id"} ->
+        H.bad_request(conn, "Parameter `event_id` is required")
+
+      e ->
+        H.bad_request(conn, "Something went wrong: #{inspect(e)}")
+    end
+  end
+
+  defp expect_param_key(params, key) do
+    case Map.fetch(params, key) do
+      :error -> {:missing, key}
+      res -> res
+    end
+  end
+
+  def handle_errors(conn, %{kind: kind, reason: reason}) do
+    json(conn, %{error: Exception.format_banner(kind, reason)})
+  end
+end

--- a/lib/plausible_web/controllers/api/external_events_controller.ex
+++ b/lib/plausible_web/controllers/api/external_events_controller.ex
@@ -7,7 +7,7 @@ defmodule PlausibleWeb.Api.ExternalEventsController do
 
   def list(conn, _params) do
     site = conn.assigns[:site]
-    json(conn, EventProps.props(site))
+    json(conn, %{"results" => EventProps.props(site)})
   end
 
   def properties(conn, params) do
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.Api.ExternalEventsController do
       event = Repo.get_by(Plausible.Goal, id: event_id, domain: site.domain)
 
       if event do
-        json(conn, EventProps.props(site, event.event_name))
+        json(conn, %{"results" => EventProps.props(site, event.event_name)})
       else
         H.not_found(conn, "Event could not be found")
       end

--- a/lib/plausible_web/plugs/authorize_events_api.ex
+++ b/lib/plausible_web/plugs/authorize_events_api.ex
@@ -1,0 +1,93 @@
+defmodule PlausibleWeb.AuthorizeEventsApiPlug do
+  import Plug.Conn
+  use Plausible.Repo
+  alias Plausible.Auth.ApiKey
+  alias PlausibleWeb.Api.Helpers, as: H
+
+  def init(options) do
+    options
+  end
+
+  def call(conn, _opts) do
+    with {:ok, token} <- get_bearer_token(conn),
+         {:ok, api_key} <- find_api_key(token),
+         :ok <- check_api_key_rate_limit(api_key),
+         {:ok, site} <- verify_access(api_key, conn.params["site_id"]) do
+      assign(conn, :site, site)
+    else
+      {:error, :missing_api_key} ->
+        H.unauthorized(
+          conn,
+          "Missing API key. Please use a valid Plausible API key as a Bearer Token."
+        )
+
+      {:error, :missing_site_id} ->
+        H.bad_request(
+          conn,
+          "Missing site ID. Please provide the required site_id parameter with your request."
+        )
+
+      {:error, :rate_limit, limit} ->
+        H.too_many_requests(
+          conn,
+          "Too many API requests. Your API key is limited to #{limit} requests per hour."
+        )
+
+      {:error, :invalid_api_key} ->
+        H.unauthorized(
+          conn,
+          "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+        )
+    end
+  end
+
+  defp verify_access(_api_key, nil), do: {:error, :missing_site_id}
+
+  defp verify_access(api_key, site_id) do
+    site = Repo.get_by(Plausible.Site, domain: site_id)
+    is_member = site && Plausible.Sites.is_member?(api_key.user_id, site)
+    is_admin = api_key.user_id in admin_user_ids()
+
+    cond do
+      site && is_member -> {:ok, site}
+      site && is_admin -> {:ok, site}
+      true -> {:error, :invalid_api_key}
+    end
+  end
+
+  defp get_bearer_token(conn) do
+    authorization_header =
+      Plug.Conn.get_req_header(conn, "authorization")
+      |> List.first()
+
+    case authorization_header do
+      "Bearer " <> token -> {:ok, String.trim(token)}
+      _ -> {:error, :missing_api_key}
+    end
+  end
+
+  defp find_api_key(token) do
+    hashed_key = ApiKey.do_hash(token)
+
+    found_key =
+      Repo.one(
+        from a in ApiKey,
+          where: a.key_hash == ^hashed_key,
+          where: fragment("? @> ?", a.scopes, ["events:read:*"])
+      )
+
+    if found_key, do: {:ok, found_key}, else: {:error, :invalid_api_key}
+  end
+
+  @one_hour 60 * 60 * 1000
+  defp check_api_key_rate_limit(api_key) do
+    case Hammer.check_rate("api_request:#{api_key.id}", @one_hour, api_key.hourly_request_limit) do
+      {:allow, _} -> :ok
+      {:deny, _} -> {:error, :rate_limit, api_key.hourly_request_limit}
+    end
+  end
+
+  defp admin_user_ids() do
+    Application.get_env(:plausible, :admin_user_ids)
+  end
+end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -84,6 +84,13 @@ defmodule PlausibleWeb.Router do
     get "/timeseries", ExternalStatsController, :timeseries
   end
 
+  scope "/api/v1/events", PlausibleWeb.Api do
+    pipe_through [:public_api, PlausibleWeb.AuthorizeEventsApiPlug]
+
+    get "/", ExternalEventsController, :list
+    get "/:event_id/properties", ExternalEventsController, :properties
+  end
+
   scope "/api/v1/sites", PlausibleWeb.Api do
     pipe_through [:public_api, PlausibleWeb.AuthorizeSitesApiPlug]
 

--- a/priv/repo/migrations/20211217120448_add_events_read_scope_to_existing_api_keys.exs
+++ b/priv/repo/migrations/20211217120448_add_events_read_scope_to_existing_api_keys.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.Repo.Migrations.AddEventsReadScopeToExistingApiKeys do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE api_keys SET scopes = array_append(scopes, 'events:read:*')"
+  end
+
+  def down do
+  end
+end

--- a/test/plausible_web/controllers/api/external_events_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/auth_test.exs
@@ -75,9 +75,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController.AuthTest do
         conn
         |> get("/api/v1/events", %{"site_id" => site.domain})
 
-      assert json_response(conn, 200) == [
-               %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
-             ]
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
+               ]
+             }
     end
 
     test "can access as an admin", %{conn: conn, user: user} do
@@ -89,9 +91,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController.AuthTest do
         conn
         |> get("/api/v1/events", %{"site_id" => site.domain})
 
-      assert json_response(conn, 200) == [
-               %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
-             ]
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
+               ]
+             }
     end
 
     test "limits the rate of API requests", %{user: user} do
@@ -186,7 +190,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController.AuthTest do
         conn
         |> get("/api/v1/events/#{event.id}/properties", %{"site_id" => site.domain})
 
-      assert json_response(conn, 200) == []
+      assert json_response(conn, 200) == %{"results" => []}
     end
 
     test "can access as an admin", %{conn: conn, user: user} do
@@ -198,7 +202,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController.AuthTest do
         conn
         |> get("/api/v1/events/#{event.id}/properties", %{"site_id" => site.domain})
 
-      assert json_response(conn, 200) == []
+      assert json_response(conn, 200) == %{"results" => []}
     end
 
     test "limits the rate of API requests", %{user: user} do

--- a/test/plausible_web/controllers/api/external_events_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/auth_test.exs
@@ -1,0 +1,229 @@
+defmodule PlausibleWeb.Api.ExternalSitesController.AuthTest do
+  use PlausibleWeb.ConnCase
+  use Plausible.Repo
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    api_key = insert(:api_key, user: user, scopes: ["events:read:*"])
+    conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer #{api_key.key}")
+    {:ok, user: user, api_key: api_key, conn: conn}
+  end
+
+  describe "POST /api/v1/events" do
+    test "cannot access with a bad API key scope", %{conn: conn, user: user} do
+      api_key = insert(:api_key, user: user, scopes: ["stats:read:*"])
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/api/v1/events", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "unauthenticated request - returns 401", %{conn: conn} do
+      conn = get(conn, "/api/v1/events", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "bad API key - returns 401", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer bad-key")
+        |> get("/api/v1/events", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "good API key but bad site id - returns 401", %{conn: conn} do
+      conn =
+        conn
+        |> get("/api/v1/events", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "good API key but missing site id - returns 400", %{conn: conn} do
+      conn =
+        conn
+        |> get("/api/v1/events", %{})
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Missing site ID. Please provide the required site_id parameter with your request."
+             }
+    end
+
+    test "can access with correct API key and site ID", %{conn: conn, user: user} do
+      site = insert(:site, members: [user])
+      event = insert(:goal, %{domain: site.domain, event_name: "404"})
+
+      conn =
+        conn
+        |> get("/api/v1/events", %{"site_id" => site.domain})
+
+      assert json_response(conn, 200) == [
+               %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
+             ]
+    end
+
+    test "can access as an admin", %{conn: conn, user: user} do
+      Application.put_env(:plausible, :admin_user_ids, [user.id])
+      site = insert(:site)
+      event = insert(:goal, %{domain: site.domain, event_name: "404"})
+
+      conn =
+        conn
+        |> get("/api/v1/events", %{"site_id" => site.domain})
+
+      assert json_response(conn, 200) == [
+               %{"event_type" => "custom", "id" => event.id, "name" => "404", "props" => []}
+             ]
+    end
+
+    test "limits the rate of API requests", %{user: user} do
+      api_key = insert(:api_key, user_id: user.id, hourly_request_limit: 3)
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events")
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events")
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events")
+
+      conn =
+        build_conn()
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/api/v1/events")
+
+      assert json_response(conn, 429) == %{
+               "error" => "Too many API requests. Your API key is limited to 3 requests per hour."
+             }
+    end
+  end
+
+  describe "POST /api/v1/events/:event_id/properties" do
+    test "cannot access with a bad API key scope", %{conn: conn, user: user} do
+      api_key = insert(:api_key, user: user, scopes: ["stats:read:*"])
+
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/api/v1/events/1/properties", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "unauthenticated request - returns 401", %{conn: conn} do
+      conn = get(conn, "/api/v1/events/1/properties", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "bad API key - returns 401", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("authorization", "Bearer bad-key")
+        |> get("/api/v1/events/1/properties", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "good API key but bad site id - returns 401", %{conn: conn} do
+      conn =
+        conn
+        |> get("/api/v1/events/1/properties", %{"site_id" => "some-site.com"})
+
+      assert json_response(conn, 401) == %{
+               "error" =>
+                 "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+             }
+    end
+
+    test "good API key but missing site id - returns 400", %{conn: conn} do
+      conn =
+        conn
+        |> get("/api/v1/events/1/properties", %{})
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Missing site ID. Please provide the required site_id parameter with your request."
+             }
+    end
+
+    test "can access with correct API key and site ID", %{conn: conn, user: user} do
+      site = insert(:site, members: [user])
+      event = insert(:goal, %{domain: site.domain, event_name: "404"})
+
+      conn =
+        conn
+        |> get("/api/v1/events/#{event.id}/properties", %{"site_id" => site.domain})
+
+      assert json_response(conn, 200) == []
+    end
+
+    test "can access as an admin", %{conn: conn, user: user} do
+      Application.put_env(:plausible, :admin_user_ids, [user.id])
+      site = insert(:site)
+      event = insert(:goal, %{domain: site.domain, event_name: "404"})
+
+      conn =
+        conn
+        |> get("/api/v1/events/#{event.id}/properties", %{"site_id" => site.domain})
+
+      assert json_response(conn, 200) == []
+    end
+
+    test "limits the rate of API requests", %{user: user} do
+      api_key = insert(:api_key, user_id: user.id, hourly_request_limit: 3)
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events/1/properties")
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events/1/properties")
+
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/api/v1/events/1/properties")
+
+      conn =
+        build_conn()
+        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/api/v1/events/1/properties")
+
+      assert json_response(conn, 429) == %{
+               "error" => "Too many API requests. Your API key is limited to 3 requests per hour."
+             }
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/external_events_controller/events_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/events_test.exs
@@ -1,0 +1,115 @@
+defmodule PlausibleWeb.Api.ExternalSitesController.EventsTest do
+  use PlausibleWeb.ConnCase
+  use Plausible.Repo
+  import Plausible.TestUtils
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    api_key = insert(:api_key, user: user, scopes: ["events:read:*"])
+    site = insert(:site, members: [user])
+    cusom_event = insert(:goal, %{domain: site.domain, event_name: "404"})
+    pageview_event = insert(:goal, %{domain: site.domain, page_path: "/test"})
+    conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer #{api_key.key}")
+
+    {:ok,
+     user: user,
+     api_key: api_key,
+     site: site,
+     cusom_event: cusom_event,
+     pageview_event: pageview_event,
+     conn: conn}
+  end
+
+  test "only events belonging to the domain are returned", %{
+    conn: conn,
+    site: site,
+    pageview_event: pageview_event,
+    cusom_event: cusom_event
+  } do
+    insert(:goal, %{domain: "another-site.domain", event_name: "Signup"})
+
+    conn =
+      conn
+      |> get("/api/v1/events", %{"site_id" => site.domain})
+
+    assert json_response(conn, 200) == [
+             %{
+               "event_type" => "custom",
+               "id" => cusom_event.id,
+               "name" => "404",
+               "props" => []
+             },
+             %{
+               "event_type" => "pageview",
+               "id" => pageview_event.id,
+               "name" => "Visit /test",
+               "props" => []
+             }
+           ]
+  end
+
+  test "custom properties are returned", %{
+    conn: conn,
+    site: site,
+    pageview_event: pageview_event,
+    cusom_event: cusom_event
+  } do
+    populate_stats([
+      build(:pageview,
+        domain: site.domain
+      ),
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["method"],
+        "meta.value": ["HTTP"]
+      ),
+      build(:pageview,
+        domain: site.domain,
+        "meta.key": ["access_method"],
+        "meta.value": ["HTTP"]
+      ),
+      build(:pageview,
+        domain: site.domain,
+        "meta.key": ["version"],
+        "meta.value": ["4"]
+      ),
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["OS", "method"],
+        "meta.value": ["Linux", "HTTP"]
+      ),
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["version"],
+        "meta.value": ["1"]
+      )
+    ])
+
+    conn =
+      conn
+      |> get("/api/v1/events", %{"site_id" => site.domain})
+
+    response = json_response(conn, 200)
+
+    response =
+      Enum.map(response, fn item -> Map.update(item, "props", [], fn x -> Enum.sort(x) end) end)
+
+    assert response == [
+             %{
+               "event_type" => "custom",
+               "id" => cusom_event.id,
+               "name" => "404",
+               "props" => ["OS", "method", "version"]
+             },
+             %{
+               "event_type" => "pageview",
+               "id" => pageview_event.id,
+               "name" => "Visit /test",
+               "props" => []
+             }
+           ]
+  end
+end

--- a/test/plausible_web/controllers/api/external_events_controller/events_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/events_test.exs
@@ -32,20 +32,22 @@ defmodule PlausibleWeb.Api.ExternalSitesController.EventsTest do
       conn
       |> get("/api/v1/events", %{"site_id" => site.domain})
 
-    assert json_response(conn, 200) == [
-             %{
-               "event_type" => "custom",
-               "id" => cusom_event.id,
-               "name" => "404",
-               "props" => []
-             },
-             %{
-               "event_type" => "pageview",
-               "id" => pageview_event.id,
-               "name" => "Visit /test",
-               "props" => []
-             }
-           ]
+    assert json_response(conn, 200) == %{
+             "results" => [
+               %{
+                 "event_type" => "custom",
+                 "id" => cusom_event.id,
+                 "name" => "404",
+                 "props" => []
+               },
+               %{
+                 "event_type" => "pageview",
+                 "id" => pageview_event.id,
+                 "name" => "Visit /test",
+                 "props" => []
+               }
+             ]
+           }
   end
 
   test "custom properties are returned", %{
@@ -92,12 +94,12 @@ defmodule PlausibleWeb.Api.ExternalSitesController.EventsTest do
       conn
       |> get("/api/v1/events", %{"site_id" => site.domain})
 
-    response = json_response(conn, 200)
+    res =
+      Enum.map(json_response(conn, 200)["results"], fn item ->
+        Map.update(item, "props", [], fn x -> Enum.sort(x) end)
+      end)
 
-    response =
-      Enum.map(response, fn item -> Map.update(item, "props", [], fn x -> Enum.sort(x) end) end)
-
-    assert response == [
+    assert res == [
              %{
                "event_type" => "custom",
                "id" => cusom_event.id,

--- a/test/plausible_web/controllers/api/external_events_controller/properties_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/properties_test.exs
@@ -1,0 +1,77 @@
+defmodule PlausibleWeb.Api.ExternalSitesController.PropertiesTest do
+  use PlausibleWeb.ConnCase
+  use Plausible.Repo
+  import Plausible.TestUtils
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    api_key = insert(:api_key, user: user, scopes: ["events:read:*"])
+    site = insert(:site, members: [user])
+    cusom_event = insert(:goal, %{domain: site.domain, event_name: "404"})
+    conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer #{api_key.key}")
+
+    {:ok, user: user, api_key: api_key, site: site, cusom_event: cusom_event, conn: conn}
+  end
+
+  test "event belonging to the domain is returned", %{
+    conn: conn,
+    site: site,
+    cusom_event: cusom_event
+  } do
+    populate_stats([
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["method"],
+        "meta.value": ["HTTP"]
+      ),
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["OS", "method"],
+        "meta.value": ["Linux", "HTTP"]
+      ),
+      build(:event,
+        name: "404",
+        domain: site.domain,
+        "meta.key": ["version"],
+        "meta.value": ["1"]
+      )
+    ])
+
+    conn =
+      conn
+      |> get("/api/v1/events/#{cusom_event.id}/properties", %{"site_id" => site.domain})
+
+    response = json_response(conn, 200)
+    assert Enum.sort(response) == ["OS", "method", "version"]
+  end
+
+  test "event not belonging to the domain is not returned", %{
+    conn: conn,
+    site: site
+  } do
+    event = insert(:goal, %{domain: "another-site.domain", event_name: "Signup"})
+
+    conn =
+      conn
+      |> get("/api/v1/events/#{event.id}/properties", %{"site_id" => site.domain})
+
+    assert json_response(conn, 404) == %{
+             "error" => "Event could not be found"
+           }
+  end
+
+  test "non existing event returns error message", %{
+    conn: conn,
+    site: site
+  } do
+    conn =
+      conn
+      |> get("/api/v1/events/-1/properties", %{"site_id" => site.domain})
+
+    assert json_response(conn, 404) == %{
+             "error" => "Event could not be found"
+           }
+  end
+end

--- a/test/plausible_web/controllers/api/external_events_controller/properties_test.exs
+++ b/test/plausible_web/controllers/api/external_events_controller/properties_test.exs
@@ -43,8 +43,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController.PropertiesTest do
       conn
       |> get("/api/v1/events/#{cusom_event.id}/properties", %{"site_id" => site.domain})
 
-    response = json_response(conn, 200)
-    assert Enum.sort(response) == ["OS", "method", "version"]
+    assert Enum.sort(json_response(conn, 200)["results"]) == ["OS", "method", "version"]
   end
 
   test "event not belonging to the domain is not returned", %{


### PR DESCRIPTION
### Changes

* Add new endpoint `/api/v1/events` to retrieve all defined goals/events with their properties

`curl -H "Authorization: Bearer ${TOKEN}" "https://plausible.io/api/v1/events/?site_id=$SITE_ID"`

Response:

```
{
  "results": [
    {
      "event_type": "custom",
      "id": 1,
      "name": "404",
      "props": [
        "path",
        "method",
        "version"
      ]
    },
    {
      "event_type": "pageview",
      "id": 2,
      "name": "Visit /x",
      "props": []
    },
    {
      "event_type": "custom",
      "id": 3,
      "name": "Signup",
      "props": []
    }
  ]
}
```

* Add new endpoint `/api/v1/events/:event_id/properties` to retrieve all properties for a single goal/event

`curl -H "Authorization: Bearer ${TOKEN}" "https://plausible.io/api/v1/events/1/properties?site_id=$SITE_ID"`

Response

```
{
  "results": ["path", "method", "version"]
}
```

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated
