### PR TITLE
Add API to retrieve site by domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - New filter type: `contains`, available for `page`, `entry_page`, `exit_page`
 - Add filter for custom property
 - Add ability to import historical data from GA: plausible/analytics#1753
+- API route `GET /api/v1/sites/:site_id`
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -28,6 +28,16 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     end
   end
 
+  def get_site(conn, %{"site_id" => site_id}) do
+    site = Sites.get_for_user(conn.assigns[:current_user].id, site_id, [:owner, :admin])
+
+    if site do
+      json(conn, site)
+    else
+      H.not_found(conn, "Site could not be found")
+    end
+  end
+
   def delete_site(conn, %{"site_id" => site_id}) do
     site = Sites.get_for_user(conn.assigns[:current_user].id, site_id, [:owner])
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -101,6 +101,7 @@ defmodule PlausibleWeb.Router do
     pipe_through [:public_api, PlausibleWeb.AuthorizeSitesApiPlug]
 
     post "/", ExternalSitesController, :create_site
+    get "/:site_id", ExternalSitesController, :get_site
     delete "/:site_id", ExternalSitesController, :delete_site
     put "/shared-links", ExternalSitesController, :find_or_create_shared_link
     put "/goals", ExternalSitesController, :find_or_create_goal

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -384,4 +384,20 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
              }
     end
   end
+
+  describe "GET /api/v1/sites/:site_id" do
+    setup :create_new_site
+
+    test "get a site by it's domain", %{conn: conn, site: site} do
+      conn = get(conn, "/api/v1/sites/" <> site.domain)
+
+      assert json_response(conn, 200) == %{"domain" => site.domain, "timezone" => site.timezone}
+    end
+
+    test "is 404 when site cannot be found", %{conn: conn} do
+      conn = get(conn, "/api/v1/sites/foobar.baz")
+
+      assert json_response(conn, 404) == %{"error" => "Site could not be found"}
+    end
+  end
 end


### PR DESCRIPTION
### Changes

Added an API endpoint to get a site based on it's domain. This is required to check if the site exists or not from my terraform provider: https://github.com/mcalpinefree/terraform-provider-plausible

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated: https://github.com/plausible/docs/pull/234

### Dark mode
- [x] This PR does not change the UI
