### PR TITLE
Re-adds underline to active top stat header

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -70,9 +70,9 @@ export default class TopStats extends React.Component {
             (
               <div className={`px-4 md:px-6 w-1/2 my-4 lg:w-auto group cursor-pointer select-none ${border}`} onClick={() => { updateMetric(METRIC_MAPPING[stat.name]) }} tabIndex={0} title={this.titleFor(stat)}>
                 <div
-                  className={`text-xs font-bold tracking-wide text-gray-500 uppercase dark:text-gray-400 whitespace-nowrap flex w-content ${isSelected ? 'text-indigo-700 dark:text-indigo-500 border-indigo-700 dark:border-indigo-500' : 'group-hover:text-indigo-700 dark:group-hover:text-indigo-500'}`}>
+                  className={`text-xs font-bold tracking-wide text-gray-500 uppercase dark:text-gray-400 whitespace-nowrap flex w-content ${isSelected ? 'text-indigo-700 dark:text-indigo-500 border-b border-indigo-700 dark:border-indigo-500' : 'group-hover:text-indigo-700 dark:group-hover:text-indigo-500'}`}>
                   {statDisplayName}
-                  <span className="hidden sm:inline-block ml-1">{statExtraName}</span>
+                  {statExtraName && <span className="hidden sm:inline-block ml-1">{statExtraName}</span>}
                 </div>
                 { this.renderStat(stat) }
               </div>


### PR DESCRIPTION
### Changes

Re-adds the underline (now thinner) for the currently selected top stat, & metric, to differentiate the hover state from the actual active state. I noticed this got removed in the cherry picked commit. I figure it wasn't fully intentional, as the hover state and the active state being identical is probably a bit problematic (as can be seen from the recent discussion in #1364), but if it was fully intentional feel free to close this PR.

![image](https://user-images.githubusercontent.com/19434157/164802908-26b3fff5-818e-4ca5-a469-b67489dd9de9.png)

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
