### PR TITLE
Automatically decode JSON payloads from HTTP

### DIFF
--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -22,12 +22,10 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(preview_update_url(), @headers, params) do
       {:ok, response} ->
-        body = Jason.decode!(response.body)
-
-        if body["success"] do
-          {:ok, body["response"]}
+        if response.body["success"] do
+          {:ok, response.body["response"]}
         else
-          {:error, body["error"]}
+          {:error, response.body["error"]}
         end
 
       {:error, error} ->
@@ -51,12 +49,10 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(update_subscription_url(), @headers, params) do
       {:ok, response} ->
-        body = Jason.decode!(response.body)
-
-        if body["success"] do
-          {:ok, body["response"]}
+        if response.body["success"] do
+          {:ok, response.body["response"]}
         else
-          {:error, body["error"]}
+          {:error, response.body["error"]}
         end
 
       {:error, %{reason: reason}} ->
@@ -75,13 +71,11 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(get_subscription_url(), @headers, params) do
       {:ok, response} ->
-        body = Jason.decode!(response.body)
-
-        if body["success"] do
-          [subscription] = body["response"]
+        if response.body["success"] do
+          [subscription] = response.body["response"]
           {:ok, subscription}
         else
-          {:error, body["error"]}
+          {:error, response.body["error"]}
         end
 
       {:error, %{reason: reason}} ->
@@ -108,8 +102,7 @@ defmodule Plausible.Billing.PaddleApi do
       to: Timex.shift(Timex.today(), days: 1) |> Timex.format!("{YYYY}-{0M}-{0D}")
     }
 
-    with {:ok, response} <- HTTPClient.post(invoices_url(), @headers, params),
-         {:ok, body} <- Jason.decode(response.body),
+    with {:ok, %{body: body}} <- HTTPClient.post(invoices_url(), @headers, params),
          true <- Map.get(body, "success"),
          [_ | _] = response <- Map.get(body, "response") do
       Enum.sort(response, fn %{"payout_date" => d1}, %{"payout_date" => d2} ->

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -734,7 +734,10 @@ defmodule PlausibleWeb.SiteControllerTest do
         "/analytics/v3/management/accounts/~all/webproperties/~all/profiles",
         fn conn ->
           response_body = File.read!("fixture/ga_list_views.json")
-          Plug.Conn.resp(conn, 200, response_body)
+
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.resp(200, response_body)
         end
       )
 


### PR DESCRIPTION
### Changes

This PR pushes JSON body decoding to the HTTP Client level - if a relevant content-type was detected. This lays out some foundation for further google integration improvements.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
