### PR TITLE
Add root url to href of page items

### DIFF
--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom'
+import { Link, useRouteMatch } from 'react-router-dom'
 import FlipMove from 'react-flip-move';
 
 
@@ -31,6 +31,7 @@ function ExternalLink({item, externalLinkDest}) {
 export default function ListReport(props) {
   const [state, setState] = useState({loading: true, list: null})
   const [visible, setVisible] = useState(false)
+  const { url } = useRouteMatch()
   const valueKey = props.valueKey || 'visitors'
   const showConversionRate = !!props.query.filters.goal
 
@@ -90,7 +91,7 @@ export default function ListReport(props) {
           plot={valueKey}
         >
           <span className="flex px-2 py-1.5 group dark:text-gray-300 relative z-9 break-all" tooltip={props.tooltipText && props.tooltipText(listItem)}>
-            <Link onClick={props.onClick || noop} className="md:truncate block hover:underline" to={{search: query.toString()}}>
+            <Link onClick={props.onClick || noop} className="md:truncate block hover:underline" to={`${url}/?${query.toString()}`}>
               {props.renderIcon && props.renderIcon(listItem)}
               {props.renderIcon && ' '}
               {listItem.name}


### PR DESCRIPTION
### Changes
Fixes #2258 

Please describe the changes made in the pull request here.

The Link tag's href had only search params, which made a command click or an open in new window always end up at a 404.
Adding the root URL makes the link behave right. 

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
