### PR TITLE
Add Custom telemetry for Plausible.Event.WriteBuffer, Plausible.Event.WriteBuffer and Cachex

### DIFF
--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -1,4 +1,4 @@
-defmodule ErrorReporter do
+defmodule ObanErrorReporter do
   def handle_event([:oban, :job, :exception], measure, %{job: job} = meta, _) do
     extra =
       job

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -70,7 +70,7 @@ defmodule Plausible.Application do
     :telemetry.attach_many(
       "oban-errors",
       [[:oban, :job, :exception], [:oban, :notifier, :exception], [:oban, :plugin, :exception]],
-      &ErrorReporter.handle_event/4,
+      &ObanErrorReporter.handle_event/4,
       %{}
     )
   end

--- a/lib/plausible/prom_ex.ex
+++ b/lib/plausible/prom_ex.ex
@@ -10,7 +10,8 @@ defmodule Plausible.PromEx do
       Plugins.Beam,
       {Plugins.Phoenix, router: PlausibleWeb.Router, endpoint: PlausibleWeb.Endpoint},
       Plugins.Ecto,
-      Plugins.Oban
+      Plugins.Oban,
+      Plausible.PromEx.Plugins.PlausibleMetrics
     ]
   end
 

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -1,0 +1,116 @@
+defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
+  @moduledoc """
+  Custom PromEx plugin for instrumenting code within Plausible app.
+  """
+  use PromEx.Plugin
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, 5_000)
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    metric_prefix =
+      Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :plausible_metrics))
+
+    [
+      write_buffer_metrics(metric_prefix, poll_rate),
+      cache_metrics(metric_prefix, poll_rate)
+    ]
+  end
+
+  @doc """
+  Add telemetry events for Session and Event write buffers
+  """
+  def execute_write_buffer_metrics do
+    event_write_buffer_pid = GenServer.whereis(Plausible.Event.WriteBuffer)
+
+    {:message_queue_len, events_message_queue_len} =
+      if is_pid(event_write_buffer_pid),
+        do: Process.info(event_write_buffer_pid, :message_queue_len),
+        else: {:message_queue_len, 0}
+
+    session_write_buffer_pid = GenServer.whereis(Plausible.Event.WriteBuffer)
+
+    {:message_queue_len, sessions_message_queue_len} =
+      if is_pid(session_write_buffer_pid),
+        do: Process.info(session_write_buffer_pid, :message_queue_len),
+        else: {:message_queue_len, 0}
+
+    :telemetry.execute([:prom_ex, :plugin, :write_buffer_metrics, :events_message_queue_len], %{
+      count: events_message_queue_len
+    })
+
+    :telemetry.execute([:prom_ex, :plugin, :write_buffer_metrics, :sessions_message_queue_len], %{
+      count: sessions_message_queue_len
+    })
+  end
+
+  @doc """
+  Add telemetry events for Cachex user agents and sessions
+  """
+  def execute_cache_metrics do
+    user_agents_count =
+      case Cachex.stats(:user_agents) do
+        {:ok, stats} -> stats
+        _ -> 0
+      end
+
+    :telemetry.execute([:prom_ex, :plugin, :cachex, :sessions_count], %{
+      count: user_agents_count
+    })
+
+    sessions_count =
+      case Cachex.stats(:sessions) do
+        {:ok, stats} -> stats
+        _ -> 0
+      end
+
+    :telemetry.execute([:prom_ex, :plugin, :cachex, :user_agents_count], %{
+      count: user_agents_count
+    })
+
+    :telemetry.execute([:prom_ex, :plugin, :cachex, :sessions_count], %{
+      count: sessions_count
+    })
+  end
+
+  defp write_buffer_metrics(metric_prefix, poll_rate) do
+    Polling.build(
+      :write_buffer_metrics,
+      poll_rate,
+      {__MODULE__, :execute_write_buffer_metrics, []},
+      [
+        last_value(
+          metric_prefix ++ [:events, :message_queue_len, :count],
+          event_name: [:prom_ex, :plugin, :write_buffer_metrics, :events_message_queue_len],
+          measurement: :count
+        ),
+        last_value(
+          metric_prefix ++ [:sessions, :message_queue_len, :count],
+          event_name: [:prom_ex, :plugin, :write_buffer_metrics, :sessions_message_queue_len],
+          measurement: :count
+        )
+      ]
+    )
+  end
+
+  defp cache_metrics(metric_prefix, poll_rate) do
+    Polling.build(
+      :cache_metrics,
+      poll_rate,
+      {__MODULE__, :execute_cache_metrics, []},
+      [
+        last_value(
+          metric_prefix ++ [:events, :cache_size, :count],
+          event_name: [:prom_ex, :plugin, :cachex, :sessions_count],
+          measurement: :count
+        ),
+        last_value(
+          metric_prefix ++ [:sessions, :cache_size, :count],
+          event_name: [:prom_ex, :plugin, :cachex, :user_agents_count],
+          measurement: :count
+        )
+      ]
+    )
+  end
+end

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -55,10 +55,6 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         _ -> 0
       end
 
-    :telemetry.execute([:prom_ex, :plugin, :cachex, :sessions_count], %{
-      count: user_agents_count
-    })
-
     sessions_count =
       case Cachex.stats(:sessions) do
         {:ok, stats} -> stats


### PR DESCRIPTION
### Changes

* Add Custom telemetry for Plausible.Event.WriteBuffer, Plausible.Event.WriteBuffer and Cachex
* Rename telemetry.ex to avoid confusion with Phoenix Telemetry supervisor

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests

- [x] This PR does not require tests

### Changelog

- [x] This PR does not make a user-facing change

### Documentation

- [x] This change does not need a documentation update

### Dark mode

- [x] This PR does not change the UI
