### PR TITLE
Ignore unknown country in imported data

### DIFF
--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -179,7 +179,7 @@ defmodule Plausible.Stats.Imported do
           |> select_merge([i], %{exit_page: i.exit_page, visits: sum(i.exits)})
 
         :country ->
-          imported_q |> select_merge([i], %{country: i.country})
+          imported_q |> where([i], i.country != "ZZ") |> select_merge([i], %{country: i.country})
 
         :region ->
           imported_q |> where([i], i.region != "") |> select_merge([i], %{region: i.region})

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -68,9 +68,12 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
     end
 
     test "ignores unknown country code ZZ", %{conn: conn, site: site} do
-      populate_stats(site, [build(:pageview, country_code: "ZZ")])
+      populate_stats(site, [
+        build(:pageview, country_code: "ZZ"),
+        build(:imported_locations, country: "ZZ")
+      ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day")
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&with_imported=true")
 
       assert json_response(conn, 200) == []
     end


### PR DESCRIPTION
### Changes

Follow-up for https://github.com/plausible/analytics/pull/2223

In that PR I forgot to ignore the ZZ country code in imported data as well.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
