### PR TITLE
Added certs to runtime container to enable SSL for SMTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV LANG=C.UTF-8
 
 RUN apk upgrade --no-cache
 
-RUN apk add --no-cache openssl ncurses libstdc++ libgcc
+RUN apk add --no-cache openssl ncurses libstdc++ libgcc ca-certificates
 
 COPY ./rel/docker-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
### Changes

If you are sending email via an SMTP server that requires SSL/TLS, you get this warning printed to the output log:

```
'Authenticity is not established by certificate path validation' 
Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'
```

And no emails are send.

Adding ca-certificats to the runtime image solves this.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
