### PR TITLE
Allow admin access to locked dashboards

### DIFF
--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -104,7 +104,7 @@ export default class SiteSwitcher extends React.Component {
   }
 
   renderSettingsLink() {
-    if (['owner', 'admin'].includes(this.props.currentUserRole)) {
+    if (['owner', 'admin', 'super_admin'].includes(this.props.currentUserRole)) {
       return (
         <React.Fragment>
           <div className="py-1">

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -61,7 +61,7 @@ db_socket_dir = get_var_from_path_or_env(config_dir, "DATABASE_SOCKET_DIR")
 admin_user = get_var_from_path_or_env(config_dir, "ADMIN_USER_NAME")
 admin_email = get_var_from_path_or_env(config_dir, "ADMIN_USER_EMAIL")
 
-admin_user_ids =
+super_admin_user_ids =
   get_var_from_path_or_env(config_dir, "ADMIN_USER_IDS", "")
   |> String.split(",")
   |> Enum.map(fn id -> Integer.parse(id) end)
@@ -190,7 +190,7 @@ config :plausible,
   admin_pwd: admin_pwd,
   environment: env,
   mailer_email: mailer_email,
-  admin_user_ids: admin_user_ids,
+  super_admin_user_ids: super_admin_user_ids,
   site_limit: site_limit,
   site_limit_exempt: site_limit_exempt,
   is_selfhost: is_selfhost,

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -92,4 +92,9 @@ defmodule Plausible.Auth do
       )
     )
   end
+
+  def is_super_admin?(nil), do: false
+  def is_super_admin?(user_id) do
+    user_id in Application.get_env(:plausible, :super_admin_user_ids)
+  end
 end

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -94,6 +94,7 @@ defmodule Plausible.Auth do
   end
 
   def is_super_admin?(nil), do: false
+
   def is_super_admin?(user_id) do
     user_id in Application.get_env(:plausible, :super_admin_user_ids)
   end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -6,7 +6,7 @@ defmodule PlausibleWeb.SiteController do
   plug PlausibleWeb.RequireAccountPlug
 
   plug PlausibleWeb.AuthorizeSiteAccess,
-       [:owner, :admin] when action not in [:index, :new, :create_site]
+       [:owner, :admin, :super_admin] when action not in [:index, :new, :create_site]
 
   def index(conn, params) do
     user = conn.assigns[:current_user]

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -8,9 +8,10 @@ defmodule PlausibleWeb.StatsController do
 
   def stats(%{assigns: %{site: site}} = conn, _params) do
     has_stats = Plausible.Sites.has_stats?(site)
+    can_see_stats = !site.locked || conn.assigns[:current_user_role] == :super_admin
 
     cond do
-      !site.locked && has_stats ->
+      has_stats && can_see_stats ->
         demo = site.domain == PlausibleWeb.Endpoint.host()
         offer_email_report = get_session(conn, site.domain <> "_offer_email_report")
 
@@ -26,7 +27,7 @@ defmodule PlausibleWeb.StatsController do
           demo: demo
         )
 
-      !site.locked && !has_stats ->
+      !has_stats && can_see_stats ->
         conn
         |> assign(:skip_plausible_tracking, true)
         |> render("waiting_first_pageview.html", site: site)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
   import Plug.Conn
   use Plausible.Repo
 
-  def init([]), do: [:public, :viewer, :admin, :owner]
+  def init([]), do: [:public, :viewer, :admin, :super_admin, :owner]
   def init(allowed_roles), do: allowed_roles
 
   def call(conn, allowed_roles) do
@@ -23,14 +23,14 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
           user_id && membership_role ->
             membership_role
 
+          Plausible.Auth.is_super_admin?(user_id) ->
+            :super_admin
+
           site.public ->
             :public
 
           shared_link_record && shared_link_record.site_id == site.id ->
             :public
-
-          user_id in admin_user_ids() ->
-            :admin
 
           true ->
             nil
@@ -42,9 +42,5 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
         PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt
       end
     end
-  end
-
-  defp admin_user_ids() do
-    Application.get_env(:plausible, :admin_user_ids)
   end
 end

--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -46,11 +46,11 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
   defp verify_access(api_key, site_id) do
     site = Repo.get_by(Plausible.Site, domain: site_id)
     is_member = site && Plausible.Sites.is_member?(api_key.user_id, site)
-    is_admin = api_key.user_id in admin_user_ids()
+    is_super_admin = Plausible.Auth.is_super_admin?(api_key.user_id)
 
     cond do
       site && is_member -> {:ok, site}
-      site && is_admin -> {:ok, site}
+      site && is_super_admin -> {:ok, site}
       true -> {:error, :invalid_api_key}
     end
   end
@@ -78,9 +78,5 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
       {:allow, _} -> :ok
       {:deny, _} -> {:error, :rate_limit, api_key.hourly_request_limit}
     end
-  end
-
-  defp admin_user_ids() do
-    Application.get_env(:plausible, :admin_user_ids)
   end
 end

--- a/lib/plausible_web/plugs/crm_auth_plug.ex
+++ b/lib/plausible_web/plugs/crm_auth_plug.ex
@@ -14,13 +14,11 @@ defmodule PlausibleWeb.CRMAuthPlug do
       id ->
         user = Repo.get_by(Plausible.Auth.User, id: id)
 
-        if user && user.id in admin_user_ids() do
+        if user && Plausible.Auth.is_super_admin?(user.id) do
           assign(conn, :current_user, user)
         else
           conn |> send_resp(403, "Not allowed") |> halt
         end
     end
   end
-
-  defp admin_user_ids(), do: Application.get_env(:plausible, :admin_user_ids)
 end

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -4,6 +4,13 @@
       <%= link("Click here to enable weekly email reports →", to: "/#{URI.encode_www_form(@site.domain)}/settings/email-reports", class: "py-2 block") %>
     </div>
   <% end %>
+
+  <%= if @site.locked do %>
+    <div class="w-full px-4 py-4 text-sm font-bold text-center text-yellow-800 bg-yellow-100 rounded transition" style="top: 91px" role="alert">
+      <p>This dashboard is actually locked. You are viewing it with super-admin access</p>
+    </div>
+  <% end %>
+
   <div class="pt-6"></div>
   <div id="stats-react-container" style="overflow-anchor: none;" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>" data-inserted-at="<%= @site.inserted_at %>" data-shared-link-auth="<%= assigns[:shared_link_auth] %>" data-embedded="<%= @conn.assigns[:embedded] %>" data-background="<%= @conn.assigns[:background] %>" data-selfhosted="<%= Application.get_env(:plausible, :is_selfhost) %>" data-current-user-role="<%= @conn.assigns[:current_user_role] %>"></div>
   <div id="modal_root"></div>

--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.eex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.eex
@@ -14,6 +14,11 @@
 </script>
 
 <div class="w-full max-w-md mx-auto mt-8">
+  <%= if @site.locked do %>
+    <div class="w-full px-4 py-4 text-sm font-bold text-center text-yellow-800 bg-yellow-100 rounded transition" style="top: 91px" role="alert">
+      <p>This dashboard is actually locked. You are viewing it with super-admin access</p>
+    </div>
+  <% end %>
   <div class="bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-16 relative text-center">
     <h2 class="text-xl font-bold dark:text-gray-100">Waiting for first pageview</h2>
     <h2 class="text-xl font-bold dark:text-gray-100">on <%= @site.domain %></h2>

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -66,7 +66,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   end
 
   test "can access as an admin", %{conn: conn, user: user, api_key: api_key} do
-    Application.put_env(:plausible, :admin_user_ids, [user.id])
+    Application.put_env(:plausible, :super_admin_user_ids, [user.id])
     site = insert(:site)
 
     conn =

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -39,9 +39,60 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "can not view stats of someone else's website", %{conn: conn} do
-      conn = get(conn, "/some-other-site.com")
+      site = insert(:site)
+      conn = get(conn, site.domain)
       assert html_response(conn, 404) =~ "There&#39;s nothing here"
     end
+  end
+
+  describe "GET /:website - as a super admin" do
+    setup [:create_user, :make_user_super_admin, :log_in]
+
+    test "can view a private dashboard with stats", %{conn: conn} do
+      site = insert(:site)
+      populate_stats(site, [build(:pageview)])
+
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "stats-react-container"
+    end
+
+    test "can view a private dashboard without stats", %{conn: conn} do
+      site = insert(:site)
+
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "Need to see the snippet again?"
+    end
+
+    test "can view a private locked dashboard with stats", %{conn: conn} do
+      user = insert(:user)
+      site = insert(:site, locked: true, members: [user])
+      populate_stats(site, [build(:pageview)])
+
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "stats-react-container"
+      assert html_response(conn, 200) =~ "This dashboard is actually locked"
+    end
+
+    test "can view a private locked dashboard without stats", %{conn: conn} do
+      user = insert(:user)
+      site = insert(:site, locked: true, members: [user])
+
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "Need to see the snippet again?"
+      assert html_response(conn, 200) =~ "This dashboard is actually locked"
+    end
+
+    test "can view a locked public dashboard", %{conn: conn} do
+      site = insert(:site, locked: true, public: true)
+      populate_stats(site, [build(:pageview)])
+
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "stats-react-container"
+    end
+  end
+
+  defp make_user_super_admin(%{user: user}) do
+    Application.put_env(:plausible, :super_admin_user_ids, [user.id])
   end
 
   describe "GET /:website/export" do


### PR DESCRIPTION
### Changes

- renamed admin users to `super_admin` (to avoid name overlapping with the site admin role)
- `super_admin` users now have access to public and private locked dashboards 
- removed some code repetition and moved the super_admin user check to `Plausible.Auth` module
- fixed the `stats_controller_test.exs:41` test that did not test the described functionality (site did not exist)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
