### PR TITLE
Remove Mimic dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,6 @@ defmodule Plausible.MixProject do
       {:jason, "~> 1.3"},
       {:kaffy, "~> 0.9.0"},
       {:location, git: "https://github.com/plausible/location.git"},
-      {:mimic, "~> 1.7", only: :test},
       {:mox, "~> 1.0", only: :test},
       {:nanoid, "~> 2.0.2"},
       {:oauther, "~> 1.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -73,7 +73,6 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.6.0", "dabde576a497cef4bbdd60aceee8160e02a6c89250d6c0b29e56c0dfb00db3d2", [:mix], [], "hexpm", "31a1a8613f8321143dde1dafc36006a17d28d02bdfecb9e95a880fa7aabd19a7"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
-  "mimic": {:hex, :mimic, "1.7.2", "27007e4e0c746ddb6d56a386c40585088b35621ae2d7167160e8c3283e8cd585", [:mix], [], "hexpm", "e4d40550523841055aa469f5125d124ab89ce8b2d3686cab908b98dff5e6111b"},
   "mint": {:hex, :mint, "1.4.2", "50330223429a6e1260b2ca5415f69b0ab086141bc76dc2fbf34d7c389a6675b2", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:hpax, "~> 0.1.1", [hex: :hpax, repo: "hexpm", optional: false]}], "hexpm", "ce75a5bbcc59b4d7d8d70f8b2fc284b1751ffb35c7b6a6302b5192f8ab4ddd80"},
   "mmdb2_decoder": {:hex, :mmdb2_decoder, "3.0.1", "78e3aedde88035c6873ada5ceaf41b7f15a6259ed034e0eaca72ccfa937798f0", [:mix], [], "hexpm", "316af0f388fac824782d944f54efe78e7c9691bbbdb0afd5cccdd0510adf559d"},
   "mox": {:hex, :mox, "1.0.2", "dc2057289ac478b35760ba74165b4b3f402f68803dd5aecd3bfd19c183815d64", [:mix], [], "hexpm", "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2"},

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule PlausibleWeb.Api.ExternalControllerTest do
   use PlausibleWeb.ConnCase
-  use Mimic
   use Plausible.ClickhouseRepo
 
   defp get_event(domain) do
@@ -269,11 +268,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     test "feature flag - blocks traffic from a domain when block_traffic is enabled", %{
       conn: conn
     } do
-      FunWithFlags
-      |> stub(:enabled?, fn
-        :block_event_ingest, [for: "feature-flag-test.com"] -> true
-        _, _ -> false
-      end)
+      FunWithFlags.enable(:block_event_ingest, for_actor: "feature-flag-test.com")
 
       params = %{
         domain: "feature-flag-test.com",

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,5 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 Plausible.Test.ClickhouseSetup.run()
-Mimic.copy(FunWithFlags)
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 ExUnit.start()
 Application.ensure_all_started(:double)


### PR DESCRIPTION
### Changes

Removes the Mimic mocking library. It was used for a single test of feature flags. The mocking is replaced with letting the app interact with `FunWithFlags` for real.

The way the new test is written means that it cannot run concurrently with any other test for the `feature-flag-test.com` domain. 