### PR TITLE
Capture no_cache sentry messages together

### DIFF
--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -169,9 +169,7 @@ defmodule Plausible.Site.Cache do
           site
 
         {:error, e} ->
-          Logger.error(
-            "Error retrieving '#{domain}' from '#{inspect(cache_name)}': #{inspect(e)}"
-          )
+          Logger.error("Error retrieving domain from '#{inspect(cache_name)}': #{inspect(e)}")
 
           nil
       end

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -23,7 +23,7 @@ defmodule Plausible.Site.CacheTest do
           assert Cache.get("key", force?: true, cache_name: NonExistingCache) == nil
         end)
 
-      assert log =~ "Error retrieving 'key' from 'NonExistingCache': :no_cache"
+      assert log =~ "Error retrieving domain from 'NonExistingCache': :no_cache"
     end
 
     test "cache caches", %{test: test} do


### PR DESCRIPTION
### Changes

Without addressing the asynchronous start just yet, this makes it less noisy in sentry in case of startup race conditions

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
