### PR TITLE
Update sites cache implementation

### DIFF
--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -54,8 +54,8 @@ defmodule Plausible.Site.Cache do
     )
   end
 
-  @spec prefill(Keyword.t()) :: :ok
-  def prefill(opts) do
+  @spec refresh_all(Keyword.t()) :: :ok
+  def refresh_all(opts) do
     cache_name = Keyword.fetch!(opts, :cache_name)
 
     sites_by_domain_query =

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -143,11 +143,12 @@ defmodule Plausible.Site.Cache do
     measure_duration_with_metadata(telemetry_event_refresh(cache_name, :one), fn ->
       {found_in_db?, item_to_cache} = select_one(domain)
 
-      with {:ok, _} <- Cachex.put(cache_name, domain, item_to_cache) do
-        result = {:ok, item_to_cache}
-        {result, with_telemetry_metadata(found_in_db?: found_in_db?)}
-      else
-        error ->
+      case Cachex.put(cache_name, domain, item_to_cache) do
+        {:ok, _} ->
+          result = {:ok, item_to_cache}
+          {result, with_telemetry_metadata(found_in_db?: found_in_db?)}
+
+        {:error, _} = error ->
           {error, with_telemetry_metadata(error: true)}
       end
     end)

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -1,13 +1,13 @@
 defmodule Plausible.Site.Cache do
   @moduledoc """
-  A sites by domain caching interface.
+  A "sites by domain" caching interface.
 
   Serves as a thin wrapper around Cachex, but the underlying
   implementation can be transparently swapped.
 
   Even though the Cachex process is started, cache access is disabled
   during tests via the `:sites_by_domain_cache_enabled` application env key.
-  This can be overriden on case by case basis, using the child specs options.
+  This can be overridden on case by case basis, using the child specs options.
 
   When Cache is disabled via application env, the `get/1` function
   falls back to pure database lookups. This should help with introducing
@@ -19,8 +19,26 @@ defmodule Plausible.Site.Cache do
   database counterpart -- to spare bandwidth and query execution time,
   only selected database columns are retrieved and cached.
 
+  There are two modes of refreshing the cache: `:all` and `:single`.
+
+    * `:all` means querying the database for all Site entries and should be done
+      periodically (via `Cache.Warmer`). All existing Cache entries all cleared 
+      prior to writing the new batch.
+
+    * `:single` attempts to re-query a specific site by domain and should be done
+      only when the initial Cache.get attempt resulted with `nil`. Single refresh will
+      write `%Ecto.NoResultsError{}` to the cache so that subsequent Cache.get calls
+      indicate that we already failed to retrieve a Site.
+
+      This helps in recognising missing/deleted Sites with minimal number of DB lookups
+      across a disconnected cluster within the periodic refresh window.
+
+      Refreshing a single Site emits a telemetry event including `duration` measurement
+      and meta-data indicating whether the site was found in the DB or is missing still.
+      The telemetry event is defined with `telemetry_event_refresh/2`.
+
   The `@cached_schema_fields` attribute defines the list of DB columns
-  queried on cache pre-fill.
+  queried on each cache refresh.
 
   Also see tests for more comprehensive examples.
   """
@@ -58,20 +76,22 @@ defmodule Plausible.Site.Cache do
   def refresh_all(opts) do
     cache_name = Keyword.fetch!(opts, :cache_name)
 
-    sites_by_domain_query =
-      from s in Site,
-        select: {
-          s.domain,
-          %{struct(s, ^@cached_schema_fields) | from_cache?: true}
-        }
+    measure_duration(telemetry_event_refresh(cache_name, :all), fn ->
+      sites_by_domain_query =
+        from s in Site,
+          select: {
+            s.domain,
+            %{struct(s, ^@cached_schema_fields) | from_cache?: true}
+          }
 
-    sites_by_domain = Plausible.Repo.all(sites_by_domain_query)
+      sites_by_domain = Plausible.Repo.all(sites_by_domain_query)
 
-    Cachex.clear!(cache_name)
+      Cachex.clear!(cache_name)
 
-    if not Enum.empty?(sites_by_domain) do
-      true = Cachex.put_many!(cache_name, sites_by_domain)
-    end
+      if not Enum.empty?(sites_by_domain) do
+        true = Cachex.put_many!(cache_name, sites_by_domain)
+      end
+    end)
 
     :ok
   end
@@ -118,27 +138,62 @@ defmodule Plausible.Site.Cache do
     cache_name = Keyword.get(opts, :cache_name, @cache_name)
     force? = Keyword.get(opts, :force?, false)
 
-    if enabled?() or force? do
-      site_by_domain_query =
-        from s in Site,
-          where: s.domain == ^domain,
-          select: %{struct(s, ^@cached_schema_fields) | from_cache?: true}
+    if not enabled?() and not force?, do: raise("Cache: '#{cache_name}' is disabled")
 
-      cached_item =
-        case Plausible.Repo.one(site_by_domain_query) do
-          nil -> %Ecto.NoResultsError{}
-          site -> site
-        end
+    measure_duration_with_metadata(telemetry_event_refresh(cache_name, :one), fn ->
+      {found_in_db?, item_to_cache} = select_one(domain)
 
-      with {:ok, _} <- Cachex.put(cache_name, domain, cached_item) do
-        {:ok, cached_item}
+      with {:ok, _} <- Cachex.put(cache_name, domain, item_to_cache) do
+        result = {:ok, item_to_cache}
+        {result, with_telemetry_metadata(found_in_db?: found_in_db?)}
+      else
+        error ->
+          {error, with_telemetry_metadata(error: true)}
       end
-    else
-      raise "Cache: '#{cache_name}' is disabled"
-    end
+    end)
+  end
+
+  @spec telemetry_event_refresh(atom(), :all | :one) :: list(atom())
+  def telemetry_event_refresh(cache_name, mode) when mode in [:all, :one] do
+    [:plausible, :cache, cache_name, :refresh, mode]
   end
 
   def enabled?() do
     Application.fetch_env!(:plausible, :sites_by_domain_cache_enabled) == true
+  end
+
+  defp select_one(domain) do
+    site_by_domain_query =
+      from s in Site,
+        where: s.domain == ^domain,
+        select: %{struct(s, ^@cached_schema_fields) | from_cache?: true}
+
+    case Plausible.Repo.one(site_by_domain_query) do
+      nil -> {false, %Ecto.NoResultsError{}}
+      site -> {true, site}
+    end
+  end
+
+  defp with_telemetry_metadata(props) do
+    Enum.into(props, %{})
+  end
+
+  defp measure_duration_with_metadata(event, fun) when is_function(fun, 0) do
+    {duration, {result, telemetry_metadata}} = time_it(fun)
+    :telemetry.execute(event, %{duration: duration}, telemetry_metadata)
+    result
+  end
+
+  defp measure_duration(event, fun) when is_function(fun, 0) do
+    {duration, result} = time_it(fun)
+    :telemetry.execute(event, %{duration: duration}, %{})
+    result
+  end
+
+  defp time_it(fun) do
+    start = System.monotonic_time()
+    result = fun.()
+    stop = System.monotonic_time()
+    {stop - start, result}
   end
 end

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -57,7 +57,8 @@ defmodule Plausible.Site.Cache do
      ingest_rate_limit_threshold
    )a
 
-  @type t() :: Site.t() | Ecto.NoResultsError.t()
+  @type not_found_in_db() :: %Ecto.NoResultsError{}
+  @type t() :: Site.t() | not_found_in_db()
 
   def name(), do: @cache_name
 

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -68,7 +68,11 @@ defmodule Plausible.Site.Cache do
     sites_by_domain = Plausible.Repo.all(sites_by_domain_query)
 
     Cachex.clear!(cache_name)
-    true = Cachex.put_many!(cache_name, sites_by_domain)
+
+    if not Enum.empty?(sites_by_domain) do
+      true = Cachex.put_many!(cache_name, sites_by_domain)
+    end
+
     :ok
   end
 

--- a/lib/plausible/site/cache/warmer.ex
+++ b/lib/plausible/site/cache/warmer.ex
@@ -35,9 +35,11 @@ defmodule Plausible.Site.Cache.Warmer do
 
   @spec child_spec(Keyword.t()) :: Supervisor.child_spec() | :ignore
   def child_spec(opts) do
+    child_name = Keyword.get(opts, :child_name, {:local, __MODULE__})
+
     %{
       id: __MODULE__,
-      start: {:gen_cycle, :start_link, [{:local, __MODULE__}, __MODULE__, opts]}
+      start: {:gen_cycle, :start_link, [child_name, __MODULE__, opts]}
     }
   end
 

--- a/lib/plausible/site/cache/warmer.ex
+++ b/lib/plausible/site/cache/warmer.ex
@@ -65,7 +65,7 @@ defmodule Plausible.Site.Cache.Warmer do
     measure_duration(telemetry_event_refresh(cache_name), fn ->
       Logger.info("Refreshing #{cache_name} cache...")
 
-      warmer_fn = Keyword.get(opts, :warmer_fn, &Cache.prefill/1)
+      warmer_fn = Keyword.get(opts, :warmer_fn, &Cache.refresh_all/1)
 
       warmer_fn.(opts)
     end)

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -36,7 +36,7 @@ defmodule Plausible.Site.CacheTest do
       %{id: first_id} = site1 = insert(:site, domain: "site1.example.com")
       _ = insert(:site, domain: "site2.example.com")
 
-      :ok = Cache.prefill(cache_name: test)
+      :ok = Cache.refresh_all(cache_name: test)
 
       {:ok, _} = Plausible.Repo.delete(site1)
 
@@ -57,7 +57,7 @@ defmodule Plausible.Site.CacheTest do
       {:ok, _} = start_test_cache(test)
 
       insert(:site, domain: "site1.example.com")
-      :ok = Cache.prefill(cache_name: test)
+      :ok = Cache.refresh_all(cache_name: test)
 
       assert Cache.hit_rate(test) == 0
       assert Cache.get("site1.example.com", force?: true, cache_name: test)
@@ -141,7 +141,7 @@ defmodule Plausible.Site.CacheTest do
       assert at3 > at2
     end
 
-    test "deleted sites don't stay in cache on another prefill", %{test: test} do
+    test "deleted sites don't stay in cache on another refresh", %{test: test} do
       {:ok, _} = start_test_cache(test)
 
       domain1 = "site1.example.com"
@@ -152,14 +152,14 @@ defmodule Plausible.Site.CacheTest do
 
       cache_opts = [cache_name: test, force?: true]
 
-      :ok = Cache.prefill(cache_opts)
+      :ok = Cache.refresh_all(cache_opts)
 
       assert Cache.get(domain1, cache_opts)
       assert Cache.get(domain2, cache_opts)
 
       Repo.delete!(site1)
 
-      :ok = Cache.prefill(cache_opts)
+      :ok = Cache.refresh_all(cache_opts)
 
       assert Cache.get(domain2, cache_opts)
 


### PR DESCRIPTION
### Changes

This is a follow-up PR to https://github.com/plausible/analytics/pull/2434 and a ground work for rate limiting ingestion, cherry-picked from a work in progress PR to hopefully keep the changes isolated and easier to review.
 
Reviewing commits one by one should give a better picture of how the ideas evolved.

Summary:
  - the tests have been reorganized
  - the `Cache` interface makes it now possible to either refresh the whole cache or re-query a single item once to account for deleted/missing domains (this will be again addressed later in greater detail)
  - warmer responsibility was reduced, tests simplified
  - more consistent/comprehensive telemetry instrumentation

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
