### PR TITLE
Fix upper limit of range A-Z

### DIFF
--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -28,7 +28,7 @@ defmodule Plausible.Site do
     site
     |> cast(attrs, [:domain, :timezone])
     |> validate_required([:domain, :timezone])
-    |> validate_format(:domain, ~r/^[a-zA-z0-9\-\.\/\:]*$/,
+    |> validate_format(:domain, ~r/^[a-zA-Z0-9\-\.\/\:]*$/,
       message: "only letters, numbers, slashes and period allowed"
     )
     |> unique_constraint(:domain)


### PR DESCRIPTION
Since the A-z range includes [, \, ], ^, _, and `, I assume this is a typo on the upper limit of the A-Z range.
