### PR TITLE
Respond with 400 when no auth supplied to shared link request

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -144,6 +144,10 @@ defmodule PlausibleWeb.StatsController do
     end
   end
 
+  def shared_link(conn, _) do
+    render_error(conn, 400)
+  end
+
   def authenticate_shared_link(conn, %{"slug" => slug, "password" => password}) do
     shared_link =
       Repo.get_by(Plausible.Site.SharedLink, slug: slug)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -263,6 +263,11 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert html_response(conn, 200) =~ "Site locked"
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
+
+    test "renders bad request when no auth parameter supplied", %{conn: conn} do
+      conn = get(conn, "/share/example.com")
+      assert response(conn, 400) =~ "Bad Request"
+    end
   end
 
   describe "POST /share/:slug/authenticate" do


### PR DESCRIPTION
### Changes

This PR makes StatsController respond with `400 Bad Request` in case no `auth` parameter is supplied to shared link request.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated: https://github.com/plausible/docs/pull/264

### Dark mode
- [x] This PR does not change the UI
