### PR TITLE
Stop logging invalid_address errors from Locus

### DIFF
--- a/lib/plausible/geo.ex
+++ b/lib/plausible/geo.ex
@@ -181,8 +181,11 @@ defmodule Plausible.Geo do
       :not_found ->
         nil
 
+      {:error, {:invalid_address, _address}} ->
+        nil
+
       {:error, reason} ->
-        Logger.error("failed to lookup ip address: " <> inspect(reason))
+        Logger.error("Failed to lookup IP address. Reason: " <> inspect(reason))
         nil
     end
   end


### PR DESCRIPTION
This commit stops logging `{:invalid_address, "ip"}` errors. This reduces noise on Sentry, that is capturing error logs. Other errors are still logged.