### PR TITLE
Some changes to the "site taken" copy

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -50,7 +50,7 @@ defmodule Plausible.Site do
     |> validate_domain_reserved_characters()
     |> unique_constraint(:domain,
       message:
-        "This domain has already been taken. Perhaps one of your team members registered it? If that's not the case, please contact support@plausible.io"
+        "This domain cannot be registered. Perhaps one of your colleagues registered it? Or did you recently delete it from your account? The deletion may take up to 48 hours before you can add the same site again. If that's not the case, please contact support@plausible.io"
     )
   end
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -192,7 +192,7 @@ defmodule Plausible.Sites do
 
       [
         domain:
-          "This domain has already been taken. Perhaps one of your team members registered it? If that's not the case, please contact support@plausible.io"
+          "This domain cannot be registered. Perhaps one of your colleagues registered it? Or did you recently delete it from your account? The deletion may take up to 48 hours before you can add the same site again. If that's not the case, please contact support@plausible.io"
       ]
     else
       []

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -98,7 +98,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
 
       assert json_response(conn, 400) == %{
                "error" =>
-                 "domain: This domain has already been taken. Perhaps one of your team members registered it? If that's not the case, please contact support@plausible.io"
+                 "domain: This domain cannot be registered. Perhaps one of your colleagues registered it? Or did you recently delete it from your account? The deletion may take up to 48 hours before you can add the same site again. If that's not the case, please contact support@plausible.io"
              }
     end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -126,7 +126,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert html = html_response(conn, 200)
-      assert html =~ "This domain has already been taken."
+      assert html =~ "This domain cannot be registered"
       assert html =~ "please contact support"
       refute Repo.get_by(Plausible.Site, domain: domain)
     end
@@ -291,7 +291,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert html_response(conn, 200) =~
-               "This domain has already been taken. Perhaps one of your team members registered it? If that&#39;s not the case, please contact support@plausible.io"
+               "This domain cannot be registered. Perhaps one of your colleagues registered it?"
     end
   end
 


### PR DESCRIPTION
adding the 48 hour delay in data deletion info to this message too to reduce the number of emails we get