### PR TITLE
Do not log sensitive info

### DIFF
--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -145,9 +145,14 @@ defmodule PlausibleWeb.AuthController do
 
   defp send_email_verification(user) do
     code = Auth.issue_email_verification(user)
-    Logger.info("VERIFICATION CODE: #{code}")
     email_template = PlausibleWeb.Email.activation_email(user, code)
-    Plausible.Mailer.send_email(email_template)
+    result = Plausible.Mailer.send_email(email_template)
+
+    Logger.debug(
+      "E-mail verification e-mail sent. In dev environment GET /sent-emails for details."
+    )
+
+    result
   end
 
   defp set_user_session(conn, user) do
@@ -250,9 +255,12 @@ defmodule PlausibleWeb.AuthController do
       if user do
         token = Auth.Token.sign_password_reset(email)
         url = PlausibleWeb.Endpoint.url() <> "/password/reset?token=#{token}"
-        Logger.debug("PASSWORD RESET LINK: " <> url)
         email_template = PlausibleWeb.Email.password_reset_email(email, url)
         Plausible.Mailer.deliver_later(email_template)
+
+        Logger.debug(
+          "Password reset e-mail sent. In dev environment GET /sent-emails for details."
+        )
 
         render(conn, "password_reset_request_success.html",
           email: email,


### PR DESCRIPTION
### Changes

This PR removes potentially sensitive security information from our log output. This information might've been useful in dev environment, however all the e-mails sent can be inspected with [`/sent-emails` endpoint](https://github.com/plausible/analytics/blob/06f09fbb14b4ff21b0155d7993e922d364d51459/lib/plausible_web/router.ex#L52).

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
