### PR TITLE
Interval label flicking when changing metric

### DIFF
--- a/assets/js/dashboard/stats/graph/interval-picker.js
+++ b/assets/js/dashboard/stats/graph/interval-picker.js
@@ -54,7 +54,7 @@ export function IntervalPicker({ graphData, query, site, updateInterval }) {
   const menuElement = React.useRef(null)
   subscribeKeybinding(menuElement)
 
-  const currentInterval = graphData?.interval
+  const currentInterval = graphData?.interval || getStoredInterval(query.period, site.domain)
   const options = site.validIntervalsByPeriod[query.period]
 
   return (


### PR DESCRIPTION
This commit fixes a bug where the interval label flickers when changing the dashboard metric. This was caused because changing the metric clears the `graphData` state property until the HTTP request is finished.

This change fixes it by falling back `interval` to the value stored in localStorage when `graphData` is falsy.

## Bug preview (see "Days")

[preview.webm](https://user-images.githubusercontent.com/5093045/216039004-e3803078-1a73-4364-a050-ba748f179a07.webm)
