### PR TITLE
Fix missing 'pageviews' column from 'pages.csv'

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -475,7 +475,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
       else
-        pages |> to_csv([:name, :visitors, :bounce_rate, :time_on_page])
+        pages |> to_csv([:name, :visitors, :pageviews, :bounce_rate, :time_on_page])
       end
     else
       json(conn, pages)

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
@@ -1,2 +1,2 @@
-name,visitors,bounce_rate,time_on_page
-/some-other-page,1,,60.0
+name,visitors,pageviews,bounce_rate,time_on_page
+/some-other-page,1,1,,60.0

--- a/test/plausible_web/controllers/CSVs/30d/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d/pages.csv
@@ -1,3 +1,3 @@
-name,visitors,bounce_rate,time_on_page
-/,4,75,
-/some-other-page,1,,60.0
+name,visitors,pageviews,bounce_rate,time_on_page
+/,4,3,75,
+/some-other-page,1,1,,60.0

--- a/test/plausible_web/controllers/CSVs/6m/pages.csv
+++ b/test/plausible_web/controllers/CSVs/6m/pages.csv
@@ -1,3 +1,3 @@
-name,visitors,bounce_rate,time_on_page
-/,5,80,
-/some-other-page,1,,60.0
+name,visitors,pageviews,bounce_rate,time_on_page
+/,5,4,80,
+/some-other-page,1,1,,60.0


### PR DESCRIPTION
### Changes

The goal of this PR is to fix the missing `pageviews` column on the generated `page.csv` file. Mainly the solution is just adding the `pageviews` header to be added into the CSV and fix some tests.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

From what I can see the only mention of CSV in the docs is [here](https://plausible.io/docs/export-stats) and the `pageviews` column is shown although its for the `visitors.csv`.

### Dark mode
- [X] This PR does not change the UI
