### PR TITLE
Add sites metadata rate limit migration

### DIFF
--- a/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
+++ b/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
@@ -2,6 +2,9 @@ defmodule Plausible.Repo.Migrations.AddRateLimitingToSites do
   use Ecto.Migration
 
   def change do
-
+    alter table(:sites) do
+      add :ingest_rate_limit_scale_seconds, :integer, null: true
+      add :ingest_rate_limit_threshold, :integer, null: true
+    end
   end
 end

--- a/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
+++ b/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddRateLimitingToSites do
 
   def change do
     alter table(:sites) do
-      add :ingest_rate_limit_scale_seconds, :integer, null: true
+      add :ingest_rate_limit_scale_seconds, :integer, null: false, default: 60
       add :ingest_rate_limit_threshold, :integer, null: true
     end
   end

--- a/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
+++ b/priv/repo/migrations/20221109082503_add_rate_limiting_to_sites.exs
@@ -1,0 +1,7 @@
+defmodule Plausible.Repo.Migrations.AddRateLimitingToSites do
+  use Ecto.Migration
+
+  def change do
+
+  end
+end


### PR DESCRIPTION
### Changes

This PR adds postgres migration extending the `sites` tagle with metadata fields required for ingestion rate limiting.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
