### PR TITLE
Adds "invite_only" disable_registration config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 - Move `entry_page` and `exit_page` to be part of the `Page` filter group
 - Paginate /api/sites results and add a `View all` link to the site-switcher dropdown in the dashboard.
 - Remove the `+ Add Site` link to the site-switcher dropdown in the dashboard.
-- `DISABLE_REGISTRATIONS` configuration parameter can now accept `allow_invites` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
+- `DISABLE_REGISTRATIONS` configuration parameter can now accept `invite_only` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
 
 ## v1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Move `entry_page` and `exit_page` to be part of the `Page` filter group
 - Paginate /api/sites results and add a `View all` link to the site-switcher dropdown in the dashboard.
 - Remove the `+ Add Site` link to the site-switcher dropdown in the dashboard.
+- `DISABLE_REGISTRATIONS` configuration parameter can now accept `allow_invites` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
 
 ## v1.4.1
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,8 +136,8 @@ disable_registration =
   |> get_var_from_path_or_env("DISABLE_REGISTRATION", "false")
   |> String.to_existing_atom()
 
-if disable_registration not in [true, false, :allow_invites] do
-  raise "DISABLE_REGISTRATION must be one of `true`, `false`, or `allow_invites`. See https://plausible.io/docs/self-hosting-configuration#server"
+if disable_registration not in [true, false, :invite_only] do
+  raise "DISABLE_REGISTRATION must be one of `true`, `false`, or `invite_only`. See https://plausible.io/docs/self-hosting-configuration#server"
 end
 
 hcaptcha_sitekey = get_var_from_path_or_env(config_dir, "HCAPTCHA_SITEKEY")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -134,6 +134,11 @@ enable_email_verification =
 disable_registration =
   config_dir
   |> get_var_from_path_or_env("DISABLE_REGISTRATION", "false")
+  |> String.to_existing_atom()
+
+if disable_registration not in [:true, :false, :allow_invites] do
+  raise "DISABLE_REGISTRATION must be one of `true`, `false`, or `allow_invites`. See https://plausible.io/docs/self-hosting-configuration#server"
+end
 
 hcaptcha_sitekey = get_var_from_path_or_env(config_dir, "HCAPTCHA_SITEKEY")
 hcaptcha_secret = get_var_from_path_or_env(config_dir, "HCAPTCHA_SECRET")
@@ -199,7 +204,7 @@ config :plausible,
 config :plausible, :selfhost,
   disable_authentication: disable_auth,
   enable_email_verification: enable_email_verification,
-  disable_registration: if(!disable_auth, do: disable_registration, else: "false")
+  disable_registration: if(!disable_auth, do: disable_registration, else: :false)
 
 config :plausible, PlausibleWeb.Endpoint,
   url: [scheme: base_url.scheme, host: base_url.host, path: base_url.path, port: base_url.port],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,7 +136,7 @@ disable_registration =
   |> get_var_from_path_or_env("DISABLE_REGISTRATION", "false")
   |> String.to_existing_atom()
 
-if disable_registration not in [:true, :false, :allow_invites] do
+if disable_registration not in [true, false, :allow_invites] do
   raise "DISABLE_REGISTRATION must be one of `true`, `false`, or `allow_invites`. See https://plausible.io/docs/self-hosting-configuration#server"
 end
 
@@ -204,7 +204,7 @@ config :plausible,
 config :plausible, :selfhost,
   disable_authentication: disable_auth,
   enable_email_verification: enable_email_verification,
-  disable_registration: if(!disable_auth, do: disable_registration, else: :false)
+  disable_registration: if(!disable_auth, do: disable_registration, else: false)
 
 config :plausible, PlausibleWeb.Endpoint,
   url: [scheme: base_url.scheme, host: base_url.host, path: base_url.path, port: base_url.port],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -134,7 +134,6 @@ enable_email_verification =
 disable_registration =
   config_dir
   |> get_var_from_path_or_env("DISABLE_REGISTRATION", "false")
-  |> String.to_existing_atom()
 
 hcaptcha_sitekey = get_var_from_path_or_env(config_dir, "HCAPTCHA_SITEKEY")
 hcaptcha_secret = get_var_from_path_or_env(config_dir, "HCAPTCHA_SECRET")
@@ -200,7 +199,7 @@ config :plausible,
 config :plausible, :selfhost,
   disable_authentication: disable_auth,
   enable_email_verification: enable_email_verification,
-  disable_registration: if(!disable_auth, do: disable_registration, else: false)
+  disable_registration: if(!disable_auth, do: disable_registration, else: "false")
 
 config :plausible, PlausibleWeb.Endpoint,
   url: [scheme: base_url.scheme, host: base_url.host, path: base_url.path, port: base_url.port],

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.AuthController do
             ]
 
   def register_form(conn, _params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       changeset = Plausible.Auth.User.changeset(%Plausible.Auth.User{})
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register(conn, params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       user = Plausible.Auth.User.new(params["user"])
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation_form(conn, %{"invitation_id" => invitation_id}) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == "true" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)
@@ -97,7 +97,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation(conn, %{"invitation_id" => invitation_id} = params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == "true" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -25,7 +25,8 @@ defmodule PlausibleWeb.AuthController do
             ]
 
   def register_form(conn, _params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) !=
+         "false" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       changeset = Plausible.Auth.User.changeset(%Plausible.Auth.User{})
@@ -38,7 +39,8 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register(conn, params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) !=
+         "false" do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       user = Plausible.Auth.User.new(params["user"])

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -25,8 +25,7 @@ defmodule PlausibleWeb.AuthController do
             ]
 
   def register_form(conn, _params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) !=
-         "false" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       changeset = Plausible.Auth.User.changeset(%Plausible.Auth.User{})
@@ -39,8 +38,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register(conn, params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) !=
-         "false" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       user = Plausible.Auth.User.new(params["user"])
@@ -76,7 +74,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation_form(conn, %{"invitation_id" => invitation_id}) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == "true" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == :true do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)
@@ -99,7 +97,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation(conn, %{"invitation_id" => invitation_id} = params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == "true" do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == :true do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.AuthController do
             ]
 
   def register_form(conn, _params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != false do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       changeset = Plausible.Auth.User.changeset(%Plausible.Auth.User{})
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register(conn, params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != false do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       user = Plausible.Auth.User.new(params["user"])
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation_form(conn, %{"invitation_id" => invitation_id}) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == :true do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == true do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)
@@ -97,7 +97,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def register_from_invitation(conn, %{"invitation_id" => invitation_id} = params) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == :true do
+    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == true do
       redirect(conn, to: Routes.auth_path(conn, :login_form))
     else
       invitation = Repo.get_by(Plausible.Auth.Invitation, invitation_id: invitation_id)

--- a/lib/plausible_web/templates/auth/login_form.html.eex
+++ b/lib/plausible_web/templates/auth/login_form.html.eex
@@ -16,7 +16,7 @@
     <p class="text-gray-500 text-xs my-2">Forgot password? <a href="/password/request-reset" class="underline text-gray-800 dark:text-gray-50">Click here</a> to reset it.</p>
   </div>
   <%= submit "Login →", class: "button mt-4 w-full" %>
-  <%= if !Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) do %>
+  <%= if Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) == "false" do %>
      <p class="text-center text-gray-500 text-xs mt-4">
       Don't have an account? <%= link("Register", to: "/register", class: "text-gray-800 dark:text-gray-50 underline") %> instead.
       </p>

--- a/lib/plausible_web/templates/auth/login_form.html.eex
+++ b/lib/plausible_web/templates/auth/login_form.html.eex
@@ -16,7 +16,7 @@
     <p class="text-gray-500 text-xs my-2">Forgot password? <a href="/password/request-reset" class="underline text-gray-800 dark:text-gray-50">Click here</a> to reset it.</p>
   </div>
   <%= submit "Login →", class: "button mt-4 w-full" %>
-  <%= if Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) == :false do %>
+  <%= if Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) == false do %>
      <p class="text-center text-gray-500 text-xs mt-4">
       Don't have an account? <%= link("Register", to: "/register", class: "text-gray-800 dark:text-gray-50 underline") %> instead.
       </p>

--- a/lib/plausible_web/templates/auth/login_form.html.eex
+++ b/lib/plausible_web/templates/auth/login_form.html.eex
@@ -16,7 +16,7 @@
     <p class="text-gray-500 text-xs my-2">Forgot password? <a href="/password/request-reset" class="underline text-gray-800 dark:text-gray-50">Click here</a> to reset it.</p>
   </div>
   <%= submit "Login →", class: "button mt-4 w-full" %>
-  <%= if Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) == "false" do %>
+  <%= if Keyword.fetch!(Application.get_env(:plausible, :selfhost),:disable_registration) == :false do %>
      <p class="text-center text-gray-500 text-xs mt-4">
       Don't have an account? <%= link("Register", to: "/register", class: "text-gray-800 dark:text-gray-50 underline") %> instead.
       </p>

--- a/lib/plausible_web/templates/layout/_header.html.eex
+++ b/lib/plausible_web/templates/layout/_header.html.eex
@@ -54,7 +54,7 @@
                     </div>
                 </li>
               </ul>
-            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false -> %>
+            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != false -> %>
               <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
                 <li>
                     <div class="inline-flex">

--- a/lib/plausible_web/templates/layout/_header.html.eex
+++ b/lib/plausible_web/templates/layout/_header.html.eex
@@ -54,7 +54,7 @@
                     </div>
                 </li>
               </ul>
-            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" -> %>
+            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != :false -> %>
               <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
                 <li>
                     <div class="inline-flex">

--- a/lib/plausible_web/templates/layout/_header.html.eex
+++ b/lib/plausible_web/templates/layout/_header.html.eex
@@ -54,7 +54,7 @@
                     </div>
                 </li>
               </ul>
-            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) -> %>
+            <%  Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) != "false" -> %>
               <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">
                 <li>
                     <div class="inline-flex">

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
     end
 
     test "disable registration", %{conn: conn} do
-      set_config(disable_registration: :true)
+      set_config(disable_registration: true)
       conn = get(conn, "/register")
       assert redirected_to(conn) == "/login"
     end

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
   def set_config(config) do
     updated_config =
       Keyword.merge(
-        [disable_authentication: false, disable_registration: :false],
+        [disable_authentication: false, disable_registration: false],
         config
       )
 

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
     end
 
     test "disable registration", %{conn: conn} do
-      set_config(disable_registration: true)
+      set_config(disable_registration: "true")
       conn = get(conn, "/register")
       assert redirected_to(conn) == "/login"
     end
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
   def set_config(config) do
     updated_config =
       Keyword.merge(
-        [disable_authentication: false, disable_registration: false],
+        [disable_authentication: false, disable_registration: "false"],
         config
       )
 

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
     end
 
     test "disable registration", %{conn: conn} do
-      set_config(disable_registration: "true")
+      set_config(disable_registration: :true)
       conn = get(conn, "/register")
       assert redirected_to(conn) == "/login"
     end
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
   def set_config(config) do
     updated_config =
       Keyword.merge(
-        [disable_authentication: false, disable_registration: "false"],
+        [disable_authentication: false, disable_registration: :false],
         config
       )
 


### PR DESCRIPTION
### Changes

Allows for the `DISABLE_REGISTRATION` config flag to support three states. 
`false` => registration is allowed as normal, for both normal users and invited users
`invite_only` => registration is allowed for those with an invite link, but prevented for normal users
`true` => registration is entirely disabled, regardless of invite status

@jesperordrup - after taking a look, this honestly was too trivial to implement for me to actually expect or accept a bounty for it (assuming it is good enough in its current state). 

I'll add the docs + changelog entry after confirming the implementation. 

### Tests
- [X] Automated tests have been ~~added~~ updated

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [X] This PR does not change the UI
