### PR TITLE
Fail the CI if tests emit log errors/warnings

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Check Credo Warnings
         run: mix credo diff --from-git-merge-base origin/master
       - name: Run tests
-        run: mix test --include slow --max-failures 1 --warnings-as-errors
+        run: mix test --include slow --max-failures 1 --warnings-as-errors | grep -P '\[(warning|error)\]' && echo "Log lines found. Capture log output in tests. Aborting." && exit 1 || exit 0
       - name: Check Dialyzer
         run: mix dialyzer
 env:

--- a/test/workers/import_google_analytics_test.exs
+++ b/test/workers/import_google_analytics_test.exs
@@ -5,6 +5,8 @@ defmodule Plausible.Workers.ImportGoogleAnalyticsTest do
 
   alias Plausible.Workers.ImportGoogleAnalytics
 
+  @moduletag capture_log: true
+
   @imported_data %Plausible.Site.ImportedData{
     start_date: Timex.today() |> Timex.shift(days: -7),
     end_date: Timex.today(),


### PR DESCRIPTION
### Changes

Minor change to GitHub action workflow that will make the run fail on uncaught log output. ExUnit comes with tools to handle (and test) logs: 

  - https://hexdocs.pm/ex_unit/1.14.3/ExUnit.CaptureLog.html 
  - https://hexdocs.pm/ex_unit/1.12.3/ExUnit.Case.html#module-known-tags

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
