### PR TITLE
Migration: native_stats_start_at

### DIFF
--- a/priv/repo/migrations/20230301095227_add_native_stats_start_date.exs
+++ b/priv/repo/migrations/20230301095227_add_native_stats_start_date.exs
@@ -1,0 +1,23 @@
+defmodule Plausible.Repo.Migrations.AddNativeStatsStartDate do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sites) do
+      add :native_stats_start_at, :naive_datetime, null: true
+    end
+
+    execute """
+    UPDATE sites SET native_stats_start_at = inserted_at
+    """
+
+    alter table(:sites) do
+      modify :native_stats_start_at, :naive_datetime, null: false, default: fragment("now()")
+    end
+  end
+
+  def down do
+    alter table(:sites) do
+      remove :native_stats_start_at
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This adds a `native_stats_start_at` pointer to sites so that we can calculate left stats boundary - "the beginning of time" for native stats. 

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
