### PR TITLE
Bug fix - show `views_per_visit` when stats include imported data

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -45,7 +45,7 @@ export default class TopStats extends React.Component {
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
     const { topStatData, lastLoadTimestamp } = this.props
-    const showingImported = topStatData && topStatData.imported_source && topStatData.with_imported
+    const showingImported = topStatData?.imported_source && topStatData?.with_imported
 
     return (
       <div>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -44,10 +44,14 @@ export default class TopStats extends React.Component {
     let statName = stat.name.toLowerCase()
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
+    const { topStatData, lastLoadTimestamp } = this.props
+    const showingImported = topStatData && topStatData.imported_source && topStatData.with_imported
+
     return (
       <div>
         <div className="whitespace-nowrap">{this.topStatNumberLong(stat)} {statName}</div>
-        {stat.name === 'Current visitors' && <p className="font-normal text-xs">Last updated <SecondsSinceLastLoad lastLoadTimestamp={this.props.lastLoadTimestamp}/>s ago</p>}
+        {stat.name === 'Current visitors' && <p className="font-normal text-xs">Last updated <SecondsSinceLastLoad lastLoadTimestamp={lastLoadTimestamp}/>s ago</p>}
+        {stat.name === 'Views per visit' && showingImported && <p className="font-normal text-xs whitespace-nowrap">Based only on native data</p>}
       </div>
     )
   }

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -452,6 +452,14 @@ defmodule Plausible.Stats.Imported do
     |> select_joined_metrics(rest)
   end
 
+  defp select_joined_metrics(q, [:views_per_visit | rest]) do
+    q
+    |> select_merge([s, _i], %{
+      views_per_visit: s.views_per_visit
+    })
+    |> select_joined_metrics(rest)
+  end
+
   defp select_joined_metrics(q, [:bounce_rate | rest]) do
     q
     |> select_merge([s, i], %{


### PR DESCRIPTION
### Changes

The current behavior is that we don't display this metric at all if imported data is displayed.

This PR fixes the bug where the new `views_per_visit` metric is not displayed when imported data is shown on the dashboard. This adds a new function clause to select this metric as well, when imported stats are being merged with native data.

However, the new function simply fetches the metric from native Plausible tables (since this metric is not imported from GA). To make it clear to the user, the metric tooltip will display the message "_Based only on native data_", when the visible stats include GA data.

That means, for example, when we're viewing a period that only has GA data, the behavior will be this (see video):

https://user-images.githubusercontent.com/56999674/224135238-4b47eabe-bb89-41ee-94b7-972e7072bf9f.mov

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
