### PR TITLE
Standardise dropdown icon margins

### DIFF
--- a/assets/js/dashboard/stats/graph/interval-picker.js
+++ b/assets/js/dashboard/stats/graph/interval-picker.js
@@ -63,7 +63,7 @@ export function IntervalPicker({ graphData, query, site, updateInterval }) {
         <>
           <Menu.Button ref={menuElement} className="text-sm inline-flex focus:outline-none text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-600 items-center">
             { INTERVAL_LABELS[currentInterval] }
-            <ChevronDownIcon className="w-4 h-4" aria-hidden="true" />
+            <ChevronDownIcon className="ml-1 h-4 w-4" aria-hidden="true" />
           </Menu.Button>
 
           <Transition

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -303,8 +303,8 @@ export default class SourceList extends React.Component {
         <Menu as="div" className="relative inline-block text-left">
           <div>
             <Menu.Button className="inline-flex justify-between focus:outline-none">
-              <span style={{ width: '4.2rem' }} className={this.state.tab.startsWith('utm_') ? activeClass : defaultClass}>{buttonText}</span>
-              <ChevronDownIcon className="-mr-1 ml-px h-4 w-4" aria-hidden="true" />
+              <span className={this.state.tab.startsWith('utm_') ? activeClass : defaultClass}>{buttonText}</span>
+              <ChevronDownIcon className="-mr-1 ml-1 h-4 w-4" aria-hidden="true" />
             </Menu.Button>
           </div>
 


### PR DESCRIPTION
⚠️ To be reviewed and merged after #2470, as I created this on top of #2470 to avoid merge conflicts.

### Changes

This commit standardises the dropdown icon spacing used for "intervals" and "campaigns". The screenshots below help spotting the difference. "Intervals" needed more space, "campagins" had too much.

#### Before
<img width="1792" alt="Screenshot 2022-11-24 at 15 24 57" src="https://user-images.githubusercontent.com/5093045/203848035-f4dbff47-da02-400f-b2e6-72ccb91444ca.png">

#### After
<img width="1792" alt="Screenshot 2022-11-24 at 15 24 56" src="https://user-images.githubusercontent.com/5093045/203848031-94d07059-0381-4405-be61-f11ccabe22a8.png">