### PR TITLE
Remove the ability to collapse the main graph + transition bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 - Always show direct traffic in sources reports plausible/analytics#2531
 - Stop recording XX and T1 country codes plausible/analytics#2556
 
+### Removed
+- Remove the ability to collapse the main graph plausible/analytics#2627
+
 ## v1.5.1 - 2022-12-06
 
 ### Fixed

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -27,6 +27,14 @@ export const METRIC_FORMATTER = {
   'conversions': numberFormatter,
 }
 
+export const LoadingState = {
+  loading: 'loading',
+  refreshing: 'refreshing',
+  loaded: 'loaded',
+  isLoadingOrRefreshing: function (state) { return [this.loading, this.refreshing].includes(state) },
+  isLoadedOrRefreshing: function (state) { return [this.loaded, this.refreshing].includes(state) }
+}
+
 export const GraphTooltip = (graphData, metric, query) => {
   return (context) => {
     const tooltipModel = context.tooltip;

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -47,22 +47,9 @@ export default class TopStats extends React.Component {
     return (
       <div>
         <div className="whitespace-nowrap">{this.topStatNumberLong(stat)} {statName}</div>
-        {this.canMetricBeGraphed(stat) && <div className="font-normal text-xs">{this.titleFor(stat)}</div>}
         {stat.name === 'Current visitors' && <p className="font-normal text-xs">Last updated <SecondsSinceLastLoad lastLoadTimestamp={this.props.lastLoadTimestamp}/>s ago</p>}
       </div>
     )
-  }
-
-  titleFor(stat) {
-    const isClickable = this.canMetricBeGraphed(stat)
-
-    if (isClickable && this.props.metric === METRIC_MAPPING[stat.name]) {
-      return "Click to hide"
-    } else if (isClickable) {
-      return "Click to show"
-    } else {
-      return null
-    }
   }
 
   canMetricBeGraphed(stat) {


### PR DESCRIPTION
This PR removes the ability to collapse the main graph. The graph collapsed whenever `metric` was a falsy value (`undefined`, `null`, `""`). I removed all code related to that. `metric` should default to `visitors` always.

We want to add new items to top stats, and this PR will make it easier to change it. Also, there's currently a bug where top stats is randomly collapsing, which should be fixed by this PR.

This pull request also fixes a bug where the graph wasn't fading out when changing metrics.

## Preview

[preview.webm](https://user-images.githubusercontent.com/5093045/215574524-83b307ce-8dd8-4130-952b-c7ff7f748acf.webm)
