### PR TITLE
Use fetch with keepalive when available

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -98,16 +98,32 @@
     payload.h = 1
     {{/if}}
 
-    var request = new XMLHttpRequest();
-    request.open('POST', endpoint, true);
-    request.setRequestHeader('Content-Type', 'text/plain');
+    if (window.fetch) {
+      // if fetch is available, use it because the 'keepalive' flag
+      // will ensure delivery even if the user navigates away
+      window.fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        keepalive: true,
+      }).then(() => {
+        options && options.callback && options.callback();
+      });
+    } else {
+      // fallback to XMLHttpRequest
+      var request = new XMLHttpRequest();
+      request.open('POST', endpoint, true);
+      request.setRequestHeader('Content-Type', 'text/plain');
 
-    request.send(JSON.stringify(payload));
+      request.send(JSON.stringify(payload));
 
-    request.onreadystatechange = function() {
-      if (request.readyState === 4) {
-        options && options.callback && options.callback()
-      }
+      request.onreadystatechange = function() {
+        if (request.readyState === 4) {
+          options && options.callback && options.callback();
+        }
+      };
     }
   }
 


### PR DESCRIPTION
### Changes

For link tracking (sending an event when clicking a link), it's useful if immediate navigation is allowed, while still having the event sent.

```js
// example code; real usage would be slightly different
window.addEventListner('click', (event) => {
  if (event.target.matches('a[href]')) {
    plausibleTracker.trackEvent('Outbound Link: Click', { props: { url: event.target.href });
  }
});
```

The `keepalive` flag in fetch [does just that](https://css-tricks.com/send-an-http-request-on-page-exit/).

I don't know if you consider fetch [available enough](https://caniuse.com/fetch) to ditch XHR, but for now I kept XHR as a fallback choice.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
