### PR TITLE
Update native stats start date when transferring

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -87,6 +87,10 @@ defmodule Plausible.Site do
     change(site, stats_start_date: val)
   end
 
+  def set_native_stats_start_at(site, val) do
+    change(site, native_stats_start_at: val)
+  end
+
   def start_import(site, start_date, end_date, imported_source, status \\ "importing") do
     change(site,
       imported_data: %{

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -96,7 +96,9 @@ defmodule Plausible.SiteAdmin do
       start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(from_site)
 
       {:ok, _} =
-        Plausible.Site.set_stats_start_date(to_site, start_date)
+        to_site
+        |> Plausible.Site.set_stats_start_date(start_date)
+        |> Plausible.Site.set_native_stats_start_at(from_site.native_stats_start_at)
         |> Repo.update()
 
       :ok

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -62,6 +62,17 @@ defmodule Plausible.SiteAdminTest do
       assert Repo.reload(to_site).stats_start_date == ~D[2022-01-01]
     end
 
+    test "updates native_stats_start_date on based on the from_site record" do
+      from_site = insert(:site, native_stats_start_at: ~N[2022-01-01 01:00:00])
+      to_site = insert(:site)
+
+      populate_stats(from_site, [build(:pageview, timestamp: ~N[2022-01-01 13:21:00])])
+
+      SiteAdmin.transfer_data([from_site], %{"domain" => to_site.domain})
+
+      assert Repo.reload(to_site).native_stats_start_at == ~N[2022-01-01 01:00:00]
+    end
+
     test "session_transfer_query" do
       actual = SiteAdmin.session_transfer_query("from.com", "to.com")
 


### PR DESCRIPTION
### Changes

Recently added `native_stats_start_date` needs to be adjusted when transferring data between domains.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
