### PR TITLE
Add new `Pages / Visit` metric to Stats API Aggregate and Timeseries

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -1,7 +1,7 @@
 defmodule Plausible.Stats.Aggregate do
   alias Plausible.Stats.Query
   use Plausible.ClickhouseRepo
-  import Plausible.Stats.{Base, Imported, Util}
+  import Plausible.Stats.{Base, Imported}
 
   @event_metrics [:visitors, :pageviews, :events, :sample_percent]
   @session_metrics [:visits, :bounce_rate, :visit_duration, :pages_per_visit, :sample_percent]
@@ -45,7 +45,6 @@ defmodule Plausible.Stats.Aggregate do
     |> select_session_metrics(metrics)
     |> merge_imported(site, query, :aggregate, metrics)
     |> ClickhouseRepo.one()
-    |> stringify_pages_per_visit()
   end
 
   defp aggregate_time_on_page(site, query) do

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -109,9 +109,11 @@ defmodule Plausible.Stats.Aggregate do
   end
 
   defp round_and_wrap_value({metric, nil}), do: {metric, %{value: 0}}
+
   defp round_and_wrap_value({:pages_per_visit = metric, value}) do
     {metric, %{value: round(value * 100) / 100}}
   end
+
   defp round_and_wrap_value({metric, value}) do
     {metric, %{value: round(value)}}
   end

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -111,7 +111,7 @@ defmodule Plausible.Stats.Aggregate do
   defp round_and_wrap_value({metric, nil}), do: {metric, %{value: 0}}
 
   defp round_and_wrap_value({:pages_per_visit = metric, value}) do
-    {metric, %{value: round(value * 100) / 100}}
+    {metric, %{value: Float.to_string(round(value * 100) / 100)}}
   end
 
   defp round_and_wrap_value({metric, value}) do

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -363,7 +363,7 @@ defmodule Plausible.Stats.Base do
     from(s in q,
       select_merge: %{
         pages_per_visit:
-          fragment("ifNotFinite(sum(? * ?) / sum(?), 0)", s.sign, s.pageviews, s.sign)
+          fragment("ifNotFinite(round(sum(? * ?) / sum(?), 2), 0)", s.sign, s.pageviews, s.sign)
       }
     )
     |> select_session_metrics(rest)

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -314,7 +314,7 @@ defmodule Plausible.Stats.Base do
   def select_session_metrics(q, [:visits | rest]) do
     from(s in q,
       select_merge: %{
-        visits: fragment("toUInt64(round(uniq(?) * any(_sample_factor)))", s.session_id)
+        visits: fragment("toUInt64(round(sum(?) * any(_sample_factor)))", s.sign)
       }
     )
     |> select_session_metrics(rest)

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -359,6 +359,16 @@ defmodule Plausible.Stats.Base do
     |> select_session_metrics(rest)
   end
 
+  def select_session_metrics(q, [:pages_per_visit | rest]) do
+    from(s in q,
+      select_merge: %{
+        pages_per_visit:
+          fragment("ifNotFinite(sum(? * ?) / sum(?), 0)", s.sign, s.pageviews, s.sign)
+      }
+    )
+    |> select_session_metrics(rest)
+  end
+
   def select_session_metrics(q, [:sample_percent | rest]) do
     from(e in q,
       select_merge: %{

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -1,6 +1,6 @@
 defmodule Plausible.Stats.Breakdown do
   use Plausible.ClickhouseRepo
-  import Plausible.Stats.{Base, Imported}
+  import Plausible.Stats.{Base, Imported, Util}
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.Query
   alias Plausible.Goals
@@ -582,18 +582,6 @@ defmodule Plausible.Stats.Breakdown do
       end)
       |> Enum.into(%{})
     end)
-  end
-
-  defp remove_internal_visits_metric(results, metrics) do
-    # "__internal_visits" is fetched when querying bounce rate and visit duration, as it
-    # is needed to calculate these from imported data. Let's remove it from the
-    # result if it wasn't requested.
-    if :bounce_rate in metrics or :visit_duration in metrics do
-      results
-      |> Enum.map(&Map.delete(&1, :__internal_visits))
-    else
-      results
-    end
   end
 
   defp apply_pagination(q, {limit, page}) do

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -1,7 +1,7 @@
 defmodule Plausible.Stats.Timeseries do
   use Plausible.ClickhouseRepo
   alias Plausible.Stats.Query
-  import Plausible.Stats.Base
+  import Plausible.Stats.{Base, Util}
   use Plausible.Stats.Fragments
 
   @event_metrics [:visitors, :pageviews]
@@ -45,6 +45,7 @@ defmodule Plausible.Stats.Timeseries do
     |> select_session_metrics(metrics)
     |> Plausible.Stats.Imported.merge_imported_timeseries(site, query, metrics)
     |> ClickhouseRepo.all()
+    |> remove_internal_visits_metric(metrics)
   end
 
   defp buckets(%Query{interval: "month"} = query) do

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -193,7 +193,7 @@ defmodule Plausible.Stats.Timeseries do
         :pageviews -> Map.merge(row, %{pageviews: 0})
         :visitors -> Map.merge(row, %{visitors: 0})
         :visits -> Map.merge(row, %{visits: 0})
-        :pages_per_visit -> Map.merge(row, %{pages_per_visit: 0.0})
+        :pages_per_visit -> Map.merge(row, %{pages_per_visit: "0.0"})
         :bounce_rate -> Map.merge(row, %{bounce_rate: nil})
         :visit_duration -> Map.merge(row, %{:visit_duration => nil})
       end
@@ -209,7 +209,7 @@ defmodule Plausible.Stats.Timeseries do
   end
 
   defp round_pages_per_visit(%{pages_per_visit: value} = bucket) do
-    Map.replace(bucket, :pages_per_visit, round(value * 100) / 100)
+    Map.replace(bucket, :pages_per_visit, Float.to_string(round(value * 100) / 100))
   end
 
   defp round_pages_per_visit(bucket), do: bucket

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -45,7 +45,6 @@ defmodule Plausible.Stats.Timeseries do
     |> select_session_metrics(metrics)
     |> Plausible.Stats.Imported.merge_imported_timeseries(site, query, metrics)
     |> ClickhouseRepo.all()
-    |> maybe_stringify_pages_per_visit(metrics)
     |> remove_internal_visits_metric(metrics)
   end
 
@@ -193,18 +192,10 @@ defmodule Plausible.Stats.Timeseries do
         :pageviews -> Map.merge(row, %{pageviews: 0})
         :visitors -> Map.merge(row, %{visitors: 0})
         :visits -> Map.merge(row, %{visits: 0})
-        :pages_per_visit -> Map.merge(row, %{pages_per_visit: "0.0"})
+        :pages_per_visit -> Map.merge(row, %{pages_per_visit: 0.0})
         :bounce_rate -> Map.merge(row, %{bounce_rate: nil})
         :visit_duration -> Map.merge(row, %{:visit_duration => nil})
       end
     end)
-  end
-
-  defp maybe_stringify_pages_per_visit(results_list, metrics) do
-    if :pages_per_visit in metrics do
-      Enum.map(results_list, &stringify_pages_per_visit/1)
-    else
-      results_list
-    end
   end
 end

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -45,7 +45,7 @@ defmodule Plausible.Stats.Timeseries do
     |> select_session_metrics(metrics)
     |> Plausible.Stats.Imported.merge_imported_timeseries(site, query, metrics)
     |> ClickhouseRepo.all()
-    |> maybe_round_pages_per_visit(metrics)
+    |> maybe_stringify_pages_per_visit(metrics)
     |> remove_internal_visits_metric(metrics)
   end
 
@@ -200,17 +200,11 @@ defmodule Plausible.Stats.Timeseries do
     end)
   end
 
-  defp maybe_round_pages_per_visit(results_list, metrics) do
+  defp maybe_stringify_pages_per_visit(results_list, metrics) do
     if :pages_per_visit in metrics do
-      Enum.map(results_list, &round_pages_per_visit/1)
+      Enum.map(results_list, &stringify_pages_per_visit/1)
     else
       results_list
     end
   end
-
-  defp round_pages_per_visit(%{pages_per_visit: value} = bucket) do
-    Map.replace(bucket, :pages_per_visit, Float.to_string(round(value * 100) / 100))
-  end
-
-  defp round_pages_per_visit(bucket), do: bucket
 end

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -211,5 +211,6 @@ defmodule Plausible.Stats.Timeseries do
   defp round_pages_per_visit(%{pages_per_visit: value} = bucket) do
     Map.replace(bucket, :pages_per_visit, round(value * 100) / 100)
   end
+
   defp round_pages_per_visit(bucket), do: bucket
 end

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -16,4 +16,10 @@ defmodule Plausible.Stats.Util do
       results
     end
   end
+
+  def stringify_pages_per_visit(%{pages_per_visit: value} = results) do
+    Map.replace(results, :pages_per_visit, Float.to_string(value))
+  end
+
+  def stringify_pages_per_visit(results), do: results
 end

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -16,10 +16,4 @@ defmodule Plausible.Stats.Util do
       results
     end
   end
-
-  def stringify_pages_per_visit(%{pages_per_visit: value} = results) do
-    Map.replace(results, :pages_per_visit, Float.to_string(value))
-  end
-
-  def stringify_pages_per_visit(results), do: results
 end

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -1,6 +1,10 @@
 defmodule Plausible.Stats.Util do
+  @moduledoc """
+  Utilities for modifying stat results
+  """
+
   @doc """
-  "__internal_visits" is fetched when querying bounce rate and visit duration, as it
+  `__internal_visits` is fetched when querying bounce rate and visit duration, as it
   is needed to calculate these from imported data. This function removes that metric
   from all entries in the results list.
   """

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -1,0 +1,15 @@
+defmodule Plausible.Stats.Util do
+  @doc """
+  "__internal_visits" is fetched when querying bounce rate and visit duration, as it
+  is needed to calculate these from imported data. This function removes that metric
+  from all entries in the results list.
+  """
+  def remove_internal_visits_metric(results, metrics) do
+    if :bounce_rate in metrics or :visit_duration in metrics do
+      results
+      |> Enum.map(&Map.delete(&1, :__internal_visits))
+    else
+      results
+    end
+  end
+end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          query <- Query.from(site, params),
-         {:ok, metrics} <- parse_metrics(params, nil, query) do
+         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
       results =
         if params["compare"] == "previous_period" do
           prev_query = Query.shift_back(query, site)
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_date(params),
          {:ok, property} <- validate_property(params),
          query <- Query.from(site, params),
-         {:ok, metrics} <- parse_metrics(params, property, query),
+         {:ok, metrics} <- parse_and_validate_metrics(params, property, query),
          {:ok, limit} <- validate_or_default_limit(params) do
       page = String.to_integer(Map.get(params, "page", "1"))
       results = Plausible.Stats.breakdown(site, query, property, metrics, {limit, page})
@@ -117,39 +117,46 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   @event_metrics ["visitors", "pageviews", "events"]
   @session_metrics ["visits", "bounce_rate", "visit_duration"]
-  defp parse_metrics(params, property, query) do
+  defp parse_and_validate_metrics(params, property, query) do
     metrics =
       Map.get(params, "metrics", "visitors")
       |> String.split(",")
 
+    case validate_all_metrics(metrics, property, query) do
+      {:error, reason} -> {:error, reason}
+      metrics -> {:ok, Enum.map(metrics, &String.to_atom/1)}
+    end
+  end
+
+  defp validate_all_metrics(metrics, property, query) do
+    Enum.reduce_while(metrics, [], fn (metric, acc) ->
+      case validate_metric(metric, property, query) do
+        {:ok, metric} -> {:cont, acc ++ [metric]}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp validate_metric(metric, _, _) when metric in @event_metrics, do: {:ok, metric}
+  defp validate_metric(metric, property, query) when metric in @session_metrics do
     event_only_filter = Map.keys(query.filters) |> Enum.find(&event_only_property?/1)
 
-    valid_metrics =
-      if event_only_property?(property) || event_only_filter do
-        @event_metrics
-      else
-        @event_metrics ++ @session_metrics
-      end
+    cond do
+      event_only_property?(property) ->
+        {:error,
+          "Session metric `#{metric}` cannot be queried for breakdown by `#{property}`."}
 
-    invalid_metric = Enum.find(metrics, fn metric -> metric not in valid_metrics end)
+      event_only_filter ->
+        {:error,
+          "Session metric `#{metric}` cannot be queried when using a filter on `#{event_only_filter}`."}
 
-    if invalid_metric do
-      cond do
-        event_only_property?(property) && invalid_metric in @session_metrics ->
-          {:error,
-           "Session metric `#{invalid_metric}` cannot be queried for breakdown by `#{property}`."}
-
-        event_only_filter && invalid_metric in @session_metrics ->
-          {:error,
-           "Session metric `#{invalid_metric}` cannot be queried when using a filter on `#{event_only_filter}`."}
-
-        true ->
-          {:error,
-           "The metric `#{invalid_metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown"}
-      end
-    else
-      {:ok, Enum.map(metrics, &String.to_atom/1)}
+      true ->
+        {:ok, metric}
     end
+  end
+  defp validate_metric(metric, _, _) do
+    {:error,
+      "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown"}
   end
 
   def timeseries(conn, params) do
@@ -160,7 +167,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_date(params),
          :ok <- validate_interval(params),
          query <- Query.from(site, params),
-         {:ok, metrics} <- parse_metrics(params, nil, query) do
+         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
       graph = Plausible.Stats.timeseries(site, query, metrics)
       metrics = metrics ++ [:date]
       json(conn, %{results: Enum.map(graph, &Map.take(&1, metrics))})

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -45,7 +45,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
       results =
         results
         |> Map.take(metrics)
-        |> stringify_float_values()
 
       json(conn, %{results: results})
     else
@@ -177,9 +176,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_interval(params),
          query <- Query.from(site, params),
          {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
-      graph =
-        Plausible.Stats.timeseries(site, query, metrics)
-        |> stringify_float_values()
+      graph = Plausible.Stats.timeseries(site, query, metrics)
 
       json(conn, %{results: graph})
     else
@@ -261,24 +258,4 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_interval(_), do: :ok
-
-  defp stringify_float_values(results) when is_list(results) do
-    Enum.map(results, &stringify_float_values/1)
-  end
-
-  defp stringify_float_values(results_map) do
-    results_map
-    |> Enum.map(&maybe_stringify/1)
-    |> Enum.into(%{})
-  end
-
-  defp maybe_stringify({metric, %{value: value}}) when is_float(value) do
-    {metric, %{value: Float.to_string(value)}}
-  end
-
-  defp maybe_stringify({metric, value}) when is_float(value) do
-    {metric, Float.to_string(value)}
-  end
-
-  defp maybe_stringify(entry), do: entry
 end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -156,7 +156,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
   defp validate_metric(metric, _, _) do
     {:error,
-      "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown"}
+      "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"}
   end
 
   def timeseries(conn, params) do

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -177,8 +177,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          query <- Query.from(site, params),
          {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
       graph = Plausible.Stats.timeseries(site, query, metrics)
-      metrics = metrics ++ [:date]
-      json(conn, %{results: Enum.map(graph, &Map.take(&1, metrics))})
+      json(conn, %{results: graph})
     else
       {:error, msg} ->
         conn

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -134,7 +134,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_all_metrics(metrics, property, query) do
-    Enum.reduce_while(metrics, [], fn (metric, acc) ->
+    Enum.reduce_while(metrics, [], fn metric, acc ->
       case validate_metric(metric, property, query) do
         {:ok, metric} -> {:cont, acc ++ [metric]}
         {:error, reason} -> {:halt, {:error, reason}}
@@ -143,6 +143,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_metric(metric, _, _) when metric in @event_metrics, do: {:ok, metric}
+
   defp validate_metric(metric, property, query) when metric in @session_metrics do
     event_only_filter = Map.keys(query.filters) |> Enum.find(&event_only_property?/1)
 
@@ -151,20 +152,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
         {:error, "Metric `#{metric}` is not supported in breakdown queries"}
 
       event_only_property?(property) ->
-        {:error,
-          "Session metric `#{metric}` cannot be queried for breakdown by `#{property}`."}
+        {:error, "Session metric `#{metric}` cannot be queried for breakdown by `#{property}`."}
 
       event_only_filter ->
         {:error,
-          "Session metric `#{metric}` cannot be queried when using a filter on `#{event_only_filter}`."}
+         "Session metric `#{metric}` cannot be queried when using a filter on `#{event_only_filter}`."}
 
       true ->
         {:ok, metric}
     end
   end
+
   defp validate_metric(metric, _, _) do
     {:error,
-      "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"}
+     "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"}
   end
 
   def timeseries(conn, params) do
@@ -179,6 +180,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
       graph =
         Plausible.Stats.timeseries(site, query, metrics)
         |> stringify_float_values()
+
       json(conn, %{results: graph})
     else
       {:error, msg} ->
@@ -263,6 +265,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   defp stringify_float_values(results) when is_list(results) do
     Enum.map(results, &stringify_float_values/1)
   end
+
   defp stringify_float_values(results_map) do
     results_map
     |> Enum.map(&maybe_stringify/1)
@@ -272,8 +275,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   defp maybe_stringify({metric, %{value: value}}) when is_float(value) do
     {metric, %{value: Float.to_string(value)}}
   end
+
   defp maybe_stringify({metric, value}) when is_float(value) do
     {metric, Float.to_string(value)}
   end
+
   defp maybe_stringify(entry), do: entry
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -73,7 +73,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
 
       assert json_response(conn, 400) == %{
                "error" =>
-                 "The metric `led_zeppelin` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown"
+                 "The metric `led_zeppelin` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"
              }
     end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -137,7 +137,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       })
 
     assert json_response(conn, 200)["results"] == %{
-             "pages_per_visit" => %{"value" => "1.67"}
+             "pages_per_visit" => %{"value" => 1.67}
            }
   end
 
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
              "pageviews" => %{"value" => 3},
              "visitors" => %{"value" => 2},
              "visits" => %{"value" => 2},
-             "pages_per_visit" => %{"value" => "1.5"},
+             "pages_per_visit" => %{"value" => 1.5},
              "bounce_rate" => %{"value" => 50},
              "visit_duration" => %{"value" => 750}
            }

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -116,7 +116,32 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
            }
   end
 
-  test "aggregates visitors, pageviews, visits, bounce rate and visit duration", %{
+  test "rounds pages_per_visit to two decimal places", %{
+    conn: conn,
+    site: site
+  } do
+    populate_stats([
+      build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, user_id: 456, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, user_id: 456, domain: site.domain, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00])
+    ])
+
+    conn =
+      get(conn, "/api/v1/stats/aggregate", %{
+        "site_id" => site.domain,
+        "period" => "day",
+        "date" => "2021-01-01",
+        "metrics" => "pages_per_visit"
+      })
+
+    assert json_response(conn, 200)["results"] == %{
+             "pages_per_visit" => %{"value" => "1.67"}
+           }
+  end
+
+  test "aggregates all metrics in a single query", %{
     conn: conn,
     site: site
   } do
@@ -131,13 +156,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         "site_id" => site.domain,
         "period" => "day",
         "date" => "2021-01-01",
-        "metrics" => "pageviews,visits,visitors,bounce_rate,visit_duration"
+        "metrics" => "pageviews,visits,pages_per_visit,visitors,bounce_rate,visit_duration"
       })
 
     assert json_response(conn, 200)["results"] == %{
              "pageviews" => %{"value" => 3},
              "visitors" => %{"value" => 2},
              "visits" => %{"value" => 2},
+             "pages_per_visit" => %{"value" => "1.5"},
              "bounce_rate" => %{"value" => 50},
              "visit_duration" => %{"value" => 750}
            }

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -67,7 +67,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
       assert json_response(conn, 400) == %{
                "error" =>
-                 "The metric `baa` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown"
+                 "The metric `baa` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"
              }
     end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -829,49 +829,49 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                    "date" => "2021-01-01",
                    "pageviews" => 3,
                    "visits" => 2,
-                   "pages_per_visit" => "1.5"
+                   "pages_per_visit" => 1.5
                  },
                  %{
                    "date" => "2021-01-02",
                    "pageviews" => 0,
                    "visits" => 0,
-                   "pages_per_visit" => "0.0"
+                   "pages_per_visit" => 0.0
                  },
                  %{
                    "date" => "2021-01-03",
                    "pageviews" => 0,
                    "visits" => 0,
-                   "pages_per_visit" => "0.0"
+                   "pages_per_visit" => 0.0
                  },
                  %{
                    "date" => "2021-01-04",
                    "pageviews" => 0,
                    "visits" => 0,
-                   "pages_per_visit" => "0.0"
+                   "pages_per_visit" => 0.0
                  },
                  %{
                    "date" => "2021-01-05",
                    "pageviews" => 0,
                    "visits" => 0,
-                   "pages_per_visit" => "0.0"
+                   "pages_per_visit" => 0.0
                  },
                  %{
                    "date" => "2021-01-06",
                    "pageviews" => 0,
                    "visits" => 0,
-                   "pages_per_visit" => "0.0"
+                   "pages_per_visit" => 0.0
                  },
                  %{
                    "date" => "2021-01-07",
                    "pageviews" => 1,
                    "visits" => 1,
-                   "pages_per_visit" => "1.0"
+                   "pages_per_visit" => 1.0
                  }
                ]
              }
     end
 
-    test "rounds pages_per_visit to two decimal places and keeps trailing zeros", %{
+    test "rounds pages_per_visit to two decimal places", %{
       conn: conn,
       site: site
     } do
@@ -911,13 +911,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
       assert json_response(conn, 200) == %{
                "results" => [
-                 %{"date" => "2021-01-01", "pages_per_visit" => "2.0"},
-                 %{"date" => "2021-01-02", "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-03", "pages_per_visit" => "1.33"},
-                 %{"date" => "2021-01-04", "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-05", "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-06", "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-07", "pages_per_visit" => "1.0"}
+                 %{"date" => "2021-01-01", "pages_per_visit" => 2.0},
+                 %{"date" => "2021-01-02", "pages_per_visit" => 0.0},
+                 %{"date" => "2021-01-03", "pages_per_visit" => 1.33},
+                 %{"date" => "2021-01-04", "pages_per_visit" => 0.0},
+                 %{"date" => "2021-01-05", "pages_per_visit" => 0.0},
+                 %{"date" => "2021-01-06", "pages_per_visit" => 0.0},
+                 %{"date" => "2021-01-07", "pages_per_visit" => 1.0}
                ]
              }
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -801,8 +801,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
   describe "metrics" do
     test "shows pageviews,visits,pages_per_visit for last 7d", %{conn: conn, site: site} do
       populate_stats([
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:05:00]),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:05:00]
+        ),
         build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview, domain: site.domain, timestamp: ~N[2021-01-07 23:59:00])
       ])
@@ -817,23 +825,77 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
       assert json_response(conn, 200) == %{
                "results" => [
-                 %{"date" => "2021-01-01", "pageviews" => 3, "visits" => 2, "pages_per_visit" => "1.5"},
-                 %{"date" => "2021-01-02", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-03", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-04", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-05", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-06", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-07", "pageviews" => 1, "visits" => 1, "pages_per_visit" => "1.0"},
+                 %{
+                   "date" => "2021-01-01",
+                   "pageviews" => 3,
+                   "visits" => 2,
+                   "pages_per_visit" => "1.5"
+                 },
+                 %{
+                   "date" => "2021-01-02",
+                   "pageviews" => 0,
+                   "visits" => 0,
+                   "pages_per_visit" => "0.0"
+                 },
+                 %{
+                   "date" => "2021-01-03",
+                   "pageviews" => 0,
+                   "visits" => 0,
+                   "pages_per_visit" => "0.0"
+                 },
+                 %{
+                   "date" => "2021-01-04",
+                   "pageviews" => 0,
+                   "visits" => 0,
+                   "pages_per_visit" => "0.0"
+                 },
+                 %{
+                   "date" => "2021-01-05",
+                   "pageviews" => 0,
+                   "visits" => 0,
+                   "pages_per_visit" => "0.0"
+                 },
+                 %{
+                   "date" => "2021-01-06",
+                   "pageviews" => 0,
+                   "visits" => 0,
+                   "pages_per_visit" => "0.0"
+                 },
+                 %{
+                   "date" => "2021-01-07",
+                   "pageviews" => 1,
+                   "visits" => 1,
+                   "pages_per_visit" => "1.0"
+                 }
                ]
              }
     end
 
-    test "rounds pages_per_visit to two decimal places and keeps trailing zeros", %{conn: conn, site: site} do
+    test "rounds pages_per_visit to two decimal places and keeps trailing zeros", %{
+      conn: conn,
+      site: site
+    } do
       populate_stats([
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:05:00]),
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
-        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-03 00:01:00]),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-01 00:05:00]
+        ),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-03 00:00:00]
+        ),
+        build(:pageview,
+          user_id: @user_id,
+          domain: site.domain,
+          timestamp: ~N[2021-01-03 00:01:00]
+        ),
         build(:pageview, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
         build(:pageview, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
         build(:pageview, domain: site.domain, timestamp: ~N[2021-01-07 23:59:00])
@@ -855,7 +917,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                  %{"date" => "2021-01-04", "pages_per_visit" => "0.0"},
                  %{"date" => "2021-01-05", "pages_per_visit" => "0.0"},
                  %{"date" => "2021-01-06", "pages_per_visit" => "0.0"},
-                 %{"date" => "2021-01-07", "pages_per_visit" => "1.0"},
+                 %{"date" => "2021-01-07", "pages_per_visit" => "1.0"}
                ]
              }
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -797,4 +797,67 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       assert second == %{"date" => "2021-01-02", "visitors" => 1}
     end
   end
+
+  describe "metrics" do
+    test "shows pageviews,visits,pages_per_visit for last 7d", %{conn: conn, site: site} do
+      populate_stats([
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:05:00]),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-07 23:59:00])
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "7d",
+          "metrics" => "pageviews,visits,pages_per_visit",
+          "date" => "2021-01-07"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"date" => "2021-01-01", "pageviews" => 3, "visits" => 2, "pages_per_visit" => "1.5"},
+                 %{"date" => "2021-01-02", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-03", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-04", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-05", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-06", "pageviews" => 0, "visits" => 0, "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-07", "pageviews" => 1, "visits" => 1, "pages_per_visit" => "1.0"},
+               ]
+             }
+    end
+
+    test "rounds pages_per_visit to two decimal places and keeps trailing zeros", %{conn: conn, site: site} do
+      populate_stats([
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-01 00:05:00]),
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
+        build(:pageview, user_id: @user_id, domain: site.domain, timestamp: ~N[2021-01-03 00:01:00]),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-03 00:00:00]),
+        build(:pageview, domain: site.domain, timestamp: ~N[2021-01-07 23:59:00])
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "7d",
+          "metrics" => "pages_per_visit",
+          "date" => "2021-01-07"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{"date" => "2021-01-01", "pages_per_visit" => "2.0"},
+                 %{"date" => "2021-01-02", "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-03", "pages_per_visit" => "1.33"},
+                 %{"date" => "2021-01-04", "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-05", "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-06", "pages_per_visit" => "0.0"},
+                 %{"date" => "2021-01-07", "pages_per_visit" => "1.0"},
+               ]
+             }
+    end
+  end
 end


### PR DESCRIPTION
### Changes

This PR adds a new `pages_per_visit` metric to two endpoints in the Stats API:

* `api/v1/stats/aggregate`
* `api/v1/stats/timeseries`

Supporting the metric in the breakdown endpoint is out of scope.

> Reviewing commit by commit suggested. Comments in-line.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
