### PR TITLE
Add unique constraint to api keys

### DIFF
--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -24,7 +24,7 @@ defmodule Plausible.Auth.ApiKey do
     |> validate_required(@required)
     |> generate_key()
     |> process_key()
-    |> unique_constraint([:user_id, :key_hash], error_key: :key)
+    |> unique_constraint(:key_hash, error_key: :key)
   end
 
   def update(schema, attrs \\ %{}) do

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -24,6 +24,7 @@ defmodule Plausible.Auth.ApiKey do
     |> validate_required(@required)
     |> generate_key()
     |> process_key()
+    |> unique_constraint([:user_id, :key_hash], error_key: :key)
   end
 
   def update(schema, attrs \\ %{}) do

--- a/lib/plausible_web/templates/auth/new_api_key.html.eex
+++ b/lib/plausible_web/templates/auth/new_api_key.html.eex
@@ -11,9 +11,10 @@
     <%= label f, :key, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <div class="relative mt-1">
       <%= text_input f, :key, id: "key-input", class: "dark:text-gray-300 shadow-sm bg-gray-50 dark:bg-gray-850 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md pr-16", readonly: "readonly" %>
-        <a onclick="var textarea = document.getElementById('key-input'); textarea.focus(); textarea.select(); document.execCommand('copy');" href="javascript:void(0)" class="absolute flex items-center text-xs font-medium text-indigo-600 no-underline hover:underline"  style="top: 12px; right: 12px;">
-          <svg class="pr-1 text-indigo-600 dark:text-indigo-500" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>COPY
-        </a>
+      <a onclick="var textarea = document.getElementById('key-input'); textarea.focus(); textarea.select(); document.execCommand('copy');" href="javascript:void(0)" class="absolute flex items-center text-xs font-medium text-indigo-600 no-underline hover:underline"  style="top: 12px; right: 12px;">
+        <svg class="pr-1 text-indigo-600 dark:text-indigo-500" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>COPY
+      </a>
+      <%= error_tag f, :key %>
       <p class="mt-2 text-sm text-gray-500 dark:text-gray-200">Make sure to store the key in a secure place. Once created, we will not be able to show it again.</p>
     </div>
   </div>

--- a/priv/repo/migrations/20230516131041_add_unique_index_to_api_keys.exs
+++ b/priv/repo/migrations/20230516131041_add_unique_index_to_api_keys.exs
@@ -2,6 +2,6 @@ defmodule Plausible.Repo.Migrations.AddUniqueIndexToApiKeys do
   use Ecto.Migration
 
   def change do
-    create unique_index(:api_keys, [:user_id, :key_hash])
+    create unique_index(:api_keys, :key_hash)
   end
 end

--- a/priv/repo/migrations/20230516131041_add_unique_index_to_api_keys.exs
+++ b/priv/repo/migrations/20230516131041_add_unique_index_to_api_keys.exs
@@ -1,0 +1,7 @@
+defmodule Plausible.Repo.Migrations.AddUniqueIndexToApiKeys do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:api_keys, [:user_id, :key_hash])
+  end
+end

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -749,8 +749,7 @@ defmodule PlausibleWeb.AuthControllerTest do
           }
         })
 
-      key = Plausible.Auth.ApiKey |> where(user_id: ^user.id) |> Repo.one()
-      assert html_response(conn2, 200) =~ "Key <> already exists"
+      assert html_response(conn2, 200) =~ "has already been taken"
     end
 
     test "can't create api key into another site", %{conn: conn, user: me} do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -709,6 +709,50 @@ defmodule PlausibleWeb.AuthControllerTest do
     setup [:create_user, :log_in]
     import Ecto.Query
 
+    test "can create an API key", %{conn: conn, user: user} do
+      site = insert(:site)
+      insert(:site_membership, site: site, user: user, role: "owner")
+
+      conn =
+        post(conn, "/settings/api-keys", %{
+          "api_key" => %{
+            "user_id" => user.id,
+            "name" => "all your code are belong to us",
+            "key" => "swordfish"
+          }
+        })
+
+      key = Plausible.Auth.ApiKey |> where(user_id: ^user.id) |> Repo.one()
+      assert conn.status == 302
+      assert key.name == "all your code are belong to us"
+    end
+
+    test "cannot create a duplicate API key", %{conn: conn, user: user} do
+      site = insert(:site)
+      insert(:site_membership, site: site, user: user, role: "owner")
+
+      conn =
+        post(conn, "/settings/api-keys", %{
+          "api_key" => %{
+            "user_id" => user.id,
+            "name" => "all your code are belong to us",
+            "key" => "swordfish"
+          }
+        })
+
+      conn2 =
+        post(conn, "/settings/api-keys", %{
+          "api_key" => %{
+            "user_id" => user.id,
+            "name" => "all your code are belong to us",
+            "key" => "swordfish"
+          }
+        })
+
+      key = Plausible.Auth.ApiKey |> where(user_id: ^user.id) |> Repo.one()
+      assert html_response(conn2, 200) =~ "Key <> already exists"
+    end
+
     test "can't create api key into another site", %{conn: conn, user: me} do
       my_site = insert(:site)
       insert(:site_membership, site: my_site, user: me, role: "owner")


### PR DESCRIPTION
### Changes

Adds unique constraint to `api_keys` on the `[:user_id, :key_hash]` field combination. This protects from duplicate API keys being created. The UI provides appropriate feedback:

<img width="859" alt="Screenshot 2023-05-16 at 16 15 44" src="https://github.com/plausible/analytics/assets/3731516/020b8c23-8e59-4d33-8de7-b18a73a72797">
