### PR TITLE
Updating password reset copy

### DIFF
--- a/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
+++ b/lib/plausible_web/templates/auth/password_reset_request_success.html.eex
@@ -1,17 +1,20 @@
 <div class="bg-white dark:bg-gray-800 max-w-md w-full mx-auto shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8">
   <h2 class="text-xl font-black dark:text-gray-100">Success!</h2>
   <div class="my-4 leading-tight dark:text-gray-100">
-    We have sent an email with password reset instructions to <b><%= @email %></b> if it exists in our database. To protect your account's security, we cannot confirm whether or not the email address you entered is registered in our database.
+    We've sent an email containing password reset instructions to <b><%= @email %></b> if it's registered in our system.
   </div>
   <div class="mt-8 text-sm dark:text-gray-100">
-    Didn't receive an email within a few minutes?
+    Didn't receive the email within a few minutes?
   </div>
   <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-tight">
-    You might have used a wrong email address. Please check what email address you used to create your Plausible account and try to reset the password for that address. Do also check your spam folder.
+    You might have used an email address that's not registered in our database. Please verify the email address associated with your Plausible account and attempt the password reset once more.
+   </div>
+   <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-tight">
     <%= if Application.get_env(:plausible, :is_selfhost) do %>
-      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please ask on our <a href="https://github.com/plausible/analytics/discussions" class="text-indigo-500">community-supported forum</a>.
+      Certain that you're using the correct email address but still aren't receiving the password reset email? Please check your spam folder or ask on our <a href="https://github.com/plausible/analytics/discussions" class="text-indigo-500">community-supported forum</a>.
     <% else %>
-      If you are positive that you are using the correct email address but still aren't receiving the password reset email, please <a href="https://plausible.io/contact" class="text-indigo-500">contact us</a>.
+      Certain that you're using the correct email address but still aren't receiving the password reset email? Please check your spam folder or <a href="https://plausible.io/contact" class="text-indigo-500">contact us</a>.
     <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
several people email us weekly asking why their password reset email is not in their inbox. pretty much every time it's because they're trying to reset password of an email that's not registered in our database. this should help reduce that
