### PR TITLE
Remove user agent cache

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -15,9 +15,6 @@ defmodule Plausible.Application do
       Plausible.Event.WriteBuffer,
       Plausible.Session.WriteBuffer,
       ReferrerBlocklist,
-      Supervisor.child_spec({Cachex, name: :user_agents, limit: 10_000, stats: true},
-        id: :cachex_user_agents
-      ),
       Supervisor.child_spec({Cachex, name: :sessions, limit: nil, stats: true},
         id: :cachex_sessions
       ),
@@ -100,15 +97,5 @@ defmodule Plausible.Application do
       &ObanErrorReporter.handle_event/4,
       %{}
     )
-  end
-
-  def report_cache_stats() do
-    case Cachex.stats(:user_agents) do
-      {:ok, stats} ->
-        Logger.info("User agent cache stats: #{inspect(stats)}")
-
-      e ->
-        IO.puts("Unable to show cache stats: #{inspect(e)}")
-    end
   end
 end

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -46,24 +46,14 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
   end
 
   @doc """
-  Add telemetry events for Cachex user agents and sessions
+  Add telemetry events for Cachex sessions
   """
   def execute_cache_metrics do
-    user_agents_count =
-      case Cachex.stats(:user_agents) do
-        {:ok, stats} -> stats
-        _ -> 0
-      end
-
     sessions_count =
       case Cachex.stats(:sessions) do
         {:ok, stats} -> stats
         _ -> 0
       end
-
-    :telemetry.execute([:prom_ex, :plugin, :cachex, :user_agents_count], %{
-      count: user_agents_count
-    })
 
     :telemetry.execute([:prom_ex, :plugin, :cachex, :sessions_count], %{
       count: sessions_count
@@ -99,11 +89,6 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         last_value(
           metric_prefix ++ [:events, :cache_size, :count],
           event_name: [:prom_ex, :plugin, :cachex, :sessions_count],
-          measurement: :count
-        ),
-        last_value(
-          metric_prefix ++ [:sessions, :cache_size, :count],
-          event_name: [:prom_ex, :plugin, :cachex, :user_agents_count],
           measurement: :count
         )
       ]


### PR DESCRIPTION
### Changes

This commit removes caching of user agents using Cachex. Parsing user agent strings should not be expensive, and not worth the complexity of managing and monitoring another cache key.

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
