### PR TITLE
Increase GA import request receive_timeout to 30s

### DIFF
--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -34,7 +34,7 @@ defmodule Plausible.Google.HTTP do
         [{"Authorization", "Bearer #{report_request.access_token}"}],
         params
       )
-      |> http_client.request(Plausible.Finch)
+      |> http_client.request(Plausible.Finch, receive_timeout: 30_000)
 
     with {:ok, %{status: 200, body: body}} <- response,
          {:ok, report} <- parse_report_from_response(body),

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -18,7 +18,7 @@ defmodule Plausible.Google.ApiTest do
     test "will fetch and persist import data from Google Analytics", %{site: site, buffer: buffer} do
       finch_double =
         Finch
-        |> stub(:request, fn _, _ ->
+        |> stub(:request, fn _, _, _ ->
           {:ok, %Finch.Response{status: 200, body: @ok_response}}
         end)
 
@@ -54,11 +54,11 @@ defmodule Plausible.Google.ApiTest do
     } do
       finch_double =
         Finch
-        |> stub(:request, fn _, _ -> {:error, :timeout} end)
-        |> stub(:request, fn _, _ -> {:error, :nx_domain} end)
-        |> stub(:request, fn _, _ -> {:error, :closed} end)
-        |> stub(:request, fn _, _ -> {:ok, %Finch.Response{status: 503}} end)
-        |> stub(:request, fn _, _ -> {:ok, %Finch.Response{status: 502}} end)
+        |> stub(:request, fn _, _, _ -> {:error, :timeout} end)
+        |> stub(:request, fn _, _, _ -> {:error, :nx_domain} end)
+        |> stub(:request, fn _, _, _ -> {:error, :closed} end)
+        |> stub(:request, fn _, _, _ -> {:ok, %Finch.Response{status: 503}} end)
+        |> stub(:request, fn _, _, _ -> {:ok, %Finch.Response{status: 502}} end)
 
       request = %Plausible.Google.ReportRequest{
         view_id: "123",
@@ -77,17 +77,17 @@ defmodule Plausible.Google.ApiTest do
                  buffer: buffer
                )
 
-      assert_receive({Finch, :request, [_, _]})
-      assert_receive({Finch, :request, [_, _]})
-      assert_receive({Finch, :request, [_, _]})
-      assert_receive({Finch, :request, [_, _]})
-      assert_receive({Finch, :request, [_, _]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
     end
 
     test "does not fail when report does not have rows key", %{site: site, buffer: buffer} do
       finch_double =
         Finch
-        |> stub(:request, fn _, _ ->
+        |> stub(:request, fn _, _, _ ->
           {:ok,
            %Finch.Response{status: 200, body: File.read!("fixture/ga_report_empty_rows.json")}}
         end)


### PR DESCRIPTION
### Changes

This commit increases the receive_timeout from 15s to 30s for Google Analytics import requests. Timeouts have been reported, and I could replay some requests that took 15-20 seconds to complete when fetching 10,000 records in a single request.

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
