### PR TITLE
Change screen_size to use browser user agent

### DIFF
--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -115,7 +115,7 @@ defmodule PlausibleWeb.Api.ExternalController do
         operating_system_version: ua && os_version(ua),
         browser: ua && browser_name(ua),
         browser_version: ua && browser_version(ua),
-        screen_size: calculate_screen_size(params["screen_width"]),
+        screen_size: calculate_screen_size(params["screen_width"], ua),
         "meta.key": Map.keys(params["meta"]),
         "meta.value": Map.values(params["meta"]) |> Enum.map(&Kernel.to_string/1)
       }
@@ -484,11 +484,25 @@ defmodule PlausibleWeb.Api.ExternalController do
     end
   end
 
-  defp calculate_screen_size(nil), do: nil
-  defp calculate_screen_size(width) when width < 576, do: "Mobile"
-  defp calculate_screen_size(width) when width < 992, do: "Tablet"
-  defp calculate_screen_size(width) when width < 1440, do: "Laptop"
-  defp calculate_screen_size(width) when width >= 1440, do: "Desktop"
+  defp calculate_screen_size(_, %UAInspector.Result{
+         device: %UAInspector.Result.Device{type: "smartphone"}
+       }),
+       do: "Mobile"
+
+  defp calculate_screen_size(_, %UAInspector.Result{
+         device: %UAInspector.Result.Device{type: "tablet"}
+       }),
+       do: "Tablet"
+
+  defp calculate_screen_size(width, _) do
+    calculate_from_screen_size(width)
+  end
+
+  defp calculate_from_screen_size(nil), do: nil
+  defp calculate_from_screen_size(width) when width < 576, do: "Mobile"
+  defp calculate_from_screen_size(width) when width < 992, do: "Tablet"
+  defp calculate_from_screen_size(width) when width < 1440, do: "Laptop"
+  defp calculate_from_screen_size(width) when width >= 1440, do: "Desktop"
 
   defp clean_referrer(nil), do: nil
 


### PR DESCRIPTION
### Changes

Change how the screen size is calculated. The library UA inspector is already used by the project. So is possible use it to calculate the screen size. If not founded by the UA inspector the mechanism of calculate from screen_width is used as a kind of fallback. The existent function is still used to calculate Desktop and Laptop devices.

Original discussion: https://github.com/plausible/analytics/discussions/157

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
