### PR TITLE
Fix up Cachex metrics

### DIFF
--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -76,19 +76,8 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
   Add telemetry events for Cachex user agents and sessions
   """
   def execute_cache_metrics do
-    user_agents_count =
-      case Cachex.stats(:user_agents) do
-        # https://github.com/whitfin/cachex/pull/301
-        {:ok, %{writes: w, evictions: e}} when is_integer(w) and is_integer(e) -> w - e
-        _ -> 0
-      end
-
-    sessions_count =
-      case Cachex.stats(:sessions) do
-        # https://github.com/whitfin/cachex/pull/301
-        {:ok, %{writes: w, evictions: e}} when is_integer(w) and is_integer(e) -> w - e
-        _ -> 0
-      end
+    {:ok, user_agents_count} = Cachex.size(:user_agents)
+    {:ok, sessions_count} = Cachex.size(:sessions)
 
     :telemetry.execute([:prom_ex, :plugin, :cachex, :user_agents_count], %{
       count: user_agents_count
@@ -126,12 +115,12 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
       {__MODULE__, :execute_cache_metrics, []},
       [
         last_value(
-          metric_prefix ++ [:events, :cache_size, :count],
+          metric_prefix ++ [:cache, :sessions, :size],
           event_name: [:prom_ex, :plugin, :cachex, :sessions_count],
           measurement: :count
         ),
         last_value(
-          metric_prefix ++ [:sessions, :cache_size, :count],
+          metric_prefix ++ [:cache, :user_agents, :size],
           event_name: [:prom_ex, :plugin, :cachex, :user_agents_count],
           measurement: :count
         )

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -19,33 +19,6 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
     ]
   end
 
-  @impl true
-  def event_metrics(_opts) do
-    metric_prefix = [:plausible, :profiling]
-
-    Event.build(
-      :plausible_event_metrics,
-      [
-        counter(
-          metric_prefix ++ [:ingestion, :site, :lookup, :counter],
-          event_name: [:plausible, :ingestion, :site, :lookup],
-          measurement: fn _ -> 1 end,
-          description: "Ingestion site lookup counter"
-        ),
-        distribution(
-          metric_prefix ++ [:ingestion, :site, :lookup, :duration, :milliseconds],
-          event_name: [:plausible, :ingestion, :site, :lookup],
-          description: "Ingestion site lookup duration",
-          measurement: :duration,
-          reporter_options: [
-            buckets: [5, 10, 50, 250, 1_000, 5_000]
-          ],
-          unit: {:native, :millisecond}
-        )
-      ]
-    )
-  end
-
   @doc """
   Add telemetry events for Session and Event write buffers
   """


### PR DESCRIPTION
### Changes

This PR introduces new Cachex related metrics and fixes up size calculation to use the native interface rather than trying to subtract writes and evictions.
We will be now calculating the hit_ratio too. Old metrics will be pruned.

The PR also reverts profiling metrics introduced via https://github.com/plausible/analytics/commit/101e5a68b5ff907978f1f7b220b17d2cf53da4b6 - they are no longer needed.

```
# HELP plausible_prom_ex_plausible_metrics_cache_sessions_hit_ratio Sessions cache hit ratio
# TYPE plausible_prom_ex_plausible_metrics_cache_sessions_hit_ratio gauge
plausible_prom_ex_plausible_metrics_cache_sessions_hit_ratio 0.0
# HELP plausible_prom_ex_plausible_metrics_cache_user_agents_hit_ratio UA cache hit ratio
# TYPE plausible_prom_ex_plausible_metrics_cache_user_agents_hit_ratio gauge
plausible_prom_ex_plausible_metrics_cache_user_agents_hit_ratio 0.0
# HELP plausible_prom_ex_plausible_metrics_cache_user_agents_size
# TYPE plausible_prom_ex_plausible_metrics_cache_user_agents_size gauge
plausible_prom_ex_plausible_metrics_cache_user_agents_size 0
# HELP plausible_prom_ex_plausible_metrics_cache_sessions_size
# TYPE plausible_prom_ex_plausible_metrics_cache_sessions_size gauge
plausible_prom_ex_plausible_metrics_cache_sessions_size 0
```

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
