### PR TITLE
Refactor: Graph Dataset functions

### DIFF
--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -38,6 +38,63 @@ const truncateToPresentIndex = function(array, presentIndex) {
   return array.slice(0, presentIndex)
 }
 
+const buildComparisonDataset = function(comparisonPlot, presentIndex, label, gradient) {
+  if (!comparisonPlot) return []
+
+  return [{
+    label,
+    data: truncateToPresentIndex(comparisonPlot, presentIndex),
+    borderWidth: 3,
+    borderColor: 'rgba(60,70,110,0.2)',
+    pointBackgroundColor: 'rgba(60,70,110,0.2)',
+    pointHoverBackgroundColor: 'rgba(60, 70, 110)',
+    pointBorderColor: 'transparent',
+    pointHoverRadius: 4,
+    backgroundColor: gradient,
+    fill: true,
+    yAxisID: 'yComparison',
+  }]
+}
+
+const buildDashedDataset = function(plot, presentIndex, label, gradient) {
+  if (!presentIndex) return []
+
+  const dashedPart = plot.slice(presentIndex - 1, presentIndex + 1);
+  const dashedPlot = (new Array(presentIndex - 1)).concat(dashedPart)
+
+  return [{
+    label,
+    data: dashedPlot,
+    borderWidth: 3,
+    borderDash: [3, 3],
+    borderColor: 'rgba(101,116,205)',
+    pointHoverBackgroundColor: 'rgba(71, 87, 193)',
+    pointBorderColor: 'transparent',
+    pointHoverRadius: 4,
+    backgroundColor: gradient,
+    fill: true,
+    yAxisID: 'y',
+  }]
+}
+
+const buildMainPlotDataset = function(plot, presentIndex, label, gradient) {
+  const data = presentIndex ? truncateToPresentIndex(plot, presentIndex) : plot
+
+  return [{
+    label,
+    data: data,
+    borderWidth: 3,
+    borderColor: 'rgba(101,116,205)',
+    pointBackgroundColor: 'rgba(101,116,205)',
+    pointHoverBackgroundColor: 'rgba(71, 87, 193)',
+    pointBorderColor: 'transparent',
+    pointHoverRadius: 4,
+    backgroundColor: gradient,
+    fill: true,
+    yAxisID: 'y',
+  }]
+}
+
 export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) => {
   var gradient = ctx.createLinearGradient(0, 0, 0, 300);
   var prev_gradient = ctx.createLinearGradient(0, 0, 0, 300);
@@ -46,72 +103,9 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
   prev_gradient.addColorStop(0, 'rgba(101,116,205, 0.075)');
   prev_gradient.addColorStop(1, 'rgba(101,116,205, 0)');
 
-  let comparisonDataSet = []
-  if (comparisonPlot) {
-    comparisonDataSet = [
-      {
-        label,
-        data: truncateToPresentIndex(comparisonPlot, present_index),
-        borderWidth: 3,
-        borderColor: 'rgba(60,70,110,0.2)',
-        pointBackgroundColor: 'rgba(60,70,110,0.2)',
-        pointHoverBackgroundColor: 'rgba(60, 70, 110)',
-        pointBorderColor: 'transparent',
-        pointHoverRadius: 4,
-        backgroundColor: gradient,
-        fill: true,
-        yAxisID: 'yComparison',
-      }
-    ]
-  }
-
-  if (present_index) {
-    var dashedPart = plot.slice(present_index - 1, present_index + 1);
-    var dashedPlot = (new Array(present_index - 1)).concat(dashedPart)
-    const _plot = truncateToPresentIndex([...plot], present_index)
-
-    return [
-      {
-        label,
-        data: _plot,
-        borderWidth: 3,
-        borderColor: 'rgba(101,116,205)',
-        pointBackgroundColor: 'rgba(101,116,205)',
-        pointHoverBackgroundColor: 'rgba(71, 87, 193)',
-        pointBorderColor: 'transparent',
-        pointHoverRadius: 4,
-        backgroundColor: gradient,
-        fill: true,
-        yAxisID: 'y',
-      },
-      {
-        label,
-        data: dashedPlot,
-        borderWidth: 3,
-        borderDash: [3, 3],
-        borderColor: 'rgba(101,116,205)',
-        pointHoverBackgroundColor: 'rgba(71, 87, 193)',
-        pointBorderColor: 'transparent',
-        pointHoverRadius: 4,
-        backgroundColor: gradient,
-        fill: true,
-        yAxisID: 'y',
-      }
-    ].concat(comparisonDataSet)
-  } else {
-    return [
-      {
-        label,
-        data: plot,
-        borderWidth: 3,
-        borderColor: 'rgba(101,116,205)',
-        pointHoverBackgroundColor: 'rgba(71, 87, 193)',
-        pointBorderColor: 'transparent',
-        pointHoverRadius: 4,
-        backgroundColor: gradient,
-        fill: true,
-        yAxisID: 'y',
-      }
-    ].concat(comparisonDataSet)
-  }
+  return [
+    ...buildMainPlotDataset(plot, present_index, label, gradient),
+    ...buildComparisonDataset(comparisonPlot, present_index, label, gradient),
+    ...buildDashedDataset(plot, present_index, label, gradient)
+  ]
 }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -37,8 +37,14 @@ export const LoadingState = {
 const buildComparisonDataset = function(comparisonPlot, presentIndex) {
   if (!comparisonPlot) return []
 
+  let data = [...comparisonPlot]
+  if (presentIndex) {
+    const dashedPartIncludedIndex = presentIndex + 1
+    data = data.slice(0, dashedPartIncludedIndex)
+  }
+
   return [{
-    data: comparisonPlot.slice(0, presentIndex),
+    data: data,
     borderColor: 'rgba(60,70,110,0.2)',
     pointBackgroundColor: 'rgba(60,70,110,0.2)',
     pointHoverBackgroundColor: 'rgba(60, 70, 110)',

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -38,59 +38,41 @@ const truncateToPresentIndex = function(array, presentIndex) {
   return array.slice(0, presentIndex)
 }
 
-const buildComparisonDataset = function(comparisonPlot, presentIndex, label, gradient) {
+const buildComparisonDataset = function(comparisonPlot, presentIndex) {
   if (!comparisonPlot) return []
 
   return [{
-    label,
     data: truncateToPresentIndex(comparisonPlot, presentIndex),
-    borderWidth: 3,
     borderColor: 'rgba(60,70,110,0.2)',
     pointBackgroundColor: 'rgba(60,70,110,0.2)',
     pointHoverBackgroundColor: 'rgba(60, 70, 110)',
-    pointBorderColor: 'transparent',
-    pointHoverRadius: 4,
-    backgroundColor: gradient,
-    fill: true,
     yAxisID: 'yComparison',
   }]
 }
 
-const buildDashedDataset = function(plot, presentIndex, label, gradient) {
+const buildDashedDataset = function(plot, presentIndex) {
   if (!presentIndex) return []
 
   const dashedPart = plot.slice(presentIndex - 1, presentIndex + 1);
   const dashedPlot = (new Array(presentIndex - 1)).concat(dashedPart)
 
   return [{
-    label,
     data: dashedPlot,
-    borderWidth: 3,
     borderDash: [3, 3],
     borderColor: 'rgba(101,116,205)',
     pointHoverBackgroundColor: 'rgba(71, 87, 193)',
-    pointBorderColor: 'transparent',
-    pointHoverRadius: 4,
-    backgroundColor: gradient,
-    fill: true,
     yAxisID: 'y',
   }]
 }
 
-const buildMainPlotDataset = function(plot, presentIndex, label, gradient) {
+const buildMainPlotDataset = function(plot, presentIndex) {
   const data = presentIndex ? truncateToPresentIndex(plot, presentIndex) : plot
 
   return [{
-    label,
     data: data,
-    borderWidth: 3,
     borderColor: 'rgba(101,116,205)',
     pointBackgroundColor: 'rgba(101,116,205)',
     pointHoverBackgroundColor: 'rgba(71, 87, 193)',
-    pointBorderColor: 'transparent',
-    pointHoverRadius: 4,
-    backgroundColor: gradient,
-    fill: true,
     yAxisID: 'y',
   }]
 }
@@ -103,9 +85,13 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
   prev_gradient.addColorStop(0, 'rgba(101,116,205, 0.075)');
   prev_gradient.addColorStop(1, 'rgba(101,116,205, 0)');
 
-  return [
-    ...buildMainPlotDataset(plot, present_index, label, gradient),
-    ...buildComparisonDataset(comparisonPlot, present_index, label, gradient),
-    ...buildDashedDataset(plot, present_index, label, gradient)
+  const defaultOptions = { label, borderWidth: 3, pointBorderColor: "transparent", pointHoverRadius: 4, backgroundColor: gradient, fill: true }
+
+  const dataset = [
+    ...buildMainPlotDataset(plot, present_index),
+    ...buildDashedDataset(plot, present_index),
+    ...buildComparisonDataset(comparisonPlot, present_index)
   ]
+
+  return dataset.map((item) => Object.assign(item, defaultOptions))
 }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -34,15 +34,11 @@ export const LoadingState = {
   isLoadedOrRefreshing: function (state) { return [this.loaded, this.refreshing].includes(state) }
 }
 
-const truncateToPresentIndex = function(array, presentIndex) {
-  return array.slice(0, presentIndex)
-}
-
 const buildComparisonDataset = function(comparisonPlot, presentIndex) {
   if (!comparisonPlot) return []
 
   return [{
-    data: truncateToPresentIndex(comparisonPlot, presentIndex),
+    data: comparisonPlot.slice(0, presentIndex),
     borderColor: 'rgba(60,70,110,0.2)',
     pointBackgroundColor: 'rgba(60,70,110,0.2)',
     pointHoverBackgroundColor: 'rgba(60, 70, 110)',
@@ -66,7 +62,7 @@ const buildDashedDataset = function(plot, presentIndex) {
 }
 
 const buildMainPlotDataset = function(plot, presentIndex) {
-  const data = presentIndex ? truncateToPresentIndex(plot, presentIndex) : plot
+  const data = presentIndex ? plot.slice(0, presentIndex) : plot
 
   return [{
     data: data,


### PR DESCRIPTION
### Changes

This PR refactors the graph dataset building functions into three separate functions, one for each plot: main plot, comparison plot, and dashed plot. Additionally, I fixed a bug where some period + interval combinations were not working properly with comparisons. This is because `present_index` is not available in every period, e.g. Last Month. Reviewing commit-by-commit may help :)

Preview of the graph working with the dashed part and comparisons after this pull request:

<img width="380" alt="Screenshot 2023-02-16 at 11 17 31" src="https://user-images.githubusercontent.com/5093045/219390611-441e963b-b255-48a4-afbd-5b4ae827dd46.png">

### Tests
- [X] This PR does not require tests

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
