### PR TITLE
Fix Google Analytics expires_at key

### DIFF
--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -239,7 +239,7 @@ defmodule Plausible.Google.Api do
 
   defp do_refresh_token(refresh_token) do
     case HTTP.refresh_auth_token(refresh_token) do
-      {:ok, %{"access_token" => new_access_token, "expires_at" => expires_in}} ->
+      {:ok, %{"access_token" => new_access_token, "expires_in" => expires_in}} ->
         expires_at = NaiveDateTime.add(NaiveDateTime.utc_now(), expires_in)
         {:ok, {new_access_token, expires_at}}
 

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -568,7 +568,7 @@ defmodule PlausibleWeb.AuthController do
           email: id["email"],
           refresh_token: res["refresh_token"],
           access_token: res["access_token"],
-          expires_at: expires_at,
+          expires: expires_at,
           user_id: conn.assigns[:current_user].id,
           site_id: site_id
         })


### PR DESCRIPTION
### Changes

This fix has been cherry picked from stable. It is a follow-up on #2254, fixing the token refresh for GA imports.

### Tests
We need better testing around this whole feature, but this involves replacing our current mock strategy for GA. I added an item in our backlog.

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
