### PR TITLE
Extra note for the domain taken message

### DIFF
--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -258,7 +258,7 @@ defmodule PlausibleWeb.SiteControllerTest do
           }
         })
 
-      assert html_response(conn, 200) =~ "has already been taken"
+      assert html_response(conn, 200) =~ "This domain has already been taken. Perhaps one of your team members registered it? If that's not the case, please contact support@plausible.io"
     end
   end
 


### PR DESCRIPTION
I wanted to add an extra note to the "has already been taken" message. We now regularly get questions about this message and in most cases it happens because a team member already registered the site but didn't share the access to the rest of the team. I hope I've added it correctly. 