### PR TITLE
Gracefully handle duplicate invitations

### DIFF
--- a/lib/plausible/auth/invitation.ex
+++ b/lib/plausible/auth/invitation.ex
@@ -19,5 +19,10 @@ defmodule Plausible.Auth.Invitation do
     %__MODULE__{invitation_id: Nanoid.generate()}
     |> cast(attrs, @required)
     |> validate_required(@required)
+    |> unique_constraint([:email, :site_id],
+      name: :invitations_site_id_email_index,
+      error_key: :invitation,
+      message: "already sent"
+    )
   end
 end


### PR DESCRIPTION
### Changes

This fixes a crash on duplicate invitation send attempt. The user is redirected to the people settings page where existing, pending invitation can be removed if need be.

![dupe-inv](https://user-images.githubusercontent.com/173738/195092982-3e61c906-e2a1-4029-8032-1db5c795333d.gif)


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
