### PR TITLE
Fix svg favicons

### DIFF
--- a/assets/.prettierrc.json
+++ b/assets/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "requirePragma": true,
-  "insertPragma": true
+  "trailingComma": "none",
+  "semi": false
 }

--- a/assets/js/dashboard/components/search-select.js
+++ b/assets/js/dashboard/components/search-select.js
@@ -3,7 +3,7 @@ import React, {useState, useCallback} from 'react'
 import {useCombobox} from 'downshift'
 import classNames from 'classnames'
 import debounce from 'debounce-promise'
-import { ChevronDownIcon } from '@heroicons/react/solid'
+import { ChevronDownIcon } from '@heroicons/react/20/solid'
 
 function selectInputText(e) {
   e.target.select()

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { withRouter } from "react-router-dom";
 import Flatpickr from "react-flatpickr";
-import { ChevronDownIcon } from '@heroicons/react/solid'
+import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import { Transition } from '@headlessui/react'
 import {
   shiftDays,

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 import { Link, withRouter } from 'react-router-dom'
-import { AdjustmentsIcon, SearchIcon, XIcon, PencilIcon } from '@heroicons/react/solid'
+import { AdjustmentsVerticalIcon, MagnifyingGlassIcon, XMarkIcon, PencilSquareIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 import { Menu, Transition } from '@headlessui/react'
 
@@ -95,10 +95,10 @@ function renderDropdownFilter(site, history, [key, value], query) {
           style={{width: 'calc(100% - 1.5rem)'}}
         >
           <span className="inline-block w-full truncate">{filterText(key, value, query)}</span>
-          <PencilIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
+          <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
         </Link>
         <b title={`Remove filter: ${formattedFilters[key]}`} className="ml-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500" onClick={() => removeFilter(key, history, query)}>
-          <XIcon className="w-4 h-4" />
+          <XMarkIcon className="w-4 h-4" />
         </b>
       </div>
     </Menu.Item>
@@ -241,7 +241,7 @@ class Filters extends React.Component {
           <span className="inline-block max-w-2xs md:max-w-xs truncate">{filterText(key, value, query)}</span>
         </Link>
         <span title={`Remove filter: ${formattedFilters[key]}`} className="flex h-full w-full px-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500 items-center" onClick={() => removeFilter(key, history, query)}>
-          <XIcon className="w-4 h-4" />
+          <XMarkIcon className="w-4 h-4" />
         </span>
       </span>
     )
@@ -252,7 +252,7 @@ class Filters extends React.Component {
       const filterCount = appliedFilters(this.props.query).length
       return (
         <>
-          <AdjustmentsIcon className="-ml-1 mr-1 h-4 w-4" aria-hidden="true" />
+          <AdjustmentsVerticalIcon className="-ml-1 mr-1 h-4 w-4" aria-hidden="true" />
           {filterCount} Filter{filterCount === 1 ? '' : 's'}
         </>
       )
@@ -260,7 +260,7 @@ class Filters extends React.Component {
 
     return (
       <>
-        <SearchIcon className="-ml-1 mr-1 h-4 w-4 md:h-4 md:w-4" aria-hidden="true" />
+        <MagnifyingGlassIcon className="-ml-1 mr-1 h-4 w-4 md:h-4 md:w-4" aria-hidden="true" />
         {/* This would have been a good use-case for JSX! But in the interest of keeping the breakpoint width logic with TailwindCSS, this is a better long-term way to deal with it. */}
         <span className="sm:hidden">Filter</span><span className="hidden sm:inline-block">Filter</span>
       </>

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -1,26 +1,31 @@
-import React from 'react';
+/**
+ * @prettier
+ */
+import React from 'react'
 import { Transition } from '@headlessui/react'
 
 function Favicon({ domain, className }) {
   return (
     <img
       src={`/favicon/sources/${encodeURIComponent(domain)}`}
-      onError={(e) => { e.target.onerror = null; e.target.src = "/favicon/sources/placeholder" }}
+      onError={(e) => {
+        e.target.onerror = null
+        e.target.src = '/favicon/sources/placeholder'
+      }}
       referrerPolicy="no-referrer"
       className={className}
     />
   )
-
 }
 
 export default class SiteSwitcher extends React.Component {
   constructor() {
     super()
-    this.handleClick = this.handleClick.bind(this);
-    this.handleKeydown = this.handleKeydown.bind(this);
-    this.populateSites = this.populateSites.bind(this);
-    this.toggle = this.toggle.bind(this);
-    this.siteSwitcherButton = React.createRef();
+    this.handleClick = this.handleClick.bind(this)
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.populateSites = this.populateSites.bind(this)
+    this.toggle = this.toggle.bind(this)
+    this.siteSwitcherButton = React.createRef()
     this.state = {
       open: false,
       sites: null,
@@ -30,60 +35,75 @@ export default class SiteSwitcher extends React.Component {
   }
 
   componentDidMount() {
-    this.populateSites();
-    this.siteSwitcherButton.current.addEventListener("click", this.toggle);
-    document.addEventListener("keydown", this.handleKeydown);
-    document.addEventListener('click', this.handleClick, false);
+    this.populateSites()
+    this.siteSwitcherButton.current.addEventListener('click', this.toggle)
+    document.addEventListener('keydown', this.handleKeydown)
+    document.addEventListener('click', this.handleClick, false)
   }
 
   componentWillUnmount() {
-    this.siteSwitcherButton.current.removeEventListener("click", this.toggle);
-    document.removeEventListener("keydown", this.handleKeydown);
-    document.removeEventListener('click', this.handleClick, false);
+    this.siteSwitcherButton.current.removeEventListener('click', this.toggle)
+    document.removeEventListener('keydown', this.handleKeydown)
+    document.removeEventListener('click', this.handleClick, false)
   }
 
   populateSites() {
-    if (!this.props.loggedIn) return;
+    if (!this.props.loggedIn) return
 
     fetch('/api/sites')
-      .then( response => {
-        if (!response.ok) { throw response }
+      .then((response) => {
+        if (!response.ok) {
+          throw response
+        }
         return response.json()
       })
-      .then((sites) => this.setState(
-        {
+      .then((sites) =>
+        this.setState({
           loading: false,
-          sites: sites.data.map(s => s.domain)
-        }))
-      .catch((e) => this.setState({loading: false, error: e}))
+          sites: sites.data.map((s) => s.domain)
+        })
+      )
+      .catch((e) => this.setState({ loading: false, error: e }))
   }
 
   handleClick(e) {
     // If this is an interaction with the dropdown menu itself, do nothing.
-    if (this.dropDownNode && this.dropDownNode.contains(e.target)) return;
+    if (this.dropDownNode && this.dropDownNode.contains(e.target)) return
 
     // If the dropdown is not open, do nothing.
-    if (!this.state.open) return;
+    if (!this.state.open) return
 
     // In any other case, close it.
-    this.setState({ open: false });
+    this.setState({ open: false })
   }
 
   handleKeydown(e) {
-    if (!this.props.loggedIn) return;
+    if (!this.props.loggedIn) return
 
-    const { site } = this.props;
-    const { sites } = this.state;
+    const { site } = this.props
+    const { sites } = this.state
 
-    if (e.target.tagName === 'INPUT') return true;
-    if (e.ctrlKey || e.metaKey || e.altKey || e.isComposing || e.keyCode === 229 || !sites) return;
+    if (e.target.tagName === 'INPUT') return true
+    if (
+      e.ctrlKey ||
+      e.metaKey ||
+      e.altKey ||
+      e.isComposing ||
+      e.keyCode === 229 ||
+      !sites
+    )
+      return
 
     const siteNum = parseInt(e.key)
 
-    if (1 <= siteNum && siteNum <= 9 && siteNum <= sites.length && sites[siteNum-1] !== site.domain) {
-      window.location = `/${encodeURIComponent(sites[siteNum-1])}`
+    if (
+      1 <= siteNum &&
+      siteNum <= 9 &&
+      siteNum <= sites.length &&
+      sites[siteNum - 1] !== site.domain
+    ) {
+      window.location = `/${encodeURIComponent(sites[siteNum - 1])}`
     }
-
   }
 
   toggle(e) {
@@ -92,40 +112,73 @@ export default class SiteSwitcher extends React.Component {
      *
      * A simple trick is to hook up our own click event listener via a ref node, which allows React to manage events in this situation better between the two.
      */
-    e.stopPropagation();
-    e.preventDefault();
-    if (!this.props.loggedIn) return;
+    e.stopPropagation()
+    e.preventDefault()
+    if (!this.props.loggedIn) return
 
     this.setState((prevState) => ({
       open: !prevState.open
     }))
 
     if (this.props.loggedIn && !this.state.sites) {
-      this.populateSites();
+      this.populateSites()
     }
   }
 
   renderSiteLink(domain, index) {
-    const extraClass = domain === this.props.site.domain ? 'font-medium text-gray-900 dark:text-gray-100 cursor-default font-bold' : 'hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100'
+    const extraClass =
+      domain === this.props.site.domain
+        ? 'font-medium text-gray-900 dark:text-gray-100 cursor-default font-bold'
+        : 'hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100'
     const showHotkey = !this.props.loggedIn
     return (
-      <a href={domain === this.props.site.domain ? null : `/${encodeURIComponent(domain)}`} key={domain} className={`flex items-center justify-between truncate px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 ${extraClass}`}>
+      <a
+        href={
+          domain === this.props.site.domain
+            ? null
+            : `/${encodeURIComponent(domain)}`
+        }
+        key={domain}
+        className={`flex items-center justify-between truncate px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 ${extraClass}`}
+      >
         <span>
-          <Favicon domain={domain} className="inline w-4 mr-2 align-middle"></Favicon>
-          <span className="truncate inline-block align-middle max-w-3xs pr-2">{domain}</span>
+          <Favicon
+            domain={domain}
+            className="inline w-4 mr-2 align-middle"
+          ></Favicon>
+          <span className="truncate inline-block align-middle max-w-3xs pr-2">
+            {domain}
+          </span>
         </span>
-        {showHotkey ? index < 9 && <span>{index+1}</span> : null}
+        {showHotkey ? index < 9 && <span>{index + 1}</span> : null}
       </a>
     )
   }
 
   renderSettingsLink() {
-    if (['owner', 'admin', 'super_admin'].includes(this.props.currentUserRole)) {
+    if (
+      ['owner', 'admin', 'super_admin'].includes(this.props.currentUserRole)
+    ) {
       return (
         <React.Fragment>
           <div className="py-1">
-            <a href={`/${encodeURIComponent(this.props.site.domain)}/settings`} className="group flex items-center px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100" role="menuitem">
-              <svg className="mr-2 h-4 w-4 text-gray-500 dark:text-gray-200 group-hover:text-gray-600 dark:group-hover:text-gray-400 group-focus:text-gray-500 dark:group-focus:text-gray-200" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd"></path></svg>
+            <a
+              href={`/${encodeURIComponent(this.props.site.domain)}/settings`}
+              className="group flex items-center px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100"
+              role="menuitem"
+            >
+              <svg
+                className="mr-2 h-4 w-4 text-gray-500 dark:text-gray-200 group-hover:text-gray-600 dark:group-hover:text-gray-400 group-focus:text-gray-500 dark:group-focus:text-gray-200"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
+                  clipRule="evenodd"
+                ></path>
+              </svg>
               Site settings
             </a>
           </div>
@@ -140,26 +193,40 @@ export default class SiteSwitcher extends React.Component {
    */
   renderDropdown() {
     if (this.state.loading) {
-      return <div className="px-4 py-6"><div className="loading sm mx-auto"><div></div></div></div>
+      return (
+        <div className="px-4 py-6">
+          <div className="loading sm mx-auto">
+            <div></div>
+          </div>
+        </div>
+      )
     } else if (this.state.error) {
-      return <div className="mx-auto px-4 py-6 dark:text-gray-100">Something went wrong, try again</div>
+      return (
+        <div className="mx-auto px-4 py-6 dark:text-gray-100">
+          Something went wrong, try again
+        </div>
+      )
     } else if (!this.props.loggedIn) {
       return (
         <React.Fragment>
           <div className="py-1">
-            { [this.props.site.domain].map(this.renderSiteLink.bind(this)) }
+            {[this.props.site.domain].map(this.renderSiteLink.bind(this))}
           </div>
         </React.Fragment>
       )
     } else {
       return (
         <React.Fragment>
-          { this.renderSettingsLink() }
+          {this.renderSettingsLink()}
           <div className="py-1">
-            { this.state.sites.map(this.renderSiteLink.bind(this)) }
+            {this.state.sites.map(this.renderSiteLink.bind(this))}
           </div>
           <div className="border-t border-gray-200 dark:border-gray-500"></div>
-          <a href='/sites' className="flex px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100" role="menuitem">
+          <a
+            href="/sites"
+            className="flex px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100"
+            role="menuitem"
+          >
             View all
           </a>
         </React.Fragment>
@@ -170,21 +237,39 @@ export default class SiteSwitcher extends React.Component {
   renderArrow() {
     if (this.props.loggedIn) {
       return (
-        <svg className="-mr-1 ml-1 md:ml-2 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+        <svg
+          className="-mr-1 ml-1 md:ml-2 h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
         </svg>
       )
     }
   }
 
   render() {
-    const hoverClass = this.props.loggedIn ? 'hover:text-gray-500 dark:hover:text-gray-200 focus:border-blue-300 focus:ring ' : 'cursor-default'
+    const hoverClass = this.props.loggedIn
+      ? 'hover:text-gray-500 dark:hover:text-gray-200 focus:border-blue-300 focus:ring '
+      : 'cursor-default'
 
     return (
       <div className="relative inline-block text-left mr-2 sm:mr-4">
-        <button ref={this.siteSwitcherButton} className={`inline-flex items-center md:text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 dark:text-gray-300 focus:outline-none transition ease-in-out duration-150 ${hoverClass}`}>
-          <Favicon domain={this.props.site.domain} className="w-4 mr-1 md:mr-2 align-middle w-4 mr-2 align-middle"></Favicon>
-          <span className="hidden sm:inline-block">{this.props.site.domain}</span>
+        <button
+          ref={this.siteSwitcherButton}
+          className={`inline-flex items-center md:text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 dark:text-gray-300 focus:outline-none transition ease-in-out duration-150 ${hoverClass}`}
+        >
+          <Favicon
+            domain={this.props.site.domain}
+            className="w-4 mr-1 md:mr-2 align-middle w-4 mr-2 align-middle"
+          ></Favicon>
+          <span className="hidden sm:inline-block">
+            {this.props.site.domain}
+          </span>
           {this.renderArrow()}
         </button>
 
@@ -197,11 +282,14 @@ export default class SiteSwitcher extends React.Component {
           leaveFrom="opacity-100 scale-100"
           leaveTo="opacity-0 scale-95"
         >
-        <div className="origin-top-left absolute left-0 mt-2 w-64 rounded-md shadow-lg" ref={node => this.dropDownNode = node} >
-          <div className="rounded-md bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5">
-            { this.renderDropdown() }
+          <div
+            className="origin-top-left absolute left-0 mt-2 w-64 rounded-md shadow-lg"
+            ref={(node) => (this.dropDownNode = node)}
+          >
+            <div className="rounded-md bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5">
+              {this.renderDropdown()}
+            </div>
           </div>
-        </div>
         </Transition>
       </div>
     )

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -1,6 +1,18 @@
 import React from 'react';
 import { Transition } from '@headlessui/react'
 
+function Favicon({ domain, className }) {
+  return (
+    <img
+      src={`/favicon/sources/${encodeURIComponent(domain)}`}
+      onError={(e) => { e.target.onerror = null; e.target.src = "/favicon/sources/placeholder" }}
+      referrerPolicy="no-referrer"
+      className={className}
+    />
+  )
+
+}
+
 export default class SiteSwitcher extends React.Component {
   constructor() {
     super()
@@ -99,7 +111,7 @@ export default class SiteSwitcher extends React.Component {
     return (
       <a href={domain === this.props.site.domain ? null : `/${encodeURIComponent(domain)}`} key={domain} className={`flex items-center justify-between truncate px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 ${extraClass}`}>
         <span>
-          <img src={`/favicon/sources/${encodeURIComponent(domain)}`} className="inline w-4 mr-2 align-middle" />
+          <Favicon domain={domain} className="inline w-4 mr-2 align-middle"></Favicon>
           <span className="truncate inline-block align-middle max-w-3xs pr-2">{domain}</span>
         </span>
         {showHotkey ? index < 9 && <span>{index+1}</span> : null}
@@ -171,8 +183,7 @@ export default class SiteSwitcher extends React.Component {
     return (
       <div className="relative inline-block text-left mr-2 sm:mr-4">
         <button ref={this.siteSwitcherButton} className={`inline-flex items-center md:text-lg w-full rounded-md py-2 leading-5 font-bold text-gray-700 dark:text-gray-300 focus:outline-none transition ease-in-out duration-150 ${hoverClass}`}>
-
-          <img src={`https://icons.duckduckgo.com/ip3/${this.props.site.domain}.ico`} onError={(e)=>{e.target.onerror = null; e.target.src="https://icons.duckduckgo.com/ip3/placeholder.ico"}} referrerPolicy="no-referrer" className="inline w-4 mr-1 md:mr-2 align-middle" />
+          <Favicon domain={this.props.site.domain} className="w-4 mr-1 md:mr-2 align-middle w-4 mr-2 align-middle"></Favicon>
           <span className="hidden sm:inline-block">{this.props.site.domain}</span>
           {this.renderArrow()}
         </button>

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -3,6 +3,7 @@
  */
 import React from 'react'
 import { Transition } from '@headlessui/react'
+import { Cog8ToothIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
 
 function Favicon({ domain, className }) {
   return (
@@ -167,18 +168,7 @@ export default class SiteSwitcher extends React.Component {
               className="group flex items-center px-4 py-2 md:text-sm leading-5 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-900 focus:text-gray-900 dark:focus:text-gray-100"
               role="menuitem"
             >
-              <svg
-                className="mr-2 h-4 w-4 text-gray-500 dark:text-gray-200 group-hover:text-gray-600 dark:group-hover:text-gray-400 group-focus:text-gray-500 dark:group-focus:text-gray-200"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
-                  clipRule="evenodd"
-                ></path>
-              </svg>
+              <Cog8ToothIcon className="mr-2 h-4 w-4 text-gray-500 dark:text-gray-200 group-hover:text-gray-600 dark:group-hover:text-gray-400 group-focus:text-gray-500 dark:group-focus:text-gray-200" />
               Site settings
             </a>
           </div>
@@ -234,24 +224,6 @@ export default class SiteSwitcher extends React.Component {
     }
   }
 
-  renderArrow() {
-    if (this.props.loggedIn) {
-      return (
-        <svg
-          className="-mr-1 ml-1 md:ml-2 h-5 w-5"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-            clipRule="evenodd"
-          />
-        </svg>
-      )
-    }
-  }
-
   render() {
     const hoverClass = this.props.loggedIn
       ? 'hover:text-gray-500 dark:hover:text-gray-200 focus:border-blue-300 focus:ring '
@@ -270,7 +242,9 @@ export default class SiteSwitcher extends React.Component {
           <span className="hidden sm:inline-block">
             {this.props.site.domain}
           </span>
-          {this.renderArrow()}
+          {this.props.loggedIn && (
+            <ChevronDownIcon className="-mr-1 ml-1 md:ml-2 h-5 w-5" />
+          )}
         </button>
 
         <Transition

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import { withRouter } from 'react-router-dom'
 import classNames from 'classnames'
 import { Menu, Transition } from '@headlessui/react'
-import { ChevronDownIcon } from '@heroicons/react/solid'
+import { ChevronDownIcon } from '@heroicons/react/20/solid'
 
 import SearchSelect from '../../components/search-select'
 import Modal from './modal'

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -270,7 +270,7 @@ class UTMSources extends React.Component {
 
 import { Fragment } from 'react'
 import { Menu, Transition } from '@headlessui/react'
-import { ChevronDownIcon } from '@heroicons/react/solid'
+import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 
 export default class SourceList extends React.Component {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.14.4",
         "@babel/preset-react": "^7.13.13",
         "@headlessui/react": "^1.3.0",
-        "@heroicons/react": "^1.0.1",
+        "@heroicons/react": "^2.0.11",
         "@juggle/resize-observer": "^3.3.1",
         "@kunukn/react-collapse": "^2.2.9",
         "@popperjs/core": "^2.11.6",
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@heroicons/react": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.1.tgz",
-      "integrity": "sha512-uikw2gKCmqnvjVxitecWfFLMOKyL9BTFcU4VM3hHj9OMwpkCr5Ke+MRMyY2/aQVmsYs4VTq7NCFX05MYwAHi3g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.11.tgz",
+      "integrity": "sha512-bASjOgSSaYj8HqXWsOqaBiB6ZLalE/g90WYGgZ5lPm4KCCG7wPXntY4kzHf5NrLh6UBAcnPwvbiw1Ne9GYfJtw==",
       "peerDependencies": {
         "react": ">= 16"
       }
@@ -10033,9 +10033,9 @@
       "requires": {}
     },
     "@heroicons/react": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.1.tgz",
-      "integrity": "sha512-uikw2gKCmqnvjVxitecWfFLMOKyL9BTFcU4VM3hHj9OMwpkCr5Ke+MRMyY2/aQVmsYs4VTq7NCFX05MYwAHi3g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.11.tgz",
+      "integrity": "sha512-bASjOgSSaYj8HqXWsOqaBiB6ZLalE/g90WYGgZ5lPm4KCCG7wPXntY4kzHf5NrLh6UBAcnPwvbiw1Ne9GYfJtw==",
       "requires": {}
     },
     "@jridgewell/gen-mapping": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "^7.14.4",
     "@babel/preset-react": "^7.13.13",
     "@headlessui/react": "^1.3.0",
-    "@heroicons/react": "^1.0.1",
+    "@heroicons/react": "^2.0.11",
     "@juggle/resize-observer": "^3.3.1",
     "@kunukn/react-collapse": "^2.2.9",
     "@popperjs/core": "^2.11.6",

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -60,6 +60,9 @@ defmodule PlausibleWeb.Favicon do
   """
   def call(conn, favicon_domains: favicon_domains) do
     case conn.path_info do
+      ["favicon", "sources", "placeholder"] ->
+        send_placeholder(conn)
+
       ["favicon", "sources", source] ->
         clean_source = URI.decode_www_form(source)
         domain = Map.get(favicon_domains, clean_source, clean_source)

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -53,6 +53,10 @@ defmodule PlausibleWeb.Favicon do
   I'm not sure why DDG sometimes returns a broken PNG image in their response but we filter that out.
   When the icon request fails, we show a placeholder favicon instead. The placeholder is an emoji
   from https://favicon.io/emoji-favicons/
+
+  DuckDuckGo favicon service has some issues with [svg favicons](https://css-tricks.com/svg-favicons-and-all-the-fun-things-we-can-do-with-them/).
+  For some reason, they return then with `content-type=image/x-icon` whereas SVG icons should be returned with `conten-type=image/svg+xml`.
+  This plug detects when the response body starts with <svg and will override the content-type to correct it.
   """
   def call(conn, favicon_domains: favicon_domains) do
     case conn.path_info do
@@ -61,9 +65,11 @@ defmodule PlausibleWeb.Favicon do
         domain = Map.get(favicon_domains, clean_source, clean_source)
 
         case HTTPClient.impl().get("https://icons.duckduckgo.com/ip3/#{domain}.ico") do
-          {:ok, %Finch.Response{body: body, headers: headers}} when body != @ddg_broken_icon ->
+          {:ok, %Finch.Response{status: 200, body: body, headers: headers}}
+          when body != @ddg_broken_icon ->
             conn
             |> forward_headers(headers)
+            |> maybe_override_content_type(body)
             |> send_resp(200, body)
             |> halt
 
@@ -89,4 +95,10 @@ defmodule PlausibleWeb.Favicon do
     headers_to_forward = Enum.filter(headers, fn {k, _} -> k in @forwarded_headers end)
     %Plug.Conn{conn | resp_headers: headers_to_forward}
   end
+
+  defp maybe_override_content_type(conn, "<svg" <> _rest) do
+    conn |> put_resp_content_type("image/svg+xml")
+  end
+
+  defp maybe_override_content_type(conn, _), do: conn
 end

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Favicon do
   from https://favicon.io/emoji-favicons/
 
   DuckDuckGo favicon service has some issues with [svg favicons](https://css-tricks.com/svg-favicons-and-all-the-fun-things-we-can-do-with-them/).
-  For some reason, they return then with `content-type=image/x-icon` whereas SVG icons should be returned with `conten-type=image/svg+xml`.
+  For some reason, they return them with `content-type=image/x-icon` whereas SVG icons should be returned with `content-type=image/svg+xml`.
   This plug detects when the response body starts with <svg and will override the content-type to correct it.
   """
   def call(conn, favicon_domains: favicon_domains) do

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -39,7 +39,7 @@
       <div class="group cursor-pointer" @click="invitationOpen = true; selectedInvitation = invitations['<%= invitation.invitation_id %>']">
         <li class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
           <div class="w-full flex items-center justify-between space-x-4">
-            <img src="/favicon/sources/<%= invitation.site.domain %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder.ico';" class="w-4 h-4 flex-shrink-0 mt-px">
+            <img src="/favicon/sources/<%= invitation.site.domain %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder';" class="w-4 h-4 flex-shrink-0 mt-px">
             <div class="flex-1 truncate -mt-px">
               <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100"><%= invitation.site.domain %></h3>
             </div>


### PR DESCRIPTION
### Changes

Fixes #2286

DDG favicon service does not handle SVG images well. Here's an SVG icon hosted at https://ptable.com/icon/pt-square-192.png which returns `content-type=image/svg+xml`. Requesting this through DDG:

```bash
➜  assets git:(fix-svg-favicons) curl -I https://icons.duckduckgo.com/ip3/ptable.com.ico
HTTP/2 200
server: nginx
date: Mon, 03 Oct 2022 08:33:30 GMT
content-type: image/x-icon
```

It has set `content-type=x-icon`. This incorrect content-type causes browsers to render a broken icon.

I also took the opportunity for some refactoring+cleanup in `assets/js/dashboard/site-switcher.js`. The diff is big because I ran the `prettier` formatter on the file, but this was done in a separate commit so you can still see the meaningful changes in [a commit diff.](https://github.com/plausible/analytics/pull/2295/commits/86ac9226bdaa966de3f17b161d3a88ee05d317af)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
