### PR TITLE
can now remove user grace period from crm

### DIFF
--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -20,8 +20,37 @@ defmodule Plausible.Auth.UserAdmin do
       email: nil,
       trial_expiry_date: nil,
       subscription_tier: %{value: &subscription_tier/1},
-      subscription_status: %{value: &subscription_status/1}
+      subscription_status: %{value: &subscription_status/1},
+      grace_period: %{value: &grace_period_status/1}
     ]
+  end
+
+  def resource_actions(_) do
+    [
+      remove_grace_period: %{
+        name: "Remove grace period",
+        action: fn _, user -> remove_grace_period(user) end
+      }
+    ]
+  end
+
+  defp remove_grace_period(user) do
+    if user.grace_period do
+      Plausible.Auth.User.remove_grace_period(user) |> Repo.update()
+    else
+      {:error, user, "No active grace period on this user"}
+    end
+  end
+
+  defp grace_period_status(%{grace_period: nil}), do: "--"
+
+  defp grace_period_status(user) do
+    if user.grace_period.is_over do
+      "ended"
+    else
+      days_left = Timex.diff(user.grace_period.end_date, Timex.now(), :days)
+      "#{days_left} days left"
+    end
   end
 
   defp subscription_tier(user) do


### PR DESCRIPTION
### Changes

Users list now shows a column `grace_period`. Clicking on a user, the grace period can be removed from "Actions" on the top right.

### Tests
- [x] This PR does not require tests
