### PR TITLE
Migration: index Sites.updated_at

### DIFF
--- a/priv/repo/migrations/20221123104203_index_updated_at_for_sites.exs
+++ b/priv/repo/migrations/20221123104203_index_updated_at_for_sites.exs
@@ -1,0 +1,7 @@
+defmodule Plausible.Repo.Migrations.IndexUpdatedAtForSites do
+  use Ecto.Migration
+
+  def change do
+    create index(:sites, :updated_at)
+  end
+end


### PR DESCRIPTION
### Changes

This PR is a migration putting index on `sites.updated_at` - potentially useful for grabbing the newly created/edited sites when a new caching layer is introduced.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
