### PR TITLE
Some changes to the "locked site" copy

### DIFF
--- a/lib/plausible_web/templates/stats/site_locked.html.eex
+++ b/lib/plausible_web/templates/stats/site_locked.html.eex
@@ -5,14 +5,14 @@
         <svg class="w-6 h-6 text-green-600" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"></path></svg>
       </div>
       <h3 class="mt-6 text-center text-2xl leading-6 font-medium text-gray-900 dark:text-gray-200">
-        Site locked
+        Dashboard locked
       </h3>
 
       <%= case @conn.assigns[:current_user_role] do %>
         <% :owner -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
-              This site is locked because you don't have an active subscription. We are still counting stats in the background but your access to the dashboard is restricted. Subscribe with the link below to access your stats again.
+              This dashboard is locked because you don't have a valid subscription. We're still counting the stats but your access to the dashboard is restricted. Please subscribe to the appropriate tier with the link below to access the stats again.
             </p>
           </div>
           <div class="mt-6 w-full text-center">
@@ -21,8 +21,8 @@
         <% role when role in [:admin, :viewer] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
-            This site is currently locked and cannot be accessed. The site owner <b><%= @owner.email %></b> must upgrade their subscription plan in order to
-            unlock the site.
+            This dashboard is currently locked and cannot be accessed. The site owner <b><%= @owner.email %></b> must upgrade their subscription plan in order to
+            unlock the stats.
             </p>
             <div class="mt-6 text-sm text-gray-500">
               <p>Want to pay for this site with the account you're logged in with?</p>
@@ -35,7 +35,7 @@
         <% _ -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
-            This site is currently locked and cannot be accessed. You can check back later or contact the site owner to unlock it.
+            This dashboard is currently locked and cannot be accessed. You can check back later or contact the site owner to unlock it.
             </p>
           </div>
           <%= if @conn.assigns[:current_user] do %>

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -34,7 +34,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "shows locked page if page is locked", %{conn: conn, user: user} do
       locked_site = insert(:site, locked: true, members: [user])
       conn = get(conn, "/" <> locked_site.domain)
-      assert html_response(conn, 200) =~ "Site locked"
+      assert html_response(conn, 200) =~ "Dashboard locked"
     end
 
     test "can not view stats of someone else's website", %{conn: conn} do
@@ -285,7 +285,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
 
-      assert html_response(conn, 200) =~ "Site locked"
+      assert html_response(conn, 200) =~ "Dashboard locked"
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
 


### PR DESCRIPTION
Some changes to be more consistent with the emails we send. Also "valid" subscription rather than "active" subscription fits better for the different cases where this screen is shown

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
