### PR TITLE
Don't rely on Mix.env check in runtime

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -96,8 +96,7 @@ defmodule PlausibleWeb.StatsController do
     query = Query.from(site, params) |> Filters.add_prefix()
 
     visits_metric_enabled =
-      FunWithFlags.enabled?(:visits_metric, for: conn.assigns[:current_user]) ||
-        Mix.env() == :test
+      FunWithFlags.enabled?(:visits_metric, for: conn.assigns[:current_user])
 
     metrics =
       if visits_metric_enabled && !query.filters["event:goal"] do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,7 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 Plausible.Test.ClickhouseSetup.run()
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
+FunWithFlags.enable(:visits_metric)
 ExUnit.start(exclude: :slow)
 Application.ensure_all_started(:double)
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)


### PR DESCRIPTION
### Changes

This makes sure no `MIX_ENV` checks are done in the runtime.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
