### PR TITLE
Double maximum header length

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -212,7 +212,12 @@ config :plausible, :selfhost,
 
 config :plausible, PlausibleWeb.Endpoint,
   url: [scheme: base_url.scheme, host: base_url.host, path: base_url.path, port: base_url.port],
-  http: [port: port, ip: listen_ip, transport_options: [max_connections: :infinity]],
+  http: [
+    port: port,
+    ip: listen_ip,
+    transport_options: [max_connections: :infinity],
+    protocol_options: [max_request_line_length: 8192, max_header_value_length: 8192]
+  ],
   secret_key_base: secret_key_base
 
 maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []


### PR DESCRIPTION
### Changes

This commit makes the permitted header length more permissive, 8,192 bytes, doubling the Phoenix default.

Related to https://github.com/4lejandrito/next-plausible/issues/67

### Tests
I tried testing with ExUnit, but I could not reproduce the HTTP 431 Request Header Fields Too Large response. I guess this is because the HTTP server does not actually run in test environment. However, I tested this locally with curl and the HTTP 431 is fixed.

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
