### PR TITLE
Aggregate DBConnection.ConnectionError in Sentry

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -224,7 +224,8 @@ config :sentry,
   root_source_code_path: [File.cwd!()],
   client: Plausible.Sentry.Client,
   send_max_attempts: 1,
-  filter: Plausible.SentryFilter
+  filter: Plausible.SentryFilter,
+  before_send_event: {Plausible.SentryFilter, :before_send}
 
 config :logger, Sentry.LoggerBackend,
   capture_log_messages: true,

--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -1,4 +1,7 @@
 defmodule Plausible.SentryFilter do
+  @moduledoc """
+  Sentry callbacks for filtering and grouping events
+  """
   @behaviour Sentry.EventFilter
 
   def exclude_exception?(%Sentry.CrashError{}, _source), do: true
@@ -6,5 +9,17 @@ defmodule Plausible.SentryFilter do
 
   def exclude_exception?(exception, source) do
     Sentry.DefaultEventFilter.exclude_exception?(exception, source)
+  end
+
+  @spec before_send(Sentry.Event.t()) :: Sentry.Event.t()
+  def before_send(event)
+
+  # https://hexdocs.pm/sentry/readme.html#fingerprinting
+  def before_send(%{exception: [%{type: DBConnection.ConnectionError}]} = event) do
+    %{event | fingerprint: ["ecto", "db_connection", "timeout"]}
+  end
+
+  def before_send(event) do
+    event
   end
 end


### PR DESCRIPTION
### Changes

This configuration change aggregates all the `DBConnection.ConnectionError` events as per https://hexdocs.pm/sentry/readme.html#fingerprinting

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
