### PR TITLE
fix clickhouse-ci rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clickhouse-prod: ## Start a container with the same version of clickhouse as the
 	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:21.11.3.6
 
 clickhouse-ci: ## Start a container with the same version of clickhouse as the one in .github/workflows/elixir.yml
-	docker run $(CH_FLAGS)--volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:21.11
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:21.11
 
 clickhouse-stop: ## Stop and remove the clickhouse container
 	docker stop plausible_clickhouse && docker rm plausible_clickhouse


### PR DESCRIPTION
### Changes

This PR adds a missing whitespace in `clickhouse-ci`'s docker command.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
