### PR TITLE
add flash ttl

### DIFF
--- a/lib/plausible_web/templates/layout/_flash.html.eex
+++ b/lib/plausible_web/templates/layout/_flash.html.eex
@@ -1,6 +1,6 @@
 <%= if get_flash(@conn, :success) do %>
   <div class="z-50 fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
-    <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, 4000)" x-transition:enter="transform ease-out duration-300 transition"  x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2" x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto">
+    <div x-data="{ show: true, ttl: <%= get_flash(@conn, :ttl) || 4000 %> }" x-show="show" x-init="setTimeout(() => show = false, ttl)" x-transition:enter="transform ease-out duration-300 transition"  x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2" x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto">
       <div class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
         <div class="p-4">
           <div class="flex items-start">
@@ -34,7 +34,7 @@
 
 <%= if get_flash(@conn, :error) do %>
   <div class="z-50 fixed inset-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
-    <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => show = false, 4000)" x-transition:enter="transform ease-out duration-300 transition"  x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2" x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto">
+    <div x-data="{ show: true, ttl: <%= get_flash(@conn, :ttl) || 4000 %> }" x-show="show" x-init="setTimeout(() => show = false, ttl)" x-transition:enter="transform ease-out duration-300 transition"  x-transition:enter-start="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2" x-transition:enter-end="translate-y-0 opacity-100 sm:translate-x-0" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto">
       <div class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
         <div class="p-4">
           <div class="flex items-start">


### PR DESCRIPTION
### Changes

This PR adds flash `:ttl` to set the duration in ms that flash is shown. Useful for longer messages like in https://github.com/plausible/analytics/pull/2651.

Usage

```elixir
conn
|> put_flash(:ttl, 8000)
|> put_flash(:error, "some long error message")
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
