### PR TITLE
Improve stats api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- The public breakdown endpoint can be queried with the "events" metric when breaking down on a visit property 
 - Integration with [Matomo's referrer spam list](https://github.com/matomo-org/referrer-spam-list/blob/master/spammers.txt) to block known spammers
 - API route `PUT /api/v1/sites/goals` with form params `site_id`, `event_name` and/or `page_path`, and `goal_type` with supported types `event` and `page`
 - API route `DELETE /api/v1/sites/goals/:goal_id` with form params `site_id`

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -267,6 +267,16 @@ defmodule Plausible.Stats.Base do
     |> select_session_metrics(rest)
   end
 
+  def select_session_metrics(q, [:events | rest]) do
+    from(s in q,
+      select_merge: %{
+        events:
+          fragment("toUInt64(round(sum(? * ?) * any(_sample_factor)))", s.sign, s.events)
+      }
+    )
+    |> select_session_metrics(rest)
+  end
+
   def select_session_metrics(q, [:visitors | rest]) do
     from(s in q,
       select_merge: %{

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1591,6 +1591,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:event,
+          name: "signup",
+          user_id: 1,
+          referrer_source: "Google",
+          timestamp: ~N[2021-01-01 00:05:00]
+        ),
         build(:pageview,
           user_id: 1,
           referrer_source: "Google",
@@ -1612,7 +1618,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           "period" => "day",
           "date" => "2021-01-01",
           "property" => "visit:source",
-          "metrics" => "visitors,visits,pageviews,bounce_rate,visit_duration"
+          "metrics" => "visitors,visits,pageviews,events,bounce_rate,visit_duration"
         })
 
       assert json_response(conn, 200) == %{
@@ -1623,7 +1629,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                    "visits" => 2,
                    "bounce_rate" => 50,
                    "visit_duration" => 300,
-                   "pageviews" => 3
+                   "pageviews" => 3,
+                   "events" => 4
                  },
                  %{
                    "source" => "Twitter",
@@ -1631,7 +1638,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                    "visits" => 1,
                    "bounce_rate" => 100,
                    "visit_duration" => 0,
-                   "pageviews" => 1
+                   "pageviews" => 1,
+                   "events" => 1
                  }
                ]
              }


### PR DESCRIPTION
### Changes

Added the ability to query the `events` metric from Stats API breakdown endpoint when breaking down on a `visit:` property. Modified one test to also use this metric in such a query.

Stats API docs don't say anything about this not working, so no update required there.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
