### PR TITLE
Pass interval param to CSV export

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -233,7 +233,9 @@ class LineGraph extends React.Component {
           </div>
         )
       } else {
-        const endpoint = `/${encodeURIComponent(this.props.site.domain)}/export${api.serializeQuery(this.props.query)}`
+        const interval = this.props.graphData?.interval || this.state.interval
+        const queryParams = api.serializeQuery(this.props.query, [{ interval }])
+        const endpoint = `/${encodeURIComponent(this.props.site.domain)}/export${queryParams}`
 
         return (
           <a className="w-4 h-4 mx-2" href={endpoint} download onClick={this.downloadSpinner.bind(this)}>


### PR DESCRIPTION
### Changes

This commit adds the interval param to the CSV export client-side request.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
