### PR TITLE
Fix graph element z-index

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -341,14 +341,14 @@ class LineGraph extends React.Component {
         </div>
         <div className="relative px-2">
           {mainGraphRefreshing && renderLoader()}
-          <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center z-20">
+          <div className="absolute right-4 -top-10 py-2 md:py-0 flex items-center z-10">
             { this.downloadLink() }
             { this.samplingNotice() }
             { this.importedNotice() }
             <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={updateInterval}/>
           </div>
           <FadeIn show={graphData}>
-            <div className="relative h-96 w-full z-10">
+            <div className="relative h-96 w-full z-0">
               <canvas id="main-graph-canvas" className={canvasClass}></canvas>
             </div>
           </FadeIn>


### PR DESCRIPTION
Previously, the graph element was overlapping with other UI elements such as the period input. This commit fixes this issue by setting the z-index of the graph element to 0, which moves it behind other elements in the stacking order.
