### PR TITLE
parse date labels by local timezone instead of UTC

### DIFF
--- a/assets/js/dashboard/stats/graph/date-formatter.js
+++ b/assets/js/dashboard/stats/graph/date-formatter.js
@@ -1,4 +1,4 @@
-import {parseUTCDate, formatMonthYYYY, formatDay, formatDayShort} from '../../util/date'
+import {formatMonthYYYY, formatDay, formatDayShort} from '../../util/date'
 
 const browserDateFormat = Intl.DateTimeFormat(navigator.language, { hour: 'numeric' })
 
@@ -7,7 +7,7 @@ const is12HourClock = function() {
 }
 
 const parseISODate = function(isoDate) {
-  const date = parseUTCDate(isoDate)
+  const date = new Date(isoDate)
   const minutes = date.getMinutes();
   return { date, minutes }
 }
@@ -60,7 +60,7 @@ const hourIntervalFormatter = {
   },
   short(isoDate, _options) {
     const formatted = formatHours(isoDate)
-    
+
     if (is12HourClock()) {
       return formatted.replace(' ', '').toLowerCase()
     } else {


### PR DESCRIPTION
### Changes

This PR fixes the date parsing in the main graph time buckets. The timestamps returned by the API are in `site.timezone`. We should not parse them as UTC.

Here's a GIF showing how it currently behaves. I am in UTC +02, which is why from 2AM (the UTC midnight) the date is changed from 16 -> 17 Jan:

![before](https://user-images.githubusercontent.com/56999674/212878825-628e9c12-c123-42fc-bf9e-15665668982f.gif)

After this change:

![after](https://user-images.githubusercontent.com/56999674/212879369-e9fd229d-251e-4dbc-8b55-f38b7b1ee5be.gif)

### Tests
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
