### PR TITLE
Do not report hard bounce e-mail errors to Sentry

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Billing do
       case Repo.update(changeset) do
         {:ok, updated} ->
           PlausibleWeb.Email.cancellation_email(subscription.user)
-          |> Plausible.Mailer.send_email_safe()
+          |> Plausible.Mailer.send()
 
           {:ok, updated}
 

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -50,6 +50,6 @@ defmodule Plausible.Billing.SiteLocker do
         suggested_plan
       )
 
-    Plausible.Mailer.send_email_safe(template)
+    Plausible.Mailer.send(template)
   end
 end

--- a/lib/plausible/mailer_test.exs
+++ b/lib/plausible/mailer_test.exs
@@ -1,0 +1,12 @@
+defmodule Plausible.MailerTest do
+  use Plausible.DataCase
+  use Bamboo.Test
+
+  test "send/1 sends an email" do
+    user = build(:user)
+    email = PlausibleWeb.Email.welcome_email(user)
+
+    assert :ok == Plausible.Mailer.send(email)
+    assert_delivered_email(email)
+  end
+end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -146,7 +146,7 @@ defmodule PlausibleWeb.AuthController do
   defp send_email_verification(user) do
     code = Auth.issue_email_verification(user)
     email_template = PlausibleWeb.Email.activation_email(user, code)
-    result = Plausible.Mailer.send_email(email_template)
+    result = Plausible.Mailer.send(email_template)
 
     Logger.debug(
       "E-mail verification e-mail sent. In dev environment GET /sent-emails for details."
@@ -228,7 +228,7 @@ defmodule PlausibleWeb.AuthController do
     code = Auth.issue_email_verification(user)
 
     email_template = PlausibleWeb.Email.activation_email(user, code)
-    Plausible.Mailer.send_email(email_template)
+    Plausible.Mailer.send(email_template)
 
     conn
     |> put_flash(:success, "Activation code was sent to #{user.email}")

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -91,22 +91,22 @@ defmodule PlausibleWeb.InvitationController do
 
   defp notify_invitation_accepted(%Invitation{role: :owner} = invitation) do
     PlausibleWeb.Email.ownership_transfer_accepted(invitation)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp notify_invitation_accepted(invitation) do
     PlausibleWeb.Email.invitation_accepted(invitation)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp notify_invitation_rejected(%Invitation{role: :owner} = invitation) do
     PlausibleWeb.Email.ownership_transfer_rejected(invitation)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp notify_invitation_rejected(invitation) do
     PlausibleWeb.Email.invitation_rejected(invitation)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   def remove_invitation(conn, %{"invitation_id" => invitation_id}) do

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -68,7 +68,7 @@ defmodule PlausibleWeb.Site.MembershipController do
               PlausibleWeb.Email.new_user_invitation(invitation)
             end
 
-          Plausible.Mailer.send_email(email_template)
+          Plausible.Mailer.send(email_template)
 
           conn
           |> put_flash(
@@ -124,7 +124,7 @@ defmodule PlausibleWeb.Site.MembershipController do
       |> Repo.preload([:site, :inviter])
 
     PlausibleWeb.Email.ownership_transfer_request(invitation, user)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
 
     conn
     |> put_flash(:success, "Site transfer request has been sent to #{email}")
@@ -199,7 +199,7 @@ defmodule PlausibleWeb.Site.MembershipController do
     Repo.delete!(membership)
 
     PlausibleWeb.Email.site_member_removed(membership)
-    |> Plausible.Mailer.send_email()
+    |> Plausible.Mailer.send()
 
     redirect_target =
       if membership.user.id == conn.assigns[:current_user].id do

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.SiteController do
       {:ok, %{site: site}} ->
         if is_first_site do
           PlausibleWeb.Email.welcome_email(user)
-          |> Plausible.Mailer.send_email()
+          |> Plausible.Mailer.send()
         end
 
         conn

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -79,7 +79,7 @@ defmodule Plausible.Workers.CheckUsage do
             site_allowance
           )
 
-        Plausible.Mailer.send_email_safe(template)
+        Plausible.Mailer.send(template)
 
         subscriber
         |> Plausible.Auth.GracePeriod.start_manual_lock_changeset(last_cycle_usage)
@@ -100,7 +100,7 @@ defmodule Plausible.Workers.CheckUsage do
             suggested_plan
           )
 
-        Plausible.Mailer.send_email_safe(template)
+        Plausible.Mailer.send(template)
 
         subscriber
         |> Plausible.Auth.GracePeriod.start_changeset(last_cycle_usage)

--- a/lib/workers/import_google_analytics.ex
+++ b/lib/workers/import_google_analytics.ex
@@ -34,7 +34,7 @@ defmodule Plausible.Workers.ImportGoogleAnalytics do
         Enum.each(site.memberships, fn membership ->
           if membership.role in [:owner, :admin] do
             PlausibleWeb.Email.import_success(membership.user, site)
-            |> Plausible.Mailer.send_email_safe()
+            |> Plausible.Mailer.send()
           end
         end)
 
@@ -62,7 +62,7 @@ defmodule Plausible.Workers.ImportGoogleAnalytics do
     Enum.each(site.memberships, fn membership ->
       if membership.role in [:owner, :admin] do
         PlausibleWeb.Email.import_failure(membership.user, site)
-        |> Plausible.Mailer.send_email_safe()
+        |> Plausible.Mailer.send()
       end
     end)
   end

--- a/lib/workers/notify_annual_renewal.ex
+++ b/lib/workers/notify_annual_renewal.ex
@@ -46,11 +46,11 @@ defmodule Plausible.Workers.NotifyAnnualRenewal do
       case user.subscription.status do
         "active" ->
           template = PlausibleWeb.Email.yearly_renewal_notification(user)
-          Plausible.Mailer.send_email_safe(template)
+          Plausible.Mailer.send(template)
 
         "deleted" ->
           template = PlausibleWeb.Email.yearly_expiration_notification(user)
-          Plausible.Mailer.send_email_safe(template)
+          Plausible.Mailer.send(template)
 
         _ ->
           Sentry.capture_message("Invalid subscription for renewal", user: user)

--- a/lib/workers/send_check_stats_emails.ex
+++ b/lib/workers/send_check_stats_emails.ex
@@ -29,7 +29,7 @@ defmodule Plausible.Workers.SendCheckStatsEmails do
 
   defp send_check_stats_email(user) do
     PlausibleWeb.Email.check_stats_email(user)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
 
     Repo.insert_all("check_stats_emails", [
       %{

--- a/lib/workers/send_email_report.ex
+++ b/lib/workers/send_email_report.ex
@@ -79,6 +79,6 @@ defmodule Plausible.Workers.SendEmailReport do
         name: name
       )
 
-    Plausible.Mailer.send_email_safe(template)
+    Plausible.Mailer.send(template)
   end
 end

--- a/lib/workers/send_site_setup_emails.ex
+++ b/lib/workers/send_site_setup_emails.ex
@@ -76,7 +76,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
 
   defp send_create_site_email(user) do
     PlausibleWeb.Email.create_site_email(user)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
 
     Repo.insert_all("create_site_emails", [
       %{
@@ -88,7 +88,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
 
   defp send_setup_success_email(user, site) do
     PlausibleWeb.Email.site_setup_success(user, site)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
 
     Repo.insert_all("setup_success_emails", [
       %{
@@ -100,7 +100,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
 
   defp send_setup_help_email(user, site) do
     PlausibleWeb.Email.site_setup_help(user, site)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
 
     Repo.insert_all("setup_help_emails", [
       %{

--- a/lib/workers/send_trial_notifications.ex
+++ b/lib/workers/send_trial_notifications.ex
@@ -51,25 +51,25 @@ defmodule Plausible.Workers.SendTrialNotifications do
 
   defp send_one_week_reminder(user) do
     PlausibleWeb.Email.trial_one_week_reminder(user)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp send_tomorrow_reminder(user) do
     usage = Plausible.Billing.usage_breakdown(user)
 
     PlausibleWeb.Email.trial_upgrade_email(user, "tomorrow", usage)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp send_today_reminder(user) do
     usage = Plausible.Billing.usage_breakdown(user)
 
     PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 
   defp send_over_reminder(user) do
     PlausibleWeb.Email.trial_over_email(user)
-    |> Plausible.Mailer.send_email_safe()
+    |> Plausible.Mailer.send()
   end
 end

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -58,6 +58,6 @@ defmodule Plausible.Workers.SpikeNotifier do
         dashboard_link
       )
 
-    Plausible.Mailer.send_email_safe(template)
+    Plausible.Mailer.send(template)
   end
 end


### PR DESCRIPTION
This commit refactors the Plausible.Mailer module, which is a wrapper around Bamboo. The original behaviour uses exceptions to control flow and reports every error to Sentry. This replaces exceptions with error tuples and parses Bamboo errors to avoid reporting unnecessary noise to Sentry.