### PR TITLE
Fix bug with multiple ARRAY JOIN query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Fix breakdown API pagination when using event metrics plausible/analytics#2562
 - Automatically update all visible dashboard reports in the realtime view
 - Connect via TLS when using HTTPS scheme in ClickHouse URL plausible/analytics#2570
+- Fix bug with [showing property breakdown with a prop filter](https://github.com/plausible/analytics/issues/1789)
 
 ### Changed
 - Reject events with long URIs and data URIs plausible/analytics#2536

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -315,7 +315,7 @@ defmodule Plausible.Stats.Breakdown do
     end
   end
 
-  defp has_join_with_table(ecto_q, table) do
+  defp joins_table?(ecto_q, table) do
     Enum.any?(
       ecto_q.joins,
       fn
@@ -330,7 +330,7 @@ defmodule Plausible.Stats.Breakdown do
          "event:props:" <> prop
        ) do
     q =
-      if has_join_with_table(q, "meta") do
+      if joins_table?(q, "meta") do
         q
       else
         from(

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -319,7 +319,7 @@ defmodule Plausible.Stats.Breakdown do
     Enum.any?(
       ecto_q.joins,
       fn
-        %Ecto.Query.JoinExpr{source: {t, _}} when t == table -> true
+        %Ecto.Query.JoinExpr{source: {^table, _}} -> true
         _ -> false
       end
     )

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -353,7 +353,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
              ]
     end
 
-    test "bug: property breakdown with prop filter", %{conn: conn, site: site} do
+    test "Property breakdown with prop and goal filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1, utm_campaign: "campaignA"),
         build(:event,

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -352,6 +352,51 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                }
              ]
     end
+
+    test "bug: property breakdown with prop filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 1, utm_campaign: "campaignA"),
+        build(:event,
+          user_id: 1,
+          name: "ButtonClick",
+          "meta.key": ["variant"],
+          "meta.value": ["A"]
+        ),
+        build(:pageview, user_id: 2, utm_campaign: "campaignA"),
+        build(:event,
+          user_id: 2,
+          name: "ButtonClick",
+          "meta.key": ["variant"],
+          "meta.value": ["B"]
+        )
+      ])
+
+      insert(:goal, %{domain: site.domain, event_name: "ButtonClick"})
+
+      filters =
+        Jason.encode!(%{
+          goal: "ButtonClick",
+          props: %{variant: "A"},
+          utm_campaign: "campaignA"
+        })
+
+      prop_key = "variant"
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/property/#{prop_key}?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200) == [
+               %{
+                 "name" => "A",
+                 "unique_conversions" => 1,
+                 "total_conversions" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
   end
 
   describe "GET /api/stats/:domain/conversions - with glob goals" do


### PR DESCRIPTION
### Changes

Fixes #1789

Small change to query building to make sure we don't `JOIN` with `meta` more than once.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
