### PR TITLE
Increase Google Analytics timeout and lower page size

### DIFF
--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -114,7 +114,7 @@ defmodule Plausible.Google.Api do
           expires_at :: String.t()
         }
 
-  @per_page 10_000
+  @per_page 7_500
   @max_attempts 5
   @spec import_analytics(Plausible.Site.t(), Date.Range.t(), String.t(), import_auth()) ::
           :ok | {:error, term()}

--- a/lib/plausible/google/http.ex
+++ b/lib/plausible/google/http.ex
@@ -34,7 +34,7 @@ defmodule Plausible.Google.HTTP do
         [{"Authorization", "Bearer #{report_request.access_token}"}],
         params
       )
-      |> http_client.request(Plausible.Finch, receive_timeout: 30_000)
+      |> http_client.request(Plausible.Finch, receive_timeout: 60_000)
 
     with {:ok, %{status: 200, body: body}} <- response,
          {:ok, report} <- parse_report_from_response(body),

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -77,11 +77,11 @@ defmodule Plausible.Google.ApiTest do
                  buffer: buffer
                )
 
-      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
-      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
-      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
-      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
-      assert_receive({Finch, :request, [_, _, [receive_timeout: 30_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 60_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 60_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 60_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 60_000]]})
+      assert_receive({Finch, :request, [_, _, [receive_timeout: 60_000]]})
     end
 
     test "does not fail when report does not have rows key", %{site: site, buffer: buffer} do


### PR DESCRIPTION
### Changes

The Google Analytics report request may take some time, especially with big imports with thousands of pages. To mitigate the issue this commit increases the timeout to 60s and lowers the page size to 7,500 records per request.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
