### PR TITLE
Prevent overwriting with_imported when comparing

### DIFF
--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -249,18 +249,19 @@ defmodule Plausible.Stats.Query do
   end
 
   defp maybe_include_imported(query, site, params) do
-    imported_data_requested = params["with_imported"] == "true"
-    has_imported_data = site.imported_data && site.imported_data.status == "ok"
+    requested? = params["with_imported"] == "true"
+    %{query | include_imported: include_imported?(query, site, requested?)}
+  end
 
-    date_range_overlaps =
-      has_imported_data && !Timex.after?(query.date_range.first, site.imported_data.end_date)
-
-    no_filters_applied = Enum.empty?(query.filters)
-
-    include_imported =
-      imported_data_requested && has_imported_data && date_range_overlaps && no_filters_applied
-
-    %{query | include_imported: !!include_imported}
+  @spec include_imported?(t(), Plausible.Site.t(), boolean()) :: boolean()
+  def include_imported?(query, site, requested?) do
+    cond do
+      is_nil(site.imported_data) -> false
+      site.imported_data.status != "ok" -> false
+      Timex.after?(query.date_range.first, site.imported_data.end_date) -> false
+      Enum.any?(query.filters) -> false
+      true -> requested?
+    end
   end
 
   @spec trace(%__MODULE__{}) :: %__MODULE__{}

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -113,10 +113,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
       comparison_opts = parse_comparison_opts(params)
 
-      comparison_result =
+      {comparison_query, comparison_result} =
         case Comparisons.compare(site, query, params["comparison"], comparison_opts) do
-          {:ok, comparison_query} -> Stats.timeseries(site, comparison_query, [selected_metric])
-          {:error, :not_supported} -> nil
+          {:ok, comparison_query} ->
+            {comparison_query, Stats.timeseries(site, comparison_query, [selected_metric])}
+
+          {:error, :not_supported} ->
+            {nil, nil}
         end
 
       labels = label_timeseries(timeseries_result, comparison_result)
@@ -130,7 +133,7 @@ defmodule PlausibleWeb.Api.StatsController do
         comparison_labels: comparison_result && label_timeseries(comparison_result, nil),
         present_index: present_index,
         interval: query.interval,
-        with_imported: query.include_imported,
+        with_imported: with_imported?(query, comparison_query),
         imported_source: site.imported_data && site.imported_data.source,
         full_intervals: full_intervals
       })
@@ -206,7 +209,7 @@ defmodule PlausibleWeb.Api.StatsController do
         top_stats: top_stats,
         interval: query.interval,
         sample_percent: sample_percent,
-        with_imported: query.include_imported,
+        with_imported: with_imported?(query, comparison_query),
         imported_source: site.imported_data && site.imported_data.source,
         comparing_from: comparison_query && comparison_query.date_range.first,
         comparing_to: comparison_query && comparison_query.date_range.last,
@@ -1320,7 +1323,16 @@ defmodule PlausibleWeb.Api.StatsController do
     [
       from: params["compare_from"],
       to: params["compare_to"],
-      match_day_of_week?: params["match_day_of_week"] == "true"
+      match_day_of_week?: params["match_day_of_week"] == "true",
+      include_imported?: params["with_imported"] == "true"
     ]
+  end
+
+  defp with_imported?(source_query, comparison_query) do
+    cond do
+      source_query.include_imported -> true
+      comparison_query && comparison_query.include_imported -> true
+      true -> false
+    end
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -135,7 +135,7 @@ imported_stats_range
         visitors: Enum.random(1..20),
         bounces: Enum.random(1..20),
         visits: Enum.random(1..200),
-        visit_duration: Enum.random(1..100)
+        visit_duration: Enum.random(1000..10000)
       ),
       Plausible.Factory.build(:imported_sources,
         date: date,
@@ -143,14 +143,14 @@ imported_stats_range
         visitors: Enum.random(1..20),
         visits: Enum.random(1..200),
         bounces: Enum.random(1..20),
-        visit_duration: Enum.random(1..100)
+        visit_duration: Enum.random(1000..10000)
       ),
       Plausible.Factory.build(:imported_pages,
         date: date,
         visitors: Enum.random(1..20),
         pageviews: Enum.random(1..20),
         exits: Enum.random(1..20),
-        time_on_page: Enum.random(1..100)
+        time_on_page: Enum.random(1000..10000)
       )
     ]
   end)

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -53,7 +53,8 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=day&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} =
+               json_response(conn, 200)
 
       assert plot == [2] ++ List.duplicate(0, 23)
     end
@@ -119,7 +120,8 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} =
+               json_response(conn, 200)
 
       assert Enum.count(plot) == 31
       assert List.first(plot) == 2
@@ -139,7 +141,8 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} =
+               json_response(conn, 200)
 
       assert Enum.count(plot) == 31
       assert List.first(plot) == 1
@@ -861,7 +864,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
                "plot" => plot,
                "comparison_plot" => comparison_plot,
                "imported_source" => "Google Analytics",
-        "with_imported" => true
+               "with_imported" => true
              } = json_response(conn, 200)
 
       assert 4 == Enum.sum(plot)
@@ -902,7 +905,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
                "plot" => plot,
                "comparison_plot" => comparison_plot,
                "imported_source" => "Google Analytics",
-        "with_imported" => false
+               "with_imported" => false
              } = json_response(conn, 200)
 
       assert 4 == Enum.sum(plot)

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -53,7 +53,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=day&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics"} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
 
       assert plot == [2] ++ List.duplicate(0, 23)
     end
@@ -119,7 +119,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics"} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
 
       assert Enum.count(plot) == 31
       assert List.first(plot) == 2
@@ -139,7 +139,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics"} = json_response(conn, 200)
+      assert %{"plot" => plot, "imported_source" => "Google Analytics", "with_imported" => true} = json_response(conn, 200)
 
       assert Enum.count(plot) == 31
       assert List.first(plot) == 1
@@ -860,7 +860,8 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{
                "plot" => plot,
                "comparison_plot" => comparison_plot,
-               "imported_source" => "Google Analytics"
+               "imported_source" => "Google Analytics",
+        "with_imported" => true
              } = json_response(conn, 200)
 
       assert 4 == Enum.sum(plot)
@@ -900,7 +901,8 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{
                "plot" => plot,
                "comparison_plot" => comparison_plot,
-               "imported_source" => "Google Analytics"
+               "imported_source" => "Google Analytics",
+        "with_imported" => false
              } = json_response(conn, 200)
 
       assert 4 == Enum.sum(plot)

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -840,6 +840,17 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
       ])
 
+      site
+      |> Ecto.Changeset.change(
+        imported_data: %{
+          start_date: ~D[2005-01-01],
+          end_date: ~D[2020-01-31],
+          source: "Google Analytics",
+          status: "ok"
+        }
+      )
+      |> Plausible.Repo.update!()
+
       conn =
         get(
           conn,
@@ -868,6 +879,17 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
       ])
+
+      site
+      |> Ecto.Changeset.change(
+        imported_data: %{
+          start_date: ~D[2005-01-01],
+          end_date: ~D[2020-01-31],
+          source: "Google Analytics",
+          status: "ok"
+        }
+      )
+      |> Plausible.Repo.update!()
 
       conn =
         get(

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -779,7 +779,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
   end
 
   describe "GET /api/stats/top-stats - with comparisons" do
-    setup [:create_user, :log_in, :create_new_site]
+    setup [:create_user, :log_in, :create_new_site, :add_imported_data]
 
     test "defaults to previous period when comparison is not set", %{site: site, conn: conn} do
       populate_stats(site, [
@@ -846,6 +846,77 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
                "from" => "2021-01-01",
                "to" => "2021-01-31"
              } = json_response(conn, 200)
+    end
+
+    test "compares native and imported data", %{site: site, conn: conn} do
+      populate_stats(site, [
+        build(:imported_visitors, date: ~D[2020-01-02]),
+        build(:imported_visitors, date: ~D[2020-01-02]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      site
+      |> Ecto.Changeset.change(
+        imported_data: %{
+          start_date: ~D[2005-01-01],
+          end_date: ~D[2020-01-31],
+          source: "Google Analytics",
+          status: "ok"
+        }
+      )
+      |> Plausible.Repo.update!()
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true&comparison=year_over_year"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"change" => 100, "comparison_value" => 2, "name" => "Total visits", "value" => 4} in res[
+               "top_stats"
+             ]
+    end
+
+    test "does not compare imported data when with_imported is set to false", %{
+      site: site,
+      conn: conn
+    } do
+      populate_stats(site, [
+        build(:imported_visitors, date: ~D[2020-01-02]),
+        build(:imported_visitors, date: ~D[2020-01-02]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      site
+      |> Ecto.Changeset.change(
+        imported_data: %{
+          start_date: ~D[2005-01-01],
+          end_date: ~D[2020-01-31],
+          source: "Google Analytics",
+          status: "ok"
+        }
+      )
+      |> Plausible.Repo.update!()
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=false&comparison=year_over_year"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 4} in res[
+               "top_stats"
+             ]
     end
   end
 end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -875,11 +875,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true&comparison=year_over_year"
         )
 
-      res = json_response(conn, 200)
+      assert %{"top_stats" => top_stats, "with_imported" => true} = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 2, "name" => "Total visits", "value" => 4} in res[
-               "top_stats"
-             ]
+      assert %{"change" => 100, "comparison_value" => 2, "name" => "Total visits", "value" => 4} in top_stats
     end
 
     test "does not compare imported data when with_imported is set to false", %{
@@ -912,11 +910,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=false&comparison=year_over_year"
         )
 
-      res = json_response(conn, 200)
+      assert %{"top_stats" => top_stats, "with_imported" => false} = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 4} in res[
-               "top_stats"
-             ]
+      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 4} in top_stats
     end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -43,10 +43,10 @@ defmodule Plausible.TestUtils do
     {:ok, site: site}
   end
 
-  def add_imported_data(%{site: site}) do
+  def add_imported_data(%{site: site}, end_at \\ Timex.today()) do
     site =
       site
-      |> Plausible.Site.start_import(~D[2005-01-01], Timex.today(), "Google Analytics", "ok")
+      |> Plausible.Site.start_import(~D[2005-01-01], end_at, "Google Analytics", "ok")
       |> Repo.update!()
 
     {:ok, site: site}

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -43,10 +43,10 @@ defmodule Plausible.TestUtils do
     {:ok, site: site}
   end
 
-  def add_imported_data(%{site: site}, end_at \\ Timex.today()) do
+  def add_imported_data(%{site: site}) do
     site =
       site
-      |> Plausible.Site.start_import(~D[2005-01-01], end_at, "Google Analytics", "ok")
+      |> Plausible.Site.start_import(~D[2005-01-01], Timex.today(), "Google Analytics", "ok")
       |> Repo.update!()
 
     {:ok, site: site}


### PR DESCRIPTION
This commit fixes a bug where comparisons would not work with imported data. This is because comparisons copies the source query and modifies the dates only, where it should reevaluate if there is imported data for the new comparison date range.

Closes #2870