### PR TITLE
Support 'AM/PM' and '24h' timeformat in stats graph

### DIFF
--- a/assets/js/dashboard/mount.js
+++ b/assets/js/dashboard/mount.js
@@ -14,6 +14,7 @@ if (container) {
     offset: container.dataset.offset,
     hasGoals: container.dataset.hasGoals === 'true',
     statsBegin: container.dataset.statsBegin,
+    timeformat: container.dataset.timeformat,
     embedded: container.dataset.embedded,
     background: container.dataset.background,
     isDbip: container.dataset.isDbip === 'true',

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -1,7 +1,7 @@
 import { METRIC_LABELS, METRIC_FORMATTER } from './visitor-graph'
 import {parseUTCDate, formatMonthYYYY, formatDay} from '../../util/date'
 
-export const dateFormatter = (interval, longForm) => {
+export const dateFormatter = (interval, longForm, ampmFormat = false) => {
   return function(isoDate, _index, _ticks) {
     let date = parseUTCDate(isoDate)
 
@@ -9,7 +9,7 @@ export const dateFormatter = (interval, longForm) => {
       return formatMonthYYYY(date);
     } else if (interval === 'date') {
       return formatDay(date);
-    } else if (interval === 'hour') {
+    } else if (interval === 'hour' && ampmFormat) {
       const parts = isoDate.split(/[^0-9]/);
       date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
       var hours = date.getHours(); // Not sure why getUTCHours doesn't work here
@@ -17,6 +17,15 @@ export const dateFormatter = (interval, longForm) => {
       hours = hours % 12;
       hours = hours ? hours : 12; // the hour '0' should be '12'
       return hours + ampm;
+    } else if (interval === 'hour' && !ampmFormat) {
+      const parts = isoDate.split(/[^0-9]/);
+      date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
+      var hours = date.getHours(); // Not sure why getUTCHours doesn't work here
+      var suffix = "h";
+      if (hours >= 12) {
+        hours = hours % 12 + 12;
+      }
+      return hours + suffix;
     } else if (interval === 'minute') {
       if (longForm) {
         const minutesAgo = Math.abs(isoDate)

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -1,7 +1,7 @@
 import { METRIC_LABELS, METRIC_FORMATTER } from './visitor-graph'
 import {parseUTCDate, formatMonthYYYY, formatDay} from '../../util/date'
 
-export const dateFormatter = (interval, longForm, ampmFormat = false) => {
+export const dateFormatter = (interval, longForm, timeformat = 'am/pm') => {
   return function(isoDate, _index, _ticks) {
     let date = parseUTCDate(isoDate)
 
@@ -9,23 +9,25 @@ export const dateFormatter = (interval, longForm, ampmFormat = false) => {
       return formatMonthYYYY(date);
     } else if (interval === 'date') {
       return formatDay(date);
-    } else if (interval === 'hour' && ampmFormat) {
+    } else if (interval === 'hour') {
       const parts = isoDate.split(/[^0-9]/);
       date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
       var hours = date.getHours(); // Not sure why getUTCHours doesn't work here
-      var ampm = hours >= 12 ? 'pm' : 'am';
-      hours = hours % 12;
-      hours = hours ? hours : 12; // the hour '0' should be '12'
-      return hours + ampm;
-    } else if (interval === 'hour' && !ampmFormat) {
-      const parts = isoDate.split(/[^0-9]/);
-      date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
-      var hours = date.getHours(); // Not sure why getUTCHours doesn't work here
-      var suffix = "h";
-      if (hours >= 12) {
-        hours = hours % 12 + 12;
+      if (timeformat == 'am/pm') {
+        var ampm = hours >= 12 ? 'pm' : 'am';
+        hours = hours % 12;
+        hours = hours ? hours : 12; // the hour '0' should be '12'
+        return hours + ampm;
+      } else {
+        const parts = isoDate.split(/[^0-9]/);
+        date = new Date(parts[0], parts[1] - 1, parts[2], parts[3], parts[4], parts[5])
+        var hours = date.getHours(); // Not sure why getUTCHours doesn't work here
+        var suffix = "h";
+        if (hours >= 12) {
+          hours = hours % 12 + 12;
+        }
+        return hours + suffix;
       }
-      return hours + suffix;
     } else if (interval === 'minute') {
       if (longForm) {
         const minutesAgo = Math.abs(isoDate)

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -62,6 +62,7 @@ class LineGraph extends React.Component {
     const dataSet = buildDataSet(graphData.plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
     // const prev_dataSet = graphData.prev_plot && buildDataSet(graphData.prev_plot, false, this.ctx, METRIC_LABELS[metric], true)
     // const combinedDataSets = comparison.enabled && prev_dataSet ? [...dataSet, ...prev_dataSet] : dataSet;
+    const timeformat = this.props.site.timeformat
 
     return new Chart(this.ctx, {
       type: 'line',
@@ -102,7 +103,7 @@ class LineGraph extends React.Component {
             grid: { display: false },
             ticks: {
               maxTicksLimit: 8,
-              callback: function(val, _index, _ticks) { return dateFormatter(graphData.interval)(this.getLabelForValue(val)) },
+              callback: function(val, _index, _ticks) { return dateFormatter(graphData.interval, false, timeformat)(this.getLabelForValue(val)) },
               color: this.props.darkTheme ? 'rgb(243, 244, 246)' : undefined
             }
           }

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -19,6 +19,7 @@ defmodule Plausible.Site do
   schema "sites" do
     field :domain, :string
     field :timezone, :string, default: "Etc/UTC"
+    field :timeformat, Ecto.Enum, values: ~w(am/pm 24h)a, default: :'am/pm'
     field :public, :boolean
     field :locked, :boolean
     field :stats_start_date, :date
@@ -39,8 +40,8 @@ defmodule Plausible.Site do
 
   def changeset(site, attrs \\ %{}) do
     site
-    |> cast(attrs, [:domain, :timezone])
-    |> validate_required([:domain, :timezone])
+    |> cast(attrs, [:domain, :timezone, :timeformat])
+    |> validate_required([:domain, :timezone, :timeformat])
     |> validate_format(:domain, ~r/^[a-zA-Z0-9\-\.\/\:]*$/,
       message: "only letters, numbers, slashes and period allowed"
     )

--- a/lib/plausible/timeformats.ex
+++ b/lib/plausible/timeformats.ex
@@ -1,0 +1,11 @@
+defmodule Plausible.Timeformats do
+
+  @formats [
+    :'am/pm',
+    :'24h'
+  ]
+
+  def formats() do
+    @formats
+  end
+end

--- a/lib/plausible_web/templates/site/settings_general.html.eex
+++ b/lib/plausible_web/templates/site/settings_general.html.eex
@@ -17,6 +17,11 @@
           <%= label f, :timezone, "Reporting Timezone", class: "block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300" %>
           <%= select f, :timezone, Plausible.Timezones.options(), class: "dark:bg-gray-900  mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:text-gray-100 cursor-pointer" %>
         </div>
+
+        <div class="col-span-4 sm:col-span-2">
+          <%= label f, :timeformat, "Time Format", class: "block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300" %>
+          <%= select f, :timeformat, Plausible.Timeformats.formats(), class: "dark:bg-gray-900  mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:text-gray-100 cursor-pointer" %>
+        </div>
       </div>
     </div>
     <div class="px-4 py-3 bg-gray-50 dark:bg-gray-850 text-right sm:px-6">

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="pt-6"></div>
-  <div id="stats-react-container" style="overflow-anchor: none;" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>" data-stats-begin="<%= @stats_start_date %>" data-shared-link-auth="<%= assigns[:shared_link_auth] %>" data-embedded="<%= @conn.assigns[:embedded] %>" data-background="<%= @conn.assigns[:background] %>" data-is-dbip="<%= @is_dbip %>" data-current-user-role="<%= @conn.assigns[:current_user_role] %>" data-flags="<%= Jason.encode!(@flags) %>"></div>
+  <div id="stats-react-container" style="overflow-anchor: none;" data-domain="<%= @site.domain %>" data-offset="<%= Timex.Timezone.total_offset(Timex.Timezone.get(@site.timezone)) %>" data-timeformat="<%= @site.timeformat %>" data-has-goals="<%= @has_goals %>" data-logged-in="<%= !!@conn.assigns[:current_user] %>" data-stats-begin="<%= @stats_start_date %>" data-shared-link-auth="<%= assigns[:shared_link_auth] %>" data-embedded="<%= @conn.assigns[:embedded] %>" data-background="<%= @conn.assigns[:background] %>" data-is-dbip="<%= @is_dbip %>" data-current-user-role="<%= @conn.assigns[:current_user_role] %>" data-flags="<%= Jason.encode!(@flags) %>"></div>
   <div id="modal_root"></div>
   <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
     <div class="bg-gray-50 dark:bg-gray-850">

--- a/priv/repo/migrations/20220704232000_add_timeformat_column_to_sites.exs
+++ b/priv/repo/migrations/20220704232000_add_timeformat_column_to_sites.exs
@@ -1,0 +1,19 @@
+defmodule Plausible.Repo.Migrations.AddTimeformatColumnToSites do
+  use Ecto.Migration
+
+  def up do
+    execute "CREATE TYPE timeformat AS ENUM ('am/pm', '24h')"
+
+    alter table(:sites) do
+      add :timeformat, :timeformat, null: false, default: "am/pm"
+    end
+  end
+
+  def down do
+    execute "DROP TYPE timeformat"
+
+    alter table(:sites) do
+      remove :timeformat
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR aims to add the feature requested [here](https://github.com/plausible/analytics/discussions/217). A `:timeformat` enumerated field was added to the `sites` table. This field defaults to `:'am/pm'` but it can be altered in the site's general settings.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

Not yet

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

Not yet

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

Not yet

### Dark mode
- [X] This PR does not change the UI

Below is a screen record showcasing this feature:
https://user-images.githubusercontent.com/3422400/177301701-da07ce35-1782-42d6-866f-2737535db635.mov