### PR TITLE
skip v1 table drop in self-host

### DIFF
--- a/priv/ingest_repo/migrations/20230509124919_clean_up_old_tables_after_v2_migration.exs
+++ b/priv/ingest_repo/migrations/20230509124919_clean_up_old_tables_after_v2_migration.exs
@@ -2,7 +2,11 @@ defmodule Plausible.IngestRepo.Migrations.CleanUpOldTablesAfterV2Migration do
   use Ecto.Migration
 
   def change do
-    drop_if_exists table(:events)
-    drop_if_exists table(:sessions)
+    selfhost? = Application.fetch_env!(:plausible, :is_selfhost)
+
+    unless selfhost? do
+      drop_if_exists table(:events)
+      drop_if_exists table(:sessions)
+    end
   end
 end


### PR DESCRIPTION
### Changes

This PR wraps v1 events and sessions tables drop in a conditional block.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
