### PR TITLE
do not show invoices for free subscription

### DIFF
--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -92,8 +92,9 @@ defmodule Plausible.Billing.PaddleApi do
   @spec get_invoices(Plausible.Billing.Subscription.t()) ::
           {:ok, list()}
           | {:error, :request_failed}
-          | {:error, :no_subscription}
-  def get_invoices(nil), do: {:error, :no_subscription}
+          | {:error, :no_invoices}
+  def get_invoices(nil), do: {:error, :no_invoices}
+  def get_invoices(%{paddle_subscription_id: nil}), do: {:error, :no_invoices}
 
   def get_invoices(subscription) do
     config = get_config()

--- a/lib/plausible_web/templates/auth/user_settings.html.eex
+++ b/lib/plausible_web/templates/auth/user_settings.html.eex
@@ -125,7 +125,7 @@
 </div>
 
 <%= case @invoices do %>
-  <% {:error, :no_subscription} -> %>
+  <% {:error, :no_invoices} -> %>
 
   <% {:error, :request_failed} -> %>
     <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-orange-200 rounded rounded-t-none shadow-md dark:bg-gray-800">

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -557,7 +557,7 @@ defmodule PlausibleWeb.AuthControllerTest do
 
     test "does not show invoice section for a user with no subscription", %{conn: conn} do
       conn = get(conn, "/settings")
-      assert !(html_response(conn, 200) =~ "Invoices")
+      refute html_response(conn, 200) =~ "Invoices"
     end
 
     test "does not show invoice section for a free subscription", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -565,7 +565,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       |> Repo.insert!()
 
       conn = get(conn, "/settings")
-      assert !(html_response(conn, 200) =~ "Invoices")
+      refute html_response(conn, 200) =~ "Invoices"
     end
   end
 

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -559,6 +559,14 @@ defmodule PlausibleWeb.AuthControllerTest do
       conn = get(conn, "/settings")
       assert !(html_response(conn, 200) =~ "Invoices")
     end
+
+    test "does not show invoice section for a free subscription", %{conn: conn, user: user} do
+      Plausible.Billing.Subscription.free(%{user_id: user.id, currency_code: "EUR"})
+      |> Repo.insert!()
+
+      conn = get(conn, "/settings")
+      assert !(html_response(conn, 200) =~ "Invoices")
+    end
   end
 
   describe "PUT /settings" do

--- a/test/support/paddle_api_mock.ex
+++ b/test/support/paddle_api_mock.ex
@@ -26,7 +26,8 @@ defmodule Plausible.PaddleApi.Mock do
      }}
   end
 
-  def get_invoices(nil), do: {:error, :no_subscription}
+  def get_invoices(nil), do: {:error, :no_invoices}
+  def get_invoices(%{paddle_subscription_id: nil}), do: {:error, :no_invoices}
 
   def get_invoices(subscription) do
     case subscription.paddle_subscription_id do


### PR DESCRIPTION
### Changes

Do not attempt to fetch invoices for a free subscription where `paddle_subscription_id=nil`.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
