### PR TITLE
Fix returning more pageviews with a visit property filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - 'Last updated X seconds ago' info to 'current visitors' tooltips
 
 ### Fixed
+- Fix [more pageviews with session prop filter than with no filters](https://github.com/plausible/analytics/issues/1666)
 - Cascade delete sent_renewal_notifications table when user is deleted plausible/analytics#2549
 - Show appropriate top-stat metric labels on the realtime dashboard when filtering by a goal
 - Fix breakdown API pagination when using event metrics plausible/analytics#2562

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -150,7 +150,7 @@ defmodule Plausible.Stats.Base do
       from(
         s in "sessions",
         where: s.domain == ^site.domain,
-        where: s.start >= ^first_datetime and s.start < ^last_datetime,
+        where: s.start >= ^first_datetime and s.start < ^last_datetime
       )
       |> add_sample_hint(query)
 

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -14,7 +14,9 @@ defmodule Plausible.Stats.Base do
       sessions_q =
         from(
           s in query_sessions(site, query),
-          select: %{session_id: fragment("DISTINCT ?", s.session_id)}
+          select: %{session_id: s.session_id},
+          where: s.sign == 1,
+          group_by: s.session_id
         )
 
       from(
@@ -148,7 +150,7 @@ defmodule Plausible.Stats.Base do
       from(
         s in "sessions",
         where: s.domain == ^site.domain,
-        where: s.start >= ^first_datetime and s.start < ^last_datetime
+        where: s.start >= ^first_datetime and s.start < ^last_datetime,
       )
       |> add_sample_hint(query)
 

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Stats.Base do
       sessions_q =
         from(
           s in query_sessions(site, query),
-          select: %{session_id: s.session_id}
+          select: %{session_id: fragment("DISTINCT ?", s.session_id)}
         )
 
       from(


### PR DESCRIPTION
### Changes

This PR fixes https://github.com/plausible/analytics/issues/1666. The bug was that we were not querying the CollapsingMergeTree table engine correctly, hence the number of pageviews (also custom events) was wrongly inflated when looking at recent periods (`today`, `realtime`).

As the 'sessions' table is using the CollapsingMergeTree engine, we have to select session_id's distinctively in the join subquery. Otherwise we will get multiple rows (with sign -1 and 1) as long as the background merge hasn't happened.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Not sure whether to log this change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
