### PR TITLE
Fix target container is not a DOM element

### DIFF
--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -26,8 +26,8 @@
     data-is-dbip="<%= @is_dbip %>"
     data-current-user-role="<%= @conn.assigns[:current_user_role] %>"
     data-flags="<%= Jason.encode!(@flags) %>"
-    data-valid-intervals-by-period="<%= Plausible.Stats.Interval.valid_by_period() |> Jason.encode!() %>"
-  />
+    data-valid-intervals-by-period="<%= Plausible.Stats.Interval.valid_by_period() |> Jason.encode!() %>">
+  </div>
   <div id="modal_root"></div>
   <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
     <div class="bg-gray-50 dark:bg-gray-850">


### PR DESCRIPTION
This commit fixes a bug where opening modals resulted in a `target container is not a DOM element` error. This was caused by a change in #1574, that was not closing the div that mounts React as expected.