### PR TITLE
Return empty list when breaking down by event:page without events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ## v1.5.1 - 2022-12-06
 
 ### Fixed
+- Return empty list when breaking down by event:page without events plausible/analytics#2530
 - Fallback to empty build metadata when failing to parse $BUILD_METADATA plausible/analytics#2503
 
 ## v1.5.0 - 2022-12-02

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -118,21 +118,25 @@ defmodule Plausible.Stats.Breakdown do
           Query.put_filter(query, "visit:entry_page", {:member, Enum.map(pages, & &1[:page])})
       end
 
-    {limit, _page} = pagination
+    if Enum.any?(event_metrics) && Enum.empty?(event_result) do
+      []
+    else
+      {limit, _page} = pagination
 
-    session_result =
-      breakdown_sessions(site, new_query, "visit:entry_page", session_metrics, {limit, 1})
-      |> transform_keys(%{entry_page: :page})
+      session_result =
+        breakdown_sessions(site, new_query, "visit:entry_page", session_metrics, {limit, 1})
+        |> transform_keys(%{entry_page: :page})
 
-    metrics = metrics ++ [:page]
+      metrics = metrics ++ [:page]
 
-    zip_results(
-      event_result,
-      session_result,
-      :page,
-      metrics
-    )
-    |> Enum.map(&Map.take(&1, metrics))
+      zip_results(
+        event_result,
+        session_result,
+        :page,
+        metrics
+      )
+      |> Enum.map(&Map.take(&1, metrics))
+    end
   end
 
   def breakdown(site, query, property, metrics, pagination) when property in @event_props do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -553,6 +553,34 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
            }
   end
 
+  test "breakdown by event:page when there are no events in the second page", %{
+    conn: conn,
+    site: site
+  } do
+    populate_stats([
+      build(:pageview, pathname: "/", domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, pathname: "/", domain: site.domain, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview,
+        pathname: "/plausible.io",
+        domain: site.domain,
+        timestamp: ~N[2021-01-01 00:00:00]
+      )
+    ])
+
+    conn =
+      get(conn, "/api/v1/stats/breakdown", %{
+        "site_id" => site.domain,
+        "period" => "day",
+        "date" => "2021-01-01",
+        "property" => "event:page",
+        "metrics" => "visitors,bounce_rate",
+        "page" => 2,
+        "limit" => 2
+      })
+
+    assert json_response(conn, 200) == %{"results" => []}
+  end
+
   describe "custom events" do
     test "can breakdown by event:name", %{conn: conn, site: site} do
       populate_stats([


### PR DESCRIPTION
### Changes

This commit fixes a bug with pagination where breaking down by event:page would always return results despite pagination.

Closes #2255

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
