### PR TITLE
Upgrade clickhousex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,8 @@ defmodule Plausible.MixProject do
       {:telemetry, "~> 1.0", override: true},
       {:timex, "~> 3.7"},
       {:ua_inspector, "~> 3.0"},
-      {:ex_doc, "~> 0.28", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.28", only: :dev, runtime: false},
+      {:clickhousex, github: "plausible/clickhousex", branch: "rebase-upstream", override: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "chatterbox": {:hex, :ts_chatterbox, "0.11.0", "b8f372c706023eb0de5bf2976764edb27c70fe67052c88c1f6a66b3a5626847f", [:rebar3], [{:hpack, "~>0.2.3", [hex: :hpack_erl, repo: "hexpm", optional: false]}], "hexpm", "722fe2bad52913ab7e87d849fc6370375f0c961ffb2f0b5e6d647c9170c382a6"},
   "clickhouse_ecto": {:git, "https://github.com/plausible/clickhouse_ecto.git", "43126c020f07b097c55a81f68a906019fd061f29", []},
-  "clickhousex": {:git, "https://github.com/plausible/clickhousex.git", "18ee9077ddfb96942546c159c54c2e4a72396167", [branch: "rebase-upstream"]},
+  "clickhousex": {:git, "https://github.com/plausible/clickhousex.git", "f0e0820fe79f7e4fa433497bf41fa2e910e51eb0", [branch: "rebase-upstream"]},
   "combination": {:hex, :combination, "0.0.3", "746aedca63d833293ec6e835aa1f34974868829b1486b1e1cb0685f0b2ae1f41", [:mix], [], "hexpm", "72b099f463df42ef7dc6371d250c7070b57b6c5902853f69deb894f79eda18ca"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
   "comeonin": {:hex, :comeonin, "5.3.3", "2c564dac95a35650e9b6acfe6d2952083d8a08e4a89b93a481acb552b325892e", [:mix], [], "hexpm", "3e38c9c2cb080828116597ca8807bb482618a315bfafd98c90bc22a821cc84df"},

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "chatterbox": {:hex, :ts_chatterbox, "0.11.0", "b8f372c706023eb0de5bf2976764edb27c70fe67052c88c1f6a66b3a5626847f", [:rebar3], [{:hpack, "~>0.2.3", [hex: :hpack_erl, repo: "hexpm", optional: false]}], "hexpm", "722fe2bad52913ab7e87d849fc6370375f0c961ffb2f0b5e6d647c9170c382a6"},
   "clickhouse_ecto": {:git, "https://github.com/plausible/clickhouse_ecto.git", "43126c020f07b097c55a81f68a906019fd061f29", []},
-  "clickhousex": {:git, "https://github.com/plausible/clickhousex", "e6b7cc5a1ea7bb26d77af8fdae03952f662469af", []},
+  "clickhousex": {:git, "https://github.com/plausible/clickhousex.git", "18ee9077ddfb96942546c159c54c2e4a72396167", [branch: "rebase-upstream"]},
   "combination": {:hex, :combination, "0.0.3", "746aedca63d833293ec6e835aa1f34974868829b1486b1e1cb0685f0b2ae1f41", [:mix], [], "hexpm", "72b099f463df42ef7dc6371d250c7070b57b6c5902853f69deb894f79eda18ca"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
   "comeonin": {:hex, :comeonin, "5.3.3", "2c564dac95a35650e9b6acfe6d2952083d8a08e4a89b93a481acb552b325892e", [:mix], [], "hexpm", "3e38c9c2cb080828116597ca8807bb482618a315bfafd98c90bc22a821cc84df"},


### PR DESCRIPTION
### Changes

@ruslandoga has been working on reconciling [our fork](https://github.com/plausible/clickhousex) of clickhousex with the [upstream repo](https://github.com/clickhouse-elixir/clickhousex).

Here's the diff for upstream <- our fork: https://github.com/clickhouse-elixir/clickhousex/compare/master...plausible:clickhousex:rebase-upstream

The main changes made upstream that we want is the migration from HTTPoison -> Mint which fixes the nonsensical pooling strategy in older versions of clickhousex.

The plan is to test this out in @ruslandoga's personal installation and our staging server for some time. If no new errors are found, we can try it out in prod.