### PR TITLE
Separate GA/SC scopes

### DIFF
--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -5,28 +5,21 @@ defmodule Plausible.Google.Api do
 
   @type google_analytics_view() :: {view_name :: String.t(), view_id :: String.t()}
 
-  @scope URI.encode_www_form(
-           "https://www.googleapis.com/auth/webmasters.readonly email https://www.googleapis.com/auth/analytics.readonly"
-         )
+  @search_console_scope URI.encode_www_form(
+                          "email https://www.googleapis.com/auth/webmasters.readonly"
+                        )
   @import_scope URI.encode_www_form("email https://www.googleapis.com/auth/analytics.readonly")
+
   @verified_permission_levels ["siteOwner", "siteFullUser", "siteRestrictedUser"]
 
-  def authorize_url(site_id, redirect_to) do
-    if Application.get_env(:plausible, :environment) == "test" do
-      ""
-    else
-      "https://accounts.google.com/o/oauth2/v2/auth?client_id=#{client_id()}&redirect_uri=#{redirect_uri()}&prompt=consent&response_type=code&access_type=offline&scope=#{@scope}&state=" <>
-        Jason.encode!([site_id, redirect_to])
-    end
+  def search_console_authorize_url(site_id, redirect_to) do
+    "https://accounts.google.com/o/oauth2/v2/auth?client_id=#{client_id()}&redirect_uri=#{redirect_uri()}&prompt=consent&response_type=code&access_type=offline&scope=#{@search_console_scope}&state=" <>
+      Jason.encode!([site_id, redirect_to])
   end
 
   def import_authorize_url(site_id, redirect_to) do
-    if Application.get_env(:plausible, :environment) == "test" do
-      ""
-    else
-      "https://accounts.google.com/o/oauth2/v2/auth?client_id=#{client_id()}&redirect_uri=#{redirect_uri()}&prompt=consent&response_type=code&access_type=offline&scope=#{@import_scope}&state=" <>
-        Jason.encode!([site_id, redirect_to])
-    end
+    "https://accounts.google.com/o/oauth2/v2/auth?client_id=#{client_id()}&redirect_uri=#{redirect_uri()}&prompt=consent&response_type=code&access_type=offline&scope=#{@import_scope}&state=" <>
+      Jason.encode!([site_id, redirect_to])
   end
 
   def fetch_verified_properties(auth) do

--- a/lib/plausible_web/templates/site/settings_general.html.eex
+++ b/lib/plausible_web/templates/site/settings_general.html.eex
@@ -96,7 +96,7 @@
               <div class="text-sm mt-2 text-gray-900 dark:text-gray-100">Your latest import has failed. You can try importing again by clicking the button below. If you try multiple times and the import keeps failing, please contact support.</div>
             <% end %>
             <div class="flex mt-2">
-              <%= button(to: Plausible.Google.Api.authorize_url(@site.id, "import"), class: "inline-flex pr-4 items-center border border-gray-100 shadow rounded-md focus:outline-none focus:ring-1 focus:ring-offset-1 focus:ring-gray-200 mt-8 hover:bg-gray-50 dark:hover:bg-gray-700") do %>
+              <%= button(to: Plausible.Google.Api.import_authorize_url(@site.id, "import"), class: "inline-flex pr-4 items-center border border-gray-100 shadow rounded-md focus:outline-none focus:ring-1 focus:ring-offset-1 focus:ring-gray-200 mt-8 hover:bg-gray-50 dark:hover:bg-gray-700") do %>
                 <%= google_logo() %>
                 <span style="font-family: Roboto, system-ui" class="text-sm font-medium text-gray-600 dark:text-gray-50">Continue with Google<span>
                   <% end %>

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -57,7 +57,7 @@
           <% end %>
       <% end %>
     <% else %>
-      <%= button("Continue with Google", to: Plausible.Google.Api.authorize_url(@site.id, "search-console"), class: "button mt-8") %>
+      <%= button("Continue with Google", to: Plausible.Google.Api.search_console_authorize_url(@site.id, "search-console"), class: "button mt-8") %>
 
       <div class="text-gray-700 dark:text-gray-300 mt-8">
         NB: You also need to set up your site on <%= link("Google Search Console", to: "https://search.google.com/search-console/about") %> for the integration to work. <%= link("Read the docs", to: "https://plausible.io/docs/google-search-console-integration", class: "text-indigo-500", rel: "noreferrer") %>


### PR DESCRIPTION
### Changes

This PR separates Google oauth scopes -- there is no point in asking for search console permissions when only import is intended and vice-versa.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
