### PR TITLE
Bump clickhouse images to 22.8.13.20-alpine (prod/CI)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -29,7 +29,7 @@ jobs:
             --health-retries 5
 
       clickhouse:
-        image: yandex/clickhouse-server:21.11
+        image: clickhouse/clickhouse-22.8.13.20-alpine
         ports:
           - 8123:8123
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -29,7 +29,7 @@ jobs:
             --health-retries 5
 
       clickhouse:
-        image: clickhouse/clickhouse-22.8.13.20-alpine
+        image: clickhouse/clickhouse-server:22.8.13.20-alpine
         ports:
           - 8123:8123
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install server clickhouse clickhouse-prod clickhouse-ci clickhouse-stop postgres postgres-prod postgres-stop
+.PHONY: help install server clickhouse clickhouse-prod clickhouse-stop postgres postgres-prod postgres-stop
 
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -22,9 +22,6 @@ clickhouse: ## Start a container with a recent version of clickhouse
 
 clickhouse-prod: ## Start a container with the same version of clickhouse as the one in prod
 	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:22.8.13.20-alpine
-
-clickhouse-ci: ## Start a container with the same version of clickhouse as the one in .github/workflows/elixir.yml
-	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:22.8.13.20-alpine
 
 clickhouse-stop: ## Stop and remove the clickhouse container
 	docker stop plausible_clickhouse && docker rm plausible_clickhouse

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ clickhouse: ## Start a container with a recent version of clickhouse
 	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:22.9-alpine
 
 clickhouse-prod: ## Start a container with the same version of clickhouse as the one in prod
-	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:21.11.3.6
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:22.8.13.20-alpine
 
 clickhouse-ci: ## Start a container with the same version of clickhouse as the one in .github/workflows/elixir.yml
-	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:21.11
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_ci:/var/lib/clickhouse yandex/clickhouse-server:22.8.13.20-alpine
 
 clickhouse-stop: ## Stop and remove the clickhouse container
 	docker stop plausible_clickhouse && docker rm plausible_clickhouse


### PR DESCRIPTION
### Changes

This PR pins clickhouse-server image to 22.8.13.20-alpine unifromly for `make clickhouse-prod` target and CI. `clickhouse-ci` target becomes redundant so it gets removed.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
