### PR TITLE
Escape domain when creating URL for favicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Add error message in case a transfer to an invited (but not joined) user is requested plausible/analytics#2651
 - Fix bug with [showing property breakdown with a prop filter](https://github.com/plausible/analytics/issues/1789)
 - Fix bug when combining goal and prop filters plausible/analytics#2654
+- Fix broken favicons when domain includes a slash
 
 ### Changed
 - Treat page filter as entry page filter for `bounce_rate`

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -80,11 +80,11 @@ defmodule PlausibleWeb.Favicon do
 
   """
   def call(conn, favicon_domains: favicon_domains) do
-    case conn.path_info do
-      ["favicon", "sources", "placeholder"] ->
+    case conn.request_path do
+      "/favicon/sources/placeholder" ->
         send_placeholder(conn)
 
-      ["favicon", "sources", source] ->
+      "/favicon/sources/" <> source ->
         clean_source = URI.decode_www_form(source)
         domain = Map.get(favicon_domains, clean_source, clean_source)
 

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -39,7 +39,7 @@
       <div class="group cursor-pointer" @click="invitationOpen = true; selectedInvitation = invitations['<%= invitation.invitation_id %>']">
         <li class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
           <div class="w-full flex items-center justify-between space-x-4">
-            <img src="/favicon/sources/<%= URI.encode_www_form(invitation.site.domain) %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder';" class="w-4 h-4 flex-shrink-0 mt-px">
+            <img src="/favicon/sources/<%= invitation.site.domain %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder';" class="w-4 h-4 flex-shrink-0 mt-px">
             <div class="flex-1 truncate -mt-px">
               <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100"><%= invitation.site.domain %></h3>
             </div>
@@ -64,7 +64,7 @@
         <%= link(to: "/" <> URI.encode_www_form(site.domain)) do %>
           <li class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
             <div class="w-full flex items-center justify-between space-x-4">
-              <img src="/favicon/sources/<%= URI.encode_www_form(site.domain) %>.ico" class="w-4 h-4 flex-shrink-0 mt-px">
+              <img src="/favicon/sources/<%= site.domain %>.ico" class="w-4 h-4 flex-shrink-0 mt-px">
               <div class="flex-1 -mt-px w-full">
                 <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100" style="width: calc(100% - 4rem)"><%= site.domain %></h3>
               </div>

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -39,7 +39,7 @@
       <div class="group cursor-pointer" @click="invitationOpen = true; selectedInvitation = invitations['<%= invitation.invitation_id %>']">
         <li class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
           <div class="w-full flex items-center justify-between space-x-4">
-            <img src="/favicon/sources/<%= invitation.site.domain %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder';" class="w-4 h-4 flex-shrink-0 mt-px">
+            <img src="/favicon/sources/<%= URI.encode_www_form(invitation.site.domain) %>.ico" onerror="this.onerror=null; this.src='/favicon/sources/placeholder';" class="w-4 h-4 flex-shrink-0 mt-px">
             <div class="flex-1 truncate -mt-px">
               <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100"><%= invitation.site.domain %></h3>
             </div>
@@ -64,7 +64,7 @@
         <%= link(to: "/" <> URI.encode_www_form(site.domain)) do %>
           <li class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
             <div class="w-full flex items-center justify-between space-x-4">
-              <img src="/favicon/sources/<%= site.domain %>.ico" class="w-4 h-4 flex-shrink-0 mt-px">
+              <img src="/favicon/sources/<%= URI.encode_www_form(site.domain) %>.ico" class="w-4 h-4 flex-shrink-0 mt-px">
               <div class="flex-1 -mt-px w-full">
                 <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100" style="width: calc(100% - 4rem)"><%= site.domain %></h3>
               </div>

--- a/test/plausible_web/plugs/favicon_test.exs
+++ b/test/plausible_web/plugs/favicon_test.exs
@@ -38,6 +38,24 @@ defmodule PlausibleWeb.FaviconTest do
     assert conn.resp_body == "favicon response body"
   end
 
+  test "requests favicon from DDG when domain contains a forward slash", %{plug_opts: plug_opts} do
+    expect(
+      Plausible.HTTPClient.Mock,
+      :get,
+      fn "https://icons.duckduckgo.com/ip3/site.com/subfolder.ico" ->
+        {:ok, %Finch.Response{status: 200, body: "favicon response body"}}
+      end
+    )
+
+    conn =
+      conn(:get, "/favicon/sources/site.com/subfolder")
+      |> Favicon.call(plug_opts)
+
+    assert conn.halted
+    assert conn.status == 200
+    assert conn.resp_body == "favicon response body"
+  end
+
   test "sets content-disposition and content-security-policy", %{plug_opts: plug_opts} do
     expect(
       Plausible.HTTPClient.Mock,


### PR DESCRIPTION
### Changes

Domains can include slashes, e.g. I have created a site with the "domain" "vangberg.github.io/adventures-in-bioimaging". I am not sure if you are supposed to be able to do that, but it does seem to work.

One thing that does not work, is that the favicon is broken on "My sites" (but not on the stats page for the site itself):

<img width="378" alt="image" src="https://github.com/plausible/analytics/assets/252/0e3b0a5c-f7cc-4a68-8a64-b5e4b5c6404a">

The culprit is that the "domain" is not being escaped before being used in the URL for the image tag. This is done in other parts of the codebase, e.g. in the `SiteSwitcher` component:

 https://github.com/plausible/analytics/blob/f29d07a49e91ecfe0aa87de1b4b5c011e26c722a/assets/js/dashboard/site-switcher.js#L11

This pull requests adds URL escaping to the domain in the site index template.

### Tests
- [x] This PR does not require tests (I think?)

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
