### PR TITLE
Adding a note to contact us for more API calls

### DIFF
--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -32,7 +32,7 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
       {:error, :rate_limit, limit} ->
         H.too_many_requests(
           conn,
-          "Too many API requests. Your API key is limited to #{limit} requests per hour."
+          "Too many API requests. Your API key is limited to #{limit} requests per hour. Please contact us to request more capacity."
         )
 
       {:error, :invalid_api_key} ->


### PR DESCRIPTION
this should make it clearer to people that they can get more API capacity when they encounter the "Too many API requests" error
