### PR TITLE
Migrate and freeze goals creation

### DIFF
--- a/lib/plausible/goals.ex
+++ b/lib/plausible/goals.ex
@@ -5,7 +5,16 @@ defmodule Plausible.Goals do
   def create(site, params) do
     params = Map.merge(params, %{"domain" => site.domain})
 
-    Goal.changeset(%Goal{}, params) |> Repo.insert()
+    Goal.changeset(%Goal{}, params)
+    |> Ecto.Changeset.add_error(
+      :event_name,
+      "Goals creation is temporarily disabled due to a planned database migration. Please try again in an hour."
+    )
+    |> Ecto.Changeset.add_error(
+      :page_path,
+      "Goals creation is temporarily disabled due to a planned database migration. Please try again in an hour."
+    )
+    |> Repo.insert()
   end
 
   def find_or_create(site, %{"goal_type" => "event", "event_name" => event_name}) do

--- a/lib/plausible/goals.ex
+++ b/lib/plausible/goals.ex
@@ -8,11 +8,11 @@ defmodule Plausible.Goals do
     Goal.changeset(%Goal{}, params)
     |> Ecto.Changeset.add_error(
       :event_name,
-      "Goals creation is temporarily disabled due to a planned database migration. Please try again in an hour."
+      "Sorry! Due to the ongoing maintenance, adding new goals is currently paused. Please try again in one hour. Thanks for your patience!"
     )
     |> Ecto.Changeset.add_error(
       :page_path,
-      "Goals creation is temporarily disabled due to a planned database migration. Please try again in an hour."
+      "Sorry! Due to the ongoing maintenance, adding new goals is currently paused. Please try again in one hour. Thanks for your patience!"
     )
     |> Repo.insert()
   end

--- a/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -124,6 +124,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
       {:missing, param} ->
         H.bad_request(conn, "Parameter `#{param}` is required to create a goal")
 
+      {:error, changeset} ->
+        conn
+        |> put_status(400)
+        |> json(serialize_errors(changeset))
+
       e ->
         H.bad_request(conn, "Something went wrong: #{inspect(e)}")
     end

--- a/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
+++ b/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
@@ -19,4 +19,10 @@ defmodule :"Elixir.Plausible.Repo.Migrations.Associate-goals-with-sites" do
     )
     """
   end
+
+  def down do
+    alter table(:goals) do
+      remove :site_id
+    end
+  end
 end

--- a/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
+++ b/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
@@ -21,7 +21,6 @@ defmodule :"Elixir.Plausible.Repo.Migrations.Associate-goals-with-sites" do
 
     alter table(:goals) do
       modify :site_id, references(:sites, on_delete: :delete_all), null: false
-      remove :domain
     end
   end
 end

--- a/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
+++ b/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
@@ -18,9 +18,5 @@ defmodule :"Elixir.Plausible.Repo.Migrations.Associate-goals-with-sites" do
       SELECT s.id FROM sites s WHERE s.domain = g.domain
     )
     """
-
-    alter table(:goals) do
-      modify :site_id, references(:sites, on_delete: :delete_all), null: false
-    end
   end
 end

--- a/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
+++ b/priv/repo/migrations/20230406110926_associate-goals-with-sites.exs
@@ -1,0 +1,27 @@
+defmodule :"Elixir.Plausible.Repo.Migrations.Associate-goals-with-sites" do
+  use Ecto.Migration
+
+  def up do
+    alter table(:goals) do
+      add :site_id, :integer, null: true
+    end
+
+    execute """
+    DELETE FROM goals g WHERE NOT EXISTS (
+      SELECT 1 FROM sites s
+      WHERE s.domain = g.domain
+    )
+    """
+
+    execute """
+    UPDATE goals g SET site_id = (
+      SELECT s.id FROM sites s WHERE s.domain = g.domain
+    )
+    """
+
+    alter table(:goals) do
+      modify :site_id, references(:sites, on_delete: :delete_all), null: false
+      remove :domain
+    end
+  end
+end

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -3,6 +3,7 @@ defmodule Plausible.GoalsTest do
 
   alias Plausible.Goals
 
+  @tag :skip
   test "create/2 trims input" do
     site = insert(:site)
     {:ok, goal} = Goals.create(site, %{"page_path" => "/foo bar "})

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -245,6 +245,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
   describe "PUT /api/v1/sites/goals" do
     setup :create_site
 
+    @tag :skip
     test "can add a goal as event to a site", %{conn: conn, site: site} do
       conn =
         put(conn, "/api/v1/sites/goals", %{
@@ -258,6 +259,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
       assert res["event_name"] == "Signup"
     end
 
+    @tag :skip
     test "can add a goal as page to a site", %{conn: conn, site: site} do
       conn =
         put(conn, "/api/v1/sites/goals", %{
@@ -272,6 +274,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
     end
 
     @tag :v2_only
+    @tag :skip
     test "can add a goal using old site_id after domain change", %{conn: conn, site: site} do
       old_domain = site.domain
       new_domain = "new.example.com"
@@ -290,6 +293,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
       assert res["event_name"] == "Signup"
     end
 
+    @tag :skip
     test "is idempotent find or create op", %{conn: conn, site: site} do
       conn =
         put(conn, "/api/v1/sites/goals", %{
@@ -390,6 +394,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
     end
   end
 
+  @tag :skip
   describe "DELETE /api/v1/sites/goals/:goal_id" do
     setup :create_new_site
 
@@ -412,6 +417,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
     end
 
     @tag :v2_only
+    @tag :skip
     test "delete a goal using old site_id after domain change", %{conn: conn, site: site} do
       old_domain = site.domain
       new_domain = "new.example.com"

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -620,6 +620,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
+  @tag :skip
   describe "POST /:website/goals" do
     setup [:create_user, :log_in, :create_site]
 
@@ -639,6 +640,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert redirected_to(conn, 302) == "/#{site.domain}/settings/goals"
     end
 
+    @tag :skip
     test "creates a custom event goal for the website", %{conn: conn, site: site} do
       conn =
         post(conn, "/#{site.domain}/goals", %{


### PR DESCRIPTION
### Changes

This PR temporarily disables goal creation and partially migrates postgres as per #2828 

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
