### PR TITLE
Fix metric undefined

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -373,24 +373,22 @@ export default class VisitorGraph extends React.Component {
     if (metric !== prevState.metric) {
       this.setState({mainGraphLoadingState: LOADING_STATE.refreshing}, this.fetchGraphData)
     }
-
-    this.maybeUpdateMetric(prevState)
   }
 
-  maybeUpdateMetric(prevState) {
+  resetMetric() {
     const { metric, topStatData } = this.state;
     const { query, site } = this.props
 
     const savedMetric = storage.getItem(`metric__${site.domain}`)
-    const topStatLabels = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
-    const prevTopStatLabels = prevState.topStatData && prevState.topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
-    if (topStatLabels && `${topStatLabels}` !== `${prevTopStatLabels}`) {
+    const selectableMetrics = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
+
+    if (selectableMetrics) {
       if (query.filters.goal && metric !== 'conversions') {
         this.setState({ metric: 'conversions' })
-      } else if (topStatLabels.includes(savedMetric) && savedMetric !== "") {
+      } else if (selectableMetrics.includes(savedMetric) && savedMetric !== "") {
         this.setState({ metric: savedMetric })
       } else {
-        this.setState({ metric: topStatLabels[0] })
+        this.setState({ metric: selectableMetrics[0] })
       }
     }
   }
@@ -437,6 +435,7 @@ export default class VisitorGraph extends React.Component {
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, this.props.query)
       .then((res) => {
         this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res })
+        this.resetMetric()
         return res
       })
   }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -433,7 +433,7 @@ export default class VisitorGraph extends React.Component {
   fetchTopStatData() {
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, this.props.query)
       .then((res) => {
-        this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res }, this.resetMetric())
+        this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res }, this.resetMetric)
         return res
       })
   }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -381,15 +381,14 @@ export default class VisitorGraph extends React.Component {
 
     const savedMetric = storage.getItem(`metric__${site.domain}`)
     const selectableMetrics = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
+    const canSelectSavedMetric = selectableMetrics && selectableMetrics.includes(savedMetric)
 
-    if (selectableMetrics) {
-      if (query.filters.goal) {
-        this.setState({ metric: 'conversions' })
-      } else if (selectableMetrics.includes(savedMetric) && savedMetric !== "") {
-        this.setState({ metric: savedMetric })
-      } else {
-        this.setState({ metric: 'visitors' })
-      }
+    if (query.filters.goal) {
+      this.setState({ metric: 'conversions' })
+    } else if (canSelectSavedMetric || savedMetric === "") {
+      this.setState({ metric: savedMetric })
+    } else {
+      this.setState({ metric: 'visitors' })
     }
   }
 

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -376,19 +376,19 @@ export default class VisitorGraph extends React.Component {
   }
 
   resetMetric() {
-    const { metric, topStatData } = this.state;
+    const { topStatData } = this.state
     const { query, site } = this.props
 
     const savedMetric = storage.getItem(`metric__${site.domain}`)
     const selectableMetrics = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
 
     if (selectableMetrics) {
-      if (query.filters.goal && metric !== 'conversions') {
+      if (query.filters.goal) {
         this.setState({ metric: 'conversions' })
       } else if (selectableMetrics.includes(savedMetric) && savedMetric !== "") {
         this.setState({ metric: savedMetric })
       } else {
-        this.setState({ metric: selectableMetrics[0] })
+        this.setState({ metric: 'visitors' })
       }
     }
   }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -358,8 +358,8 @@ export default class VisitorGraph extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { metric, topStatData } = this.state;
-    const { query, site } = this.props
+    const { metric } = this.state;
+    const { query } = this.props
 
     if (query !== prevProps.query) {
       if (this.isGraphCollapsed()) {
@@ -373,6 +373,13 @@ export default class VisitorGraph extends React.Component {
     if (metric !== prevState.metric) {
       this.setState({mainGraphLoadingState: LOADING_STATE.refreshing}, this.fetchGraphData)
     }
+
+    this.maybeUpdateMetric(prevState)
+  }
+
+  maybeUpdateMetric(prevState) {
+    const { metric, topStatData } = this.state;
+    const { query, site } = this.props
 
     const savedMetric = storage.getItem(`metric__${site.domain}`)
     const topStatLabels = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -433,8 +433,7 @@ export default class VisitorGraph extends React.Component {
   fetchTopStatData() {
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, this.props.query)
       .then((res) => {
-        this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res })
-        this.resetMetric()
+        this.setState({ topStatsLoadingState: LOADING_STATE.loaded, topStatData: res }, this.resetMetric())
         return res
       })
   }


### PR DESCRIPTION
### Changes

This PR fixes a bug introduced in https://github.com/plausible/analytics/pull/2560. For a reproduction of the bug, go to [this dashboard URL](https://plausible.io/plausible.io?goal=Signup&props=%7B%22logged_in%22%3A%22false%22%7D&period=realtime) and remove the `Signup.logged_in is false` filter. After doing so:

- The graph disappears (main-graph API request returns 500)
- An error is shown in the console: `ApiError: ** (CaseClauseError) no case clause matching: :undefined`

This is because `metric` becomes undefined in the `VisitorGraph` state when setting it to `topStatLabels[0]` [on this line](https://github.com/plausible/analytics/blob/b6349df475a17c8fdc3a30cdeace18e88b29c52d/assets/js/dashboard/stats/graph/visitor-graph.js#L386) (if `topStatLabels` is an empty array).

This PR makes sure that we're not relying on the top stat labels when setting the metric. It also does some refactoring to make the code more readable. Reviewing commit-by-commit suggested.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
