### PR TITLE
Allow super-admin Stats API access for locked sites

### DIFF
--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -57,9 +57,9 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
         is_super_admin? = Plausible.Auth.is_super_admin?(api_key.user_id)
 
         cond do
+          is_super_admin? -> {:ok, site}
           Sites.locked?(site) -> {:error, :site_locked}
           is_member? -> {:ok, site}
-          is_super_admin? -> {:ok, site}
           true -> {:error, :invalid_api_key}
         end
 


### PR DESCRIPTION
### Changes

Super admins should be still capable of using the Stats API for locked sites.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
