### PR TITLE
enable google import for everyone

### DIFF
--- a/lib/plausible_web/templates/site/settings_general.html.eex
+++ b/lib/plausible_web/templates/site/settings_general.html.eex
@@ -47,8 +47,6 @@
   </div>
 <% end %>
 
-<%= if FunWithFlags.enabled?(:google_analytics_imports, for: @conn.assigns[:current_user]) do %>
-
 <div class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
   <header class="relative mt-4">
     <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Data Import from Google Analytics</h2>
@@ -113,4 +111,3 @@
           </div>
         <% end %>
 </div>
-<% end %>


### PR DESCRIPTION
### Changes

As GA imports are now enabled for everyone, removing this feature flag check makes it also enabled for self-hosters without doing any extra work.

### Tests
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
