### PR TITLE
Show last 12 month period up until the last day of the previous month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - Remove the `+ Add Site` link to the site-switcher dropdown in the dashboard.
 - `DISABLE_REGISTRATIONS` configuration parameter can now accept `invite_only` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
 - New and improved Session tracking module for higher throughput and lower latency. [PR#1934](https://github.com/plausible/analytics#1934)
+- Last 12 months now shows the last year up until the previous month of the current one [PR#2055](https://github.com/plausible/analytics/pull/2055)
 
 ## v1.4.1
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -153,6 +153,7 @@ defmodule Plausible.Stats.Query do
   def from(site, %{"period" => "12mo"} = params) do
     end_date =
       parse_single_date(site.timezone, params)
+      |> Timex.shift(months: -1)
       |> Timex.end_of_month()
 
     start_date =

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -53,11 +53,11 @@ defmodule Plausible.Stats.QueryTest do
 
   test "parses 12 month format" do
     q = Query.from(@site, %{"period" => "12mo"})
+    start_date = Timex.today() |> Timex.shift(months: -12) |> Timex.beginning_of_month()
+    end_date = Timex.today() |> Timex.shift(months: -1) |> Timex.end_of_month()
 
-    assert q.date_range.first ==
-             Timex.shift(Timex.today(), months: -11) |> Timex.beginning_of_month()
-
-    assert q.date_range.last == Timex.today() |> Timex.end_of_month()
+    assert q.date_range.first == start_date
+    assert q.date_range.last == end_date
     assert q.interval == "month"
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -315,10 +315,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
   test "shows last 12 months of visitors", %{conn: conn, site: site} do
     populate_stats([
-      build(:pageview, domain: site.domain, timestamp: ~N[2020-02-01 00:00:00]),
-      build(:pageview, domain: site.domain, timestamp: ~N[2020-12-31 00:00:00]),
-      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
-      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00])
+      build(:pageview, domain: site.domain, timestamp: ~N[2020-01-01 00:00:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2020-11-30 00:00:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2020-12-01 00:00:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2020-12-01 00:00:00])
     ])
 
     conn =
@@ -330,7 +330,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"date" => "2020-02-01", "visitors" => 1},
+               %{"date" => "2020-01-01", "visitors" => 1},
+               %{"date" => "2020-02-01", "visitors" => 0},
                %{"date" => "2020-03-01", "visitors" => 0},
                %{"date" => "2020-04-01", "visitors" => 0},
                %{"date" => "2020-05-01", "visitors" => 0},
@@ -339,9 +340,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                %{"date" => "2020-08-01", "visitors" => 0},
                %{"date" => "2020-09-01", "visitors" => 0},
                %{"date" => "2020-10-01", "visitors" => 0},
-               %{"date" => "2020-11-01", "visitors" => 0},
-               %{"date" => "2020-12-01", "visitors" => 1},
-               %{"date" => "2021-01-01", "visitors" => 2}
+               %{"date" => "2020-11-01", "visitors" => 1},
+               %{"date" => "2020-12-01", "visitors" => 2}
              ]
            }
   end

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -160,7 +160,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/main-graph?period=12mo&date=2021-12-31&with_imported=true"
+          "/api/stats/#{site.domain}/main-graph?period=12mo&date=2022-01-01&with_imported=true"
         )
 
       assert %{"plot" => plot} = json_response(conn, 200)


### PR DESCRIPTION
### Changes
As discussed [here](https://github.com/plausible/analytics/discussions/1817) this PR alters the way the "last 12 months" query is performed as to do the last 12 months up until the previous month than the current one. This makes sense as most of the time it's not sensible to compare complete months against the current one which hasn't finished.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
