### PR TITLE
Fix improper pattern matching on Finch responses

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -1,6 +1,6 @@
 defmodule Plausible.Billing do
   use Plausible.Repo
-  alias Plausible.Billing.{Subscription, PaddleApi}
+  alias Plausible.Billing.Subscription
 
   def active_subscription_for(user_id) do
     Repo.get_by(Subscription, user_id: user_id, status: "active")
@@ -113,7 +113,16 @@ defmodule Plausible.Billing do
   end
 
   def change_plan_preview(subscription, new_plan_id) do
-    PaddleApi.update_subscription_preview(subscription.paddle_subscription_id, new_plan_id)
+    case paddle_api().update_subscription_preview(
+           subscription.paddle_subscription_id,
+           new_plan_id
+         ) do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   def needs_to_upgrade?(%Plausible.Auth.User{trial_expiry_date: nil}), do: {true, :no_trial}

--- a/lib/plausible/http_client.ex
+++ b/lib/plausible/http_client.ex
@@ -12,7 +12,7 @@ defmodule Plausible.HTTPClient do
   @type url() :: Finch.Request.url()
   @type headers() :: Finch.Request.headers()
   @type params() :: Finch.Request.body() | map()
-  @type response() :: {:ok, Finch.Response.t()} | {:error, Mint.Types.error()}
+  @type response() :: {:ok, Finch.Response.t()} | {:error, Mint.Types.error() | Finch.Error.t()}
 
   @doc """
   Make a POST request

--- a/lib/plausible/http_client.ex
+++ b/lib/plausible/http_client.ex
@@ -1,23 +1,38 @@
 defmodule Plausible.HTTPClient do
   @moduledoc """
   HTTP Client built on top of Finch.
+
+  By default, request parameters are json-encoded.
+
+  If a raw binary value is supplied, no encoding is performed.
+  If x-www-form-urlencoded content-type is set in headers, 
+  URL encoding is invoked.
   """
+
+  @type url() :: Finch.Request.url()
+  @type headers() :: Finch.Request.headers()
+  @type params() :: Finch.Request.body() | map()
+  @type response() :: {:ok, Finch.Response.t()} | {:error, Mint.Types.error()}
 
   @doc """
   Make a POST request
   """
-  def post(url, headers \\ [], params \\ nil) do
+  @spec post(url(), headers(), params()) :: response()
+  def(post(url, headers \\ [], params \\ nil)) do
     call(:post, url, headers, params)
   end
 
   @doc """
   Make a GET request
   """
+  @spec get(url(), headers(), params()) :: response()
   def get(url, headers \\ [], params \\ nil) do
     call(:get, url, headers, params)
   end
 
   defp call(method, url, headers, params) do
+    params = maybe_encode_params(params, headers)
+
     method
     |> build_request(url, headers, params)
     |> do_request
@@ -29,5 +44,26 @@ defmodule Plausible.HTTPClient do
 
   defp do_request(request) do
     Finch.request(request, Plausible.Finch)
+  end
+
+  defp maybe_encode_params(params, _headers) when is_binary(params) or is_nil(params) do
+    params
+  end
+
+  defp maybe_encode_params(params, headers) when is_map(params) do
+    content_type =
+      Enum.find_value(headers, "", fn {k, v} ->
+        if String.downcase(k) == "content-type" do
+          v
+        end
+      end)
+
+    case String.downcase(content_type) do
+      "x-www-form-urlencoded" ->
+        URI.encode_query(params)
+
+      _ ->
+        Jason.encode!(params)
+    end
   end
 end

--- a/lib/plausible_web/captcha.ex
+++ b/lib/plausible_web/captcha.ex
@@ -17,8 +17,11 @@ defmodule PlausibleWeb.Captcha do
       res =
         HTTPClient.post(
           @verify_endpoint,
-          [{"Content-Type", "application/x-www-form-urlencoded"}],
-          "response=#{token}&secret=#{secret()}"
+          [{"content-type", "application/x-www-form-urlencoded"}],
+          %{
+            response: token,
+            secret: secret()
+          }
         )
 
       case res do

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -109,18 +109,16 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def change_plan_preview(conn, %{"plan_id" => new_plan_id}) do
-    subscription = Billing.active_subscription_for(conn.assigns[:current_user].id)
-
-    if subscription do
-      {:ok, preview_info} = Billing.change_plan_preview(subscription, new_plan_id)
-
+    with {:ok, {subscription, preview_info}} <-
+           preview_subscription(conn.assigns.current_user, new_plan_id) do
       render(conn, "change_plan_preview.html",
         subscription: subscription,
         preview_info: preview_info,
         layout: {PlausibleWeb.LayoutView, "focus.html"}
       )
     else
-      redirect(conn, to: "/billing/upgrade")
+      _ ->
+        redirect(conn, to: "/billing/upgrade")
     end
   end
 
@@ -158,5 +156,21 @@ defmodule PlausibleWeb.BillingController do
         |> put_flash(:error, msg)
         |> redirect(to: "/settings")
     end
+  end
+
+  defp preview_subscription(%{id: user_id}, new_plan_id) do
+    subscription = Billing.active_subscription_for(user_id)
+
+    if subscription do
+      with {:ok, preview_info} <- Billing.change_plan_preview(subscription, new_plan_id) do
+        {:ok, {subscription, preview_info}}
+      end
+    else
+      {:error, :no_subscription}
+    end
+  end
+
+  def preview_susbcription(_, _) do
+    {:error, :no_user_id}
   end
 end


### PR DESCRIPTION
### Changes

This PR fixes improper pattern matching on Finch responses
for 3rd party integration as seen in sentry.

By the way, abstracting away some request building details,
encapsulating redundant request encoding.

Type specs were added which immediately made some mismatches
visible via lsp integration.

Potential follow-ups to this:
  - a more comprehensive mocking setup for 3rd party
    integrations (preferably via https://github.com/dashbitco/mox)
    so that erroneous code paths can be tested
  - CI linting (such as credo to enforce typespecs/moduledocs in any
    files touched in a given PR) + perhaps a dialyzer run

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests
- [x] This PR requires extra tests but they can't be added yet (e.g. paddle API docs excluded the subscription preview docs). Should be done in a follow up PR. Otherwise this is only refactoring, no public interfaces are changed.

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
