### PR TITLE
Remove intervals feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Set a different interval on the top graph plausible/analytics#1574 (thanks to @Vigasaurus for this feature)
 - A `tagged-events` script extension for out-of-the-box custom event tracking
 - The ability to escape `|` characters with `\` in Stats API filter values
 - An upper bound of 1000 to the `limit` parameter in Stats API

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -295,8 +295,7 @@ class LineGraph extends React.Component {
             { this.downloadLink() }
             { this.samplingNotice() }
             { this.importedNotice() }
-            { site.flags && site.flags.intervals &&
-              <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={this.props.updateInterval}/> }
+            <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={this.props.updateInterval}/>
           </div>
           <FadeIn show={graphData}>
             <canvas id="main-graph-canvas" className={'mt-4 select-none ' + extraClass} width="1054" height="342"></canvas>

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -308,8 +308,7 @@ defmodule PlausibleWeb.StatsController do
 
   defp get_flags(user) do
     %{
-      custom_dimension_filter: FunWithFlags.enabled?(:custom_dimension_filter, for: user),
-      intervals: FunWithFlags.enabled?(:intervals, for: user)
+      custom_dimension_filter: FunWithFlags.enabled?(:custom_dimension_filter, for: user)
     }
   end
 


### PR DESCRIPTION
This commit removes the intervals feature flag, as this feature has already been released to 100% of the users.