### PR TITLE
Enable Cachex stats

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -15,8 +15,12 @@ defmodule Plausible.Application do
       Plausible.Event.WriteBuffer,
       Plausible.Session.WriteBuffer,
       ReferrerBlocklist,
-      Supervisor.child_spec({Cachex, name: :user_agents, limit: 1000}, id: :cachex_user_agents),
-      Supervisor.child_spec({Cachex, name: :sessions, limit: nil}, id: :cachex_sessions),
+      Supervisor.child_spec({Cachex, name: :user_agents, limit: 1000, stats: true},
+        id: :cachex_user_agents
+      ),
+      Supervisor.child_spec({Cachex, name: :sessions, limit: nil, stats: true},
+        id: :cachex_sessions
+      ),
       PlausibleWeb.Endpoint,
       {Oban, Application.get_env(:plausible, Oban)},
       Plausible.PromEx


### PR DESCRIPTION
### Changes

Enable `Cachex` stats to collect metrics on user agent cache and sessions cache

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
