### PR TITLE
Escape pipes in goal names

### DIFF
--- a/assets/js/dashboard/stats/conversions/index.js
+++ b/assets/js/dashboard/stats/conversions/index.js
@@ -8,6 +8,7 @@ import PropBreakdown from './prop-breakdown'
 import numberFormatter from '../../util/number-formatter'
 import * as api from '../../api'
 import * as url from '../../util/url'
+import { escapeFilterValue } from '../../util/filters'
 import LazyLoader from '../../components/lazy-loader'
 
 const MOBILE_UPPER_WIDTH = 767
@@ -79,7 +80,7 @@ export default class Conversions extends React.Component {
             maxWidthDeduction={this.getBarMaxWidth()}
             plot="unique_conversions"
           >
-            <Link to={url.setQuery('goal', goal.name)} className="block px-2 py-1.5 hover:underline relative z-9 break-all lg:truncate dark:text-gray-200">{goal.name}</Link>
+            <Link to={url.setQuery('goal', escapeFilterValue(goal.name))} className="block px-2 py-1.5 hover:underline relative z-9 break-all lg:truncate dark:text-gray-200">{goal.name}</Link>
           </Bar>
           <div className="dark:text-gray-200">
             <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.unique_conversions)}</span>

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -33,7 +33,7 @@ try {
 
 const ESCAPED_PIPE = '\\|'
 
-function escapeFilterValue(value) {
+export function escapeFilterValue(value) {
   return value.replaceAll(NON_ESCAPED_PIPE_REGEX, ESCAPED_PIPE)
 }
 

--- a/lib/plausible/stats/filters.ex
+++ b/lib/plausible/stats/filters.ex
@@ -57,7 +57,7 @@ defmodule Plausible.Stats.Filters do
     {is_contains, val} = parse_contains_prefix(val)
     is_list = Regex.match?(@non_escaped_pipe_regex, val)
     is_wildcard = String.contains?(key, ["page", "goal"]) && String.match?(val, ~r/\*/)
-    val = if is_list, do: parse_member_list(val), else: val
+    val = if is_list, do: parse_member_list(val), else: remove_escape_chars(val)
     val = if key == "goal", do: wrap_goal_value(val), else: val
 
     cond do

--- a/test/plausible/stats/filters_test.exs
+++ b/test/plausible/stats/filters_test.exs
@@ -76,12 +76,12 @@ defmodule Plausible.Stats.FiltersTest do
 
   describe "escaping pipe character" do
     test "in simple is filter" do
-      %{"goal" => "Foo \\| Bar"}
+      %{"goal" => ~S(Foo \| Bar)}
       |> assert_parsed(%{"event:goal" => {:is, {:event, "Foo | Bar"}}})
     end
 
     test "in member filter" do
-      %{"page" => "/|\\|"}
+      %{"page" => ~S(/|\|)}
       |> assert_parsed(%{"event:page" => {:member, ["/", "|"]}})
     end
   end

--- a/test/plausible/stats/filters_test.exs
+++ b/test/plausible/stats/filters_test.exs
@@ -74,6 +74,18 @@ defmodule Plausible.Stats.FiltersTest do
     end
   end
 
+  describe "escaping pipe character" do
+    test "in simple is filter" do
+      %{"goal" => "Foo \\| Bar"}
+      |> assert_parsed(%{"event:goal" => {:is, {:event, "Foo | Bar"}}})
+    end
+
+    test "in member filter" do
+      %{"page" => "/|\\|"}
+      |> assert_parsed(%{"event:page" => {:member, ["/", "|"]}})
+    end
+  end
+
   describe "is not filter type" do
     test "simple is not filter" do
       %{"page" => "!/"}


### PR DESCRIPTION
### Changes

With the recent addition of the `member` filter type using pipes, goals that contain pipes don't always work. Demo of a case that's broken on master but fixed with this PR:

https://user-images.githubusercontent.com/3731516/229509412-3a240cf0-0949-4c06-8c93-a85029779a2d.mov



### Tests
- [x] Automated tests have been added

### Changelog
- I don't think it's needed since it's a quick fix for something that was released very recently.

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
