### PR TITLE
Pin clickhouse image to 21.11.3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ server:
 	mix phx.server
 
 clickhouse:
-	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse --name plausible_clickhouse yandex/clickhouse-server:21.3.2.5
+	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse --name plausible_clickhouse clickhouse/clickhouse-server:21.11.3.6
 
 clickhouse-arm:
 	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse --name plausible_clickhouse altinity/clickhouse-server:21.12.3.32.altinitydev.arm


### PR DESCRIPTION
### Changes

This pins dev clickhouse image to lickhouse/clickhouse-server:21.11.3.6 -- the previous one had tests failing consistently with 

```
     ** (Clickhousex.Error) Code: 53, e.displayText() = DB::Exception: Type mismatch of columns to JOIN by: country FixedString(2) at left, s1.country String at right (version 21.3.2.5 (official build))
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
