### PR TITLE
Improve tagged events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Ability to use '--' instead of '=' sign in the `tagged-events` classnames
 - 'Last updated X seconds ago' info to 'current visitors' tooltips
 - Add support for more Bamboo adapters, i.e. `Bamboo.MailgunAdapter`, `Bamboo.MandrillAdapter`, `Bamboo.SendGridAdapter` plausible/analytics#2649
 - Ability to change domain for existing site (requires numeric IDs data migration, instructions will be provided separately) UI + API (`PUT /api/v1/sites`)

--- a/tracker/src/customEvents.js
+++ b/tracker/src/customEvents.js
@@ -104,11 +104,11 @@ function getTaggedEventAttributes(htmlElement) {
   for (var i = 0; i < classList.length; i++) {
     var className = classList.item(i)
 
-    var matchList = className.match(/plausible-event-(.+)=(.+)/)
+    var matchList = className.match(/plausible-event-(.+)(=|--)(.+)/)
     if (!matchList) { continue }
 
     var key = matchList[1]
-    var value = matchList[2].replace(/\+/g, ' ')
+    var value = matchList[3].replace(/\+/g, ' ')
 
     if (key.toLowerCase() === 'name') {
       eventAttrs.name = value
@@ -180,7 +180,7 @@ function isTagged(element) {
   var classList = element && element.classList
   if (classList) {
     for (var i = 0; i < classList.length; i++) {
-      if (classList.item(i).match(/plausible-event-name=(.+)/)) { return true }
+      if (classList.item(i).match(/plausible-event-name(=|--)(.+)/)) { return true }
     }
   }
   return false

--- a/tracker/test/fixtures/tagged-event.html
+++ b/tracker/test/fixtures/tagged-event.html
@@ -12,7 +12,7 @@
 
 <body>
   <a id="link"
-    class="plausible-event-name=Payment+Complete should ignore-this plausible-event-amount=100 plausible-event-method=Credit+Card"
+    class="plausible-event-name--Payment+Complete should ignore-this plausible-event-amount--100 plausible-event-method--Credit+Card"
     href="https://awesome.website.com/payment/">tagged link</a>
 
   <form class="plausible-event-name=Signup plausible-event-type=Newsletter"
@@ -56,6 +56,7 @@
   <span id="not-tracked-span" class="plausible-event-name= still not tracked">
     Span (without plausible-event-name class)
   </span>
+
 
 
   <script>


### PR DESCRIPTION
### Changes

A small changes to the regex that matches with the `tagged-events` classnames. Allowing  to write `--` instead of `=` will make the integration easier for CMSs that change the `class` attribute format after adding it from the UI (for example Webflow).

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
