### PR TITLE
Refresh Google Analytics token before import

### DIFF
--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -636,7 +636,9 @@ defmodule PlausibleWeb.SiteController do
 
   def import_from_google_user_metric_notice(conn, %{
         "view_id" => view_id,
-        "access_token" => access_token
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "expires_at" => expires_at
       }) do
     site = conn.assigns[:site]
 
@@ -646,11 +648,17 @@ defmodule PlausibleWeb.SiteController do
       site: site,
       view_id: view_id,
       access_token: access_token,
+      refresh_token: refresh_token,
+      expires_at: expires_at,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )
   end
 
-  def import_from_google_view_id_form(conn, %{"access_token" => access_token}) do
+  def import_from_google_view_id_form(conn, %{
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "expires_at" => expires_at
+      }) do
     site = conn.assigns[:site]
     view_ids = Plausible.Google.Api.list_views(access_token)
 
@@ -658,6 +666,8 @@ defmodule PlausibleWeb.SiteController do
     |> assign(:skip_plausible_tracking, true)
     |> render("import_from_google_view_id_form.html",
       access_token: access_token,
+      refresh_token: refresh_token,
+      expires_at: expires_at,
       site: site,
       view_ids: view_ids,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
@@ -666,7 +676,12 @@ defmodule PlausibleWeb.SiteController do
 
   # see https://stackoverflow.com/a/57416769
   @google_analytics_new_user_metric_date ~D[2016-08-24]
-  def import_from_google_view_id(conn, %{"view_id" => view_id, "access_token" => access_token}) do
+  def import_from_google_view_id(conn, %{
+        "view_id" => view_id,
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "expires_at" => expires_at
+      }) do
     site = conn.assigns[:site]
     start_date = Plausible.Google.HTTP.get_analytics_start_date(view_id, access_token)
 
@@ -679,6 +694,8 @@ defmodule PlausibleWeb.SiteController do
         |> assign(:skip_plausible_tracking, true)
         |> render("import_from_google_view_id_form.html",
           access_token: access_token,
+          refresh_token: refresh_token,
+          expires_at: expires_at,
           site: site,
           view_ids: view_ids,
           selected_view_id_error: "No data found. Nothing to import",
@@ -691,7 +708,9 @@ defmodule PlausibleWeb.SiteController do
             to:
               Routes.site_path(conn, :import_from_google_user_metric_notice, site.domain,
                 view_id: view_id,
-                access_token: access_token
+                access_token: access_token,
+                refresh_token: refresh_token,
+                expires_at: expires_at
               )
           )
         else
@@ -699,14 +718,21 @@ defmodule PlausibleWeb.SiteController do
             to:
               Routes.site_path(conn, :import_from_google_confirm, site.domain,
                 view_id: view_id,
-                access_token: access_token
+                access_token: access_token,
+                refresh_token: refresh_token,
+                expires_at: expires_at
               )
           )
         end
     end
   end
 
-  def import_from_google_confirm(conn, %{"access_token" => access_token, "view_id" => view_id}) do
+  def import_from_google_confirm(conn, %{
+        "view_id" => view_id,
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "expires_at" => expires_at
+      }) do
     site = conn.assigns[:site]
 
     start_date = Plausible.Google.HTTP.get_analytics_start_date(view_id, access_token)
@@ -720,6 +746,8 @@ defmodule PlausibleWeb.SiteController do
     |> assign(:skip_plausible_tracking, true)
     |> render("import_from_google_confirm.html",
       access_token: access_token,
+      refresh_token: refresh_token,
+      expires_at: expires_at,
       site: site,
       selected_view_id: view_id,
       selected_view_id_name: view_name,
@@ -733,7 +761,9 @@ defmodule PlausibleWeb.SiteController do
         "view_id" => view_id,
         "start_date" => start_date,
         "end_date" => end_date,
-        "access_token" => access_token
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "expires_at" => expires_at
       }) do
     site = conn.assigns[:site]
 
@@ -743,7 +773,9 @@ defmodule PlausibleWeb.SiteController do
         "view_id" => view_id,
         "start_date" => start_date,
         "end_date" => end_date,
-        "access_token" => access_token
+        "access_token" => access_token,
+        "refresh_token" => refresh_token,
+        "token_expires_at" => expires_at
       })
 
     Ecto.Multi.new()

--- a/lib/plausible_web/templates/site/import_from_google_confirm.html.eex
+++ b/lib/plausible_web/templates/site/import_from_google_confirm.html.eex
@@ -2,6 +2,8 @@
   <h2 class="text-xl font-black dark:text-gray-100">Import from Google Analytics</h2>
 
   <%= hidden_input(f, :access_token, value: @access_token) %>
+  <%= hidden_input(f, :refresh_token, value: @refresh_token) %>
+  <%= hidden_input(f, :expires_at, value: @expires_at) %>
 
   <%= case @start_date do %>
     <% {:ok, start_date} -> %>

--- a/lib/plausible_web/templates/site/import_from_google_user_metric_form.html.eex
+++ b/lib/plausible_web/templates/site/import_from_google_user_metric_form.html.eex
@@ -22,5 +22,5 @@
     </p>
   </div>
 
-  <%= link("Continue ->", to: Routes.site_path(@conn, :import_from_google_confirm, @site.domain, view_id: @view_id, access_token: @access_token), class: "button mt-6") %>
+  <%= link("Continue ->", to: Routes.site_path(@conn, :import_from_google_confirm, @site.domain, view_id: @view_id, access_token: @access_token, refresh_token: @refresh_token, expires_at: @expires_at), class: "button mt-6") %>
 </div>

--- a/lib/plausible_web/templates/site/import_from_google_view_id_form.html.eex
+++ b/lib/plausible_web/templates/site/import_from_google_view_id_form.html.eex
@@ -2,6 +2,8 @@
   <h2 class="text-xl font-black dark:text-gray-100">Import from Google Analytics</h2>
 
   <%= hidden_input(f, :access_token, value: @access_token) %>
+  <%= hidden_input(f, :refresh_token, value: @refresh_token) %>
+  <%= hidden_input(f, :expires_at, value: @expires_at) %>
 
   <%= case @view_ids do %>
     <% {:ok, view_ids} -> %>

--- a/lib/workers/import_google_analytics.ex
+++ b/lib/workers/import_google_analytics.ex
@@ -9,13 +9,13 @@ defmodule Plausible.Workers.ImportGoogleAnalytics do
   @impl Oban.Worker
   def perform(
         %Oban.Job{
-          args: %{
-            "site_id" => site_id,
-            "view_id" => view_id,
-            "start_date" => start_date,
-            "end_date" => end_date,
-            "access_token" => access_token
-          }
+          args:
+            %{
+              "site_id" => site_id,
+              "view_id" => view_id,
+              "start_date" => start_date,
+              "end_date" => end_date
+            } = args
         },
         google_api \\ Plausible.Google.Api
       ) do
@@ -24,7 +24,9 @@ defmodule Plausible.Workers.ImportGoogleAnalytics do
     end_date = Date.from_iso8601!(end_date)
     date_range = Date.range(start_date, end_date)
 
-    case google_api.import_analytics(site, date_range, view_id, access_token) do
+    auth = {args["access_token"], args["refresh_token"], args["token_expires_at"]}
+
+    case google_api.import_analytics(site, date_range, view_id, auth) do
       :ok ->
         Plausible.Site.import_success(site)
         |> Repo.update!()

--- a/test/plausible/google/vcr_test.exs
+++ b/test/plausible/google/vcr_test.exs
@@ -21,11 +21,13 @@ defmodule Plausible.Google.Api.VCRTest do
       inserts_before_importing = get_insert_count()
       before_importing_timestamp = DateTime.utc_now()
 
-      access_token = "***"
       view_id = "54297898"
       date_range = Date.range(~D[2011-01-01], ~D[2022-07-19])
 
-      assert :ok == Plausible.Google.Api.import_analytics(site, date_range, view_id, access_token)
+      future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
+      auth = {"***", "refresh_token", future}
+
+      assert :ok == Plausible.Google.Api.import_analytics(site, date_range, view_id, auth)
 
       total_seconds = DateTime.diff(DateTime.utc_now(), before_importing_timestamp, :second)
       total_inserts = get_insert_count() - inserts_before_importing

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -745,7 +745,11 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       response =
         conn
-        |> get("/#{site.domain}/import/google-analytics/view-id", %{"access_token" => "token"})
+        |> get("/#{site.domain}/import/google-analytics/view-id", %{
+          "access_token" => "token",
+          "refresh_token" => "foo",
+          "expires_at" => "2022-09-22T20:01:37.112777"
+        })
         |> html_response(200)
 
       assert response =~ "57238190 - one.test"
@@ -761,7 +765,9 @@ defmodule PlausibleWeb.SiteControllerTest do
         "view_id" => "123",
         "start_date" => "2018-03-01",
         "end_date" => "2022-03-01",
-        "access_token" => "token"
+        "access_token" => "token",
+        "refresh_token" => "foo",
+        "expires_at" => "2022-09-22T20:01:37.112777"
       })
 
       imported_data = Repo.reload(site).imported_data
@@ -777,7 +783,9 @@ defmodule PlausibleWeb.SiteControllerTest do
         "view_id" => "123",
         "start_date" => "2018-03-01",
         "end_date" => "2022-03-01",
-        "access_token" => "token"
+        "access_token" => "token",
+        "refresh_token" => "foo",
+        "expires_at" => "2022-09-22T20:01:37.112777"
       })
 
       assert_enqueued(
@@ -787,7 +795,9 @@ defmodule PlausibleWeb.SiteControllerTest do
           "view_id" => "123",
           "start_date" => "2018-03-01",
           "end_date" => "2022-03-01",
-          "access_token" => "token"
+          "access_token" => "token",
+          "refresh_token" => "foo",
+          "token_expires_at" => "2022-09-22T20:01:37.112777"
         }
       )
     end


### PR DESCRIPTION
### Changes

Now that we've enabled Google Analytics imports for everyone, the import queue is growing. That is not necessarily a problem, but I noticed a spike on GA authorization errors.

Currently the background job is enqueued with the access token for later use. The issue is the token is only valid for 60 minutes, and we're not refreshing it. This pull request saves refresh and access tokens so we can have valid tokens when a job is waiting for more than an hour.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
