### PR TITLE
Add percentage difference back to default view

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -15,11 +15,18 @@ function Maybe({condition, children}) {
 }
 
 export default class TopStats extends React.Component {
-  renderPercentageComparison(name, comparison) {
+  renderPercentageComparison(name, comparison, forceDarkBg = false) {
     const formattedComparison = numberFormatter(Math.abs(comparison))
 
-    const defaultClassName = "text-xs text-gray-100"
-    const noChangeClassName = "text-xs text-gray-300"
+    const defaultClassName = classNames({
+       "text-xs dark:text-gray-100": !forceDarkBg,
+       "text-xs text-gray-100": forceDarkBg
+     })
+
+     const noChangeClassName = classNames({
+       "text-xs text-gray-700 dark:text-gray-300": !forceDarkBg,
+       "text-xs text-gray-300": forceDarkBg
+     })
 
     if (comparison > 0) {
       const color = name === 'Bounce rate' ? 'text-red-400' : 'text-green-500'
@@ -65,7 +72,7 @@ export default class TopStats extends React.Component {
       <div>
         {query.comparison && <div className="whitespace-nowrap">
           {this.topStatNumberLong(stat.name, stat.value)} vs. {this.topStatNumberLong(stat.name, stat.comparison_value)} {statName}
-          <span className="ml-2">{this.renderPercentageComparison(stat.name, stat.change)}</span>
+          <span className="ml-2">{this.renderPercentageComparison(stat.name, stat.change, true)}</span>
         </div>}
 
         {!query.comparison && <div className="whitespace-nowrap">
@@ -134,6 +141,9 @@ export default class TopStats extends React.Component {
               <div>
                 <span className="flex items-center justify-between whitespace-nowrap">
                   <p className="font-bold text-xl dark:text-gray-100" id={METRIC_MAPPING[stat.name]}>{this.topStatNumberShort(stat.name, stat.value)}</p>
+                  <Maybe condition={!query.comparison}>
+                    { this.renderPercentageComparison(stat.name, stat.change) }
+                  </Maybe>
                 </span>
                   <Maybe condition={query.comparison}>
                     <p className="text-xs dark:text-gray-100">{ formatDateRange(site, topStatData.from, topStatData.to) }</p>

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -14,6 +14,7 @@ import FadeIn from '../../fade-in';
 import * as url from '../../util/url'
 import classNames from 'classnames';
 import { parseNaiveDate, isBefore } from '../../util/date'
+import { isComparisonEnabled } from '../../comparison-input'
 
 const calculateMaximumY = function(dataset) {
   const yAxisValues = dataset
@@ -474,7 +475,10 @@ export default class VisitorGraph extends React.Component {
   }
 
   fetchTopStatData() {
-    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, this.props.query)
+    const query = { ...this.props.query }
+    if (!isComparisonEnabled(query.comparison)) query.comparison = 'previous_period'
+
+    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/top-stats`, query)
       .then((res) => {
         res.top_stats = this.maybeRemoveFeatureFlaggedMetrics(res.top_stats)
         this.setState({ topStatsLoadingState: LoadingState.loaded, topStatData: res }, () => {


### PR DESCRIPTION
This commit brings back percentage arrows to default view. These were removed by the recent comparisons work, and we've had reports of people missing it. As we haven't noticed any difference in performance, I've decided to revert that change.