### PR TITLE
fix qemu arm64 builds

### DIFF
--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -43,6 +43,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_METADATA=${{ steps.meta.outputs.json }}
+            ERL_FLAGS=+JPperf true
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY rel rel
 RUN mix release plausible
 
 # Main Docker Image
-FROM alpine:3.17.0@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c
+FROM alpine:3.17.0
 LABEL maintainer="plausible.io <hello@plausible.io>"
 
 ARG BUILD_METADATA={}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ENV MIX_ENV=prod
 ENV NODE_ENV=production
 ENV NODE_OPTIONS=--openssl-legacy-provider
 
+# custom ERL_FLAGS are passed for (public) multi-platform builds
+# to fix qemu segfault, more info: https://github.com/erlang/otp/pull/6340
+ARG ERL_FLAGS
+ENV ERL_FLAGS=$ERL_FLAGS
+
 RUN mkdir /app
 WORKDIR /app
 


### PR DESCRIPTION
### Changes

This PR adds `ERL_FLAGS=+JPperf true` to public image builds to stop it from segfaulting in qemu when building for arm64. More info for why it works: https://github.com/erlang/otp/pull/6340 (once v26 is released, we can switch to `+JMsingle bool`)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
