### PR TITLE
Closes #1994

### DIFF
--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -181,7 +181,7 @@ class DatePicker extends React.Component {
     this.setState({open: false});
 
     const keys = ['d', 'e', 'r', 'w', 'm', 'y', 't', 's', 'l', 'a'];
-    const redirects = [{date: false, period: 'day'}, {date: shiftDays(nowForSite(this.props.site), -1), period: 'day'}, {period: 'realtime'}, {date: false, period: '7d'}, {date: false, period: 'month'}, {date: false, period: 'year'}, {date: false, period: '30d'}, {date: false, period: '6mo'}, {date: false, period: '12mo'}, {date: false, period: 'all'}];
+    const redirects = [{date: false, period: 'day'}, {date: formatISO(shiftDays(nowForSite(this.props.site), -1)), period: 'day'}, {period: 'realtime'}, {date: false, period: '7d'}, {date: false, period: 'month'}, {date: false, period: 'year'}, {date: false, period: '30d'}, {date: false, period: '6mo'}, {date: false, period: '12mo'}, {date: false, period: 'all'}];
 
     if (keys.includes(e.key.toLowerCase())) {
       navigateToQuery(history, query, {...newSearch, ...(redirects[keys.indexOf(e.key.toLowerCase())])});


### PR DESCRIPTION
### Changes
Fix "Yesterday" Shortcut!

When the "Yesterday" shortcut is pressed:
- it sends a "&date" query string to the current URL, to make the filter for the dashboard.
- the "Yesterday" shortcut is not sending a valid date to the `date` query string.
- this PR adjusts the parameters sent to `date`, by using the existing function `formatISO` above the `shiftDays` function
- with this, for the current day = `2022-06-13` instead of sending:
 `date=Tue+Jul+12+2022+23%3A04%3A46+GMT-0300+%28Horário+Padrão+de+Brasília%29`
  it passes to return the formatted date (`Y-M-D`):
 `2022-07-12`

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [X] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [X] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [X] This PR does not change the UI
