### PR TITLE
Realtime prop breakdown

### DIFF
--- a/assets/js/dashboard/stats/conversions/prop-breakdown.js
+++ b/assets/js/dashboard/stats/conversions/prop-breakdown.js
@@ -149,7 +149,7 @@ export default class PropertyBreakdown extends React.Component {
   renderLoading() {
     if (this.state.loading) {
       return <div className="px-4 py-2"><div className="loading sm mx-auto"><div></div></div></div>
-    } else if (this.state.moreResultsAvailable) {
+    } else if (this.state.moreResultsAvailable && this.props.query.period !== 'realtime') {
       return (
         <div className="w-full text-center my-4">
           <button onClick={this.loadMore.bind(this)} type="button" className="button">

--- a/assets/js/dashboard/stats/conversions/prop-breakdown.js
+++ b/assets/js/dashboard/stats/conversions/prop-breakdown.js
@@ -46,6 +46,7 @@ export default class PropertyBreakdown extends React.Component {
     }
 
     this.handleResize = this.handleResize.bind(this);
+    this.fetchPropBreakdown = this.fetchPropBreakdown.bind(this)
   }
 
   componentDidMount() {
@@ -53,10 +54,15 @@ export default class PropertyBreakdown extends React.Component {
 
     this.handleResize();
     this.fetchPropBreakdown()
+
+    if (this.props.query.period === 'realtime') {
+      document.addEventListener('tick', this.fetchPropBreakdown)
+    }
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize, false);
+    document.removeEventListener('tick', this.fetchPropBreakdown)
   }
 
   handleResize() {

--- a/assets/js/dashboard/stats/conversions/prop-breakdown.js
+++ b/assets/js/dashboard/stats/conversions/prop-breakdown.js
@@ -69,13 +69,17 @@ export default class PropertyBreakdown extends React.Component {
 
   fetchPropBreakdown() {
     if (this.props.query.filters['goal']) {
-      api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/property/${encodeURIComponent(this.state.propKey)}`, this.props.query, {limit: 100, page: this.state.page})
+      this.doFetch()
         .then((res) => this.setState((state) => ({
             loading: false,
             breakdown: state.breakdown.concat(res),
             moreResultsAvailable: res.length === 100
           })))
     }
+  }
+
+  doFetch() {
+    return api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/property/${encodeURIComponent(this.state.propKey)}`, this.props.query, {limit: 100, page: this.state.page})
   }
 
   loadMore() {


### PR DESCRIPTION
### Changes

This PR makes the custom event property breakdown automatically update in realtime mode. It also disables the "Load more" button in realtime mode (screenshot of the button I mean), because supporting paginated results in realtime is too complex.

![image](https://user-images.githubusercontent.com/56999674/208879368-3d2c6dd2-564a-4a3a-8ec2-3b1bdbfdb547.png)

This is how the automatic updates look like (realtime ticks are sped up from 30s to 5s, and there's an artificial delay in fetching the data to make the loading spinner visible):

https://user-images.githubusercontent.com/56999674/208881570-6554f7e0-89ad-49b3-8dc9-ca7073f309ed.mp4

I also considered using `react-flip-move` as in `ListReport`, but as the container size changes, it causes the animation to overflow the container borders:

https://user-images.githubusercontent.com/56999674/208881785-3d8eac28-b265-4ee7-9e56-972f19c64ce5.mp4

That's why I didn't use FlipMove here.

### Tests
- [x] Writing unit tests for the React dashboard is currently out of scope

### Changelog
- [x] https://github.com/plausible/analytics/pull/2445 updates changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
