### PR TITLE
Chore/improve dev env onboarding startup errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Make sure Docker, Elixir, Erlang and Node.js are all installed on your developme
     2. Run `mix ecto.create`. This will create the required databases in both Postgres and Clickhouse.
     3. Run `mix ecto.migrate` to build the database schema.
     4. Run `npm ci --prefix assets` to install the required node dependencies.
+    5. Run `mix download_country_database` to fetch geolocation database
 3. Run `make server` or `mix phx.server` to start the Phoenix server.
 4. The system is now available on `localhost:8000`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop dummy_event
+
 install:
 	mix deps.get
 	mix ecto.create

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ install:
 	mix deps.get
 	mix ecto.create
 	mix ecto.migrate
+	mix download_country_database
 	npm install --prefix assets
 
 server:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -114,7 +114,7 @@ geolite2_country_db =
   get_var_from_path_or_env(
     config_dir,
     "GEOLITE2_COUNTRY_DB",
-    Application.app_dir(:plausible) <> "/priv/geodb/dbip-city-lite-2022-05.mmdb"
+    Application.app_dir(:plausible, "/priv/geodb/dbip-country.mmdb")
   )
 
 ip_geolocation_db = get_var_from_path_or_env(config_dir, "IP_GEOLOCATION_DB", geolite2_country_db)

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Plausible.MixProject do
       mod: {Plausible.Application, []},
       extra_applications: [
         :logger,
-        :runtime_tools
+        :runtime_tools,
+        :tls_certificate_check
       ]
     ]
   end


### PR DESCRIPTION
### Changes

This PR slightly improves dev environment onboarding experience by making sure that:
  - the GeoIP database is fetched on provisioning so that no `:geolocation` related logs are reported on startup
  - `tls_certificate_check` dependency is started early so that the app logs are not polluted with OTLP exporter initialization failures on startup
  
Additionally I took the liberty of marking all the Makefile targets as `.PHONY` - as none of them are files.

<details><summary>Before/after screenshots</summary>
#### Before: 

![image](https://user-images.githubusercontent.com/173738/177477427-04e06e6f-b88c-407d-b432-3dda1c90f567.png)

#### After:

![image](https://user-images.githubusercontent.com/173738/177477643-94684e14-7e7f-4562-bd00-34c89ff58493.png)
</details>

Thanks.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
