### PR TITLE
Tweak general settings display

### DIFF
--- a/lib/plausible_web/templates/site/settings_general.html.eex
+++ b/lib/plausible_web/templates/site/settings_general.html.eex
@@ -8,8 +8,12 @@
         <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
       <% end %>
     </header>
-  </div>
-  <div class="px-4 py-3 bg-gray-50 dark:bg-gray-850 text-right sm:px-6">
+    <div class="grid grid-cols-4 gap-6">
+      <div class="col-span-4 sm:col-span-2">
+        <%= label nil, "Domain", class: "block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300" %>
+        <%= text_input nil, :domain, value: @site.domain, disabled: "disabled", class: "dark:bg-gray-900 w-full mt-1 block pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:text-gray-500 text-gray-500" %>
+      </div>
+    </div>
     <span class="inline-flex rounded-md shadow-sm">
       <%= link "Change domain", to: Routes.site_path(@conn, :change_domain, @site.domain), class: "button" %>
     </span>
@@ -27,16 +31,12 @@
           <svg class="w-6 h-6 absolute top-0 right-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
         <% end %>
       </header>
-
       <div class="grid grid-cols-4 gap-6">
-
         <div class="col-span-4 sm:col-span-2">
           <%= label f, :timezone, "Reporting Timezone", class: "block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300" %>
-          <%= select f, :timezone, Plausible.Timezones.options(), class: "dark:bg-gray-900  mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:text-gray-100 cursor-pointer" %>
+          <%= select f, :timezone, Plausible.Timezones.options(), class: "dark:bg-gray-900 mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md dark:text-gray-100 cursor-pointer" %>
         </div>
       </div>
-    </div>
-    <div class="px-4 py-3 bg-gray-50 dark:bg-gray-850 text-right sm:px-6">
       <span class="inline-flex rounded-md shadow-sm">
         <%= submit "Save", class: "button" %>
       </span>


### PR DESCRIPTION
### Changes

Removing the extra button panel and aligning buttons to the left, just like everywhere else.
Also displaying an inactive field with current domain in domain change panel.

![image](https://user-images.githubusercontent.com/173738/229768862-ab7b43f4-0761-4b7d-82d2-139d8128fcf1.png)

![image](https://user-images.githubusercontent.com/173738/229768876-3a7f1d96-7a54-4267-afe1-9ae93391002d.png)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
