### PR TITLE
V2 site transfers: postgres migration

### DIFF
--- a/priv/repo/migrations/20230328062644_add_site_transfer_columns.exs
+++ b/priv/repo/migrations/20230328062644_add_site_transfer_columns.exs
@@ -1,0 +1,12 @@
+defmodule Plausible.Repo.Migrations.AddSiteTransferColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites) do
+      add :transferred_from, :string, null: true
+      add :transferred_at, :naive_datetime, null: true
+    end
+
+    create unique_index(:sites, :transferred_from)
+  end
+end


### PR DESCRIPTION
### Changes

This PR contains posgres migration only for new, user-controlled site transfers (domain changes) to be rolled out after V2 migration is done (ref #2780).

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
