### PR TITLE
Fix email links

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -305,11 +305,21 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  defp base_email() do
+  defp base_email(), do: base_email(%{layout: "base_email.html"})
+
+  defp base_email(%{layout: layout}) do
     mailer_from = Application.get_env(:plausible, :mailer_email)
 
     new_email()
     |> put_param("TrackOpens", false)
     |> from(mailer_from)
+    |> maybe_put_layout(layout)
+  end
+
+  defp maybe_put_layout(email, nil), do: email
+
+  defp maybe_put_layout(email, layout) do
+    email
+    |> put_html_layout({PlausibleWeb.LayoutView, layout})
   end
 end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.Email do
   end
 
   def password_reset_email(email, reset_link) do
-    base_email()
+    base_email(%{layout: nil})
     |> to(email)
     |> tag("password-reset-email")
     |> subject("Plausible password reset")
@@ -104,7 +104,7 @@ defmodule PlausibleWeb.Email do
   end
 
   def weekly_report(email, site, assigns) do
-    base_email()
+    base_email(%{layout: nil})
     |> to(email)
     |> tag("weekly-report")
     |> subject("#{assigns[:name]} report for #{site.domain}")

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -139,7 +139,7 @@ defmodule PlausibleWeb.Email do
   end
 
   def enterprise_over_limit_internal_email(user, usage, last_cycle, site_usage, site_allowance) do
-    base_email()
+    base_email(%{layout: nil})
     |> to("enterprise@plausible.io")
     |> tag("enterprise-over-limit")
     |> subject("#{user.email} has outgrown their enterprise plan")

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -188,7 +188,7 @@ defmodule PlausibleWeb.Email do
     |> to(user.email)
     |> tag("cancelled-email")
     |> subject("Your Plausible Analytics subscription has been canceled")
-    |> render("cancellation_email.html", name: user.name)
+    |> render("cancellation_email.html", user: user)
   end
 
   def new_user_invitation(invitation) do
@@ -230,6 +230,7 @@ defmodule PlausibleWeb.Email do
       "[Plausible Analytics] #{invitation.email} accepted your invitation to #{invitation.site.domain}"
     )
     |> render("invitation_accepted.html",
+      user: invitation.inviter,
       invitation: invitation
     )
   end
@@ -242,6 +243,7 @@ defmodule PlausibleWeb.Email do
       "[Plausible Analytics] #{invitation.email} rejected your invitation to #{invitation.site.domain}"
     )
     |> render("invitation_rejected.html",
+      user: invitation.inviter,
       invitation: invitation
     )
   end
@@ -254,6 +256,7 @@ defmodule PlausibleWeb.Email do
       "[Plausible Analytics] #{invitation.email} accepted the ownership transfer of #{invitation.site.domain}"
     )
     |> render("ownership_transfer_accepted.html",
+      user: invitation.inviter,
       invitation: invitation
     )
   end
@@ -266,6 +269,7 @@ defmodule PlausibleWeb.Email do
       "[Plausible Analytics] #{invitation.email} rejected the ownership transfer of #{invitation.site.domain}"
     )
     |> render("ownership_transfer_rejected.html",
+      user: invitation.inviter,
       invitation: invitation
     )
   end
@@ -276,6 +280,7 @@ defmodule PlausibleWeb.Email do
     |> tag("site-member-removed")
     |> subject("[Plausible Analytics] Your access to #{membership.site.domain} has been revoked")
     |> render("site_member_removed.html",
+      user: membership.user,
       membership: membership
     )
   end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -320,9 +320,9 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  defp base_email(), do: base_email(%{layout: "base_email.html"})
+  def base_email(), do: base_email(%{layout: "base_email.html"})
 
-  defp base_email(%{layout: layout}) do
+  def base_email(%{layout: layout}) do
     mailer_from = Application.get_env(:plausible, :mailer_email)
 
     new_email()

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -19,7 +19,7 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("welcome-email")
     |> subject("Welcome to Plausible")
-    |> render("welcome_email.html", user: user)
+    |> render("welcome_email.html", user: user, unsubscribe: true)
   end
 
   def create_site_email(user) do
@@ -27,7 +27,7 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("create-site-email")
     |> subject("Your Plausible setup: Add your website details")
-    |> render("create_site_email.html", user: user)
+    |> render("create_site_email.html", user: user, unsubscribe: true)
   end
 
   def site_setup_help(user, site) do
@@ -35,7 +35,11 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("help-email")
     |> subject("Your Plausible setup: Waiting for the first page views")
-    |> render("site_setup_help_email.html", user: user, site: site)
+    |> render("site_setup_help_email.html",
+      user: user,
+      site: site,
+      unsubscribe: true
+    )
   end
 
   def site_setup_success(user, site) do
@@ -43,7 +47,11 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("setup-success-email")
     |> subject("Plausible is now tracking your website stats")
-    |> render("site_setup_success_email.html", user: user, site: site)
+    |> render("site_setup_success_email.html",
+      user: user,
+      site: site,
+      unsubscribe: true
+    )
   end
 
   def check_stats_email(user) do
@@ -51,7 +59,7 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("check-stats-email")
     |> subject("Check your Plausible website stats")
-    |> render("check_stats_email.html", user: user)
+    |> render("check_stats_email.html", user: user, unsubscribe: true)
   end
 
   def password_reset_email(email, reset_link) do
@@ -67,7 +75,7 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("trial-one-week-reminder")
     |> subject("Your Plausible trial expires next week")
-    |> render("trial_one_week_reminder.html", user: user)
+    |> render("trial_one_week_reminder.html", user: user, unsubscribe: true)
   end
 
   def trial_upgrade_email(user, day, {pageviews, custom_events}) do
@@ -82,7 +90,8 @@ defmodule PlausibleWeb.Email do
       day: day,
       custom_events: custom_events,
       usage: pageviews + custom_events,
-      suggested_plan: suggested_plan
+      suggested_plan: suggested_plan,
+      unsubscribe: true
     )
   end
 
@@ -91,7 +100,7 @@ defmodule PlausibleWeb.Email do
     |> to(user)
     |> tag("trial-over-email")
     |> subject("Your Plausible trial has ended")
-    |> render("trial_over_email.html", user: user)
+    |> render("trial_over_email.html", user: user, unsubscribe: true)
   end
 
   def weekly_report(email, site, assigns) do
@@ -124,7 +133,8 @@ defmodule PlausibleWeb.Email do
       user: user,
       usage: usage,
       last_cycle: last_cycle,
-      suggested_plan: suggested_plan
+      suggested_plan: suggested_plan,
+      unsubscribe: true
     })
   end
 

--- a/lib/plausible_web/templates/email/activation_email.html.eex
+++ b/lib/plausible_web/templates/email/activation_email.html.eex
@@ -1,3 +1,1 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Enter <%= @code %> to verify your email address. This code will expire in 4 hours.

--- a/lib/plausible_web/templates/email/cancellation_email.html.eex
+++ b/lib/plausible_web/templates/email/cancellation_email.html.eex
@@ -1,5 +1,3 @@
-Hi <%= @name %>,
-<br /><br />
 Thanks for being a Plausible Analytics subscriber and I'm sorry to see you go.<br/><br/>
 
 I'd love to hear about your experience and how you think we can improve Plausible Analytics for our other subscribers (and for you if you decide to come back). Please reply back to this email with your feedback.<br /><br />

--- a/lib/plausible_web/templates/email/cancellation_email.html.eex
+++ b/lib/plausible_web/templates/email/cancellation_email.html.eex
@@ -4,5 +4,4 @@ I'd love to hear about your experience and how you think we can improve Plausibl
 
 If you decide you'd like to continue keeping track of your site traffic while respecting the privacy of your visitors, obviously we'd love to have you back. You can restart your subscription from your <a href="https://plausible.io/settings">account settings</a>.<br /><br />
 
-Hope to see you around!<br />
-Uku Taht
+Hope to see you around!

--- a/lib/plausible_web/templates/email/cancellation_email.html.eex
+++ b/lib/plausible_web/templates/email/cancellation_email.html.eex
@@ -1,6 +1,6 @@
-Thanks for being a Plausible Analytics subscriber and I'm sorry to see you go.<br/><br/>
+Thanks for being a Plausible Analytics subscriber and we're sorry to see you go.<br/><br/>
 
-I'd love to hear about your experience and how you think we can improve Plausible Analytics for our other subscribers (and for you if you decide to come back). Please reply back to this email with your feedback.<br /><br />
+We'd love to hear about your experience and how you think we can improve Plausible Analytics for our other subscribers (and for you if you decide to come back). Please reply back to this email with your feedback.<br /><br />
 
 If you decide you'd like to continue keeping track of your site traffic while respecting the privacy of your visitors, obviously we'd love to have you back. You can restart your subscription from your <a href="https://plausible.io/settings">account settings</a>.<br /><br />
 

--- a/lib/plausible_web/templates/email/check_stats_email.html.eex
+++ b/lib/plausible_web/templates/email/check_stats_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Plausible is tracking your website stats without compromising the user experience and the privacy of your visitors.
 <br /><br />
 <%= link("View your Plausible dashboard now", to: "#{plausible_url()}") %> for the most valuable traffic insights at a glance.

--- a/lib/plausible_web/templates/email/check_stats_email.html.eex
+++ b/lib/plausible_web/templates/email/check_stats_email.html.eex
@@ -10,4 +10,3 @@ Uku Taht
 --
 <br /><br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/check_stats_email.html.eex
+++ b/lib/plausible_web/templates/email/check_stats_email.html.eex
@@ -3,10 +3,3 @@ Plausible is tracking your website stats without compromising the user experienc
 <%= link("View your Plausible dashboard now", to: "#{plausible_url()}") %> for the most valuable traffic insights at a glance.
 <br /><br />
 Do reply back to this email if you have any questions or need some guidance.
-<br /></br>
-Thanks,<br />
-Uku Taht
-<br /><br />
---
-<br /><br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/create_site_email.html.eex
+++ b/lib/plausible_web/templates/email/create_site_email.html.eex
@@ -8,4 +8,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/create_site_email.html.eex
+++ b/lib/plausible_web/templates/email/create_site_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 You've activated your free 30-day trial of Plausible, a simple and privacy-friendly website analytics tool.
 <br /><br />
 <%= link("Click here", to: "#{plausible_url()}/sites/new") %> to add your website URL, your timezone and install our one-line JavaScript snippet to start collecting visitor statistics.

--- a/lib/plausible_web/templates/email/create_site_email.html.eex
+++ b/lib/plausible_web/templates/email/create_site_email.html.eex
@@ -3,8 +3,3 @@ You've activated your free 30-day trial of Plausible, a simple and privacy-frien
 <%= link("Click here", to: "#{plausible_url()}/sites/new") %> to add your website URL, your timezone and install our one-line JavaScript snippet to start collecting visitor statistics.
 <br /><br />
 Do reply back to this email if you have any questions or need some guidance.
-<br /></br>
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/dashboard_locked.html.eex
+++ b/lib/plausible_web/templates/email/dashboard_locked.html.eex
@@ -14,8 +14,3 @@ Based on that we recommend you select the <%= @suggested_plan[:volume] %>/mo pla
 The new charge will be prorated to reflect the amount you have already paid and the time until your current subscription is supposed to expire. We will unlock your dashboard immediately after your account has been upgraded to the appropriate tier.
 <br /><br />
 Thanks for understanding and for being a Plausible subscriber!
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/dashboard_locked.html.eex
+++ b/lib/plausible_web/templates/email/dashboard_locked.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Last week we sent a reminder that your traffic has exceeded your Plausible Analytics subscription tier two months in a row.
 <br /><br />
 Your dashboard is now locked. We're still counting your stats, but you no longer have access to the stats. As you have outgrown your subscription tier, we kindly ask you to upgrade your subscription to accommodate your new traffic levels.

--- a/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.eex
+++ b/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.eex
@@ -4,6 +4,3 @@ Customer email: <%= @user.email %><br />
 Last billing cycle: <%= date_format(@last_cycle.first) %> to <%= date_format(@last_cycle.last) %><br >
 Pageview Usage: <%= PlausibleWeb.StatsView.large_number_format(@usage) %> billable pageviews<br />
 Site usage: <%= @site_usage %> / <%= @site_allowance %> allowed sites<br />
-
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/existing_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/existing_user_invitation.html.eex
@@ -1,5 +1,3 @@
-Hey,
-<br /><br />
 <%= @invitation.inviter.email %> has invited you to the <%= @invitation.site.domain %> site on Plausible Analytics.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent.

--- a/lib/plausible_web/templates/email/existing_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/existing_user_invitation.html.eex
@@ -1,8 +1,3 @@
 <%= @invitation.inviter.email %> has invited you to the <%= @invitation.site.domain %> site on Plausible Analytics.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/google_analytics_import.html.eex
+++ b/lib/plausible_web/templates/email/google_analytics_import.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 <%= if @success do %>
   Your Google Analytics import has completed successfully. The Plausible dashboard for <%= @site.domain %> now contains historical imported data from <%= date_format(@site.imported_data.start_date) %> to <%= date_format(@site.imported_data.end_date) %>
 <br /><br />

--- a/lib/plausible_web/templates/email/google_analytics_import.html.eex
+++ b/lib/plausible_web/templates/email/google_analytics_import.html.eex
@@ -29,14 +29,6 @@
 
   <%= if !Application.get_env(:plausible, :is_selfhost) do %>
     <br /> <br />
-
-    Please reply to this email to let us know if you're still experiencing issues with the import. Thanks!
-    <br /> <br />
-
-    The Plausible Team 💌
+    Please reply to this email to let us know if you're still experiencing issues with the import.
   <% end %>
 <% end %>
-<br /><br />
---
-<br /><br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/invitation_accepted.html.eex
+++ b/lib/plausible_web/templates/email/invitation_accepted.html.eex
@@ -1,7 +1,2 @@
 <%= @invitation.email %> has accepted your invitation to <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/invitation_accepted.html.eex
+++ b/lib/plausible_web/templates/email/invitation_accepted.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@invitation.inviter) %>,
-<br /><br />
 <%= @invitation.email %> has accepted your invitation to <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
 <br /><br />

--- a/lib/plausible_web/templates/email/invitation_rejected.html.eex
+++ b/lib/plausible_web/templates/email/invitation_rejected.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@invitation.inviter) %>,
-<br /><br />
 <%= @invitation.email %> has rejected your invitation to <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
 <br /><br />

--- a/lib/plausible_web/templates/email/invitation_rejected.html.eex
+++ b/lib/plausible_web/templates/email/invitation_rejected.html.eex
@@ -1,7 +1,2 @@
 <%= @invitation.email %> has rejected your invitation to <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/new_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/new_user_invitation.html.eex
@@ -2,8 +2,3 @@
 <%= link("Click here", to: Routes.auth_url(PlausibleWeb.Endpoint, :register_from_invitation_form, @invitation.invitation_id)) %> to create your account. The link is valid for 48 hours after this email is sent.
 <br /><br />
 Plausible is a lightweight and open-source website analytics tool. We hope you like our simple and ethical approach to tracking website visitors.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/new_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/new_user_invitation.html.eex
@@ -1,5 +1,3 @@
-Hey,
-<br /><br />
 <%= @invitation.inviter.email %> has invited you to join the <%= @invitation.site.domain %> site on Plausible Analytics.
 <%= link("Click here", to: Routes.auth_url(PlausibleWeb.Endpoint, :register_from_invitation_form, @invitation.invitation_id)) %> to create your account. The link is valid for 48 hours after this email is sent.
 <br /><br />

--- a/lib/plausible_web/templates/email/over_limit.html.eex
+++ b/lib/plausible_web/templates/email/over_limit.html.eex
@@ -18,8 +18,3 @@ You can upgrade your subscription using our self-serve platform. The new charge 
 Have questions or need help with anything? Just reply to this email and we'll gladly help.
 <br /><br />
 Thanks again for using our product and for your support!
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/over_limit.html.eex
+++ b/lib/plausible_web/templates/email/over_limit.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Thanks for being a Plausible Analytics subscriber!
 <br /><br />
 This is a notice that your traffic has exceeded your subscription tier two months in a row. Congrats on all that traffic!

--- a/lib/plausible_web/templates/email/over_limit.html.eex
+++ b/lib/plausible_web/templates/email/over_limit.html.eex
@@ -23,4 +23,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/ownership_transfer_accepted.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_accepted.html.eex
@@ -1,8 +1,3 @@
 <%= @invitation.email %> has accepted the ownership transfer of <%= @invitation.site.domain %>. They will be responsible for billing of it going
 forward and your role has been changed to <b>admin</b>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/ownership_transfer_accepted.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_accepted.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@invitation.inviter) %>,
-<br /><br />
 <%= @invitation.email %> has accepted the ownership transfer of <%= @invitation.site.domain %>. They will be responsible for billing of it going
 forward and your role has been changed to <b>admin</b>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.

--- a/lib/plausible_web/templates/email/ownership_transfer_rejected.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_rejected.html.eex
@@ -1,7 +1,2 @@
 <%= @invitation.email %> has rejected the ownership transfer of <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/ownership_transfer_rejected.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_rejected.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@invitation.inviter) %>,
-<br /><br />
 <%= @invitation.email %> has rejected the ownership transfer of <%= @invitation.site.domain %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)) %> to view site settings.
 <br /><br />

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
@@ -1,5 +1,3 @@
-Hey,
-<br /><br />
 <%= @invitation.inviter.email %> has requested to transfer the ownership of <%= @invitation.site.domain %> site on Plausible Analytics to you.
 <%= if @new_owner_account do %>
   <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view and respond to the invitation.

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
@@ -6,8 +6,3 @@
   <br /><br />
   Plausible is a lightweight and open-source website analytics tool. We hope you like our simple and ethical approach to tracking website visitors.
 <% end %>
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/site_member_removed.html.eex
+++ b/lib/plausible_web/templates/email/site_member_removed.html.eex
@@ -1,8 +1,3 @@
 An administrator of <%= @membership.site.domain %> has removed you as a member. You won't be able to see the stats anymore.
 <br /><br />
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view your sites.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/site_member_removed.html.eex
+++ b/lib/plausible_web/templates/email/site_member_removed.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@membership.user) %>,
-<br /><br />
 An administrator of <%= @membership.site.domain %> has removed you as a member. You won't be able to see the stats anymore.
 <br /><br />
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view your sites.

--- a/lib/plausible_web/templates/email/site_setup_help_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_help_email.html.eex
@@ -7,8 +7,3 @@ To finish your setup for <%= @site.domain %>, you need to install <%= link("this
 This Plausible script is 45 times smaller than Google Analytics script so you’ll have a fast loading site while getting all the important traffic insights on one single page.
 <br /><br />
 Do reply back to this email if you have any questions or need some guidance.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/site_setup_help_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_help_email.html.eex
@@ -12,4 +12,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/site_setup_help_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_help_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 <%= if Plausible.Billing.on_trial?(@user) do %>
   You signed up for a free 30-day trial of Plausible, a simple and privacy-friendly website analytics tool.
   <br /><br />

--- a/lib/plausible_web/templates/email/site_setup_success_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_success_email.html.eex
@@ -9,8 +9,3 @@ Congrats! The Plausible script has been installed correctly on <%= link(@site.do
 PS: You can import your historical Google Analytics (Universal Analytics) stats into your Plausible dashboard. <%= link("Learn how our GA importer works", to: "https://plausible.io/docs/google-analytics-import") %>.
 <br /><br />
 Do reply back to this email if you have any questions.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/site_setup_success_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_success_email.html.eex
@@ -14,4 +14,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/site_setup_success_email.html.eex
+++ b/lib/plausible_web/templates/email/site_setup_success_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Congrats! The Plausible script has been installed correctly on <%= link(@site.domain, to: "https://#{@site.domain}") %>. Your website traffic is now being tracked without compromising the user experience and the privacy of your visitors.
 <br /><br />
 <%= link("Check your stats", to: "#{plausible_url()}/#{URI.encode_www_form(@site.domain)}") %>

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -12,7 +12,3 @@ There are currently <%= @current_visitors %> visitors on <%= link(@site.domain, 
 <br /><br />
 View dashboard: <%= link(@link, to: @link) %>
 <% end %>
-<br /><br />
---
-<br /><br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/spike_notification.html.eex
+++ b/lib/plausible_web/templates/email/spike_notification.html.eex
@@ -10,7 +10,7 @@ There are currently <%= @current_visitors %> visitors on <%= link(@site.domain, 
 
 <%= if @link do %>
 <br /><br />
-View dashboard: @link
+View dashboard: <%= link(@link, to: @link) %>
 <% end %>
 <br /><br />
 --

--- a/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
+++ b/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
@@ -1,7 +1,7 @@
 Time flies! Your 30-day free trial of Plausible will end next week.
 <br /><br />
-Over the last three weeks, I hope you got to experience the potential benefits of having website stats in a simple dashboard while respecting the privacy of your visitors, not annoying them with the cookie and privacy notices and still having a fast loading site.
+Over the last three weeks, We hope you got to experience the potential benefits of having website stats in a simple dashboard while respecting the privacy of your visitors, not annoying them with the cookie and privacy notices and still having a fast loading site.
 <br /><br />
 In order to continue receiving valuable website traffic insights at a glance, you’ll need to <%= link("Upgrade your account", to: "#{plausible_url()}/billing/upgrade") %>.
 <br /><br />
-If you have any questions or feedback for me, feel free to reply to this email.
+If you have any questions or feedback for us, feel free to reply to this email.

--- a/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
+++ b/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
@@ -5,8 +5,3 @@ Over the last three weeks, I hope you got to experience the potential benefits o
 In order to continue receiving valuable website traffic insights at a glance, you’ll need to <%= link("Upgrade your account", to: "#{plausible_url()}/billing/upgrade") %>.
 <br /><br />
 If you have any questions or feedback for me, feel free to reply to this email.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
+++ b/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
@@ -10,4 +10,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
+++ b/lib/plausible_web/templates/email/trial_one_week_reminder.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Time flies! Your 30-day free trial of Plausible will end next week.
 <br /><br />
 Over the last three weeks, I hope you got to experience the potential benefits of having website stats in a simple dashboard while respecting the privacy of your visitors, not annoying them with the cookie and privacy notices and still having a fast loading site.

--- a/lib/plausible_web/templates/email/trial_over_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_over_email.html.eex
@@ -4,9 +4,3 @@ Your free Plausible trial has now expired. Upgrade your account to continue rece
 <br /><br />
 
 We will keep recording stats for another month to give you time to upgrade.
-
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/trial_over_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_over_email.html.eex
@@ -10,4 +10,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/trial_over_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_over_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Your free Plausible trial has now expired. Upgrade your account to continue receiving valuable website traffic insights at a glance while respecting the privacy of your visitors and still having a fast loading site. <br /><br />
 
 <%= link("Upgrade now", to: "#{plausible_url()}/billing/upgrade") %>

--- a/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Thanks for exploring Plausible, a simple and privacy-friendly alternative to Google Analytics. Your free 30-day trial is ending <%= @day %>, but you can keep using Plausible by upgrading to a paid plan.
 <br /><br />
 In the last month, your account has used <%= PlausibleWeb.AuthView.delimit_integer(@usage) %> billable pageviews<%= if @custom_events > 0, do: " and custom events in total", else: "" %>.

--- a/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
@@ -10,8 +10,3 @@ Have a question, feedback or need some guidance? Just reply to this email to get
 <% else %>
 This is more than our standard plans, so please reply back to this email to get a quote for your volume.
 <% end %>
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
@@ -15,4 +15,3 @@ Thanks,<br />
 Uku and Marko<br />
 --<br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/welcome_email.html.eex
+++ b/lib/plausible_web/templates/email/welcome_email.html.eex
@@ -20,4 +20,3 @@ Uku and Marko
 --
 <br />
 <%= plausible_url() %><br />
-{{{ pm:unsubscribe }}}

--- a/lib/plausible_web/templates/email/welcome_email.html.eex
+++ b/lib/plausible_web/templates/email/welcome_email.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 We are building Plausible to provide a simple and ethical approach to tracking website visitors.
 We're super excited to have you on board!
 <br /><br />

--- a/lib/plausible_web/templates/email/welcome_email.html.eex
+++ b/lib/plausible_web/templates/email/welcome_email.html.eex
@@ -13,10 +13,3 @@ Here's how to get the most out of your Plausible experience:
 Then you're ready to start exploring your fast loading, ethical and actionable <%= link("Plausible dashboard", to: "https://plausible.io/sites") %>.
 <br /><br />
 Have a question, feedback or need some guidance? Do reply back to this email.
-<br /><br />
-Thanks,<br />
-Uku and Marko
-<br />
---
-<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
@@ -5,8 +5,3 @@ You need to renew your subscription on <%= link("account settings page", to: "#{
 If you don't want to continue your subscription, there's no action required. You will lose access to the stats on <%= @date %>.
 <br /><br />
 Have a question, feedback or need some guidance? Just reply to this email to get in touch!
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Time flies! This is a reminder that your annual subscription for Plausible Analytics will expire on <%= @date %>.
 <br /><br />
 You need to renew your subscription on <%= link("account settings page", to: "#{plausible_url()}/billing/upgrade") %> if you want to continue using Plausible to count your website stats in a privacy-friendly way.

--- a/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
@@ -5,8 +5,3 @@ There's no action required if you're happy to continue using Plausible to count 
 If you don't want to continue your subscription, you can cancel it on your <%= link("account settings page", to: "#{plausible_url()}/settings") %>.
 <br /><br />
 Have a question, feedback or need some guidance? Do reply back to this email.
-<br /><br />
-Thanks,<br />
-Uku and Marko<br />
---<br />
-<%= plausible_url() %><br />

--- a/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
@@ -1,5 +1,3 @@
-Hey <%= user_salutation(@user) %>,
-<br /><br />
 Time flies! This is a reminder that your annual subscription for Plausible Analytics is due to renew on <%= @date %>. We will automatically charge <%= PlausibleWeb.BillingView.present_currency(@currency) %><%= @next_bill_amount %> from your preferred billing method.
 <br /><br />
 There's no action required if you're happy to continue using Plausible to count your website stats in a privacy-friendly way.

--- a/lib/plausible_web/templates/layout/base_email.html.eex
+++ b/lib/plausible_web/templates/layout/base_email.html.eex
@@ -1,0 +1,24 @@
+<%= case Map.get(assigns, :user) do
+  %{name: name} when is_binary(name) -> "Hey #{String.split(name) |> List.first()},"
+  _any -> "Hey,"
+end %>
+<br /><br />
+
+<%= @inner_content %>
+<br /><br />
+
+Thanks,<br />
+<%= if Application.get_env(:plausible, :is_selfhost) do %>
+Plausible
+<% else %>
+Uku and Marko
+<% end %>
+<br /><br />
+
+--
+<br /><br />
+<%= link(plausible_url(), to: plausible_url()) %><br />
+
+<%= if Map.get(assigns, :unsubscribe, false) do %>
+{{{ pm:unsubscribe }}}
+<% end %>

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -31,7 +31,7 @@ defmodule Plausible.Workers.SpikeNotifier do
     :ok
   end
 
-  def notify(notification, current_visitors, sources) do
+  defp notify(notification, current_visitors, sources) do
     for recipient <- notification.recipients do
       send_notification(recipient, notification.site, current_visitors, sources)
     end
@@ -45,7 +45,7 @@ defmodule Plausible.Workers.SpikeNotifier do
     site = Repo.preload(site, :members)
 
     dashboard_link =
-      if Enum.member?(site.members, recipient) do
+      if Enum.any?(site.members, &(&1.email == recipient)) do
         PlausibleWeb.Endpoint.url() <> "/" <> URI.encode_www_form(site.domain)
       end
 

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -1,0 +1,68 @@
+defmodule PlausibleWeb.EmailTest do
+  alias PlausibleWeb.Email
+  use ExUnit.Case, async: true
+  import Plausible.Factory
+
+  describe "base_email layout" do
+    test "greets user by first name if user in template assigns" do
+      email =
+        Email.base_email()
+        |> Email.render("activation_email.html", %{
+          user: build(:user, name: "John Doe"),
+          code: "123"
+        })
+
+      assert email.html_body =~ "Hey John,"
+    end
+
+    test "greets impersonally when user not in template assigns" do
+      email =
+        Email.base_email()
+        |> Email.render("password_reset_email.html", %{
+          reset_link: "imaginary"
+        })
+
+      assert email.html_body =~ "Hey,"
+    end
+
+    test "renders plausible link" do
+      email =
+        Email.base_email()
+        |> Email.render("cancellation_email.html")
+
+      assert email.html_body =~ plausible_link()
+    end
+
+    test "does not render unsubscribe placeholder by default" do
+      email =
+        Email.base_email()
+        |> Email.render("welcome_email.html")
+
+      refute email.html_body =~ "{{{ pm:unsubscribe }}}"
+    end
+
+    test "renders unsubscribe placeholder if told" do
+      email =
+        Email.base_email()
+        |> Email.render("welcome_email.html", %{unsubscribe: true})
+
+      assert email.html_body =~ "{{{ pm:unsubscribe }}}"
+    end
+
+    test "can be disabled with a nil layout" do
+      email =
+        Email.base_email(%{layout: nil})
+        |> Email.render("welcome_email.html", %{
+          user: build(:user, name: "John Doe")
+        })
+
+      refute email.html_body =~ "Hey John,"
+      refute email.html_body =~ plausible_link()
+    end
+  end
+
+  def plausible_link() do
+    plausible_url = PlausibleWeb.EmailView.plausible_url()
+    "<a href=\"#{plausible_url}\">#{plausible_url}</a>"
+  end
+end

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -85,4 +85,18 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     assert_no_emails_delivered()
   end
+
+  test "adds a dashboard link if recipient has access to the site" do
+    user = insert(:user, email: "robert@example.com")
+    site = insert(:site, domain: "example.com", members: [user])
+    insert(:spike_notification, site: site, threshold: 10, recipients: ["robert@example.com"])
+
+    clickhouse_stub =
+      stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
+      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+
+    SpikeNotifier.perform(nil, clickhouse_stub)
+
+    assert_email_delivered_with(html_body: ~r/View dashboard: <a href=\"http.+\/example.com/)
+  end
 end


### PR DESCRIPTION
### Changes

- [x] Fix a bug where dashboard links were not rendered in traffic spike emails (+ test)
  - bug: https://github.com/plausible/analytics/issues/2120
- [x] Wrap the `plausible_url()` in the email footer into a link element to make it clickable in every email client
- [x] Create a standard email layout template called `base_email` that does the following:
  - greets the user by first name if a user is given in the template assigns
  - renders the https://plausible.io link in the footer
  - renders the Postmark unsubscribe placeholder, if `unsubscribe: true` is in the template assigns.
  - adds
    ```
    Thanks,
    Uku and Marko
    ```
    to the email footer, or
    ```
    Thanks,
    Plausible
    ```
    when application is self-hosted

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
