### PR TITLE
Add Content-Security-Policy to favicon Plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ All notable changes to this project will be documented in this file.
 - Do not display ZZ country code in countries report [PR#1934](https://github.com/plausible/analytics#2223)
 - Add fallback icon for when DDG favicon cannot be fetched [PR#2279](https://github.com/plausible/analytics#2279)
 
+### Security
+- Add Content-Security-Policy header to favicon path
+
 ## v1.4.1 - 2021-11-29
 
 ### Fixed

--- a/test/plausible_web/plugs/favicon_test.exs
+++ b/test/plausible_web/plugs/favicon_test.exs
@@ -38,6 +38,26 @@ defmodule PlausibleWeb.FaviconTest do
     assert conn.resp_body == "favicon response body"
   end
 
+  test "sets content-disposition and content-security-policy", %{plug_opts: plug_opts} do
+    expect(
+      Plausible.HTTPClient.Mock,
+      :get,
+      fn "https://icons.duckduckgo.com/ip3/plausible.io.ico" ->
+        {:ok, %Finch.Response{status: 200, body: "favicon response body"}}
+      end
+    )
+
+    conn =
+      conn(:get, "/favicon/sources/plausible.io")
+      |> Favicon.call(plug_opts)
+
+    assert conn.halted
+    assert conn.status == 200
+    assert conn.resp_body == "favicon response body"
+    assert Plug.Conn.get_resp_header(conn, "content-security-policy") == ["script-src 'none'"]
+    assert Plug.Conn.get_resp_header(conn, "content-disposition") == ["attachment"]
+  end
+
   test "maps a categorized source to URL for favicon", %{plug_opts: plug_opts} do
     expect(
       Plausible.HTTPClient.Mock,
@@ -79,10 +99,7 @@ defmodule PlausibleWeb.FaviconTest do
 
     assert conn.halted
     assert conn.status == 200
-
-    assert conn.resp_headers == [
-             {"content-type", "should-pass-through"}
-           ]
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["should-pass-through"]
   end
 
   test "overrides content-type header if proxied response starts with <svg", %{
@@ -106,10 +123,7 @@ defmodule PlausibleWeb.FaviconTest do
       |> Favicon.call(plug_opts)
 
     assert conn.halted
-
-    assert conn.resp_headers == [
-             {"content-type", "image/svg+xml; charset=utf-8"}
-           ]
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["image/svg+xml; charset=utf-8"]
   end
 
   describe "Fallback to placeholder icon" do


### PR DESCRIPTION
### Changes

This commit adds two headers as additional security on favicons.

This commit updates the favicon Plug to set a strict `Content-Security-Policy` header telling the browser not to run scripts. Additionally, it sets `Content-Disposition=attachment` to prevent the SVG from rendering when navigating to `/favicon/sources/:domain` directly.

SVGs may contain `<script>` tags, and as these SVGs come from external sources, we need to prevent untrusted code from running on the browser.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
