### PR TITLE
Fix geolocation subdivision pattern matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ plausible-report.xml
 /priv/plts/*.plt.hash
 
 .env
+
+# Geolocation databases
+/priv/geodb/*.mmdb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Prevent dashboard graph from being selected when long pressing on the graph in a mobile browser
 - The exported `pages.csv` file now includes pageviews again [plausible/analytics#1878](https://github.com/plausible/analytics/issues/1878)
 - Fix a bug where city, region and country filters were filtering stats but not the location list
+- Fix a bug where regions were not being saved
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,6 +20,29 @@ config :plausible,
 
 config :bamboo, :refute_timeout, 10
 
+geolix_sample_lookup = %{
+  city: %{geoname_id: 2_988_507, names: %{en: "Paris"}},
+  continent: %{code: "EU", geoname_id: 6_255_148, names: %{en: "Europe"}},
+  country: %{
+    geoname_id: 3_017_382,
+    is_in_european_union: true,
+    iso_code: "FR",
+    names: %{en: "France"}
+  },
+  ip_address: {2, 2, 2, 2},
+  location: %{
+    latitude: 48.8566,
+    longitude: 2.35222,
+    time_zone: "Europe/Paris",
+    weather_code: "FRXX0076"
+  },
+  postal: %{code: "75000"},
+  subdivisions: [
+    %{geoname_id: 3_012_874, iso_code: "IDF", names: %{en: "Île-de-France"}},
+    %{geoname_id: 2_968_815, iso_code: "75", names: %{en: "Paris"}}
+  ]
+}
+
 config :geolix,
   databases: [
     %{
@@ -27,6 +50,7 @@ config :geolix,
       adapter: Geolix.Adapter.Fake,
       data: %{
         {1, 1, 1, 1} => %{country: %{iso_code: "US"}},
+        {2, 2, 2, 2} => geolix_sample_lookup,
         {1, 1, 1, 1, 1, 1, 1, 1} => %{country: %{iso_code: "US"}},
         {0, 0, 0, 0} => %{country: %{iso_code: "ZZ"}}
       }

--- a/lib/mix/tasks/download_country_database.ex
+++ b/lib/mix/tasks/download_country_database.ex
@@ -1,4 +1,9 @@
 defmodule Mix.Tasks.DownloadCountryDatabase do
+  @moduledoc """
+  This task downloads the Country Lite database from DB-IP for self-hosted or development purposes.
+  Plausible Cloud runs a paid version of DB-IP with more detailed geolocation data.
+  """
+
   use Mix.Task
   use Plausible.Repo
   require Logger

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -481,13 +481,13 @@ defmodule PlausibleWeb.Api.ExternalController do
 
     country_code =
       get_in(result, [:country, :iso_code])
-      |> ignore_unknown_country
+      |> ignore_unknown_country()
 
     city_geoname_id = get_in(result, [:city, :geoname_id])
 
     subdivision1_code =
       case result do
-        %{geolocation: %{subdivisions: [%{iso_code: iso_code} | _rest]}} ->
+        %{subdivisions: [%{iso_code: iso_code} | _rest]} ->
           country_code <> "-" <> iso_code
 
         _ ->
@@ -496,7 +496,7 @@ defmodule PlausibleWeb.Api.ExternalController do
 
     subdivision2_code =
       case result do
-        %{geolocation: %{subdivisions: [_first, %{iso_code: iso_code} | _rest]}} ->
+        %{subdivisions: [_first, %{iso_code: iso_code} | _rest]} ->
           country_code <> "-" <> iso_code
 
         _ ->

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -636,7 +636,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
 
     # Fake data is set up in config/test.exs
-    test "looks up the country from the ip address", %{conn: conn} do
+    test "looks up location data from the ip address", %{conn: conn} do
       params = %{
         name: "pageview",
         domain: "external-controller-test-20.com",
@@ -644,12 +644,15 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       }
 
       conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
+      |> put_req_header("x-forwarded-for", "2.2.2.2")
       |> post("/api/event", params)
 
       pageview = get_event("external-controller-test-20.com")
 
-      assert pageview.country_code == "US"
+      assert pageview.country_code == "FR"
+      assert pageview.subdivision1_code == "FR-IDF"
+      assert pageview.subdivision2_code == "FR-75"
+      assert pageview.city_geoname_id == 2_988_507
     end
 
     test "ignores unknown country code ZZ", %{conn: conn} do


### PR DESCRIPTION
This commit fixes a bug where regions were not being saved. This was
caused because Geolix response was returning an additional
`:geolocation` map key. It also adds a test case for this.

Closes #2033

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
