### PR TITLE
Add script to send pageview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Make sure Docker, Elixir, Erlang and Node.js are all installed on your developme
 1. Navigate to `http://localhost:8000/register` and fill in the form.
 2. Fill in the rest of the forms and for the domain use `dummy.site`
 3. Skip the JS snippet and click start collecting data.
-4. Run `make dummy_event` from the terminal to generate a fake pageview event for the dummy site.
+4. Run `mix send_pageview` from the terminal to generate a fake pageview event for the dummy site.
 5. You should now be all set!
 
 ### Stopping Docker containers

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,3 @@ postgres:
 
 postgres-stop:
 	docker stop plausible_db && docker rm plausible_db
-
-dummy_event:
-	curl 'http://localhost:8000/api/event' \
-		-H 'X-Forwarded-For: 127.0.0.1' \
-		-H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 OPR/71.0.3770.284' \
-		-H 'Content-Type: text/plain' \
-		--data-binary '{"n":"pageview","u":"http://dummy.site/some-page","d":"dummy.site","r":null,"w":1666}' \
-		--compressed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop dummy_event
+.PHONY: install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop
 
 install:
 	mix deps.get

--- a/lib/mix/tasks/send_pageview.ex
+++ b/lib/mix/tasks/send_pageview.ex
@@ -1,0 +1,92 @@
+defmodule Mix.Tasks.SendPageview do
+  @moduledoc """
+  It's often necessary to generate fake events for development and testing purposes. This Mix Task provides a quick and easy
+  way to generate a pageview or custom event, either in your development environment or a remote Plausible instance.
+
+  See Mix.Tasks.SendPageview.usage/1 for more detailed documentation.
+  """
+
+  use Mix.Task
+  require Logger
+
+  @default_ip_address "127.0.0.1"
+  @default_user_agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 OPR/71.0.3770.284"
+  @default_domain "dummy.site"
+  @default_page "/"
+  @default_referrer "https://google.com"
+  @options [
+    ip: :string,
+    user_agent: :string,
+    domain: :string,
+    page: :string,
+    referer: :string
+  ]
+
+  def run(opts) do
+    Finch.start_link(name: Plausible.Finch)
+
+    {parsed, _, invalid} = OptionParser.parse(opts, strict: @options)
+
+    case invalid do
+      [] ->
+        do_send_pageview(parsed)
+
+      [invalid_option | _] ->
+        {key, _val} = invalid_option
+        IO.puts("Invalid opton #{key}. Aborting.")
+        IO.puts(usage())
+    end
+  end
+
+  defp do_send_pageview(parsed_opts) do
+    ip = Keyword.get(parsed_opts, :ip, @default_ip_address)
+    user_agent = Keyword.get(parsed_opts, :user_agent, @default_user_agent)
+
+    url = get_url()
+    headers = get_headers(ip, user_agent)
+    body = get_body(parsed_opts)
+
+    case Plausible.HTTPClient.post(url, headers, body) do
+      {:ok, _} ->
+        IO.puts(
+          "✅ Succesfully sent #{body[:name]} event to #{url} ✅ \n\nip=#{ip}\nuser_agent=#{user_agent}\nbody= #{inspect(body, pretty: true)}"
+        )
+
+      {:error, e} ->
+        IO.puts("❌ Could not send event to #{url}. Got the following error: \n\n #{inspect(e)}")
+    end
+  end
+
+  defp get_url() do
+    "http://localhost:8000/api/event"
+  end
+
+  defp get_headers(ip, user_agent) do
+    [
+      {"x-forwarded-for", ip},
+      {"user-agent", user_agent},
+      {"content-type", "text/plain"}
+    ]
+  end
+
+  defp get_body(opts) do
+    domain = Keyword.get(opts, :domain, @default_domain)
+    page = Keyword.get(opts, :page, @default_page)
+    referrer = Keyword.get(opts, :referrer, @default_referrer)
+
+    %{
+      name: "pageview",
+      url: "http://#{domain}#{page}",
+      domain: domain,
+      referrer: referrer,
+      width: 1666
+    }
+  end
+
+  defp usage() do
+    """
+    usage: $ mix send_pageview [--domain domain] [--ip ip_address]"
+    options: #{inspect(@options, pretty: true)}
+    """
+  end
+end

--- a/lib/mix/tasks/send_pageview.ex
+++ b/lib/mix/tasks/send_pageview.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.SendPageview do
     user_agent: :string,
     domain: :string,
     page: :string,
-    referer: :string
+    referrer: :string
   ]
 
   def run(opts) do


### PR DESCRIPTION
### Changes

For development we need a convenient way to generate fake pageview events.

Currently this is done via `make dummy_event` but it's not very convenient because you cannot
override parameters from the command line like so:

```bash
$ make dummy_event --ip 127.0.0.2
$ make dummy_event --domain some-test-domain.com
```

In order to support command-line options like this, I thought I would write a small Mix task for it:
```bash
$ mix send_pageview --ip 127.0.0.2
$ mix send_pageview --domain some-test-domain.com
```

I'm not sure of the value of `Make` in this project in general. Mix is a great build tool and task runner, do we need another one?