### PR TITLE
Revert "Automatically decode JSON payloads from HTTP (#2329)"

### DIFF
--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -22,10 +22,12 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(preview_update_url(), @headers, params) do
       {:ok, response} ->
-        if response.body["success"] do
-          {:ok, response.body["response"]}
+        body = Jason.decode!(response.body)
+
+        if body["success"] do
+          {:ok, body["response"]}
         else
-          {:error, response.body["error"]}
+          {:error, body["error"]}
         end
 
       {:error, error} ->
@@ -49,10 +51,12 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(update_subscription_url(), @headers, params) do
       {:ok, response} ->
-        if response.body["success"] do
-          {:ok, response.body["response"]}
+        body = Jason.decode!(response.body)
+
+        if body["success"] do
+          {:ok, body["response"]}
         else
-          {:error, response.body["error"]}
+          {:error, body["error"]}
         end
 
       {:error, %{reason: reason}} ->
@@ -71,11 +75,13 @@ defmodule Plausible.Billing.PaddleApi do
 
     case HTTPClient.post(get_subscription_url(), @headers, params) do
       {:ok, response} ->
-        if response.body["success"] do
-          [subscription] = response.body["response"]
+        body = Jason.decode!(response.body)
+
+        if body["success"] do
+          [subscription] = body["response"]
           {:ok, subscription}
         else
-          {:error, response.body["error"]}
+          {:error, body["error"]}
         end
 
       {:error, %{reason: reason}} ->
@@ -102,7 +108,8 @@ defmodule Plausible.Billing.PaddleApi do
       to: Timex.shift(Timex.today(), days: 1) |> Timex.format!("{YYYY}-{0M}-{0D}")
     }
 
-    with {:ok, %{body: body}} <- HTTPClient.post(invoices_url(), @headers, params),
+    with {:ok, response} <- HTTPClient.post(invoices_url(), @headers, params),
+         {:ok, body} <- Jason.decode(response.body),
          true <- Map.get(body, "success"),
          [_ | _] = response <- Map.get(body, "response") do
       Enum.sort(response, fn %{"payout_date" => d1}, %{"payout_date" => d2} ->

--- a/lib/plausible/http_client.ex
+++ b/lib/plausible/http_client.ex
@@ -65,7 +65,6 @@ defmodule Plausible.HTTPClient do
     method
     |> build_request(url, headers, params)
     |> do_request()
-    |> maybe_decode_body()
     |> tag_error()
   end
 
@@ -112,29 +111,5 @@ defmodule Plausible.HTTPClient do
 
   defp tag_error({:error, _} = error) do
     error
-  end
-
-  defp maybe_decode_body({:ok, %{headers: headers, body: body} = resp})
-       when is_binary(body) and body != "" do
-    if json?(headers) do
-      {:ok, update_in(resp.body, &Jason.decode!/1)}
-    else
-      {:ok, resp}
-    end
-  end
-
-  defp maybe_decode_body(resp), do: resp
-
-  defp json?(headers) do
-    found =
-      Enum.find(headers, fn
-        {"content-type", "application/json" <> _} ->
-          true
-
-        _ ->
-          false
-      end)
-
-    is_tuple(found)
   end
 end

--- a/test/plausible/http_client_test.exs
+++ b/test/plausible/http_client_test.exs
@@ -124,9 +124,8 @@ defmodule Plausible.HTTPClientTest do
 
   test "header keys are downcased but values are not", %{bypass: bypass} do
     Bypass.expect_once(bypass, "GET", "/get", fn conn ->
-      conn
+      Conn.resp(conn, 200, "ok")
       |> Conn.put_resp_header("Some-Header", "Header-Value")
-      |> Conn.resp(200, "ok")
     end)
 
     assert {:ok, res} = HTTPClient.get(bypass_url(bypass, path: "/get"))
@@ -138,17 +137,5 @@ defmodule Plausible.HTTPClientTest do
     path = Keyword.get(opts, :path, "/")
 
     "http://localhost:#{port}#{path}"
-  end
-
-  test "decodes json in case content-type is found", %{bypass: bypass} do
-    Bypass.expect_once(bypass, "GET", "/json", fn conn ->
-      conn
-      |> Conn.put_resp_header("content-type", "application/json; something")
-      |> Conn.resp(200, """
-      {"answer": 42}
-      """)
-    end)
-
-    assert {:ok, %{body: %{"answer" => 42}}} = HTTPClient.get(bypass_url(bypass, path: "/json"))
   end
 end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -734,10 +734,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         "/analytics/v3/management/accounts/~all/webproperties/~all/profiles",
         fn conn ->
           response_body = File.read!("fixture/ga_list_views.json")
-
-          conn
-          |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.resp(200, response_body)
+          Plug.Conn.resp(conn, 200, response_body)
         end
       )
 


### PR DESCRIPTION
This reverts commit 28cec9d93956ba364eccc0117514e1204004ab0d.

I will re-apply this commit along with test for the captcha controller.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
