### PR TITLE
Use the correct email address for password reset

### DIFF
--- a/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
+++ b/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
@@ -1,18 +1,17 @@
 <div class="bg-white dark:bg-gray-800 max-w-md w-full mx-auto shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8">
   <h2 class="text-xl font-black dark:text-gray-100">Success!</h2>
   <div class="my-4 leading-tight dark:text-gray-100">
-    We have sent an email with password reset instructions to <b><%= @email %></b> if it exists in our database.
+    We have sent an email with password reset instructions to <b><%= @email %></b> if it exists in our database. To protect your account's security, we cannot confirm whether or not the email address you entered is registered in our database.
   </div>
   <div class="mt-8 text-sm dark:text-gray-100">
-    Didn't receive an email?
+    Didn't receive an email within a few minutes?
   </div>
   <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-tight">
-    Please check your spam folder and
+    You might have used a wrong email address. Please check what email address you used to create your Plausible account and try to reset the password for that address. Do also check your spam folder.
     <%= if Application.get_env(:plausible, :is_selfhost) do %>
-      ask on our <a href="https://github.com/plausible/analytics/discussions" class="text-indigo-500">community-supported forum</a>
+      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please ask on our <a href="https://github.com/plausible/analytics/discussions" class="text-indigo-500">community-supported forum</a>.
     <% else %>
-      contact <a href="mailto:support@plausible.io" class="text-indigo-500">support@plausible.io</a>
+      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please contact <a href="mailto:support@plausible.io" class="text-indigo-500">support@plausible.io</a>.
     <% end %>
-    if the problem persists
   </div>
 </div>


### PR DESCRIPTION
A note to use the correct email address for password reset as we regularly get questions on why the password reset email wasn't delivered. In all cases, it's because people try to reset the password of a wrong email address