### PR TITLE
Stop relying on npm-bin (hard deprecated)

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -3,12 +3,12 @@
   "version": "1.4.0",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "deploy": "$(npm bin)/webpack --mode production",
-    "watch": "$(npm bin)/webpack --mode development --watch",
-    "format": "$(npm bin)/prettier --write {css,js}/**",
-    "check-format": "$(npm bin)/prettier --check {css,js}/**",
-    "lint": "$(npm bin)/eslint js/**",
-    "bundlemon": "$(npm bin)/bundlemon"
+    "deploy": "webpack --mode production",
+    "watch": "webpack --mode development --watch",
+    "format": "prettier --write {css,js}/**",
+    "check-format": "prettier --check {css,js}/**",
+    "lint": "eslint js/**",
+    "bundlemon": "bundlemon"
   },
   "dependencies": {
     "@babel/core": "^7.14.3",


### PR DESCRIPTION
### Changes
 
![image](https://user-images.githubusercontent.com/173738/202197453-3566eaa9-9abf-48b6-a1e9-1d0f34ec2ca7.png)

We're running npm@latest so `npm bin` is gone making builds fail. Example https://github.com/plausible/analytics/actions/runs/3479317335/jobs/5818525028
