### PR TITLE
Support alternative mailing services (Mailgun, Mandrill, Sendgrid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - 'Last updated X seconds ago' info to 'current visitors' tooltips
+- Add support for more Bamboo adapters, i.e. `Bamboo.MailgunAdapter`, `Bamboo.MandrillAdapter`, `Bamboo.SendGridAdapter` plausible/analytics#2649
 
 ### Fixed
 - Fix [more pageviews with session prop filter than with no filters](https://github.com/plausible/analytics/issues/1666)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -278,13 +278,32 @@ config :plausible, Plausible.ClickhouseRepo,
 case mailer_adapter do
   "Bamboo.PostmarkAdapter" ->
     config :plausible, Plausible.Mailer,
-      adapter: :"Elixir.#{mailer_adapter}",
+      adapter: Bamboo.PostmarkAdapter,
       request_options: [recv_timeout: 10_000],
       api_key: get_var_from_path_or_env(config_dir, "POSTMARK_API_KEY")
 
+  "Bamboo.MailgunAdapter" ->
+    config :plausible, Plausible.Mailer,
+      adapter: Bamboo.MailgunAdapter,
+      hackney_opts: [recv_timeout: :timer.seconds(10)],
+      api_key: get_var_from_path_or_env(config_dir, "MAILGUN_API_KEY"),
+      domain: get_var_from_path_or_env(config_dir, "MAILGUN_DOMAIN")
+
+  "Bamboo.MandrillAdapter" ->
+    config :plausible, Plausible.Mailer,
+      adapter: Bamboo.MandrillAdapter,
+      hackney_opts: [recv_timeout: :timer.seconds(10)],
+      api_key: get_var_from_path_or_env(config_dir, "MANDRILL_API_KEY")
+
+  "Bamboo.SendGridAdapter" ->
+    config :plausible, Plausible.Mailer,
+      adapter: Bamboo.SendGridAdapter,
+      hackney_opts: [recv_timeout: :timer.seconds(10)],
+      api_key: get_var_from_path_or_env(config_dir, "SENDGRID_API_KEY")
+
   "Bamboo.SMTPAdapter" ->
     config :plausible, Plausible.Mailer,
-      adapter: :"Elixir.#{mailer_adapter}",
+      adapter: Bamboo.SMTPAdapter,
       server: get_var_from_path_or_env(config_dir, "SMTP_HOST_ADDR", "mail"),
       hostname: base_url.host,
       port: get_var_from_path_or_env(config_dir, "SMTP_HOST_PORT", "25"),
@@ -303,7 +322,12 @@ case mailer_adapter do
     config :plausible, Plausible.Mailer, adapter: Bamboo.TestAdapter
 
   _ ->
-    raise "Unknown mailer_adapter; expected SMTPAdapter or PostmarkAdapter"
+    raise """
+    Unknown mailer_adapter: #{inspect(mailer_adapter)}
+
+    Please see https://hexdocs.pm/bamboo/readme.html#available-adapters
+    for the list of available adapters that ship with Bamboo
+    """
 end
 
 config :plausible, PlausibleWeb.Firewall,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -322,7 +322,7 @@ case mailer_adapter do
     config :plausible, Plausible.Mailer, adapter: Bamboo.TestAdapter
 
   _ ->
-    raise """
+    raise ArgumentError, """
     Unknown mailer_adapter: #{inspect(mailer_adapter)}
 
     Please see https://hexdocs.pm/bamboo/readme.html#available-adapters

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -1,0 +1,130 @@
+defmodule Plausible.ConfigTest do
+  use ExUnit.Case
+
+  describe "mailer" do
+    test "defaults to Bamboo.SMTPAdapter" do
+      env = {"MAILER_ADAPTER", nil}
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.SMTPAdapter,
+               server: "mail",
+               hostname: "localhost",
+               port: "25",
+               username: nil,
+               password: nil,
+               tls: :if_available,
+               allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+               ssl: false,
+               retries: 2,
+               no_mx_lookups: true
+             ]
+    end
+
+    test "Bamboo.PostmarkAdapter" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.PostmarkAdapter"},
+        {"POSTMARK_API_KEY", "some-postmark-key"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.PostmarkAdapter,
+               request_options: [recv_timeout: 10_000],
+               api_key: "some-postmark-key"
+             ]
+    end
+
+    test "Bamboo.MailgunAdapter" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.MailgunAdapter"},
+        {"MAILGUN_API_KEY", "some-mailgun-key"},
+        {"MAILGUN_DOMAIN", "example.com"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.MailgunAdapter,
+               hackney_opts: [recv_timeout: 10_000],
+               api_key: "some-mailgun-key",
+               domain: "example.com"
+             ]
+    end
+
+    test "Bamboo.MandrillAdapter" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.MandrillAdapter"},
+        {"MANDRILL_API_KEY", "some-mandrill-key"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.MandrillAdapter,
+               hackney_opts: [recv_timeout: 10_000],
+               api_key: "some-mandrill-key"
+             ]
+    end
+
+    test "Bamboo.SendGridAdapter" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.SendGridAdapter"},
+        {"SENDGRID_API_KEY", "some-sendgrid-key"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.SendGridAdapter,
+               hackney_opts: [recv_timeout: 10_000],
+               api_key: "some-sendgrid-key"
+             ]
+    end
+
+    test "Bamboo.SMTPAdapter" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.SMTPAdapter"},
+        {"SMTP_HOST_ADDR", "localhost"},
+        {"SMTP_HOST_PORT", "2525"},
+        {"SMTP_USER_NAME", "neo"},
+        {"SMTP_USER_PWD", "one"},
+        {"SMTP_HOST_SSL_ENABLED", "true"},
+        {"SMTP_RETRIES", "3"},
+        {"SMTP_MX_LOOKUPS_ENABLED", "true"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               {:adapter, Bamboo.SMTPAdapter},
+               {:server, "localhost"},
+               {:hostname, "localhost"},
+               {:port, "2525"},
+               {:username, "neo"},
+               {:password, "one"},
+               {:tls, :if_available},
+               {:allowed_tls_versions, [:tlsv1, :"tlsv1.1", :"tlsv1.2"]},
+               {:ssl, "true"},
+               {:retries, "3"},
+               {:no_mx_lookups, "true"}
+             ]
+    end
+
+    test "unknown adapter raises" do
+      env = {"MAILER_ADAPTER", "Bamboo.FakeAdapter"}
+
+      assert_raise ArgumentError,
+                   ~r/Unknown mailer_adapter: "Bamboo.FakeAdapter"/,
+                   fn -> runtime_config(env) end
+    end
+  end
+
+  defp runtime_config(env) do
+    put_system_env_undo(env)
+    Config.Reader.read!("config/runtime.exs", env: :prod)
+  end
+
+  defp put_system_env_undo(env) do
+    before = System.get_env()
+
+    {to_delete, to_put} = Enum.split_with(List.wrap(env), fn {_, v} -> is_nil(v) end)
+    Enum.each(to_delete, fn {k, _} -> System.delete_env(k) end)
+    System.put_env(to_put)
+
+    on_exit(fn ->
+      Enum.each(System.get_env(), fn {k, _} -> System.delete_env(k) end)
+      System.put_env(before)
+    end)
+  end
+end


### PR DESCRIPTION
### Changes

This PR is similar to https://github.com/plausible/analytics/pull/2596 but hardcodes all adapters that bamboo ships with and adds some config tests.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated https://github.com/plausible/docs/pull/351

### Dark mode
- [x] This PR does not change the UI
