### PR TITLE
Ignore unknown country code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - Remove the `+ Add Site` link to the site-switcher dropdown in the dashboard.
 - `DISABLE_REGISTRATIONS` configuration parameter can now accept `invite_only` to allow invited users to register an account while keeping regular registrations disabled plausible/analytics#1841
 - New and improved Session tracking module for higher throughput and lower latency. [PR#1934](https://github.com/plausible/analytics#1934)
+- Do not display ZZ country code in countries report [PR#1934](https://github.com/plausible/analytics#2223)
 
 ## v1.4.1
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -381,7 +381,7 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:country") do
     from(
       s in q,
-      where: s.country_code != "\0\0",
+      where: s.country_code != "\0\0" and s.country_code != "ZZ",
       group_by: s.country_code,
       select_merge: %{country: s.country_code}
     )

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -67,6 +67,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
              ]
     end
 
+    test "ignores unknown country code ZZ", %{conn: conn, site: site} do
+      populate_stats(site, [build(:pageview, country_code: "ZZ")])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day")
+
+      assert json_response(conn, 200) == []
+    end
+
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,


### PR DESCRIPTION
### Changes

Sentry error: https://sentry.plausible.io/organizations/sentry/issues/1095/?environment=prod&project=1&query=is%3Aunresolved

This error is caused by attempting to enrich data for the  `ZZ` country code. This is a special reserved country code for 'unknown country'. The distinction between `ZZ` and `null` return value from the geolocation library is a mystery to me, but there we go.

We [don't accept](https://github.com/plausible/analytics/blob/2692bf4e38dfec9e12496fc000d6d856f7b03d90/lib/plausible/ingestion/event.ex#L245) the `ZZ` country code during ingestion anymore. However, some ZZ values did get into the database and are causing issues now.

An alternative approach would be to run a data migration and remove all the `ZZ` values from Clickhouse. Since we don't accept any new `ZZ` values, it should fix the issue, at least for Plasible.Cloud. But running an `ALTER TABLE` command on a 500GB table doesn't sound like fun if we don't have a replica to try it out first. [More reading](https://altinitydb.medium.com/updates-and-deletes-in-clickhouse-d5df6f336ce9a) on Clickhouse mutations.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
