### PR TITLE
Increase flaky test timeout

### DIFF
--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -145,13 +145,13 @@ defmodule Plausible.TestUtils do
   end
 
   def eventually(expectation, wait_time_ms \\ 50, retries \\ 10) do
-    Enum.reduce_while(1..retries, nil, fn _i, _acc ->
+    Enum.reduce_while(1..retries, nil, fn attempt, _acc ->
       case expectation.() do
         {true, result} ->
           {:halt, result}
 
         {false, _} ->
-          Process.sleep(wait_time_ms)
+          Process.sleep(wait_time_ms * attempt)
           {:cont, nil}
       end
     end)


### PR DESCRIPTION
### Changes

This pull requests increases the timeout of tests using `eventually/3`, e.g. when waiting for Clickhouse async deletes.

![image](https://user-images.githubusercontent.com/5093045/195598890-72c448c6-8034-4b09-bbb3-94e9c7a72aad.png)
