### PR TITLE
feat(tracker): navigator.sendBeacon support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add `navigator.sendBeacon` support in all variants except `compat`
 - The `exclusions` script extension now also takes a `data-include` attribute tag
 - A `file-downloads` script extension for automatically tracking file downloads as custom events
 - Integration with [Matomo's referrer spam list](https://github.com/matomo-org/referrer-spam-list/blob/master/spammers.txt) to block known spammers

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -92,6 +92,7 @@
     payload.h = 1
     {{/if}}
 
+    {{#if compat}}
     var request = new XMLHttpRequest();
     request.open('POST', endpoint, true);
     request.setRequestHeader('Content-Type', 'text/plain');
@@ -103,6 +104,12 @@
         options && options.callback && options.callback()
       }
     }
+    {{else}}
+    var requestQueued = navigator.sendBeacon(endpoint, JSON.stringify(payload));
+    if (requestQueued) {
+      options && options.callback && options.callback()
+    }
+    {{/if}}
   }
 
   {{#if outbound_links}}
@@ -119,6 +126,7 @@
           plausible('Outbound Link: Click', {props: {url: link.href}})
         }
 
+        {{#if compat}}
         // Delay navigation so that Plausible is notified of the click
         if(!link.target || link.target.match(/^_(self|parent|top)$/i)) {
           if (!(event.ctrlKey || event.metaKey || event.shiftKey) && click) {
@@ -128,6 +136,7 @@
             event.preventDefault();
           }
         }
+        {{/if}}
       }
   }
 
@@ -163,7 +172,8 @@
       if (middle || click) {
         plausible('File Download', {props: {url: linkTarget}})
       }
-
+      
+      {{#if compat}}
       // Delay navigation so that Plausible is notified of the click
       if(!link.target || link.target.match(/^_(self|parent|top)$/i)) {
         if (!(event.ctrlKey || event.metaKey || event.shiftKey) && click) {
@@ -173,6 +183,7 @@
           event.preventDefault();
         }
       }
+      {{/if}}
     }
   }
 


### PR DESCRIPTION
### Changes

This PR introduces `navigator.sendBeacon` support. The API is not supported by Internet Explorer, I think the browser is already dead but since you did provide sort of polyfill for `URL API` I added this piece of code in all variants except `compat`.

This lets you to omit these timeouts which slows down navigation to the next page:

https://github.com/plausible/analytics/blob/2b8e3ea62af5972d5e2a8e5b301eef438fdae922/tracker/src/plausible.js#L122-L130

You can read more details about that api here: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon

Unfortunately I'm not an Elixir expert, so I would be grateful if you could test this in some way.

Thanks

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
