### PR TITLE
Mirror Docker images to GHCR

### DIFF
--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -8,12 +8,18 @@ jobs:
   build:
     runs-on: buildjet-4vcpu-ubuntu-2004
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: plausible/analytics
+          images: |
+            plausible/analytics
+            ghcr.io/plausible/analytics
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -31,9 +37,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### Changes

This PR mirrors all Docker images to GitHub Container Registry, so they're available at `ghcr.io/plausible/analytics`.

Docker Hub is severely [rate-limiting pulls](https://docs.docker.com/docker-hub/download-rate-limit/) these days, as little as 100 pulls per 6 hours per IP (especially bad for people behind CG-NAT).

### Tests
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
