### PR TITLE
Update session screen_size if unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Subscribed users can see their Paddle invoices from the last 12 months under the user settings
 - Allow custom styles to be passed to embedded iframe plausible/analytics#1522
 - New UTM Tags `utm_content` and `utm_term` plausible/analytics#515
+- If a session was started without a screen_size it is updated if an event with screen_size occurs
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/lib/plausible/session/store.ex
+++ b/lib/plausible/session/store.ex
@@ -91,6 +91,8 @@ defmodule Plausible.Session.Store do
         duration: Timex.diff(event.timestamp, session.start, :second) |> abs,
         pageviews:
           if(event.name == "pageview", do: session.pageviews + 1, else: session.pageviews),
+        screen_size:
+          if(session.screen_size == "", do: event.screen_size, else: session.screen_size),
         events: session.events + 1
     }
   end

--- a/test/plausible/session/store_test.exs
+++ b/test/plausible/session/store_test.exs
@@ -70,7 +70,8 @@ defmodule Plausible.Session.StoreTest do
         domain: event1.domain,
         user_id: event1.user_id,
         name: "pageview",
-        timestamp: timestamp
+        timestamp: timestamp,
+        screen_size: "Desktop"
       )
 
     Store.on_event(event1, nil, store)
@@ -80,6 +81,7 @@ defmodule Plausible.Session.StoreTest do
     assert session.duration == 10
     assert session.pageviews == 2
     assert session.events == 2
+    assert session.screen_size == "Desktop"
   end
 
   test "calculates duration correctly for out-of-order events", %{store: store} do


### PR DESCRIPTION
### Changes

If a session is created without a screen size and later requests specify a screen size update the session
fixes #1605 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
