### PR TITLE
Reject events with long URIs and data URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
+- Reject events with long URIs and data URIs plausible/analytics#2536
 - Always show direct traffic in sources reports plausible/analytics#2531
 
 ## v1.5.1 - 2022-12-06

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -128,18 +128,15 @@ defmodule Plausible.Ingestion.Request do
     end
   end
 
+  @disallowed_schemes ~w(data)
   defp put_uri(changeset, %{} = request_body) do
-    url = request_body["u"] || request_body["url"]
-
-    case url do
-      nil ->
-        Changeset.add_error(changeset, :url, "is required")
-
-      url when is_binary(url) ->
-        Changeset.put_change(changeset, :uri, URI.parse(url))
-
-      _ ->
-        Changeset.add_error(changeset, :url, "must be a string")
+    with url when is_binary(url) <- request_body["u"] || request_body["url"],
+         %URI{} = uri when uri.scheme not in @disallowed_schemes <- URI.parse(url) do
+      Changeset.put_change(changeset, :uri, uri)
+    else
+      nil -> Changeset.add_error(changeset, :url, "is required")
+      %URI{} -> Changeset.add_error(changeset, :url, "scheme is not allowed")
+      _ -> Changeset.add_error(changeset, :url, "must be a string")
     end
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -57,6 +57,7 @@ defmodule Plausible.Ingestion.Request do
           :pathname,
           :timestamp
         ])
+        |> Changeset.validate_length(:pathname, max: 2000)
         |> Changeset.apply_action(nil)
 
       {:error, :invalid_json} ->

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -202,4 +202,16 @@ defmodule Plausible.Ingestion.RequestTest do
     assert request.query_params["foo"] == "bar"
     assert request.query_params["baz"] == "bam"
   end
+
+  test "returns validation error when using data uris" do
+    payload = %{
+      name: "pageview",
+      domain: "dummy.site",
+      url: "data:text/html,%3Cscript%3Ealert%28%27hi%27%29%3B%3C%2Fscript%3E"
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+    assert {:error, changeset} = Request.build(conn)
+    assert {"scheme is not allowed", []} == changeset.errors[:url]
+  end
 end

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -212,6 +212,20 @@ defmodule Plausible.Ingestion.RequestTest do
 
     conn = build_conn(:post, "/api/events", payload)
     assert {:error, changeset} = Request.build(conn)
-    assert {"scheme is not allowed", []} == changeset.errors[:url]
+    assert {"scheme is not allowed", _} = changeset.errors[:url]
+  end
+
+  test "returns validation error when pathname is too long" do
+    long_string = for _ <- 1..5000, do: "a", into: ""
+
+    payload = %{
+      name: "pageview",
+      domain: "dummy.site",
+      url: "https://dummy.site/#{long_string}"
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+    assert {:error, changeset} = Request.build(conn)
+    assert {"should be at most %{count} character(s)", _} = changeset.errors[:pathname]
   end
 end


### PR DESCRIPTION
### Changes

This pull request makes a change to ingestion that rejects events with data URIs and long URIs.

We haven't seen a practical case for tracking data URIs, and those can actually cause some noise on the dashboard when triggered by a browser extension or any other external source.

Additionally, long URIs are also rejected. I set a maximum length of 2,000 characters for pathnames, which should be a reasonable size. I've searched for an official specification for pathnames, but [RFC 2616](http://www.faqs.org/rfcs/rfc2616.html) says there is no limit, so each browser implements it differently. Modern browsers accept gigantic URIs due data URIs I mentioned before.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] [Docs](https://github.com/plausible/docs) have been updated https://github.com/plausible/docs/pull/336/files

### Dark mode
- [X] This PR does not change the UI
