### PR TITLE
Streamlining support

### DIFF
--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -18,7 +18,8 @@ defmodule Plausible.Auth.UserAdmin do
     [
       name: nil,
       email: nil,
-      trial_expiry_date: nil,
+      inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)},
+      trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},
       subscription_tier: %{value: &subscription_tier/1},
       subscription_status: %{value: &subscription_status/1},
       grace_period: %{value: &grace_period_status/1}
@@ -74,5 +75,9 @@ defmodule Plausible.Auth.UserAdmin do
       true ->
         "Trial expired"
     end
+  end
+
+  defp format_date(date) do
+    Timex.format!(date, "{Mshort} {D}, {YYYY}")
   end
 end

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -20,8 +20,37 @@ defmodule Plausible.Auth.UserAdmin do
       email: nil,
       trial_expiry_date: nil,
       subscription_tier: %{value: &subscription_tier/1},
-      subscription_status: %{value: &subscription_status/1}
+      subscription_status: %{value: &subscription_status/1},
+      grace_period: %{value: &grace_period_status/1}
     ]
+  end
+
+  def resource_actions(_) do
+    [
+      remove_grace_period: %{
+        name: "Remove grace period",
+        action: fn _, user -> remove_grace_period(user) end
+      }
+    ]
+  end
+
+  defp remove_grace_period(user) do
+    if user.grace_period do
+      Plausible.Auth.User.remove_grace_period(user) |> Repo.update()
+    else
+      {:error, user, "No active grace period on this user"}
+    end
+  end
+
+  defp grace_period_status(%{grace_period: nil}), do: "--"
+
+  defp grace_period_status(user) do
+    if user.grace_period.is_over do
+      "ended"
+    else
+      days_left = Timex.diff(user.grace_period.end_date, Timex.now(), :days)
+      "#{days_left} days left"
+    end
   end
 
   defp subscription_tier(user) do

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -23,6 +23,7 @@ defmodule Plausible.SiteAdmin do
   def index(_) do
     [
       domain: nil,
+      inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)},
       timezone: nil,
       public: nil,
       owner: %{value: &get_owner_email/1},
@@ -37,5 +38,9 @@ defmodule Plausible.SiteAdmin do
   defp get_other_members_emails(site) do
     memberships = Enum.reject(site.memberships, fn m -> m.role == :owner end)
     Enum.map(memberships, fn m -> m.user.email end) |> Enum.join(", ")
+  end
+
+  defp format_date(date) do
+    Timex.format!(date, "{Mshort} {D}, {YYYY}")
   end
 end


### PR DESCRIPTION
### Changes

- Users list now shows a column grace_period
- Clicking on a user, the grace period can be removed from "Actions" on the top right
- CRM now shows a `created at` date for both sites and users

### Tests
- [x] This PR does not require tests