### PR TITLE
Fix date picker shifting day bug

### DIFF
--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import * as storage from './util/storage'
 import Flatpickr from 'react-flatpickr'
 import { formatISO, parseUTCDate, formatDateRange } from './util/date.js'
+import dayjs from 'dayjs'
 
 const COMPARISON_MODES = {
   'off': 'Disable comparison',
@@ -145,7 +146,11 @@ const ComparisonInput = function({ site, query, history }) {
     static: true,
     onClose: ([from, to], _dateStr, _instance) => {
       setUiMode("menu")
-      if (from && to) updateMode("custom", formatISO(parseUTCDate(from)), formatISO(parseUTCDate(to)))
+
+      if (from && to) {
+        [from, to] = [dayjs(from), dayjs(to)]
+        updateMode("custom", formatISO(from), formatISO(to))
+      }
     }
   }
 

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -6,7 +6,7 @@ import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 import * as storage from './util/storage'
 import Flatpickr from 'react-flatpickr'
-import { formatISO, parseUTCDate, formatDateRange } from './util/date.js'
+import { formatISO, formatDateRange } from './util/date.js'
 import dayjs from 'dayjs'
 
 const COMPARISON_MODES = {
@@ -141,7 +141,7 @@ const ComparisonInput = function({ site, query, history }) {
     mode: 'range',
     showMonths: 1,
     maxDate: 'today',
-    minDate: parseUTCDate(site.statsBegin),
+    minDate: site.statsBegin,
     animate: true,
     static: true,
     onClose: ([from, to], _dateStr, _instance) => {

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -6,8 +6,7 @@ import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 import * as storage from './util/storage'
 import Flatpickr from 'react-flatpickr'
-import { formatISO, formatDateRange } from './util/date.js'
-import dayjs from 'dayjs'
+import { parseNaiveDate, formatISO, formatDateRange } from './util/date.js'
 
 const COMPARISON_MODES = {
   'off': 'Disable comparison',
@@ -148,7 +147,7 @@ const ComparisonInput = function({ site, query, history }) {
       setUiMode("menu")
 
       if (from && to) {
-        [from, to] = [dayjs(from), dayjs(to)]
+        [from, to] = [parseNaiveDate(from), parseNaiveDate(to)]
         updateMode("custom", formatISO(from), formatISO(to))
       }
     }

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -17,6 +17,7 @@ import {
   isThisMonth,
   isThisYear,
   parseUTCDate,
+  parseNaiveDate,
   isBefore,
   isAfter,
   formatDateRange
@@ -25,7 +26,6 @@ import { navigateToQuery, QueryLink, QueryButton } from "./query";
 import { shouldIgnoreKeypress } from "./keybinding.js"
 import { COMPARISON_DISABLED_PERIODS, toggleComparisons, isComparisonEnabled } from "../dashboard/comparison-input.js"
 import classNames from "classnames"
-import dayjs from "dayjs"
 
 function renderArrow(query, site, period, prevDate, nextDate) {
   const insertionDate = parseUTCDate(site.statsBegin);
@@ -257,7 +257,7 @@ function DatePicker({query, site, history}) {
 
   function setCustomDate([from, to], _dateStr, _instance) {
     if (from && to) {
-      [from, to] = [dayjs(from), dayjs(to)]
+      [from, to] = [parseNaiveDate(from), parseNaiveDate(to)]
 
       if (from.isSame(to)) {
         navigateToQuery( history, query, { period: 'day', date: formatISO(from), from: false, to: false })

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -385,7 +385,7 @@ function DatePicker({query, site, history}) {
             options={{
               mode: 'range',
               maxDate: 'today',
-              minDate: parseUTCDate(site.statsBegin),
+              minDate: site.statsBegin,
               showMonths: 1,
               static: true,
               animate: true}}

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -25,6 +25,7 @@ import { navigateToQuery, QueryLink, QueryButton } from "./query";
 import { shouldIgnoreKeypress } from "./keybinding.js"
 import { COMPARISON_DISABLED_PERIODS, toggleComparisons, isComparisonEnabled } from "../dashboard/comparison-input.js"
 import classNames from "classnames"
+import dayjs from "dayjs"
 
 function renderArrow(query, site, period, prevDate, nextDate) {
   const insertionDate = parseUTCDate(site.statsBegin);
@@ -254,34 +255,18 @@ function DatePicker({query, site, history}) {
     return () => { document.removeEventListener("mousedown", handleClick, false); }
   }, [])
 
-  function setCustomDate(dates) {
-    if (dates.length === 2) {
-      const [from, to] = dates.map(parseUTCDate)
-      if (formatISO(from) === formatISO(to)) {
-        navigateToQuery(
-          history,
-          query,
-          {
-            period: 'day',
-            date: formatISO(from),
-            from: false,
-            to: false
-          }
-        )
+  function setCustomDate([from, to], _dateStr, _instance) {
+    if (from && to) {
+      [from, to] = [dayjs(from), dayjs(to)]
+
+      if (from.isSame(to)) {
+        navigateToQuery( history, query, { period: 'day', date: formatISO(from), from: false, to: false })
       } else {
-        navigateToQuery(
-          history,
-          query,
-          {
-            period: 'custom',
-            date: false,
-            from: formatISO(from),
-            to: formatISO(to),
-          }
-        )
+        navigateToQuery( history, query, { period: 'custom', date: false, from: formatISO(from), to: formatISO(to) })
       }
-      setOpen(false)
     }
+
+    setOpen(false)
   }
 
   function toggle() {
@@ -406,7 +391,7 @@ function DatePicker({query, site, history}) {
               animate: true}}
             ref={calendar}
             className="invisible"
-            onChange={setCustomDate}
+            onClose={setCustomDate}
           />
         </div>
       )

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -63,6 +63,10 @@ export function parseUTCDate(dateString) {
   return dayjs.utc(dateString)
 }
 
+export function parseNaiveDate(dateString) {
+  return dayjs(dateString)
+}
+
 export function nowForSite(site) {
   return dayjs.utc().utcOffset(site.offset / 60)
 }


### PR DESCRIPTION
This commit fixes a bug where picking a specific date in custom range takes you to the stats of the day before.

This was caused because Flatpickr returns a Date instance, and we were trying to parse this Date instance into day.js using the `utc` function, assuming it was a ISO-8601 string.

This commit fixes it by casting Date into dayjs using the `dayjs` function instead of `utc`.