### PR TITLE
Add option to configure sentry pool size, and geolix worker size

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -227,7 +227,8 @@ config :sentry,
   release: app_version,
   tags: %{app_version: app_version},
   enable_source_code_context: true,
-  root_source_code_path: [File.cwd!()]
+  root_source_code_path: [File.cwd!()],
+  hackney_pool_max_connections: get_var_from_path_or_env(config_dir, "SENTRY_POOL_SIZE") || 50
 
 config :logger, Sentry.LoggerBackend,
   capture_log_messages: true,
@@ -403,6 +404,10 @@ config :kaffy,
 
 if config_env() != :test do
   config :geolix,
+    pool: [
+      size: get_var_from_path_or_env(config_dir, "GEOLIX_POOL_SIZE") || 5,
+      max_overflow: get_var_from_path_or_env(config_dir, "GEOLIX_POOL_MAX_OVERLFOW") || 10
+    ],
     databases: [
       %{
         id: :geolocation,


### PR DESCRIPTION
PR add option to configure:

* max hackney pool size for Sentry
* worker size for Geolix