### PR TITLE
Block Stats API for locked sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - Add support for international domain names (IDNs) plausible/analytics#2034
 
 ### Fixed
+- Stats API is now protected from access in case of missing active subscription
 - Plausible script does not prevent default if it's been prevented by an external script [plausible/analytics#1941](https://github.com/plausible/analytics/issues/1941)
 - Hash part of the URL can now be used when excluding pages with `script.exclusions.hash.js`.
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ All notable changes to this project will be documented in this file.
 - Add support for international domain names (IDNs) plausible/analytics#2034
 
 ### Fixed
-- Stats API is now protected from access in case of missing active subscription
 - Plausible script does not prevent default if it's been prevented by an external script [plausible/analytics#1941](https://github.com/plausible/analytics/issues/1941)
 - Hash part of the URL can now be used when excluding pages with `script.exclusions.hash.js`.
 - UI fix where multi-line text in pills would not be underlined properly on small screens.

--- a/lib/plausible_web/controllers/api/helpers.ex
+++ b/lib/plausible_web/controllers/api/helpers.ex
@@ -28,4 +28,11 @@ defmodule PlausibleWeb.Api.Helpers do
     |> Phoenix.Controller.json(%{error: msg})
     |> halt()
   end
+
+  def payment_required(conn, msg) do
+    conn
+    |> put_status(402)
+    |> Phoenix.Controller.json(%{error: msg})
+    |> halt()
+  end
 end

--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -2,6 +2,7 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
   import Plug.Conn
   use Plausible.Repo
   alias Plausible.Auth.ApiKey
+  alias Plausible.Sites
   alias PlausibleWeb.Api.Helpers, as: H
 
   def init(options) do
@@ -38,20 +39,32 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
           conn,
           "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
         )
+
+      {:error, :site_locked} ->
+        H.payment_required(
+          conn,
+          "This Plausible site is locked due to missing active subscription. In order to access it, the site owner should subscribe to a suitable plan"
+        )
     end
   end
 
   defp verify_access(_api_key, nil), do: {:error, :missing_site_id}
 
   defp verify_access(api_key, site_id) do
-    site = Repo.get_by(Plausible.Site, domain: site_id)
-    is_member = site && Plausible.Sites.is_member?(api_key.user_id, site)
-    is_super_admin = Plausible.Auth.is_super_admin?(api_key.user_id)
+    case Repo.get_by(Plausible.Site, domain: site_id) do
+      %Plausible.Site{} = site ->
+        is_member? = Sites.is_member?(api_key.user_id, site)
+        is_super_admin? = Plausible.Auth.is_super_admin?(api_key.user_id)
 
-    cond do
-      site && is_member -> {:ok, site}
-      site && is_super_admin -> {:ok, site}
-      true -> {:error, :invalid_api_key}
+        cond do
+          Sites.locked?(site) -> {:error, :site_locked}
+          is_member? -> {:ok, site}
+          is_super_admin? -> {:ok, site}
+          true -> {:error, :invalid_api_key}
+        end
+
+      nil ->
+        {:error, :invalid_api_key}
     end
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -5,91 +5,78 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   setup [:create_user, :create_api_key]
 
   test "unauthenticated request - returns 401", %{conn: conn} do
-    conn =
-      get(conn, "/api/v1/stats/aggregate", %{
-        "site_id" => "some-site.com",
-        "metrics" => "pageviews"
-      })
-
-    assert json_response(conn, 401) == %{
-             "error" => "Missing API key. Please use a valid Plausible API key as a Bearer Token."
-           }
+    conn
+    |> get("/api/v1/stats/aggregate", %{
+      "site_id" => "some-site.com",
+      "metrics" => "pageviews"
+    })
+    |> assert_error(
+      401,
+      "Missing API key. Please use a valid Plausible API key as a Bearer Token."
+    )
   end
 
   test "bad API key - returns 401", %{conn: conn} do
-    conn =
-      conn
-      |> with_api_key("Bad key")
-      |> get("/api/v1/stats/aggregate", %{"site_id" => "some-site.com", "metrics" => "pageviews"})
-
-    assert json_response(conn, 401) == %{
-             "error" =>
-               "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
-           }
+    conn
+    |> with_api_key("Bad key")
+    |> get("/api/v1/stats/aggregate", %{"site_id" => "some-site.com", "metrics" => "pageviews"})
+    |> assert_error(
+      401,
+      "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+    )
   end
 
   test "good API key but bad site id - returns 401", %{conn: conn, api_key: api_key} do
-    conn =
-      conn
-      |> with_api_key(api_key)
-      |> get("/api/v1/stats/aggregate", %{"site_id" => "some-site.com", "metrics" => "pageviews"})
-
-    assert json_response(conn, 401) == %{
-             "error" =>
-               "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
-           }
+    conn
+    |> with_api_key(api_key)
+    |> get("/api/v1/stats/aggregate", %{"site_id" => "some-site.com", "metrics" => "pageviews"})
+    |> assert_error(
+      401,
+      "Invalid API key or site ID. Please make sure you're using a valid API key with access to the site you've requested."
+    )
   end
 
   test "good API key but missing site id - returns 400", %{conn: conn, api_key: api_key} do
-    conn =
-      conn
-      |> with_api_key(api_key)
-      |> get("/api/v1/stats/aggregate", %{"metrics" => "pageviews"})
-
-    assert json_response(conn, 400) == %{
-             "error" =>
-               "Missing site ID. Please provide the required site_id parameter with your request."
-           }
+    conn
+    |> with_api_key(api_key)
+    |> get("/api/v1/stats/aggregate", %{"metrics" => "pageviews"})
+    |> assert_error(
+      400,
+      "Missing site ID. Please provide the required site_id parameter with your request."
+    )
   end
 
   test "locked site - returns 402", %{conn: conn, api_key: api_key, user: user} do
     site = insert(:site, members: [user])
     {1, _} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
 
-    conn =
-      conn
-      |> with_api_key(api_key)
-      |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
-
-    assert %{"error" => error} = json_response(conn, 402)
-    assert error =~ "missing active subscription"
+    conn
+    |> with_api_key(api_key)
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
+    |> assert_error(402, "missing active subscription")
   end
 
   test "can access with correct API key and site ID", %{conn: conn, user: user, api_key: api_key} do
     site = insert(:site, members: [user])
 
-    conn =
-      conn
-      |> with_api_key(api_key)
-      |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
-
-    assert json_response(conn, 200) == %{
-             "results" => %{"pageviews" => %{"value" => 0}}
-           }
+    conn
+    |> with_api_key(api_key)
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
+    |> assert_ok(%{
+      "results" => %{"pageviews" => %{"value" => 0}}
+    })
   end
 
   test "can access as an admin", %{conn: conn, user: user, api_key: api_key} do
     Application.put_env(:plausible, :super_admin_user_ids, [user.id])
     site = insert(:site)
 
-    conn =
-      conn
-      |> with_api_key(api_key)
-      |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
-
-    assert json_response(conn, 200) == %{
-             "results" => %{"pageviews" => %{"value" => 0}}
-           }
+    conn
+    |> with_api_key(api_key)
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
+    |> assert_ok(%{
+      "results" => %{"pageviews" => %{"value" => 0}}
+    })
   end
 
   test "limits the rate of API requests", %{user: user} do
@@ -107,17 +94,24 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
     |> with_api_key(api_key.key)
     |> get("/api/v1/stats/aggregate")
 
-    conn =
-      build_conn()
-      |> with_api_key(api_key.key)
-      |> get("/api/v1/stats/aggregate")
-
-    assert json_response(conn, 429) == %{
-             "error" => "Too many API requests. Your API key is limited to 3 requests per hour."
-           }
+    build_conn()
+    |> with_api_key(api_key.key)
+    |> get("/api/v1/stats/aggregate")
+    |> assert_error(
+      429,
+      "Too many API requests. Your API key is limited to 3 requests per hour."
+    )
   end
 
   defp with_api_key(conn, api_key) do
     Plug.Conn.put_req_header(conn, "authorization", "Bearer #{api_key}")
+  end
+
+  defp assert_error(conn, status, message) do
+    assert json_response(conn, status)["error"] =~ message
+  end
+
+  defp assert_ok(conn, payload) do
+    assert json_response(conn, 200) == payload
   end
 end


### PR DESCRIPTION
### Changes

This PR adds site locked status check to External API authorization.
In case a site is locked, an subscription renewal message is returned along with 402 HTTP status.

I took the liberty of tidying the tests by the way.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
