### PR TITLE
Disallow site creation with insufficient input

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -43,8 +43,8 @@ defmodule Plausible.Site do
   def changeset(site, attrs \\ %{}) do
     site
     |> cast(attrs, [:domain, :timezone])
-    |> validate_required([:domain, :timezone])
     |> clean_domain()
+    |> validate_required([:domain, :timezone])
     |> validate_format(:domain, ~r/^[-\.\\\/:\p{L}\d]*$/u,
       message: "only letters, numbers, slashes and period allowed"
     )

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -108,6 +108,18 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
+    test "fails to create the site if only http:// provided", %{conn: conn} do
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "domain" => "http://",
+            "timezone" => "Europe/London"
+          }
+        })
+
+      assert html_response(conn, 200) =~ "can&#39;t be blank"
+    end
+
     test "starts trial if user does not have trial yet", %{conn: conn, user: user} do
       Plausible.Auth.User.remove_trial_expiry(user) |> Repo.update!()
 


### PR DESCRIPTION
### Changes

Closes https://github.com/plausible/analytics/issues/2725

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
