### PR TITLE
[Sentry APP-5B] Ensure form errors can be rendered on /settings

### DIFF
--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -584,6 +584,12 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       assert redirected_to(conn, 302) == "/settings"
     end
+
+    test "renders form with error if form validations fail", %{conn: conn, user: user} do
+      conn = put(conn, "/settings", %{"user" => %{"name" => ""}})
+
+      assert html_response(conn, 200) =~ "can&#39;t be blank"
+    end
   end
 
   describe "DELETE /me" do


### PR DESCRIPTION
### Changes

[Sentry link](https://sentry.plausible.io/organizations/sentry/issues/170/?environment=prod&project=1&query=is%3Aunresolved&statsPeriod=14d)

The user settings page could not be rendered after a form error. This PR fixes that.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
