### PR TITLE
Communicate site creation edge cases to the users

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -191,11 +191,8 @@ defmodule Plausible.Sites do
       )
 
       [
-        domain: """
-        We cannot create '#{domain}' at the moment; if the site was recently deleted, 
-        we are still processing the deletion, in which case please try again later. 
-        Otherwise, please contact support.
-        """
+        domain:
+          "This domain has already been taken. Perhaps one of your team members registered it? If that's not the case, please contact support@plausible.io"
       ]
     else
       []

--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
         |> put_status(400)
         |> json(serialize_errors(changeset))
 
-      {:error, :limit, limit} ->
+      {:error, :limit, limit, _} ->
         conn
         |> put_status(403)
         |> json(%{

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -84,16 +84,16 @@ defmodule PlausibleWeb.SiteController do
         |> put_session(site.domain <> "_offer_email_report", true)
         |> redirect(to: Routes.site_path(conn, :add_snippet, site.domain))
 
-      {:error, :site, changeset, _} ->
+      {:error, :limit, _limit} ->
+        send_resp(conn, 400, "Site limit reached")
+
+      {:error, _, changeset, _} ->
         render(conn, "new.html",
           changeset: changeset,
           is_first_site: is_first_site,
           is_at_limit: false,
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
-
-      {:error, :limit, _limit} ->
-        send_resp(conn, 400, "Site limit reached")
     end
   end
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -84,8 +84,14 @@ defmodule PlausibleWeb.SiteController do
         |> put_session(site.domain <> "_offer_email_report", true)
         |> redirect(to: Routes.site_path(conn, :add_snippet, site.domain))
 
-      {:error, :limit, _limit} ->
-        send_resp(conn, 400, "Site limit reached")
+      {:error, :limit, limit, _} ->
+        render(conn, "new.html",
+          changeset: Plausible.Site.changeset(%Plausible.Site{}),
+          is_first_site: is_first_site,
+          is_at_limit: true,
+          site_limit: limit,
+          layout: {PlausibleWeb.LayoutView, "focus.html"}
+        )
 
       {:error, _, changeset, _} ->
         render(conn, "new.html",

--- a/lib/plausible_web/templates/site/new.html.eex
+++ b/lib/plausible_web/templates/site/new.html.eex
@@ -16,7 +16,7 @@
             </h3>
             <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
               <p>
-              Your account is limited to <%= @site_limit %> sites. Please contact support to add more sites.
+                Your account is limited to <%= @site_limit %> sites. Please contact support@plausible.io to add more sites.
               </p>
             </div>
           </div>

--- a/lib/plausible_web/templates/site/new.html.eex
+++ b/lib/plausible_web/templates/site/new.html.eex
@@ -16,7 +16,7 @@
             </h3>
             <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
               <p>
-              Your account is limited to <%= @site_limit %> sites. Please contact hello@plausible.io to add more sites.
+              Your account is limited to <%= @site_limit %> sites. Please contact support to add more sites.
               </p>
             </div>
           </div>

--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -38,6 +38,5 @@ defmodule Plausible.SentryFilter do
 
   def before_send(event) do
     event
-    |> IO.inspect(label: :hello)
   end
 end

--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -38,5 +38,6 @@ defmodule Plausible.SentryFilter do
 
   def before_send(event) do
     event
+    |> IO.inspect(label: :hello)
   end
 end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -126,7 +126,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert html = html_response(conn, 200)
-      assert html =~ "We cannot create &#39;#{domain}&#39;"
+      assert html =~ "This domain has already been taken."
       assert html =~ "please contact support"
       refute Repo.get_by(Plausible.Site, domain: domain)
     end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -183,12 +183,16 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn =
         post(conn, "/sites", %{
           "site" => %{
-            "domain" => "example.com",
+            "domain" => "over-limit.example.com",
             "timezone" => "Europe/London"
           }
         })
 
-      assert conn.status == 400
+      assert html = html_response(conn, 200)
+      assert html =~ "Upgrade required"
+      assert html =~ "Your account is limited to 3 sites"
+      assert html =~ "Please contact support"
+      refute Repo.get_by(Plausible.Site, domain: "over-limit.example.com")
     end
 
     test "allows accounts registered before 2021-05-05 to go over the limit", %{

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -105,7 +105,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert redirected_to(conn) == "/example.com/snippet"
-      assert Repo.exists?(Plausible.Site, domain: "example.com")
+      assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
     test "refuses to create the site when events exist (pending deletion)", %{conn: conn} do
@@ -128,7 +128,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html = html_response(conn, 200)
       assert html =~ "We cannot create &#39;#{domain}&#39;"
       assert html =~ "please contact support"
-      refute Repo.exists?(Plausible.Site, domain: domain)
+      refute Repo.get_by(Plausible.Site, domain: domain)
     end
 
     test "starts trial if user does not have trial yet", %{conn: conn, user: user} do
@@ -217,7 +217,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert redirected_to(conn) == "/example.com/snippet"
-      assert Repo.exists?(Plausible.Site, domain: "example.com")
+      assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
     test "allows enterprise accounts to create unlimited sites", %{
@@ -240,7 +240,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert redirected_to(conn) == "/example.com/snippet"
-      assert Repo.exists?(Plausible.Site, domain: "example.com")
+      assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
     test "cleans up the url", %{conn: conn} do
@@ -253,7 +253,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert redirected_to(conn) == "/example.com/snippet"
-      assert Repo.exists?(Plausible.Site, domain: "example.com")
+      assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
     test "renders form again when domain is missing", %{conn: conn} do


### PR DESCRIPTION
### Changes

This PR introduces the following changes:
  - Domains with existing events cannot be created; either asynchronous deletion is in progress or support intervention is necessary.
![image](https://user-images.githubusercontent.com/173738/213120767-eb4b75b2-b29a-422e-ac2e-3d64d40137ef.png)

  - I found user-facing code presenting a warning when site limit is reached, but it was never displayed (raw 4xx error page was returned). It is now shown when applicable:
![image](https://user-images.githubusercontent.com/173738/213120669-e8771024-637f-4dc0-b36c-8aea40689aeb.png)

  - The whole site creation process is wrapped with a single Postgres transaction
  - Some tests were naively misusing `Repo.exists?` so that it always evaluated to true - this has been fixed

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
