### PR TITLE
Fix a bug in percent change calculation

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -427,6 +427,8 @@ defmodule PlausibleWeb.Api.StatsController do
     percent_change(old_count, new_count)
   end
 
+  defp percent_change(nil, _new_count), do: nil
+
   defp percent_change(old_count, new_count) do
     cond do
       old_count == 0 and new_count > 0 ->
@@ -1007,7 +1009,7 @@ defmodule PlausibleWeb.Api.StatsController do
     end
   end
 
-  defp calculate_cr(nil, _converted_visitors), do: 100.0
+  defp calculate_cr(nil, _converted_visitors), do: nil
 
   defp calculate_cr(unique_visitors, converted_visitors) do
     if unique_visitors > 0,

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -419,5 +419,29 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{"name" => "Conversion rate", "value" => 33.3, "change" => 100} in res["top_stats"]
     end
+
+    test "returns conversion rate with change=nil when comparison mode disallowed", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, user_id: @user_id),
+        build(:pageview, user_id: @user_id),
+        build(:pageview),
+        build(:event, name: "Signup")
+      ])
+
+      filters = Jason.encode!(%{goal: "Signup"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"name" => "Conversion rate", "value" => 33.3, "change" => nil} in res["top_stats"]
+    end
   end
 end


### PR DESCRIPTION
### Changes

This PR fixes a bug where the Top Stats crashed, trying to calculate percent difference for goal filtered data.   

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
