### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,10 @@ Make sure Docker, Elixir, Erlang and Node.js are all installed on your developme
 ### Creating an account
 
 1. Navigate to `http://localhost:8000/register` and fill in the form.
-2. An e-mail won't actually be sent, but you can find the activation in the Phoenix logs in your terminal. Search for `[info] VERIFICATION CODE:`  and enter the verification code.
-3. Fill in the rest of the forms and for the domain use `dummy.site`
-4. Skip the JS snippet and click start collecting data.
-5. Run `make dummy_event` from the terminal to generate a fake pageview event for the dummy site.
-6. You should now be all set!
+2. Fill in the rest of the forms and for the domain use `dummy.site`
+3. Skip the JS snippet and click start collecting data.
+4. Run `make dummy_event` from the terminal to generate a fake pageview event for the dummy site.
+5. You should now be all set!
 
 ### Stopping Docker containers
 


### PR DESCRIPTION
### Changes

Updates the 'Creating an Account' instructions inside CONTRIBUTING.md to remove the step about verification codes as a user account is created with `email_verified=true` when running locally.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
