### PR TITLE
Better error message on site creation error

### DIFF
--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -13,11 +13,6 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
       {:ok, %{site: site}} ->
         json(conn, site)
 
-      {:error, :site, changeset, _} ->
-        conn
-        |> put_status(400)
-        |> json(serialize_errors(changeset))
-
       {:error, :limit, limit, _} ->
         conn
         |> put_status(403)
@@ -25,6 +20,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
           error:
             "Your account has reached the limit of #{limit} sites per account. Please contact hello@plausible.io to unlock more sites."
         })
+
+      {:error, _, changeset, _} ->
+        conn
+        |> put_status(400)
+        |> json(serialize_errors(changeset))
     end
   end
 
@@ -139,7 +139,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
   defp serialize_errors(changeset) do
     {field, {msg, _opts}} = List.first(changeset.errors)
-    error_msg = Atom.to_string(field) <> " " <> msg
+    error_msg = Atom.to_string(field) <> ": " <> msg
     %{"error" => error_msg}
   end
 

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
       conn = post(conn, "/api/v1/sites", %{})
 
       assert json_response(conn, 400) == %{
-               "error" => "domain can't be blank"
+               "error" => "domain: can't be blank"
              }
     end
 
@@ -57,7 +57,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         conn = post(conn, "/api/v1/sites", %{"domain" => bad_domain})
 
         assert %{"error" => error} = json_response(conn, 400)
-        assert error =~ "domain must not contain URI reserved characters"
+        assert error =~ "domain: must not contain URI reserved characters"
       end)
     end
 


### PR DESCRIPTION
### Changes

We've been leaking some internal error details. This PR makes the site creation errors (e.g. due to existing events) human readable.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated - https://github.com/plausible/docs/pull/349
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
