### PR TITLE
Fix shared link with bad auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - Fix a bug where city, region and country filters were filtering stats but not the location list
 - Fix a bug where regions were not being saved
 - Timezone offset labels now update with time changes
+- Render 404 if shared link auth cannot be verified [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - Fix a bug where regions were not being saved
 - Timezone offset labels now update with time changes
 - Render 404 if shared link auth cannot be verified [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
+- Restore compatibility with older format of shared links [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -129,6 +129,8 @@ defmodule PlausibleWeb.StatsController do
       else
         render_shared_link(conn, shared_link)
       end
+    else
+      render_error(conn, 404)
     end
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -6,42 +6,26 @@ defmodule PlausibleWeb.StatsController do
   rendering. Since the dashboards are heavily interactive, they are built with React
   which is an appropraite choice for highly interactive browser UIs.
 
-                                     +---------------+                +-----------------+ +---------------------+
-                                     | BrowserClient |                | StatsController | | ApiStatsController  |
-                                     +---------------+                +-----------------+ +---------------------+
-                                             |                                 |                     |
-                                             | GET /mydomain.com               |                     |
-                                             |-------------------------------->|                     |
-                                             |                                 |                     |
-                                             | StatsView.render("stats.html")  |                     |
-                                             |<--------------------------------|                     |
-      -------------------------------------\ |                                 |                     |
-      |  JS renders with ReactDom.mount()  |-|                                 |                     |
-      |------------------------------------| |                                 |                     |
-  -----------------------------------------\ |                                 |                     |
-  |  Hydrate React reports in parallel...  |-|                                 |                     |
-  |----------------------------------------| |                                 |                     |
-                                             |                                 |                     |
-                                             | GET /api/stats/mydomain.com/top-stats                 |
-                                             |------------------------------------------------------>|
-                                             |                                 |                     |
-                                             |                                 |       JSON response |
-                                             |<------------------------------------------------------|
-                       --------------------\ |                                 |                     |
-                       | TopStats.render() |-|                                 |                     |
-                       |-------------------| |                                 |                     |
-                                             |                                 |                     |
-                                             | GET /api/stats/mydomain.com/sources                   |
-                                             |------------------------------------------------------>|
-                                             |                                 |                     |
-                                             |                                 |       JSON response |
-                                             |<------------------------------------------------------|
-                        -------------------\ |                                 |                     |
-                        | Sources.render() |-|                                 |                     |
-                        |------------------| |                                 |                     |
-                                             |                                 |                     |
-                                                     ... ETC until all reports are hydrated ...
+  <div class="mermaid">
+  sequenceDiagram
+    Browser->>StatsController: GET /mydomain.com
+    StatsController-->>Browser: StatsView.render("stats.html")
+    Note left of Browser: ReactDom.render(Dashboard)
 
+    Browser -) Api.StatsController: GET /api/stats/mydomain.com/top-stats
+    Api.StatsController --) Browser: {"top_stats": [...]}
+    Note left of Browser: TopStats.render()
+
+    Browser -) Api.StatsController: GET /api/stats/mydomain.com/main-graph
+    Api.StatsController --) Browser: [{"name": "Google", "visitors": 292150}, ...]
+    Note left of Browser: VisitorGraph.render()
+
+    Browser -) Api.StatsController: GET /api/stats/mydomain.com/sources
+    Api.StatsController --) Browser: [{"name": "Google", "visitors": 292150}, ...]
+    Note left of Browser: Sources.render()
+
+    Note over Browser,StatsController: And so on, for all reports in the viewport
+  </div>
 
   This reasoning for this sequence is as follows:
     1. First paint is fast because it doesn't do any data aggregation yet - good UX

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.StatsController do
     Note left of Browser: TopStats.render()
 
     Browser -) Api.StatsController: GET /api/stats/mydomain.com/main-graph
-    Api.StatsController --) Browser: [{"name": "Google", "visitors": 292150}, ...]
+    Api.StatsController --) Browser: [{"plot": [...], "labels": [...]}, ...]
     Note left of Browser: VisitorGraph.render()
 
     Browser -) Api.StatsController: GET /api/stats/mydomain.com/sources

--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,7 @@ defmodule Plausible.MixProject do
       {:telemetry, "~> 1.0", override: true},
       {:timex, "~> 3.7"},
       {:ua_inspector, "~> 3.0"},
-      {:ex_doc, "~> 0.28"}
+      {:ex_doc, "~> 0.28", only: :dev, runtime: false}
     ]
   end
 
@@ -140,7 +140,17 @@ defmodule Plausible.MixProject do
           ],
       groups_for_extras: [
         Features: Path.wildcard("guides/features/*.md")
-      ]
+      ],
+      before_closing_body_tag: fn
+        :html ->
+          """
+          <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+          <script>mermaid.initialize({startOnLoad: true})</script>
+          """
+
+        _ ->
+          ""
+      end
     ]
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -979,13 +979,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         build(:event,
           name: "Purchase",
           "meta.key": ["cost"],
-          "meta.value": ["16"],
-          domain: site.domain,
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:event,
-          name: "Purchase",
-          "meta.key": ["cost"],
           "meta.value": ["18"],
           domain: site.domain,
           timestamp: ~N[2021-01-01 00:25:00]
@@ -1019,7 +1012,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert json_response(conn, 200) == %{
                "results" => [
                  %{"cost" => "14", "visitors" => 2},
-                 %{"cost" => "16", "visitors" => 2}
+                 %{"cost" => "16", "visitors" => 1}
                ]
              }
     end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -264,9 +264,9 @@ defmodule PlausibleWeb.StatsControllerTest do
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
 
-    test "renders bad request when no auth parameter supplied", %{conn: conn} do
+    test "renders 404 not found when no auth parameter supplied", %{conn: conn} do
       conn = get(conn, "/share/example.com")
-      assert response(conn, 400) =~ "Bad Request"
+      assert response(conn, 404) =~ "nothing here"
     end
 
     test "renders 404 not found when non-existent auth parameter is supplied", %{conn: conn} do
@@ -280,6 +280,24 @@ defmodule PlausibleWeb.StatsControllerTest do
       site1_link = insert(:shared_link, site: site1)
 
       conn = get(conn, "/share/#{site2.domain}/?auth=#{site1_link.slug}")
+      assert response(conn, 404) =~ "nothing here"
+    end
+  end
+
+  describe "GET /share/:slug - backwards compatibility" do
+    test "it redirects to new shared link format for historical links", %{conn: conn} do
+      site = insert(:site, domain: "test-site.com")
+      site_link = insert(:shared_link, site: site, inserted_at: ~N[2021-12-31 00:00:00])
+
+      conn = get(conn, "/share/#{site_link.slug}")
+      assert redirected_to(conn, 302) == "/share/#{site.domain}?auth=#{site_link.slug}"
+    end
+
+    test "it does nothing for newer links", %{conn: conn} do
+      site = insert(:site, domain: "test-site.com")
+      site_link = insert(:shared_link, site: site, inserted_at: ~N[2022-01-01 00:00:00])
+
+      conn = get(conn, "/share/#{site_link.slug}")
       assert response(conn, 404) =~ "nothing here"
     end
   end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -223,7 +223,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /share/:slug" do
+  describe "GET /share/:domain?auth=:auth" do
     test "prompts a password for a password-protected link", %{conn: conn} do
       site = insert(:site)
 
@@ -267,6 +267,20 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "renders bad request when no auth parameter supplied", %{conn: conn} do
       conn = get(conn, "/share/example.com")
       assert response(conn, 400) =~ "Bad Request"
+    end
+
+    test "renders 404 not found when non-existent auth parameter is supplied", %{conn: conn} do
+      conn = get(conn, "/share/example.com?auth=bad-token")
+      assert response(conn, 404) =~ "nothing here"
+    end
+
+    test "renders 404 not found when auth parameter for another site is supplied", %{conn: conn} do
+      site1 = insert(:site, domain: "test-site-1.com")
+      site2 = insert(:site, domain: "test-site-2.com")
+      site1_link = insert(:shared_link, site: site1)
+
+      conn = get(conn, "/share/#{site2.domain}/?auth=#{site1_link.slug}")
+      assert response(conn, 404) =~ "nothing here"
     end
   end
 


### PR DESCRIPTION
### Changes

This work started as a bug fix for a [Sentry error](https://sentry.plausible.io/organizations/sentry/issues/258/?environment=prod&project=1&query=is%3Aunresolved). I used the opportunity for some refactoring & docs as well.

- [x] Render 404 when shared link cannot be found (resolves https://sentry.plausible.io/organizations/sentry/issues/258/?environment=prod&project=1&query=is%3Aunresolved)
- [x] Add documentation for StatsController
- [x] Refactor `Plausible.StatsController.shared_link/2` for clarity

During development I found that backwards compatibility for the older format of shared links was broken in [this commit](https://github.com/plausible/analytics/commit/b0b9b9212bb7900e6d4060ae3dc85167f99c9543).
- [x] Restore backwards compatibility for old format of shared links


### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI