### PR TITLE
Refactor top stats and graph positioning

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -67,64 +67,6 @@ blockquote {
 @tailwind utilities;
 
 
-.main-graph {
-  position: relative;
-  height: 0;
-
-  /* Formula is: (top row height + (graph height / graph width * 100%) - adjustment for stat selectors) */
-  padding-top: calc(168px + (451 / 1088 * 100%) - 20px);
-}
-
-@screen sm {
-  .main-graph {
-    padding-top: calc(148px + (451 / 1088 * 100%));
-  }
-}
-
-@screen md {
-  .main-graph {
-    padding-top: calc(128px + (451 / 1088 * 100%));
-  }
-}
-
-@screen lg {
-  .main-graph {
-    padding-top: calc(28px + (451 / 1088 * 100%) - 10px);
-  }
-}
-
-.top-stats-only {
-  position: relative;
-  height: 0;
-  padding-top: calc(158px + 15px);
-}
-
-@screen sm {
-  .top-stats-only {
-    padding-top: calc(155px + 15px);
-  }
-}
-
-@screen md {
-  .top-stats-only {
-    padding-top: calc(168px + 15px);
-  }
-}
-
-@screen lg {
-  .top-stats-only {
-    padding-top: calc(75px + 15px);
-  }
-}
-
-.graph-inner {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: auto;
-}
-
 .light-text {
   color: #F0F4F8;
 }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -463,16 +463,15 @@ export default class VisitorGraph extends React.Component {
 
   render() {
     const {mainGraphLoadingState, topStatsLoadingState} = this.state
-    const mainGraphRefreshing = mainGraphLoadingState === LoadingState.refreshing
 
     const showLoader =
-      LoadingState.isLoadingOrRefreshing(mainGraphLoadingState) ||
-      topStatsLoadingState === LoadingState.loading
+      [mainGraphLoadingState, topStatsLoadingState].includes(LoadingState.loading) &&
+      mainGraphLoadingState !== LoadingState.refreshing
 
     return (
       <LazyLoader onVisible={this.onVisible}>
         <div className={"relative w-full mt-2 bg-white rounded shadow-xl dark:bg-gray-825"}>
-          {showLoader && !mainGraphRefreshing && renderLoader()}
+          {showLoader && renderLoader()}
           {this.renderInner()}
         </div>
       </LazyLoader>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -11,6 +11,7 @@ import TopStats from './top-stats';
 import { IntervalPicker, getStoredInterval, storeInterval } from './interval-picker';
 import FadeIn from '../../fade-in';
 import * as url from '../../util/url'
+import classNames from 'classnames';
 
 class LineGraph extends React.Component {
   constructor(props) {
@@ -287,7 +288,7 @@ class LineGraph extends React.Component {
 
   render() {
     const { onlyGraphLoading, updateMetric, metric, topStatData, query, site, graphData } = this.props
-    const extraClass = this.props.graphData && this.props.graphData.interval === 'hour' ? '' : 'cursor-pointer'
+    const canvasClass = classNames('mt-4 select-none', {'cursor-pointer': !['minute', 'hour'].includes(graphData?.interval)})
 
     return (
       <div>
@@ -304,7 +305,7 @@ class LineGraph extends React.Component {
           </div>
           <FadeIn show={graphData}>
             <div className="relative h-96 w-full">
-              <canvas id="main-graph-canvas" className={'mt-4 select-none ' + extraClass}></canvas>
+              <canvas id="main-graph-canvas" className={canvasClass}></canvas>
             </div>
           </FadeIn>
         </div>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -11,7 +11,6 @@ import TopStats from './top-stats';
 import { IntervalPicker, getStoredInterval, storeInterval } from './interval-picker';
 import FadeIn from '../../fade-in';
 import * as url from '../../util/url'
-import classNames from "classnames";
 
 class LineGraph extends React.Component {
   constructor(props) {

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -287,7 +287,7 @@ class LineGraph extends React.Component {
   }
 
   render() {
-    const { onlyGraphLoading, updateMetric, metric, topStatData, query, site, graphData } = this.props
+    const { mainGraphRefreshing, updateMetric, metric, topStatData, query, site, graphData } = this.props
     const canvasClass = classNames('mt-4 select-none', {'cursor-pointer': !['minute', 'hour'].includes(graphData?.interval)})
 
     return (
@@ -296,7 +296,7 @@ class LineGraph extends React.Component {
           <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={this.props.lastLoadTimestamp} />
         </div>
         <div className="relative px-2">
-          {onlyGraphLoading && renderLoader()}
+          {mainGraphRefreshing && renderLoader()}
           <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center">
             { this.downloadLink() }
             { this.samplingNotice() }
@@ -446,17 +446,17 @@ export default class VisitorGraph extends React.Component {
 
     const theme = document.querySelector('html').classList.contains('dark') || false
 
-    const onlyGraphLoading = (mainGraphLoadingState === LoadingState.refreshing)
+    const mainGraphRefreshing = (mainGraphLoadingState === LoadingState.refreshing)
     const topStatAndGraphLoaded = !!(topStatData && graphData)
 
-    const showGraph =
-      LoadingState.isLoadedOrRefreshing(topStatsLoadingState) &&
+    const shouldShow =
+      topStatsLoadingState === LoadingState.loaded &&
       LoadingState.isLoadedOrRefreshing(mainGraphLoadingState) &&
-      (topStatData && onlyGraphLoading || topStatAndGraphLoaded)
+      (topStatData && mainGraphRefreshing || topStatAndGraphLoaded)
 
     return (
-      <FadeIn show={showGraph}>
-        <LineGraphWithRouter onlyGraphLoading={onlyGraphLoading} graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
+      <FadeIn show={shouldShow}>
+        <LineGraphWithRouter mainGraphRefreshing={mainGraphRefreshing} graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
       </FadeIn>
     )
   }
@@ -467,7 +467,7 @@ export default class VisitorGraph extends React.Component {
 
     const showLoader =
       LoadingState.isLoadingOrRefreshing(mainGraphLoadingState) ||
-      LoadingState.isLoadingOrRefreshing(topStatsLoadingState)
+      topStatsLoadingState === LoadingState.loading
 
     return (
       <LazyLoader onVisible={this.onVisible}>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -274,15 +274,16 @@ class LineGraph extends React.Component {
   }
 
   render() {
-    const { updateMetric, metric, topStatData, query, site, graphData } = this.props
+    const { shouldRenderLoader, updateMetric, metric, topStatData, query, site, graphData } = this.props
     const extraClass = this.props.graphData && this.props.graphData.interval === 'hour' ? '' : 'cursor-pointer'
 
     return (
-      <div className="graph-inner">
+      <div>
         <div className="flex flex-wrap" ref={this.boundary}>
           <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={this.props.lastLoadTimestamp} />
         </div>
         <div className="relative px-2">
+          {shouldRenderLoader && renderLoader()}
           <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center">
             { this.downloadLink() }
             { this.samplingNotice() }
@@ -433,17 +434,14 @@ export default class VisitorGraph extends React.Component {
 
     return (
       <FadeIn show={showGraph}>
-        <LineGraphWithRouter graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
+        <LineGraphWithRouter shouldRenderLoader={mainGraphRefreshing} graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
       </FadeIn>
     )
   }
 
   render() {
     const {mainGraphLoadingState, topStatsLoadingState} = this.state
-    const loaderClassName = classNames('mx-auto loading', {
-      'pt-52 sm:pt-56 md:pt-60': mainGraphLoadingState == LoadingState.refreshing,
-      'pt-32 sm:pt-36 md:pt-48': mainGraphLoadingState !== LoadingState.refreshing,
-    })
+    const mainGraphRefreshing = mainGraphLoadingState === LoadingState.refreshing
 
     const showLoader =
       LoadingState.isLoadingOrRefreshing(mainGraphLoadingState) ||
@@ -451,11 +449,21 @@ export default class VisitorGraph extends React.Component {
 
     return (
       <LazyLoader onVisible={this.onVisible}>
-        <div className={"relative w-full mt-2 bg-white rounded shadow-xl dark:bg-gray-825 main-graph"}>
-          {showLoader && <div className="graph-inner"><div className={loaderClassName}><div></div></div></div>}
+        <div className={"relative w-full mt-2 bg-white rounded shadow-xl dark:bg-gray-825"}>
+          {showLoader && !mainGraphRefreshing && renderLoader()}
           {this.renderInner()}
         </div>
       </LazyLoader>
     )
   }
+}
+
+function renderLoader() {
+  return (
+    <div className="absolute h-full w-full flex items-center justify-center">
+      <div className="loading">
+        <div></div>
+      </div>
+    </div>
+  )
 }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -275,16 +275,16 @@ class LineGraph extends React.Component {
   }
 
   render() {
-    const { shouldRenderLoader, updateMetric, metric, topStatData, query, site, graphData } = this.props
+    const { onlyGraphLoading, updateMetric, metric, topStatData, query, site, graphData } = this.props
     const extraClass = this.props.graphData && this.props.graphData.interval === 'hour' ? '' : 'cursor-pointer'
-
+    
     return (
       <div>
         <div className="flex flex-wrap" ref={this.boundary}>
           <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={this.props.lastLoadTimestamp} />
         </div>
         <div className="relative px-2">
-          {shouldRenderLoader && renderLoader()}
+          {onlyGraphLoading && renderLoader()}
           <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center">
             { this.downloadLink() }
             { this.samplingNotice() }
@@ -427,17 +427,17 @@ export default class VisitorGraph extends React.Component {
 
     const theme = document.querySelector('html').classList.contains('dark') || false
 
-    const mainGraphRefreshing = (mainGraphLoadingState === LoadingState.refreshing)
+    const onlyGraphLoading = (mainGraphLoadingState === LoadingState.refreshing)
     const topStatAndGraphLoaded = !!(topStatData && graphData)
 
     const showGraph =
       LoadingState.isLoadedOrRefreshing(topStatsLoadingState) &&
       LoadingState.isLoadedOrRefreshing(mainGraphLoadingState) &&
-      (topStatData && mainGraphRefreshing || topStatAndGraphLoaded)
+      (topStatData && onlyGraphLoading || topStatAndGraphLoaded)
 
     return (
       <FadeIn show={showGraph}>
-        <LineGraphWithRouter shouldRenderLoader={mainGraphRefreshing} graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
+        <LineGraphWithRouter onlyGraphLoading={onlyGraphLoading} graphData={graphData} topStatData={topStatData} site={site} query={query} darkTheme={theme} metric={metric} updateMetric={this.updateMetric} updateInterval={this.updateInterval} lastLoadTimestamp={this.props.lastLoadTimestamp} />
       </FadeIn>
     )
   }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -49,6 +49,7 @@ class LineGraph extends React.Component {
           },
         },
         responsive: true,
+        maintainAspectRatio: false,
         onResize: this.updateWindowDimensions,
         elements: { line: { tension: 0 }, point: { radius: 0 } },
         onClick: this.onClick.bind(this),
@@ -291,7 +292,9 @@ class LineGraph extends React.Component {
             <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={this.props.updateInterval}/>
           </div>
           <FadeIn show={graphData}>
-            <canvas id="main-graph-canvas" className={'mt-4 select-none ' + extraClass} width="1054" height="342"></canvas>
+            <div className="relative h-96 w-full">
+              <canvas id="main-graph-canvas" className={'mt-4 select-none ' + extraClass}></canvas>
+            </div>
           </FadeIn>
         </div>
       </div>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -287,13 +287,13 @@ class LineGraph extends React.Component {
   }
 
   render() {
-    const { mainGraphRefreshing, updateMetric, metric, topStatData, query, site, graphData } = this.props
+    const { mainGraphRefreshing, updateMetric, updateInterval, metric, topStatData, query, site, graphData, lastLoadTimestamp } = this.props
     const canvasClass = classNames('mt-4 select-none', {'cursor-pointer': !['minute', 'hour'].includes(graphData?.interval)})
 
     return (
       <div>
         <div id="top-stats-container" className="flex flex-wrap" ref={this.boundary} style={{height: this.getTopStatsHeight()}}>
-          <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={this.props.lastLoadTimestamp} />
+          <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={lastLoadTimestamp} />
         </div>
         <div className="relative px-2">
           {mainGraphRefreshing && renderLoader()}
@@ -301,7 +301,7 @@ class LineGraph extends React.Component {
             { this.downloadLink() }
             { this.samplingNotice() }
             { this.importedNotice() }
-            <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={this.props.updateInterval}/>
+            <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={updateInterval}/>
           </div>
           <FadeIn show={graphData}>
             <div className="relative h-96 w-full">
@@ -352,7 +352,7 @@ export default class VisitorGraph extends React.Component {
   updateInterval(interval) {
     if (this.isIntervalValid(interval)) {
       storeInterval(this.props.query.period, this.props.site.domain, interval)
-      this.setState({ mainGraphLoadingState: LoadingState.refreshing }, this.fetchGraphData)
+      this.setState({ mainGraphLoadingState: LoadingState.refreshing, graphData: null }, this.fetchGraphData)
     }
   }
 


### PR DESCRIPTION
### Changes

This PR is the foundation for displaying additional Top Stat metrics on the dashboard. It replaces the manual (absolute) CSS positioning with relative positioning, which significantly simplifies writing code for a varying number of Top Stat metrics.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
