### PR TITLE
Added new container-related user-agents on client-libraries.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ All notable changes to this project will be documented in this file.
 - Filter goals in realtime filter by clicking goal name
 - The time format (12 hour or 24 hour) for graph timelines is now presented based on the browser's defined language
 - Choice of metric for main-graph both in UI and API (visitors, pageviews, bounce_rate, visit_duration) plausible/analytics#1364
+- Add regex rules for the following container-related libraries:
+  + `artifactory`
+  + `openbuildservice`
+  + `buildah`
+  + `buildkit`
+  + `containerd`
+  + `containers`
+  + `cri`
+  + `docker`
+  + `gcr`
+  + `libpod`
+  + `skopeo`
 
 ### Fixed
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/priv/ua_inspector/client.libraries.yml
+++ b/priv/ua_inspector/client.libraries.yml
@@ -202,3 +202,48 @@
 - regex: 'jsdom/([\.\d]+)'
   name: 'jsdom'
   version: '$1'
+
+# Container-related useragents
+- regex: 'Artifactory/([\.\d]+)'
+  name: 'artifactory'
+  version: '$1'
+
+- regex: 'BSRPC ([\.\d]+)'
+  name: 'openbuildservice'
+  version: '$1'
+
+- regex: 'Buildah/([\.\d]+)'
+  name: 'buildah'
+  version: '$1'
+
+- regex: 'buildkit/(?:(v))?([\.\d]+)'
+  name: 'buildkit'
+  version: '$1'
+
+- regex: 'containerd/(?:(v))?([\.\d]+)'
+  name: 'containerd'
+  version: '$1'
+
+- regex: 'containers/([\.\d]+)'
+  name: 'containers'
+  version: '$1'
+
+- regex: 'cri-o/([\.\d]+)'
+  name: 'cri-o'
+  version: '$1'
+
+- regex: 'docker/([\.\d]+)'
+  name: 'docker'
+  version: '$1'
+
+- regex: 'go-containerregistry/v([\.\d]+)'
+  name: 'gcr'
+  version: '$1'
+
+- regex: 'libpod/([\.\d]+)'
+  name: 'libpod'
+  version: '$1'
+
+- regex: 'skopeo/([\.\d]+)'
+  name: 'skopeo'
+  version: '$1'


### PR DESCRIPTION
### Changes

Added user-agents for the following clients:

artifactory
openbuildservice
buildah
buildkit
containerd
containers
cri-o
docker
gcr
libpod
skopeo

Addresses plausible/analytics#2017

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
