### PR TITLE
Clear stats_start_date after clearing GA stats

### DIFF
--- a/lib/plausible/purge.ex
+++ b/lib/plausible/purge.ex
@@ -23,13 +23,16 @@ defmodule Plausible.Purge do
 
   @spec delete_imported_stats!(Plausible.Site.t()) :: :ok
   @doc """
-  Deletes imported stats from Google Analytics.
+  Deletes imported stats from Google Analytics, and clears the
+  `stats_start_date` field.
   """
   def delete_imported_stats!(site) do
     Enum.each(Plausible.Imported.tables(), fn table ->
       sql = "ALTER TABLE #{table} DELETE WHERE site_id = ?"
       Ecto.Adapters.SQL.query!(Plausible.ClickhouseRepo, sql, [site.id])
     end)
+
+    clear_stats_start_date!(site)
 
     :ok
   end

--- a/test/plausible/purge_test.exs
+++ b/test/plausible/purge_test.exs
@@ -45,9 +45,9 @@ defmodule Plausible.PurgeTest do
     end)
   end
 
-  test "delete_imported_stats!/1 does not reset stats_start_date", %{site: site} do
+  test "delete_imported_stats!/1 resets stats_start_date", %{site: site} do
     assert :ok == Plausible.Purge.delete_imported_stats!(site)
-    assert %Date{} = site.stats_start_date
+    assert %Plausible.Site{stats_start_date: nil} = Plausible.Repo.reload(site)
   end
 
   test "delete_native_stats!/1 deletes native stats", %{site: site} do


### PR DESCRIPTION
### Changes

This commit fixes a bug where users clearing one import and trying to re-import would get invalid import date ranges. This was caused because the stats_start_date field was not updated to nil after clearing imported stats, as this field defines the end date of the import.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
