### PR TITLE
add `v` prefix to version tags in public images

### DIFF
--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           images: plausible/analytics
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Cont. from https://github.com/plausible/analytics/discussions/2324#discussioncomment-3867370

[More info on `@metadata-action`'s semver](https://github.com/docker/metadata-action#typesemver)
[Demo workflow](https://github.com/ruslandoga/version-tag-test/blob/master/.github/workflows/build.yml)
[Result images](https://github.com/ruslandoga/version-tag-test/pkgs/container/version-tag-test)

```console
$ docker run -ti --rm ghcr.io/ruslandoga/version-tag-test:v1.5.0-rc.4 ash
$ cat meta.json | jq
{
  "tags": [
    "ghcr.io/ruslandoga/version-tag-test:v1.5.0-rc.4"
  ],
  "labels": {
    "org.opencontainers.image.title": "version-tag-test",
    "org.opencontainers.image.description": "",
    "org.opencontainers.image.url": "https://github.com/ruslandoga/version-tag-test",
    "org.opencontainers.image.source": "https://github.com/ruslandoga/version-tag-test",
    "org.opencontainers.image.version": "v1.5.0-rc.4",
    "org.opencontainers.image.created": "2022-10-17T05:23:39.594Z",
    "org.opencontainers.image.revision": "afcaa3d7ec07bbe060b96dd402ecb4b3797bdd1d",
    "org.opencontainers.image.licenses": ""
  }
}
```