### PR TITLE
Fix interval selector z-index

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -341,14 +341,14 @@ class LineGraph extends React.Component {
         </div>
         <div className="relative px-2">
           {mainGraphRefreshing && renderLoader()}
-          <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center">
+          <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center z-20">
             { this.downloadLink() }
             { this.samplingNotice() }
             { this.importedNotice() }
             <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={updateInterval}/>
           </div>
           <FadeIn show={graphData}>
-            <div className="relative h-96 w-full">
+            <div className="relative h-96 w-full z-10">
               <canvas id="main-graph-canvas" className={canvasClass}></canvas>
             </div>
           </FadeIn>


### PR DESCRIPTION
This commit fixes a bug where the interval selector was not clickable
because it was behind the graph.
