### PR TITLE
Render an error on site creation with `domain=domain_changed_from`

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -57,6 +57,10 @@ defmodule Plausible.Site do
     |> unique_constraint(:domain,
       message: @domain_unique_error
     )
+    |> unique_constraint(:domain,
+      name: "domain_change_disallowed",
+      message: @domain_unique_error
+    )
   end
 
   def update_changeset(site, attrs \\ %{}, opts \\ []) do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -284,6 +284,23 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html_response(conn, 200) =~
                "This domain cannot be registered. Perhaps one of your colleagues registered it?"
     end
+
+    test "renders form again when domain was changed from elsewhere", %{conn: conn} do
+      :site
+      |> insert(domain: "example.com")
+      |> Plausible.Site.Domain.change("new.example.com")
+
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "domain" => "example.com",
+            "timezone" => "Europe/London"
+          }
+        })
+
+      assert html_response(conn, 200) =~
+               "This domain cannot be registered. Perhaps one of your colleagues registered it?"
+    end
   end
 
   describe "GET /:website/snippet" do


### PR DESCRIPTION
### Changes

Small fix up to #2803 - the trigger-raised constraint is now checked on site creation too.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
