### PR TITLE
Make goals clickable in realtime view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to import historical data from GA: plausible/analytics#1753
 - API route `GET /api/v1/sites/:site_id`
 - Hovering on top of list items will now show a [tooltip with the exact number instead of a shortened version](https://github.com/plausible/analytics/discussions/1968)
+- Filter goals in realtime filter by clicking goal name
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/assets/js/dashboard/stats/conversions/index.js
+++ b/assets/js/dashboard/stats/conversions/index.js
@@ -59,20 +59,6 @@ export default class Conversions extends React.Component {
       .then((res) => this.setState({loading: false, goals: res, prevHeight: null}))
   }
 
-  renderGoalText(goalName) {
-    if (this.props.query.period === 'realtime') {
-      return <span className="block px-2 py-1.5 relative z-9 md:truncate break-all dark:text-gray-200">{goalName}</span>
-    } else {
-      return (
-        <Link to={url.setQuery('goal', goalName)} className="block px-2 py-1.5 hover:underline relative z-9 break-all lg:truncate dark:text-gray-200">
-          {goalName}
-        </Link>
-      )
-    }
-  }
-
-
-
   renderGoal(goal) {
     const { viewport } = this.state;
     const renderProps = this.props.query.filters['goal'] == goal.name && goal.prop_names
@@ -87,7 +73,7 @@ export default class Conversions extends React.Component {
             maxWidthDeduction={this.getBarMaxWidth()}
             plot="unique_conversions"
           >
-            {this.renderGoalText(goal.name)}
+            <Link to={url.setQuery('goal', goal.name)} className="block px-2 py-1.5 hover:underline relative z-9 break-all lg:truncate dark:text-gray-200">{goal.name}</Link>
           </Bar>
           <div className="dark:text-gray-200">
             <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.unique_conversions)}</span>


### PR DESCRIPTION
### Changes

This pull request closes #1739. More on that on #520. Goals could already be filtered on realtime view, but only by clicking the filter button. This PR makes the goal label clickable as another way of filtering by goal, to keep consistency between views.

![](https://user-images.githubusercontent.com/5093045/179868129-231c02a5-918e-4185-87b5-ceec246ea162.gif)

### Tests
- [X] This PR does not require tests

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
