### PR TITLE
CRM: order sites by latest. Tolerate missing owner

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -2,6 +2,10 @@ defmodule Plausible.SiteAdmin do
   use Plausible.Repo
   import Ecto.Query
 
+  def ordering(_schema) do
+    [desc: :inserted_at]
+  end
+
   def search_fields(_schema) do
     [
       :domain,
@@ -49,7 +53,11 @@ defmodule Plausible.SiteAdmin do
   end
 
   defp get_owner_email(site) do
-    Enum.find(site.memberships, fn m -> m.role == :owner end).user.email
+    owner = Enum.find(site.memberships, fn m -> m.role == :owner end)
+
+    if owner do
+      owner.user.email
+    end
   end
 
   defp get_other_members(site) do


### PR DESCRIPTION
### Changes

This change makes the Sites CRM section order by `inserted_at`. We'll also gracefully ignore no `owner` role for a site - a data error to be fixed through data migration probably.

![image](https://user-images.githubusercontent.com/173738/193842624-5f81d84d-e457-4927-b661-076c5338a13c.png)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
