### PR TITLE
Add custom goal props to breakdown endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - New UTM Tags `utm_content` and `utm_term` plausible/analytics#515
 - If a session was started without a screen_size it is updated if an event with screen_size occurs
 - Added `LISTEN_IP` configuration parameter plausible/analytics#1189
+- The breakdown endpoint with the property query `property=event:goal` returns custom goal properties (within `props`)
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.


### PR DESCRIPTION
### Changes

If the public `breakdown` API is queried with the undocumented `event:goal` property, now custom event properties are returned (within `props`) as the internal `conversions` endpoint does (within `prop_names`).

```
curl -H "Authorization: Bearer ${TOKEN}" "https://plausible.io/api/v1/stats/breakdown?site_id=$SITE_ID&property=event:goal"
```

Response:

```
{
  "results": [
    {
      "goal": "404",
      "props": [
        "foo",
        "method",
        "path"
      ],
      "visitors": 2
    },
    {
      "goal": "Visit /test",
      "props": [],
      "visitors": 1
    }
  ]
}
```

This is useful to find out which custom properties can be queried in general (https://plausible.io/docs/stats-api#custom-props).

Closes #1577 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
