### PR TITLE
Ignore missing subscription on update

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -201,11 +201,14 @@ defmodule Plausible.Billing do
   end
 
   defp handle_subscription_updated(params) do
-    Subscription
-    |> Repo.get_by!(paddle_subscription_id: params["subscription_id"])
-    |> Subscription.changeset(format_subscription(params))
-    |> Repo.update!()
-    |> after_subscription_update()
+    subscription = Repo.get_by(Subscription, paddle_subscription_id: params["subscription_id"])
+
+    if subscription do
+      subscription
+      |> Subscription.changeset(format_subscription(params))
+      |> Repo.update!()
+      |> after_subscription_update()
+    end
   end
 
   defp handle_subscription_cancelled(params) do

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -507,6 +507,26 @@ defmodule Plausible.BillingTest do
       assert Repo.reload!(site).locked == true
       assert Repo.reload!(user).grace_period.allowance_required == 11_000
     end
+
+    test "ignores if subscription cannot be found" do
+      user = insert(:user)
+
+      res =
+        Billing.subscription_updated(%{
+          "alert_name" => "subscription_updated",
+          "subscription_id" => "666",
+          "subscription_plan_id" => "new-plan-id",
+          "update_url" => "update_url.com",
+          "cancel_url" => "cancel_url.com",
+          "passthrough" => user.id,
+          "status" => "active",
+          "next_bill_date" => "2019-06-01",
+          "new_unit_price" => "12.00",
+          "currency" => "EUR"
+        })
+
+      assert res == {:ok, nil}
+    end
   end
 
   describe "subscription_cancelled" do


### PR DESCRIPTION
### Changes

Stop throwing Sentry error when subscription cannot be found in Paddle webhook handler.