### PR TITLE
revert admin.ex changes

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -87,13 +87,11 @@ defmodule Plausible.SiteAdmin do
     to_site = Repo.get_by(Plausible.Site, domain: params["domain"])
 
     if to_site do
-      opts = [timeout: 30_000, command: :insert_select]
-
       event_q = event_transfer_query(from_site.domain, to_site.domain)
-      {:ok, _} = Ecto.Adapters.SQL.query(Plausible.ClickhouseRepo, event_q, [], opts)
+      {:ok, _} = Ecto.Adapters.SQL.query(Plausible.ClickhouseRepo, event_q, [], timeout: 30_000)
 
       session_q = session_transfer_query(from_site.domain, to_site.domain)
-      {:ok, _} = Ecto.Adapters.SQL.query(Plausible.ClickhouseRepo, session_q, [], opts)
+      {:ok, _} = Ecto.Adapters.SQL.query(Plausible.ClickhouseRepo, session_q, [], timeout: 30_000)
 
       start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(from_site)
 


### PR DESCRIPTION
### Changes

This PR reverts changes to `admin.ex` as they are no longer necessary.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
