### PR TITLE
Postgres migration to add `allowed_event_props` field to `site`

### DIFF
--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
 
   def change do
     alter table("sites") do
-      add :allowed_event_props, {:array, :string}, default: []
+      add :allowed_event_props, {:array, :string}, null: false, default: []
     end
   end
 end

--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
 
   def change do
     alter table("sites") do
-      add :allowed_event_props, {:array, :string}, null: false, default: []
+      add :allowed_event_props, {:array, :string}
     end
   end
 end

--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
+  use Ecto.Migration
+
+  def change do
+    alter table("sites") do
+      add :allowed_event_props, {:array, :string}, default: []
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR only adds a new migration file that adds a field needed to stop showing garbage properties on the dashboard.

For all sites that have this field with the default value of `[]`, we will show all properties that exist in Clickhouse. However, if at least one element exists in that array, we show only the props that are included in that array.

**EDIT: I think in the end it makes sense to keep the default value for this field as `null`.**

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
