### PR TITLE
Add fallback for GA reports without rows

### DIFF
--- a/fixture/ga_report_empty_rows.json
+++ b/fixture/ga_report_empty_rows.json
@@ -1,0 +1,25 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": [
+          "ga:date",
+          "ga:source",
+          "ga:medium",
+          "ga:campaign",
+          "ga:adContent",
+          "ga:keyword"
+        ],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            { "name": "ga:users", "type": "INTEGER" },
+            { "name": "ga:sessions", "type": "INTEGER" },
+            { "name": "ga:bounces", "type": "INTEGER" },
+            { "name": "ga:sessionDuration", "type": "TIME" }
+          ]
+        }
+      },
+      "data": { "isDataGolden": true }
+    }
+  ]
+}

--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -44,13 +44,14 @@ defmodule Plausible.Google.HTTP do
   end
 
   defp convert_to_maps(%{
-         "data" => %{"rows" => rows},
+         "data" => %{} = data,
          "columnHeader" => %{
            "dimensions" => dimension_headers,
            "metricHeader" => %{"metricHeaderEntries" => metric_headers}
          }
        }) do
     metric_headers = Enum.map(metric_headers, & &1["name"])
+    rows = Map.get(data, "rows", [])
 
     Enum.map(rows, fn %{"dimensions" => dimensions, "metrics" => [%{"values" => metrics}]} ->
       metrics = Enum.zip(metric_headers, metrics)

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -84,6 +84,33 @@ defmodule Plausible.Google.ApiTest do
       assert_receive({Finch, :request, [_, _]})
       assert_receive({Finch, :request, [_, _]})
     end
+
+    test "does not fail when report does not have rows key", %{site: site, buffer: buffer} do
+      finch_double =
+        Finch
+        |> stub(:request, fn _, _ ->
+          {:ok,
+           %Finch.Response{status: 200, body: File.read!("fixture/ga_report_empty_rows.json")}}
+        end)
+
+      request = %Plausible.Google.ReportRequest{
+        dataset: "imported_exit_pages",
+        view_id: "123",
+        date_range: Date.range(~D[2022-01-01], ~D[2022-02-01]),
+        dimensions: ["ga:date", "ga:exitPagePath"],
+        metrics: ["ga:users", "ga:exits"],
+        access_token: "fake-token",
+        page_token: nil,
+        page_size: 10_000
+      }
+
+      assert :ok ==
+               Api.fetch_and_persist(site, request,
+                 http_client: finch_double,
+                 sleep_time: 0,
+                 buffer: buffer
+               )
+    end
   end
 
   describe "fetch_stats/3" do


### PR DESCRIPTION
### Changes

This pull request fixes a bug when trying to import from GA. When the requested report does not have data, the response does not have a `rows` key. The current implementation was expecting a rows key with an empty list.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
