### PR TITLE
Prevent canvas (main graph) from being selected on long press on mobile browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - UI fix to align footer columns
 - Guests can now use the favicon to toggle additional info about the site bing viewed (such as in public embeds).
 - Fix SecurityError in tracking script when user has blocked all local storage
+- Prevent dashboard graph from being selected when long pressing on the graph in a mobile browser
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/assets/js/dashboard/stats/visitor-graph.js
+++ b/assets/js/dashboard/stats/visitor-graph.js
@@ -385,7 +385,7 @@ class LineGraph extends React.Component {
             { this.samplingNotice() }
             { this.importedNotice() }
           </div>
-          <canvas id="main-graph-canvas" className={'mt-4 ' + extraClass} width="1054" height="342"></canvas>
+          <canvas id="main-graph-canvas" className={'mt-4 select-none ' + extraClass} width="1054" height="342"></canvas>
         </div>
       </div>
     )


### PR DESCRIPTION
### Changes

Fixes an issue while long pressing on the graph, where the canvas + some other elements on the page get selected. It's pretty common to long press on mobile graphs that have hover effects.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI

Fix:
https://tailwindcss.com/docs/user-select

Tested in iOS simulator to show the fix:

https://user-images.githubusercontent.com/5155373/160242592-147651c5-1de0-47f7-ba1e-ed23aa0574c2.mp4