### PR TITLE
Fix tracker bug - call callback function when ignoring event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Ability to change domain for existing site (requires numeric IDs data migration, instructions will be provided separately) UI + API (`PUT /api/v1/sites`)
 
 ### Fixed
+- Fix tracker bug - call callback function even when event is ignored
 - Make goal-filtered CSV export return only unique_conversions timeseries in the 'visitors.csv' file
 - Stop treating page filter as an entry page filter
 - City report showing N/A instead of city names with imported data plausible/analytics#2675


### PR DESCRIPTION
### Changes

This PR fixes tracker behavior in the situation where an event is ignored. If a callback function is provided within the `options`, we still want to call that, even when the event is ignored.

I'm almost sure that this fixes https://github.com/plausible/analytics/issues/2940.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
