### PR TITLE
add transport opts to clickhouse repos

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -279,17 +279,24 @@ config :plausible, :google,
   reporting_api_url: "https://analyticsreporting.googleapis.com",
   max_buffer_size: get_int_from_path_or_env(config_dir, "GOOGLE_MAX_BUFFER_SIZE", 10_000)
 
+ch_transport_opts = [
+  keepalive: true,
+  show_econnreset: true
+]
+
 config :plausible, Plausible.ClickhouseRepo,
   loggers: [Ecto.LogEntry],
   queue_target: 500,
   queue_interval: 2000,
-  url: ch_db_url
+  url: ch_db_url,
+  transport_opts: ch_transport_opts
 
 config :plausible, Plausible.IngestRepo,
   loggers: [Ecto.LogEntry],
   queue_target: 500,
   queue_interval: 2000,
   url: ch_db_url,
+  transport_opts: ch_transport_opts,
   flush_interval_ms: ch_flush_interval_ms,
   max_buffer_size: ch_max_buffer_size,
   pool_size: ingest_pool_size
@@ -299,6 +306,7 @@ config :plausible, Plausible.AsyncInsertRepo,
   queue_target: 500,
   queue_interval: 2000,
   url: ch_db_url,
+  transport_opts: ch_transport_opts,
   pool_size: 1,
   settings: [
     async_insert: 1,


### PR DESCRIPTION
### Changes

This PR adds `transport_opts: [keepalive: true, show_econnreset: true]` to ClickHouse repos.

Relevant: https://github.com/plausible/ch/pull/23

```elixir
# since transport opts are set on all conns to clickhouse, we can get any one of them for inspection
iex> :inet.i
# Port Module   Recv   Sent  Owner      Local Address   Foreign Address      State        Type
# 152  inet_tcp 248595 62739 <0.1935.0> localhost:62338 localhost:8123       CONNECTED(O) STREAM
# ...

# we can get state on the port owner to verify it's indeed a dbconnection and that opts have arrived correctly
iex> %Connection{} = conn = :sys.get_state(pid(0,1935,0))
iex> conn.mod_state.opts[:transport_opts]
[keepalive: true, show_econnreset: true]

# and we can verify the opts have been set on the socket
iex> socket = port(0, 152)
iex> :inet.getopts(socket, [:keepalive, :show_econnreset])
{:ok, [keepalive: true, show_econnreset: true]}
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
