### PR TITLE
Treat page filter as entry page filter only for bounce rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug when combining goal and prop filters plausible/analytics#2654
 
 ### Changed
+- Treat page filter as entry page filter for `bounce_rate`
 - Reject events with long URIs and data URIs plausible/analytics#2536
 - Always show direct traffic in sources reports plausible/analytics#2531
 - Stop recording XX and T1 country codes plausible/analytics#2556

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -40,7 +40,7 @@ defmodule Plausible.Stats.Aggregate do
   defp aggregate_sessions(site, query, metrics) do
     from(e in query_sessions(site, query), select: %{})
     |> filter_converted_sessions(site, query)
-    |> select_session_metrics(metrics)
+    |> select_session_metrics(metrics, query)
     |> merge_imported(site, query, :aggregate, metrics)
     |> ClickhouseRepo.one()
   end

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -352,6 +352,7 @@ defmodule Plausible.Stats.Base do
     |> select_session_metrics(rest, query)
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp dynamic_filter_condition(query, filter_key, db_field) do
     case query && query.filters && query.filters[filter_key] do
       {:is, value} ->

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -194,7 +194,7 @@ defmodule Plausible.Stats.Breakdown do
     )
     |> filter_converted_sessions(site, query)
     |> do_group_by(property)
-    |> select_session_metrics(metrics)
+    |> select_session_metrics(metrics, query)
     |> merge_imported(site, query, property, metrics)
     |> apply_pagination(pagination)
     |> ClickhouseRepo.all()

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -46,7 +46,7 @@ defmodule Plausible.Stats.Timeseries do
     from(e in query_sessions(site, query), select: %{})
     |> filter_converted_sessions(site, query)
     |> select_bucket(site, query)
-    |> select_session_metrics(metrics)
+    |> select_session_metrics(metrics, query)
     |> Plausible.Stats.Imported.merge_imported_timeseries(site, query, metrics)
     |> ClickhouseRepo.all()
     |> remove_internal_visits_metric(metrics)

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -147,8 +147,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     event_only_filter = Map.keys(query.filters) |> Enum.find(&event_only_property?/1)
 
     cond do
+      metric == "views_per_visit" && query.filters["event:page"] ->
+        {:error, "Metric `#{metric}` cannot be queried with a filter on `event:page`."}
+
       metric == "views_per_visit" && property != nil ->
-        {:error, "Metric `#{metric}` is not supported in breakdown queries"}
+        {:error, "Metric `#{metric}` is not supported in breakdown queries."}
 
       event_only_property?(property) ->
         {:error, "Session metric `#{metric}` cannot be queried for breakdown by `#{property}`."}

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -396,7 +396,6 @@ defmodule PlausibleWeb.Api.StatsController do
           :visitors,
           :visits,
           :pageviews,
-          :views_per_visit,
           :bounce_rate,
           :time_on_page,
           :sample_percent

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -642,7 +642,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 2},
                "visitors" => %{"value" => 2},
-               "bounce_rate" => %{"value" => 50},
+               "bounce_rate" => %{"value" => 100},
                "visit_duration" => %{"value" => 750}
              }
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -94,6 +94,23 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
                  "Session metric `visit_duration` cannot be queried when using a filter on `event:name`."
              }
     end
+
+    test "validates that views_per_visit cannot be used with event:page filter", %{
+      conn: conn,
+      site: site
+    } do
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "filters" => "event:page==/something",
+          "metrics" => "views_per_visit"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Metric `views_per_visit` cannot be queried with a filter on `event:page`."
+             }
+    end
   end
 
   test "aggregates a single metric", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1228,7 +1228,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       end
     end
 
-        test "event:page filter is interpreted as entry_page filter only for bounce_rate", %{
+    test "event:page filter is interpreted as entry_page filter only for bounce_rate", %{
       conn: conn,
       site: site
     } do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1228,6 +1228,63 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       end
     end
 
+        test "event:page filter is interpreted as entry_page filter only for bounce_rate", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          browser: "Chrome",
+          user_id: @user_id,
+          pathname: "/ignore",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          browser: "Chrome",
+          user_id: @user_id,
+          pathname: "/plausible.io",
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          browser: "Chrome",
+          user_id: 456,
+          pathname: "/important-page",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          browser: "Chrome",
+          user_id: 456,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          browser: "Chrome",
+          pathname: "/plausible.io",
+          timestamp: ~N[2021-01-01 00:01:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "metrics" => "visitors,bounce_rate",
+          "property" => "visit:browser",
+          "filters" => "event:page == /plausible.io|/important-page"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{
+                   "browser" => "Chrome",
+                   "bounce_rate" => 50,
+                   "visitors" => 3
+                 }
+               ]
+             }
+    end
+
     test "event:goal pageview filter for breakdown by visit source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -708,7 +708,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                "visits" => 2,
                "pageviews" => 2,
                "views_per_visit" => 1.5,
-               "bounce_rate" => 50,
+               "bounce_rate" => 100,
                "visit_duration" => 150
              }
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -697,7 +697,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
           "period" => "month",
           "date" => "2021-01-01",
           "filters" => "event:page==/hello",
-          "metrics" => "visitors,visits,pageviews,views_per_visit,bounce_rate,visit_duration"
+          "metrics" => "visitors,visits,pageviews,bounce_rate,visit_duration"
         })
 
       res = json_response(conn, 200)["results"]
@@ -707,7 +707,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                "visitors" => 2,
                "visits" => 2,
                "pageviews" => 2,
-               "views_per_visit" => 1.5,
                "bounce_rate" => 100,
                "visit_duration" => 150
              }

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -665,6 +665,30 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
                "top_stats"
              ]
     end
+
+    test "does not return the views_per_visit metric when a page filter is applied", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, pathname: "/")
+      ])
+
+      filters = Jason.encode!(%{page: "/"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=day&filters=#{filters}"
+        )
+
+      res = json_response(conn, 200)
+
+      refute Enum.any?(res["top_stats"], fn
+               %{"name" => "Views per visit"} -> true
+               _ -> false
+             end)
+    end
   end
 
   describe "GET /api/stats/top-stats - filtered for goal" do


### PR DESCRIPTION
### Changes

* When querying for `bounce_rate`, treat a page filter as entry page filter
* Stop displaying the `views_per_visit` metric in Top Stats when a page filter is applied
* Disallow querying for `views_per_visit` with a page filter in the Stats API

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
