### PR TITLE
link to contact page instead of mailto

### DIFF
--- a/lib/plausible_web/templates/auth/activate.html.eex
+++ b/lib/plausible_web/templates/auth/activate.html.eex
@@ -24,7 +24,7 @@
         <%= if Application.get_env(:plausible, :is_selfhost) do %>
           <li>Ask on our <%= link("community-supported forum", to: "https://github.com/plausible/analytics/discussions", class: "text-indigo-600 underline" ) %></li>
         <% else %>
-          <li>Contact <a class="underline text-indigo-600" href="mailto:support@plausible.io">support@plausible.io</a> if the problem persists</li>
+          <li><a class="underline text-indigo-600" href="https://plausible.io/contact">Contact us</a> if the problem persists</li>
         <% end %>
       </ol>
       <div class="mt-4 text-sm dark:text-gray-100">

--- a/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
+++ b/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
@@ -11,7 +11,7 @@
     <%= if Application.get_env(:plausible, :is_selfhost) do %>
       If you are positive that you are using the correct email address but still aren't receiving the password reset email, please ask on our <a href="https://github.com/plausible/analytics/discussions" class="text-indigo-500">community-supported forum</a>.
     <% else %>
-      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please contact <a href="mailto:support@plausible.io" class="text-indigo-500">support@plausible.io</a>.
+      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please <a href="https://plausible.io/contact" class="text-indigo-500">contact us</a>.
     <% end %>
   </div>
 </div>

--- a/lib/plausible_web/templates/auth/register_success.html.eex
+++ b/lib/plausible_web/templates/auth/register_success.html.eex
@@ -24,7 +24,7 @@
       Didn't receive an email?
     </div>
     <div class="mt-2 text-sm text-gray-500 leading-tight">
-      Please check your spam folder and contact <a class="underline text-indigo-500" href="mailto:support@plausible.io">support@plausible.io</a> if the problem persists
+      Please check your spam folder and <a class="underline text-indigo-500" href="https://plausible.io/contact">contact us</a> if the problem persists
     </div>
   <% end %>
 

--- a/lib/plausible_web/templates/billing/change_enterprise_plan.html.eex
+++ b/lib/plausible_web/templates/billing/change_enterprise_plan.html.eex
@@ -62,7 +62,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
+  Questions? <%= link("Contact us", to: "https://plausible.io/contact", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/change_plan.html.eex
+++ b/lib/plausible_web/templates/billing/change_plan.html.eex
@@ -116,7 +116,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
+  Questions? <%= link("Contact us", to: "https://plausible.io/contact", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/change_plan_preview.html.eex
+++ b/lib/plausible_web/templates/billing/change_plan_preview.html.eex
@@ -78,7 +78,7 @@
 </div>
 
 <div class="text-center mt-8 dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
+  Questions? <%= link("Contact us", to: "https://plausible.io/contact", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/upgrade.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade.html.eex
@@ -122,7 +122,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
+  Questions? <%= link("Contact us", to: "https://plausible.io/contact", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>

--- a/lib/plausible_web/templates/billing/upgrade_to_plan.html.eex
+++ b/lib/plausible_web/templates/billing/upgrade_to_plan.html.eex
@@ -61,7 +61,7 @@
 </div>
 
 <div class="mt-8 text-center dark:text-gray-100">
-  Questions? Contact <%= link("support@plausible.io", to: "mailto:support@plausible.io", class: "text-indigo-500") %>
+  Questions? <%= link("Contact us", to: "https://plausible.io/contact", class: "text-indigo-500") %>
 </div>
 
 <%= render("_paddle_script.html") %>


### PR DESCRIPTION
### Changes

Pointed in-app contact links to `https://plausible.io/contact` instead of `mailto:support@plausible.io`. I left the mailto links in the following error messages:

- this domain has already been taken ... please contact `support@plausible.io`
- something went wrong. Please try again or contact support at `support@plausible.io` (when Paddle returns an error on payment)

because:

- it would require a bigger change to embed links in error messages
- it makes sense for a customer to instantly see the support email after encountering an error message

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
