### PR TITLE
Prepare Comparisons for release

### DIFF
--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -42,7 +42,6 @@ export const isComparisonEnabled = function(mode) {
 }
 
 export const toggleComparisons = function(history, query, site) {
-  if (!site.flags.comparisons) return
   if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return
 
   if (isComparisonEnabled(query.comparison)) {
@@ -112,7 +111,6 @@ function MatchDayOfWeekInput({ history, query, site }) {
 }
 
 const ComparisonInput = function({ site, query, history }) {
-  if (!site.flags.comparisons) return null
   if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return null
   if (!isComparisonEnabled(query.comparison)) return null
 

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -131,7 +131,9 @@ const ComparisonInput = function({ site, query, history }) {
 
   const [uiMode, setUiMode] = React.useState("menu")
   React.useEffect(() => {
-    if (uiMode == "datepicker" && calendar) calendar.current.flatpickr.open()
+    if (uiMode == "datepicker") {
+      setTimeout(() => calendar.current.flatpickr.open(), 100)
+    }
   }, [uiMode])
 
   const flatpickrOptions = {
@@ -181,8 +183,7 @@ const ComparisonInput = function({ site, query, history }) {
             { uiMode == "datepicker" &&
             <div className="h-0 absolute">
               <Flatpickr ref={calendar} options={flatpickrOptions} className="invisible" />
-            </div>
-            }
+            </div> }
           </Menu>
         </div>
       </div>

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -362,7 +362,7 @@ function DatePicker({query, site, history}) {
                 <span className='font-normal'>C</span>
               </span>
             </div>
-            { !COMPARISON_DISABLED_PERIODS.includes(query.period) && site.flags.comparisons &&
+            { !COMPARISON_DISABLED_PERIODS.includes(query.period) &&
               <div className="py-1 date-option-group border-t border-gray-200 dark:border-gray-500">
                 <span
                   onClick={() => {

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -15,18 +15,11 @@ function Maybe({condition, children}) {
 }
 
 export default class TopStats extends React.Component {
-  renderPercentageComparison(name, comparison, forceDarkMode = false) {
+  renderPercentageComparison(name, comparison) {
     const formattedComparison = numberFormatter(Math.abs(comparison))
 
-    const defaultClassName = classNames({
-      "text-xs dark:text-gray-100": !forceDarkMode,
-      "text-xs text-gray-100": forceDarkMode
-    })
-
-    const noChangeClassName = classNames({
-      "text-xs text-gray-700 dark:text-gray-300": !forceDarkMode,
-      "text-xs text-gray-300": forceDarkMode
-    })
+    const defaultClassName = "text-xs text-gray-100"
+    const noChangeClassName = "text-xs text-gray-300"
 
     if (comparison > 0) {
       const color = name === 'Bounce rate' ? 'text-red-400' : 'text-green-500'
@@ -141,9 +134,6 @@ export default class TopStats extends React.Component {
               <div>
                 <span className="flex items-center justify-between whitespace-nowrap">
                   <p className="font-bold text-xl dark:text-gray-100" id={METRIC_MAPPING[stat.name]}>{this.topStatNumberShort(stat.name, stat.value)}</p>
-                  <Maybe condition={!query.comparison}>
-                    {this.renderPercentageComparison(stat.name, stat.change)}
-                  </Maybe>
                 </span>
                   <Maybe condition={query.comparison}>
                     <p className="text-xs dark:text-gray-100">{ formatDateRange(site, topStatData.from, topStatData.to) }</p>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -65,7 +65,7 @@ export default class TopStats extends React.Component {
       <div>
         {query.comparison && <div className="whitespace-nowrap">
           {this.topStatNumberLong(stat.name, stat.value)} vs. {this.topStatNumberLong(stat.name, stat.comparison_value)} {statName}
-          <span className="ml-2">{this.renderPercentageComparison(stat.name, stat.change, true)}</span>
+          <span className="ml-2">{this.renderPercentageComparison(stat.name, stat.change)}</span>
         </div>}
 
         {!query.comparison && <div className="whitespace-nowrap">

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -331,8 +331,7 @@ defmodule PlausibleWeb.StatsController do
     %{
       custom_dimension_filter: FunWithFlags.enabled?(:custom_dimension_filter, for: user),
       visits_metric: FunWithFlags.enabled?(:visits_metric, for: user),
-      views_per_visit_metric: FunWithFlags.enabled?(:views_per_visit_metric, for: user),
-      comparisons: FunWithFlags.enabled?(:comparisons, for: user)
+      views_per_visit_metric: FunWithFlags.enabled?(:views_per_visit_metric, for: user)
     }
   end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,8 +10,6 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-FunWithFlags.enable(:comparisons)
-
 user = Plausible.Factory.insert(:user, email: "user@plausible.test", password: "plausible")
 
 native_stats_range =

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -1119,36 +1119,12 @@ defmodule Plausible.ImportedTest do
 
       assert %{
                "top_stats" => [
-                 %{
-                   "change" => 100,
-                   "name" => "Unique visitors",
-                   "value" => 1
-                 },
-                 %{
-                   "change" => 100,
-                   "name" => "Total visits",
-                   "value" => 1
-                 },
-                 %{
-                   "change" => 100,
-                   "name" => "Total pageviews",
-                   "value" => 1
-                 },
-                 %{
-                   "change" => 0,
-                   "name" => "Views per visit",
-                   "value" => 0.0
-                 },
-                 %{
-                   "change" => nil,
-                   "name" => "Bounce rate",
-                   "value" => 0
-                 },
-                 %{
-                   "change" => 100,
-                   "name" => "Visit duration",
-                   "value" => 60
-                 }
+                 %{"name" => "Unique visitors", "value" => 1},
+                 %{"name" => "Total visits", "value" => 1},
+                 %{"name" => "Total pageviews", "value" => 1},
+                 %{"name" => "Views per visit", "value" => 0.0},
+                 %{"name" => "Bounce rate", "value" => 0},
+                 %{"name" => "Visit duration", "value" => 60}
                ]
              } = json_response(conn, 200)
     end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -18,8 +18,6 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert %{
-               "change" => 100,
-               "comparison_value" => 0,
                "name" => "Unique visitors",
                "value" => 2
              } in res["top_stats"]
@@ -37,8 +35,6 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert %{
-               "change" => 100,
-               "comparison_value" => 0,
                "name" => "Total pageviews",
                "value" => 3
              } in res["top_stats"]
@@ -56,9 +52,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 3} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Total visits", "value" => 3} in res["top_stats"]
     end
 
     test "counts pages per visit", %{conn: conn, site: site} do
@@ -73,12 +67,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0.0,
-               "name" => "Views per visit",
-               "value" => 1.33
-             } in res["top_stats"]
+      assert %{"name" => "Views per visit", "value" => 1.33} in res["top_stats"]
     end
 
     test "calculates bounce rate", %{conn: conn, site: site} do
@@ -92,9 +81,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => nil, "comparison_value" => 0, "name" => "Bounce rate", "value" => 50} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Bounce rate", "value" => 50} in res["top_stats"]
     end
 
     test "calculates average visit duration", %{conn: conn, site: site} do
@@ -116,12 +103,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Visit duration",
-               "value" => 450
-             } in res["top_stats"]
+      assert %{"name" => "Visit duration", "value" => 450} in res["top_stats"]
     end
 
     test "calculates time on page instead when filtered for page", %{conn: conn, site: site} do
@@ -152,9 +134,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 900} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Time on page", "value" => 900} in res["top_stats"]
     end
 
     test "calculates time on page when filtered for multiple pages", %{
@@ -193,9 +173,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 480} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Time on page", "value" => 480} in res["top_stats"]
     end
 
     test "calculates time on page when filtered for multiple negated pages", %{
@@ -234,9 +212,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 60} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Time on page", "value" => 60} in res["top_stats"]
     end
 
     test "calculates time on page when filtered for multiple wildcard pages", %{
@@ -276,9 +252,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 480} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Time on page", "value" => 480} in res["top_stats"]
     end
 
     test "calculates time on page when filtered for multiple negated wildcard pages", %{
@@ -320,9 +294,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Time on page", "value" => 600} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Time on page", "value" => 600} in res["top_stats"]
     end
   end
 
@@ -357,42 +329,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert res["top_stats"] == [
-               %{
-                 "change" => 100,
-                 "comparison_value" => 0,
-                 "name" => "Unique visitors",
-                 "value" => 3
-               },
-               %{
-                 "change" => 100,
-                 "comparison_value" => 0,
-                 "name" => "Total visits",
-                 "value" => 3
-               },
-               %{
-                 "change" => 100,
-                 "comparison_value" => 0,
-                 "name" => "Total pageviews",
-                 "value" => 4
-               },
-               %{
-                 "change" => 100,
-                 "comparison_value" => 0.0,
-                 "name" => "Views per visit",
-                 "value" => 1.5
-               },
-               %{
-                 "change" => nil,
-                 "comparison_value" => 0,
-                 "name" => "Bounce rate",
-                 "value" => 33
-               },
-               %{
-                 "change" => 100,
-                 "comparison_value" => 0,
-                 "name" => "Visit duration",
-                 "value" => 303
-               }
+               %{"name" => "Unique visitors", "value" => 3},
+               %{"name" => "Total visits", "value" => 3},
+               %{"name" => "Total pageviews", "value" => 4},
+               %{"name" => "Views per visit", "value" => 1.5},
+               %{"name" => "Bounce rate", "value" => 33},
+               %{"name" => "Visit duration", "value" => 303}
              ]
     end
   end
@@ -498,12 +440,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "page glob filter", %{conn: conn, site: site} do
@@ -523,12 +460,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "contains (~) filter", %{conn: conn, site: site} do
@@ -548,12 +480,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
@@ -573,12 +500,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "returns only visitors with specific browser", %{conn: conn, site: site} do
@@ -598,12 +520,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "returns only visitors with specific operating system", %{conn: conn, site: site} do
@@ -623,12 +540,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 2
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 2} in res["top_stats"]
     end
 
     test "returns number of visits from one specific referral source", %{conn: conn, site: site} do
@@ -661,9 +573,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 100, "comparison_value" => 0, "name" => "Total visits", "value" => 2} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Total visits", "value" => 2} in res["top_stats"]
     end
   end
 
@@ -688,12 +598,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique visitors",
-               "value" => 3
-             } in res["top_stats"]
+      assert %{"name" => "Unique visitors", "value" => 3} in res["top_stats"]
     end
 
     test "returns converted visitors", %{conn: conn, site: site} do
@@ -714,12 +619,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0,
-               "name" => "Unique conversions",
-               "value" => 1
-             } in res["top_stats"]
+      assert %{"name" => "Unique conversions", "value" => 1} in res["top_stats"]
     end
 
     test "returns conversion rate", %{conn: conn, site: site} do
@@ -740,15 +640,10 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => 100,
-               "comparison_value" => 0.0,
-               "name" => "Conversion rate",
-               "value" => 33.3
-             } in res["top_stats"]
+      assert %{"name" => "Conversion rate", "value" => 33.3} in res["top_stats"]
     end
 
-    test "returns conversion rate with change=nil when comparison mode disallowed", %{
+    test "returns conversion rate without change when comparison mode disallowed", %{
       conn: conn,
       site: site
     } do
@@ -764,17 +659,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}"
+          "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}&comparison_mode=year_over_year"
         )
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => nil,
-               "comparison_value" => nil,
-               "name" => "Conversion rate",
-               "value" => 33.3
-             } in res["top_stats"]
+      assert %{"name" => "Conversion rate", "value" => 33.3} in res["top_stats"]
     end
   end
 
@@ -794,9 +684,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"change" => 50, "comparison_value" => 2, "name" => "Total visits", "value" => 3} in res[
-               "top_stats"
-             ]
+      assert %{"name" => "Total visits", "value" => 3} in res["top_stats"]
     end
 
     test "returns comparison data when mode is custom", %{site: site, conn: conn} do


### PR DESCRIPTION
This pull request removes the comparisons feature flag, making it visible to all users. It also removes percentages from top stats in default view, leaving those for the comparison view only.