### PR TITLE
Upgrade Chart.js dependency

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withRouter, Link } from 'react-router-dom'
-import Chart from 'chart.js/auto';
+import {Chart, LineController, LineElement, PointElement, CategoryScale, LinearScale, Tooltip} from 'chart.js';
 import { navigateToQuery } from '../../query'
 import * as api from '../../api'
 import * as storage from '../../util/storage'
@@ -41,6 +41,7 @@ class LineGraph extends React.Component {
     const graphEl = document.getElementById("main-graph-canvas")
     this.ctx = graphEl.getContext('2d');
     const dataSet = buildDataSet(graphData.plot, graphData.comparison_plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
+    Chart.register([LineController, LineElement, PointElement, CategoryScale, LinearScale, Tooltip])
 
     return new Chart(this.ctx, {
       type: 'line',

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -24,7 +24,7 @@
         "alpinejs": "^2.8.2",
         "autoprefixer": "^10.2.6",
         "babel-loader": "^8.2.2",
-        "chart.js": "^3.3.2",
+        "chart.js": "^4.2.1",
         "classnames": "^2.3.1",
         "copy-webpack-plugin": "^9.0.0",
         "css-loader": "^5.2.6",
@@ -1721,6 +1721,11 @@
         "react-dom": "^16.8 || ^17.x"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.3",
       "license": "MIT",
@@ -2797,8 +2802,15 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "3.3.2",
-      "license": "MIT"
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": "^7.0.0"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -10094,6 +10106,11 @@
       "integrity": "sha512-MKauq6R4HAHS/nGei+na8EpyO4qluTcoDeYetUnT1ME7K+CqxRCAIB4a4xo+gkufg2CuLhORA+s6sNjqm0oHEA==",
       "requires": {}
     },
+    "@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "requires": {
@@ -10845,7 +10862,12 @@
       }
     },
     "chart.js": {
-      "version": "3.3.2"
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "requires": {
+        "@kurkle/color": "^0.3.0"
+      }
     },
     "chokidar": {
       "version": "3.5.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,7 +26,7 @@
     "alpinejs": "^2.8.2",
     "autoprefixer": "^10.2.6",
     "babel-loader": "^8.2.2",
-    "chart.js": "^3.3.2",
+    "chart.js": "^4.2.1",
     "classnames": "^2.3.1",
     "copy-webpack-plugin": "^9.0.0",
     "css-loader": "^5.2.6",


### PR DESCRIPTION
### Changes

Upgrades Chart.js from v3 -> v4. In v4 they fixed tree-shaking so I changed how we import and initialize Chart.js as well. The result should be less JS shipped to the client overall.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
