### PR TITLE
optional ipv6 for repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - If a session was started without a screen_size it is updated if an event with screen_size occurs
 - Added `LISTEN_IP` configuration parameter plausible/analytics#1189
 - The breakdown endpoint with the property query `property=event:goal` returns custom goal properties (within `props`)
+- Added IPv6 Ecto support (via the environment-variable `ECTO_IPV6`)
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -207,8 +207,12 @@ config :plausible, PlausibleWeb.Endpoint,
   http: [port: port, ip: listen_ip, transport_options: [max_connections: :infinity]],
   secret_key_base: secret_key_base
 
+maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
+
 if is_nil(db_socket_dir) do
-  config :plausible, Plausible.Repo, url: db_url
+  config :plausible, Plausible.Repo,
+    url: db_url,
+    socket_options: maybe_ipv6
 else
   config :plausible, Plausible.Repo,
     socket_dir: db_socket_dir,


### PR DESCRIPTION
### Changes

I tried to self-host on fly.io, but it uses IPv6 for DB access:
https://hexdocs.pm/phoenix/fly.html#runtime-configuration

This changes follows the current Phoenix generator setup:
https://github.com/phoenixframework/phoenix/blob/master/installer/lib/phx_new/generator.ex#L355

It had been defaulted to inet6:
https://github.com/phoenixframework/phoenix/pull/4289

but that caused an issue:
https://github.com/phoenixframework/phoenix/issues/4389

### Tests
- [X] This PR does not require tests

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [X] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [X] This PR does not change the UI
