### PR TITLE
Set license to AGPL-3.0-or-later for assets package

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,7 +1,7 @@
 {
   "repository": {},
   "version": "1.4.0",
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "deploy": "$(npm bin)/webpack --mode production",
     "watch": "$(npm bin)/webpack --mode development --watch",


### PR DESCRIPTION
### Changes
As the whole project is AGPL v3 licensed, this just reflects that in the package.json. This is not changing the tracker JS license.
This change is from the non-merged PR https://github.com/plausible/analytics/pull/757

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
