### PR TITLE
Update links to documents

### DIFF
--- a/assets/js/dashboard/stats/sources/search-terms.js
+++ b/assets/js/dashboard/stats/sources/search-terms.js
@@ -91,7 +91,7 @@ export default class SearchTerms extends React.Component {
           <RocketIcon />
           <div>Could not find any search terms for this period</div>
           <div>Google Search Console data is sampled and delayed by 24-36h</div>
-          <div>Read more on <a href="https://docs.plausible.io/google-search-console-integration/#i-dont-see-google-search-query-data-in-my-dashboard" target="_blank" rel="noreferrer" className="hover:underline text-indigo-700 dark:text-indigo-500">our documentation</a></div>
+          <div>Read more on <a href="https://plausible.io/docs/google-search-console-integration#i-dont-see-google-search-query-data-in-my-dashboard" target="_blank" rel="noreferrer" className="hover:underline text-indigo-700 dark:text-indigo-500">our documentation</a></div>
         </div>
       )
     }

--- a/lib/plausible_web/templates/email/welcome_email.html.eex
+++ b/lib/plausible_web/templates/email/welcome_email.html.eex
@@ -5,7 +5,7 @@ We're super excited to have you on board!
 <br /><br />
 Here's how to get the most out of your Plausible experience:
 <br /><br />
-* <%= link("Enable email reports", to: "https://docs.plausible.io/email-reports/") %> and notifications for <%= link("traffic spikes", to: "https://plausible.io/docs/traffic-spikes") %><br />
+* <%= link("Enable email reports", to: "https://plausible.io/docs/email-reports") %> and notifications for <%= link("traffic spikes", to: "https://plausible.io/docs/traffic-spikes") %><br />
 * <%= link("Integrate with Search Console", to: "https://plausible.io/docs/google-search-console-integration") %> to get keyword phrases people find your site with<br />
 * <%= link("Invite team members and other collaborators", to: "https://plausible.io/docs/users-roles") %><br />
 * Set up easy goals including <%= link("404 error pages", to: "https://plausible.io/docs/error-pages-tracking-404") %>, <%= link("file downloads", to: "https://plausible.io/docs/file-downloads-tracking") %> and <%= link("outbound link clicks", to: "https://plausible.io/docs/outbound-link-click-tracking") %><br />

--- a/lib/plausible_web/templates/site/settings_custom_domain.html.eex
+++ b/lib/plausible_web/templates/site/settings_custom_domain.html.eex
@@ -24,7 +24,7 @@
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Custom domain</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Serve the tracking script from your domain name as a first-party resource instead of loading the script from our domain.</p>
 
-    <%= link(to: "https://docs.plausible.io/custom-domain/", target: "_blank") do %>
+    <%= link(to: "https://plausible.io/docs/proxy/introduction", target: "_blank") do %>
       <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>

--- a/lib/plausible_web/templates/site/settings_goals.html.eex
+++ b/lib/plausible_web/templates/site/settings_goals.html.eex
@@ -2,7 +2,7 @@
   <header class="relative">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Goals</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Define actions that you want your users to take like visiting a certain page, submitting a form, etc.</p>
-    <%= link(to: "https://docs.plausible.io/goal-conversions/", target: "_blank", rel: "noreferrer") do %>
+    <%= link(to: "https://plausible.io/docs/goal-conversions", target: "_blank", rel: "noreferrer") do %>
       <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -2,7 +2,7 @@
   <header class="relative">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Google Search Console integration</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">You can integrate with Google Search Console to get all of your important search results stats such as keyword phrases people find your site with.</p>
-    <%= link(to: "https://docs.plausible.io/google-search-console-integration/", target: "_blank", rel: "noreferrer") do %>
+    <%= link(to: "https://plausible.io/docs/google-search-console-integration", target: "_blank", rel: "noreferrer") do %>
       <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>
@@ -22,7 +22,7 @@
             </p>
           <% else %>
             <p class="text-gray-700 dark:text-gray-300 mt-6">
-            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://docs.plausible.io/google-search-console-integration", class: "text-indigo-500") %> on Search Console first.
+            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://plausible.io/docs/google-search-console-integration", class: "text-indigo-500") %> on Search Console first.
             </p>
           <% end %>
 

--- a/lib/plausible_web/templates/site/settings_visibility.html.eex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.eex
@@ -2,7 +2,7 @@
   <header class="relative">
     <h2 class="text-lg font-medium text-gray-900 leading-6 dark:text-gray-100">Public dashboard</h2>
     <p class="mt-1 text-sm text-gray-500 leading-5 dark:text-gray-200">Share your stats publicly or keep them private</p>
-    <%= link(to: "https://docs.plausible.io/visibility", target: "_blank", rel: "noreferrer") do %>
+    <%= link(to: "https://plausible.io/docs/visibility", target: "_blank", rel: "noreferrer") do %>
       <svg class="absolute top-0 right-0 w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>
@@ -28,7 +28,7 @@
   <header class="relative">
     <h2 class="text-lg font-medium text-gray-900 leading-6 dark:text-gray-100">Shared links</h2>
     <p class="mt-1 text-sm text-gray-500 leading-5 dark:text-gray-200">You can share your stats privately by generating a shared link. The links are impossible to guess and you can add password protection for extra security.</p>
-    <%= link(to: "https://docs.plausible.io/shared-links", target: "_blank", rel: "noreferrer") do %>
+    <%= link(to: "https://plausible.io/docs/shared-links", target: "_blank", rel: "noreferrer") do %>
       <svg class="absolute top-0 right-0 w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
     <% end %>
   </header>


### PR DESCRIPTION
### Changes

Some of links to documents are still using `docs.plausible.io`, and this PR updated it.

### Tests

- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog

- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation

- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode

- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
