### PR TITLE
Override stats_start_date in CRM

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -21,7 +21,8 @@ defmodule Plausible.SiteAdmin do
     [
       domain: %{update: :readonly},
       timezone: nil,
-      public: nil
+      public: nil,
+      stats_start_date: nil
     ]
   end
 
@@ -130,4 +131,7 @@ defmodule Plausible.SiteAdmin do
     end)
     |> stringify_fields()
   end
+
+  def create_changeset(schema, attrs), do: Plausible.Site.crm_changeset(schema, attrs)
+  def update_changeset(schema, attrs), do: Plausible.Site.crm_changeset(schema, attrs)
 end

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -19,7 +19,7 @@ defmodule Plausible.SiteAdmin do
 
   def form_fields(_) do
     [
-      domain: nil,
+      domain: %{update: :readonly},
       timezone: nil,
       public: nil
     ]

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -20,7 +20,7 @@ defmodule Plausible.SiteAdmin do
   def form_fields(_) do
     [
       domain: %{update: :readonly},
-      timezone: nil,
+      timezone: %{choices: Plausible.Timezones.options()},
       public: nil,
       stats_start_date: nil
     ]

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -57,7 +57,7 @@ defmodule Plausible.Site do
   def crm_changeset(site, attrs) do
     site
     |> cast(attrs, [:timezone, :public, :stats_start_date])
-    |> validate_required([:timezone])
+    |> validate_required([:timezone, :public])
   end
 
   def make_public(site) do

--- a/lib/plausible/site/schema.ex
+++ b/lib/plausible/site/schema.ex
@@ -54,6 +54,12 @@ defmodule Plausible.Site do
     )
   end
 
+  def crm_changeset(site, attrs) do
+    site
+    |> cast(attrs, [:timezone, :public, :stats_start_date])
+    |> validate_required([:timezone])
+  end
+
   def make_public(site) do
     change(site, public: true)
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -49,11 +49,11 @@ defmodule Plausible.Sites do
   """
   def stats_start_date(site)
 
-  def stats_start_date(%Plausible.Site{stats_start_date: %Date{} = date}) do
+  def stats_start_date(%Site{stats_start_date: %Date{} = date}) do
     date
   end
 
-  def stats_start_date(%Plausible.Site{} = site) do
+  def stats_start_date(%Site{} = site) do
     if start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site) do
       updated_site =
         site

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -39,18 +39,28 @@ defmodule Plausible.Sites do
     end
   end
 
-  def stats_start_date(site) do
-    if site.stats_start_date do
-      site.stats_start_date
-    else
-      start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site)
+  @spec stats_start_date(Plausible.Site.t()) :: Date.t() | nil
+  @doc """
+  Returns the date of the first event of the given site, or `nil` if the site
+  does not have stats yet.
 
-      if start_date do
-        Site.set_stats_start_date(site, start_date)
-        |> Repo.update()
+  If this is the first time the function is called for the site, it queries
+  Clickhouse and saves the date in the sites table.
+  """
+  def stats_start_date(site)
 
-        start_date
-      end
+  def stats_start_date(%Plausible.Site{stats_start_date: %Date{} = date}) do
+    date
+  end
+
+  def stats_start_date(%Plausible.Site{} = site) do
+    if start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site) do
+      updated_site =
+        site
+        |> Site.set_stats_start_date(start_date)
+        |> Repo.update!()
+
+      updated_site.stats_start_date
     end
   end
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Stats.Clickhouse do
   use Plausible.Stats.Fragments
   @no_ref "Direct / None"
 
+  @spec pageview_start_date_local(Plausible.Site.t()) :: Date.t() | nil
   def pageview_start_date_local(site) do
     datetime =
       ClickhouseRepo.one(

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -736,9 +736,7 @@ defmodule PlausibleWeb.SiteController do
     site = conn.assigns[:site]
 
     start_date = Plausible.Google.HTTP.get_analytics_start_date(view_id, access_token)
-
-    end_date =
-      Plausible.Stats.Clickhouse.pageview_start_date_local(site) || Timex.today(site.timezone)
+    end_date = Plausible.Sites.stats_start_date(site) || Timex.today(site.timezone)
 
     {:ok, {view_name, view_id}} = Plausible.Google.Api.get_view(access_token, view_id)
 


### PR DESCRIPTION
### Changes

This pull request adds the `stats_start_date` field to the CRM site form. This allows this field to be manually overridden, so Google Analytics imports date ranges can be overridden also.

Reviewing commit-by-commit can help understand some decisions and minor refactoring we made. 

### Tests
We don't have a test suite for the CRM.

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
