### PR TITLE
ARM64 support for docker images

### DIFF
--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -19,6 +19,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -34,6 +37,7 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64, linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.
 - Add new strategy to recommend timezone when creating a new site
 - Alert outgrown enterprise users of their usage plausible/analytics#2197
 - Manually lock and unlock enterprise users plausible/analytics#2197
-- ARM64 support for docker images plausible/analytics#2197
+- ARM64 support for docker images plausible/analytics#2103
 
 ### Fixed
 - Hash part of the URL can now be used when excluding pages with `script.exclusions.hash.js`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Add new strategy to recommend timezone when creating a new site
 - Alert outgrown enterprise users of their usage plausible/analytics#2197
 - Manually lock and unlock enterprise users plausible/analytics#2197
+- ARM64 support for docker images plausible/analytics#2197
 
 ### Fixed
 - Hash part of the URL can now be used when excluding pages with `script.exclusions.hash.js`.


### PR DESCRIPTION
### Changes
This PR adds ARM64 builds for plausible docker images.
I tested the builds, and everything worked.

Test builds:
https://github.com/FZR-forks/analytics/pkgs/container/plausible

the latest tag is the self-hosting version
the master version is built to the latest commit

**This PR requires switching from yandex/clickhouse-server to a recent [clickhouse/clickhouse-server](https://hub.docker.com/r/clickhouse/clickhouse-server) image which supports ARM64**

I tested it using the latest version, which has an ARM64 image.

If this PR gets merged, I can create another one to update the hosting repo.

Related:
#1286 
#903

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
