### PR TITLE
Replace empty OS/screen size/Browser with `(not set)` in UI/API/exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - 'Last updated X seconds ago' info to 'current visitors' tooltips
 
 ### Fixed
+- Empty values for Screen Size, OS and Browser are uniformly replaced with "(not set)"
 - Fix [more pageviews with session prop filter than with no filters](https://github.com/plausible/analytics/issues/1666)
 - Cascade delete sent_renewal_notifications table when user is deleted plausible/analytics#2549
 - Show appropriate top-stat metric labels on the realtime dashboard when filtering by a goal

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -50,11 +50,11 @@ function filterText(key, rawValue, query) {
     return <>{eventName}.{metaKey} {toFilterType(metaValue)} <b>{valueWithoutPrefix(metaValue)}</b></>
   }
   if (key === "browser_version") {
-    const browserName = query.filters.browser ? query.filters.browser : 'Browser'
+    const browserName = query.filters.browser === '(not set)' ? 'Browser' : query.filters.browser
     return <>{browserName}.Version {type} <b>{value}</b></>
   }
   if (key === "os_version") {
-    const osName = query.filters.os ? query.filters.os : 'OS'
+    const osName = query.filters.os === '(not set)' ? 'OS' : query.filters.os
     return <>{osName}.Version {type} <b>{value}</b></>
   }
   if (key === "country") {

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -18,8 +18,8 @@ function removeFilter(key, history, query) {
     [key]: false
   }
   if (key === 'country') { newOpts.country_name = false }
-  if (key === 'region')  { newOpts.region_name = false }
-  if (key === 'city')    { newOpts.city_name = false }
+  if (key === 'region') { newOpts.region_name = false }
+  if (key === 'city') { newOpts.city_name = false }
 
   navigateToQuery(
     history,
@@ -50,11 +50,14 @@ function filterText(key, rawValue, query) {
     return <>{eventName}.{metaKey} {toFilterType(metaValue)} <b>{valueWithoutPrefix(metaValue)}</b></>
   }
   if (key === "browser_version") {
-    const browserName = query.filters.browser === '(not set)' ? 'Browser' : query.filters.browser
+    const isNotSet = query.filters.browser === '(not set)' || (!query.filters.browser)
+    const browserName = isNotSet ? 'Browser' : query.filters.browser
     return <>{browserName}.Version {type} <b>{value}</b></>
   }
   if (key === "os_version") {
-    const osName = query.filters.os === '(not set)' ? 'OS' : query.filters.os
+    const isNotSet = query.filters.os === '(not set)' || (!query.filters.os)
+    const osName = isNotSet ? 'Operating System' : query.filters.os
+    console.info('osname', osName)
     return <>{osName}.Version {type} <b>{value}</b></>
   }
   if (key === "country") {
@@ -92,7 +95,7 @@ function renderDropdownFilter(site, history, [key, value], query) {
           title={`Edit filter: ${formattedFilters[key]}`}
           to={{ pathname: `/${encodeURIComponent(site.domain)}/filter/${filterGroupForFilter(key)}`, search: window.location.search }}
           className="group flex w-full justify-between items-center"
-          style={{width: 'calc(100% - 1.5rem)'}}
+          style={{ width: 'calc(100% - 1.5rem)' }}
         >
           <span className="inline-block w-full truncate">{filterText(key, value, query)}</span>
           <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
@@ -123,7 +126,7 @@ function filterDropdownOption(site, option) {
   )
 }
 
-function DropdownContent({history, site, query, wrapped}) {
+function DropdownContent({ history, site, query, wrapped }) {
   const [addingFilter, setAddingFilter] = useState(false);
 
   if (wrapped === 0 || addingFilter) {
@@ -191,7 +194,7 @@ class Filters extends React.Component {
   }
 
   handleKeyup(e) {
-    const {query, history} = this.props
+    const { query, history } = this.props
 
     if (e.ctrlKey || e.metaKey || e.altKey) return
 
@@ -201,7 +204,7 @@ class Filters extends React.Component {
   }
 
   handleResize() {
-    this.setState({ viewport: window.innerWidth || 639});
+    this.setState({ viewport: window.innerWidth || 639 });
   }
 
   // Checks if the filter container is wrapping items
@@ -325,8 +328,8 @@ class Filters extends React.Component {
   render() {
     return (
       <>
-        { this.renderFilterList() }
-        { this.renderDropDown() }
+        {this.renderFilterList()}
+        {this.renderDropDown()}
       </>
     )
   }

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -25,25 +25,16 @@ function BrowserVersions({ query, site }) {
     return api.get(url.apiPath(site, '/browser-versions'), query)
   }
 
-  if (query.filters.browser == "(not set)") {
-    return (
-      <ListReport
-        fetchData={fetchData}
-        filter={{}}
-        keyLabel="Browser"
-        query={query}
-      />
-    )
-  } else {
-    return (
-      <ListReport
-        fetchData={fetchData}
-        filter={{ browser_version: 'name' }}
-        keyLabel={query.filters.browser + ' version'}
-        query={query}
-      />
-    )
-  }
+  const browserName = query.filters.browser === '(not set)' ? 'Browser' : query.filters.browser
+
+  return (
+    <ListReport
+      fetchData={fetchData}
+      filter={{ browser_version: 'name' }}
+      keyLabel={browserName + ' version'}
+      query={query}
+    />
+  )
 
 }
 
@@ -67,25 +58,16 @@ function OperatingSystemVersions({ query, site }) {
     return api.get(url.apiPath(site, '/operating-system-versions'), query)
   }
 
-  if (query.filters.os == "(not set)") {
-    return (
-      <ListReport
-        fetchData={fetchData}
-        filter={{}}
-        keyLabel="Operating System"
-        query={query}
-      />
-    )
-  } else {
-    return (
-      <ListReport
-        fetchData={fetchData}
-        filter={{ os_version: 'name' }}
-        keyLabel={query.filters.os + ' version'}
-        query={query}
-      />
-    )
-  }
+  const osName = query.filters.os === '(not set)' ? 'Operating System' : query.filters.os
+
+  return (
+    <ListReport
+      fetchData={fetchData}
+      filter={{ os_version: 'name' }}
+      keyLabel={osName + ' version'}
+      query={query}
+    />
+  )
 
 }
 
@@ -139,11 +121,7 @@ function iconFor(screenSize) {
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2" /><line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" /></svg>
     )
   } else if (screenSize === '(not set)') {
-    return (
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
-      </svg>
-    )
+    return null
   }
 }
 

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -5,7 +5,7 @@ import ListReport from '../reports/list'
 import * as api from '../../api'
 import * as url from '../../util/url'
 
-function Browsers({query, site}) {
+function Browsers({ query, site }) {
   function fetchData() {
     return api.get(url.apiPath(site, '/browsers'), query)
   }
@@ -13,29 +13,41 @@ function Browsers({query, site}) {
   return (
     <ListReport
       fetchData={fetchData}
-      filter={{browser: 'name'}}
+      filter={{ browser: 'name' }}
       keyLabel="Browser"
       query={query}
     />
   )
 }
 
-function BrowserVersions({query, site}) {
+function BrowserVersions({ query, site }) {
   function fetchData() {
     return api.get(url.apiPath(site, '/browser-versions'), query)
   }
 
-  return (
-    <ListReport
-      fetchData={fetchData}
-      filter={{browser_version: 'name'}}
-      keyLabel={query.filters.browser + ' version'}
-      query={query}
-    />
-  )
+  if (query.filters.browser == "(not set)") {
+    return (
+      <ListReport
+        fetchData={fetchData}
+        filter={{}}
+        keyLabel="Browser"
+        query={query}
+      />
+    )
+  } else {
+    return (
+      <ListReport
+        fetchData={fetchData}
+        filter={{ browser_version: 'name' }}
+        keyLabel={query.filters.browser + ' version'}
+        query={query}
+      />
+    )
+  }
+
 }
 
-function OperatingSystems({query, site}) {
+function OperatingSystems({ query, site }) {
   function fetchData() {
     return api.get(url.apiPath(site, '/operating-systems'), query)
   }
@@ -43,29 +55,41 @@ function OperatingSystems({query, site}) {
   return (
     <ListReport
       fetchData={fetchData}
-      filter={{os: 'name'}}
+      filter={{ os: 'name' }}
       keyLabel="Operating system"
       query={query}
     />
   )
 }
 
-function OperatingSystemVersions({query, site}) {
+function OperatingSystemVersions({ query, site }) {
   function fetchData() {
     return api.get(url.apiPath(site, '/operating-system-versions'), query)
   }
 
-  return (
-    <ListReport
-      fetchData={fetchData}
-      filter={{os_version: 'name'}}
-      keyLabel={query.filters.os + ' version'}
-      query={query}
-    />
-  )
+  if (query.filters.os == "(not set)") {
+    return (
+      <ListReport
+        fetchData={fetchData}
+        filter={{}}
+        keyLabel="Operating System"
+        query={query}
+      />
+    )
+  } else {
+    return (
+      <ListReport
+        fetchData={fetchData}
+        filter={{ os_version: 'name' }}
+        keyLabel={query.filters.os + ' version'}
+        query={query}
+      />
+    )
+  }
+
 }
 
-function ScreenSizes({query, site}) {
+function ScreenSizes({ query, site }) {
   function fetchData() {
     return api.get(url.apiPath(site, '/screen-sizes'), query)
   }
@@ -81,7 +105,7 @@ function ScreenSizes({query, site}) {
   return (
     <ListReport
       fetchData={fetchData}
-      filter={{screen: 'name'}}
+      filter={{ screen: 'name' }}
       keyLabel="Screen size"
       query={query}
       renderIcon={renderIcon}
@@ -100,19 +124,25 @@ const EXPLANATION = {
 function iconFor(screenSize) {
   if (screenSize === 'Mobile') {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="5" y="2" width="14" height="20" rx="2" ry="2" /><line x1="12" y1="18" x2="12" y2="18" /></svg>
     )
   } else if (screenSize === 'Tablet') {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="4" y="2" width="16" height="20" rx="2" ry="2" transform="rotate(180 12 12)"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="4" y="2" width="16" height="20" rx="2" ry="2" transform="rotate(180 12 12)" /><line x1="12" y1="18" x2="12" y2="18" /></svg>
     )
   } else if (screenSize === 'Laptop') {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="2" y1="20" x2="22" y2="20"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2" /><line x1="2" y1="20" x2="22" y2="20" /></svg>
     )
   } else if (screenSize === 'Desktop') {
     return (
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather"><rect x="2" y="3" width="20" height="14" rx="2" ry="2" /><line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" /></svg>
+    )
+  } else if (screenSize === '(not set)') {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="-mt-px feather">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+      </svg>
     )
   }
 }
@@ -120,18 +150,17 @@ function iconFor(screenSize) {
 export default class Devices extends React.Component {
   constructor(props) {
     super(props)
-    this.tabKey = `deviceTab__${  props.site.domain}`
+    this.tabKey = `deviceTab__${props.site.domain}`
     const storedTab = storage.getItem(this.tabKey)
     this.state = {
       mode: storedTab || 'size'
     }
   }
 
-
   setMode(mode) {
     return () => {
       storage.setItem(this.tabKey, mode)
-      this.setState({mode})
+      this.setState({ mode })
     }
   }
 
@@ -189,12 +218,12 @@ export default class Devices extends React.Component {
           <div className="flex justify-between w-full">
             <h3 className="font-bold dark:text-gray-100">Devices</h3>
             <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
-              { this.renderPill('Size', 'size') }
-              { this.renderPill('Browser', 'browser') }
-              { this.renderPill('OS', 'os') }
+              {this.renderPill('Size', 'size')}
+              {this.renderPill('Browser', 'browser')}
+              {this.renderPill('OS', 'os')}
             </div>
           </div>
-          { this.renderContent() }
+          {this.renderContent()}
         </div>
       </div>
     )

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -25,12 +25,14 @@ function BrowserVersions({ query, site }) {
     return api.get(url.apiPath(site, '/browser-versions'), query)
   }
 
-  const browserName = query.filters.browser === '(not set)' ? 'Browser' : query.filters.browser
+  const isNotSet = query.filters.browser === '(not set)'
+  const browserName = isNotSet ? 'Browser' : query.filters.browser
+  const filter = isNotSet ? {} : { browser_version: 'name' }
 
   return (
     <ListReport
       fetchData={fetchData}
-      filter={{ browser_version: 'name' }}
+      filter={filter}
       keyLabel={browserName + ' version'}
       query={query}
     />
@@ -58,12 +60,14 @@ function OperatingSystemVersions({ query, site }) {
     return api.get(url.apiPath(site, '/operating-system-versions'), query)
   }
 
-  const osName = query.filters.os === '(not set)' ? 'Operating System' : query.filters.os
+  const isNotSet = query.filters.os === '(not set)'
+  const osName = isNotSet ? 'Operating System' : query.filters.os
+  const filter = isNotSet ? {} : { os_version: 'name' }
 
   return (
     <ListReport
       fetchData={fetchData}
-      filter={{ os_version: 'name' }}
+      filter={filter}
       keyLabel={osName + ' version'}
       query={query}
     />

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -6,6 +6,7 @@ defmodule Plausible.Stats.Base do
   # Ecto typespec has not been updated for this PR: https://github.com/elixir-ecto/ecto/pull/3592
   @dialyzer {:nowarn_function, add_sample_hint: 2}
   @no_ref "Direct / None"
+  @not_set "(not set)"
 
   def base_event_query(site, query) do
     events_q = query_events(site, query)
@@ -391,6 +392,7 @@ defmodule Plausible.Stats.Base do
   defp db_prop_val(:utm_campaign, @no_ref), do: ""
   defp db_prop_val(:utm_content, @no_ref), do: ""
   defp db_prop_val(:utm_term, @no_ref), do: ""
+  defp db_prop_val(_, @not_set), do: ""
   defp db_prop_val(_, val), do: val
 
   def utc_boundaries(%Query{period: "realtime"}, _timezone) do

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Stats.Breakdown do
   alias Plausible.Stats.Query
   alias Plausible.Goals
   @no_ref "Direct / None"
+  @not_set "(not set)"
 
   @event_metrics [:visitors, :pageviews, :events]
   @session_metrics [:visits, :bounce_rate, :visit_duration]
@@ -512,7 +513,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.screen_size,
-      select_merge: %{device: s.screen_size},
+      select_merge: %{
+        device: fragment("if(empty(?), ?, ?)", s.screen_size, @not_set, s.screen_size)
+      },
       order_by: {:asc, s.screen_size}
     )
   end
@@ -521,7 +524,10 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.operating_system,
-      select_merge: %{operating_system: s.operating_system},
+      select_merge: %{
+        operating_system:
+          fragment("if(empty(?), ?, ?)", s.operating_system, @not_set, s.operating_system)
+      },
       order_by: {:asc, s.operating_system}
     )
   end
@@ -530,7 +536,15 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.operating_system_version,
-      select_merge: %{os_version: s.operating_system_version},
+      select_merge: %{
+        os_version:
+          fragment(
+            "if(empty(?), ?, ?)",
+            s.operating_system_version,
+            @not_set,
+            s.operating_system_version
+          )
+      },
       order_by: {:asc, s.operating_system_version}
     )
   end
@@ -539,7 +553,9 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.browser,
-      select_merge: %{browser: s.browser},
+      select_merge: %{
+        browser: fragment("if(empty(?), ?, ?)", s.browser, @not_set, s.browser)
+      },
       order_by: {:asc, s.browser}
     )
   end
@@ -548,7 +564,10 @@ defmodule Plausible.Stats.Breakdown do
     from(
       s in q,
       group_by: s.browser_version,
-      select_merge: %{browser_version: s.browser_version},
+      select_merge: %{
+        browser_version:
+          fragment("if(empty(?), ?, ?)", s.browser_version, @not_set, s.browser_version)
+      },
       order_by: {:asc, s.browser_version}
     )
   end

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/browsers.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-,1,50.0
+(not set),1,50.0

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/devices.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/devices.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-,1,25.0
+(not set),1,25.0

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/operating_systems.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/operating_systems.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-,1,25.0
+(not set),1,25.0

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/browsers.csv
@@ -1,2 +1,2 @@
 name,visitors
-,1
+(not set),1

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/devices.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/devices.csv
@@ -1,2 +1,2 @@
 name,visitors
-,1
+(not set),1

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/operating_systems.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/operating_systems.csv
@@ -1,2 +1,2 @@
 name,visitors
-,1
+(not set),1

--- a/test/plausible_web/controllers/CSVs/30d/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/30d/browsers.csv
@@ -1,3 +1,3 @@
 name,visitors
 ABrowserName,2
-,2
+(not set),2

--- a/test/plausible_web/controllers/CSVs/30d/devices.csv
+++ b/test/plausible_web/controllers/CSVs/30d/devices.csv
@@ -1,2 +1,2 @@
 name,visitors
-,4
+(not set),4

--- a/test/plausible_web/controllers/CSVs/30d/operating_systems.csv
+++ b/test/plausible_web/controllers/CSVs/30d/operating_systems.csv
@@ -1,2 +1,2 @@
 name,visitors
-,4
+(not set),4

--- a/test/plausible_web/controllers/CSVs/6m/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/6m/browsers.csv
@@ -1,3 +1,3 @@
 name,visitors
 ABrowserName,3
-,2
+(not set),2

--- a/test/plausible_web/controllers/CSVs/6m/devices.csv
+++ b/test/plausible_web/controllers/CSVs/6m/devices.csv
@@ -1,2 +1,2 @@
 name,visitors
-,5
+(not set),5

--- a/test/plausible_web/controllers/CSVs/6m/operating_systems.csv
+++ b/test/plausible_web/controllers/CSVs/6m/operating_systems.csv
@@ -1,2 +1,2 @@
 name,visitors
-,5
+(not set),5

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -129,6 +129,21 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
                %{"name" => "Firefox", "visitors" => 1, "percentage" => 33}
              ]
     end
+
+    test "returns (not set) when appropriate", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          browser: ""
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
+             ]
+    end
   end
 
   describe "GET /api/stats/:domain/browser-versions" do
@@ -153,6 +168,24 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       assert json_response(conn, 200) == [
                %{"name" => "78.0", "visitors" => 2, "percentage" => 67},
                %{"name" => "77.0", "visitors" => 1, "percentage" => 33}
+             ]
+    end
+
+    test "returns results for (not set)", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "", browser_version: "")
+      ])
+
+      filters = Jason.encode!(%{browser: "(not set)"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -19,6 +19,33 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
              ]
     end
 
+    test "returns (not set) when appropriate", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          operating_system: ""
+        ),
+        build(:pageview,
+          operating_system: "Linux"
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 50},
+               %{"name" => "Linux", "visitors" => 1, "percentage" => 50}
+             ]
+
+      filters = Jason.encode!(%{os: "(not set)"})
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
+             ]
+    end
+
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1, operating_system: "Mac"),

--- a/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
@@ -19,6 +19,33 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
              ]
     end
 
+    test "returns (not set) when appropriate", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          screen_size: ""
+        ),
+        build(:pageview,
+          screen_size: "Desktop"
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/screen-sizes?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 50},
+               %{"name" => "Desktop", "visitors" => 1, "percentage" => 50}
+             ]
+
+      conn = get(conn, "/api/stats/#{site.domain}/screen-sizes?period=day")
+
+      filters = Jason.encode!(%{screen: "(not set)"})
+      conn = get(conn, "/api/stats/#{site.domain}/screen-sizes?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
+             ]
+    end
+
     test "returns screen sizes with :is filter on custom pageview props", %{
       conn: conn,
       site: site


### PR DESCRIPTION
### Changes

This PR replaces missing device properties with "(not set)".
Screen size, OS/version, Browser/version are optional, in case they are missing, **(not set)** is displayed in the UI/API/export. Sub-filtering by versions is disabled in the UI in case the Browser/OS are not set.

https://user-images.githubusercontent.com/173738/216993178-0bfb83c3-0408-4e9c-a544-5dcf2d76ca8b.mp4


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
