### PR TITLE
Improve GA Imports error reporting

### DIFF
--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -151,12 +151,8 @@ defmodule Plausible.Google.Api do
     result
   end
 
-  @spec fetch_and_persist(Plausible.Site.t(), ReportRequest.t(),
-          buffer: pid(),
-          attempt: non_neg_integer(),
-          sleep_time: non_neg_integer(),
-          http_client: module()
-        ) :: :ok | {:error, term()}
+  @spec fetch_and_persist(Plausible.Site.t(), ReportRequest.t(), Keyword.t()) ::
+          :ok | {:error, term()}
   def fetch_and_persist(site, %ReportRequest{} = report_request, opts \\ []) do
     buffer_pid = Keyword.get(opts, :buffer)
     attempt = Keyword.get(opts, :attempt, 1)

--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -181,7 +181,7 @@ defmodule Plausible.Google.Api do
       {:error, cause} ->
         if attempt >= @max_attempts do
           Sentry.capture_message("Failed to import from Google Analytics",
-            extra: %{site: site.domain, error: cause}
+            extra: %{site: site.domain, error: inspect(cause)}
           )
 
           {:error, cause}

--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -41,6 +41,13 @@ defmodule Plausible.Google.HTTP do
          token <- Map.get(report, "nextPageToken"),
          {:ok, report} <- convert_to_maps(report) do
       {:ok, {report, token}}
+    else
+      {:ok, %{status: _non_http_200, body: body}} ->
+        Sentry.Context.set_extra_context(%{google_analytics_response: body})
+        {:error, :request_failed}
+
+      {:error, cause} ->
+        {:error, cause}
     end
   end
 

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -15,6 +15,8 @@ defmodule Plausible.Site do
   alias Plausible.Auth.User
   alias Plausible.Site.GoogleAuth
 
+  @type t() :: %__MODULE__{}
+
   @derive {Jason.Encoder, only: [:domain, :timezone]}
   schema "sites" do
     field :domain, :string

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -70,13 +70,12 @@ defmodule Plausible.Google.ApiTest do
         page_size: 10_000
       }
 
-      assert_raise RuntimeError, "Google API request failed too many times", fn ->
-        Api.fetch_and_persist(site, request,
-          http_client: finch_double,
-          sleep_time: 0,
-          buffer: buffer
-        )
-      end
+      assert {:error, :request_failed} =
+               Api.fetch_and_persist(site, request,
+                 http_client: finch_double,
+                 sleep_time: 0,
+                 buffer: buffer
+               )
 
       assert_receive({Finch, :request, [_, _]})
       assert_receive({Finch, :request, [_, _]})


### PR DESCRIPTION
### Changes

This pull request improves error reporting and documentation for Google Analytics imports. Currently unexpected errors from GA (unauthorized, timeouts, connection closed, etc) are raised as an exception. I changed this to a regular error tuple, reporting the site domain, error and GA response body to Sentry.

### Tests
- [X] Automated tests have been added

I also tested this in our staging Sentry app.

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
