### PR TITLE
Update sentry server_name handling

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -118,8 +118,7 @@ runtime_metadata = [
   version: get_in(build_metadata, ["labels", "org.opencontainers.image.version"]),
   commit: get_in(build_metadata, ["labels", "org.opencontainers.image.revision"]),
   created: get_in(build_metadata, ["labels", "org.opencontainers.image.created"]),
-  tags: get_in(build_metadata, ["tags"]),
-  host: get_var_from_path_or_env(config_dir, "APP_HOST", "app-unknown")
+  tags: get_in(build_metadata, ["tags"])
 ]
 
 config :plausible, :runtime_metadata, runtime_metadata
@@ -245,7 +244,7 @@ config :sentry,
   environment_name: env,
   included_environments: included_environments,
   release: sentry_app_version,
-  tags: %{app_version: sentry_app_version, server_name: runtime_metadata[:host]},
+  tags: %{app_version: sentry_app_version},
   enable_source_code_context: true,
   root_source_code_path: [File.cwd!()],
   client: Plausible.Sentry.Client,


### PR DESCRIPTION
### Changes

Update sentry server_name handling.

Our infrastructure now sets the correct hostname instead of the mutable container name.
The changes introduced in #2317 to set the APP_HOST env var as server_name also did not have any effect, because we server_name needs to be set as an option (not as a tag).

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
