### PR TITLE
update clickhouse and postgres images in Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Make sure Docker, Elixir, Erlang and Node.js are all installed on your developme
 ### Start the environment:
 
 1. Run both `make postgres` and `make clickhouse`.
-    1. If you are using Apple Silicon (any of the M1 or similar SoC variants), `make clickhouse-arm` offers a development-only substitute that will work on your local machine. Not intended for production.
 2. You can set up everything with `make install`, alternatively run each command separately:
     1. Run `mix deps.get`. This will download the required Elixir dependencies.
     2. Run `mix ecto.create`. This will create the required databases in both Postgres and Clickhouse.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop
+.PHONY: help install server clickhouse clickhouse-prod clickhouse-ci clickhouse-stop postgres postgres-prod postgres-stop
 
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop
+.PHONY: help install server clickhouse clickhouse-arm clickhouse-stop postgres postgres-stop
 
-install:
+help:
+	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+install: ## Run the initial setup
 	mix deps.get
 	mix ecto.create
 	mix ecto.migrate
@@ -8,20 +11,30 @@ install:
 	npm install --prefix assets
 	npm install --prefix tracker
 
-server:
+server: ## Start the web server
 	mix phx.server
 
-clickhouse:
-	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse --name plausible_clickhouse clickhouse/clickhouse-server:21.11.3.6
+CH_FLAGS ?= --detach -p 8123:8123 --ulimit nofile=262144:262144 --name plausible_clickhouse
 
-clickhouse-arm:
-	docker run --detach -p 8123:8123 --ulimit nofile=262144:262144 --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse --name plausible_clickhouse altinity/clickhouse-server:21.12.3.32.altinitydev.arm
+clickhouse: ## Start a container with a recent version of clickhouse
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:22.9-alpine
 
-clickhouse-stop:
+clickhouse-prod: ## Start a container with the same version of clickhouse as the one in prod
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:21.11.3.6
+
+clickhouse-ci: ## Start a container with the same version of clickhouse as the one in .github/workflows/elixir.yml
+	docker run $(CH_FLAGS)--volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:21.11
+
+clickhouse-stop: ## Stop and remove the clickhouse container
 	docker stop plausible_clickhouse && docker rm plausible_clickhouse
 
-postgres:
-	docker run --detach -e POSTGRES_PASSWORD="postgres" -p 5432:5432 --volume=plausible_db:/var/lib/postgresql/data --name plausible_db postgres:12
+PG_FLAGS ?= --detach -e POSTGRES_PASSWORD="postgres" -p 5432:5432 --name plausible_db
 
-postgres-stop:
+postgres: ## Start a container with a recent version of postgres
+	docker run $(PG_FLAGS) --volume=plausible_db:/var/lib/postgresql/data postgres:14-alpine
+
+postgres-prod: ## Start a container with the same version of postgres as the one in prod
+	docker run $(PG_FLAGS) --volume=plausible_db_prod:/var/lib/postgresql/data postgres:12
+
+postgres-stop: ## Stop and remove the postgres container
 	docker stop plausible_db && docker rm plausible_db


### PR DESCRIPTION
### Changes

This PR updates Makefile's `postgres` version [to the one used in `plausible/hosting` (version 14)](https://github.com/plausible/hosting/blob/a6fe8d13df3566f7bb3625a1a524f5498d56693d/docker-compose.yml#L9) and `clickhouse` -- to the version [that replaced `hyperscan` with `vectorscan` for better arm64 support (version 22.9)](https://github.com/ClickHouse/ClickHouse/pull/38171)

Relevant:
- https://github.com/plausible/analytics/discussions/2292
- https://github.com/plausible/hosting/pull/57
- https://github.com/plausible/analytics/discussions/2342

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
