### PR TITLE
Changing the settings link in the renewal email

### DIFF
--- a/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
@@ -4,7 +4,7 @@ Time flies! This is a reminder that your annual subscription for Plausible Analy
 <br /><br />
 There's no action required if you're happy to continue using Plausible to count your website stats in a privacy-friendly way.
 <br /><br />
-If you don't want to continue your subscription, you can cancel it on your <%= link("account settings page", to: "#{plausible_url()}/billing/upgrade") %>.
+If you don't want to continue your subscription, you can cancel it on your <%= link("account settings page", to: "#{plausible_url()}/settings") %>.
 <br /><br />
 Have a question, feedback or need some guidance? Do reply back to this email.
 <br /><br />


### PR DESCRIPTION
Someone mentioned there's no way to cancel from the link we include in this email (https://plausible.io/billing/upgrade) so I'm changing it to the settings page instead https://plausible.io/settings. My own https://plausible.io/billing/upgrade is a bit different than normal subscribers see it so I don't actually know if there's a way to cancel on it. If there is a way there too, feel free to ignore this
