### PR TITLE
Do not assume any order in browser data import test

### DIFF
--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -846,11 +846,11 @@ defmodule Plausible.ImportedTest do
           "/api/stats/#{site.domain}/browsers?period=day&date=2021-01-01&with_imported=true"
         )
 
-      assert json_response(conn, 200) == [
-               %{"name" => "Firefox", "visitors" => 2, "percentage" => 50},
-               %{"name" => "Mobile App", "visitors" => 1, "percentage" => 25},
-               %{"name" => "Chrome", "visitors" => 1, "percentage" => 25}
-             ]
+      assert stats = json_response(conn, 200)
+      assert length(stats) == 3
+      assert %{"name" => "Firefox", "visitors" => 2, "percentage" => 50} in stats
+      assert %{"name" => "Mobile App", "visitors" => 1, "percentage" => 25} in stats
+      assert %{"name" => "Chrome", "visitors" => 1, "percentage" => 25} in stats
     end
 
     test "OS data imported from Google Analytics", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

The test is constantly failing on my machine with the following assumption not met:

```
  1) test Parse and import third party data fetched from Google Analytics Browsers data imported from Google Analytics (Plausible.ImportedTest)
     test/plausible/imported/imported_test.exs:809
     Assertion with == failed
     code:  assert json_response(conn, 200) == [
              %{"name" => "Firefox", "visitors" => 2, "percentage" => 50},
              %{"name" => "Mobile App", "visitors" => 1, "percentage" => 25},
              %{"name" => "Chrome", "visitors" => 1, "percentage" => 25}
            ]
     left:  [%{"name" => "Firefox", "percentage" => 50, "visitors" => 2}, %{"name" => "Chrome", "percentage" => 25, "visitors" => 1}, %{"name" => "Mobile App", "percentage" => 25, "visitors" => 1}]
     right: [%{"name" => "Firefox", "percentage" => 50, "visitors" => 2}, %{"name" => "Mobile App", "percentage" => 25, "visitors" => 1}, %{"name" => "Chrome", "percentage" => 25, "visitors" => 1}]
     stacktrace:
       test/plausible/imported/imported_test.exs:849: (test)
```

The clickhouse query invoked is:

```elixir
#Ecto.Query<from s0 in subquery(from s0 in "sessions",
  where: s0.domain == ^"example-42.com",
  where: s0.start >= ^~U[2021-01-01 00:00:00Z] and s0.start < ^~U[2021-01-02 00:00:00Z],
  group_by: [s0.browser],
  order_by: [desc: fragment("uniq(?)", s0.user_id), asc: fragment("min(?)", s0.start)],
  select: %{
  browser: s0.browser,
  visitors: fragment("toUInt64(round(uniq(?) * any(_sample_factor)))", s0.user_id)
}),
 full_join: i1 in subquery(from i0 in "imported_browsers",
  where: i0.site_id == ^7946,
  where: i0.date >= ^~D[2021-01-01] and i0.date <= ^~D[2021-01-01],
  group_by: [i0.browser],
  select: %{visitors: sum(i0.visitors), browser: i0.browser}),
 on: s0.browser == i1.browser,
 order_by: [desc: fragment("coalesce(?, 0) + coalesce(?, 0)", s0.visitors, i1.visitors)],
 limit: ^9, offset: ^0,
 select: merge(
  merge(s0, %{visitors: fragment("coalesce(?, 0) + coalesce(?, 0)", s0.visitors, i1.visitors)}),
  %{browser: fragment("if(empty(?), ?, ?)", i1.browser, s0.browser, i1.browser)}
)>
```

Based on that I am assuming ordering is implicit here?

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
