### PR TITLE
Embedded dashboard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Always show direct traffic in sources reports plausible/analytics#2531
 - Stop recording XX and T1 country codes plausible/analytics#2556
 - Device type is now determined from the User-Agent instead of window.innerWidth plausible/analytics#2711
+- Add padding by default to embedded dashboards so that shadows are not cut off plausible/analytics#2744
 
 ### Removed
 - Remove Firewall plug and `IP_BLOCKLIST` environment variable

--- a/assets/js/embed.host.js
+++ b/assets/js/embed.host.js
@@ -2,7 +2,8 @@ import iframeResize from 'iframe-resizer/js/iframeResizer'
 
 var iframes = iframeResize({
   heightCalculationMethod: 'taggedElement',
-  onInit: onInit
+  onInit: onInit,
+  checkOrigin: false
 }, '[plausible-embed]')
 
 function onInit() {

--- a/lib/plausible_web/views/stats_view.ex
+++ b/lib/plausible_web/views/stats_view.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.StatsView do
   def stats_container_class(conn) do
     cond do
       conn.assigns[:embedded] && conn.assigns[:width] == "manual" -> ""
-      conn.assigns[:embedded] -> "max-w-screen-lg mx-auto"
+      conn.assigns[:embedded] -> "max-w-screen-xl mx-auto px-6"
       !conn.assigns[:embedded] -> "container"
     end
   end


### PR DESCRIPTION
### Changes

Adds a default `1.5rem` padding to embedded dashboards. This allows enough space for the shadows to render properly.

Fixes https://github.com/plausible/analytics/issues/1954

As a small improvement, also configures `iframe-resizer` with `checkOrigin: false`. This seems to have no effect on the actual behaviour but gets rid of an error log in console:

<img width="631" alt="Screenshot 2023-03-13 at 16 54 32" src="https://user-images.githubusercontent.com/3731516/224739052-c1c3549d-ecff-4214-864f-4ed20ef8ba9a.png">


### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
