### PR TITLE
Treat non-200 HTTP responses as errors

### DIFF
--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -138,7 +138,7 @@ defmodule Plausible.Google.HTTP do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, %Finch.Response{body: body}} ->
+      {:error, %{reason: %Finch.Response{body: body}}} ->
         Sentry.capture_message("Error fetching Google view ID", extra: Jason.decode!(body))
         {:error, body}
 
@@ -174,16 +174,16 @@ defmodule Plausible.Google.HTTP do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, %Finch.Response{body: body, status: 401}} ->
+      {:error, %{reason: %Finch.Response{body: body, status: 401}}} ->
         Sentry.capture_message("Error fetching Google queries", extra: Jason.decode!(body))
         {:error, :invalid_credentials}
 
-      {:ok, %Finch.Response{body: body, status: 403}} ->
+      {:error, %{reason: %Finch.Response{body: body, status: 403}}} ->
         body = Jason.decode!(body)
         Sentry.capture_message("Error fetching Google queries", extra: body)
         {:error, get_in(body, ["error", "message"])}
 
-      {:ok, %Finch.Response{body: body}} ->
+      {:error, %{reason: %Finch.Response{body: body}}} ->
         Sentry.capture_message("Error fetching Google queries", extra: Jason.decode!(body))
         {:error, :unknown}
 
@@ -212,7 +212,7 @@ defmodule Plausible.Google.HTTP do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, %Finch.Response{body: body, status: _non_http_200}} ->
+      {:error, %{reason: %Finch.Response{body: body, status: _non_http_200}}} ->
         body
         |> Jason.decode!()
         |> Map.get("error")
@@ -261,7 +261,7 @@ defmodule Plausible.Google.HTTP do
 
         {:ok, date}
 
-      {:ok, %Finch.Response{body: body}} ->
+      {:error, %{reason: %Finch.Response{body: body}}} ->
         Sentry.capture_message("Error fetching Google view ID", extra: Jason.decode!(body))
         {:error, body}
 

--- a/lib/plausible_web/templates/auth/user_settings.html.eex
+++ b/lib/plausible_web/templates/auth/user_settings.html.eex
@@ -136,7 +136,7 @@
       </p>
     </div>
 
-  <% invoice_list -> %>
+    <% {:ok, invoice_list} when is_list(invoice_list) -> %>
     <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-orange-200 rounded rounded-t-none shadow-md dark:bg-gray-800">
       <h2 class="text-xl font-black dark:text-gray-100">Invoices</h2>
       <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -41,7 +41,7 @@
           <%= if error == "invalid_grant" do %>
             <p class="text-red-700 font-medium mt-3"><a href="https://plausible.io/docs/google-search-console-integration#i-get-the-invalid-grant-error">Invalid Grant error returned from Google. <span class="text-indigo-500">See here on how to fix it.</a></p>
           <% else %>
-            <p class="text-red-700 font-medium mt-3"><%= error %></p>
+            <p class="text-red-700 font-medium mt-3">Something went wrong</p>
           <% end %>
       <% end %>
     <% else %>

--- a/test/support/paddle_api_mock.ex
+++ b/test/support/paddle_api_mock.ex
@@ -34,20 +34,21 @@ defmodule Plausible.PaddleApi.Mock do
         {:error, :request_failed}
 
       _ ->
-        [
-          %{
-            "amount" => 11.11,
-            "currency" => "EUR",
-            "payout_date" => "2020-12-24",
-            "receipt_url" => "https://some-receipt-url.com"
-          },
-          %{
-            "amount" => 22,
-            "currency" => "USD",
-            "payout_date" => "2020-11-24",
-            "receipt_url" => "https://other-receipt-url.com"
-          }
-        ]
+        {:ok,
+         [
+           %{
+             "amount" => 11.11,
+             "currency" => "EUR",
+             "payout_date" => "2020-12-24",
+             "receipt_url" => "https://some-receipt-url.com"
+           },
+           %{
+             "amount" => 22,
+             "currency" => "USD",
+             "payout_date" => "2020-11-24",
+             "receipt_url" => "https://other-receipt-url.com"
+           }
+         ]}
     end
   end
 end


### PR DESCRIPTION
### Changes

We're universally changing the way HTTPClient abstraction works - we'll now tag every non-200 response with an `:error`. Additionally we'll send a Sentry message every time get_invoices/1 fails.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
