### PR TITLE
Ensure comparison line Y axis scale matches main plot

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -66,13 +66,15 @@ class LineGraph extends React.Component {
         onResize: this.updateWindowDimensions,
         elements: { line: { tension: 0 }, point: { radius: 0 } },
         onClick: this.onClick.bind(this),
+        scale: {
+          ticks: { precision: 0, maxTicksLimit: 8 }
+        },
         scales: {
           y: {
             min: 0,
             suggestedMax: calculateMaximumY(dataSet),
             ticks: {
               callback: METRIC_FORMATTER[metric],
-              maxTicksLimit: 8,
               color: this.props.darkTheme ? 'rgb(243, 244, 246)' : undefined
             },
             grid: {
@@ -89,7 +91,6 @@ class LineGraph extends React.Component {
           x: {
             grid: { display: false },
             ticks: {
-              maxTicksLimit: 8,
               callback: function (val, _index, _ticks) {
                 if (this.getLabelForValue(val) == "__blank__") return ""
 
@@ -215,7 +216,6 @@ class LineGraph extends React.Component {
    */
   updateWindowDimensions(chart, dimensions) {
     chart.options.scales.x.ticks.maxTicksLimit = dimensions.width < 720 ? 5 : 8
-    chart.options.scales.y.ticks.maxTicksLimit = dimensions.height < 233 ? 3 : 8
   }
 
   onClick(e) {


### PR DESCRIPTION
Previously, the comparison line could sometimes be displayed with a different scale than the main plot due to the maxTicksLimit option not being fixed and changing based on the data. This commit fixes the issue by setting the maxTicksLimit value to 8 in the graph settings instead of for each individual axis.

Additionally, a callback that attempted to dynamically change the Y axis ticks while resizing has been removed. As the graph has a fixed height, dynamically resizing the Y axis no longer makes sense.

| Before | After |
|--------|--------|
| <img width="691" alt="Screenshot 2023-04-27 at 13 14 50" src="https://user-images.githubusercontent.com/5093045/234859223-3164a25b-1e98-4479-8d9d-3a04dd9f216c.png"> | <img width="649" alt="Screenshot 2023-04-27 at 13 01 02" src="https://user-images.githubusercontent.com/5093045/234859218-69a4e8d7-0b5d-4fe3-b2fd-4d43f76d5f98.png"> |

