### PR TITLE
Reset goal stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to import historical data from GA: plausible/analytics#1753
 - API route `GET /api/v1/sites/:site_id`
 - Hovering on top of list items will now show a [tooltip with the exact number instead of a shortened version](https://github.com/plausible/analytics/discussions/1968)
+- Add ability to [reset goal stats](https://github.com/plausible/analytics/discussions/186)
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/lib/plausible/clickhouse_repo.ex
+++ b/lib/plausible/clickhouse_repo.ex
@@ -18,6 +18,17 @@ defmodule Plausible.ClickhouseRepo do
     Ecto.Adapters.SQL.query!(__MODULE__, sessions_sql, [domain])
   end
 
+  @doc """
+  Deletes all past events for the given domain and event name. This is executed
+  asynchronously and might take some time to actually delete the records.
+  """
+  @spec clear_events_for(String.t(), String.t()) :: :ok
+  def clear_events_for(domain, name) do
+    events_sql = "ALTER TABLE events DELETE WHERE domain = ? AND name = ? AND timestamp <= ?"
+    Ecto.Adapters.SQL.query!(__MODULE__, events_sql, [domain, name, DateTime.utc_now()])
+    :ok
+  end
+
   def clear_imported_stats_for(site_id) do
     [
       "imported_visitors",

--- a/lib/plausible/goals.ex
+++ b/lib/plausible/goals.ex
@@ -37,6 +37,10 @@ defmodule Plausible.Goals do
     )
   end
 
+  def get_by_id_and_domain(id, domain) do
+    Repo.one(from g in Goal, where: g.domain == ^domain and g.id == ^id)
+  end
+
   def delete(id) do
     Repo.one(from g in Goal, where: g.id == ^id) |> Repo.delete!()
   end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -161,6 +161,24 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(to: Routes.site_path(conn, :settings_goals, website))
   end
 
+  def reset_goal(conn, %{"website" => website, "id" => goal_id}) do
+    with %Plausible.Goal{} = goal <-
+           Goals.get_by_id_and_domain(goal_id, conn.assigns.site.domain),
+         :ok <- Plausible.ClickhouseRepo.clear_events_for(goal.domain, goal.event_name) do
+      conn
+      |> put_flash(
+        :success,
+        "Your request to reset goal stats is in process. This may take a few minutes."
+      )
+      |> redirect(to: Routes.site_path(conn, :settings_goals, website))
+    else
+      nil ->
+        conn
+        |> put_flash(:error, "Goal does not exist")
+        |> redirect(to: Routes.site_path(conn, :settings_goals, website))
+    end
+  end
+
   def settings(conn, %{"website" => website}) do
     redirect(conn, to: Routes.site_path(conn, :settings_general, website))
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -245,6 +245,7 @@ defmodule PlausibleWeb.Router do
     get "/:website/settings/danger-zone", SiteController, :settings_danger_zone
     get "/:website/goals/new", SiteController, :new_goal
     post "/:website/goals", SiteController, :create_goal
+    post "/:website/goals/:id/reset", SiteController, :reset_goal
     delete "/:website/goals/:id", SiteController, :delete_goal
     put "/:website/settings", SiteController, :update_settings
     put "/:website/settings/google", SiteController, :update_google_auth

--- a/lib/plausible_web/templates/site/settings_goals.html.eex
+++ b/lib/plausible_web/templates/site/settings_goals.html.eex
@@ -1,4 +1,4 @@
-<div class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
+<div class="shadow bg-white dark:bg-gray-800 sm:rounded-md py-6 px-4 sm:p-6">
   <header class="relative">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Goals</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Define actions that you want your users to take like visiting a certain page, submitting a form, etc.</p>
@@ -10,9 +10,39 @@
     <%= if Enum.count(@goals) > 0 do %>
       <div class="mt-4">
         <%= for goal <- @goals do %>
-          <div class="border-b border-gray-300 dark:border-gray-500 py-3 flex justify-between">
-            <span class="text-sm font-medium text-gray-900 dark:text-gray-100"><%= goal_name(goal) %></span>
-            <%= button(to: "/#{URI.encode_www_form(@site.domain)}/goals/#{goal.id}", method: :delete, class: "text-sm text-red-600", data: [confirm: "Are you sure you want to remove goal #{goal_name(goal)}? This will just affect the UI, all of your analytics data will stay intact."]) do %>
+          <div class="border-b border-gray-300 dark:border-gray-500 py-3 flex">
+            <span class="flex-auto text-sm font-medium text-gray-900 dark:text-gray-100"><%= goal_name(goal) %></span>
+            <div x-data="{open: false}" @click.away="open = false" x-cloak class="relative">
+              <button @click="open = !open" class="flex-none inline-flex items-center shadow-sm px-2.5 py-0.5 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-full bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800">
+                Reset stats
+                <svg class="w-4 h-4 pt-px ml-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+              </button>
+              <ul
+                x-show="open"
+                x-transition:leave="transition ease-in duration-100"
+                x-transition:leave-start="opacity-100"
+                x-transition:leave-end="opacity-0"
+                class="origin-top-right absolute z-10 right-0 mt-2 w-72 rounded-md shadow-lg overflow-hidden bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-400 ring-1 ring-black ring-opacity-5 focus:outline-none" tabindex="-1" role="listbox" aria-labelledby="listbox-label" aria-activedescendant="listbox-option-0"
+                tabindex="-1"
+                role="listbox"
+                aria-labelledby="listbox-label"
+                aria-activedescendant="listbox-option-0"
+                >
+                  <li class="p-4 text-sm cursor-default group flex justify-between" role="option">
+                    <div>
+                      <p class="text-base font-medium text-gray-900 dark:text-gray-100">Reset stats</p>
+                      <p class="mt-1 text-sm text-gray-500">Resetting stats is a destructive action. Data will not be recoverable.</p>
+                    </div>
+                  </li>
+                  <li class="select-none hover:bg-gray-100 dark:hover:bg-gray-900 text-red-600" role="option">
+                    <%= button(to: "/#{URI.encode_www_form(@site.domain)}/goals/#{goal.id}/reset", method: :post, class: "inline-block w-full p-4 text-sm text-red-600 font-medium", data: [confirm: "Are you sure you want to reset goal #{goal_name(goal)}? This is a destructive action."]) do %>
+                      <%= "Reset #{goal_name(goal)} stats" %>
+                    <% end %>
+                  </li>
+              </ul>
+            </div>
+
+            <%= button(to: "/#{URI.encode_www_form(@site.domain)}/goals/#{goal.id}", method: :delete, class: "flex-none ml-3 text-sm text-red-600", data: [confirm: "Are you sure you want to remove goal #{goal_name(goal)}? This will just affect the UI, all of your analytics data will stay intact."]) do %>
               <svg class="feather feather-sm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
             <% end %>
           </div>

--- a/test/plausible/clickhouse_repo_test.exs
+++ b/test/plausible/clickhouse_repo_test.exs
@@ -1,0 +1,60 @@
+defmodule Plausible.ClickhouseRepoTest do
+  use Plausible.DataCase
+  import Plausible.TestUtils
+  import Ecto.Query
+
+  setup [:create_user, :create_new_site]
+
+  test "clear_events_for/2 deletes events by name and domain", %{site: %{domain: domain} = site} do
+    event_to_delete = "clean_events_for_to_delete"
+
+    populate_stats(site, [
+      build(:event, name: event_to_delete),
+      build(:event, name: event_to_delete),
+      build(:event, name: "clear_events_for_other"),
+      build(:pageview, pathname: "/"),
+      build(:pageview, pathname: "/"),
+      build(:pageview, pathname: "/register"),
+      build(:pageview, pathname: "/register"),
+      build(:pageview, pathname: "/contact")
+    ])
+
+    assert :ok == Plausible.ClickhouseRepo.clear_events_for(domain, event_to_delete)
+
+    assert eventually(fn ->
+             from(e in Plausible.ClickhouseEvent,
+               where: e.domain == ^domain and e.name == ^event_to_delete
+             )
+             |> Plausible.ClickhouseRepo.aggregate(:count)
+             |> Kernel.==(0)
+           end),
+           "expected events to be deleted"
+  end
+
+  test "clear_events_for/2 deletes only past events", %{site: %{domain: domain} = site} do
+    event_to_delete = "clean_events_for_to_delete"
+
+    future =
+      DateTime.utc_now()
+      |> DateTime.add(3600, :second)
+      |> DateTime.to_naive()
+      |> NaiveDateTime.truncate(:second)
+
+    populate_stats(site, [
+      build(:event, name: event_to_delete),
+      build(:event, name: event_to_delete),
+      build(:event, name: event_to_delete, timestamp: future)
+    ])
+
+    assert :ok == Plausible.ClickhouseRepo.clear_events_for(domain, event_to_delete)
+
+    assert eventually(fn ->
+             from(e in Plausible.ClickhouseEvent,
+               where: e.domain == ^domain and e.name == ^event_to_delete
+             )
+             |> Plausible.ClickhouseRepo.aggregate(:count)
+             |> Kernel.==(1)
+           end),
+           "expected past events to be deleted"
+  end
+end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -143,4 +143,15 @@ defmodule Plausible.TestUtils do
     |> Timex.shift(shifts)
     |> NaiveDateTime.truncate(:second)
   end
+
+  def eventually(expectation, wait_time \\ 100, retries \\ 10) do
+    Enum.reduce_while(1..retries, nil, fn _i, _acc ->
+      if expectation.() do
+        {:halt, true}
+      else
+        :timer.sleep(wait_time)
+        {:cont, false}
+      end
+    end)
+  end
 end


### PR DESCRIPTION
### Changes

This pull request adds new button in Site > Settings > Goals to reset goals by deleting all related events. This was suggested in https://github.com/plausible/analytics/discussions/186.

<img width="1097" alt="Screen Shot 2022-07-12 at 7 54 04 PM" src="https://user-images.githubusercontent.com/5093045/178612854-84d35f2b-1aff-421e-b23c-9b7985012e1b.png">

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated (link: https://github.com/plausible/docs/pull/247)

### Dark mode
- [x] The UI has been tested both in dark and light mode
