### PR TITLE
add cacertfile to smtp adapter

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -356,6 +356,7 @@ case mailer_adapter do
       password: get_var_from_path_or_env(config_dir, "SMTP_USER_PWD"),
       tls: :if_available,
       allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+      tls_cacertfile: CAStore.file_path(),
       ssl: get_var_from_path_or_env(config_dir, "SMTP_HOST_SSL_ENABLED") || false,
       retries: get_var_from_path_or_env(config_dir, "SMTP_RETRIES") || 2,
       no_mx_lookups: get_var_from_path_or_env(config_dir, "SMTP_MX_LOOKUPS_ENABLED") || true

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -14,6 +14,7 @@ defmodule Plausible.ConfigTest do
                password: nil,
                tls: :if_available,
                allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+               tls_cacertfile: CAStore.file_path(),
                ssl: false,
                retries: 2,
                no_mx_lookups: true
@@ -87,17 +88,18 @@ defmodule Plausible.ConfigTest do
       ]
 
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
-               {:adapter, Bamboo.SMTPAdapter},
-               {:server, "localhost"},
-               {:hostname, "localhost"},
-               {:port, "2525"},
-               {:username, "neo"},
-               {:password, "one"},
-               {:tls, :if_available},
-               {:allowed_tls_versions, [:tlsv1, :"tlsv1.1", :"tlsv1.2"]},
-               {:ssl, "true"},
-               {:retries, "3"},
-               {:no_mx_lookups, "true"}
+               adapter: Bamboo.SMTPAdapter,
+               server: "localhost",
+               hostname: "localhost",
+               port: "2525",
+               username: "neo",
+               password: "one",
+               tls: :if_available,
+               allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+               tls_cacertfile: CAStore.file_path(),
+               ssl: "true",
+               retries: "3",
+               no_mx_lookups: "true"
              ]
     end
 


### PR DESCRIPTION
### Changes

This PR adds cacertfile for SMTP adapter. We can also probably remove `ca-certificates` apk package from the container image if it's not used for anything else.

- [ ] verify it works on my self-hosted instance

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
