### PR TITLE
Make checkly alert after 5 minutes of downtime

### DIFF
--- a/test/e2e/main.tf
+++ b/test/e2e/main.tf
@@ -213,6 +213,14 @@ resource "checkly_check_group" "reachability" {
     channel_id = checkly_alert_channel.pagerduty.id
     activated  = true
   }
+
+  alert_settings {
+    escalation_type = "TIME_BASED"
+
+    time_based_escalation {
+      minutes_failing_threshold = 5
+    }
+  }
 }
 
 resource "checkly_alert_channel" "pagerduty" {


### PR DESCRIPTION
### Changes

Relaxes the Checkly config to alert after 5 minutes of downtime so it's less sensitive.

Ref: https://registry.terraform.io/providers/checkly/checkly/latest/docs/resources/check_group#nestedblock--alert_settings--time_based_escalation