### PR TITLE
Prop filter modal

### DIFF
--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -169,8 +169,13 @@ export default function PlausibleCombobox(props) {
     'hidden': props.singleOption && props.values.length === 1
   })
 
+  const containerClass = classNames('relative w-full', {
+    [props.className]: !!props.className,
+    'opacity-20 cursor-default pointer-events-none': props.isDisabled
+  })
+
   return (
-    <div onKeyDown={onKeyDown} ref={containerRef} className={`relative w-full ${props.className || ''}`}>
+    <div onKeyDown={onKeyDown} ref={containerRef} className={containerClass}>
       <div onClick={toggleOpen} className={classNames('pl-2 pr-8 py-1 w-full dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm border border-gray-300 dark:border-gray-700 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500', {'border-indigo-500 ring-1 ring-indigo-500': isOpen, '': !isOpen})}>
         { props.values.map((value) => {
             return (

--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -159,7 +159,7 @@ export default function PlausibleCombobox(props) {
   const noMatchesFound = !loading && visibleOptions.length === 0
 
   return (
-    <div onKeyDown={onKeyDown} ref={containerRef} className="relative ml-2 w-full">
+    <div onKeyDown={onKeyDown} ref={containerRef} className={`relative w-full ${props.className || ''}`}>
       <div onClick={toggleOpen} className={classNames('pl-2 pr-8 py-1 w-full dark:bg-gray-900 dark:text-gray-300 rounded-md shadow-sm border border-gray-300 dark:border-gray-700 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500', {'border-indigo-500 ring-1 ring-indigo-500': isOpen, '': !isOpen})}>
         { props.values.map((value) => {
             return (

--- a/assets/js/dashboard/components/filter-type-selector.js
+++ b/assets/js/dashboard/components/filter-type-selector.js
@@ -31,39 +31,41 @@ export default function FilterTypeSelector(props) {
   }
 
   return (
-    <Menu as="div" className="relative inline-block text-left mr-2">
-      {({ open }) => (
-        <>
-          <div className="w-24">
-            <Menu.Button className="inline-flex justify-between items-center w-full rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-850 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-900 focus:ring-indigo-500">
-              {props.selectedType}
-              <ChevronDownIcon className="-mr-2 ml-2 h-4 w-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
-            </Menu.Button>
-          </div>
+    <div className={props.isDisabled ? 'opacity-20 cursor-default pointer-events-none' : ''}>
+      <Menu as="div" className="relative inline-block text-left mr-2">
+        {({ open }) => (
+          <>
+            <div className="w-24">
+              <Menu.Button className="inline-flex justify-between items-center w-full rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-850 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-900 focus:ring-indigo-500">
+                {props.selectedType}
+                <ChevronDownIcon className="-mr-2 ml-2 h-4 w-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+              </Menu.Button>
+            </div>
 
-          <Transition
-            show={open}
-            as={Fragment}
-            enter="transition ease-out duration-100"
-            enterFrom="transform opacity-0 scale-95"
-            enterTo="transform opacity-100 scale-100"
-            leave="transition ease-in duration-75"
-            leaveFrom="transform opacity-100 scale-100"
-            leaveTo="transform opacity-0 scale-95"
-          >
-            <Menu.Items
-              static
-              className="z-10 origin-top-left absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none"
+            <Transition
+              show={open}
+              as={Fragment}
+              enter="transition ease-out duration-100"
+              enterFrom="transform opacity-0 scale-95"
+              enterTo="transform opacity-100 scale-100"
+              leave="transition ease-in duration-75"
+              leaveFrom="transform opacity-100 scale-100"
+              leaveTo="transform opacity-0 scale-95"
             >
-              <div className="py-1">
-                {renderTypeItem(FILTER_TYPES.is, true)}
-                {renderTypeItem(FILTER_TYPES.isNot, supportsIsNot(filterName))}
-                {renderTypeItem(FILTER_TYPES.contains, isFreeChoiceFilter(filterName))}
-              </div>
-            </Menu.Items>
-          </Transition>
-        </>
-      )}
-    </Menu>
+              <Menu.Items
+                static
+                className="z-10 origin-top-left absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none"
+              >
+                <div className="py-1">
+                  {renderTypeItem(FILTER_TYPES.is, true)}
+                  {renderTypeItem(FILTER_TYPES.isNot, supportsIsNot(filterName))}
+                  {renderTypeItem(FILTER_TYPES.contains, isFreeChoiceFilter(filterName))}
+                </div>
+              </Menu.Items>
+            </Transition>
+          </>
+        )}
+      </Menu>
+    </div>
   )
 }

--- a/assets/js/dashboard/components/filter-type-selector.js
+++ b/assets/js/dashboard/components/filter-type-selector.js
@@ -31,7 +31,7 @@ export default function FilterTypeSelector(props) {
   }
 
   return (
-    <Menu as="div" className="relative inline-block text-left">
+    <Menu as="div" className="relative inline-block text-left mr-2">
       {({ open }) => (
         <>
           <div className="w-24">

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -55,21 +55,36 @@ function renderDropdownFilter(site, history, [key, value], query) {
   return (
     <Menu.Item key={key}>
       <div className="px-3 md:px-4 sm:py-2 py-3 text-sm leading-tight flex items-center justify-between" key={key + value}>
-        <Link
-          title={`Edit filter: ${formattedFilters[key]}`}
-          to={{ pathname: `/${encodeURIComponent(site.domain)}/filter/${filterGroupForFilter(key)}`, search: window.location.search }}
-          className="group flex w-full justify-between items-center"
-          style={{ width: 'calc(100% - 1.5rem)' }}
-        >
-          <span className="inline-block w-full truncate">{filterText(key, value, query)}</span>
-          <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
-        </Link>
+        {shouldLinkToFilterModal(site, key) &&
+          <Link
+            title={`Edit filter: ${formattedFilters[key]}`}
+            to={{ pathname: `/${encodeURIComponent(site.domain)}/filter/${filterGroupForFilter(key)}`, search: window.location.search }}
+            className="group flex w-full justify-between items-center"
+            style={{ width: 'calc(100% - 1.5rem)' }}
+          >
+            <span className="inline-block w-full truncate">{filterText(key, value, query)}</span>
+            <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
+          </Link>
+        }
+        {!shouldLinkToFilterModal(site, key) && 
+          <div
+            onClick={(e) => {e.preventDefault()}}
+            className="group flex w-full justify-between items-center"
+            style={{ width: 'calc(100% - 1.5rem)' }}
+          >
+            <span className="inline-block w-full truncate">{filterText(key, value, query)}</span>
+          </div>
+        }
         <b title={`Remove filter: ${formattedFilters[key]}`} className="ml-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500" onClick={() => removeFilter(key, history, query)}>
           <XMarkIcon className="w-4 h-4" />
         </b>
       </div>
     </Menu.Item>
   )
+}
+
+function shouldLinkToFilterModal(site, key) {
+  return key !== 'props' || site.flags.custom_dimension_filter
 }
 
 function filterDropdownOption(site, option) {
@@ -204,9 +219,16 @@ class Filters extends React.Component {
   renderListFilter(history, [key, value], query) {
     return (
       <span key={key} title={value} className="flex bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 shadow text-sm rounded mr-2 items-center">
-        <Link title={`Edit filter: ${formattedFilters[key]}`} className="flex w-full h-full items-center py-2 pl-3" to={{ pathname: `/${encodeURIComponent(this.props.site.domain)}/filter/${filterGroupForFilter(key)}`, search: window.location.search }}>
-          <span className="inline-block max-w-2xs md:max-w-xs truncate">{filterText(key, value, query)}</span>
-        </Link>
+        {shouldLinkToFilterModal(this.props.site, key) &&
+          <Link title={`Edit filter: ${formattedFilters[key]}`} className="flex w-full h-full items-center py-2 pl-3" to={{ pathname: `/${encodeURIComponent(this.props.site.domain)}/filter/${filterGroupForFilter(key)}`, search: window.location.search }}>
+            <span className="inline-block max-w-2xs md:max-w-xs truncate">{filterText(key, value, query)}</span>
+          </Link>
+        }
+        {!shouldLinkToFilterModal(this.props.site, key) &&
+          <div className="flex w-full h-full items-center py-2 pl-3">
+            <span className="inline-block max-w-2xs md:max-w-xs truncate">{filterText(key, value, query)}</span>
+          </div>
+        }
         <span title={`Remove filter: ${formattedFilters[key]}`} className="flex h-full w-full px-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500 items-center" onClick={() => removeFilter(key, history, query)}>
           <XMarkIcon className="w-4 h-4" />
         </span>

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -43,7 +43,7 @@ function filterText(key, _rawValue, query) {
 
   if (key === "props") {
     const [[propKey, _propValue]] = Object.entries(query.filters['props'])
-    return <>props.{propKey} {type} {clauses.map(({label}) => <b key={label}>{label}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
+    return <>Property <b>{propKey}</b> {type} {clauses.map(({label}) => <b key={label}>{label}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
   } else if (formattedFilter) {
     return <>{formattedFilter} {type} {clauses.map(({label}) => <b key={label}>{label}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
   }

--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -2,12 +2,16 @@ import React from "react"
 import { withRouter } from 'react-router-dom'
 import Modal from './modal'
 import RegularFilterModal from './regular-filter-modal'
+import PropFilterModal from "./prop-filter-modal"
 
 function FilterModal(props) {
   function renderBody() {
     const filterGroup = props.match.params.field || 'page'
-
-    return <RegularFilterModal site={props.site} filterGroup={filterGroup}/>
+    if (filterGroup === 'props') {
+      return <PropFilterModal site={props.site} />
+    } else {
+      return <RegularFilterModal site={props.site} filterGroup={filterGroup} />
+    }
   }
 
   return (

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -6,7 +6,8 @@ import FilterTypeSelector from "../../components/filter-type-selector";
 import { FILTER_TYPES } from "../../util/filters";
 import { parseQuery } from '../../query'
 import * as api from '../../api'
-import { apiPath } from '../../util/url'
+import { apiPath, siteBasePath } from '../../util/url'
+import { toFilterQuery } from '../../util/filters';
 
 function PropFilterModal(props) {
   const query = parseQuery(props.location.search, props.site)
@@ -72,11 +73,28 @@ function PropFilterModal(props) {
   }
 
   function isDisabled() {
-    return false
+    return !(formState.prop_key && formState.prop_value.clauses.length > 0)
   }
 
   function shouldShowClear() {
     return true
+  }
+
+  function handleSubmit() {
+    const filterString = JSON.stringify({ [formState.prop_key.value]: toFilterQuery(formState.prop_value.type, formState.prop_value.clauses) })
+    selectFiltersAndCloseModal(filterString)
+  }
+
+  function selectFiltersAndCloseModal(filterString) {
+    const queryString = new URLSearchParams(window.location.search)
+
+    if (filterString) {
+      queryString.set('props', filterString)
+    } else {
+      queryString.delete('props')
+    }
+
+    props.history.replace({ pathname: siteBasePath(props.site), search: queryString.toString() })
   }
 
   return (
@@ -85,7 +103,7 @@ function PropFilterModal(props) {
 
       <div className="mt-4 border-b border-gray-300"></div>
       <main className="modal__content">
-        <form className="flex flex-col" onSubmit={() => { }}>
+        <form className="flex flex-col" onSubmit={handleSubmit}>
           {renderFilterInputs()}
 
           <div className="mt-6 flex items-center justify-start">

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -4,25 +4,38 @@ import { withRouter } from "react-router-dom";
 import Combobox from '../../components/combobox'
 import FilterTypeSelector from "../../components/filter-type-selector";
 import { FILTER_TYPES } from "../../util/filters";
+import { parseQuery } from '../../query'
+import * as api from '../../api'
+import { apiPath } from '../../util/url'
 
 function PropFilterModal(props) {
+  const query = parseQuery(props.location.search, props.site)
   const [formState, setFormState] = useState(getFormState())
 
   function getFormState() {
     return {
-      prop_key: '',
+      prop_key: null,
       prop_value: { type: FILTER_TYPES.is, clauses: [] }
     }
   }
 
   function fetchOptions(filter) {
-    return () => {
-      []
+    return (input) => {
+      if (filter === 'prop_key') {
+        return api.get(apiPath(props.site, `/suggestions/${filter}`), query, { q: input.trim() })
+      }
     }
   }
 
-  function onComboboxSelect(filter) {
-    return () => { }
+  function onPropKeySelect() {
+    return (selectedOptions) => {
+      const newPropKey = selectedOptions.length === 0 ? null : selectedOptions[0]
+      setFormState(prevState => ({ ...prevState, prop_key: newPropKey }))
+    }
+  }
+
+  function onPropValueSelect() {
+    return (selection) => { }
   }
 
   function onFilterTypeSelect() {
@@ -40,9 +53,9 @@ function PropFilterModal(props) {
   function renderFilterInputs() {
     return (
       <div className="flex items-start mt-6">
-        <Combobox className="mr-2" fetchOptions={fetchOptions('prop_key')} values={[]} onSelect={onComboboxSelect('prop_key')} placeholder={'Property'} />
+        <Combobox className="mr-2" fetchOptions={fetchOptions('prop_key')} singleOption={true} values={formState.prop_key ? [formState.prop_key] : []} onSelect={onPropKeySelect()} placeholder={'Property'} />
         <FilterTypeSelector forFilter={'prop_value'} onSelect={onFilterTypeSelect()} selectedType={selectedFilterType()} />
-        <Combobox fetchOptions={fetchOptions('prop_value')} values={[]} onSelect={onComboboxSelect('prop_value')} placeholder={'Value'} />
+        <Combobox fetchOptions={fetchOptions('prop_value')} values={[]} onSelect={onPropValueSelect()} placeholder={'Value'} />
       </div>
     )
   }

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -23,6 +23,10 @@ function PropFilterModal(props) {
     return (input) => {
       if (filter === 'prop_key') {
         return api.get(apiPath(props.site, `/suggestions/${filter}`), query, { q: input.trim() })
+      } else {
+        const propKey = formState.prop_key?.value
+        const updatedQuery = { ...query, filters: { ...query.filters, props: {[propKey]: '!(none)'} } }
+        return api.get(apiPath(props.site, `/suggestions/${filter}`), updatedQuery, { q: input.trim() })
       }
     }
   }
@@ -30,12 +34,19 @@ function PropFilterModal(props) {
   function onPropKeySelect() {
     return (selectedOptions) => {
       const newPropKey = selectedOptions.length === 0 ? null : selectedOptions[0]
-      setFormState(prevState => ({ ...prevState, prop_key: newPropKey }))
+      setFormState(prevState => ({
+        prop_key: newPropKey,
+        prop_value: { type: prevState.prop_value.type, clauses: [] }
+      }))
     }
   }
 
   function onPropValueSelect() {
-    return (selection) => { }
+    return (selection) => {
+      setFormState(prevState => ({
+        ...prevState, prop_value: { ...prevState.prop_value, clauses: selection }
+      }))
+    }
   }
 
   function onFilterTypeSelect() {
@@ -54,8 +65,8 @@ function PropFilterModal(props) {
     return (
       <div className="flex items-start mt-6">
         <Combobox className="mr-2" fetchOptions={fetchOptions('prop_key')} singleOption={true} values={formState.prop_key ? [formState.prop_key] : []} onSelect={onPropKeySelect()} placeholder={'Property'} />
-        <FilterTypeSelector forFilter={'prop_value'} onSelect={onFilterTypeSelect()} selectedType={selectedFilterType()} />
-        <Combobox fetchOptions={fetchOptions('prop_value')} values={[]} onSelect={onPropValueSelect()} placeholder={'Value'} />
+        <FilterTypeSelector isDisabled={!formState.prop_key} forFilter={'prop_value'} onSelect={onFilterTypeSelect()} selectedType={selectedFilterType()} />
+        <Combobox isDisabled={!formState.prop_key} fetchOptions={fetchOptions('prop_value')} values={formState.prop_value.clauses} onSelect={onPropValueSelect()} placeholder={'Value'} />
       </div>
     )
   }

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { withRouter } from "react-router-dom";
+import Combobox from '../../components/combobox'
+import FilterTypeSelector from "../../components/filter-type-selector";
+import { FILTER_TYPES } from "../../util/filters";
+
+function PropFilterModal(props) {
+  function fetchOptions(filter) {
+    return () => {
+      []
+    }
+  }
+
+  function onComboboxSelect(filter) {
+    return () => { }
+  }
+
+  function onFilterTypeSelect(filter) {
+    return () => { }
+  }
+
+  function selectedFilterType() {
+    return FILTER_TYPES.is
+  }
+
+  function renderFilterInputs() {
+    return (
+      <div className="flex items-start mt-6">
+        <Combobox className="mr-2" fetchOptions={fetchOptions('prop_key')} values={[]} onSelect={onComboboxSelect('prop_key')} placeholder={'Property'} />
+        <FilterTypeSelector forFilter={'prop_value'} onSelect={onFilterTypeSelect('prop_value')} selectedType={selectedFilterType()} />
+        <Combobox fetchOptions={fetchOptions('prop_value')} values={[]} onSelect={onComboboxSelect('prop_value')} placeholder={'Value'} />
+      </div>
+    )
+  }
+
+  function isDisabled() {
+    return false
+  }
+
+  function shouldShowClear() {
+    return true
+  }
+
+  return (
+    <>
+      <h1 className="text-xl font-bold dark:text-gray-100">Filter by Property</h1>
+
+      <div className="mt-4 border-b border-gray-300"></div>
+      <main className="modal__content">
+        <form className="flex flex-col" onSubmit={() => { }}>
+          {renderFilterInputs()}
+
+          <div className="mt-6 flex items-center justify-start">
+            <button
+              type="submit"
+              className="button"
+              disabled={isDisabled()}
+            >
+              Apply Filter
+            </button>
+
+            {shouldShowClear() && (
+              <button
+                type="button"
+                className="ml-2 button px-4 flex bg-red-500 dark:bg-red-500 hover:bg-red-600 dark:hover:bg-red-700 items-center"
+                onClick={() => { }}
+              >
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                Remove filter
+              </button>
+            )}
+          </div>
+        </form>
+      </main>
+    </>
+  )
+}
+
+export default withRouter(PropFilterModal)

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -1,10 +1,20 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { withRouter } from "react-router-dom";
+
 import Combobox from '../../components/combobox'
 import FilterTypeSelector from "../../components/filter-type-selector";
 import { FILTER_TYPES } from "../../util/filters";
 
 function PropFilterModal(props) {
+  const [formState, setFormState] = useState(getFormState())
+
+  function getFormState() {
+    return {
+      prop_key: '',
+      prop_value: { type: FILTER_TYPES.is, clauses: [] }
+    }
+  }
+
   function fetchOptions(filter) {
     return () => {
       []
@@ -15,19 +25,23 @@ function PropFilterModal(props) {
     return () => { }
   }
 
-  function onFilterTypeSelect(filter) {
-    return () => { }
+  function onFilterTypeSelect() {
+    return (newType) => {
+      setFormState(prevState => ({
+        ...prevState, prop_value: { ...prevState.prop_value, type: newType }
+      }))
+    }
   }
 
   function selectedFilterType() {
-    return FILTER_TYPES.is
+    return formState.prop_value.type
   }
 
   function renderFilterInputs() {
     return (
       <div className="flex items-start mt-6">
         <Combobox className="mr-2" fetchOptions={fetchOptions('prop_key')} values={[]} onSelect={onComboboxSelect('prop_key')} placeholder={'Property'} />
-        <FilterTypeSelector forFilter={'prop_value'} onSelect={onFilterTypeSelect('prop_value')} selectedType={selectedFilterType()} />
+        <FilterTypeSelector forFilter={'prop_value'} onSelect={onFilterTypeSelect()} selectedType={selectedFilterType()} />
         <Combobox fetchOptions={fetchOptions('prop_value')} values={[]} onSelect={onComboboxSelect('prop_value')} placeholder={'Value'} />
       </div>
     )

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -7,13 +7,25 @@ import { FILTER_TYPES } from "../../util/filters";
 import { parseQuery } from '../../query'
 import * as api from '../../api'
 import { apiPath, siteBasePath } from '../../util/url'
-import { toFilterQuery } from '../../util/filters';
+import { toFilterQuery, parsePrefix } from '../../util/filters';
 
 function PropFilterModal(props) {
   const query = parseQuery(props.location.search, props.site)
   const [formState, setFormState] = useState(getFormState())
 
   function getFormState() {
+    const rawValue = query.filters['props']
+    if (rawValue) {
+      const [[propKey, propVal]] = Object.entries(rawValue)
+      const {type, values} = parsePrefix(propVal)
+      const clauses = values.map(val => { return {value: val, label: val}})
+      
+      return {
+        prop_key: {value: propKey, label: propKey},
+        prop_value: { type: type, clauses: clauses }
+      }
+    }
+
     return {
       prop_key: null,
       prop_value: { type: FILTER_TYPES.is, clauses: [] }
@@ -77,7 +89,7 @@ function PropFilterModal(props) {
   }
 
   function shouldShowClear() {
-    return true
+    return !!query.filters['props']
   }
 
   function handleSubmit() {
@@ -119,7 +131,7 @@ function PropFilterModal(props) {
               <button
                 type="button"
                 className="ml-2 button px-4 flex bg-red-500 dark:bg-red-500 hover:bg-red-600 dark:hover:bg-red-700 items-center"
-                onClick={() => { }}
+                onClick={() => {selectFiltersAndCloseModal(null)}}
               >
                 <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                 Remove filter

--- a/assets/js/dashboard/stats/modals/regular-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/regular-filter-modal.js
@@ -11,21 +11,6 @@ import { shouldIgnoreKeypress } from '../../keybinding'
 import { isFreeChoiceFilter } from "../../util/filters";
 
 function getFormState(filterGroup, query) {
-  if (filterGroup === 'props') {
-    const propsObject = query.filters['props']
-    const entries = propsObject && Object.entries(propsObject)
-
-    if (entries && entries.length == 1) {
-      const [[propKey, _propVal]] = entries
-      const {type, clauses} = parseQueryFilter(query, 'props')
-
-      return {
-        'prop_key': { type: FILTER_TYPES.is, clauses: [{label: propKey, value: propKey}] },
-        'prop_value': { type, clauses }
-      }
-    }
-  }
-
   return FILTER_GROUPS[filterGroup].reduce((result, filter) => {
     const {type, clauses} = parseQueryFilter(query, filter)
 
@@ -75,12 +60,6 @@ class RegularFilterModal extends React.Component {
       if (filterKey === 'country') { res.push({ filter: 'country_labels', value: clauses.map(clause => clause.label).join('|') }) }
       if (filterKey === 'region') { res.push({ filter: 'region_labels', value: clauses.map(clause => clause.label).join('|') }) }
       if (filterKey === 'city') { res.push({ filter: 'city_labels', value: clauses.map(clause => clause.label).join('|') }) }
-      if (filterKey === 'prop_value') { return res }
-      if (filterKey === 'prop_key') {
-        const [{value: propKey}] = clauses
-        res.push({ filter: 'props', value: JSON.stringify({ [propKey]: toFilterQuery(formState.prop_value.type, formState.prop_value.clauses) }) })
-        return res
-      }
 
       res.push({ filter: filterKey, value: toFilterQuery(type, clauses) })
       return res
@@ -125,15 +104,7 @@ class RegularFilterModal extends React.Component {
   }
 
   queryForSuggestions(query, formFilters, filter) {
-    if (filter === 'prop_key') {
-      const propsFilter = formFilters.prop_value ? { '': formFilters.prop_value } : null
-      return { ...query, filters: { ...query.filters, props: propsFilter } }
-    } else if (filter === 'prop_value') {
-      const propsFilter = formFilters.prop_key ? { [formFilters.prop_key]: '!(none)' } : null
-      return { ...query, filters: { ...query.filters, props: propsFilter } }
-    } else {
-      return { ...query, filters: { ...query.filters, ...formFilters, [filter]: this.negate(formFilters[filter]) } }
-    }
+    return { ...query, filters: { ...query.filters, ...formFilters, [filter]: this.negate(formFilters[filter]) } }
   }
 
   negate(filterVal) {
@@ -153,11 +124,7 @@ class RegularFilterModal extends React.Component {
   }
 
   isDisabled() {
-    if (this.props.filterGroup === 'props') {
-      return Object.entries(this.state.formState).some(([_key, { clauses }]) => clauses.length === 0)
-    } else {
-      return Object.entries(this.state.formState).every(([_key, { clauses }]) => clauses.length === 0)
-    }
+    return Object.entries(this.state.formState).every(([_key, { clauses }]) => clauses.length === 0)
   }
 
   selectFiltersAndCloseModal(filters) {

--- a/assets/js/dashboard/stats/modals/regular-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/regular-filter-modal.js
@@ -32,7 +32,8 @@ class RegularFilterModal extends React.Component {
     super(props)
     const query = parseQuery(props.location.search, props.site)
     const formState = getFormState(props.filterGroup, query)
-
+    
+    this.handleKeydown = this.handleKeydown.bind(this)
     this.state = { query, formState }
   }
 

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -55,9 +55,7 @@ function parsePrefix(rawValue) {
   const type = Object.keys(FILTER_PREFIXES)
     .find(type => FILTER_PREFIXES[type] === rawValue[0]) || FILTER_TYPES.is;
 
-  const value = [FILTER_TYPES.isNot, FILTER_TYPES.contains].includes(type)
-    ? rawValue.substring(1)
-    : rawValue;
+  const value = type === FILTER_TYPES.is ? rawValue : rawValue.substring(1)
 
   const values = value
     .split(NON_ESCAPED_PIPE_REGEX)

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -51,7 +51,7 @@ export function toFilterQuery(type, clauses) {
   return prefix + result;
 }
 
-function parsePrefix(rawValue) {
+export function parsePrefix(rawValue) {
   const type = Object.keys(FILTER_PREFIXES)
     .find(type => FILTER_PREFIXES[type] === rawValue[0]) || FILTER_TYPES.is;
 

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -158,25 +158,30 @@ defmodule Plausible.Stats.FilterSuggestions do
   def filter_suggestions(site, query, "prop_value", filter_search) do
     filter_query = if filter_search == nil, do: "%", else: "%#{filter_search}%"
 
-    q =
+    {"event:props:" <> key, _filter} = Query.get_filter_by_prefix(query, "event:props")
+
+    none_q =
+      from(e in base_event_query(site, Query.remove_event_filters(query, [:props])),
+        left_lateral_join: meta in "meta",
+        as: :meta,
+        select: "(none)",
+        where: fragment("not has(?, ?)", field(e, :"meta.key"), ^key),
+        limit: 1
+      )
+
+    search_q =
       from(e in base_event_query(site, query),
         inner_lateral_join: meta in "meta",
         as: :meta,
         select: meta.value,
-        where: fragment("? ilike ?", meta.value, ^filter_query),
+        where: meta.key == ^key and fragment("? ilike ?", meta.value, ^filter_query),
         group_by: meta.value,
         order_by: [desc: fragment("count(*)")],
         limit: 25
       )
 
-    q =
-      case Query.get_filter_by_prefix(query, "event:props") do
-        {"event:props:" <> key, _filter} -> from([e, m] in q, where: m.key == ^key)
-        _ -> q
-      end
-
-    ClickhouseRepo.all(q)
-    |> Enum.filter(fn suggestion -> suggestion != "" end)
+    ClickhouseRepo.all(none_q)
+    |> Kernel.++(ClickhouseRepo.all(search_q))
     |> wrap_suggestions()
   end
 

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -144,14 +144,7 @@ defmodule Plausible.Stats.FilterSuggestions do
         limit: 25
       )
 
-    q =
-      case Query.get_filter_by_prefix(query, "event:props") do
-        {"event:props:", {:is, val}} -> from([e, m] in q, where: m.value == ^val)
-        _ -> q
-      end
-
     ClickhouseRepo.all(q)
-    |> Enum.filter(fn suggestion -> suggestion != "" end)
     |> wrap_suggestions()
   end
 

--- a/lib/plausible/stats/props.ex
+++ b/lib/plausible/stats/props.ex
@@ -30,23 +30,10 @@ defmodule Plausible.Stats.Props do
   def valid_prop?(_), do: false
 
   def props(site, query) do
-    prop_filter =
-      Enum.find(query.filters, fn {key, _} -> String.starts_with?(key, "event:props:") end)
-
-    case prop_filter do
-      {"event:props:" <> key, {_, "(none)"}} ->
+    case Plausible.Stats.Query.get_filter_by_prefix(query, "event:props:") do
+      {"event:props:" <> key, _} ->
         {_, {_, goal_name}} = query.filters["event:goal"]
         %{goal_name => [key]}
-
-      {"event:props:" <> _key, _} ->
-        ClickhouseRepo.all(
-          from [e, meta: meta] in base_event_query(site, query),
-            select: {e.name, meta.key},
-            distinct: true
-        )
-        |> Enum.reduce(%{}, fn {goal_name, meta_key}, acc ->
-          Map.update(acc, goal_name, [meta_key], fn list -> [meta_key | list] end)
-        end)
 
       nil ->
         ClickhouseRepo.all(

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -307,6 +307,86 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    test "returns top pages with :not_member filter on custom pageview props", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          pathname: "/chrome",
+          "meta.key": ["browser"],
+          "meta.value": ["Chrome"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/chrome",
+          "meta.key": ["browser"],
+          "meta.value": ["Chrome"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/safari",
+          "meta.key": ["browser"],
+          "meta.value": ["Safari"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/firefox",
+          "meta.key": ["browser"],
+          "meta.value": ["Firefox"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/firefox",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!(%{props: %{"browser" => "!Chrome|Safari"}})
+      conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+        %{
+          "name" => "/firefox",
+          "visitors" => 2
+        }
+      ]
+    end
+
+    test "returns top pages with :not_member filter on custom pageview props including (none) value", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          pathname: "/chrome",
+          "meta.key": ["browser"],
+          "meta.value": ["Chrome"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/chrome",
+          "meta.key": ["browser"],
+          "meta.value": ["Chrome"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/safari",
+          "meta.key": ["browser"],
+          "meta.value": ["Safari"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          pathname: "/no-browser-prop",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!(%{props: %{"browser" => "!Chrome|(none)"}})
+      conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+        %{
+          "name" => "/safari",
+          "visitors" => 1
+        }
+      ]
+    end
+
     test "calculates bounce_rate and time_on_page for pages filtered by page path",
          %{conn: conn, site: site} do
       populate_stats(site, [

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -234,11 +234,26 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
   describe "suggestions for props" do
     setup [:create_user, :log_in, :create_new_site]
 
-    test "returns suggestions for prop key with no filter", %{conn: conn, site: site} do
+    test "returns suggestions for prop key ordered by count", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
           "meta.key": ["author"],
           "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["logged_in"],
+          "meta.value": ["false"],
           timestamp: ~N[2022-01-01 00:00:00]
         ),
         build(:pageview,
@@ -256,73 +271,11 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
 
-      assert json_response(conn, 200) |> Enum.map(& &1["value"]) |> Enum.sort() == [
-               "author",
-               "dark_mode",
-               "logged_in"
-             ]
-    end
-
-    test "returns suggestions for prop key with value filter", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          "meta.key": ["author"],
-          "meta.value": ["Uku Taht"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        ),
-        build(:pageview,
-          "meta.key": ["logged_in"],
-          "meta.value": ["true"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        ),
-        build(:pageview,
-          "meta.key": ["dark_mode"],
-          "meta.value": ["true"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        )
-      ])
-
-      filters = Jason.encode!(%{props: %{"": "true"}})
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&filters=#{filters}"
-        )
-
-      assert json_response(conn, 200) |> Enum.map(& &1["value"]) |> Enum.sort() == [
-               "dark_mode",
-               "logged_in"
-             ]
-    end
-
-    test "returns suggestions for prop value with no filter", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          "meta.key": ["author"],
-          "meta.value": ["Uku Taht"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        ),
-        build(:pageview,
-          "meta.key": ["logged_in"],
-          "meta.value": ["false"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        ),
-        build(:pageview,
-          "meta.key": ["dark_mode"],
-          "meta.value": ["true"],
-          timestamp: ~N[2022-01-01 00:00:00]
-        )
-      ])
-
-      conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/prop_value?period=day&date=2022-01-01")
-
-      assert json_response(conn, 200) |> Enum.map(& &1["value"]) |> Enum.sort() == [
-               "Uku Taht",
-               "false",
-               "true"
-             ]
+      assert json_response(conn, 200) == [
+        %{"label" => "author", "value" => "author"},
+        %{"label" => "logged_in", "value" => "logged_in"},
+        %{"label" => "dark_mode", "value" => "dark_mode"}
+      ]
     end
 
     test "returns suggestions for prop value ordered by count, but (none) value is always first", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

This PR adds a new filter modal component that allows filtering by custom pageview (and custom event) properties. The feature will be enabled with the already existing `custom_dimension_filter` feature flag.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

> Should be added once the feature flag is enabled for everyone

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

> Should be updated once the feature flag is enabled for everyone

### Dark mode
- [x] The UI has been tested both in dark and light mode
