### PR TITLE
Remove inserts per second Google Analytics test assertion 

### DIFF
--- a/test/plausible/google/vcr_test.exs
+++ b/test/plausible/google/vcr_test.exs
@@ -6,21 +6,8 @@ defmodule Plausible.Google.Api.VCRTest do
 
   setup [:create_user, :create_site]
 
-  defp get_insert_count do
-    Plausible.ClickhouseRepo.aggregate(
-      from(ql in "query_log",
-        prefix: "system",
-        where: ql.query_kind == "Insert" and ql.is_initial_query == true
-      ),
-      :count
-    )
-  end
-
   test "imports page views from Google Analytics", %{site: site} do
     use_cassette "google_analytics_import#1", match_requests_on: [:request_body] do
-      inserts_before_importing = get_insert_count()
-      before_importing_timestamp = DateTime.utc_now()
-
       view_id = "54297898"
       date_range = Date.range(~D[2011-01-01], ~D[2022-07-19])
 
@@ -28,13 +15,6 @@ defmodule Plausible.Google.Api.VCRTest do
       auth = {"***", "refresh_token", future}
 
       assert :ok == Plausible.Google.Api.import_analytics(site, date_range, view_id, auth)
-
-      total_seconds = DateTime.diff(DateTime.utc_now(), before_importing_timestamp, :second)
-      total_inserts = get_insert_count() - inserts_before_importing
-
-      assert total_inserts / total_seconds > 1.0,
-             "should not call Clickhouse more than 1 time per second"
-
       assert 1_495_150 == Plausible.Stats.Clickhouse.imported_pageview_count(site)
     end
   end


### PR DESCRIPTION
This commit removes a flaky test assertion from the GA suite. The initial purpose of this test was to ensure we are not inserting to Clickhouse more than 1 time per second during an import.

Although it is nice to have an assertion like this, the test is flaky and fails sometimes. To get the total inserts during a time range, it queries Clickhouse internal tables for insert commands, and this number is not deterministic.

In a real-world scenario with Clickhouse, the app runs in multiple nodes not aware of their neighbors' CH calls. In that case, Grafana provides us visibility over CH, and these tests do not suffice.