### PR TITLE
Cascade delete sent_renewal_notifications table when user is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Reject events with long URIs and data URIs plausible/analytics#2536
 - Always show direct traffic in sources reports plausible/analytics#2531
 
+## Fixed
+- Cascade delete sent_renewal_notifications table when user is deleted plausible/analytics#2549
+
 ## v1.5.1 - 2022-12-06
 
 ### Fixed

--- a/priv/repo/migrations/20221228123226_cascade_delete_sent_renewal_notifications.exs
+++ b/priv/repo/migrations/20221228123226_cascade_delete_sent_renewal_notifications.exs
@@ -1,0 +1,11 @@
+defmodule Plausible.Repo.Migrations.CascadeDeleteSentRenewalNotifications do
+  use Ecto.Migration
+
+  def change do
+    drop constraint("sent_renewal_notifications", "sent_renewal_notifications_user_id_fkey")
+
+    alter table(:sent_renewal_notifications) do
+      modify :user_id, references(:users, on_delete: :delete_all), null: false
+    end
+  end
+end

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -677,6 +677,13 @@ defmodule PlausibleWeb.AuthControllerTest do
         }
       ])
 
+      Repo.insert_all("sent_renewal_notifications", [
+        %{
+          user_id: user.id,
+          timestamp: NaiveDateTime.utc_now()
+        }
+      ])
+
       insert(:google_auth, site: site, user: user)
       insert(:subscription, user: user, status: "deleted")
 


### PR DESCRIPTION
### Changes

This pull request fixes a bug when deleting a user would trigger a database constraint error.

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
