### PR TITLE
Trim the value in case it contains newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - Restore compatibility with older format of shared links [plausible/analytics#2225](https://github.com/plausible/analytics/pull/2225)
 - Fix 'All time' period for sites with no recorded stats [plausible/analytics#2277](https://github.com/plausible/analytics/pull/2277)
 - Ensure settings page can be rendered after a form error [plausible/analytics#2278](https://github.com/plausible/analytics/pull/2278)
+- Ensure newlines from settings files are trimmed [plausible/analytics#2480](https://github.com/plausible/analytics/pull/2480)
 
 ### Changed
 - `script.file-downloads.outbound-links.js` only sends an outbound link event when an outbound download link is clicked

--- a/lib/plausible/helpers/config.ex
+++ b/lib/plausible/helpers/config.ex
@@ -3,7 +3,7 @@ defmodule Plausible.ConfigHelpers do
     var_path = Path.join(config_dir, var_name)
 
     if File.exists?(var_path) do
-      File.read!(var_path)
+      File.read!(var_path) |> String.trim()
     else
       System.get_env(var_name, default)
     end


### PR DESCRIPTION
### Changes

Hello friends, I'm trying to self-host plausible on my server and have observed that if I add a file named (for example) `secrets/LISTEN_IP` to configure the bind IP I'll get the following error:

```
Compiling 1 file (.ex)
** (RuntimeError) Invalid LISTEN_IP '172.19.130.83
' error: :einval
    /home/serafeim/plausible/config/runtime.exs:20: (file)
```

(notice that I get the same error when configuring the DATABASE_URL or whatever comes first)

It seems that for whatever reason the File.read! will insert a newline at the end of the file. Notice that I have double checked the file with vim and *it does not contain a newline at the end* or at least I don't know *how* to make the file not have a newline at the end.

Thus I'm adding a `String.trim()` there to fix that thing; even if I am doing something wrong and my files *do* contain a newline at the end, adding a `String.trim()` there definite won't hurt :)

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
