### PR TITLE
Pageview prop filter improvements

### DIFF
--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -37,16 +37,17 @@ function clearAllFilters(history, query) {
 }
 
 function filterText(key, rawValue, query) {
+  if (key === "props") {
+    const entries = Object.entries(rawValue)[0]
+    const prop = entries[0]
+    const { type, value } = parseQueryFilter(entries[1])
+    return <>Property <b>{prop}</b> {type} <b>{value}</b></>
+  }
+  
   const {type, value} = parseQueryFilter(rawValue)
 
   if (key === "goal") {
     return <>Completed goal <b>{value}</b></>
-  }
-  if (key === "props") {
-    const [metaKey, metaValue] = Object.entries(value)[0]
-    const eventName = query.filters.goal ? query.filters.goal : 'event'
-    const metaFilter = parseQueryFilter(metaValue)
-    return <>{eventName}.{metaKey} {metaFilter.type} <b>{metaFilter.value}</b></>
   }
   if (key === "browser_version") {
     const isNotSet = query.filters.browser === '(not set)' || (!query.filters.browser)

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -255,12 +255,30 @@ class FilterModal extends React.Component {
         <div className="mt-4" key={filter}>
           <div className="text-sm font-medium text-gray-700 dark:text-gray-300">{formattedFilters[filter]}</div>
           <div className="flex items-start mt-1">
-            {this.renderFilterTypeSelector(filter)}
+            {this.renderFilterTypeBox(filter)}
             {this.renderSearchBox(filter)}
           </div>
         </div>
       )
     })
+  }
+
+  renderFilterTypeBox(filterName) {
+    const isMultiTypeFilter = supportsContains(filterName) || supportsIsNot(filterName)
+
+    if (isMultiTypeFilter) {
+      return this.renderFilterTypeSelector(filterName)
+    } else {
+      return (
+        <div className="relative inline-block text-left">
+          <div className="w-24">
+            <div className="inline-flex justify-between items-center w-full rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-900 focus:ring-indigo-500">
+              is
+            </div>
+          </div>
+        </div>
+      )
+    }    
   }
 
   renderFilterTypeSelector(filterName) {

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -225,7 +225,13 @@ class FilterModal extends React.Component {
   }
 
   isDisabled() {
-    return Object.entries(this.state.formState).every(([_key, { value: val }]) => !val)
+    const { formState, selectedFilterGroup} = this.state
+    
+    if (selectedFilterGroup === 'props') {
+      return !formState.prop_key.value || !formState.prop_value.value
+    } else {
+      return Object.entries(formState).every(([_key, { value: val }]) => !val)
+    }
   }
 
   selectFiltersAndCloseModal(filters) {

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -251,6 +251,8 @@ class FilterModal extends React.Component {
     const groups = FILTER_GROUPS[this.state.selectedFilterGroup]
 
     return groups.map((filter) => {
+      if (filter === 'prop_value' && !this.state.formState.prop_key.value) { return }
+
       return (
         <div className="mt-4" key={filter}>
           <div className="text-sm font-medium text-gray-700 dark:text-gray-300">{formattedFilters[filter]}</div>

--- a/assets/js/dashboard/stats/modals/filter.js
+++ b/assets/js/dashboard/stats/modals/filter.js
@@ -234,6 +234,16 @@ class FilterModal extends React.Component {
     }
   }
 
+  showClear() {
+    const { selectedFilterGroup, query } = this.state
+    
+    if (selectedFilterGroup === 'props') {
+      return !!query.filters.props
+    } else {
+      return FILTER_GROUPS[selectedFilterGroup].some((filterName) => query.filters[filterName])
+    }
+  }
+
   selectFiltersAndCloseModal(filters) {
     const queryString = new URLSearchParams(window.location.search)
 
@@ -350,7 +360,6 @@ class FilterModal extends React.Component {
 
   renderBody() {
     const { selectedFilterGroup, query } = this.state;
-    const showClear = FILTER_GROUPS[selectedFilterGroup].some((filterName) => query.filters[filterName])
 
     return (
       <>
@@ -370,13 +379,17 @@ class FilterModal extends React.Component {
                 Save Filter
               </button>
 
-              {showClear && (
+              {this.showClear() && (
                 <button
                   type="button"
                   className="ml-2 button px-4 flex bg-red-500 dark:bg-red-500 hover:bg-red-600 dark:hover:bg-red-700 items-center"
                   onClick={() => {
-                    const updatedFilters = FILTER_GROUPS[selectedFilterGroup].map((filterName) => ({ filter: filterName, value: null }))
-                    this.selectFiltersAndCloseModal(updatedFilters)
+                    if (selectedFilterGroup === 'props') {
+                      this.selectFiltersAndCloseModal([{filter: 'props', value: null}])
+                    } else {
+                      const updatedFilters = FILTER_GROUPS[selectedFilterGroup].map((filterName) => ({ filter: filterName, value: null }))
+                      this.selectFiltersAndCloseModal(updatedFilters)
+                    }
                   }}
                 >
                   <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>

--- a/test/plausible_web/controllers/api/stats_controller/filter_suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/filter_suggestions_test.exs
@@ -1,4 +1,4 @@
-defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
+defmodule PlausibleWeb.Api.StatsController.FilterSuggestionsTest do
   use PlausibleWeb.ConnCase
 
   describe "GET /api/stats/:domain/suggestions/:filter_name" do


### PR DESCRIPTION
@ukutaht, here's a draft PR with the changes I've made so far, and below are also the changes I'm planning to make.

- [x] Change custom prop filter label format from - `event.author is John` to `Property author is John`
- [x] Disable filter type selector dropdown for `goal` and `prop_key` (which only allow an `is` filter type)
- [x] Hide `prop_value` input before a `prop_key` input is provided by the user
- [x] Disable the “Save Filter” button when no `prop_value` input is provided (currently becomes clickable as soon as `prop_key` is provided)
- [x] Add “Remove Filters” functionality for props filter modal (the red button in the UI)
- [ ] Ignore `prop_value` input when fetching filter suggestions for `prop_key` (should fetch all props, not only the ones that have a certain value)
- [ ] Show `(none)` as a filter suggestion when there is at least one missing value for the currently selected property
- [ ] Fetch all filter suggestions with the first click on the Combobox component (ignore the previous value written in the input field, and start querying by written user input only when the user types or deletes the first character)
- [ ] When a goal filter and a property filter are active at the same time, make sure to display it correctly in the conversions section with all possible filter types and the `(none)` value too. Screenshots of the current wrong behaviour below

Expected
![Pasted Graphic](https://user-images.githubusercontent.com/56999674/225696842-1410aa20-e5ee-4e21-8e27-904f58ca10f9.png)

Broken behaviour with `(none)` value
![image](https://user-images.githubusercontent.com/56999674/225696542-b4a10853-1abe-460f-bd4b-c1246f3c45e7.png)

Broken behaviour with `is_not` filter type
![image](https://user-images.githubusercontent.com/56999674/225697950-0dd47893-f5c7-464d-a586-dcb540a8d110.png)

