### PR TITLE
Reduce tracker size by using `navigator.sendBeacon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Cache the tracking script for 24 hours
+- Replace `XMLHttpRequest` for `navigator.sendBeacon`
 
 ## v1.4.1
 

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -69,17 +69,7 @@
     payload.h = 1
     {{/if}}
 
-    var request = new XMLHttpRequest();
-    request.open('POST', endpoint, true);
-    request.setRequestHeader('Content-Type', 'text/plain');
-
-    request.send(JSON.stringify(payload));
-
-    request.onreadystatechange = function() {
-      if (request.readyState == 4) {
-        options && options.callback && options.callback()
-      }
-    }
+    navigator.sendBeacon(endpoint, payload)
   }
 
   {{#if outbound_links}}


### PR DESCRIPTION
### Changes

Replace `XMLHttpRequest` for `navigator.sendBeacon`. Also adds in the ability to allow events to be triggered on page exit.

This will likely need an update to the back end (sorry, don't know elixir) to change what headers are used (ie use `ping-from` over `Referer` maybe?). Not sure what others header are send along with the request that maybe be used by plausible. Some testing will be needed.

> It's intended to be used for sending analytics data to a web server, and avoids some of the problems with legacy techniques for sending analytics, such as the use of [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest). ~ MDN

- HTTP on page exit: https://css-tricks.com/send-an-http-request-on-page-exit/
- MDN: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
- Browser Support: https://caniuse.com/beacon

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
