### PR TITLE
Refactor visits metric internals

### DIFF
--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -305,7 +305,7 @@ defmodule Plausible.Stats.Base do
       select_merge: %{
         bounce_rate:
           fragment("toUInt32(ifNotFinite(round(sum(is_bounce * sign) / sum(sign) * 100), 0))"),
-        visits: fragment("toUInt32(sum(sign))")
+        __internal_visits: fragment("toUInt32(sum(sign))")
       }
     )
     |> select_session_metrics(rest)
@@ -353,7 +353,7 @@ defmodule Plausible.Stats.Base do
       select_merge: %{
         :visit_duration =>
           fragment("toUInt32(ifNotFinite(round(sum(duration * sign) / sum(sign)), 0))"),
-        visits: fragment("toUInt32(sum(sign))")
+        __internal_visits: fragment("toUInt32(sum(sign))")
       }
     )
     |> select_session_metrics(rest)

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -217,7 +217,7 @@ defmodule Plausible.Stats.Breakdown do
     |> apply_pagination(pagination)
     |> ClickhouseRepo.all()
     |> transform_keys(%{operating_system: :os})
-    |> maybe_remove_visits_metric(metrics)
+    |> remove_internal_visits_metric(metrics)
   end
 
   defp breakdown_events(_, _, _, [], _), do: []
@@ -584,13 +584,13 @@ defmodule Plausible.Stats.Breakdown do
     end)
   end
 
-  defp maybe_remove_visits_metric(results, metrics) do
-    # "visits" is fetched when querying bounce rate and visit duration, as it
+  defp remove_internal_visits_metric(results, metrics) do
+    # "__internal_visits" is fetched when querying bounce rate and visit duration, as it
     # is needed to calculate these from imported data. Let's remove it from the
     # result if it wasn't requested.
-    if (:bounce_rate in metrics or :visit_duration in metrics) and :visits not in metrics do
+    if :bounce_rate in metrics or :visit_duration in metrics do
       results
-      |> Enum.map(&Map.delete(&1, :visits))
+      |> Enum.map(&Map.delete(&1, :__internal_visits))
     else
       results
     end

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -383,7 +383,7 @@ defmodule Plausible.Stats.Imported do
     q
     |> select_merge([i], %{
       bounces: sum(i.bounces),
-      visits: sum(i.entrances)
+      __internal_visits: sum(i.entrances)
     })
     |> select_imported_metrics(rest)
   end
@@ -392,7 +392,7 @@ defmodule Plausible.Stats.Imported do
     q
     |> select_merge([i], %{
       bounces: sum(i.bounces),
-      visits: sum(i.visits)
+      __internal_visits: sum(i.visits)
     })
     |> select_imported_metrics(rest)
   end
@@ -404,7 +404,7 @@ defmodule Plausible.Stats.Imported do
     q
     |> select_merge([i], %{
       visit_duration: sum(i.visit_duration),
-      visits: sum(i.entrances)
+      __internal_visits: sum(i.entrances)
     })
     |> select_imported_metrics(rest)
   end
@@ -413,7 +413,7 @@ defmodule Plausible.Stats.Imported do
     q
     |> select_merge([i], %{
       visit_duration: sum(i.visit_duration),
-      visits: sum(i.visits)
+      __internal_visits: sum(i.visits)
     })
     |> select_imported_metrics(rest)
   end
@@ -462,9 +462,9 @@ defmodule Plausible.Stats.Imported do
           "round(100 * (coalesce(?, 0) + coalesce((? * ? / 100), 0)) / (coalesce(?, 0) + coalesce(?, 0)))",
           i.bounces,
           s.bounce_rate,
-          s.visits,
-          i.visits,
-          s.visits
+          s.__internal_visits,
+          i.__internal_visits,
+          s.__internal_visits
         )
     })
     |> select_joined_metrics(rest)
@@ -478,9 +478,9 @@ defmodule Plausible.Stats.Imported do
           "round((? + ? * ?) / (? + ?), 1)",
           i.visit_duration,
           s.visit_duration,
-          s.visits,
-          s.visits,
-          i.visits
+          s.__internal_visits,
+          s.__internal_visits,
+          i.__internal_visits
         )
     })
     |> select_joined_metrics(rest)


### PR DESCRIPTION
### Changes

In some cases the query composition code will add `visits` metric to the `SELECT` clause because it's needed for merging with imported data. In order to not confuse this internally used metric with the publicly accessible `visits` metric, this PR separates the two and renames internal use to `__internal_visits`.

cc/ @RobertJoonas 