### PR TITLE
add debugging info to failed GA import email template

### DIFF
--- a/lib/plausible_web/templates/email/google_analytics_import.html.eex
+++ b/lib/plausible_web/templates/email/google_analytics_import.html.eex
@@ -5,7 +5,38 @@ Hey <%= user_salutation(@user) %>,
 <br /><br />
 <%= link("Click here", to: @link) %> to view your dashboard.
 <% else %>
-  Unfortunately, your Google Analytics import for <%= @site.domain %> did not complete successfully. Please try again <%= if !Application.get_env(:plausible, :is_selfhost) do %>or <%= link("contact support", to: "https://plausible.io/contact") %><% end %>.
+  Unfortunately, your Google Analytics import for <%= @site.domain %> did not complete successfully. Sorry about that!
+  <br /> <br />
+
+  This may be due to the user metric setting in your Google Analytics account. We found that changing the user metric setting is necessary to get the correct data out of the Google API.
+  <br /> <br />
+
+  Please log into your Google Analytics account and go to Admin -> Property Settings -> User Analysis. Then make sure that "Enable User Metric in Reporting" is set to OFF. Then try importing again. You can switch the setting back after the import.
+  <br /> <br />
+
+  If you've already changed that setting, then it is something else:
+  <br />
+
+  <ul>
+    <li>
+      Do you have any stats in the Google Analytics property you tried to import? We only import the stats from your first Google Analytics visitor until your first Plausible Analytics visitor. The import fails if there's no returned data from Google from before you counted your first Plausible visitor.
+    </li>
+    <li>
+      Did you set strict data retention limits in your Google Analytics account? You can check the data retention limit you have set for your property in your Google Analytics admin settings by visiting the "Tracking Info" section and clicking on "Data Retention".
+    </li>
+  </ul>
+  <br />
+
+  If all of the above is fine, please try to do the import once again. Sometimes the Google Analytics API just randomly returns empty data. It's intermittent and random. Trying to do the import again may return what you need.
+
+  <%= if !Application.get_env(:plausible, :is_selfhost) do %>
+    <br /> <br />
+
+    Please reach out to <%= link("our support", to: "https://plausible.io/contact") %> and let us know if you're still experiencing issues with the import. Thanks!
+    <br /> <br />
+
+    The Plausible Team 💌
+  <% end %>
 <% end %>
 <br /><br />
 --

--- a/lib/plausible_web/templates/email/google_analytics_import.html.eex
+++ b/lib/plausible_web/templates/email/google_analytics_import.html.eex
@@ -32,7 +32,7 @@ Hey <%= user_salutation(@user) %>,
   <%= if !Application.get_env(:plausible, :is_selfhost) do %>
     <br /> <br />
 
-    Please reach out to <%= link("our support", to: "https://plausible.io/contact") %> and let us know if you're still experiencing issues with the import. Thanks!
+    Please reply to this email to let us know if you're still experiencing issues with the import. Thanks!
     <br /> <br />
 
     The Plausible Team 💌


### PR DESCRIPTION
### Changes

This PR changes the email that is sent when a Google Analytics import fails. Rather than simply saying that the import failed and linking to our contact page, it now gives some instant debugging steps that the customers can follow before writing to our support.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
