### PR TITLE
1421 contains filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to this project will be documented in this file.
 - The breakdown endpoint with the property query `property=event:goal` returns custom goal properties (within `props`)
 - Added IPv6 Ecto support (via the environment-variable `ECTO_IPV6`)
 - New filter type: `contains`, available for `page`, `entry_page`, `exit_page`
-- Move `entry_page` and `exit_page` to be part of the `Page` filter group
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.
@@ -31,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Cache the tracking script for 24 hours
+- Move `entry_page` and `exit_page` to be part of the `Page` filter group
 
 ## v1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
 - Added `LISTEN_IP` configuration parameter plausible/analytics#1189
 - The breakdown endpoint with the property query `property=event:goal` returns custom goal properties (within `props`)
 - Added IPv6 Ecto support (via the environment-variable `ECTO_IPV6`)
+- New filter type: `contains`, available for `page`, `entry_page`, `exit_page`
+- Move `entry_page` and `exit_page` to be part of the `Page` filter group
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -5,7 +5,13 @@ import classNames from 'classnames'
 import { Menu, Transition } from '@headlessui/react'
 
 import { appliedFilters, navigateToQuery, formattedFilters } from './query'
-import { FILTER_GROUPS, formatFilterGroup, filterGroupForFilter } from './stats/modals/filter'
+import {
+  FILTER_GROUPS,
+  formatFilterGroup,
+  filterGroupForFilter,
+  toFilterType,
+  valueWithoutPrefix
+} from "./stats/modals/filter";
 
 function removeFilter(key, history, query) {
   const newOpts = {
@@ -32,16 +38,9 @@ function clearAllFilters(history, query) {
   );
 }
 
-function filterType(val) {
-  if (typeof(val) === 'string' && val.startsWith('!')) {
-    return ['is not', val.substr(1)]
-  }
-
-  return ['is', val]
-}
-
 function filterText(key, rawValue, query) {
-  const [type, value] = filterType(rawValue)
+  const type = toFilterType(rawValue)
+  const value = valueWithoutPrefix(rawValue)
 
   if (key === "goal") {
     return <>Completed goal <b>{value}</b></>

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -42,48 +42,31 @@ function getFormState(filterGroup, query) {
   }, {})
 }
 
-const filterTypes = {
+const FILTER_TYPES = {
   isNot: 'is not',
   contains: 'contains',
   is: 'is'
 };
 
-const filterPrefixes = {
-  isNot: '!',
-  contains: '~',
-  is: ''
+const FILTER_PREFIXES = {
+  [FILTER_TYPES.isNot]: '!',
+  [FILTER_TYPES.contains]: '~',
+  [FILTER_TYPES.is]: ''
 };
 
 export function toFilterType(value) {
-  switch (value[0]) {
-    case filterPrefixes.isNot:
-      return filterTypes.isNot;
-    case filterPrefixes.contains:
-      return filterTypes.contains;
-    default:
-      return filterTypes.is;
-  }
+  return Object.keys(FILTER_PREFIXES)
+    .find(type => FILTER_PREFIXES[type] === value[0]) || FILTER_TYPES.is;
 }
 
 export function valueWithoutPrefix(value) {
-  return [filterTypes.isNot, filterTypes.contains].includes(toFilterType(value))
+  return [FILTER_TYPES.isNot, FILTER_TYPES.contains].includes(toFilterType(value))
     ? value.substring(1)
     : value;
 }
 
 function toFilterQuery(value, type) {
-  let prefix;
-  switch (type) {
-    case filterTypes.isNot:
-      prefix = filterPrefixes.isNot;
-      break;
-    case filterTypes.contains:
-      prefix = filterPrefixes.contains;
-      break;
-    default:
-      prefix = filterPrefixes.is;
-      break;
-  }
+  const prefix = FILTER_PREFIXES[type];
   return prefix + value.trim();
 }
 
@@ -284,9 +267,9 @@ class FilterModal extends React.Component {
                 className="z-10 origin-top-left absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none"
               >
                 <div className="py-1">
-                  { this.renderTypeItem(filterName, filterTypes.is, true) }
-                  { this.renderTypeItem(filterName, filterTypes.isNot, filterName !== 'goal') }
-                  { this.renderTypeItem(filterName, filterTypes.contains, supportsContains(filterName)) }
+                  { this.renderTypeItem(filterName, FILTER_TYPES.is, true) }
+                  { this.renderTypeItem(filterName, FILTER_TYPES.isNot, filterName !== 'goal') }
+                  { this.renderTypeItem(filterName, FILTER_TYPES.contains, supportsContains(filterName)) }
                 </div>
               </Menu.Items>
             </Transition>

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -11,15 +11,13 @@ import * as api from '../../api'
 import {apiPath, siteBasePath} from '../../util/url'
 
 export const FILTER_GROUPS = {
-  'page': ['page'],
+  'page': ['page', 'entry_page', 'exit_page'],
   'source': ['source', 'referrer'],
   'location': ['country', 'region', 'city'],
   'screen': ['screen'],
   'browser': ['browser', 'browser_version'],
   'os': ['os', 'os_version'],
   'utm': ['utm_medium', 'utm_source', 'utm_campaign', 'utm_term', 'utm_content'],
-  'entry_page': ['entry_page'],
-  'exit_page': ['exit_page'],
   'goal': ['goal']
 }
 

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -46,26 +46,29 @@ const filterTypes = {
   isNot: 'is not',
   contains: 'contains',
   is: 'is'
-}
+};
 
 const filterPrefixes = {
   isNot: '!',
   contains: '~',
   is: ''
-}
+};
 
 export function toFilterType(value) {
   switch (value[0]) {
-    case filterPrefixes.isNot: return filterTypes.isNot
-    case filterPrefixes.contains: return filterTypes.contains
-    default: return filterTypes.is
+    case filterPrefixes.isNot:
+      return filterTypes.isNot;
+    case filterPrefixes.contains:
+      return filterTypes.contains;
+    default:
+      return filterTypes.is;
   }
 }
 
 export function valueWithoutPrefix(value) {
   return [filterTypes.isNot, filterTypes.contains].includes(toFilterType(value))
-      ? value.substring(1)
-      : value
+    ? value.substring(1)
+    : value;
 }
 
 function toFilterQuery(value, type) {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "assets",
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "assets",
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {

--- a/lib/plausible/stats/filters.ex
+++ b/lib/plausible/stats/filters.ex
@@ -70,6 +70,10 @@ defmodule Plausible.Stats.Filters do
     end
   end
 
+  defp filter_value(key, "~" <> val) do
+    {:matches, "**" <> val <> "**"}
+  end
+
   defp filter_value(key, val) do
     if String.contains?(key, ["page", "goal"]) && String.match?(val, ~r/\*/) do
       {:matches, val}

--- a/lib/plausible/stats/filters.ex
+++ b/lib/plausible/stats/filters.ex
@@ -70,7 +70,7 @@ defmodule Plausible.Stats.Filters do
     end
   end
 
-  defp filter_value(key, "~" <> val) do
+  defp filter_value(_, "~" <> val) do
     {:matches, "**" <> val <> "**"}
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -408,6 +408,26 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
     end
 
+    test "contains (~) filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/some-blog-post"),
+        build(:pageview, pathname: "/blog/post1"),
+        build(:pageview, pathname: "/another/post")
+      ])
+
+      filters = Jason.encode!(%{page: "~blog"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&filters=#{filters}"
+        )
+
+      res = json_response(conn, 200)
+      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+    end
+
+
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, screen_size: "Desktop"),

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -427,7 +427,6 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
     end
 
-
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, screen_size: "Desktop"),


### PR DESCRIPTION
### Changes

- Moves `page_entry` and `page_exit` filters to be part of the same filter group as `page`
- Adds a "contains" option as a filter type for page-based filters, which has the same effect as using double asterisks before and after the keyword (i.e. `**<keyword>**`).
- Fixes two small UI bugs (see the screenshots below)

I picked tilde (`~`) as the character to signify a 'contains' query, I hope that's ok?

This is what the new filter type looks like:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/16692471/160199412-70e57532-9c1c-4bac-9237-260b6be3fc14.png">
<img width="389" alt="image" src="https://user-images.githubusercontent.com/16692471/160199454-c2420be6-058b-42d5-9ba6-87484759d7a3.png">

The small UI bugs are:

- the 'is not' filter type would display as `is_not` once selected:
<img width="327" alt="image" src="https://user-images.githubusercontent.com/16692471/160199706-290bdf00-157a-4f80-9974-02d7b82c8e7a.png">
- if I select any 'is not' filter, save and then edit the filter, `!` is added in front of the filter keyword:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/16692471/160199830-b54a1c36-b81e-4677-93fb-e27d1973f8e3.png">



### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] The UI has been tested both in dark and light mode
