### PR TITLE
Add tooltip to show exact number in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Add filter for custom property
 - Add ability to import historical data from GA: plausible/analytics#1753
 - API route `GET /api/v1/sites/:site_id`
+- Hovering on top of list items will now show a [tooltip with the exact number instead of a shortened version](https://github.com/plausible/analytics/discussions/1968)
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -91,7 +91,7 @@ export default function ListReport(props) {
             <ExternalLink item={listItem} externalLinkDest={props.externalLinkDest}  />
           </span>
         </Bar>
-        <span className="font-medium dark:text-gray-200 w-20 text-right">
+        <span className="font-medium dark:text-gray-200 w-20 text-right" tooltip={listItem[valueKey]}>
           {numberFormatter(listItem[valueKey])}
           {
             listItem.percentage >= 0


### PR DESCRIPTION
### Changes
This PR adds a tooltip when hovering over list items to show the exact number instead of the formatted short version of the number as suggested in this [discussion](https://github.com/plausible/analytics/discussions/1968).

### Tests
- [X] This PR does not require tests

### Changelog
- [X ] Entry has been added to `CHANGELOG`

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
