### PR TITLE
Added manifest and serviceworker for PWA support

### DIFF
--- a/assets/static/js/manifest.json
+++ b/assets/static/js/manifest.json
@@ -1,0 +1,26 @@
+{
+    "name": "Plausible Analytics",
+    "short_name": "Plausible",
+    "start_url": "/",
+    "display": "standalone",
+    "orientation": "any",
+    "status_bar": "black",
+    "icons": [
+        {
+            "src": "\/images\/icon\/plausible_logo_sm.png",
+            "type": "image\/png",
+            "sizes": "150x200",
+            "purpose": "any"
+        }
+    ],
+    "shortcuts": [
+        {
+            "name": "Create",
+            "description": "Create",
+            "url": "\/create",
+            "icons": [
+                []
+            ]
+        }
+    ]
+}

--- a/assets/static/js/serviceworker.js
+++ b/assets/static/js/serviceworker.js
@@ -1,0 +1,1 @@
+self.addEventListener("fetch",(function(){}));

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -9,6 +9,8 @@
     <link rel="apple-touch-icon" href="/images/icon/apple-touch-icon.png">
     <title><%= assigns[:title] || "Plausible · Simple, privacy-friendly alternative to Google Analytics" %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <link rel="manifest" href="<%= Routes.static_path(@conn, "/js/manifest.json") %>"/>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/serviceworker.js") %>"></script>
     <%= render("_tracking.html", assigns) %>
     <script type="text/javascript" data-pref="<%= @conn.assigns[:theme] || (@conn.assigns[:current_user] && @conn.assigns[:current_user].theme) %>" src="<%= Routes.static_path(@conn, "/js/applyTheme.js") %>"></script>
   </head>


### PR DESCRIPTION
### Changes

This adds the minimal requirements for PWA apps:

<img width="100" src="https://user-images.githubusercontent.com/7342321/176785555-4535537a-8bcd-45a2-8b16-dbedefb19ef4.jpg" alt="screenshot"></img>

The serviceworker is the bare minimum and would not allow offline use yet. 

- [ ] The manifest should also include icons and splashscreens at different sizes which aren't added yet.

### Tests
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
