### PR TITLE
Fix a bug with query bindings

### DIFF
--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -51,7 +51,7 @@ defmodule Plausible.Stats.CustomProps do
   end
 
   def maybe_allowed_props_only(q, allowed_props) when is_list(allowed_props) do
-    from [_e, m] in q, where: m.key in ^allowed_props
+    from [..., m] in q, where: m.key in ^allowed_props
   end
 
   def maybe_allowed_props_only(q, nil), do: q


### PR DESCRIPTION
### Changes

The number of bindings in the query passed to `maybe_allowed_props_only` depends on whether there are session filters applied or not. This PR adds a test for that case and fixes the bug by using the `...` syntax in Ecto.Query to only get the last binding that we actually want.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
