### PR TITLE
Correct the spelling of JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ To stay up to date with all the latest news and product updates, make sure to fo
 
 Plausible is open-source under the GNU Affero General Public License Version 3 (AGPLv3) or any later version. You can [find it here](https://github.com/plausible/analytics/blob/master/LICENSE.md).
 
-The only exception is our javascript tracker which gets included on your website. To avoid issues with AGPL virality, we've
+The only exception is our JavaScript tracker which gets included on your website. To avoid issues with AGPL virality, we've
 released the tracker under the MIT license. You can [find it here](https://github.com/plausible/analytics/blob/master/tracker/LICENSE.md).

--- a/lib/plausible_web/templates/site/settings_general.html.eex
+++ b/lib/plausible_web/templates/site/settings_general.html.eex
@@ -29,7 +29,7 @@
 
 <%= form_for @conn, "/", [class: "shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6"], fn f -> %>
   <header class="relative">
-    <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">Javascript snippet</h2>
+    <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">JavaScript snippet</h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">Include this snippet in the <code>&lt;head&gt;</code> of your website.</p>
 
     <%= link(to: "https://plausible.io/docs/plausible-script", target: "_blank", rel: "noreferrer") do %>

--- a/lib/plausible_web/templates/site/snippet.html.eex
+++ b/lib/plausible_web/templates/site/snippet.html.eex
@@ -1,6 +1,6 @@
 <div class="w-full max-w-3xl mt-4 mx-auto flex">
   <%= form_for @conn, "/", [class: "max-w-lg w-full mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8"], fn f -> %>
-    <h2 class="text-xl font-bold dark:text-gray-100">Add javascript snippet</h2>
+    <h2 class="text-xl font-bold dark:text-gray-100">Add JavaScript snippet</h2>
     <div class="my-4">
       <p class="dark:text-gray-100">Paste this snippet in the <code>&lt;head&gt;</code> of your website.</p>
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -274,7 +274,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     test "shows snippet", %{conn: conn, site: site} do
       conn = get(conn, "/#{site.domain}/snippet")
 
-      assert html_response(conn, 200) =~ "Add javascript snippet"
+      assert html_response(conn, 200) =~ "Add JavaScript snippet"
     end
   end
 


### PR DESCRIPTION
One person reported that we are spelling JavaScript without capital J and S so I thought I'd fix that and other places where we don't capitalize it correctly.