### PR TITLE
fix ownership transfer when is_selfhost=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - ARM64 support for docker images plausible/analytics#2103
 - Add support for international domain names (IDNs) plausible/analytics#2034
 - Allow self-hosters to register an account on first launch
+- Fix ownership transfer invitation link in self-hosted deployments
 
 ### Fixed
 - Plausible script does not prevent default if it's been prevented by an external script [plausible/analytics#1941](https://github.com/plausible/analytics/issues/1941)

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -68,7 +68,9 @@ defmodule PlausibleWeb.InvitationController do
   end
 
   defp maybe_end_trial_of_new_owner(multi, new_owner) do
-    if !Application.get_env(:plausible, :is_selfhost) do
+    if Application.get_env(:plausible, :is_selfhost) do
+      multi
+    else
       end_trial_of_new_owner(multi, new_owner)
     end
   end


### PR DESCRIPTION
### Changes

Fixes invitation links for ownership transfer in self-hosted setups.

More info: https://github.com/plausible/analytics/discussions/2051

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI