### PR TITLE
Remove interval from VisitorGraph state

### DIFF
--- a/assets/js/dashboard/stats/conversions/index.js
+++ b/assets/js/dashboard/stats/conversions/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom'
+import FlipMove from 'react-flip-move'
+
 
 import Bar from '../bar'
 import PropBreakdown from './prop-breakdown'
@@ -106,8 +108,9 @@ export default class Conversions extends React.Component {
               <span className="inline-block w-20">CR</span>
             </div>
           </div>
-
-          { this.state.goals.map(this.renderGoal.bind(this)) }
+          <FlipMove>
+            { this.state.goals.map(this.renderGoal.bind(this)) }
+          </FlipMove>
         </React.Fragment>
       )
     }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -1,8 +1,6 @@
 import numberFormatter, {durationFormatter} from '../../util/number-formatter'
 import dateFormatter from './date-formatter.js'
 
-export const INTERVALS = ["month", "week", "date", "hour", "minute"]
-
 export const METRIC_MAPPING = {
   'Unique visitors (last 30 min)': 'visitors',
   'Pageviews (last 30 min)': 'pageviews',

--- a/assets/js/dashboard/stats/graph/interval-picker.js
+++ b/assets/js/dashboard/stats/graph/interval-picker.js
@@ -21,6 +21,10 @@ export const storeInterval = function(period, domain, interval) {
   storage.setItem(`interval__${period}__${domain}`, interval)
 }
 
+export const removeStoredInterval = function(period, domain) {
+  storage.removeItem(`interval__${period}__${domain}`)
+}
+
 function subscribeKeybinding(element) {
   const handleKeyPress = useCallback((event) => {
     if (isKeyPressed(event, "i")) element.current?.click()

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -395,7 +395,7 @@ export default class VisitorGraph extends React.Component {
   }
 
   updateMetric(clickedMetric) {
-    const newMetric = clickedMetric !== this.state.metric ? clickedMetric : ""
+    const newMetric = clickedMetric === this.state.metric ? "" : clickedMetric
 
     storage.setItem(`metric__${this.props.site.domain}`, newMetric)
     this.setState({ metric: newMetric })

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -362,10 +362,10 @@ export default class VisitorGraph extends React.Component {
     const { metric, topStatData } = this.state;
 
     if (this.props.query !== prevProps.query) {
-      if (metric) {
-        this.setState({ mainGraphLoadingState: LOADING_STATE.loading, topStatsLoadingState: LOADING_STATE.loading, graphData: null, topStatData: null }, this.maybeRollbackInterval)
-      } else {
+      if (this.isGraphCollapsed()) {
         this.setState({ topStatsLoadingState: LOADING_STATE.loading, topStatData: null })
+      } else {
+        this.setState({ mainGraphLoadingState: LOADING_STATE.loading, topStatsLoadingState: LOADING_STATE.loading, graphData: null, topStatData: null }, this.maybeRollbackInterval)
       }
       this.fetchTopStatData()
     }
@@ -388,6 +388,10 @@ export default class VisitorGraph extends React.Component {
     }
   }
 
+  isGraphCollapsed() {
+    return !this.state.metric
+  }
+
   componentWillUnmount() {
     document.removeEventListener('tick', this.maybeRollbackInterval)
     document.removeEventListener('tick', this.fetchTopStatData)
@@ -401,13 +405,13 @@ export default class VisitorGraph extends React.Component {
   }
 
   fetchGraphData() {
-    if (!this.state.metric) {
+    if (this.isGraphCollapsed()) {
       this.setState({ mainGraphLoadingState: LOADING_STATE.loaded, graphData: null })
       return
     }
 
     const url = `/api/stats/${encodeURIComponent(this.props.site.domain)}/main-graph`
-    let params = {metric: this.state.metric || 'none'}
+    let params = {metric: this.state.metric}
     if (this.state.interval) { params.interval = this.state.interval }
 
     api.get(url, this.props.query, params)

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -360,8 +360,9 @@ export default class VisitorGraph extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { metric, topStatData } = this.state;
+    const { query, site } = this.props
 
-    if (this.props.query !== prevProps.query) {
+    if (query !== prevProps.query) {
       if (this.isGraphCollapsed()) {
         this.setState({ topStatsLoadingState: LOADING_STATE.loading, topStatData: null })
       } else {
@@ -374,11 +375,11 @@ export default class VisitorGraph extends React.Component {
       this.setState({mainGraphLoadingState: LOADING_STATE.refreshing}, this.maybeRollbackInterval)
     }
 
-    const savedMetric = storage.getItem(`metric__${this.props.site.domain}`)
+    const savedMetric = storage.getItem(`metric__${site.domain}`)
     const topStatLabels = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
     const prevTopStatLabels = prevState.topStatData && prevState.topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
     if (topStatLabels && `${topStatLabels}` !== `${prevTopStatLabels}`) {
-      if (this.props.query.filters.goal && metric !== 'conversions') {
+      if (query.filters.goal && metric !== 'conversions') {
         this.setState({ metric: 'conversions' })
       } else if (topStatLabels.includes(savedMetric) && savedMetric !== "") {
         this.setState({ metric: savedMetric })

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -393,14 +393,11 @@ export default class VisitorGraph extends React.Component {
     document.removeEventListener('tick', this.fetchTopStatData)
   }
 
-  updateMetric(newMetric) {
-    if (newMetric === this.state.metric) {
-      storage.setItem(`metric__${this.props.site.domain}`, "")
-      this.setState({ metric: "" })
-    } else {
-      storage.setItem(`metric__${this.props.site.domain}`, newMetric)
-      this.setState({ metric: newMetric })
-    }
+  updateMetric(clickedMetric) {
+    const newMetric = clickedMetric !== this.state.metric ? clickedMetric : ""
+
+    storage.setItem(`metric__${this.props.site.domain}`, newMetric)
+    this.setState({ metric: newMetric })
   }
 
   fetchGraphData() {

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -415,7 +415,7 @@ export default class VisitorGraph extends React.Component {
 
   fetchGraphData() {
     if (!this.state.metric) {
-      this.setState({ mainGraphLoadingState: LOADING_STATE.ready, graphData: null })
+      this.setState({ mainGraphLoadingState: LOADING_STATE.loaded, graphData: null })
       return
     }
 
@@ -425,19 +425,19 @@ export default class VisitorGraph extends React.Component {
 
     api.get(url, this.props.query, params)
       .then((res) => {
-        this.setState({ mainGraphLoadingState: LOADING_STATE.ready, graphData: res })
+        this.setState({ mainGraphLoadingState: LOADING_STATE.loaded, graphData: res })
         return res
       })
       .catch((err) => {
         console.log(err)
-        this.setState({ mainGraphLoadingState: LOADING_STATE.ready, graphData: false })
+        this.setState({ mainGraphLoadingState: LOADING_STATE.loaded, graphData: false })
       })
   }
 
   fetchTopStatData() {
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, this.props.query)
       .then((res) => {
-        this.setState({ topStatsLoadingState: LOADING_STATE.ready, topStatData: res })
+        this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res })
         return res
       })
   }
@@ -448,8 +448,8 @@ export default class VisitorGraph extends React.Component {
 
     const theme = document.querySelector('html').classList.contains('dark') || false
 
-    const topStatsReadyOrRefreshing = (topStatsLoadingState === LOADING_STATE.ready || topStatsLoadingState === LOADING_STATE.refreshing)
-    const mainGraphReadyOrRefreshing = (mainGraphLoadingState === LOADING_STATE.ready || mainGraphLoadingState === LOADING_STATE.refreshing)
+    const topStatsReadyOrRefreshing = (topStatsLoadingState === LOADING_STATE.loaded || topStatsLoadingState === LOADING_STATE.refreshing)
+    const mainGraphReadyOrRefreshing = (mainGraphLoadingState === LOADING_STATE.loaded || mainGraphLoadingState === LOADING_STATE.refreshing)
     const noMetricOrRefreshing = (!metric || mainGraphLoadingState === LOADING_STATE.refreshing)
     const topStatAndGraphLoaded = !!(topStatData && graphData)
 

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -386,7 +386,7 @@ export default class VisitorGraph extends React.Component {
   }
 
   isGraphCollapsed() {
-    return !this.state.metric
+    return this.state.metric === ""
   }
 
   componentWillUnmount() {

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -325,21 +325,15 @@ export default class VisitorGraph extends React.Component {
     this.updateInterval = this.updateInterval.bind(this)
   }
 
-  isIntervalValid({ query, site }) {
-    const period = query?.period
-    const validIntervalsForPeriod = site.validIntervalsByPeriod[period] || []
-    const storedInterval = getStoredInterval(period, site.domain)
-
-    return validIntervalsForPeriod.includes(storedInterval)
+  isIntervalValid(interval) {
+    const validIntervals = this.props.site.validIntervalsByPeriod[this.props.query.period] || []
+    return validIntervals.includes(interval)
   }
 
   maybeRollbackInterval() {
-    if (this.isIntervalValid(this.props)) {
-      const interval = getStoredInterval(this.props.query.period, this.props.site.domain)
-
-      this.setState({interval}, () => {
-        this.fetchGraphData()
-      })
+    const interval = getStoredInterval(this.props.query.period, this.props.site.domain)
+    if (this.isIntervalValid(interval)) {
+      this.setState({interval}, this.fetchGraphData)
     } else {
       this.setState({interval: undefined}, () => {
         this.setState({graphData: null})

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -359,7 +359,7 @@ export default class VisitorGraph extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { metric, topStatData, interval } = this.state;
+    const { metric, topStatData } = this.state;
 
     if (this.props.query !== prevProps.query) {
       if (metric) {
@@ -371,10 +371,6 @@ export default class VisitorGraph extends React.Component {
     }
 
     if (metric !== prevState.metric) {
-      this.setState({mainGraphLoadingState: LOADING_STATE.refreshing}, this.maybeRollbackInterval)
-    }
-
-    if (interval !== prevState.interval && interval) {
       this.setState({mainGraphLoadingState: LOADING_STATE.refreshing}, this.maybeRollbackInterval)
     }
 

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -436,14 +436,14 @@ export default class VisitorGraph extends React.Component {
 
     const theme = document.querySelector('html').classList.contains('dark') || false
 
-    const topStatsReadyOrRefreshing = (topStatsLoadingState === LOADING_STATE.loaded || topStatsLoadingState === LOADING_STATE.refreshing)
-    const mainGraphReadyOrRefreshing = (mainGraphLoadingState === LOADING_STATE.loaded || mainGraphLoadingState === LOADING_STATE.refreshing)
+    const topStatsLoadedOrRefreshing = (topStatsLoadingState === LOADING_STATE.loaded || topStatsLoadingState === LOADING_STATE.refreshing)
+    const mainGraphLoadedOrRefreshing = (mainGraphLoadingState === LOADING_STATE.loaded || mainGraphLoadingState === LOADING_STATE.refreshing)
     const noMetricOrRefreshing = (!metric || mainGraphLoadingState === LOADING_STATE.refreshing)
     const topStatAndGraphLoaded = !!(topStatData && graphData)
 
     const showGraph =
-      topStatsReadyOrRefreshing &&
-      mainGraphReadyOrRefreshing &&
+    topStatsLoadedOrRefreshing &&
+    mainGraphLoadedOrRefreshing &&
       (topStatData && noMetricOrRefreshing || topStatAndGraphLoaded)
 
     return (

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -5,7 +5,7 @@ import { navigateToQuery } from '../../query'
 import * as api from '../../api'
 import * as storage from '../../util/storage'
 import LazyLoader from '../../components/lazy-loader'
-import {GraphTooltip, buildDataSet, INTERVALS, METRIC_MAPPING, METRIC_LABELS, METRIC_FORMATTER} from './graph-util';
+import {GraphTooltip, buildDataSet, METRIC_MAPPING, METRIC_LABELS, METRIC_FORMATTER} from './graph-util';
 import dateFormatter from './date-formatter';
 import TopStats from './top-stats';
 import { IntervalPicker, getStoredInterval, storeInterval } from './interval-picker';
@@ -331,9 +331,9 @@ export default class VisitorGraph extends React.Component {
   }
 
   maybeRollbackInterval() {
-    const interval = getStoredInterval(this.props.query.period, this.props.site.domain)
-    if (this.isIntervalValid(interval)) {
-      this.setState({interval}, this.fetchGraphData)
+    const storedInterval = getStoredInterval(this.props.query.period, this.props.site.domain)
+    if (storedInterval) {
+      this.setState({interval: storedInterval}, this.fetchGraphData)
     } else {
       this.setState({interval: undefined}, () => {
         this.setState({graphData: null})
@@ -343,8 +343,8 @@ export default class VisitorGraph extends React.Component {
   }
 
   updateInterval(interval) {
-    if (INTERVALS.includes(interval)) {
-      this.setState({interval, mainGraphLoadingState: LOADING_STATE.refreshing}, this.maybeRollbackInterval)
+    if (this.isIntervalValid(interval)) {
+      this.setState({interval, mainGraphLoadingState: LOADING_STATE.refreshing}, this.fetchGraphData)
       storeInterval(this.props.query.period, this.props.site.domain, interval)
     }
   }

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom'
+import FlipMove from 'react-flip-move';
+
 
 import FadeIn from '../../fade-in'
 import MoreLink from '../more-link'
@@ -33,7 +35,6 @@ export default function ListReport(props) {
   const showConversionRate = !!props.query.filters.goal
 
   const fetchData = useCallback(() => {
-      setState({loading: true, list: null})
       props.fetchData()
         .then((res) => setState({loading: false, list: res}))
     }, [props.query])
@@ -118,7 +119,9 @@ export default function ListReport(props) {
               {showConversionRate && <span className="inline-block w-20">CR</span>}
             </span>
           </div>
-          { state.list && state.list.map(renderListItem) }
+          <FlipMove>
+          { state.list.map(renderListItem) }
+          </FlipMove>
         </>
       )
     }

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -114,7 +114,7 @@ class AllSources extends React.Component {
         </React.Fragment>
       )
     } else {
-      return <div className="font-medium text-center text-gray-500 mt-44">No data yet</div>
+      return <div className="font-medium text-center text-gray-500 mt-44 dark:text-gray-400">No data yet</div>
     }
   }
 

--- a/assets/js/dashboard/util/storage.js
+++ b/assets/js/dashboard/util/storage.js
@@ -33,3 +33,11 @@ export function getItem(key) {
     return memStore[key]
   }
 }
+
+export function removeItem(key) {
+  if (isLocalStorageAvailable) {
+    window.localStorage.removeItem(key)
+  } else {
+    delete memStore[key]
+  }
+}


### PR DESCRIPTION
### Changes

Remove `interval` from the `VisitorGraph` component state to remove unnecessary code complexity. We can only use localStorage for that.