### PR TITLE
Suggest enterprise plan when usage is greater than 10M pageviews

### DIFF
--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -126,7 +126,7 @@ defmodule Plausible.Billing.Plans do
     )
   end
 
-  @enterprise_level_usage 20_000_000
+  @enterprise_level_usage 10_000_000
   @spec suggested_plan(Plausible.Auth.User.t(), non_neg_integer()) :: plan()
   def suggested_plan(user, usage_during_cycle) do
     cond do

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -97,6 +97,30 @@ defmodule Plausible.Workers.CheckUsageTest do
     assert Repo.reload(user).grace_period.end_date == Timex.shift(Timex.today(), days: 7)
   end
 
+  test "sends an email suggesting enterprise plan when usage is greater than 10M ", %{
+    user: user
+  } do
+    billing_stub =
+      Plausible.Billing
+      |> stub(:last_two_billing_months_usage, fn _user -> {11_000_000, 11_000_000} end)
+      |> stub(:last_two_billing_cycles, fn _user ->
+        {Date.range(Timex.today(), Timex.today()), Date.range(Timex.today(), Timex.today())}
+      end)
+
+    insert(:subscription,
+      user: user,
+      paddle_plan_id: @paddle_id_10k,
+      last_bill_date: Timex.shift(Timex.today(), days: -1)
+    )
+
+    CheckUsage.perform(nil, billing_stub)
+
+    assert_delivered_email_matches(%{html_body: html_body})
+
+    assert html_body =~
+             "This is more than our standard plans, so please reply back to this email to get a quote for your volume."
+  end
+
   test "skips checking users who already have a grace period", %{user: user} do
     user |> Plausible.Auth.GracePeriod.start_changeset(12_000) |> Repo.update()
 


### PR DESCRIPTION
### Changes

This pull request updates the e-mail sent to outgrown subscriptions. The current template suggest an enterprise plan when the monthly usage is over 20M, however, this should be 10M, our standard plan limit.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
