### PR TITLE
Catch Google Search Console grant error

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,10 @@ config :plausible,
   paddle_api: Plausible.PaddleApi.Mock,
   google_api: Plausible.Google.Api.Mock
 
+config :plausible, :google,
+  client_id: "fake_client_id",
+  client_secret: "fake_client_secret"
+
 config :bamboo, :refute_timeout, 10
 
 geolix_sample_lookup = %{

--- a/fixture/vcr_cassettes/google_analytics_auth#invalid_grant.json
+++ b/fixture/vcr_cassettes/google_analytics_auth#invalid_grant.json
@@ -1,0 +1,35 @@
+[
+  {
+    "request": {
+      "body": "client_id=fake_client_id&client_secret=fake_client_secret&refresh_token=*****&grant_type=refresh_token&redirect_uri=http://localhost:8000/auth/google/callback",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://www.googleapis.com/oauth2/v4/token"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\n  \"error\": \"invalid_grant\",\n  \"error_description\": \"Bad Request\"\n}",
+      "headers": {
+        "date": "Fri, 12 Aug 2022 16:43:57 GMT",
+        "pragma": "no-cache",
+        "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
+        "expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "vary": "X-Origin",
+        "server": "scaffolding on HTTPServer2",
+        "x-xss-protection": "0",
+        "x-frame-options": "SAMEORIGIN",
+        "x-content-type-options": "nosniff",
+        "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+        "accept-ranges": "none",
+        "transfer-encoding": "chunked"
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -163,7 +163,7 @@ defmodule Plausible.Google.HTTP do
 
       {:error, %Finch.Response{body: body}} ->
         body
-        |> Jason.decode!(body)
+        |> Jason.decode!()
         |> Map.get("error")
         |> then(&{:error, &1})
     end

--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -161,11 +161,15 @@ defmodule Plausible.Google.HTTP do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, Jason.decode!(body)}
 
-      {:error, %Finch.Response{body: body}} ->
+      {:ok, %Finch.Response{body: body, status: _non_http_200}} ->
         body
         |> Jason.decode!()
         |> Map.get("error")
         |> then(&{:error, &1})
+
+      {:error, %Finch.Response{body: body}} ->
+        Sentry.capture_message("Error fetching Google queries", extra: Jason.decode!(body))
+        {:error, :unknown}
     end
   end
 

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -37,7 +37,12 @@
           <% end %>
         <% {:error, error} -> %>
           <p class="text-gray-700 dark:text-gray-300 mt-6">The following error happened when fetching your Google Search Console domains.</p>
-          <p class="text-red-700 font-medium mt-3"><%= error %></p>
+
+          <%= if error == "invalid_grant" do %>
+            <p class="text-red-700 font-medium mt-3"><a href="https://plausible.io/docs/google-search-console-integration#i-get-the-invalid-grant-error">Invalid Grant error returned from Google. <span class="text-indigo-500">See here on how to fix it.</a></p>
+          <% else %>
+            <p class="text-red-700 font-medium mt-3"><%= error %></p>
+          <% end %>
       <% end %>
     <% else %>
       <%= button("Continue with Google", to: Plausible.Google.Api.authorize_url(@site.id, "search-console"), class: "button mt-8") %>

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -146,5 +146,22 @@ defmodule Plausible.Google.ApiTest do
                 ]} = Plausible.Google.Api.fetch_stats(site, query, 5)
       end
     end
+
+    test "returns error when token refresh fails", %{user: user, site: site} do
+      use_cassette "google_analytics_auth#invalid_grant" do
+        insert(:google_auth,
+          user: user,
+          site: site,
+          property: "sc-domain:dummy.test",
+          access_token: "*****",
+          refresh_token: "*****",
+          expires: NaiveDateTime.add(NaiveDateTime.utc_now(), -3600)
+        )
+
+        query = %Plausible.Stats.Query{date_range: Date.range(~D[2022-01-01], ~D[2022-01-05])}
+
+        assert {:error, "invalid_grant"} = Plausible.Google.Api.fetch_stats(site, query, 5)
+      end
+    end
   end
 end

--- a/test/plausible/google/buffer_test.exs
+++ b/test/plausible/google/buffer_test.exs
@@ -1,5 +1,5 @@
 defmodule Plausible.Google.BufferTest do
-  use Plausible.DataCase, async: true
+  use Plausible.DataCase, async: false
   import Plausible.TestUtils
   import Ecto.Query
   alias Plausible.Google.Buffer
@@ -7,7 +7,11 @@ defmodule Plausible.Google.BufferTest do
   setup [:create_user, :create_new_site, :set_buffer_size]
 
   defp set_buffer_size(_setup_args) do
-    Application.put_env(:plausible, :google, max_buffer_size: 10)
+    google_setting = Application.get_env(:plausible, :google)
+    on_exit(fn -> Application.put_env(:plausible, :google, google_setting) end)
+    test_setting = Keyword.put(google_setting, :max_buffer_size, 10)
+    Application.put_env(:plausible, :google, test_setting)
+
     :ok
   end
 


### PR DESCRIPTION
### Changes

This PR fixes a bug where grant errors were not being caught and adds a custom error message pointing to documentation.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/5093045/184403184-13d04cf2-dd43-42c4-85b0-8e9e88d93aa4.png">

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
