### PR TITLE
Fix an issue with hourly stats with non-UTC Clickhouse

### DIFF
--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -67,7 +67,8 @@ defmodule Plausible.Stats.Timeseries do
   def buckets(%Query{interval: "hour"} = query) do
     # Adjusts hourly buckets in accordance with the Clickhouse server timezone.
     # See: https://github.com/plausible/analytics/issues/2432.
-    # TODO: replace with ClickHouse's timezone when it's supported by HTTP API.
+    # It would be better to replace it with ClickHouse's client timezone when
+    # it is supported by HTTP API.
     {:ok, res} = ClickhouseRepo.query("SELECT timezone()")
     [[timezone]] = res.rows
     {first_datetime, _last_datetime} = utc_boundaries(query, timezone)


### PR DESCRIPTION
This commit resolves an issue with Clickhouse configured to use a timezone different from UTC.

With the old code we had the following situation:
1. The hourly buckets are built without taking site's timezone into account. In our case these were just 00:00, 01:00, etc.
2. At the same time Clickhouse query was returning dates that did take both the timezone and UTC into account, i.e. hourly stats were starting from 21:00 previous day (as the Clickhouse server lives in GMT+3 timezone in our case).

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
