### PR TITLE
add upper bound to limit parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- An upper bound of 1000 to the `limit` parameter in Stats API
 - The `exclusions` script extension now also takes a `data-include` attribute tag
 - A `file-downloads` script extension for automatically tracking file downloads as custom events
 - Integration with [Matomo's referrer spam list](https://github.com/matomo-org/referrer-spam-list/blob/master/spammers.txt) to block known spammers

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -98,12 +98,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   @max_breakdown_limit 1000
   defp validate_or_default_limit(%{"limit" => limit}) do
-    limit = String.to_integer(limit)
-
-    if limit <= @max_breakdown_limit do
+    with {limit, ""} when limit > 0 and limit <= @max_breakdown_limit <- Integer.parse(limit) do
       {:ok, limit}
     else
-      {:error, "Limit too large. Please use a limit not higher than #{@max_breakdown_limit}."}
+      _ ->
+        {:error, "Please provide limit as a number between 1 and #{@max_breakdown_limit}."}
     end
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1567,19 +1567,39 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert Enum.count(res["results"]) == 2
     end
 
+    @invalid_limit_message "Please provide limit as a number between 1 and 1000."
+
     test "returns error when limit too large", %{conn: conn, site: site} do
       conn =
         get(conn, "/api/v1/stats/breakdown", %{
           "site_id" => site.domain,
-          "period" => "day",
-          "date" => "2021-01-01",
           "property" => "event:page",
           "limit" => 1001
         })
 
-      assert json_response(conn, 400) == %{
-               "error" => "Limit too large. Please use a limit not higher than 1000."
-             }
+      assert json_response(conn, 400) == %{"error" => @invalid_limit_message}
+    end
+
+    test "returns error with non-integer limit", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "limit" => "bad_limit"
+        })
+
+      assert json_response(conn, 400) == %{"error" => @invalid_limit_message}
+    end
+
+    test "returns error with negative integer limit", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "limit" => -1
+        })
+
+      assert json_response(conn, 400) == %{"error" => @invalid_limit_message}
     end
 
     test "can paginate results", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1567,6 +1567,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert Enum.count(res["results"]) == 2
     end
 
+    test "returns error when limit too large", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:page",
+          "limit" => 1001
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" => "Limit too large. Please use a limit not higher than 1000."
+             }
+    end
+
     test "can paginate results", %{conn: conn, site: site} do
       populate_stats([
         build(:pageview, pathname: "/a", domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),


### PR DESCRIPTION
### Changes

Define an upper boundary for the `limit` parameter used in Stats API.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] a pending PR to docs is added: https://github.com/plausible/docs/pull/274

### Dark mode
- [x] This PR does not change the UI
