### PR TITLE
Remove redundant logger

### DIFF
--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -32,7 +32,6 @@ defmodule PlausibleWeb.Endpoint do
   plug Plug.RequestId
   plug PromEx.Plug, prom_ex_module: Plausible.PromEx
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
-  plug Plug.Logger
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],


### PR DESCRIPTION
### Changes

It looks like we're having some log duplication due to `Plug.Logger` being explicit set for `PlausibleWeb.Endpoint`.

before:

![image](https://user-images.githubusercontent.com/173738/193811379-b37c231b-14c8-454e-acda-4aa8246a05e6.png)


after:

![image](https://user-images.githubusercontent.com/173738/193811265-7e00a008-aef8-4c64-b2ae-8774af51b2b7.png)
 

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
