### PR TITLE
Move bounce rate from Top Pages to Entry Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
+- Move bounce rate from Top Pages to Entry Pages plausible/analytics#2552
 - Reject events with long URIs and data URIs plausible/analytics#2536
 - Always show direct traffic in sources reports plausible/analytics#2531
 

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -94,6 +94,7 @@ class EntryPagesModal extends React.Component {
         {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_entrances)}</td>}
         {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{durationFormatter(page.visit_duration)}</td>}
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.conversion_rate)}%</td>}
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
       </tr>
     )
   }
@@ -133,6 +134,7 @@ class EntryPagesModal extends React.Component {
                   {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Total Entrances </th> }
                   {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Visit Duration </th> }
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >CR </th>}
+                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th> }
                 </tr>
               </thead>
               <tbody>

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -48,14 +48,6 @@ class PagesModal extends React.Component {
     return !!this.state.query.filters.goal
   }
 
-  formatBounceRate(page) {
-    if (typeof(page.bounce_rate) === 'number') {
-      return page.bounce_rate + '%'
-    } else {
-      return '-'
-    }
-  }
-
   renderPage(page) {
     const query = new URLSearchParams(window.location.search)
     const timeOnPage = page['time_on_page'] ? durationFormatter(page['time_on_page']) : '-';
@@ -69,7 +61,6 @@ class PagesModal extends React.Component {
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.total_visitors}</td> }
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visitors)}</td>
         {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }
-        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
         {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td> }
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.conversion_rate}%</td> }
       </tr>
@@ -117,7 +108,6 @@ class PagesModal extends React.Component {
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Total visitors</th>}
                   <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">{ this.label() }</th>
                   {this.showPageviews() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Pageviews</th>}
-                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th>}
                   {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Time on Page</th>}
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">CR</th>}
                 </tr>

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -603,7 +603,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     metrics =
       if params["detailed"],
-        do: [:visitors, :pageviews, :bounce_rate, :time_on_page],
+        do: [:visitors, :pageviews, :time_on_page],
         else: [:visitors]
 
     pagination = parse_pagination(params)
@@ -619,7 +619,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
       else
-        pages |> to_csv([:name, :visitors, :pageviews, :bounce_rate, :time_on_page])
+        pages |> to_csv([:name, :visitors, :pageviews, :time_on_page])
       end
     else
       json(conn, pages)
@@ -647,7 +647,8 @@ defmodule PlausibleWeb.Api.StatsController do
         |> transform_keys(%{unique_entrances: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
       else
-        entry_pages |> to_csv([:name, :unique_entrances, :total_entrances, :visit_duration, :bounce_rate])
+        entry_pages
+        |> to_csv([:name, :unique_entrances, :total_entrances, :visit_duration, :bounce_rate])
       end
     else
       json(conn, entry_pages)

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -630,7 +630,7 @@ defmodule PlausibleWeb.Api.StatsController do
     site = conn.assigns[:site]
     query = Query.from(site, params) |> Filters.add_prefix()
     pagination = parse_pagination(params)
-    metrics = [:visitors, :visits, :visit_duration]
+    metrics = [:visitors, :visits, :visit_duration, :bounce_rate]
 
     entry_pages =
       Stats.breakdown(site, query, "visit:entry_page", metrics, pagination)
@@ -647,7 +647,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> transform_keys(%{unique_entrances: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
       else
-        entry_pages |> to_csv([:name, :unique_entrances, :total_entrances, :visit_duration])
+        entry_pages |> to_csv([:name, :unique_entrances, :total_entrances, :visit_duration, :bounce_rate])
       end
     else
       json(conn, entry_pages)

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -670,14 +670,12 @@ defmodule Plausible.ImportedTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "bounce_rate" => nil,
                  "time_on_page" => 60,
                  "visitors" => 3,
                  "pageviews" => 4,
                  "name" => "/some-other-page"
                },
                %{
-                 "bounce_rate" => 25.0,
                  "time_on_page" => 800.0,
                  "visitors" => 2,
                  "pageviews" => 2,

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/entry_pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/entry_pages.csv
@@ -1,2 +1,2 @@
-name,unique_entrances,total_entrances,visit_duration
-/,1,1,60
+name,unique_entrances,total_entrances,visit_duration,bounce_rate
+/,1,1,60,0

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
@@ -1,2 +1,2 @@
-name,visitors,pageviews,bounce_rate,time_on_page
-/some-other-page,1,1,,60.0
+name,visitors,pageviews,time_on_page
+/some-other-page,1,1,60.0

--- a/test/plausible_web/controllers/CSVs/30d/entry_pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d/entry_pages.csv
@@ -1,2 +1,2 @@
-name,unique_entrances,total_entrances,visit_duration
-/,4,4,15
+name,unique_entrances,total_entrances,visit_duration,bounce_rate
+/,4,4,15,75

--- a/test/plausible_web/controllers/CSVs/30d/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d/pages.csv
@@ -1,3 +1,3 @@
-name,visitors,pageviews,bounce_rate,time_on_page
-/,4,3,75,
-/some-other-page,1,1,,60.0
+name,visitors,pageviews,time_on_page
+/,4,3,
+/some-other-page,1,1,60.0

--- a/test/plausible_web/controllers/CSVs/6m/entry_pages.csv
+++ b/test/plausible_web/controllers/CSVs/6m/entry_pages.csv
@@ -1,2 +1,2 @@
-name,unique_entrances,total_entrances,visit_duration
-/,5,5,12
+name,unique_entrances,total_entrances,visit_duration,bounce_rate
+/,5,5,12,80

--- a/test/plausible_web/controllers/CSVs/6m/pages.csv
+++ b/test/plausible_web/controllers/CSVs/6m/pages.csv
@@ -1,3 +1,3 @@
-name,visitors,pageviews,bounce_rate,time_on_page
-/,5,4,80,
-/some-other-page,1,1,,60.0
+name,visitors,pageviews,time_on_page
+/,5,4,
+/some-other-page,1,1,60.0

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -124,20 +124,18 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/blog/john-2",
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "bounce_rate" => 0,
                  "time_on_page" => 600
                },
                %{
                  "name" => "/blog/john-1",
                  "visitors" => 1,
                  "pageviews" => 1,
-                 "bounce_rate" => 0,
                  "time_on_page" => 60
                }
              ]
     end
 
-    test "calculates bounce_rate and time_on_page with :is_not filter on custom pageview props",
+    test "calculates time_on_page with :is_not filter on custom pageview props",
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
@@ -186,20 +184,18 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/blog",
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "bounce_rate" => 0,
                  "time_on_page" => 120.0
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
-                 "bounce_rate" => nil,
                  "time_on_page" => nil
                }
              ]
     end
 
-    test "calculates bounce_rate and time_on_page with :is (none) filter on custom pageview props",
+    test "calculates time_on_page with :is (none) filter on custom pageview props",
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
@@ -238,20 +234,18 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/blog",
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "bounce_rate" => 50,
                  "time_on_page" => 60
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
-                 "bounce_rate" => nil,
                  "time_on_page" => nil
                }
              ]
     end
 
-    test "calculates bounce_rate and time_on_page with :is_not (none) filter on custom pageview props",
+    test "calculates time_on_page with :is_not (none) filter on custom pageview props",
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
@@ -294,20 +288,18 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/blog/other-post",
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "bounce_rate" => 100,
                  "time_on_page" => nil
                },
                %{
                  "name" => "/blog/john-1",
                  "visitors" => 1,
                  "pageviews" => 1,
-                 "bounce_rate" => 0,
                  "time_on_page" => 60
                }
              ]
     end
 
-    test "calculates bounce_rate and time_on_page for pages filtered by page path",
+    test "calculates time_on_page for pages filtered by page path",
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
@@ -348,7 +340,6 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/",
                  "visitors" => 2,
                  "pageviews" => 3,
-                 "bounce_rate" => 50,
                  "time_on_page" => 60
                }
              ]
@@ -409,14 +400,12 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "bounce_rate" => 50.0,
                  "time_on_page" => 900.0,
                  "visitors" => 2,
                  "pageviews" => 2,
                  "name" => "/"
                },
                %{
-                 "bounce_rate" => nil,
                  "time_on_page" => nil,
                  "visitors" => 1,
                  "pageviews" => 1,
@@ -470,14 +459,12 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "bounce_rate" => 40.0,
                  "time_on_page" => 800.0,
                  "visitors" => 3,
                  "pageviews" => 3,
                  "name" => "/"
                },
                %{
-                 "bounce_rate" => nil,
                  "time_on_page" => 60,
                  "visitors" => 2,
                  "pageviews" => 2,

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -559,13 +559,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "unique_entrances" => 2,
                  "total_entrances" => 2,
                  "name" => "/page1",
-                 "visit_duration" => 0
+                 "visit_duration" => 0,
+                 "bounce_rate" => 100
                },
                %{
                  "unique_entrances" => 1,
                  "total_entrances" => 2,
                  "name" => "/page2",
-                 "visit_duration" => 450
+                 "visit_duration" => 450,
+                 "bounce_rate" => 50
                }
              ]
     end
@@ -615,13 +617,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "unique_entrances" => 1,
                  "total_entrances" => 1,
                  "name" => "/blog",
-                 "visit_duration" => 60
+                 "visit_duration" => 60,
+                 "bounce_rate" => 0
                },
                %{
                  "unique_entrances" => 1,
                  "total_entrances" => 1,
                  "name" => "/blog/john-2",
-                 "visit_duration" => 0
+                 "visit_duration" => 0,
+                 "bounce_rate" => 100
                }
              ]
     end
@@ -670,13 +674,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "unique_entrances" => 2,
                  "total_entrances" => 2,
                  "name" => "/page1",
-                 "visit_duration" => 0
+                 "visit_duration" => 0,
+                 "bounce_rate" => 100
                },
                %{
                  "unique_entrances" => 1,
                  "total_entrances" => 2,
                  "name" => "/page2",
-                 "visit_duration" => 450
+                 "visit_duration" => 450,
+                 "bounce_rate" => 50
                }
              ]
 
@@ -691,13 +697,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "unique_entrances" => 3,
                  "total_entrances" => 5,
                  "name" => "/page2",
-                 "visit_duration" => 240.0
+                 "visit_duration" => 240.0,
+                 "bounce_rate" => 20.0
                },
                %{
                  "unique_entrances" => 2,
                  "total_entrances" => 2,
                  "name" => "/page1",
-                 "visit_duration" => 0
+                 "visit_duration" => 0,
+                 "bounce_rate" => 100.0
                }
              ]
     end
@@ -751,7 +759,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "total_entrances" => 1,
                  "name" => "/page2",
                  "visit_duration" => 900,
-                 "conversion_rate" => 100.0
+                 "conversion_rate" => 100.0,
+                 "bounce_rate" => 0
                },
                %{
                  "total_visitors" => 2,
@@ -759,7 +768,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "total_entrances" => 1,
                  "name" => "/page1",
                  "visit_duration" => 0,
-                 "conversion_rate" => 50.0
+                 "conversion_rate" => 50.0,
+                 "bounce_rate" => 0
                }
              ]
     end


### PR DESCRIPTION
### Changes

This pull request moves bounce rate from Top Pages to Entry Pages. This is the first change to disallow session_metrics when doing breakdowns by `event:page`. A next pull request will disallow that in the `Plausible.Query.Breakdown` module, consequently changing the API.

Related to #2544


Top Pages | Entry Pages
:-------------------------:|:-------------------------:
<img width="1135" alt="Screenshot 2022-12-29 at 12 12 02" src="https://user-images.githubusercontent.com/5093045/209972676-d926c967-8321-4d92-b9cb-483a36746663.png"> |  <img width="1137" alt="Screenshot 2022-12-29 at 12 12 07" src="https://user-images.githubusercontent.com/5093045/209972680-ed52acb6-be14-4a50-bd5e-9e6eb02a9b0d.png">



### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
