### PR TITLE
Remove obsolete migration config

### DIFF
--- a/priv/repo/migrations/20190618165016_add_public_sites.exs
+++ b/priv/repo/migrations/20190618165016_add_public_sites.exs
@@ -1,12 +1,9 @@
 defmodule Plausible.Repo.Migrations.AddPublicSites do
   use Ecto.Migration
-  @host Application.get_env(:plausible, :url, :host)
 
   def change do
     alter table(:sites) do
       add :public, :boolean, null: false, default: false
     end
-
-    execute "update sites set public=true where domain='#{@host}'"
   end
 end


### PR DESCRIPTION
### Changes

Small house keeping to address compile time warning. 🧹

The warning advises to use `Application.compile_env/3` however there is no `:url` environment setting under `:plausible` key anyway, if I'm not mistaken, so we might as well get rid of it completely.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
