### PR TITLE
Add metric ID to HTML

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -106,7 +106,7 @@ export default class TopStats extends React.Component {
             {statExtraName && <span className="hidden sm:inline-block ml-1">{statExtraName}</span>}
           </div>
           <div className="flex items-center justify-between my-1 whitespace-nowrap">
-            <b className="mr-4 text-xl md:text-2xl dark:text-gray-100">{this.topStatNumberShort(stat)}</b>
+            <b className="mr-4 text-xl md:text-2xl dark:text-gray-100" id={METRIC_MAPPING[stat.name]}>{this.topStatNumberShort(stat)}</b>
             {this.renderComparison(stat.name, stat.change)}
           </div>
         </Tooltip>


### PR DESCRIPTION
### Changes

This PR adds an `id` attribute to HTML tags in order to facilitate browser testing.

I'm trying to write some very basic headless browser checks using [Checkly](https://www.checklyhq.com).

ID are only added to the top stats. This allows us to write assertions in Playwright tests like: _'make sure unique visitors is > 0 on a dashboard'_.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
