### PR TITLE
Allow admins to grant admin rights

### DIFF
--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -14,7 +14,6 @@ defmodule Plausible.Site.Membership do
     schema
     |> cast(attrs, [:user_id, :site_id, :role])
     |> validate_required([:user_id, :site_id])
-    |> validate_inclusion(:role, valid_roles(schema.role))
   end
 
   def override_role(schema, role) do
@@ -22,9 +21,4 @@ defmodule Plausible.Site.Membership do
     |> change(%{role: role})
     |> validate_required([:user_id, :site_id, :role])
   end
-
-  defp valid_roles(_prev_role = nil), do: [:owner, :admin, :viewer]
-  defp valid_roles(:owner), do: [:owner, :admin, :viewer]
-  defp valid_roles(:admin), do: [:admin, :viewer]
-  defp valid_roles(:viewer), do: [:viewer]
 end

--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -15,10 +15,4 @@ defmodule Plausible.Site.Membership do
     |> cast(attrs, [:user_id, :site_id, :role])
     |> validate_required([:user_id, :site_id])
   end
-
-  def override_role(schema, role) do
-    schema
-    |> change(%{role: role})
-    |> validate_required([:user_id, :site_id, :role])
-  end
 end

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -27,7 +27,7 @@ defmodule PlausibleWeb.InvitationController do
     membership_changeset =
       (existing_membership ||
          %Membership{user_id: user.id, site_id: invitation.site.id})
-      |> Membership.override_role(invitation.role)
+      |> Membership.changeset(%{role: invitation.role})
 
     multi =
       multi

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -154,7 +154,8 @@ defmodule PlausibleWeb.Site.MembershipController do
   defp intern_role("admin"), do: :admin
   defp intern_role("viewer"), do: :viewer
 
-  defp can_grant_role?(:owner, _), do: true
+  defp can_grant_role?(:owner, :admin), do: true
+  defp can_grant_role?(:owner, :viewer), do: true
   defp can_grant_role?(:admin, :admin), do: true
   defp can_grant_role?(:admin, :viewer), do: true
   defp can_grant_role?(_, _), do: false

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -144,7 +144,7 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> Repo.update!()
 
       redirect_target =
-        if membership.user.id == current_user.id && new_role == :viewer do
+        if membership.user.id == current_user.id and new_role == :viewer do
           "/#{URI.encode_www_form(site.domain)}"
         else
           Routes.site_path(conn, :settings_people, site.domain)

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -130,14 +130,14 @@ defmodule PlausibleWeb.Site.MembershipController do
     membership = Repo.get!(Membership, id) |> Repo.preload(:user)
     new_role = Map.fetch!(@role_mappings, new_role_str)
 
-    can_grant_role =
+    can_grant_role? =
       if membership.user.id == current_user.id do
         can_grant_role_to_self?(current_user_role, new_role)
       else
         can_grant_role_to_other?(current_user_role, new_role)
       end
 
-    if can_grant_role do
+    if can_grant_role? do
       membership =
         membership
         |> Membership.changeset(%{role: new_role})

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -1,4 +1,15 @@
 defmodule PlausibleWeb.Site.MembershipController do
+  @moduledoc """
+    This controller deals with user management via the UI in Site Settings -> People. It's important to enforce permissions in this controller.
+
+    Owner - Can manage users, can trigger a 'transfer ownership' request
+    Admin - Can manage users
+    Viewer - Can not access user management settings
+    Anyone - Can accept invitations
+
+    Everything else should be explicitly disallowed.
+  """
+
   use PlausibleWeb, :controller
   use Plausible.Repo
   alias Plausible.Sites
@@ -12,17 +23,6 @@ defmodule PlausibleWeb.Site.MembershipController do
 
   plug PlausibleWeb.AuthorizeSiteAccess,
        [:owner, :admin] when action not in @only_owner_is_allowed_to
-
-  @moduledoc """
-    This controller deals with user management via the UI in Site Settings -> People. It's important to enforce permissions in this controller.
-
-    Owner - Can manage users, can trigger a 'transfer ownership' request
-    Admin - Can manage users
-    Viewer - Can not access user management settings
-    Anyone - Can accept invitations
-
-    Everything else should be explicitly disallowed.
-  """
 
   def invite_member_form(conn, %{"website" => site_domain}) do
     site = Sites.get_for_user!(conn.assigns[:current_user].id, site_domain)

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -184,6 +184,22 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       assert get_flash(conn, :error) == "You are not allowed to grant the owner role"
     end
 
+    test "owner cannot downgrade themselves", %{
+      conn: conn,
+      user: user
+    } do
+      site = insert(:site, memberships: [build(:site_membership, user: user, role: :owner)])
+
+      membership = Repo.get_by(Plausible.Site.Membership, user_id: user.id)
+
+      conn = put(conn, "/sites/#{site.domain}/memberships/#{membership.id}/role/admin")
+
+      membership = Repo.reload!(membership)
+
+      assert membership.role == :owner
+      assert get_flash(conn, :error) == "You are not allowed to grant the admin role"
+    end
+
     test "admin can make another user admin", %{
       conn: conn,
       user: user

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -160,6 +160,30 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       assert redirected_to(conn) == "/#{site.domain}"
     end
 
+    test "owner cannot make anyone else owner", %{
+      conn: conn,
+      user: user
+    } do
+      admin = insert(:user)
+
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner),
+            build(:site_membership, user: admin, role: :admin)
+          ]
+        )
+
+      membership = Repo.get_by(Plausible.Site.Membership, user_id: admin.id)
+
+      conn = put(conn, "/sites/#{site.domain}/memberships/#{membership.id}/role/owner")
+
+      membership = Repo.reload!(membership)
+
+      assert membership.role == :admin
+      assert get_flash(conn, :error) == "You are not allowed to grant the owner role"
+    end
+
     test "admin can make another user admin", %{
       conn: conn,
       user: user


### PR DESCRIPTION
### Changes

Sentry error: https://sentry.plausible.io/organizations/sentry/issues/1945/events/2f6ea4f040284deebea16469384e0f60/?project=1

This error is caused by people taking a reasonable action: someone with `admin` rights wants to grant someone else `admin` rights as well. I think this action should be supported but it currently isn't.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
