### PR TITLE
Drop events/sessions tables after V2 migration

### DIFF
--- a/priv/ingest_repo/migrations/20230509124919_clean_up_old_tables_after_v2_migration.exs
+++ b/priv/ingest_repo/migrations/20230509124919_clean_up_old_tables_after_v2_migration.exs
@@ -1,0 +1,8 @@
+defmodule Plausible.IngestRepo.Migrations.CleanUpOldTablesAfterV2Migration do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists table(:events)
+    drop_if_exists table(:sessions)
+  end
+end


### PR DESCRIPTION
### Changes

This PR adds a housekeeping migration to drop the unused tables ref: #2868 
#2825 #2777  

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
