### PR TITLE
Limit ingestion payload size

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -37,6 +37,7 @@ defmodule Plausible.Goal do
     |> validate_event_name_and_page_path()
     |> update_change(:event_name, &String.trim/1)
     |> update_change(:page_path, &String.trim/1)
+    |> validate_length(:event_name, max: 120)
   end
 
   defp validate_event_name_and_page_path(changeset) do

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -58,6 +58,7 @@ defmodule Plausible.Ingestion.Request do
         ])
         |> Changeset.validate_length(:pathname, max: 2000)
         |> Changeset.validate_length(:referrer, max: 2000)
+        |> Changeset.validate_length(:event_name, max: 300)
         |> Changeset.apply_action(nil)
 
       {:error, :invalid_json} ->

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -57,6 +57,7 @@ defmodule Plausible.Ingestion.Request do
           :timestamp
         ])
         |> Changeset.validate_length(:pathname, max: 2000)
+        |> Changeset.validate_length(:referrer, max: 2000)
         |> Changeset.apply_action(nil)
 
       {:error, :invalid_json} ->

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -187,14 +187,10 @@ defmodule Plausible.Ingestion.Request do
     end
   end
 
-  @max_props 50
   @max_prop_key_length 300
   @max_prop_value_length 2000
   defp validate_props(changeset) do
     case Changeset.get_field(changeset, :props) do
-      props when map_size(props) > @max_props ->
-        Changeset.add_error(changeset, :props, "should not have more than #{@max_props} items")
-
       props ->
         Enum.reduce_while(props, changeset, fn
           {key, value}, changeset

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -59,7 +59,7 @@ defmodule Plausible.Ingestion.Request do
         ])
         |> Changeset.validate_length(:pathname, max: 2000)
         |> Changeset.validate_length(:referrer, max: 2000)
-        |> Changeset.validate_length(:event_name, max: 300)
+        |> Changeset.validate_length(:event_name, max: 120)
         |> Changeset.apply_action(nil)
 
       {:error, :invalid_json} ->

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -57,7 +57,6 @@ defmodule Plausible.Ingestion.Request do
           :pathname,
           :timestamp
         ])
-        |> Changeset.validate_length(:pathname, max: 2000)
         |> Changeset.validate_length(:referrer, max: 2000)
         |> Changeset.validate_length(:event_name, max: 120)
         |> Changeset.apply_action(nil)

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -179,7 +179,7 @@ defmodule Plausible.Ingestion.Request do
   @max_props 50
   @max_prop_key_length 300
   @max_prop_value_length 2000
-defp validate_props(changeset) do
+  defp validate_props(changeset) do
     case Changeset.get_field(changeset, :props) do
       props when map_size(props) > @max_props ->
         Changeset.add_error(changeset, :props, "should not have more than #{@max_props} items")
@@ -193,7 +193,7 @@ defp validate_props(changeset) do
              Changeset.add_error(
                changeset,
                :props,
-               "keys should have at most #{@max_prop_key_length} chars and values #{@max_prop_value_length} chars"
+               "keys should have at most #{@max_prop_key_length} bytes and values #{@max_prop_value_length} bytes"
              )}
 
           _, changeset ->

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -12,6 +12,12 @@ defmodule Plausible.GoalsTest do
     assert goal.event_name == "some event name"
   end
 
+  test "create/2 validates goal name is at most 120 chars" do
+    site = insert(:site)
+    assert {:error, changeset} = Goals.create(site, %{"event_name" => String.duplicate("a", 130)})
+    assert {"should be at most %{count} character(s)", _} = changeset.errors[:event_name]
+  end
+
   test "for_site2 returns trimmed input even if it was saved with trailing whitespace" do
     site = insert(:site)
     insert(:goal, %{site: site, event_name: " Signup "})

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -237,7 +237,7 @@ defmodule Plausible.Ingestion.RequestTest do
     assert {"should be at most %{count} character(s)", _} = changeset.errors[:event_name]
   end
 
-  test "returns validaton error when referrer is too long" do
+  test "truncates referrer when too long" do
     payload = %{
       name: "pageview",
       domain: "dummy.site",
@@ -246,8 +246,8 @@ defmodule Plausible.Ingestion.RequestTest do
     }
 
     conn = build_conn(:post, "/api/events", payload)
-    assert {:error, changeset} = Request.build(conn)
-    assert {"should be at most %{count} character(s)", _} = changeset.errors[:referrer]
+    assert {:ok, request} = Request.build(conn)
+    assert request.referrer == String.duplicate("a", 2000)
   end
 
   test "returns validation error when props keys are too long" do

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -213,7 +213,7 @@ defmodule Plausible.Ingestion.RequestTest do
     assert {"scheme is not allowed", _} = changeset.errors[:url]
   end
 
-  test "returns validation error when pathname is too long" do
+  test "returns validation error when url is too long" do
     long_string = for _ <- 1..5000, do: "a", into: ""
 
     payload = %{
@@ -224,7 +224,7 @@ defmodule Plausible.Ingestion.RequestTest do
 
     conn = build_conn(:post, "/api/events", payload)
     assert {:error, changeset} = Request.build(conn)
-    assert {"should be at most %{count} character(s)", _} = changeset.errors[:pathname]
+    assert {"must be a valid url", _} = changeset.errors[:url]
   end
 
   test "malicious input, technically valid json" do

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -261,7 +261,7 @@ defmodule Plausible.Ingestion.RequestTest do
     conn = build_conn(:post, "/api/events", payload)
     assert {:error, changeset} = Request.build(conn)
 
-    assert {"keys should have at most 300 chars and values 2000 chars", _} =
+    assert {"keys should have at most 300 bytes and values 2000 bytes", _} =
              changeset.errors[:props]
   end
 
@@ -276,7 +276,7 @@ defmodule Plausible.Ingestion.RequestTest do
     conn = build_conn(:post, "/api/events", payload)
     assert {:error, changeset} = Request.build(conn)
 
-    assert {"keys should have at most 300 chars and values 2000 chars", _} =
+    assert {"keys should have at most 300 bytes and values 2000 bytes", _} =
              changeset.errors[:props]
   end
 

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -280,7 +280,7 @@ defmodule Plausible.Ingestion.RequestTest do
              changeset.errors[:props]
   end
 
-  test "returns validation error when there are too many props" do
+  test "does not fail when sending many props" do
     payload = %{
       name: "pageview",
       domain: "dummy.site",
@@ -289,8 +289,8 @@ defmodule Plausible.Ingestion.RequestTest do
     }
 
     conn = build_conn(:post, "/api/events", payload)
-    assert {:error, changeset} = Request.build(conn)
-    assert {"should not have more than 50 items", _} = changeset.errors[:props]
+    assert {:ok, request} = Request.build(conn)
+    assert map_size(request.props) == 100
   end
 
   test "malicious input, technically valid json" do

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -35,6 +35,23 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.pathname == "/"
     end
 
+    test "validates event name length", %{conn: conn, site: site} do
+      params = %{
+        domain: site.domain,
+        name: for(_ <- 1..500, do: "a", into: ""),
+        url: "http://gigride.live/",
+        referrer: "http://m.facebook.com/"
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      assert %{"errors" => %{"event_name" => ["should be at most 300 character(s)"]}} =
+               json_response(conn, 400)
+    end
+
     test "works with Content-Type: text/plain", %{conn: conn, site: site} do
       params = %{
         domain: site.domain,

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -250,6 +250,23 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.referrer_source == "Facebook"
     end
 
+    test "limits referrer string size", %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://gigride.live/",
+        referrer: "https://facebook.com/#{for _ <- 1..2500, do: "a", into: ""}",
+        domain: site.domain
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      assert %{"errors" => %{"referrer" => ["should be at most 2000 character(s)"]}} =
+               json_response(conn, 400)
+    end
+
     test "strips trailing slash from referrer", %{conn: conn, site: site} do
       params = %{
         name: "pageview",

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -448,6 +448,28 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert pageview.utm_campaign == "video_story"
     end
 
+    test "validates url length with query params", %{conn: conn, site: site} do
+      long_string = for _ <- 1..500, do: "a", into: ""
+
+      utm_tags =
+        URI.encode_query(%{
+          utm_content: long_string,
+          utm_medium: long_string,
+          utm_source: long_string,
+          utm_campaign: long_string,
+          utm_term: long_string
+        })
+
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?#{utm_tags}",
+        domain: site.domain
+      }
+
+      conn = post(conn, "/api/event", params)
+      assert %{"errors" => %{"url" => ["must be a valid url"]}} = json_response(conn, 400)
+    end
+
     test "if it's an :unknown referrer, just the domain is used", %{conn: conn, site: site} do
       params = %{
         name: "pageview",

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     test "validates event name length", %{conn: conn, site: site} do
       params = %{
         domain: site.domain,
-        name: for(_ <- 1..500, do: "a", into: ""),
+        name: String.duplicate("a", 500),
         url: "http://gigride.live/",
         referrer: "http://m.facebook.com/"
       }
@@ -271,7 +271,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       params = %{
         name: "pageview",
         url: "http://gigride.live/",
-        referrer: "https://facebook.com/#{for _ <- 1..2500, do: "a", into: ""}",
+        referrer: "https://facebook.com/" <> String.duplicate("a", 2500),
         domain: site.domain
       }
 
@@ -449,7 +449,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
 
     test "validates url length with query params", %{conn: conn, site: site} do
-      long_string = for _ <- 1..500, do: "a", into: ""
+      long_string = String.duplicate("a", 500)
 
       utm_tags =
         URI.encode_query(%{
@@ -622,7 +622,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
 
     test "validates props key length", %{conn: conn, site: site} do
-      long_string = for _ <- 1..500, do: "a", into: ""
+      long_string = String.duplicate("a", 500)
 
       params = %{
         name: "Signup",
@@ -641,7 +641,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
 
     test "validates props value length", %{conn: conn, site: site} do
-      long_string = for _ <- 1..2500, do: "a", into: ""
+      long_string = String.duplicate("a", 2500)
 
       params = %{
         name: "Signup",

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -635,7 +635,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert %{
                "errors" => %{
-                 "props" => ["keys should have at most 300 chars and values 2000 chars"]
+                 "props" => ["keys should have at most 300 bytes and values 2000 bytes"]
                }
              } = json_response(conn, 400)
     end
@@ -654,7 +654,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert %{
                "errors" => %{
-                 "props" => ["keys should have at most 300 chars and values 2000 chars"]
+                 "props" => ["keys should have at most 300 bytes and values 2000 bytes"]
                }
              } = json_response(conn, 400)
     end

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -48,7 +48,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      assert %{"errors" => %{"event_name" => ["should be at most 300 character(s)"]}} =
+      assert %{"errors" => %{"event_name" => ["should be at most 120 character(s)"]}} =
                json_response(conn, 400)
     end
 


### PR DESCRIPTION
### Changes

This pull request adds constraints on user input values during ingestion. The purpose of this PR is to filter out unrealistic or invalid inputs. More comments about each limit inline. 

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI