### PR TITLE
Stop using Double in cache store tests

### DIFF
--- a/test/plausible/session/cache_store_test.exs
+++ b/test/plausible/session/cache_store_test.exs
@@ -1,14 +1,16 @@
 defmodule Plausible.Session.CacheStoreTest do
   use Plausible.DataCase
-  import Double
-  alias Plausible.Session.{CacheStore, WriteBuffer}
+  alias Plausible.Session.CacheStore
+
+  defmodule FakeBuffer do
+    def insert(sessions) do
+      send(self(), {WriteBuffer, :insert, [sessions]})
+      {:ok, sessions}
+    end
+  end
 
   setup do
-    buffer =
-      WriteBuffer
-      |> stub(:insert, fn _sessions -> nil end)
-
-    [buffer: buffer]
+    [buffer: FakeBuffer]
   end
 
   test "creates a session from an event", %{buffer: buffer} do


### PR DESCRIPTION
### Changes

I had nothing better to do and we can gradually move away from those mocks

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
