### PR TITLE
Keep user filter when listing cities, countries, and regions stats 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Fix SecurityError in tracking script when user has blocked all local storage
 - Prevent dashboard graph from being selected when long pressing on the graph in a mobile browser
 - The exported `pages.csv` file now includes pageviews again [plausible/analytics#1878](https://github.com/plausible/analytics/issues/1878)
+- Fix a bug where city, region and country filters were filtering stats but not the location list
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -381,6 +381,7 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:country") do
     from(
       s in q,
+      where: s.country_code != "\0\0",
       group_by: s.country_code,
       select_merge: %{country: s.country_code}
     )
@@ -389,6 +390,7 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:region") do
     from(
       s in q,
+      where: s.subdivision1_code != "",
       group_by: s.subdivision1_code,
       select_merge: %{region: s.subdivision1_code}
     )
@@ -397,6 +399,7 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:city") do
     from(
       s in q,
+      where: s.city_geoname_id != 0,
       group_by: s.city_geoname_id,
       select_merge: %{city: s.city_geoname_id}
     )

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -182,10 +182,10 @@ defmodule Plausible.Stats.Imported do
           imported_q |> select_merge([i], %{country: i.country})
 
         :region ->
-          imported_q |> select_merge([i], %{region: i.region})
+          imported_q |> where([i], i.region != "") |> select_merge([i], %{region: i.region})
 
         :city ->
-          imported_q |> select_merge([i], %{city: i.city})
+          imported_q |> where([i], i.city != 0) |> select_merge([i], %{city: i.city})
 
         :device ->
           imported_q |> select_merge([i], %{device: i.device})

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -567,12 +567,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def countries(conn, params) do
     site = conn.assigns[:site]
-
-    query =
-      Query.from(site, params)
-      |> Filters.add_prefix()
-      |> Query.put_filter("visit:country", {:is_not, "\0\0"})
-
+    query = site |> Query.from(params) |> Filters.add_prefix()
     pagination = parse_pagination(params)
 
     countries =
@@ -624,12 +619,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def regions(conn, params) do
     site = conn.assigns[:site]
-
-    query =
-      Query.from(site, params)
-      |> Filters.add_prefix()
-      |> Query.put_filter("visit:region", {:is_not, ""})
-
+    query = site |> Query.from(params) |> Filters.add_prefix()
     pagination = parse_pagination(params)
 
     regions =
@@ -662,12 +652,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def cities(conn, params) do
     site = conn.assigns[:site]
-
-    query =
-      Query.from(site, params)
-      |> Filters.add_prefix()
-      |> Query.put_filter("visit:city", {:is_not, 0})
-
+    query = site |> Query.from(params) |> Filters.add_prefix()
     pagination = parse_pagination(params)
 
     cities =

--- a/test/plausible_web/controllers/api/stats_controller/cities_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/cities_test.exs
@@ -1,0 +1,36 @@
+defmodule PlausibleWeb.Api.StatsController.CitiesTest do
+  use PlausibleWeb.ConnCase
+  import Plausible.TestUtils
+
+  describe "GET /api/stats/:domain/cities" do
+    defp seed(%{site: site}) do
+      populate_stats(site, [
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632)
+      ])
+    end
+
+    setup [:create_user, :log_in, :create_new_site, :add_imported_data, :seed]
+
+    test "returns top cities by new visitors", %{conn: conn, site: site} do
+      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"code" => 588_409, "country_flag" => "🇪🇪", "name" => "Tallinn", "visitors" => 3},
+               %{"code" => 591_632, "country_flag" => "🇪🇪", "name" => "Kärdla", "visitors" => 2}
+             ]
+    end
+
+    test "when list is filtered returns one city only", %{conn: conn, site: site} do
+      filters = Jason.encode!(%{city: "591632"})
+      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{"code" => 591_632, "country_flag" => "🇪🇪", "name" => "Kärdla", "visitors" => 2}
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -267,5 +267,27 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                }
              ]
     end
+
+    test "when list is filtered by country returns one country only", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB")
+      ])
+
+      filters = Jason.encode!(%{country: "GB"})
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 1,
+                 "percentage" => 100
+               }
+             ]
+    end
   end
 end

--- a/test/plausible_web/controllers/api/stats_controller/regions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_test.exs
@@ -1,0 +1,36 @@
+defmodule PlausibleWeb.Api.StatsController.RegionsTest do
+  use PlausibleWeb.ConnCase
+  import Plausible.TestUtils
+
+  describe "GET /api/stats/:domain/regions" do
+    defp seed(%{site: site}) do
+      populate_stats(site, [
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632)
+      ])
+    end
+
+    setup [:create_user, :log_in, :create_new_site, :add_imported_data, :seed]
+
+    test "returns top cities by new visitors", %{conn: conn, site: site} do
+      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"code" => "EE-37", "country_flag" => "🇪🇪", "name" => "Harjumaa", "visitors" => 3},
+               %{"code" => "EE-39", "country_flag" => "🇪🇪", "name" => "Hiiumaa", "visitors" => 2}
+             ]
+    end
+
+    test "when list is filtered returns one city only", %{conn: conn, site: site} do
+      filters = Jason.encode!(%{region: "EE-39"})
+      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{"code" => "EE-39", "country_flag" => "🇪🇪", "name" => "Hiiumaa", "visitors" => 2}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This commit fixes a bug where location filters were filtering stats but not the locations list. This was caused by a `Map.put/3` call that overrides the user filter. I rolled back 5b571432737fb121e1b2a6c9e977500cb70f8880 changes and removed the `Map.put/3` call.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI

Closes #1982