### PR TITLE
[Sentry APP-189] Fallback to current date in all time parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,10 @@ All notable changes to this project will be documented in this file.
 - Timezone offset labels now update with time changes
 - Render 404 if shared link auth cannot be verified [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
 - Restore compatibility with older format of shared links [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
+- Fix 'All time' period for sites with no recorded stats [plausible/analytics#2277](https://github.com/plausible/analytics/pull/2277)
 - Ensure settings page can be rendered after a form error [plausible/analytics#2278](https://github.com/plausible/analytics/pull/2278)
+
+>>>>>>> 09af319b (Add changelog)
 
 ### Changed
 - Cache the tracking script for 24 hours

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -101,6 +101,39 @@ defmodule Plausible.Site do
     change(site, imported_data: nil)
   end
 
+  @doc """
+  Returns the date of the first recorded stat in the timezone configured by the user.
+  This function does 2 transformations:
+    UTC %NaiveDateTime{} -> Local %DateTime{} -> Local %Date
+
+  ## Examples
+
+    iex> Plausible.Site.local_start_date(%Plausible.Site{stats_start_date: nil})
+    nil
+
+    iex> utc_start = ~N[2022-09-28 00:00:00]
+    iex> tz = "Europe/Helsinki"
+    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
+    iex> Plausible.Site.local_start_date(site)
+    ~D[2022-09-28]
+
+    iex> utc_start = ~N[2022-09-28 00:00:00]
+    iex> tz = "America/Los_Angeles"
+    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
+    iex> Plausible.Site.local_start_date(site)
+    ~D[2022-09-27]
+  """
+  def local_start_date(%__MODULE__{stats_start_date: nil}) do
+    nil
+  end
+
+  def local_start_date(site) do
+    site.stats_start_date
+    |> Timex.Timezone.convert("UTC")
+    |> Timex.Timezone.convert(site.timezone)
+    |> Timex.to_date()
+  end
+
   defp clean_domain(changeset) do
     clean_domain =
       (get_field(changeset, :domain) || "")

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -188,13 +188,8 @@ defmodule Plausible.Stats.Query do
   end
 
   def from(site, %{"period" => "all"} = params) do
-    start_date =
-      site.stats_start_date
-      |> Timex.Timezone.convert("UTC")
-      |> Timex.Timezone.convert(site.timezone)
-      |> Timex.to_date()
-
     now = today(site.timezone)
+    start_date = Plausible.Site.local_start_date(site) || now
 
     cond do
       Timex.diff(now, start_date, :months) > 0 ->

--- a/test/plausible/site/schema_test.exs
+++ b/test/plausible/site/schema_test.exs
@@ -1,0 +1,5 @@
+defmodule Plausible.SiteTest do
+  use ExUnit.Case
+
+  doctest Plausible.Site
+end

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -90,6 +90,16 @@ defmodule Plausible.Stats.QueryTest do
     assert q.date_range.last == Timex.today("America/Cancun")
   end
 
+  test "all time shows today if site has no start date" do
+    site = Map.put(@site, :stats_start_date, nil)
+    q = Query.from(site, %{"period" => "all"})
+
+    assert q.date_range.first == Timex.today()
+    assert q.date_range.last == Timex.today()
+    assert q.period == "all"
+    assert q.interval == "hour"
+  end
+
   test "all time shows hourly if site is completely new" do
     site = Map.put(@site, :stats_start_date, Timex.now())
     q = Query.from(site, %{"period" => "all"})


### PR DESCRIPTION
### Changes

[Sentry link](https://sentry.plausible.io/organizations/sentry/issues/1289/?environment=prod&project=1&query=is%3Aunresolved&statsPeriod=14d)

The `All time` period is failing for sites where `stats_start_date=nil`. This PR adds a fallback for when this field is missing.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
