### PR TITLE
Ingestion db site lookups

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -20,6 +20,7 @@ defmodule Plausible.Ingestion.Event do
          events when is_list(events) <- map_domains(event, request),
          events when is_list(events) <- put_user_id(events, request, salts),
          {:ok, events} <- validate_events(events),
+         :ok <- measured_sites_get(events),
          events when is_list(events) <- register_session(events, request, salts) do
       Enum.each(events, &Plausible.Event.WriteBuffer.insert/1)
     end
@@ -331,5 +332,28 @@ defmodule Plausible.Ingestion.Event do
     else
       nil
     end
+  end
+
+  defp measured_sites_get(events) do
+    events
+    |> Enum.map(& &1.domain)
+    |> Enum.uniq()
+    |> Enum.each(fn domain ->
+      if should_lookup_site?(domain) do
+        start = System.monotonic_time()
+        Plausible.Sites.get_by_domain(domain)
+        stop = System.monotonic_time()
+
+        :telemetry.execute(
+          [:plausible, :ingestion, :site, :lookup],
+          %{duration: stop - start},
+          %{}
+        )
+      end
+    end)
+  end
+
+  defp should_lookup_site?(domain) do
+    FunWithFlags.enabled?(:ingestion_pg_lookup, for: domain)
   end
 end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -4,6 +4,10 @@ defmodule Plausible.Sites do
   alias Plausible.Site.SharedLink
   import Ecto.Query
 
+  def get_by_domain(domain) do
+    Repo.get_by(Site, domain: domain)
+  end
+
   def create(user, params) do
     limit = Plausible.Billing.sites_limit(user)
 

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -78,13 +78,15 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
   def execute_cache_metrics do
     user_agents_count =
       case Cachex.stats(:user_agents) do
-        {:ok, stats} -> stats
+        # https://github.com/whitfin/cachex/pull/301
+        {:ok, %{writes: w, evictions: e}} when is_integer(w) and is_integer(e) -> w - e
         _ -> 0
       end
 
     sessions_count =
       case Cachex.stats(:sessions) do
-        {:ok, stats} -> stats
+        # https://github.com/whitfin/cachex/pull/301
+        {:ok, %{writes: w, evictions: e}} when is_integer(w) and is_integer(e) -> w - e
         _ -> 0
       end
 

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -18,6 +18,33 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
     ]
   end
 
+  @impl true
+  def event_metrics(_opts) do
+    metric_prefix = [:plausible, :profiling]
+
+    Event.build(
+      :plausible_event_metrics,
+      [
+        counter(
+          metric_prefix ++ [:ingestion, :site, :lookup, :counter],
+          event_name: [:plausible, :ingestion, :site, :lookup],
+          measurement: fn _ -> 1 end,
+          description: "Ingestion site lookup counter"
+        ),
+        distribution(
+          metric_prefix ++ [:ingestion, :site, :lookup, :duration, :milliseconds],
+          event_name: [:plausible, :ingestion, :site, :lookup],
+          description: "Ingestion site lookup duration",
+          measurement: :duration,
+          reporter_options: [
+            buckets: [5, 10, 50, 250, 1_000, 5_000]
+          ],
+          unit: {:native, :millisecond}
+        )
+      ]
+    )
+  end
+
   @doc """
   Add telemetry events for Session and Event write buffers
   """


### PR DESCRIPTION
### Changes

We like to see the impact of doing a simple postgres lookup on each
ingestion event. The percentage-based feature flag `:ingestion_pg_lookup`
must be set in order for lookups to be executed.

![image](https://user-images.githubusercontent.com/173738/199205306-0a1e26b8-c8aa-4140-832f-7326f69c6dff.png)

This PR also fixes a bug counting Cachex entries (the telemetry events were never consumed).

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
