### PR TITLE
Save city name when importing from GA

### DIFF
--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -1,4 +1,8 @@
 defmodule ObanErrorReporter do
+  @moduledoc false
+
+  require Logger
+
   def handle_event([:oban, :job, :exception], measure, %{job: job} = meta, _) do
     extra =
       job
@@ -7,18 +11,21 @@ defmodule ObanErrorReporter do
 
     on_job_exception(job)
 
+    Logger.warn("Failed to complete Oban job. Reason: #{inspect(meta.reason)}")
     Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 
   def handle_event([:oban, :notifier, :exception], _timing, meta, _) do
     extra = Map.take(meta, ~w(channel payload)a)
 
+    Logger.warn("Failed to complete Oban job. Reason: #{inspect(meta.reason)}")
     Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 
   def handle_event([:oban, :plugin, :exception], _timing, meta, _) do
     extra = Map.take(meta, ~w(plugin)a)
 
+    Logger.warn("Failed to complete Oban job. Reason: #{inspect(meta.reason)}")
     Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 

--- a/lib/plausible/google/report_request.ex
+++ b/lib/plausible/google/report_request.ex
@@ -57,7 +57,7 @@ defmodule Plausible.Google.ReportRequest do
       },
       %__MODULE__{
         dataset: "imported_locations",
-        dimensions: ["ga:date", "ga:countryIsoCode", "ga:regionIsoCode"],
+        dimensions: ["ga:date", "ga:countryIsoCode", "ga:regionIsoCode", "ga:city"],
         metrics: ["ga:users", "ga:sessions", "ga:bounces", "ga:sessionDuration"]
       },
       %__MODULE__{

--- a/lib/plausible/imported/site.ex
+++ b/lib/plausible/imported/site.ex
@@ -98,12 +98,24 @@ defmodule Plausible.Imported do
   end
 
   defp new_from_google_analytics(site_id, "imported_locations", row) do
+    city_name =
+      row.dimensions
+      |> Map.fetch!("ga:city")
+      |> default_if_missing("")
+
+    country_code =
+      row.dimensions
+      |> Map.fetch!("ga:countryIsoCode")
+      |> default_if_missing("")
+
+    city = Location.City.get_city(city_name, country_code) || %{}
+
     %{
       site_id: site_id,
       date: get_date(row),
-      country: row.dimensions |> Map.fetch!("ga:countryIsoCode") |> default_if_missing(""),
+      country: country_code,
       region: row.dimensions |> Map.fetch!("ga:regionIsoCode") |> default_if_missing(""),
-      city: 0,
+      city: Map.get(city, :id, 0),
       visitors: row.metrics |> Map.fetch!("ga:users") |> parse_number(),
       visits: row.metrics |> Map.fetch!("ga:sessions") |> parse_number(),
       bounces: row.metrics |> Map.fetch!("ga:bounces") |> parse_number(),

--- a/lib/workers/import_google_analytics.ex
+++ b/lib/workers/import_google_analytics.ex
@@ -1,5 +1,6 @@
 defmodule Plausible.Workers.ImportGoogleAnalytics do
   use Plausible.Repo
+  require Logger
 
   use Oban.Worker,
     queue: :google_analytics_imports,
@@ -41,6 +42,7 @@ defmodule Plausible.Workers.ImportGoogleAnalytics do
         :ok
 
       {:error, error} ->
+        Logger.error("Import: Failed to import from GA. Reason: #{inspect(error)}")
         import_failed(site)
 
         {:error, error}


### PR DESCRIPTION
This commit adds city data to imported records from Google Analytics. The current implementation sets city to `0` because GA does not use the GeoNames database.

Google Analytics Reporting API uses [Geographical IDs](https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid) to identify cities and countries. Plausible uses [GeoNames](https://geonames.org) and I couldn't find databases corelating the two.

Fortunately, GA also returns the city name and this commit uses the city name when querying imported data. I tried deleting the `imported_locations.city` column from ClickHouse, but this is primary key and can't be deleted. I also couldn't make city flags work, because the country code is from the GeoName, and we don't have it for imported data.

<img width="547" alt="Screenshot 2023-01-25 at 11 04 28" src="https://user-images.githubusercontent.com/5093045/214585396-77666b86-80fe-449c-8a55-356d62dbf0c5.png">