### PR TITLE
Display pageviews in details modal for top pages when filtering by a source

### DIFF
--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -40,8 +40,7 @@ class PagesModal extends React.Component {
   }
 
   showPageviews() {
-    const {filters} = this.state.query
-    return this.state.query.period !== 'realtime' && !(filters.goal || filters.source || filters.referrer)
+    return this.state.query.period !== 'realtime' && !this.state.query.filters.goal
   }
 
   showConversionRate() {


### PR DESCRIPTION
### Changes
Fixes https://github.com/plausible/analytics/issues/2182
The pageviews column is now displayed in the details modal for top pages when filtering by a source.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
