### PR TITLE
Add .iex.exs with common aliases/imports

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,19 @@
+alias Plausible.{Repo, ClickhouseRepo, IngestRepo}
+alias Plausible.{Site, Sites, Goal, Goals, Stats}
+
+import_if_available(Ecto.Query)
+import_if_available(Plausible.Factory)
+
+Logger.configure(level: :warn)
+
+IO.puts(
+  IO.ANSI.cyan() <>
+    ~S[
+        .*$$$$$$s.
+       *$$$$$$$$$$$,
+      :$$SSS#######S   *$$$$/. $$                      ** $$     l$:
+      ,$$SSS#######.   $$   ,$:$$  $$$$$ .S*  $: $$@$* $% $$$$@s :$: s$@$s
+      .**$$$#####`     $@$$$$' $l  s-' $:.@*  $| '$@s. $% $$  \$ :$:,$$ *$:
+      ,***/`           #$      `$$ %$$%$$ *$$$#`.*sss$ $% $#$$$'  %$ *$sss,
+      ,$$'] <> IO.ANSI.reset() <> "\n\n"
+)


### PR DESCRIPTION
### Changes

This PR adds .iex.exs rc file (see: https://hexdocs.pm/iex/1.14/IEx.html#module-the-iex-exs-file) with common aliases and imports to make using the development console a more pleasant experience. cc @RobertJoonas 

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
