### PR TITLE
Perform calculations in SQL instead of app when creating sites

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -159,17 +159,16 @@ defmodule Plausible.Billing do
 
   def last_two_billing_months_usage(user, today \\ Timex.today()) do
     {first, second} = last_two_billing_cycles(user, today)
-    sites = Plausible.Sites.owned_by(user)
+    domains = Plausible.Sites.owned_sites_domains(user)
 
-    usage_for_sites = fn sites, date_range ->
-      domains = Enum.map(sites, & &1.domain)
+    usage_for_sites = fn domains, date_range ->
       {pageviews, custom_events} = Plausible.Stats.Clickhouse.usage_breakdown(domains, date_range)
       pageviews + custom_events
     end
 
     {
-      usage_for_sites.(sites, first),
-      usage_for_sites.(sites, second)
+      usage_for_sites.(domains, first),
+      usage_for_sites.(domains, second)
     }
   end
 
@@ -194,7 +193,7 @@ defmodule Plausible.Billing do
   end
 
   def usage_breakdown(user) do
-    domains = Plausible.Sites.owned_by(user) |> Enum.map(& &1.domain)
+    domains = Plausible.Sites.owned_sites_domains(user)
     Plausible.Stats.Clickhouse.usage_breakdown(domains)
   end
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -50,14 +50,12 @@ defmodule PlausibleWeb.SiteController do
   end
 
   def new(conn, _params) do
-    current_user = conn.assigns[:current_user] |> Repo.preload(site_memberships: :site)
+    current_user = conn.assigns[:current_user]
 
-    owned_site_count =
-      current_user.site_memberships |> Enum.filter(fn m -> m.role == :owner end) |> Enum.count()
-
+    owned_site_count = Plausible.Sites.owned_sites_count(current_user)
     site_limit = Plausible.Billing.sites_limit(current_user)
     is_at_limit = site_limit && owned_site_count >= site_limit
-    is_first_site = Enum.empty?(current_user.site_memberships)
+    is_first_site = owned_site_count == 0
 
     changeset = Plausible.Site.changeset(%Plausible.Site{})
 
@@ -72,7 +70,7 @@ defmodule PlausibleWeb.SiteController do
 
   def create_site(conn, %{"site" => site_params}) do
     user = conn.assigns[:current_user]
-    site_count = Enum.count(Plausible.Sites.owned_by(user))
+    site_count = Plausible.Sites.owned_sites_count(user)
     is_first_site = site_count == 0
 
     case Sites.create(user, site_params) do

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -131,7 +131,7 @@ defmodule Plausible.Workers.CheckUsage do
 
   defp check_site_limit(subscriber) do
     allowance = subscriber.enterprise_plan.site_limit
-    total_sites = Plausible.Sites.count_owned_by(subscriber)
+    total_sites = Plausible.Sites.owned_sites_count(subscriber)
 
     if total_sites >= allowance do
       {:over_limit, {total_sites, allowance}}


### PR DESCRIPTION
### Changes

This PR removes some Enum calls to rely on the database for aggregating data. This improves performance when creating new sites, especially if the user has multiple sites.


### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
