### PR TITLE
Have entrypoint script run required steps directly

### DIFF
--- a/.gitlab/build-scripts/docker-entrypoint.sh
+++ b/.gitlab/build-scripts/docker-entrypoint.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
+
 set -e
 
-if [ "$1" = 'run' ]; then
-      exec /app/bin/plausible start
+# Confirm database exists in the required state
+/app/createdb.sh
+/app/migrate.sh
 
-elif [ "$1" = 'db' ]; then
-      exec /app/"$2".sh
- else
-      exec "$@"
-
-fi
-
-exec "$@"
+# Start Plausible
+/app/bin/plausible start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Paginate /api/sites results and add a `View all` link to the site-switcher dropdown in the dashboard.
 - Remove the `+ Add Site` link to the site-switcher dropdown in the dashboard.
 - `DISABLE_REGISTRATIONS` configuration parameter can now accept `invite_only` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
+- Simplify container entrypoint to remove need for custom `command`
 
 ## v1.4.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,5 @@ USER plausibleuser
 WORKDIR /app
 ENV GEONAMES_SOURCE_FILE=/app/lib/plausible-0.0.1/priv/geonames.csv
 ENV LISTEN_IP=0.0.0.0
-ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 8000
-CMD ["run"]
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
### Changes

This removes the need for a custom `command` in `docker-compose.yml`. https://github.com/plausible/hosting/blob/f7682057104671b42e3fff3a106f93a32ea14775/docker-compose.yml#L30

It intentionally removes `init-admin` from the setup, as this should really only be done once.

This should make the installation much simpler, as it works more expected, and means people can unset the environment variables required for the admin setup script. It should also make it start up _marginally_ faster.

Interested to hear what people think.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated (I'll do this once the approach is approved, but before merge)
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
