### PR TITLE
Expand oban error tracking for plugins/notifiers

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -47,7 +47,7 @@ defmodule Plausible.Application do
 
     :telemetry.attach_many(
       "oban-errors",
-      [[:oban, :job, :exception], [:oban, :circuit, :trip]],
+      [[:oban, :job, :exception], [:oban, :notifier, :exception], [:oban, :plugin, :exception]],
       &ErrorReporter.handle_event/4,
       %{}
     )

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -7,11 +7,19 @@ defmodule ErrorReporter do
 
     on_job_exception(job)
 
-    Sentry.capture_exception(meta.error, stacktrace: meta.stacktrace, extra: extra)
+    Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 
-  def handle_event([:oban, :circuit, :trip], _measure, meta, _) do
-    Sentry.capture_exception(meta.error, stacktrace: meta.stacktrace, extra: meta)
+  def handle_event([:oban, :notifier, :exception], _timing, meta, _) do
+    extra = Map.take(meta, ~w(channel payload)a)
+
+    Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
+  end
+
+  def handle_event([:oban, :plugin, :exception], _timing, meta, _) do
+    extra = Map.take(meta, ~w(plugin)a)
+
+    Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 
   defp on_job_exception(%Oban.Job{


### PR DESCRIPTION
### Changes

* Plugin exceptions may silently cover-up database problems such as failed cron job inserts.
* The previously tracked `:circuit` event is no longer emitted.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
