### PR TITLE
Added IPv6 Finch support (via the environment-variable FINCH_IPV6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - 'Last updated X seconds ago' info to 'current visitors' tooltips
 - Add support for more Bamboo adapters, i.e. `Bamboo.MailgunAdapter`, `Bamboo.MandrillAdapter`, `Bamboo.SendGridAdapter` plausible/analytics#2649
+- Added IPv6 Finch support (via the environment-variable `FINCH_IPV6`)
 
 ### Fixed
 - City report showing N/A instead of city names with imported data plausible/analytics#2675

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -268,11 +268,10 @@ config :plausible, :paddle,
   vendor_auth_code: paddle_auth_code,
   vendor_id: paddle_vendor_id
 
-finch_ipv6 = if System.get_env("FINCH_IPV6"), do: true, else: false
+finch_transport_opts = if System.get_env("FINCH_IPV6"), do: [timeout: 15_000, inet6: true], else: [timeout: 15_000]
 
-config :plausible, :finch_transport),
-  inet6: finch_ipv6,
-  timeout: 15_000
+config :plausible, :finch,
+  transport_opts: finch_transport_opts
 
 config :plausible, :google,
   client_id: google_cid,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -268,6 +268,12 @@ config :plausible, :paddle,
   vendor_auth_code: paddle_auth_code,
   vendor_id: paddle_vendor_id
 
+finch_ipv6 = if System.get_env("FINCH_IPV6"), do: true, else: false
+
+config :plausible, :finch_transport),
+  inet6: finch_ipv6,
+  timeout: 15_000
+
 config :plausible, :google,
   client_id: google_cid,
   client_secret: google_secret,

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -50,13 +50,13 @@ defmodule Plausible.Application do
   end
 
   defp finch_pool_config() do
-    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
+    finch_conf = Application.get_env(:plausible, :finch)
     base_config = %{
       "https://icons.duckduckgo.com" => [
-        conn_opts: [transport_opts: finch_transport_opts]
+        conn_opts: [transport_opts: finch_conf[:transport_opts]]
       ],
       default: [
-        conn_opts: [transport_opts: finch_transport_opts]
+        conn_opts: [transport_opts: finch_conf[:transport_opts]]
       ]
     }
 
@@ -78,12 +78,12 @@ defmodule Plausible.Application do
 
   defp maybe_add_paddle_pool(pool_config) do
     paddle_conf = Application.get_env(:plausible, :paddle)
-    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
+    finch_conf = Application.get_env(:plausible, :finch)
 
     cond do
       paddle_conf[:vendor_id] && paddle_conf[:vendor_auth_code] ->
         Map.put(pool_config, Plausible.Billing.PaddleApi.vendors_domain(),
-          conn_opts: [transport_opts: finch_transport_opts]
+          conn_opts: [transport_opts: finch_conf[:transport_opts]]
         )
 
       true ->
@@ -93,13 +93,13 @@ defmodule Plausible.Application do
 
   defp maybe_add_google_pools(pool_config) do
     google_conf = Application.get_env(:plausible, :google)
-    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
+    finch_conf = Application.get_env(:plausible, :finch)
 
     cond do
       google_conf[:client_id] && google_conf[:client_secret] ->
         pool_config
-        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: finch_transport_opts])
-        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: finch_transport_opts])
+        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: finch_conf[:transport_opts]])
+        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: finch_conf[:transport_opts]])
 
       true ->
         pool_config

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -50,12 +50,13 @@ defmodule Plausible.Application do
   end
 
   defp finch_pool_config() do
+    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
     base_config = %{
       "https://icons.duckduckgo.com" => [
-        conn_opts: [transport_opts: finch_transport_opts()]
+        conn_opts: [transport_opts: finch_transport_opts]
       ],
       default: [
-        conn_opts: [transport_opts: finch_transport_opts()]
+        conn_opts: [transport_opts: finch_transport_opts]
       ]
     }
 
@@ -77,11 +78,12 @@ defmodule Plausible.Application do
 
   defp maybe_add_paddle_pool(pool_config) do
     paddle_conf = Application.get_env(:plausible, :paddle)
+    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
 
     cond do
       paddle_conf[:vendor_id] && paddle_conf[:vendor_auth_code] ->
         Map.put(pool_config, Plausible.Billing.PaddleApi.vendors_domain(),
-          conn_opts: [transport_opts: finch_transport_opts()]
+          conn_opts: [transport_opts: finch_transport_opts]
         )
 
       true ->
@@ -91,20 +93,17 @@ defmodule Plausible.Application do
 
   defp maybe_add_google_pools(pool_config) do
     google_conf = Application.get_env(:plausible, :google)
+    finch_transport_opts = Application.get_env(:plausible, :finch_transport)
 
     cond do
       google_conf[:client_id] && google_conf[:client_secret] ->
         pool_config
-        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: finch_transport_opts()])
-        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: finch_transport_opts()])
+        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: finch_transport_opts])
+        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: finch_transport_opts])
 
       true ->
         pool_config
     end
-  end
-
-  defp finch_transport_opts() do
-      maybe_ipv6 = if System.get_env("FINCH_IPV6"), do: [timeout: 15_000, inet6: true], else: [timeout: 15_000]
   end
 
   def setup_sentry() do

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -52,7 +52,10 @@ defmodule Plausible.Application do
   defp finch_pool_config() do
     base_config = %{
       "https://icons.duckduckgo.com" => [
-        conn_opts: [transport_opts: [timeout: 15_000]]
+        conn_opts: [transport_opts: finch_transport_opts()]
+      ],
+      default: [
+        conn_opts: [transport_opts: finch_transport_opts()]
       ]
     }
 
@@ -78,7 +81,7 @@ defmodule Plausible.Application do
     cond do
       paddle_conf[:vendor_id] && paddle_conf[:vendor_auth_code] ->
         Map.put(pool_config, Plausible.Billing.PaddleApi.vendors_domain(),
-          conn_opts: [transport_opts: [timeout: 15_000]]
+          conn_opts: [transport_opts: finch_transport_opts()]
         )
 
       true ->
@@ -92,12 +95,16 @@ defmodule Plausible.Application do
     cond do
       google_conf[:client_id] && google_conf[:client_secret] ->
         pool_config
-        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: [timeout: 15_000]])
-        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: [timeout: 15_000]])
+        |> Map.put(google_conf[:api_url], conn_opts: [transport_opts: finch_transport_opts()])
+        |> Map.put(google_conf[:reporting_api_url], conn_opts: [transport_opts: finch_transport_opts()])
 
       true ->
         pool_config
     end
+  end
+
+  defp finch_transport_opts() do
+      maybe_ipv6 = if System.get_env("FINCH_IPV6"), do: [timeout: 15_000, inet6: true], else: [timeout: 15_000]
   end
 
   def setup_sentry() do


### PR DESCRIPTION
### Background

We are working with [Hetzner Cloud](https://www.hetzner.com/cloud) and have a setup, where only the proxy server is available via IPv4. The Docker hosts used to run services like plausible are attached to the network via IPv6.

Now we run unto the problem that plausible was not able to connect to Google API to connect with Analytics/Search Console.

After some research I found the following issue on finch: [IPv6 Documentation](https://github.com/sneako/finch/issues/163)

### Changes

Updates `lib/plausible/application.ex` and enables IPv6 support for Finch by setting `transport_opts: [inet6: true]` when environment variable `FINCH_IPV6` is set.

### Tests
- [X] This PR does not require tests

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [X] This PR does not change the UI
