### PR TITLE
First pass at Comparisons

### DIFF
--- a/assets/js/dashboard/api.js
+++ b/assets/js/dashboard/api.js
@@ -45,6 +45,7 @@ export function serializeQuery(query, extraQuery=[]) {
   if (query.filters) { queryObj.filters = serializeFilters(query.filters)  }
   if (query.with_imported) { queryObj.with_imported = query.with_imported  }
   if (SHARED_LINK_AUTH) { queryObj.auth = SHARED_LINK_AUTH }
+  if (true) { queryObj.comparison = true }
   Object.assign(queryObj, ...extraQuery)
 
   return '?' + serialize(queryObj)

--- a/assets/js/dashboard/api.js
+++ b/assets/js/dashboard/api.js
@@ -45,7 +45,7 @@ export function serializeQuery(query, extraQuery=[]) {
   if (query.filters) { queryObj.filters = serializeFilters(query.filters)  }
   if (query.with_imported) { queryObj.with_imported = query.with_imported  }
   if (SHARED_LINK_AUTH) { queryObj.auth = SHARED_LINK_AUTH }
-  if (true) { queryObj.comparison = true }
+  if (query.comparison) { queryObj.comparison = true }
   Object.assign(queryObj, ...extraQuery)
 
   return '?' + serialize(queryObj)

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -15,7 +15,7 @@ const ComparisonInput = function({ site, query, history }) {
   return (
     <div className="flex-none mx-3">
       <input id="comparison-input" type="checkbox" onChange={update} checked={query.comparison} className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
-      <label htmlFor="comparison-input" className="ml-1.5 font-medium text-xs md:text-sm text-gray-700">Compare</label>
+      <label htmlFor="comparison-input" className="ml-1.5 font-medium text-xs md:text-sm text-gray-700 dark:text-white">Compare</label>
     </div>
   )
 }

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -4,7 +4,8 @@ import { navigateToQuery } from './query'
 
 export const COMPARISON_DISABLED_PERIODS = ['realtime', 'all']
 
-const ComparisonInput = function({ _graphData, query, history }) {
+const ComparisonInput = function({ site, query, history }) {
+  if (!site.flags.comparisons) return null
   if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return null
 
   function update(event) {

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { withRouter } from "react-router-dom";
 import { navigateToQuery } from './query'
 
-const DISABLED_PERIODS = ['realtime', 'all']
+export const COMPARISON_DISABLED_PERIODS = ['realtime', 'all']
 
 const ComparisonInput = function({ _graphData, query, history }) {
-  if (DISABLED_PERIODS.includes(query.period)) return null
+  if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return null
 
   function update(event) {
     navigateToQuery(history, query, { comparison: event.target.checked })

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { withRouter } from "react-router-dom";
+import { navigateToQuery } from './query'
+
+const DISABLED_PERIODS = ['realtime', 'all']
+
+const ComparisonInput = function({ _graphData, query, history }) {
+  if (DISABLED_PERIODS.includes(query.period)) return null
+
+  function update(event) {
+    navigateToQuery(history, query, { comparison: event.target.checked })
+  }
+
+  return (
+    <div className="flex-none mx-3">
+      <input id="comparison-input" type="checkbox" onChange={update} checked={query.comparison} className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+      <label htmlFor="comparison-input" className="ml-1.5 font-medium text-xs md:text-sm text-gray-700">Compare</label>
+    </div>
+  )
+}
+
+export default withRouter(ComparisonInput)

--- a/assets/js/dashboard/historical.js
+++ b/assets/js/dashboard/historical.js
@@ -10,6 +10,7 @@ import Pages from './stats/pages'
 import Locations from './stats/locations';
 import Devices from './stats/devices'
 import Conversions from './stats/conversions'
+import ComparisonInput from './comparison-input'
 import { withPinnedHeader } from './pinned-header-hoc';
 
 function Historical(props) {
@@ -38,6 +39,7 @@ function Historical(props) {
             <Filters className="flex" site={props.site} query={props.query} history={props.history} />
           </div>
           <Datepicker site={props.site} query={props.query} />
+          <ComparisonInput site={props.site} query={props.query} />
         </div>
       </div>
       <VisitorGraph site={props.site} query={props.query} />

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, withRouter } from 'react-router-dom'
 import {formatDay, formatMonthYYYY, nowForSite, parseUTCDate} from './util/date'
 import * as storage from './util/storage'
+import { COMPARISON_DISABLED_PERIODS } from './comparison-input'
 
 const PERIODS = ['realtime', 'day', 'month', '7d', '30d', '6mo', '12mo', 'year', 'all', 'custom']
 
@@ -18,13 +19,16 @@ export function parseQuery(querystring, site) {
     period = '30d'
   }
 
+  let comparison = !!q.get('comparison')
+  if (COMPARISON_DISABLED_PERIODS.includes(period)) comparison = null
+
   return {
     period,
     date: q.get('date') ? parseUTCDate(q.get('date')) : nowForSite(site),
     from: q.get('from') ? parseUTCDate(q.get('from')) : undefined,
     to: q.get('to') ? parseUTCDate(q.get('to')) : undefined,
     with_imported: q.get('with_imported') ? q.get('with_imported') === 'true' : true,
-    comparison: !!q.get('comparison'),
+    comparison: comparison,
     filters: {
       'goal': q.get('goal'),
       'props': JSON.parse(q.get('props')),

--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -24,6 +24,7 @@ export function parseQuery(querystring, site) {
     from: q.get('from') ? parseUTCDate(q.get('from')) : undefined,
     to: q.get('to') ? parseUTCDate(q.get('to')) : undefined,
     with_imported: q.get('with_imported') ? q.get('with_imported') === 'true' : true,
+    comparison: !!q.get('comparison'),
     filters: {
       'goal': q.get('goal'),
       'props': JSON.parse(q.get('props')),

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -149,11 +149,7 @@ export const GraphTooltip = (graphData, metric, query) => {
 }
 
 const truncateToPresentIndex = function(array, presentIndex) {
-  if (presentIndex) {
-    for (var i = presentIndex; i < array.length; i++) {
-      array[i] = undefined
-    }
-  }
+  return array.slice(0, presentIndex)
 }
 
 export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) => {
@@ -166,12 +162,10 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
 
   let comparisonDataSet = []
   if (comparisonPlot) {
-    truncateToPresentIndex(comparisonPlot, present_index)
-
     comparisonDataSet = [
       {
         label,
-        data: comparisonPlot,
+        data: truncateToPresentIndex(comparisonPlot, present_index),
         borderWidth: 3,
         borderColor: 'rgba(60,70,110,0.2)',
         pointBackgroundColor: 'rgba(60,70,110,0.2)',
@@ -188,9 +182,7 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
   if (present_index) {
     var dashedPart = plot.slice(present_index - 1, present_index + 1);
     var dashedPlot = (new Array(present_index - 1)).concat(dashedPart)
-    const _plot = [...plot]
-
-    truncateToPresentIndex(_plot, present_index)
+    const _plot = truncateToPresentIndex([...plot], present_index)
 
     return [
       {

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -65,10 +65,6 @@ export const GraphTooltip = (graphData, metric, query) => {
       return;
     }
 
-    function getBody(bodyItem) {
-      return bodyItem.lines;
-    }
-
     // Returns a string describing the bucket. Used when hovering the graph to
     // show time buckets.
     function renderBucketLabel(label) {
@@ -89,16 +85,13 @@ export const GraphTooltip = (graphData, metric, query) => {
 
     // Set Tooltip Body
     if (tooltipModel.body) {
-      var bodyLines = tooltipModel.body.map(getBody);
-
-      // Remove duplicated line on overlap between dashed and normal
-      if (bodyLines.length == 3) {
-        bodyLines[1] = false
-      }
-
       const data = tooltipModel.dataPoints[0]
-      const label = graphData.labels[data.dataIndex]
+      const dataToCompare = tooltipModel.dataPoints[tooltipModel.dataPoints.length - 1]
+
       const point = data.raw || 0
+      const pointToCompare = dataToCompare?.raw || 0
+
+      const label = graphData.labels[data.dataIndex]
 
       let innerHtml = `
       <div class='text-gray-100 flex flex-col'>
@@ -112,6 +105,8 @@ export const GraphTooltip = (graphData, metric, query) => {
               <span>${renderBucketLabel(label)}</span>
             </span>
             <span class='text-base font-bold'>${METRIC_FORMATTER[metric](point)}</span>
+            vs.
+            <span class='text-base font-bold'>${METRIC_FORMATTER[metric](pointToCompare)}</span>
           </div>
         </div>
         <span class='font-semibold italic'>${graphData.interval === 'month' ? 'Click to view month' : graphData.interval === 'date' ? 'Click to view day' : ''}</span>
@@ -124,7 +119,7 @@ export const GraphTooltip = (graphData, metric, query) => {
   }
 }
 
-export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
+export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) => {
   var gradient = ctx.createLinearGradient(0, 0, 0, 300);
   var prev_gradient = ctx.createLinearGradient(0, 0, 0, 300);
   gradient.addColorStop(0, 'rgba(101,116,205, 0.2)');
@@ -132,16 +127,35 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
   prev_gradient.addColorStop(0, 'rgba(101,116,205, 0.075)');
   prev_gradient.addColorStop(1, 'rgba(101,116,205, 0)');
 
-  if (!isPrevious) {
-    if (present_index) {
-      var dashedPart = plot.slice(present_index - 1, present_index + 1);
-      var dashedPlot = (new Array(present_index - 1)).concat(dashedPart)
-      const _plot = [...plot]
-      for (var i = present_index; i < _plot.length; i++) {
-        _plot[i] = undefined
+  let comparisonDataSet = []
+  if (comparisonPlot) {
+    comparisonDataSet = [
+      {
+        label,
+        data: comparisonPlot,
+        borderWidth: 3,
+        borderColor: 'rgba(60,70,110,0.2)',
+        pointBackgroundColor: 'rgba(60,70,110,0.2)',
+        pointHoverBackgroundColor: 'rgba(60, 70, 110)',
+        pointBorderColor: 'transparent',
+        pointHoverRadius: 4,
+        backgroundColor: gradient,
+        fill: true,
+        yAxisID: 'yComparison',
       }
+    ]
+  }
 
-      return [{
+  if (present_index) {
+    var dashedPart = plot.slice(present_index - 1, present_index + 1);
+    var dashedPlot = (new Array(present_index - 1)).concat(dashedPart)
+    const _plot = [...plot]
+    for (var i = present_index; i < _plot.length; i++) {
+      _plot[i] = undefined
+    }
+
+    return [
+      {
         label,
         data: _plot,
         borderWidth: 3,
@@ -152,6 +166,7 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
+        yAxisID: 'y',
       },
       {
         label,
@@ -164,9 +179,12 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
-      }]
-    } else {
-      return [{
+        yAxisID: 'y',
+      }
+    ].concat(comparisonDataSet)
+  } else {
+    return [
+      {
         label,
         data: plot,
         borderWidth: 3,
@@ -176,20 +194,8 @@ export const buildDataSet = (plot, present_index, ctx, label, isPrevious) => {
         pointHoverRadius: 4,
         backgroundColor: gradient,
         fill: true,
-      }]
-    }
-  } else {
-    return [{
-      label,
-      data: plot,
-      borderWidth: 2,
-      borderColor: 'rgba(166,187,210,0.5)',
-      pointHoverBackgroundColor: 'rgba(166,187,210,0.8)',
-      pointBorderColor: 'transparent',
-      pointHoverBorderColor: 'transparent',
-      pointHoverRadius: 4,
-      backgroundColor: prev_gradient,
-      fill: true,
-    }]
+        yAxisID: 'y',
+      }
+    ].concat(comparisonDataSet)
   }
 }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -64,20 +64,19 @@ const calculatePercentageDifference = function(oldValue, newValue) {
 }
 
 const buildTooltipData = function(query, graphData, metric, tooltipModel) {
-  const hasComparison = !!graphData.comparison_plot
-  const data = tooltipModel.dataPoints[0]
-  const comparisonData = hasComparison && tooltipModel.dataPoints[tooltipModel.dataPoints.length - 1]
+  const data = tooltipModel.dataPoints.find((dataPoint) => dataPoint.dataset.yAxisID == "y")
+  const comparisonData = tooltipModel.dataPoints.find((dataPoint) => dataPoint.dataset.yAxisID == "yComparison")
 
   const label = renderBucketLabel(query, graphData, graphData.labels[data.dataIndex])
-  const comparisonLabel = hasComparison && renderBucketLabel(query, graphData, graphData.comparison_labels[data.dataIndex], true)
+  const comparisonLabel = comparisonData && renderBucketLabel(query, graphData, graphData.comparison_labels[data.dataIndex], true)
 
   const value = data?.raw || 0
   const comparisonValue = comparisonData?.raw || 0
-  const comparisonDifference = hasComparison && calculatePercentageDifference(comparisonValue, value)
+  const comparisonDifference = comparisonData && calculatePercentageDifference(comparisonValue, value)
 
   const metricFormatter = METRIC_FORMATTER[metric]
   const formattedValue = metricFormatter(value)
-  const formattedComparisonValue = hasComparison && metricFormatter(comparisonValue)
+  const formattedComparisonValue = comparisonData && metricFormatter(comparisonValue)
 
   return { label, formattedValue, comparisonLabel, formattedComparisonValue, comparisonDifference }
 }
@@ -131,7 +130,7 @@ export const GraphTooltip = (graphData, metric, query) => {
             <span class='text-base font-bold'>${tooltipData.formattedValue}</span>
           </div>
 
-          ${tooltipData.formattedComparisonValue ? `<div class='flex flex-row justify-between items-center'>
+          ${tooltipData.comparisonLabel ? `<div class='flex flex-row justify-between items-center'>
             <span class='flex items-center mr-4'>
               <div class='w-3 h-3 mr-1 rounded-full bg-gray-500'></div>
               <span>${tooltipData.comparisonLabel}</span>

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -148,6 +148,14 @@ export const GraphTooltip = (graphData, metric, query) => {
   }
 }
 
+const truncateToPresentIndex = function(array, presentIndex) {
+  if (presentIndex) {
+    for (var i = presentIndex; i < array.length; i++) {
+      array[i] = undefined
+    }
+  }
+}
+
 export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) => {
   var gradient = ctx.createLinearGradient(0, 0, 0, 300);
   var prev_gradient = ctx.createLinearGradient(0, 0, 0, 300);
@@ -158,6 +166,8 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
 
   let comparisonDataSet = []
   if (comparisonPlot) {
+    truncateToPresentIndex(comparisonPlot, present_index)
+
     comparisonDataSet = [
       {
         label,
@@ -179,9 +189,8 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
     var dashedPart = plot.slice(present_index - 1, present_index + 1);
     var dashedPlot = (new Array(present_index - 1)).concat(dashedPart)
     const _plot = [...plot]
-    for (var i = present_index; i < _plot.length; i++) {
-      _plot[i] = undefined
-    }
+
+    truncateToPresentIndex(_plot, present_index)
 
     return [
       {

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -18,10 +18,11 @@ const calculateMaximumY = function(dataset) {
     .flatMap((item) => item.data)
     .map((item) => item || 0)
 
-  const maximumY = Math.max(...yAxisValues)
-  const maximumYWithMargin = Math.round(maximumY * 1.2)
-
-  return maximumYWithMargin > 0 ? maximumYWithMargin : 1
+  if (yAxisValues) {
+    return Math.max(...yAxisValues)
+  } else {
+    return 1
+  }
 }
 
 class LineGraph extends React.Component {
@@ -66,7 +67,7 @@ class LineGraph extends React.Component {
         scales: {
           y: {
             min: 0,
-            max: calculateMaximumY(dataSet),
+            suggestedMax: calculateMaximumY(dataSet),
             ticks: {
               callback: METRIC_FORMATTER[metric],
               maxTicksLimit: 8,
@@ -79,7 +80,7 @@ class LineGraph extends React.Component {
           },
           yComparison: {
             min: 0,
-            max: calculateMaximumY(dataSet),
+            suggestedMax: calculateMaximumY(dataSet),
             display: false,
             grid: { display: false },
           },

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -13,6 +13,17 @@ import FadeIn from '../../fade-in';
 import * as url from '../../util/url'
 import classNames from "classnames";
 
+const calculateMaximumY = function(dataset) {
+  const yAxisValues = dataset
+    .flatMap((item) => item.data)
+    .map((item) => item || 0)
+
+  const maximumY = Math.max(...yAxisValues)
+  const maximumYWithMargin = Math.round(maximumY * 1.2)
+
+  return maximumYWithMargin > 0 ? maximumYWithMargin : 1
+}
+
 class LineGraph extends React.Component {
   constructor(props) {
     super(props);
@@ -28,7 +39,7 @@ class LineGraph extends React.Component {
     const { graphData, metric, query } = this.props
     const graphEl = document.getElementById("main-graph-canvas")
     this.ctx = graphEl.getContext('2d');
-    const dataSet = buildDataSet(graphData.plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
+    const dataSet = buildDataSet(graphData.plot, graphData.comparison_plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
 
     return new Chart(this.ctx, {
       type: 'line',
@@ -54,7 +65,8 @@ class LineGraph extends React.Component {
         onClick: this.onClick.bind(this),
         scales: {
           y: {
-            beginAtZero: true,
+            min: 0,
+            max: calculateMaximumY(dataSet),
             ticks: {
               callback: METRIC_FORMATTER[metric],
               maxTicksLimit: 8,
@@ -64,6 +76,12 @@ class LineGraph extends React.Component {
               zeroLineColor: 'transparent',
               drawBorder: false,
             }
+          },
+          yComparison: {
+            min: 0,
+            max: calculateMaximumY(dataSet),
+            display: false,
+            grid: { display: false },
           },
           x: {
             grid: { display: false },

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -311,7 +311,8 @@ defmodule PlausibleWeb.StatsController do
 
   defp get_flags(user) do
     %{
-      custom_dimension_filter: FunWithFlags.enabled?(:custom_dimension_filter, for: user)
+      custom_dimension_filter: FunWithFlags.enabled?(:custom_dimension_filter, for: user),
+      comparisons: FunWithFlags.enabled?(:comparisons, for: user)
     }
   end
 


### PR DESCRIPTION
### Changes

This pull request adds support for comparing the actual showed period on the main graph with the previous one. This is a first pass and it's hidden under a feature flag because it's not feature complete yet as we want to support other comparison modes.

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/5093045/217081575-540f0cf6-69fb-4855-8c86-e547df0922a4.png">

Next PRs will include some refactoring, especially in the graph-utils.js file which is calling for a split. And after that I'll push comparison modes.

Reviewing commit-by-commit may help understanding some of my decisions.

### Tests
Not sure if it's worth testing the current behavior as next PRs will include comparison modes (previous period, year over year, custom date).

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
