### PR TITLE
Prevent error reports from being sent with short feedback

### DIFF
--- a/lib/plausible_web/controllers/error_report_controller.ex
+++ b/lib/plausible_web/controllers/error_report_controller.ex
@@ -5,12 +5,13 @@ defmodule PlausibleWeb.ErrorReportController do
 
   def submit_error_report(conn, %{
         "error" => %{"trace_id" => trace_id, "user_feedback" => feedback}
-      })
-      when byte_size(feedback) > 5 do
-    reported_by = "#{conn.assigns.current_user.name} <#{conn.assigns.current_user.email}>"
-    email_template = PlausibleWeb.Email.error_report(reported_by, trace_id, feedback)
+      }) do
+    if String.length(String.trim(feedback)) > 5 do
+      reported_by = "#{conn.assigns.current_user.name} <#{conn.assigns.current_user.email}>"
+      email_template = PlausibleWeb.Email.error_report(reported_by, trace_id, feedback)
 
-    Plausible.Mailer.deliver_later(email_template)
+      Plausible.Mailer.deliver_later(email_template)
+    end
 
     thanks(conn)
   end

--- a/lib/plausible_web/controllers/error_report_controller.ex
+++ b/lib/plausible_web/controllers/error_report_controller.ex
@@ -5,7 +5,8 @@ defmodule PlausibleWeb.ErrorReportController do
 
   def submit_error_report(conn, %{
         "error" => %{"trace_id" => trace_id, "user_feedback" => feedback}
-      }) do
+      })
+      when byte_size(feedback) > 5 do
     reported_by = "#{conn.assigns.current_user.name} <#{conn.assigns.current_user.email}>"
     email_template = PlausibleWeb.Email.error_report(reported_by, trace_id, feedback)
 

--- a/test/plausible_web/controllers/error_report_controller_test.exs
+++ b/test/plausible_web/controllers/error_report_controller_test.exs
@@ -68,6 +68,22 @@ defmodule PlausibleWeb.ErrorReportControllerTest do
       })
     end
 
+    test "short feedback is not sent", %{conn: conn} do
+      action_path = Routes.error_report_path(Endpoint, :submit_error_report)
+
+      conn =
+        post(conn, action_path, %{
+          "error" => %{"trace_id" => "some-trace-id", "user_feedback" => "short"}
+        })
+
+      assert html = html_response(conn, 200)
+      assert html =~ "Your report has been submitted"
+
+      refute_email_delivered_with(%{
+        subject: "Feedback to Sentry Trace some-trace-id"
+      })
+    end
+
     test "submitting no feedback for authenticated user", %{conn: conn} do
       action_path = Routes.error_report_path(Endpoint, :submit_error_report)
 


### PR DESCRIPTION
### Changes

This PR makes sure no e-mail is sent when the users submit feedback with less than 5 characters. 

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
