### PR TITLE
removed a space from 6 mailto links

### DIFF
--- a/lib/plausible_web/templates/billing/change_enterprise_plan.html.eex
+++ b/lib/plausible_web/templates/billing/change_enterprise_plan.html.eex
@@ -62,7 +62,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/change_plan.html.eex
+++ b/lib/plausible_web/templates/billing/change_plan.html.eex
@@ -116,7 +116,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/change_plan_preview.html.eex
+++ b/lib/plausible_web/templates/billing/change_plan_preview.html.eex
@@ -78,7 +78,7 @@
 </div>
 
 <div class="text-center mt-8 dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/upgrade.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade.html.eex
@@ -122,7 +122,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/upgrade_enterprise_plan.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade_enterprise_plan.html.eex
@@ -37,7 +37,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/upgrade_to_plan.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade_to_plan.html.eex
@@ -37,7 +37,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto: support@plausible.io", class: "text-indigo-500") %>
+  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>


### PR DESCRIPTION
### Changes

The "mailto: support@plausible.io" link has a space in front of the email address which prevents this link from working correctly in some cases. There should be no space in there