### PR TITLE
Make Finch pools lighter for self-hosting

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -372,12 +372,6 @@ config :plausible, :hcaptcha,
   sitekey: hcaptcha_sitekey,
   secret: hcaptcha_secret
 
-config :plausible, Plausible.Finch,
-  default_pool_size: get_int_from_path_or_env(config_dir, "DEFAULT_FINCH_POOL_SIZE", 50),
-  default_pool_count: get_int_from_path_or_env(config_dir, "DEFAULT_FINCH_POOL_COUNT", 1),
-  sentry_pool_size: get_int_from_path_or_env(config_dir, "SENTRY_FINCH_POOL_SIZE", 50),
-  sentry_pool_count: get_int_from_path_or_env(config_dir, "SENTRY_FINCH_POOL_COUNT", 1)
-
 config :plausible, Plausible.Sentry.Client,
   finch_request_opts: [
     pool_timeout: get_int_from_path_or_env(config_dir, "SENTRY_FINCH_POOL_TIMEOUT", 5000),

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -43,7 +43,6 @@ defmodule Plausible.Application do
   defp finch_pool_config() do
     base_config = %{
       "https://icons.duckduckgo.com" => [
-        protocol: :http2,
         conn_opts: [transport_opts: [timeout: 15_000]]
       ]
     }
@@ -70,7 +69,6 @@ defmodule Plausible.Application do
     cond do
       paddle_conf[:vendor_id] && paddle_conf[:vendor_auth_code] ->
         Map.put(pool_config, Plausible.Billing.PaddleApi.vendors_domain(),
-          protocol: :http2,
           conn_opts: [transport_opts: [timeout: 15_000]]
         )
 
@@ -85,14 +83,8 @@ defmodule Plausible.Application do
     cond do
       google_conf[:client_id] && google_conf[:client_secret] ->
         pool_config
-        |> Map.put(google_conf[:api_url],
-          protocol: :http2,
-          conn_opts: [transport_opts: [timeout: 15_000]]
-        )
-        |> Map.put(google_conf[:reporting_api_url],
-          protocol: :http2,
-          conn_opts: [transport_opts: [timeout: 15_000]]
-        )
+        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: [timeout: 15_000]])
+        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: [timeout: 15_000]])
 
       true ->
         pool_config

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -41,41 +41,61 @@ defmodule Plausible.Application do
   end
 
   defp finch_pool_config() do
-    config = Application.fetch_env!(:plausible, Plausible.Finch)
-
-    pool_config = %{
-      :default => [size: config[:default_pool_size], count: config[:default_pool_count]],
-      "https://vendors.paddle.com" => [
-        protocol: :http2,
-        count: 50,
-        conn_opts: [transport_opts: [timeout: 15_000]]
-      ],
-      "https://www.googleapis.com" => [
-        protocol: :http2,
-        count: 200,
-        conn_opts: [transport_opts: [timeout: 15_000]]
-      ],
-      "https://analyticsreporting.googleapis.com" => [
-        protocol: :http2,
-        count: 200,
-        conn_opts: [transport_opts: [timeout: 15_000]]
-      ],
+    base_config = %{
       "https://icons.duckduckgo.com" => [
         protocol: :http2,
-        count: 100,
         conn_opts: [transport_opts: [timeout: 15_000]]
       ]
     }
 
-    sentry_dsn = Application.get_env(:sentry, :dsn)
+    base_config
+    |> maybe_add_sentry_pool()
+    |> maybe_add_paddle_pool()
+    |> maybe_add_google_pools()
+  end
 
-    if is_binary(sentry_dsn) do
-      Map.put(pool_config, sentry_dsn,
-        size: config[:sentry_pool_size],
-        count: config[:sentry_pool_count]
-      )
-    else
-      pool_config
+  defp maybe_add_sentry_pool(pool_config) do
+    case Application.get_env(:sentry, :dsn) do
+      dsn when is_binary(dsn) ->
+        Map.put(pool_config, dsn, size: 50)
+
+      _ ->
+        pool_config
+    end
+  end
+
+  defp maybe_add_paddle_pool(pool_config) do
+    paddle_conf = Application.get_env(:plausible, :paddle)
+
+    cond do
+      paddle_conf[:vendor_id] && paddle_conf[:vendor_auth_code] ->
+        Map.put(pool_config, Plausible.Billing.PaddleApi.vendors_domain(),
+          protocol: :http2,
+          conn_opts: [transport_opts: [timeout: 15_000]]
+        )
+
+      true ->
+        pool_config
+    end
+  end
+
+  defp maybe_add_google_pools(pool_config) do
+    google_conf = Application.get_env(:plausible, :google)
+
+    cond do
+      google_conf[:client_id] && google_conf[:client_secret] ->
+        pool_config
+        |> Map.put(google_conf[:api_url],
+          protocol: :http2,
+          conn_opts: [transport_opts: [timeout: 15_000]]
+        )
+        |> Map.put(google_conf[:reporting_api_url],
+          protocol: :http2,
+          conn_opts: [transport_opts: [timeout: 15_000]]
+        )
+
+      true ->
+        pool_config
     end
   end
 


### PR DESCRIPTION
### Changes

Previous discussion: https://github.com/plausible/analytics/pull/2224

The current pool config eats a lot of memory for self-hosted installations. The pool count seems excessive so this is an attempt to make the app more lean by default.

If it turns out we need beefier pool counts for Plausible.Cloud now or in the future, we can add a config option but keep the lighter pools in the default configuration for easy self-hosting.


### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI