### PR TITLE
Update site footer to include tools

### DIFF
--- a/lib/plausible_web/templates/layout/_footer.html.eex
+++ b/lib/plausible_web/templates/layout/_footer.html.eex
@@ -90,6 +90,24 @@
             </ul>
           </div>
         </div>
+        <div class="mt-32 md:mt-0">
+            <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
+              Tools
+            </h4>
+            <ul class="mt-4">
+              <li>
+                <a rel="noferrer" href="https://plausible.io/docs/stats-api" class="text-base text-gray-300 leading-6 hover:text-white">
+                  Plausible APIs
+                </a>
+              </li>
+              <li class="mt-4">
+                <a rel="noferrer" href="https://plausible.io/blog/utm-tracking-tags#plausible-utm-tag-builder-tool" class="text-base text-gray-300 leading-6 hover:text-white">
+                  UTM tag builder
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
 <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
             <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">


### PR DESCRIPTION
Updating the site footer to include the "Tools" heading underneath "Comparisons". This is untested so best to double check how it looks. Ideally there should be a blank space underneath "vs Cloudflare" before the "Tools" heading starts so it all is aligned with other columns. Thanks!
