### PR TITLE
Fixes inane Safari Date.parse compatibility issue

### DIFF
--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -54,10 +54,15 @@ export function formatDayShort(date) {
 }
 
 export function parseUTCDate(dateString) {
+  var date;
   // Safari Compatibility
-  const parts = dateString.split(/[^0-9]/);
-  parts[1] -= 1;
-  var date = dateString.includes(' ') ? new Date(...parts) : new Date(dateString);
+  if (typeof dateString === "string" && dateString.includes(' ')) {
+    const parts = dateString.split(/[^0-9]/);
+    parts[1] -= 1;
+    date = new Date(...parts);
+  } else {
+    date = new Date(dateString);
+  }
 
   return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
 }

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -54,7 +54,11 @@ export function formatDayShort(date) {
 }
 
 export function parseUTCDate(dateString) {
-  var date = new Date(dateString);
+  // Safari Compatibility
+  const parts = dateString.split(/[^0-9]/);
+  parts[1] -= 1;
+  var date = dateString.includes(' ') ? new Date(...parts) : new Date(dateString);
+
   return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
 }
 


### PR DESCRIPTION
### Changes

Fixes #1886 

Safari is modern IE 🤦

#### Firefox
![image](https://user-images.githubusercontent.com/19434157/166888527-bcb34a42-2812-4c8b-87fb-d831d8b64218.png)

#### Chrome
![image](https://user-images.githubusercontent.com/19434157/166888666-2b4c7490-a8a6-4132-8a7e-ec761ceb0a8a.png)

#### Safari ... why
![image](https://user-images.githubusercontent.com/19434157/166888566-e5bac7e3-c2e4-4b32-9c51-dc79f35b3e25.png)

#### IE 11
![image](https://user-images.githubusercontent.com/19434157/166889101-d7f38a51-b07a-4d0c-9aa0-33fd9f01ffe0.png)

I see a pattern.

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not need a changelog item

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
