### PR TITLE
Sort timezone list by current offset

### DIFF
--- a/lib/plausible/timezones.ex
+++ b/lib/plausible/timezones.ex
@@ -1,4 +1,5 @@
 defmodule Plausible.Timezones do
+  @spec options() :: [{:key, String.t()}, {:value, String.t()}, {:offset, integer()}]
   def options do
     Tzdata.zone_list()
     |> Enum.map(&build_option/1)
@@ -7,7 +8,7 @@ defmodule Plausible.Timezones do
 
   defp build_option(timezone_code) do
     timezone_info = Timex.Timezone.get(timezone_code)
-    offset_in_minutes = div(timezone_info.offset_utc, -60)
+    offset_in_minutes = timezone_info |> Timex.Timezone.total_offset() |> div(-60)
 
     hhmm_formatted_offset =
       timezone_info


### PR DESCRIPTION
### Changes

This PR fixes a bug where the timezone list was sorted by the standard offset, not considering timezone changes. The list was working properly, but sorting was wrong.

### Tests
We currently test offsets, but this is a specific case where there is a timezone change (e.g. daylight saving time), and mocking `tzdata` just for this seems overkill. We can add if you think we need.

- [ ] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
