### PR TITLE
Filter out garbage props by `site.allowed_event_props`

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -17,6 +17,7 @@ defmodule Plausible.Site do
     field :locked, :boolean
     field :stats_start_date, :date
     field :native_stats_start_at, :naive_datetime
+    field :allowed_event_props, {:array, :string}
 
     field :ingest_rate_limit_scale_seconds, :integer, default: 60
     # default is set via changeset/2
@@ -158,6 +159,10 @@ defmodule Plausible.Site do
         source: imported_source
       }
     )
+  end
+
+  def set_allowed_event_props(site, list) do
+    change(site, allowed_event_props: list)
   end
 
   def remove_imported_data(site) do

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -41,7 +41,14 @@ defmodule Plausible.SiteAdmin do
       public: nil,
       owner: %{value: &get_owner_email/1},
       other_members: %{value: &get_other_members/1},
-      allowed_event_props: %{value: &Enum.join(&1.allowed_event_props, ", ")},
+      allowed_event_props: %{
+        value: fn site ->
+          case site.allowed_event_props do
+            nil -> ""
+            list -> Enum.join(list, ", ")
+          end
+        end
+      },
       limits: %{
         value: fn site ->
           case site.ingest_rate_limit_threshold do
@@ -74,7 +81,9 @@ defmodule Plausible.SiteAdmin do
   def set_allowed_props_for_site(_conn, [site], params) do
     props_list =
       case params["props"] do
-        "" -> []
+        "" ->
+          nil
+
         props ->
           props
           |> String.trim()
@@ -83,6 +92,7 @@ defmodule Plausible.SiteAdmin do
 
     Plausible.Site.set_allowed_event_props(site, props_list)
     |> Repo.update!()
+
     :ok
   end
 

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -41,6 +41,7 @@ defmodule Plausible.SiteAdmin do
       public: nil,
       owner: %{value: &get_owner_email/1},
       other_members: %{value: &get_other_members/1},
+      allowed_event_props: %{value: &Enum.join(&1.allowed_event_props, ", ")},
       limits: %{
         value: fn site ->
           case site.ingest_rate_limit_threshold do
@@ -51,6 +52,42 @@ defmodule Plausible.SiteAdmin do
         end
       }
     ]
+  end
+
+  def list_actions(_conn) do
+    [
+      set_allowed_event_props: %{
+        inputs: [
+          %{
+            name: "props",
+            title:
+              "Insert comma separated property names (e.g: author, logged_in, url, ...). Submit a blank field to allow all property names",
+            default: ""
+          }
+        ],
+        name: "Allow only these custom properties",
+        action: &set_allowed_props_for_site/3
+      }
+    ]
+  end
+
+  def set_allowed_props_for_site(_conn, [site], params) do
+    props_list =
+      case params["props"] do
+        "" -> []
+        props ->
+          props
+          |> String.trim()
+          |> String.split(~r/\s*,\s*/)
+      end
+
+    Plausible.Site.set_allowed_event_props(site, props_list)
+    |> Repo.update!()
+    :ok
+  end
+
+  def set_allowed_props_for_site(_, _, _) do
+    {:error, "Please select only one site for this action"}
   end
 
   defp format_date(date) do

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -80,14 +80,9 @@ defmodule Plausible.SiteAdmin do
 
   def set_allowed_props_for_site(_conn, [site], params) do
     props_list =
-      case params["props"] do
-        "" ->
-          nil
-
-        props ->
-          props
-          |> String.trim()
-          |> String.split(~r/\s*,\s*/)
+      case String.trim(params["props"]) do
+        "" -> nil
+        props -> String.split(props, ~r/\s*,\s*/)
       end
 
     Plausible.Site.set_allowed_event_props(site, props_list)

--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -48,4 +48,11 @@ defmodule Plausible.Stats.CustomProps do
         |> ClickhouseRepo.all()
     end
   end
+
+  def drop_garbage_props(props, site) do
+    case site.allowed_event_props do
+      [] -> props
+      allowed_props -> Enum.filter(props, &(&1 in allowed_props))
+    end
+  end
 end

--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -32,6 +32,7 @@ defmodule Plausible.Stats.CustomProps do
       {:matches, _} -> fetch_prop_names(site, query)
       _ -> []
     end
+    |> drop_garbage_props(site)
   end
 
   defp fetch_prop_names(site, query) do

--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -52,7 +52,7 @@ defmodule Plausible.Stats.CustomProps do
 
   def drop_garbage_props(props, site) do
     case site.allowed_event_props do
-      [] -> props
+      nil -> props
       allowed_props -> Enum.filter(props, &(&1 in allowed_props))
     end
   end

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -133,23 +133,17 @@ defmodule Plausible.Stats.FilterSuggestions do
   def filter_suggestions(site, query, "prop_key", filter_search) do
     filter_query = if filter_search == nil, do: "%", else: "%#{filter_search}%"
 
-    all_props_allowed = is_nil(site.allowed_event_props)
-    allowed_props = if all_props_allowed, do: [], else: site.allowed_event_props
-
-    q =
-      from(e in base_event_query(site, Query.remove_event_filters(query, [:props])),
-        inner_lateral_join: meta in "meta",
-        as: :meta,
-        select: meta.key,
-        where:
-          fragment("? ilike ?", meta.key, ^filter_query) and
-            (^all_props_allowed or meta.key in ^allowed_props),
-        group_by: meta.key,
-        order_by: [desc: fragment("count(*)")],
-        limit: 25
-      )
-
-    ClickhouseRepo.all(q)
+    from(e in base_event_query(site, Query.remove_event_filters(query, [:props])),
+      inner_lateral_join: meta in "meta",
+      as: :meta,
+      select: meta.key,
+      where: fragment("? ilike ?", meta.key, ^filter_query),
+      group_by: meta.key,
+      order_by: [desc: fragment("count(*)")],
+      limit: 25
+    )
+    |> Plausible.Stats.CustomProps.maybe_allowed_props_only(site.allowed_event_props)
+    |> ClickhouseRepo.all()
     |> wrap_suggestions()
   end
 

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -145,6 +145,7 @@ defmodule Plausible.Stats.FilterSuggestions do
       )
 
     ClickhouseRepo.all(q)
+    |> Plausible.Stats.CustomProps.drop_garbage_props(site)
     |> wrap_suggestions()
   end
 

--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
 
   def change do
     alter table("sites") do
-      add :allowed_event_props, {:array, :string}, default: []
+      add :allowed_event_props, {:array, :string}, null: false, default: []
     end
   end
 end

--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
 
   def change do
     alter table("sites") do
-      add :allowed_event_props, {:array, :string}, null: false, default: []
+      add :allowed_event_props, {:array, :string}
     end
   end
 end

--- a/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
+++ b/priv/repo/migrations/20230503094245_add_event_prop_allowlist_to_site.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddEventPropAllowlistToSite do
+  use Ecto.Migration
+
+  def change do
+    alter table("sites") do
+      add :allowed_event_props, {:array, :string}, default: []
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -362,7 +362,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert [%{"prop_names" => []}] = json_response(conn, 200)
     end
 
-    test "does not filter any prop names by default (when allowed_event_props=[])",
+    test "does not filter any prop names by default (when site.allowed_event_props is nil)",
          %{
            conn: conn,
            site: site

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -299,7 +299,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
              ]
     end
 
-    test "returns prop_names=nil when goal :member + property filter are applied at the same time",
+    test "returns prop_names=[] when goal :member + property filter are applied at the same time",
          %{
            conn: conn,
            site: site
@@ -329,6 +329,65 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
 
       assert [%{"prop_names" => []}] = json_response(conn, 200)
+    end
+
+    test "filters out garbage prop_names",
+         %{
+           conn: conn,
+           site: site
+         } do
+      site =
+        site
+        |> Plausible.Site.set_allowed_event_props(["author"])
+        |> Plausible.Repo.update!()
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          "meta.key": ["Garbage"],
+          "meta.value": ["321"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["OnlyGarbage"],
+          "meta.value": ["123"]
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!(%{goal: "Payment"})
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert [%{"prop_names" => []}] = json_response(conn, 200)
+    end
+
+    test "does not filter any prop names by default (when allowed_event_props=[])",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          "meta.key": ["Garbage"],
+          "meta.value": ["321"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["OnlyGarbage"],
+          "meta.value": ["123"]
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!(%{goal: "Payment"})
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert [%{"prop_names" => prop_names}] = json_response(conn, 200)
+      assert "Garbage" in prop_names
+      assert "OnlyGarbage" in prop_names
     end
 
     test "can filter by multiple mixed goals", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -344,6 +344,11 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       populate_stats(site, [
         build(:event,
           name: "Payment",
+          "meta.key": ["author"],
+          "meta.value": ["Valdis"]
+        ),
+        build(:event,
+          name: "Payment",
           "meta.key": ["Garbage"],
           "meta.value": ["321"]
         ),
@@ -359,7 +364,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       filters = Jason.encode!(%{goal: "Payment"})
       conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
 
-      assert [%{"prop_names" => []}] = json_response(conn, 200)
+      assert [%{"prop_names" => ["author"]}] = json_response(conn, 200)
     end
 
     test "does not filter any prop names by default (when site.allowed_event_props is nil)",

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -313,7 +313,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
              ]
     end
 
-    test "does not filter out prop key suggestions by default (when site.allowed_event_props=[])",
+    test "does not filter out prop key suggestions by default (when site.allowed_event_props is nil)",
          %{
            conn: conn,
            site: site

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -278,6 +278,73 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
              ]
     end
 
+    test "returns suggestions for prop key based on site.allowed_event_props list", %{
+      conn: conn,
+      site: site
+    } do
+      site =
+        site
+        |> Plausible.Site.set_allowed_event_props(["author"])
+        |> Plausible.Repo.update!()
+
+      populate_stats(site, [
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["garbage1"],
+          "meta.value": ["somegarbage1"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["garbage2"],
+          "meta.value": ["somegarbage2"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
+
+      assert json_response(conn, 200) == [
+               %{"label" => "author", "value" => "author"}
+             ]
+    end
+
+    test "does not filter out prop key suggestions by default (when site.allowed_event_props=[])",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["garbage1"],
+          "meta.value": ["somegarbage1"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["garbage2"],
+          "meta.value": ["somegarbage2"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
+
+      suggestions = json_response(conn, 200)
+      assert %{"label" => "author", "value" => "author"} in suggestions
+      assert %{"label" => "garbage1", "value" => "garbage1"} in suggestions
+      assert %{"label" => "garbage2", "value" => "garbage2"} in suggestions
+    end
+
     test "returns suggestions for prop value ordered by count, but (none) value is always first",
          %{conn: conn, site: site} do
       populate_stats(site, [


### PR DESCRIPTION
### Changes

This PR builds on top of https://github.com/plausible/analytics/pull/2894 that contains the migration that should be run on production **before this PR is deployed**.

This PR changes the behavior of returning custom properties for:

* property name suggestions
![image](https://user-images.githubusercontent.com/56999674/237035742-961728ca-1385-4d2d-8c38-46a32713c5e4.png)

* goal conversions:
![image](https://user-images.githubusercontent.com/56999674/237036027-b5ad60c2-64f1-42c6-aa13-628b41a9a5e9.png)

The properties returned will now be filtered by the custom allowlist, that can be defined for each site in the CRM. For example, if we were to set the allowlist to `author, logged_in`, the above screenshots would only contain those property names - nothing else.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
