### PR TITLE
Revenue tracking: Add revenue tracking fields to events

### DIFF
--- a/priv/ingest_repo/migrations/20230417104025_add_revenue_to_events.exs
+++ b/priv/ingest_repo/migrations/20230417104025_add_revenue_to_events.exs
@@ -1,0 +1,13 @@
+defmodule Plausible.IngestRepo.Migrations.AddRevenueToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events_v2) do
+      add :revenue_reporting_amount, :"Decimal64(4)"
+      add :revenue_reporting_currency, :"LowCardinality(FixedString(3))"
+
+      add :revenue_source_amount, :"Decimal64(4)"
+      add :revenue_source_currency, :"LowCardinality(FixedString(3))"
+    end
+  end
+end

--- a/priv/ingest_repo/migrations/20230417104025_add_revenue_to_events.exs
+++ b/priv/ingest_repo/migrations/20230417104025_add_revenue_to_events.exs
@@ -4,10 +4,10 @@ defmodule Plausible.IngestRepo.Migrations.AddRevenueToEvents do
   def change do
     alter table(:events_v2) do
       add :revenue_reporting_amount, :"Decimal64(4)"
-      add :revenue_reporting_currency, :"LowCardinality(FixedString(3))"
+      add :revenue_reporting_currency, :"FixedString(3)"
 
       add :revenue_source_amount, :"Decimal64(4)"
-      add :revenue_source_currency, :"LowCardinality(FixedString(3))"
+      add :revenue_source_currency, :"FixedString(3)"
     end
   end
 end


### PR DESCRIPTION
This commit adds 4 fields to the ClickHouse events_v2 table:

* `revenue_source_amount` and `revenue_source_currency` store revenue in the original currency sent during ingestion

* `revenue_reporting_amount` and `revenue_reporting_currency` store revenue in a common currency to perform calculations, and this currency is defined by the user when setting up the goal