### PR TITLE
Temporarily disable site creation

### DIFF
--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     |> put_status(503)
     |> json(%{
       error:
-        "Creating sites is not currently possible due to regular database maintenance. Please try again after 1 hour."
+        "Creating sites is currently unavailable due to regular database maintenance. Please try again after 1 hour."
     })
 
     # case Sites.create(user, params) do

--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -6,26 +6,33 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
   alias Plausible.Goals
   alias PlausibleWeb.Api.Helpers, as: H
 
-  def create_site(conn, params) do
-    user = conn.assigns[:current_user]
+  def create_site(conn, _params) do
+    # user = conn.assigns[:current_user]
 
-    case Sites.create(user, params) do
-      {:ok, %{site: site}} ->
-        json(conn, site)
+    conn
+    |> put_status(503)
+    |> json(%{
+      error:
+        "Creating sites is not currently possible due to regular database maintenance. Please try again after 1 hour."
+    })
 
-      {:error, :limit, limit, _} ->
-        conn
-        |> put_status(403)
-        |> json(%{
-          error:
-            "Your account has reached the limit of #{limit} sites per account. Please contact hello@plausible.io to unlock more sites."
-        })
+    # case Sites.create(user, params) do
+    #   {:ok, %{site: site}} ->
+    #     json(conn, site)
 
-      {:error, _, changeset, _} ->
-        conn
-        |> put_status(400)
-        |> json(serialize_errors(changeset))
-    end
+    #   {:error, :limit, limit, _} ->
+    #     conn
+    #     |> put_status(403)
+    #     |> json(%{
+    #       error:
+    #         "Your account has reached the limit of #{limit} sites per account. Please contact hello@plausible.io to unlock more sites."
+    #     })
+
+    #   {:error, _, changeset, _} ->
+    #     conn
+    #     |> put_status(400)
+    #     |> json(serialize_errors(changeset))
+    # end
   end
 
   def get_site(conn, %{"site_id" => site_id}) do

--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -144,11 +144,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     end
   end
 
-  defp serialize_errors(changeset) do
-    {field, {msg, _opts}} = List.first(changeset.errors)
-    error_msg = Atom.to_string(field) <> ": " <> msg
-    %{"error" => error_msg}
-  end
+  # defp serialize_errors(changeset) do
+  #   {field, {msg, _opts}} = List.first(changeset.errors)
+  #   error_msg = Atom.to_string(field) <> ": " <> msg
+  #   %{"error" => error_msg}
+  # end
 
   def handle_errors(conn, %{kind: kind, reason: reason}) do
     json(conn, %{error: Exception.format_banner(kind, reason)})

--- a/lib/plausible_web/templates/site/new.html.eex
+++ b/lib/plausible_web/templates/site/new.html.eex
@@ -2,6 +2,26 @@
   <%= form_for @changeset, "/sites", [class: "max-w-lg w-full mx-auto bg-white dark:bg-gray-800 shadow-lg rounded px-8 pt-6 pb-8 mb-4 mt-8"], fn f -> %>
     <h2 class="text-xl font-black dark:text-gray-100">Your website details</h2>
 
+    <div class="rounded-md bg-yellow-50 dark:bg-transparent dark:border border-yellow-200 p-4 mt-4">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-5 w-5 text-yellow-400 dark:text-yellow-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+          </svg>
+        </div>
+        <div class="ml-3">
+          <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-400">
+            Site creation disabled
+          </h3>
+          <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+            <p>
+              Creating sites is not currently possible due to regular database maintenance. Please try again after 1 hour.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <%= if @is_at_limit do %>
       <div class="rounded-md bg-yellow-50 dark:bg-transparent dark:border border-yellow-200 p-4 mt-4">
         <div class="flex">
@@ -78,7 +98,7 @@
       if (option) { option.selected = "selected"}
     </script>
 
-    <%= submit "Add snippet →", class: "button mt-4 w-full", disabled: @is_at_limit %>
+    <%= submit "Add snippet →", class: "button mt-4 w-full", disabled: true %>
   <% end %>
 
   <%= if @is_first_site do %>

--- a/lib/plausible_web/templates/site/new.html.eex
+++ b/lib/plausible_web/templates/site/new.html.eex
@@ -15,7 +15,7 @@
           </h3>
           <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
             <p>
-              Creating sites is not currently possible due to regular database maintenance. Please try again after 1 hour.
+              Creating sites is currently unavailable due to regular database maintenance. Please try again after 1 hour.
             </p>
           </div>
         </div>

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -9,90 +9,90 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
     {:ok, user: user, api_key: api_key, conn: conn}
   end
 
-  describe "POST /api/v1/sites" do
-    test "can create a site", %{conn: conn} do
-      conn =
-        post(conn, "/api/v1/sites", %{
-          "domain" => "some-site.domain",
-          "timezone" => "Europe/Tallinn"
-        })
-
-      assert json_response(conn, 200) == %{
-               "domain" => "some-site.domain",
-               "timezone" => "Europe/Tallinn"
-             }
-    end
-
-    test "timezone defaults to Etc/UTC", %{conn: conn} do
-      conn =
-        post(conn, "/api/v1/sites", %{
-          "domain" => "some-site.domain"
-        })
-
-      assert json_response(conn, 200) == %{
-               "domain" => "some-site.domain",
-               "timezone" => "Etc/UTC"
-             }
-    end
-
-    test "domain is required", %{conn: conn} do
-      conn = post(conn, "/api/v1/sites", %{})
-
-      assert json_response(conn, 400) == %{
-               "error" => "domain: can't be blank"
-             }
-    end
-
-    test "accepts international domain names", %{conn: conn} do
-      ["müllers-café.test", "音乐.cn", "до.101домен.рф/pages"]
-      |> Enum.each(fn idn_domain ->
-        conn = post(conn, "/api/v1/sites", %{"domain" => idn_domain})
-        assert %{"domain" => ^idn_domain} = json_response(conn, 200)
-      end)
-    end
-
-    test "validates uri breaking domains", %{conn: conn} do
-      ["quero:café.test", "h&llo.test", "iamnotsur&about?this.com"]
-      |> Enum.each(fn bad_domain ->
-        conn = post(conn, "/api/v1/sites", %{"domain" => bad_domain})
-
-        assert %{"error" => error} = json_response(conn, 400)
-        assert error =~ "domain: must not contain URI reserved characters"
-      end)
-    end
-
-    test "does not allow creating more sites than the limit", %{conn: conn, user: user} do
-      patch_env(:site_limit, 3)
-      insert(:site, members: [user])
-      insert(:site, members: [user])
-      insert(:site, members: [user])
-
-      conn =
-        post(conn, "/api/v1/sites", %{
-          "domain" => "some-site.domain",
-          "timezone" => "Europe/Tallinn"
-        })
-
-      assert json_response(conn, 403) == %{
-               "error" =>
-                 "Your account has reached the limit of 3 sites per account. Please contact hello@plausible.io to unlock more sites."
-             }
-    end
-
-    test "cannot access with a bad API key scope", %{conn: conn, user: user} do
-      api_key = insert(:api_key, user: user, scopes: ["stats:read:*"])
-
-      conn =
-        conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
-        |> post("/api/v1/sites", %{"site" => %{"domain" => "domain.com"}})
-
-      assert json_response(conn, 401) == %{
-               "error" =>
-                 "Invalid API key. Please make sure you're using a valid API key with access to the resource you've requested."
-             }
-    end
-  end
+  #  describe "POST /api/v1/sites" do
+  #    test "can create a site", %{conn: conn} do
+  #      conn =
+  #        post(conn, "/api/v1/sites", %{
+  #          "domain" => "some-site.domain",
+  #          "timezone" => "Europe/Tallinn"
+  #        })
+  #
+  #      assert json_response(conn, 200) == %{
+  #               "domain" => "some-site.domain",
+  #               "timezone" => "Europe/Tallinn"
+  #             }
+  #    end
+  #
+  #    test "timezone defaults to Etc/UTC", %{conn: conn} do
+  #      conn =
+  #        post(conn, "/api/v1/sites", %{
+  #          "domain" => "some-site.domain"
+  #        })
+  #
+  #      assert json_response(conn, 200) == %{
+  #               "domain" => "some-site.domain",
+  #               "timezone" => "Etc/UTC"
+  #             }
+  #    end
+  #
+  #    test "domain is required", %{conn: conn} do
+  #      conn = post(conn, "/api/v1/sites", %{})
+  #
+  #      assert json_response(conn, 400) == %{
+  #               "error" => "domain: can't be blank"
+  #             }
+  #    end
+  #
+  #    test "accepts international domain names", %{conn: conn} do
+  #      ["müllers-café.test", "音乐.cn", "до.101домен.рф/pages"]
+  #      |> Enum.each(fn idn_domain ->
+  #        conn = post(conn, "/api/v1/sites", %{"domain" => idn_domain})
+  #        assert %{"domain" => ^idn_domain} = json_response(conn, 200)
+  #      end)
+  #    end
+  #
+  #    test "validates uri breaking domains", %{conn: conn} do
+  #      ["quero:café.test", "h&llo.test", "iamnotsur&about?this.com"]
+  #      |> Enum.each(fn bad_domain ->
+  #        conn = post(conn, "/api/v1/sites", %{"domain" => bad_domain})
+  #
+  #        assert %{"error" => error} = json_response(conn, 400)
+  #        assert error =~ "domain: must not contain URI reserved characters"
+  #      end)
+  #    end
+  #
+  #    test "does not allow creating more sites than the limit", %{conn: conn, user: user} do
+  #      patch_env(:site_limit, 3)
+  #      insert(:site, members: [user])
+  #      insert(:site, members: [user])
+  #      insert(:site, members: [user])
+  #
+  #      conn =
+  #        post(conn, "/api/v1/sites", %{
+  #          "domain" => "some-site.domain",
+  #          "timezone" => "Europe/Tallinn"
+  #        })
+  #
+  #      assert json_response(conn, 403) == %{
+  #               "error" =>
+  #                 "Your account has reached the limit of 3 sites per account. Please contact hello@plausible.io to unlock more sites."
+  #             }
+  #    end
+  #
+  #    test "cannot access with a bad API key scope", %{conn: conn, user: user} do
+  #      api_key = insert(:api_key, user: user, scopes: ["stats:read:*"])
+  #
+  #      conn =
+  #        conn
+  #        |> Plug.Conn.put_req_header("authorization", "Bearer #{api_key.key}")
+  #        |> post("/api/v1/sites", %{"site" => %{"domain" => "domain.com"}})
+  #
+  #      assert json_response(conn, 401) == %{
+  #               "error" =>
+  #                 "Invalid API key. Please make sure you're using a valid API key with access to the resource you've requested."
+  #             }
+  #    end
+  #  end
 
   describe "DELETE /api/v1/sites/:site_id" do
     setup :create_new_site


### PR DESCRIPTION
We need to disable new site creation for a short period of time (max 1 hour) while we migrate the Clickhouse database.