### PR TITLE
Refactor event struct creation function

### DIFF
--- a/lib/plausible/ingestion/city_overrides.ex
+++ b/lib/plausible/ingestion/city_overrides.ex
@@ -1,0 +1,198 @@
+defmodule Plausible.Ingestion.CityOverrides do
+  @moduledoc false
+
+  @overrides %{
+    # Austria
+    # Gemeindebezirk Floridsdorf -> Vienna
+    2_779_467 => 2_761_369,
+    # Gemeindebezirk Leopoldstadt -> Vienna
+    2_772_614 => 2_761_369,
+    # Gemeindebezirk Landstrasse -> Vienna
+    2_773_040 => 2_761_369,
+    # Gemeindebezirk Donaustadt -> Vienna
+    2_780_851 => 2_761_369,
+    # Gemeindebezirk Favoriten -> Vienna
+    2_779_776 => 2_761_369,
+    # Gemeindebezirk Währing -> Vienna
+    2_762_091 => 2_761_369,
+    # Gemeindebezirk Wieden -> Vienna
+    2_761_393 => 2_761_369,
+    # Gemeindebezirk Innere Stadt -> Vienna
+    2_775_259 => 2_761_369,
+    # Gemeindebezirk Alsergrund -> Vienna
+    2_782_729 => 2_761_369,
+    # Gemeindebezirk Liesing -> Vienna
+    2_772_484 => 2_761_369,
+    # Urfahr -> Linz
+    2_762_518 => 2_772_400,
+
+    # Canada
+    # Old Toronto -> Toronto
+    8_436_019 => 6_167_865,
+    # Etobicoke -> Toronto
+    5_950_267 => 6_167_865,
+    # East York -> Toronto
+    5_946_235 => 6_167_865,
+    # Scarborough -> Toronto
+    6_948_711 => 6_167_865,
+    # North York -> Toronto
+    6_091_104 => 6_167_865,
+
+    # Czech republic
+    # Praha 5 -> Prague
+    11_951_220 => 3_067_696,
+    # Praha 4 -> Prague
+    11_951_218 => 3_067_696,
+    # Praha 11 -> Prague
+    11_951_232 => 3_067_696,
+    # Praha 10 -> Prague
+    11_951_210 => 3_067_696,
+    # Praha 4 -> Prague
+    8_378_772 => 3_067_696,
+
+    # Denmark
+    # København SV -> Copenhagen
+    11_747_123 => 2_618_425,
+    # København NV -> Copenhagen
+    11_746_894 => 2_618_425,
+    # Odense S -> Odense
+    11_746_825 => 2_615_876,
+    # Odense M -> Odense
+    11_746_974 => 2_615_876,
+    # Odense SØ -> Odense
+    11_746_888 => 2_615_876,
+    # Aarhus C -> Aarhus
+    11_746_746 => 2_624_652,
+    # Aarhus N -> Aarhus
+    11_746_890 => 2_624_652,
+
+    # Estonia
+    # Kristiine linnaosa -> Tallinn
+    11_050_530 => 588_409,
+    # Kesklinna linnaosa -> Tallinn
+    11_053_706 => 588_409,
+    # Lasnamäe linnaosa -> Tallinn
+    11_050_526 => 588_409,
+    # Põhja-Tallinna linnaosa -> Tallinn
+    11_049_594 => 588_409,
+    # Mustamäe linnaosa -> Tallinn
+    11_050_531 => 588_409,
+    # Haabersti linnaosa -> Tallinn
+    11_053_707 => 588_409,
+    # Viimsi -> Tallinn
+    587_629 => 588_409,
+
+    # Germany
+    # Bezirk Tempelhof-Schöneberg -> Berlin
+    3_336_297 => 2_950_159,
+    # Bezirk Mitte -> Berlin
+    2_870_912 => 2_950_159,
+    # Bezirk Charlottenburg-Wilmersdorf -> Berlin
+    3_336_294 => 2_950_159,
+    # Bezirk Friedrichshain-Kreuzberg -> Berlin
+    3_336_295 => 2_950_159,
+    # Moosach -> Munich
+    8_351_447 => 2_867_714,
+    # Schwabing-Freimann -> Munich
+    8_351_448 => 2_867_714,
+    # Stadtbezirk 06 -> Düsseldorf
+    6_947_276 => 2_934_246,
+    # Stadtbezirk 04 -> Düsseldorf
+    6_947_274 => 2_934_246,
+    # Köln-Ehrenfeld -> Köln
+    6_947_479 => 2_886_242,
+    # Köln-Lindenthal- -> Köln
+    6_947_481 => 2_886_242,
+    # Beuel -> Bonn
+    2_949_619 => 2_946_447,
+    # Innenstadt I -> Frankfurt am Main
+    6_946_225 => 2_925_533,
+
+    # India
+    # Navi Mumbai -> Mumbai
+    6_619_347 => 1_275_339,
+
+    # Mexico
+    # Miguel Hidalgo Villa Olímpica -> Mexico city
+    11_561_026 => 3_530_597,
+    # Zedec Santa Fe -> Mexico city
+    3_517_471 => 3_530_597,
+    #  Fuentes del Pedregal-> Mexico city
+    11_562_596 => 3_530_597,
+    #  Centro -> Mexico city
+    9_179_691 => 3_530_597,
+    #  Cuauhtémoc-> Mexico city
+    12_266_959 => 3_530_597,
+
+    # Netherlands
+    # Schiphol-Rijk -> Amsterdam
+    10_173_838 => 2_759_794,
+    # Westpoort -> Amsterdam
+    11_525_047 => 2_759_794,
+    # Amsterdam-Zuidoost -> Amsterdam
+    6_544_881 => 2_759_794,
+    # Loosduinen -> The Hague
+    11_525_037 => 2_747_373,
+    # Laak -> The Hague
+    11_525_042 => 2_747_373,
+
+    # Norway
+    # Nordre Aker District -> Oslo
+    6_940_981 => 3_143_244,
+
+    # Romania
+    # Sector 1 -> Bucharest,
+    11_055_041 => 683_506,
+    # Sector 2 -> Bucharest
+    11_055_040 => 683_506,
+    # Sector 3 -> Bucharest
+    11_055_044 => 683_506,
+    # Sector 4 -> Bucharest
+    11_055_042 => 683_506,
+    # Sector 5 -> Bucharest
+    11_055_043 => 683_506,
+    # Sector 6 -> Bucharest
+    11_055_039 => 683_506,
+    # Bucuresti -> Bucharest
+    6_691_781 => 683_506,
+
+    # Slovakia
+    # Bratislava -> Bratislava
+    3_343_955 => 3_060_972,
+
+    # Sweden
+    # Södermalm -> Stockholm
+    2_676_209 => 2_673_730,
+
+    # Switzerland
+    # Vorstädte -> Basel
+    11_789_440 => 2_661_604,
+    # Zürich (Kreis 11) / Oerlikon -> Zürich
+    2_659_310 => 2_657_896,
+    # Zürich (Kreis 3) / Alt-Wiedikon -> Zürich
+    2_658_007 => 2_657_896,
+    # Zürich (Kreis 5) -> Zürich
+    6_295_521 => 2_657_896,
+    # Zürich (Kreis 1) / Hochschulen -> Zürich
+    6_295_489 => 2_657_896,
+
+    # UK
+    # Shadwell -> London
+    6_690_595 => 2_643_743,
+    # City of London -> London
+    2_643_741 => 2_643_743,
+    # South Bank -> London
+    6_545_251 => 2_643_743,
+    # Soho -> London
+    6_545_173 => 2_643_743,
+    # Whitechapel -> London
+    2_634_112 => 2_643_743,
+    # King's Cross -> London
+    6_690_589 => 2_643_743,
+    # Poplar -> London
+    2_640_091 => 2_643_743,
+    # Hackney -> London
+    2_647_694 => 2_643_743
+  }
+  def get, do: @overrides
+end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -1,4 +1,4 @@
-defmodule Plausible.Ingestion do
+defmodule Plausible.Ingestion.Event do
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Ingestion.{Request, CityOverrides}
 

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -92,11 +92,11 @@ defmodule Plausible.Ingestion.Event do
 
     %Plausible.ClickhouseEvent{
       event
-      | utm_medium: request.utm_medium,
-        utm_source: request.utm_source,
-        utm_campaign: request.utm_campaign,
-        utm_content: request.utm_content,
-        utm_term: request.utm_term,
+      | utm_medium: request.query_params["utm_medium"],
+        utm_source: request.query_params["utm_source"],
+        utm_campaign: request.query_params["utm_campaign"],
+        utm_content: request.query_params["utm_content"],
+        utm_term: request.query_params["utm_term"],
         referrer_source: get_referrer_source(request, ref),
         referrer: clean_referrer(ref)
     }
@@ -113,7 +113,10 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp get_referrer_source(request, ref) do
-    source = request.utm_source || request.source_param || request.ref_param
+    source =
+      request.query_params["utm_source"] || request.query_params["source"] ||
+        request.query_params["ref"]
+
     source || PlausibleWeb.RefInspector.parse(ref)
   end
 

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -2,49 +2,27 @@ defmodule Plausible.Ingestion.Event do
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Ingestion.{Request, CityOverrides}
 
-  @spec build_and_buffer(Request.t(), [atom()], [{atom(), map()}]) ::
-          {:ok, [{atom(), map()}]} | :skip | {:error, Ecto.Changeset.t()}
+  @spec build_and_buffer(Request.t()) :: :ok | :skip | {:error, Ecto.Changeset.t()}
   @doc """
   Builds events from %Plausible.Ingestion.Request{} and adds them to Plausible.Event.WriteBuffer.
   This function reads geolocation data and parses the user agent string. Returns :skip if the
   request is identified as spam, or blocked.
-
-    iex> build_and_buffer(request)
-    {:ok, []}
-
-  The `stash` and `apply` options allows given %Plausible.ClickhouseEvent{} fields be used later.
-  This is useful when the caller makes two subsequent requests and don't want to re-fetch
-  geolocation and user agent dependent fields. Check the following example:
-
-    iex> {:ok, stash} = build_and_buffer(first_request, [:geolocation])
-    ...> {:ok, stash} = build_and_buffer(second_request, [:geolocation], stash)
-    ...> {:ok, stash} = build_and_buffer(third_request, [:geolocation], stash)
-    iex> stash
-    [geolocation: %{country_code: "BR"}]
-
-  Currently `stash` only supports `:geolocation` and `:user_agent`, which are the most expensive
-  calls.
-
   """
-  def build_and_buffer(%Request{} = request, stash \\ [], apply \\ []) do
+  def build_and_buffer(%Request{} = request) do
     with :ok <- spam_or_blocked?(request),
          salts <- Plausible.Session.Salts.fetch(),
          event <- Map.new(),
-         %{} = event <-
-           apply_stash(event, apply[:user_agent], fn -> put_user_agent(event, request) end),
+         %{} = event <- put_user_agent(event, request),
          %{} = event <- put_basic_info(event, request),
          %{} = event <- put_referrer(event, request),
-         %{} = event <-
-           apply_stash(event, apply[:geolocation], fn -> put_geolocation(event, request) end),
+         %{} = event <- put_geolocation(event, request),
          %{} = event <- put_screen_size(event, request),
          %{} = event <- put_props(event, request),
          events when is_list(events) <- map_domains(event, request),
          events when is_list(events) <- put_user_id(events, request, salts),
          {:ok, events} <- validate_events(events),
-         events when is_list(events) <- register_session(events, request, salts),
-         stash <- save_stash(events, stash) do
+         events when is_list(events) <- register_session(events, request, salts) do
       Enum.each(events, &Plausible.Event.WriteBuffer.insert/1)
-      {:ok, stash}
     end
   end
 
@@ -362,22 +340,5 @@ defmodule Plausible.Ingestion.Event do
     else
       nil
     end
-  end
-
-  defp apply_stash(%{} = event, stashed, fallback_fun) do
-    if stashed, do: Map.merge(event, stashed), else: fallback_fun.()
-  end
-
-  @stash_mapping [
-    user_agent: [:operating_system, :operating_system_version, :browser, :browser_version],
-    geolocation: [:country_code, :subdivision1_code, :subdivision2_code, :city_geoname_id]
-  ]
-
-  defp save_stash([%{} = event | _rest], stash) do
-    Enum.map(stash, fn stash_key ->
-      event_keys = @stash_mapping[stash_key] || []
-      attrs = Map.take(event, event_keys)
-      {stash_key, attrs}
-    end)
   end
 end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -37,7 +37,7 @@ defmodule Plausible.Ingestion.Event do
          %{} = event <-
            apply_stash(event, apply[:geolocation], fn -> put_geolocation(event, request) end),
          %{} = event <- put_screen_size(event, request),
-         %{} = event <- put_meta(event, request),
+         %{} = event <- put_props(event, request),
          events when is_list(events) <- map_domains(event, request),
          events when is_list(events) <- put_user_id(events, request, salts),
          :ok <- validate_events(events),
@@ -76,11 +76,11 @@ defmodule Plausible.Ingestion.Event do
     end
   end
 
-  defp put_meta(%Plausible.ClickhouseEvent{} = event, %Request{} = request) do
-    if is_map(request.meta) do
+  defp put_props(%Plausible.ClickhouseEvent{} = event, %Request{} = request) do
+    if is_map(request.props) do
       event
-      |> Map.put(:"meta.key", Map.keys(request.meta))
-      |> Map.put(:"meta.value", Map.values(request.meta) |> Enum.map(&to_string/1))
+      |> Map.put(:"meta.key", Map.keys(request.props))
+      |> Map.put(:"meta.value", Map.values(request.props) |> Enum.map(&to_string/1))
     else
       event
     end

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -1,29 +1,44 @@
 defmodule Plausible.Ingestion.Request do
-  defstruct ~w(remote_ip params query_params user_agent)a
+  @moduledoc """
+  The %Plausible.Ingestion.Request{} struct stores all needed fields to create an event downstream.
+  """
+
+  defstruct ~w(
+    remote_ip user_agent event_name url referrer domain screen_width hash_mode meta utm_medium
+    utm_source utm_campaign utm_content utm_term source_param ref_param
+  )a
 
   @type t() :: %__MODULE__{
           remote_ip: String.t() | nil,
-          params: map(),
-          query_params: map(),
-          user_agent: String.t() | nil
+          user_agent: String.t() | nil,
+          event_name: term(),
+          url: term(),
+          referrer: term(),
+          domain: term(),
+          screen_width: term(),
+          hash_mode: term(),
+          meta: map(),
+          utm_medium: String.t() | nil,
+          utm_source: String.t() | nil,
+          utm_campaign: String.t() | nil,
+          utm_content: String.t() | nil,
+          utm_term: String.t() | nil,
+          source_param: String.t() | nil,
+          ref_param: String.t() | nil
         }
-
-  @allowed_query_params ~w(utm_medium utm_source utm_campaign utm_content utm_term utm_source source ref)
 
   @spec build(Plug.Conn.t()) :: {:ok, t()} | {:error, :invalid_json}
   @doc """
   Builds a %Plausible.Ingestion.Request{} struct from %Plug.Conn{}.
   """
   def build(%Plug.Conn{} = conn) do
-    with {:ok, body} <- parse_body(conn),
-         %{} = params <- build_params(body),
-         %{} = query_params <- decode_query_params(params),
-         remote_ip <- PlausibleWeb.RemoteIp.get(conn) do
+    with {:ok, request_body} <- parse_body(conn) do
       %__MODULE__{}
-      |> Map.put(:remote_ip, remote_ip)
-      |> Map.put(:params, params)
-      |> Map.put(:query_params, query_params)
+      |> Map.put(:remote_ip, PlausibleWeb.RemoteIp.get(conn))
       |> put_user_agent(conn)
+      |> put_request_params(request_body)
+      |> put_utm_fields()
+      |> then(&{:ok, &1})
     end
   end
 
@@ -42,33 +57,30 @@ defmodule Plausible.Ingestion.Request do
     end
   end
 
-  defp build_params(body) do
-    %{
-      name: body["n"] || body["name"],
-      url: body["u"] || body["url"],
-      referrer: body["r"] || body["referrer"],
-      domain: body["d"] || body["domain"],
-      screen_width: body["w"] || body["screen_width"],
-      hash_mode: body["h"] || body["hashMode"],
-      meta: parse_meta(body)
+  defp put_request_params(%__MODULE__{} = request, %{} = request_body) do
+    %__MODULE__{
+      request
+      | event_name: request_body["n"] || request_body["name"],
+        url: request_body["u"] || request_body["url"],
+        referrer: request_body["r"] || request_body["referrer"],
+        domain: request_body["d"] || request_body["domain"],
+        screen_width: request_body["w"] || request_body["screen_width"],
+        hash_mode: request_body["h"] || request_body["hashMode"],
+        meta: parse_meta(request_body)
     }
   end
 
-  defp parse_meta(params) do
-    raw_meta = params["m"] || params["meta"] || params["p"] || params["props"]
+  defp parse_meta(%{} = request_body) do
+    raw_meta =
+      request_body["m"] || request_body["meta"] || request_body["p"] || request_body["props"]
 
     case decode_raw_props(raw_meta) do
       {:ok, parsed_json} ->
-        Enum.filter(parsed_json, fn
-          {_, ""} -> false
-          {_, nil} -> false
-          {_, val} when is_list(val) -> false
-          {_, val} when is_map(val) -> false
-          _ -> true
-        end)
+        parsed_json
+        |> Enum.filter(&valid_prop_value?/1)
         |> Map.new()
 
-      _ ->
+      _error ->
         %{}
     end
   end
@@ -87,25 +99,33 @@ defmodule Plausible.Ingestion.Request do
 
   defp decode_raw_props(_), do: :bad_format
 
-  defp decode_query_params(params) do
-    with url when is_binary(url) <- params.url,
-         %URI{query: query} when is_binary(query) <- URI.parse(url) do
-      do_decode_query_params(query)
-    else
-      _any -> %{}
+  defp valid_prop_value?({key, value}) do
+    case {key, value} do
+      {_key, ""} -> false
+      {_key, nil} -> false
+      {_key, value} when is_list(value) -> false
+      {_key, value} when is_map(value) -> false
+      {_key, _value} -> true
     end
   end
 
-  defp do_decode_query_params(query) do
-    try do
+  defp put_utm_fields(%__MODULE__{url: url} = request) do
+    with url when is_binary(url) <- url,
+         %URI{query: query} when is_binary(query) <- URI.parse(url) do
       query
       |> URI.query_decoder()
-      |> Enum.reduce(%{}, fn
-        {key, value}, acc when key in @allowed_query_params -> Map.put(acc, key, value)
+      |> Enum.reduce(request, fn
+        {"utm_medium", value}, acc when is_binary(value) -> Map.put(acc, :utm_medium, value)
+        {"utm_source", value}, acc when is_binary(value) -> Map.put(acc, :utm_source, value)
+        {"utm_campaign", value}, acc when is_binary(value) -> Map.put(acc, :utm_campaign, value)
+        {"utm_content", value}, acc when is_binary(value) -> Map.put(acc, :utm_content, value)
+        {"utm_term", value}, acc when is_binary(value) -> Map.put(acc, :utm_term, value)
+        {"source", value}, acc when is_binary(value) -> Map.put(acc, :source_param, value)
+        {"ref", value}, acc when is_binary(value) -> Map.put(acc, :ref_param, value)
         _any, acc -> acc
       end)
-    rescue
-      _ -> %{}
+    else
+      _any -> request
     end
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Ingestion.Request do
   """
 
   defstruct ~w(
-    remote_ip user_agent event_name url referrer domain screen_width hash_mode meta utm_medium
+    remote_ip user_agent event_name url referrer domain screen_width hash_mode props utm_medium
     utm_source utm_campaign utm_content utm_term source_param ref_param
   )a
 
@@ -17,7 +17,7 @@ defmodule Plausible.Ingestion.Request do
           domain: term(),
           screen_width: term(),
           hash_mode: term(),
-          meta: map(),
+          props: map(),
           utm_medium: String.t() | nil,
           utm_source: String.t() | nil,
           utm_campaign: String.t() | nil,
@@ -66,15 +66,15 @@ defmodule Plausible.Ingestion.Request do
         domain: request_body["d"] || request_body["domain"],
         screen_width: request_body["w"] || request_body["screen_width"],
         hash_mode: request_body["h"] || request_body["hashMode"],
-        meta: parse_meta(request_body)
+        props: parse_props(request_body)
     }
   end
 
-  defp parse_meta(%{} = request_body) do
-    raw_meta =
+  defp parse_props(%{} = request_body) do
+    raw_props =
       request_body["m"] || request_body["meta"] || request_body["p"] || request_body["props"]
 
-    case decode_raw_props(raw_meta) do
+    case decode_raw_props(raw_props) do
       {:ok, parsed_json} ->
         parsed_json
         |> Enum.filter(&valid_prop_value?/1)

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Api.ExternalController do
   def event(conn, _params) do
     with {:ok, ingestion_request} <- Plausible.Ingestion.Request.build(conn),
          _ <- Sentry.Context.set_extra_context(%{request: ingestion_request}),
-         :ok <- Plausible.Ingestion.build_and_buffer(ingestion_request) do
+         :ok <- Plausible.Ingestion.Event.build_and_buffer(ingestion_request) do
       conn |> put_status(202) |> text("ok")
     else
       :skip ->

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -11,15 +11,25 @@ defmodule PlausibleWeb.Api.ExternalController do
   def event(conn, _params) do
     with {:ok, ingestion_request} <- Plausible.Ingestion.Request.build(conn),
          _ <- Sentry.Context.set_extra_context(%{request: ingestion_request}),
-         :ok <- Plausible.Ingestion.add_to_buffer(ingestion_request) do
+         :ok <- Plausible.Ingestion.build_and_buffer(ingestion_request) do
       conn |> put_status(202) |> text("ok")
     else
+      :skip ->
+        conn |> put_status(202) |> text("ok")
+
       {:error, :invalid_json} ->
         conn
         |> put_status(400)
         |> json(%{errors: %{request: "Unable to parse request body as json"}})
 
-      {:error, errors} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
+        errors =
+          Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+            Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+              opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+            end)
+          end)
+
         conn |> put_status(400) |> json(%{errors: errors})
     end
   end

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Api.ExternalController do
 
   def event(conn, _params) do
     with {:ok, ingestion_request} <- Plausible.Ingestion.Request.build(conn),
-         _ <- Sentry.Context.set_extra_context(%{request: ingestion_request.params}),
+         _ <- Sentry.Context.set_extra_context(%{request: ingestion_request}),
          :ok <- Plausible.Ingestion.add_to_buffer(ingestion_request) do
       conn |> put_status(202) |> text("ok")
     else

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Api.ExternalController do
   def event(conn, _params) do
     with {:ok, ingestion_request} <- Plausible.Ingestion.Request.build(conn),
          _ <- Sentry.Context.set_extra_context(%{request: ingestion_request}),
-         {:ok, _} <- Plausible.Ingestion.Event.build_and_buffer(ingestion_request) do
+         :ok <- Plausible.Ingestion.Event.build_and_buffer(ingestion_request) do
       conn |> put_status(202) |> text("ok")
     else
       :skip ->

--- a/lib/plausible_web/controllers/api/external_controller.ex
+++ b/lib/plausible_web/controllers/api/external_controller.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Api.ExternalController do
   def event(conn, _params) do
     with {:ok, ingestion_request} <- Plausible.Ingestion.Request.build(conn),
          _ <- Sentry.Context.set_extra_context(%{request: ingestion_request}),
-         :ok <- Plausible.Ingestion.Event.build_and_buffer(ingestion_request) do
+         {:ok, _} <- Plausible.Ingestion.Event.build_and_buffer(ingestion_request) do
       conn |> put_status(202) |> text("ok")
     else
       :skip ->

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -23,13 +23,15 @@ defmodule Plausible.Ingestion.EventTest do
     referrer: "http://m.facebook.test/",
     screen_width: 1440,
     hash_mode: nil,
-    utm_medium: "utm_medium",
-    utm_source: "utm_source",
-    utm_campaign: "utm_campaign",
-    utm_content: "utm_content",
-    utm_term: "utm_term",
-    source_param: "source_param",
-    ref_param: "ref_param"
+    query_params: %{
+      "utm_medium" => "utm_medium",
+      "utm_source" => "utm_source",
+      "utm_campaign" => "utm_campaign",
+      "utm_content" => "utm_content",
+      "utm_term" => "utm_term",
+      "source" => "source",
+      "ref" => "ref"
+    }
   }
 
   test "build_and_buffer/3 creates an event" do

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -35,7 +35,7 @@ defmodule Plausible.Ingestion.EventTest do
   }
 
   test "build_and_buffer/3 creates an event" do
-    assert {:ok, _stash} =
+    assert :ok ==
              @valid_request
              |> Map.put(:domain, "plausible-ingestion-event-basic.test")
              |> Plausible.Ingestion.Event.build_and_buffer()
@@ -70,41 +70,5 @@ defmodule Plausible.Ingestion.EventTest do
 
     assert is_integer(session_id)
     assert is_integer(user_id)
-  end
-
-  test "build_and_buffer/3 stashes user_agent and geolocation" do
-    assert {:ok, stash} =
-             @valid_request
-             |> Map.put(:domain, "plausible-ingestion-event-stash-1.test")
-             |> Plausible.Ingestion.Event.build_and_buffer([:user_agent, :geolocation])
-
-    assert %Plausible.ClickhouseEvent{
-             browser: "Safari",
-             browser_version: "",
-             operating_system: "iOS",
-             operating_system_version: "3.2",
-             subdivision1_code: "FR-IDF",
-             subdivision2_code: "FR-75",
-             city_geoname_id: 2_988_507,
-             country_code: "FR"
-           } = get_event("plausible-ingestion-event-stash-1.test")
-
-    assert {:ok, _stash} =
-             @valid_request
-             |> Map.put(:domain, "plausible-ingestion-event-stash-2.test")
-             |> Map.put(:user_agent, "Dummy UA")
-             |> Map.put(:remote_ip, "127.0.0.1")
-             |> Plausible.Ingestion.Event.build_and_buffer([:user_agent, :geolocation], stash)
-
-    assert %Plausible.ClickhouseEvent{
-             browser: "Safari",
-             browser_version: "",
-             operating_system: "iOS",
-             operating_system_version: "3.2",
-             subdivision1_code: "FR-IDF",
-             subdivision2_code: "FR-75",
-             city_geoname_id: 2_988_507,
-             country_code: "FR"
-           } = get_event("plausible-ingestion-event-stash-2.test")
   end
 end

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -1,0 +1,108 @@
+defmodule Plausible.Ingestion.EventTest do
+  use Plausible.DataCase
+
+  def get_event(domain) do
+    Plausible.TestUtils.eventually(fn ->
+      Plausible.Event.WriteBuffer.flush()
+
+      event =
+        Plausible.ClickhouseRepo.one(
+          from e in Plausible.ClickhouseEvent, where: e.domain == ^domain
+        )
+
+      {!is_nil(event), event}
+    end)
+  end
+
+  @valid_request %Plausible.Ingestion.Request{
+    remote_ip: "2.2.2.2",
+    user_agent:
+      "Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405",
+    event_name: "pageview",
+    url: "http://skywalker.test",
+    referrer: "http://m.facebook.test/",
+    screen_width: 1440,
+    hash_mode: nil,
+    utm_medium: "utm_medium",
+    utm_source: "utm_source",
+    utm_campaign: "utm_campaign",
+    utm_content: "utm_content",
+    utm_term: "utm_term",
+    source_param: "source_param",
+    ref_param: "ref_param"
+  }
+
+  test "build_and_buffer/3 creates an event" do
+    assert {:ok, _stash} =
+             @valid_request
+             |> Map.put(:domain, "plausible-ingestion-event-basic.test")
+             |> Plausible.Ingestion.Event.build_and_buffer()
+
+    assert %Plausible.ClickhouseEvent{
+             session_id: session_id,
+             user_id: user_id,
+             domain: "plausible-ingestion-event-basic.test",
+             browser: "Safari",
+             browser_version: "",
+             city_geoname_id: 2_988_507,
+             country_code: "FR",
+             hostname: "skywalker.test",
+             "meta.key": [],
+             "meta.value": [],
+             name: "pageview",
+             operating_system: "iOS",
+             operating_system_version: "3.2",
+             pathname: "/",
+             referrer: "m.facebook.test",
+             referrer_source: "utm_source",
+             screen_size: "Desktop",
+             subdivision1_code: "FR-IDF",
+             subdivision2_code: "FR-75",
+             transferred_from: "",
+             utm_campaign: "utm_campaign",
+             utm_content: "utm_content",
+             utm_medium: "utm_medium",
+             utm_source: "utm_source",
+             utm_term: "utm_term"
+           } = get_event("plausible-ingestion-event-basic.test")
+
+    assert is_integer(session_id)
+    assert is_integer(user_id)
+  end
+
+  test "build_and_buffer/3 stashes user_agent and geolocation" do
+    assert {:ok, stash} =
+             @valid_request
+             |> Map.put(:domain, "plausible-ingestion-event-stash-1.test")
+             |> Plausible.Ingestion.Event.build_and_buffer([:user_agent, :geolocation])
+
+    assert %Plausible.ClickhouseEvent{
+             browser: "Safari",
+             browser_version: "",
+             operating_system: "iOS",
+             operating_system_version: "3.2",
+             subdivision1_code: "FR-IDF",
+             subdivision2_code: "FR-75",
+             city_geoname_id: 2_988_507,
+             country_code: "FR"
+           } = get_event("plausible-ingestion-event-stash-1.test")
+
+    assert {:ok, _stash} =
+             @valid_request
+             |> Map.put(:domain, "plausible-ingestion-event-stash-2.test")
+             |> Map.put(:user_agent, "Dummy UA")
+             |> Map.put(:remote_ip, "127.0.0.1")
+             |> Plausible.Ingestion.Event.build_and_buffer([:user_agent, :geolocation], stash)
+
+    assert %Plausible.ClickhouseEvent{
+             browser: "Safari",
+             browser_version: "",
+             operating_system: "iOS",
+             operating_system_version: "3.2",
+             subdivision1_code: "FR-IDF",
+             subdivision2_code: "FR-75",
+             city_geoname_id: 2_988_507,
+             country_code: "FR"
+           } = get_event("plausible-ingestion-event-stash-2.test")
+  end
+end

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -927,7 +927,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert json_response(conn, 400) == %{
                "errors" => %{
-                 "domain" => ["can't be blank"]
+                 "domain" => ["can't be blank"],
+                 "hostname" => ["can't be blank"],
+                 "user_id" => ["can't be blank"]
                }
              }
     end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -143,4 +143,17 @@ defmodule Plausible.TestUtils do
     |> Timex.shift(shifts)
     |> NaiveDateTime.truncate(:second)
   end
+
+  def eventually(expectation, wait_time_ms \\ 50, retries \\ 10) do
+    Enum.reduce_while(1..retries, nil, fn _i, _acc ->
+      case expectation.() do
+        {true, result} ->
+          {:halt, result}
+
+        {false, _} ->
+          Process.sleep(wait_time_ms)
+          {:cont, nil}
+      end
+    end)
+  end
 end


### PR DESCRIPTION
### Changes

This pull request is a follow-up on #2084. I replaced HTTP protocol specific fields from `%Plausible.Ingestion.Request{}` with more specific fields. I also refactored the event creation from a big function with small functions that can be overridden. For example, now user agent and geolocation parsing can be overridden if the function caller has this data. This will be useful for the process per session strategy.

I made small commits that can help reviewing :)

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
