### PR TITLE
Add missing `application/` to Content-Type match

### DIFF
--- a/lib/plausible/http_client.ex
+++ b/lib/plausible/http_client.ex
@@ -59,7 +59,7 @@ defmodule Plausible.HTTPClient do
       end)
 
     case String.downcase(content_type) do
-      "x-www-form-urlencoded" ->
+      "application/x-www-form-urlencoded" ->
         URI.encode_query(params)
 
       _ ->


### PR DESCRIPTION
### Changes

This commit fixes a typo when matching `application/x-www-form-urlencoded` Content-Type headers.

Related: #2181 

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
