### PR TITLE
Show detailed comparison dates in top stats

### DIFF
--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -6,7 +6,7 @@ import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 import * as storage from './util/storage'
 import Flatpickr from 'react-flatpickr'
-import { formatISO, parseUTCDate } from './util/date.js'
+import { formatISO, parseUTCDate, formatDateRange } from './util/date.js'
 
 const COMPARISON_MODES = {
   'off': 'Disable comparison',
@@ -90,11 +90,9 @@ const ComparisonInput = function({ site, query, history }) {
     navigateToQuery(history, query, { comparison: mode, compare_from: from, compare_to: to })
   }
 
-  const buildLabel = (query) => {
+  const buildLabel = (site, query) => {
     if (query.comparison == "custom") {
-      const from = query.compare_from.format('D MMM')
-      const to = query.compare_to.format('D MMM')
-      return `${from} - ${to}`
+      return formatDateRange(site, query.compare_from, query.compare_to)
     } else {
       return COMPARISON_MODES[query.comparison]
     }
@@ -127,7 +125,7 @@ const ComparisonInput = function({ site, query, history }) {
         <div className="min-w-32 md:w-48 md:relative">
           <Menu as="div" className="relative inline-block pl-2 w-full">
             <Menu.Button className="bg-white text-gray-800 text-xs md:text-sm font-medium dark:bg-gray-800 dark:hover:bg-gray-900 dark:text-gray-200 hover:bg-gray-200 flex md:px-3 px-2 py-2 items-center justify-between leading-tight rounded shadow cursor-pointer w-full truncate">
-              <span className="truncate">{ buildLabel(query) }</span>
+              <span className="truncate">{ buildLabel(site, query) }</span>
               <ChevronDownIcon className="hidden sm:inline-block h-4 w-4 md:h-5 md:w-5 text-gray-500 ml-2" aria-hidden="true" />
             </Menu.Button>
             <Transition

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -7,7 +7,6 @@ import {
   shiftDays,
   shiftMonths,
   formatDay,
-  formatDayShort,
   formatMonthYYYY,
   formatYear,
   formatISO,
@@ -19,7 +18,8 @@ import {
   isThisYear,
   parseUTCDate,
   isBefore,
-  isAfter
+  isAfter,
+  formatDateRange
 } from "./util/date";
 import { navigateToQuery, QueryLink, QueryButton } from "./query";
 import { shouldIgnoreKeypress } from "./keybinding.js"
@@ -137,7 +137,7 @@ function DisplayPeriod({query, site}) {
   } if (query.period === 'all') {
     return 'All time'
   } if (query.period === 'custom') {
-    return `${formatDayShort(query.from)} - ${formatDayShort(query.to)}`
+    return formatDateRange(site, query.from, query.to)
   }
   return 'Realtime'
 }

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -6,6 +6,14 @@ import numberFormatter, { durationFormatter } from '../../util/number-formatter'
 import { METRIC_MAPPING } from './graph-util'
 import { parseUTCDate, formatDayShort } from '../../util/date.js'
 
+function Maybe({condition, children}) {
+  if (condition) {
+    return children
+  } else {
+    return null
+  }
+}
+
 export default class TopStats extends React.Component {
   renderPercentageComparison(name, comparison, forceDarkMode = false) {
     const formattedComparison = numberFormatter(Math.abs(comparison))
@@ -145,15 +153,21 @@ export default class TopStats extends React.Component {
               <div>
                 <span className="flex items-center justify-between whitespace-nowrap">
                   <p className="font-bold text-xl dark:text-gray-100" id={METRIC_MAPPING[stat.name]}>{this.topStatNumberShort(stat.name, stat.value)}</p>
-                  { !query.comparison && this.renderPercentageComparison(stat.name, stat.change) }
+                  <Maybe condition={!query.comparison}>
+                    {this.renderPercentageComparison(stat.name, stat.change)}
+                  </Maybe>
                 </span>
-                { query.comparison && <p className="text-xs dark:text-gray-100">{ formatRange(topStatData.from, topStatData.to) }</p> }
+                  <Maybe condition={query.comparison}>
+                    <p className="text-xs dark:text-gray-100">{ formatRange(topStatData.from, topStatData.to) }</p>
+                  </Maybe>
               </div>
 
-              { query.comparison && <div>
-                <p className="font-bold text-xl text-gray-500 dark:text-gray-400">{ this.topStatNumberShort(stat.name, stat.comparison_value) }</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{ formatRange(topStatData.comparing_from, topStatData.comparing_to) }</p>
-              </div> }
+              <Maybe condition={query.comparison}>
+                <div>
+                  <p className="font-bold text-xl text-gray-500 dark:text-gray-400">{ this.topStatNumberShort(stat.name, stat.comparison_value) }</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{ formatRange(topStatData.comparing_from, topStatData.comparing_to) }</p>
+                </div>
+              </Maybe>
             </div>
           </Tooltip>
       )

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -7,7 +7,7 @@ import { METRIC_MAPPING } from './graph-util'
 import { parseUTCDate, formatDayShort } from '../../util/date.js'
 
 export default class TopStats extends React.Component {
-  renderComparison(name, comparison, forceDarkMode = false) {
+  renderPercentageComparison(name, comparison, forceDarkMode = false) {
     const formattedComparison = numberFormatter(Math.abs(comparison))
 
     const defaultClassName = classNames({
@@ -62,7 +62,7 @@ export default class TopStats extends React.Component {
       <div>
         {query.comparison && <div className="whitespace-nowrap">
           {this.topStatNumberLong(stat.name, stat.value)} vs. {this.topStatNumberLong(stat.name, stat.comparison_value)} {statName}
-          <span className="ml-2">{this.renderComparison(stat.name, stat.change, true)}</span>
+          <span className="ml-2">{this.renderPercentageComparison(stat.name, stat.change, true)}</span>
         </div>}
 
         {!query.comparison && <div className="whitespace-nowrap">
@@ -145,7 +145,7 @@ export default class TopStats extends React.Component {
               <div>
                 <span className="flex items-center justify-between whitespace-nowrap">
                   <p className="font-bold text-xl dark:text-gray-100" id={METRIC_MAPPING[stat.name]}>{this.topStatNumberShort(stat.name, stat.value)}</p>
-                  { !query.comparison && this.renderComparison(stat.name, stat.change) }
+                  { !query.comparison && this.renderPercentageComparison(stat.name, stat.change) }
                 </span>
                 { query.comparison && <p className="text-xs dark:text-gray-100">{ formatRange(topStatData.from, topStatData.to) }</p> }
               </div>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -4,7 +4,7 @@ import { SecondsSinceLastLoad } from '../../util/seconds-since-last-load'
 import classNames from "classnames";
 import numberFormatter, { durationFormatter } from '../../util/number-formatter'
 import { METRIC_MAPPING } from './graph-util'
-import { parseUTCDate, formatDayShort } from '../../util/date.js'
+import { formatDateRange } from '../../util/date.js'
 
 function Maybe({condition, children}) {
   if (condition) {
@@ -36,6 +36,8 @@ export default class TopStats extends React.Component {
       return <span className={defaultClassName}><span className={color + ' font-bold'}>&darr;</span> {formattedComparison}%</span>
     } else if (comparison === 0) {
       return <span className={noChangeClassName}>&#12336; 0%</span>
+    } else {
+      return null
     }
   }
 
@@ -122,7 +124,7 @@ export default class TopStats extends React.Component {
   }
 
   render() {
-    const { topStatData, query } = this.props
+    const { topStatData, query, site } = this.props
 
     const stats = topStatData && topStatData.top_stats.map((stat, index) => {
 
@@ -131,20 +133,6 @@ export default class TopStats extends React.Component {
         'lg:border-l border-gray-300': index > 0,
         'border-r lg:border-r-0': index % 2 === 0
       })
-
-      const formatRange = (from, to) => {
-        if (!from || !to) return
-
-        from = parseUTCDate(from)
-        to = parseUTCDate(to)
-
-        if (from.getTime() == to.getTime()) {
-          return formatDayShort(from, true)
-        } else {
-          const includeFromYear = from.getFullYear() != to.getFullYear()
-          return `${formatDayShort(from, includeFromYear)} - ${formatDayShort(to, true)}`
-        }
-      }
 
       return (
           <Tooltip key={stat.name} info={this.topStatTooltip(stat, query)} className={className} onClick={() => { this.maybeUpdateMetric(stat) }} boundary={this.props.tooltipBoundary}>
@@ -158,14 +146,14 @@ export default class TopStats extends React.Component {
                   </Maybe>
                 </span>
                   <Maybe condition={query.comparison}>
-                    <p className="text-xs dark:text-gray-100">{ formatRange(topStatData.from, topStatData.to) }</p>
+                    <p className="text-xs dark:text-gray-100">{ formatDateRange(site, topStatData.from, topStatData.to) }</p>
                   </Maybe>
               </div>
 
               <Maybe condition={query.comparison}>
                 <div>
                   <p className="font-bold text-xl text-gray-500 dark:text-gray-400">{ this.topStatNumberShort(stat.name, stat.comparison_value) }</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">{ formatRange(topStatData.comparing_from, topStatData.comparing_to) }</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{ formatDateRange(site, topStatData.comparing_from, topStatData.comparing_to) }</p>
                 </div>
               </Maybe>
             </div>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -323,7 +323,7 @@ class LineGraph extends React.Component {
     return (
       <div>
         <div id="top-stats-container" className="flex flex-wrap" ref={this.boundary} style={{height: this.getTopStatsHeight()}}>
-          <TopStats query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={lastLoadTimestamp} />
+          <TopStats site={site} query={query} metric={metric} updateMetric={updateMetric} topStatData={topStatData} tooltipBoundary={this.boundary.current} lastLoadTimestamp={lastLoadTimestamp} />
         </div>
         <div className="relative px-2">
           {mainGraphRefreshing && renderLoader()}

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -44,6 +44,21 @@ export function formatDayShort(date, includeYear = false) {
   }
 }
 
+export function formatDateRange(site, from, to) {
+  if (!from || !to) return
+  if (typeof from === 'string') from = parseUTCDate(from)
+  if (typeof to === 'string') to = parseUTCDate(to)
+
+  if (from.isSame(to)) {
+    return formatDay(from)
+  } else if (from.isSame(to, 'year')) {
+    const includeYear = !isThisYear(site, from)
+    return `${formatDayShort(from, false)} - ${formatDayShort(to, includeYear)}`
+  } else {
+    return `${formatDayShort(from, true)} - ${formatDayShort(to, true)}`
+  }
+}
+
 export function parseUTCDate(dateString) {
   return dayjs.utc(dateString)
 }

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -208,7 +208,11 @@ defmodule PlausibleWeb.Api.StatsController do
         interval: query.interval,
         sample_percent: sample_percent,
         with_imported: query.include_imported,
-        imported_source: site.imported_data && site.imported_data.source
+        imported_source: site.imported_data && site.imported_data.source,
+        comparing_from: comparison_query && comparison_query.date_range.first,
+        comparing_to: comparison_query && comparison_query.date_range.last,
+        from: query.date_range.first,
+        to: query.date_range.last
       })
     else
       {:error, message} when is_binary(message) -> bad_request(conn, message)
@@ -360,21 +364,25 @@ defmodule PlausibleWeb.Api.StatsController do
       %{
         name: "Unique visitors",
         value: unique_visitors,
+        comparison_value: prev_unique_visitors,
         change: percent_change(prev_unique_visitors, unique_visitors)
       },
       %{
         name: "Unique conversions",
         value: converted_visitors,
+        comparison_value: prev_converted_visitors,
         change: percent_change(prev_converted_visitors, converted_visitors)
       },
       %{
         name: "Total conversions",
         value: completions,
+        comparison_value: prev_completions,
         change: percent_change(prev_completions, completions)
       },
       %{
         name: "Conversion rate",
         value: conversion_rate,
+        comparison_value: prev_conversion_rate,
         change: percent_change(prev_conversion_rate, conversion_rate)
       }
     ]
@@ -430,7 +438,7 @@ defmodule PlausibleWeb.Api.StatsController do
       prev_value = get_in(prev_results, [key, :value])
       change = prev_value && calculate_change(key, prev_value, value)
 
-      %{name: name, value: value, change: change}
+      %{name: name, value: value, comparison_value: prev_value, change: change}
     end
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -16,7 +16,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "counts total pageviews", %{conn: conn, site: site} do
@@ -29,7 +35,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Total pageviews", "value" => 3, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Total pageviews",
+               "value" => 3
+             } in res["top_stats"]
     end
 
     test "counts total visits", %{conn: conn, site: site} do
@@ -43,7 +55,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Total visits", "value" => 3, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 3} in res[
+               "top_stats"
+             ]
     end
 
     test "counts pages per visit", %{conn: conn, site: site} do
@@ -57,7 +72,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Views per visit", "value" => 1.33, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0.0,
+               "name" => "Views per visit",
+               "value" => 1.33
+             } in res["top_stats"]
     end
 
     test "calculates bounce rate", %{conn: conn, site: site} do
@@ -70,7 +91,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Bounce rate", "value" => 50, "change" => nil} in res["top_stats"]
+
+      assert %{"change" => nil, "comparison_value" => 0, "name" => "Bounce rate", "value" => 50} in res[
+               "top_stats"
+             ]
     end
 
     test "calculates average visit duration", %{conn: conn, site: site} do
@@ -91,7 +115,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01")
 
       res = json_response(conn, 200)
-      assert %{"name" => "Visit duration", "value" => 450, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Visit duration",
+               "value" => 450
+             } in res["top_stats"]
     end
 
     test "calculates time on page instead when filtered for page", %{conn: conn, site: site} do
@@ -121,7 +151,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Time on page", "value" => 900, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 900} in res[
+               "top_stats"
+             ]
     end
 
     test "calculates time on page when filtered for multiple pages", %{
@@ -159,7 +192,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Time on page", "value" => 480, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 480} in res[
+               "top_stats"
+             ]
     end
 
     test "calculates time on page when filtered for multiple negated pages", %{
@@ -197,7 +233,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Time on page", "value" => 60, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 60} in res[
+               "top_stats"
+             ]
     end
 
     test "calculates time on page when filtered for multiple wildcard pages", %{
@@ -236,7 +275,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Time on page", "value" => 480, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 480} in res[
+               "top_stats"
+             ]
     end
 
     test "calculates time on page when filtered for multiple negated wildcard pages", %{
@@ -277,7 +319,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Time on page", "value" => 600, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 600} in res[
+               "top_stats"
+             ]
     end
   end
 
@@ -312,12 +357,42 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert res["top_stats"] == [
-               %{"name" => "Unique visitors", "value" => 3, "change" => 100},
-               %{"name" => "Total visits", "value" => 3, "change" => 100},
-               %{"name" => "Total pageviews", "value" => 4, "change" => 100},
-               %{"name" => "Views per visit", "value" => 1.5, "change" => 100},
-               %{"name" => "Bounce rate", "value" => 33, "change" => nil},
-               %{"name" => "Visit duration", "value" => 303, "change" => 100}
+               %{
+                 "change" => 100,
+                 "comparison_value" => 0,
+                 "name" => "Unique visitors",
+                 "value" => 3
+               },
+               %{
+                 "change" => 100,
+                 "comparison_value" => 0,
+                 "name" => "Total visits",
+                 "value" => 3
+               },
+               %{
+                 "change" => 100,
+                 "comparison_value" => 0,
+                 "name" => "Total pageviews",
+                 "value" => 4
+               },
+               %{
+                 "change" => 100,
+                 "comparison_value" => 0.0,
+                 "name" => "Views per visit",
+                 "value" => 1.5
+               },
+               %{
+                 "change" => nil,
+                 "comparison_value" => 0,
+                 "name" => "Bounce rate",
+                 "value" => 33
+               },
+               %{
+                 "change" => 100,
+                 "comparison_value" => 0,
+                 "name" => "Visit duration",
+                 "value" => 303
+               }
              ]
     end
   end
@@ -422,7 +497,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "page glob filter", %{conn: conn, site: site} do
@@ -441,7 +522,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "contains (~) filter", %{conn: conn, site: site} do
@@ -460,7 +547,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
@@ -479,7 +572,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "returns only visitors with specific browser", %{conn: conn, site: site} do
@@ -498,7 +597,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "returns only visitors with specific operating system", %{conn: conn, site: site} do
@@ -517,7 +622,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 2
+             } in res["top_stats"]
     end
 
     test "returns number of visits from one specific referral source", %{conn: conn, site: site} do
@@ -549,7 +660,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Total visits", "value" => 2, "change" => 100} in res["top_stats"]
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 2} in res[
+               "top_stats"
+             ]
     end
   end
 
@@ -573,7 +687,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique visitors", "value" => 3, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique visitors",
+               "value" => 3
+             } in res["top_stats"]
     end
 
     test "returns converted visitors", %{conn: conn, site: site} do
@@ -593,7 +713,13 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
 
       res = json_response(conn, 200)
-      assert %{"name" => "Unique conversions", "value" => 1, "change" => 100} in res["top_stats"]
+
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0,
+               "name" => "Unique conversions",
+               "value" => 1
+             } in res["top_stats"]
     end
 
     test "returns conversion rate", %{conn: conn, site: site} do
@@ -614,7 +740,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Conversion rate", "value" => 33.3, "change" => 100} in res["top_stats"]
+      assert %{
+               "change" => 100,
+               "comparison_value" => 0.0,
+               "name" => "Conversion rate",
+               "value" => 33.3
+             } in res["top_stats"]
     end
 
     test "returns conversion rate with change=nil when comparison mode disallowed", %{
@@ -638,7 +769,83 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Conversion rate", "value" => 33.3, "change" => nil} in res["top_stats"]
+      assert %{
+               "change" => nil,
+               "comparison_value" => nil,
+               "name" => "Conversion rate",
+               "value" => 33.3
+             } in res["top_stats"]
+    end
+  end
+
+  describe "GET /api/stats/top-stats - with comparisons" do
+    setup [:create_user, :log_in, :create_new_site]
+
+    test "defaults to previous period when comparison is not set", %{site: site, conn: conn} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2020-12-31 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-12-31 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 10:00:00])
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01")
+
+      res = json_response(conn, 200)
+
+      assert %{"change" => 50, "comparison_value" => 2, "name" => "Total visits", "value" => 3} in res[
+               "top_stats"
+             ]
+    end
+
+    test "returns comparison data when mode is custom", %{site: site, conn: conn} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2020-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-01-05 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-01-20 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-12-31 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 10:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&comparison=custom&compare_from=2020-01-01&compare_to=2020-01-20"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"change" => 0, "comparison_value" => 3, "name" => "Total visits", "value" => 3} in res[
+               "top_stats"
+             ]
+    end
+
+    test "returns source query and comparison query date range", %{site: site, conn: conn} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2020-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-01-05 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-01-20 00:00:00]),
+        build(:pageview, timestamp: ~N[2020-12-31 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 10:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&comparison=previous_period"
+        )
+
+      assert %{
+               "comparing_from" => "2020-12-01",
+               "comparing_to" => "2020-12-31",
+               "from" => "2021-01-01",
+               "to" => "2021-01-31"
+             } = json_response(conn, 200)
     end
   end
 end


### PR DESCRIPTION
### Changes

This pull request adds more details to top stats when comparisons are enabled. The details are: the original query date range, the comparison query date range, and the comparison values.

Preview:

[preview.webm](https://user-images.githubusercontent.com/5093045/228620723-910c9f82-b97c-46c8-bd9f-d27eb26f9d42.webm)

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
