### PR TITLE
Add data-domain to dogfooding script tag

### DIFF
--- a/lib/plausible_web/templates/layout/_tracking.html.eex
+++ b/lib/plausible_web/templates/layout/_tracking.html.eex
@@ -1,11 +1,11 @@
 <%= if !Application.get_env(:plausible, :is_selfhost) && !@conn.assigns[:skip_plausible_tracking] do %>
   <%= if Application.get_env(:plausible, :environment) in ["prod", "staging"] do %>
-    <script defer event-logged_in="<%= !!@conn.assigns[:current_user] %>" src="<%="#{plausible_url()}/js/script.dimensions.js"%>"></script>
+    <script defer data-domain="<%= base_domain() %>" event-logged_in="<%= !!@conn.assigns[:current_user] %>" src="<%="#{plausible_url()}/js/script.dimensions.js"%>"></script>
     <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   <% end %>
 
   <%= if Application.get_env(:plausible, :environment) == "dev" do %>
-    <script defer event-logged_in="<%= !!@conn.assigns[:current_user] %>" src="<%="#{plausible_url()}/js/plausible.local.dimensions.js"%>"></script>
+    <script defer data-domain="<%= base_domain() %>" event-logged_in="<%= !!@conn.assigns[:current_user] %>" src="<%="#{plausible_url()}/js/plausible.local.dimensions.js"%>"></script>
     <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   <% end %>
 <% end %>


### PR DESCRIPTION
### Changes

Context: @cnkk is setting up traffic mirroring for live demo data to staging. This means we'll have some nice real-world data to mess around with in staging.

The mirroring doesn't work at the moment because pageviews from the live demo are missing `domain: "plausible.io"` in the JSON body. In this case the backend falls back to parsing the domain from the `url` parameter instead.

This PR adds an explicit `data-domain` for our own tracking script so that HAProxy can parse it and mirror events that have `domain: "plausible.io"`

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
