### PR TITLE
Add keyboard navigation to intervals

### DIFF
--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -22,6 +22,7 @@ import {
   isAfter,
 } from "./util/date";
 import { navigateToQuery, QueryLink, QueryButton } from "./query";
+import { shouldIgnoreKeypress } from "./keybinding.js"
 
 function renderArrow(query, site, period, prevDate, nextDate) {
   const insertionDate = parseUTCDate(site.statsBegin);
@@ -133,8 +134,7 @@ class DatePicker extends React.Component {
   handleKeydown(e) {
     const { query, history } = this.props;
 
-    if (e.target.tagName === 'INPUT') return true;
-    if (e.ctrlKey || e.metaKey || e.altKey || e.isComposing || e.keyCode === 229) return true;
+    if (shouldIgnoreKeypress(e)) return true
 
     const newSearch = {
       period: false,

--- a/assets/js/dashboard/keybinding.js
+++ b/assets/js/dashboard/keybinding.js
@@ -1,0 +1,35 @@
+/**
+ * Returns whether a keydown or keyup event should be ignored or not.
+ *
+ * Keybindings are ignored when a modifier key is pressed, for example, if the
+ * keybinding is <i>, but the user pressed <Ctrl-i> or <Meta-i>, the event
+ * should be discarded.
+ *
+ * Another case for ignoring a keybinding, is when the user is typing into a
+ * form, and presses the keybinding. For example, if the keybinding is <p> and
+ * the user types <apple>, the event should also be discarded.
+ *
+ * @param {*} event - Captured HTML DOM event
+ * @return {boolean} Whether the event should be ignored or not.
+ *
+ */
+export function shouldIgnoreKeypress(event) {
+  const modifierPressed = event.ctrlKey || event.metaKey || event.altKey || event.keyCode == 229
+  const isTyping = event.isComposing || event.target.tagName == "INPUT" || event.target.tagName == "TEXTAREA"
+
+  return modifierPressed || isTyping
+}
+
+
+/**
+ * Returns whether the given keybinding has been pressed and should be
+ * processed. Events can be ignored based on `shouldIgnoreKeypress(event)`.
+ *
+ * @param {string} keybinding - The target key to checked, e.g. `"i"`.
+ * @return {boolean} Whether the event should be processed or not.
+ *
+ */
+export function isKeyPressed(event, keybinding) {
+  const keyPressed = event.key.toLowerCase() == keybinding.toLowerCase() 
+  return keyPressed && !shouldIgnoreKeypress(event)
+}

--- a/assets/js/dashboard/stats/graph/interval-picker.js
+++ b/assets/js/dashboard/stats/graph/interval-picker.js
@@ -1,8 +1,9 @@
 import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
-import React, { Fragment } from 'react';
+import React, { Fragment, useCallback, useEffect } from 'react';
 import classNames from 'classnames'
 import * as storage from '../../util/storage'
+import { isKeyPressed } from '../../keybinding.js'
 
 export const INTERVAL_LABELS = {
   'minute': 'Minutes',
@@ -18,6 +19,17 @@ export const getStoredInterval = function(period, domain) {
 
 export const storeInterval = function(period, domain, interval) {
   storage.setItem(`interval__${period}__${domain}`, interval)
+}
+
+function subscribeKeybinding(element) {
+  const handleKeyPress = useCallback((event) => {
+    if (isKeyPressed(event, "i")) element.current?.click()
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress)
+    return () => document.removeEventListener('keydown', handleKeyPress)
+  }, [handleKeyPress])
 }
 
 function DropdownItem({ option, currentInterval, updateInterval }) {
@@ -39,29 +51,35 @@ function DropdownItem({ option, currentInterval, updateInterval }) {
 export function IntervalPicker({ graphData, query, site, updateInterval }) {
   if (query.period == 'realtime') return null
 
+  const menuElement = React.useRef(null)
+  subscribeKeybinding(menuElement)
+
   const currentInterval = graphData?.interval
   const options = site.validIntervalsByPeriod[query.period]
 
   return (
     <Menu as="div" className="relative inline-block pl-2">
-      <Menu.Button className="text-sm inline-flex focus:outline-none text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-600 items-center">
-        { INTERVAL_LABELS[currentInterval] }
-        <ChevronDownIcon className="w-4 h-4" aria-hidden="true" />
-      </Menu.Button>
+      {({ open }) => (
+        <>
+          <Menu.Button ref={menuElement} className="text-sm inline-flex focus:outline-none text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-600 items-center">
+            { INTERVAL_LABELS[currentInterval] }
+            <ChevronDownIcon className="w-4 h-4" aria-hidden="true" />
+          </Menu.Button>
 
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <Menu.Items className="py-1 text-left origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
-          { options.map((option) => DropdownItem({ option, currentInterval, updateInterval })) }
-        </Menu.Items>
-      </Transition>
+          <Transition
+            show={open}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95">
+            <Menu.Items className="py-1 text-left origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-10" static>
+              { options.map((option) => DropdownItem({ option, currentInterval, updateInterval })) }
+            </Menu.Items>
+          </Transition>
+        </>
+      )}
     </Menu>
   )
 }


### PR DESCRIPTION
### Changes

This pull request adds keyboard navigation to intervals. Pressing `<i>` will open the interval menu, and pressing `<i>` again will close it. You can navigate with arrows and press `<Enter>` to select an interval.

![out](https://user-images.githubusercontent.com/5093045/203830180-f8718c9f-295d-49bb-8ce8-11b5c5bcdbdc.gif)

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
