### PR TITLE
Ignore unknown countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Reject events with long URIs and data URIs plausible/analytics#2536
 - Always show direct traffic in sources reports plausible/analytics#2531
+- Stop recording XX and T1 country codes plausible/analytics#2556
 
 ## Fixed
 - Cascade delete sent_renewal_notifications table when user is deleted plausible/analytics#2549

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,7 +56,9 @@ config :geolix,
         {1, 1, 1, 1} => %{country: %{iso_code: "US"}},
         {2, 2, 2, 2} => geolix_sample_lookup,
         {1, 1, 1, 1, 1, 1, 1, 1} => %{country: %{iso_code: "US"}},
-        {0, 0, 0, 0} => %{country: %{iso_code: "ZZ"}}
+        {0, 0, 0, 0} => %{country: %{iso_code: "ZZ"}},
+        {0, 0, 0, 1} => %{country: %{iso_code: "XX"}},
+        {0, 0, 0, 2} => %{country: %{iso_code: "1"}}
       }
     }
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,9 +56,9 @@ config :geolix,
         {1, 1, 1, 1} => %{country: %{iso_code: "US"}},
         {2, 2, 2, 2} => geolix_sample_lookup,
         {1, 1, 1, 1, 1, 1, 1, 1} => %{country: %{iso_code: "US"}},
-        {0, 0, 0, 0} => %{country: %{iso_code: "ZZ"}},
-        {0, 0, 0, 1} => %{country: %{iso_code: "XX"}},
-        {0, 0, 0, 2} => %{country: %{iso_code: "1"}}
+        {0, 0, 0, 0} => %{country: %{iso_code: "ZZ"}, city: %{geoname_id: 123_123}},
+        {0, 0, 0, 1} => %{country: %{iso_code: "XX"}, subdivisions: [%{iso_code: "IDF"}]},
+        {0, 0, 0, 2} => %{country: %{iso_code: "T1"}, subdivisions: [%{}, %{iso_code: "IDF"}]}
       }
     }
   ]

--- a/lib/plausible/ingestion/city_overrides.ex
+++ b/lib/plausible/ingestion/city_overrides.ex
@@ -198,5 +198,5 @@ defmodule Plausible.Ingestion.CityOverrides do
     # Hackney -> London
     2_647_694 => 2_643_743
   }
-  def get, do: @overrides
+  def get(key, default), do: Map.get(@overrides, key, default)
 end

--- a/lib/plausible/ingestion/geolocation.ex
+++ b/lib/plausible/ingestion/geolocation.ex
@@ -1,0 +1,51 @@
+defmodule Plausible.Ingestion.Geolocation do
+  alias Plausible.Ingestion.CityOverrides
+
+  def lookup(remote_ip) do
+    result = Geolix.lookup(remote_ip, where: :geolocation)
+
+    country_code =
+      get_in(result, [:country, :iso_code])
+      |> ignore_unknown_country()
+
+    city_geoname_id = get_in(result, [:city, :geoname_id])
+    city_geoname_id = Map.get(CityOverrides.get(), city_geoname_id, city_geoname_id)
+
+    subdivision1_code =
+      case result do
+        %{subdivisions: [%{iso_code: iso_code} | _rest]} ->
+          country_code <> "-" <> iso_code
+
+        _ ->
+          ""
+      end
+
+    subdivision2_code =
+      case result do
+        %{subdivisions: [_first, %{iso_code: iso_code} | _rest]} ->
+          country_code <> "-" <> iso_code
+
+        _ ->
+          ""
+      end
+
+    %{
+      country_code: country_code,
+      subdivision1_code: subdivision1_code,
+      subdivision2_code: subdivision2_code,
+      city_geoname_id: city_geoname_id
+    }
+  end
+
+  @ignored_countries [
+    # Worldwide
+    "ZZ",
+    # Disputed territory
+    "XX",
+    # Tor exit node
+    "T1"
+  ]
+  # ZZ - worldwide
+  defp ignore_unknown_country(code) when code in @ignored_countries, do: nil
+  defp ignore_unknown_country(country), do: country
+end

--- a/lib/plausible/ingestion/geolocation.ex
+++ b/lib/plausible/ingestion/geolocation.ex
@@ -1,4 +1,5 @@
 defmodule Plausible.Ingestion.Geolocation do
+  @moduledoc false
   alias Plausible.Ingestion.CityOverrides
 
   def lookup(remote_ip) do

--- a/lib/plausible/ingestion/geolocation.ex
+++ b/lib/plausible/ingestion/geolocation.ex
@@ -9,7 +9,7 @@ defmodule Plausible.Ingestion.Geolocation do
       |> ignore_unknown_country()
 
     city_geoname_id = country_code && get_in(result, [:city, :geoname_id])
-    city_geoname_id = Map.get(CityOverrides.get(), city_geoname_id, city_geoname_id)
+    city_geoname_id = CityOverrides.get(city_geoname_id, city_geoname_id)
 
     %{
       country_code: country_code,

--- a/lib/plausible/ingestion/geolocation.ex
+++ b/lib/plausible/ingestion/geolocation.ex
@@ -42,7 +42,6 @@ defmodule Plausible.Ingestion.Geolocation do
     # Tor exit node
     "T1"
   ]
-  # ZZ - worldwide
   defp ignore_unknown_country(code) when code in @ignored_countries, do: nil
   defp ignore_unknown_country(country), do: country
 end

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -685,6 +685,47 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       pageview = get_event(domain)
 
       assert pageview.country_code == <<0, 0>>
+      assert pageview.subdivision1_code == ""
+      assert pageview.subdivision2_code == ""
+      assert pageview.city_geoname_id == 0
+    end
+
+    test "ignores disputed territory code XX", %{conn: conn, domain: domain} do
+      params = %{
+        name: "pageview",
+        domain: domain,
+        url: "http://gigride.live/"
+      }
+
+      conn
+      |> put_req_header("x-forwarded-for", "0.0.0.1")
+      |> post("/api/event", params)
+
+      pageview = get_event(domain)
+
+      assert pageview.country_code == <<0, 0>>
+      assert pageview.subdivision1_code == ""
+      assert pageview.subdivision2_code == ""
+      assert pageview.city_geoname_id == 0
+    end
+
+    test "ignores TOR exit node country code T1", %{conn: conn, domain: domain} do
+      params = %{
+        name: "pageview",
+        domain: domain,
+        url: "http://gigride.live/"
+      }
+
+      conn
+      |> put_req_header("x-forwarded-for", "0.0.0.2")
+      |> post("/api/event", params)
+
+      pageview = get_event(domain)
+
+      assert pageview.country_code == <<0, 0>>
+      assert pageview.subdivision1_code == ""
+      assert pageview.subdivision2_code == ""
+      assert pageview.city_geoname_id == 0
     end
 
     test "scrubs port from x-forwarded-for", %{conn: conn, domain: domain} do


### PR DESCRIPTION
### Changes

There are some country codes we're recording that cannot be displayed. These are not real countries they are:
`XX` - disputed territory (https://sentry.plausible.io/organizations/sentry/issues/1095/events/b01fa99ae92f4712ba3579371416be39/?environment=prod&project=1)
`T1` - Tor exit node (https://sentry.plausible.io/organizations/sentry/issues/1095/events/af5adb05fb79486d9e90f48cf3707be6/?environment=prod&project=1)

Also makes the following changes:
* Do not attempt to look up region and city codes if country is unknown
* Extracts geolocation to a dedicated module

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Changelog has been updated

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
