### PR TITLE
added a test and changed hashmode condition

### DIFF
--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -273,7 +273,7 @@ defmodule PlausibleWeb.Api.ExternalController do
       |> URI.decode()
       |> String.trim_trailing()
 
-    if hash_mode && uri.fragment do
+    if hash_mode == 1 && uri.fragment do
       pathname <> "#" <> URI.decode(uri.fragment)
     else
       pathname

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -842,6 +842,22 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.pathname == "/#page-a"
     end
 
+    test "does not record hash when hash mode is 0", %{conn: conn} do
+      params = %{
+        n: "pageview",
+        u: "http://www.example.com/#page-a",
+        d: "external-controller-test-hash-0.com",
+        h: 0
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      pageview = get_event("external-controller-test-hash-0.com")
+
+      assert pageview.pathname == "/"
+    end
+
     test "decodes URL pathname, fragment and search", %{conn: conn} do
       params = %{
         n: "pageview",


### PR DESCRIPTION
### Changes

The NPM package sends events with the `h: 0` option. Currently, the if statement only checks if the hash option is present, not its value. With this change, `h: 0` in the event payload will not track the hash part of the URL.

There's an issue and a PR in the tracker repo, to fix this on the tracker side (https://github.com/plausible/plausible-tracker/issues/42) but I think it makes sense to change this one in our app instead.

### Tests
- [x] Automated tests have been added