### PR TITLE
Don't let tooltip text break onto a new line

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -45,7 +45,7 @@ export default class TopStats extends React.Component {
 
     return (
       <div>
-        <div>{this.topStatNumberLong(stat)} {statName}</div>
+        <div className="whitespace-nowrap">{this.topStatNumberLong(stat)} {statName}</div>
         {this.canMetricBeGraphed(stat) && <div className="font-normal text-xs">{this.titleFor(stat)}</div>}
       </div>
     )
@@ -99,7 +99,7 @@ export default class TopStats extends React.Component {
       })
 
       return (
-        <Tooltip key={stat.name} info={this.topStatTooltip(stat)} className={className} onClick={() => { this.maybeUpdateMetric(stat) }}>
+        <Tooltip key={stat.name} info={this.topStatTooltip(stat)} className={className} onClick={() => { this.maybeUpdateMetric(stat) }} boundary={this.props.tooltipBoundary}>
           <div
             className={`text-xs font-bold tracking-wide text-gray-500 uppercase dark:text-gray-400 whitespace-nowrap flex w-content border-b ${isSelected ? 'text-indigo-700 dark:text-indigo-500 border-indigo-700 dark:border-indigo-500' : 'group-hover:text-indigo-700 dark:group-hover:text-indigo-500 border-transparent'}`}>
             {statDisplayName}

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -48,6 +48,7 @@ export const METRIC_FORMATTER = {
 class LineGraph extends React.Component {
   constructor(props) {
     super(props);
+    this.boundary = React.createRef()
     this.regenerateChart = this.regenerateChart.bind(this);
     this.updateWindowDimensions =  this.updateWindowDimensions.bind(this);
     this.state = {

--- a/assets/js/dashboard/util/tooltip.js
+++ b/assets/js/dashboard/util/tooltip.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { usePopper } from 'react-popper';
 import classNames from 'classnames'
 
-export function Tooltip({ children, info, className, onClick }) {
+export function Tooltip({ children, info, className, onClick, boundary }) {
   const [visible, setVisible] = useState(false);
   const [referenceElement, setReferenceElement] = useState(null);
   const [popperElement, setPopperElement] = useState(null);
@@ -15,6 +15,12 @@ export function Tooltip({ children, info, className, onClick }) {
         name: 'offset',
         options: {
           offset: [0, 4],
+        },
+      },
+      boundary && {
+        name: 'preventOverflow',
+        options: {
+          boundary: boundary,
         },
       },
     ],


### PR DESCRIPTION
### Changes

A small improvement to make sure the tooltip doesn't break onto a new line. Had to use `boundary` in Popper.js to make sure the tooltip doesn't overflow the graph container to the left when the line gets long.

**Current:**
<img width="775" alt="Screenshot 2022-09-12 at 14 31 37" src="https://user-images.githubusercontent.com/3731516/189643068-23e10244-e18b-49fe-aa18-a0002203e03c.png">

**With this PR**
<img width="700" alt="Screenshot 2022-09-12 at 14 31 58" src="https://user-images.githubusercontent.com/3731516/189642970-5f8e89f7-8736-44fd-ab62-0e053c3514aa.png">


### Tests
- [x] This PR does not require tests

### Changelog
- [x] No need for a changelog entry

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
