### PR TITLE
Fix issue with sampling and joins

### DIFF
--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -424,7 +424,10 @@ defmodule Plausible.Stats.Base do
     if Query.has_event_filters?(query) do
       converted_sessions =
         from(e in query_events(site, query),
-          select: %{session_id: fragment("DISTINCT ?", e.session_id)}
+          select: %{
+            session_id: fragment("DISTINCT ?", e.session_id),
+            _sample_factor: fragment("_sample_factor")
+          }
         )
 
       from(s in db_query,


### PR DESCRIPTION
### Changes

We have a sampling-related bug which seems to be caused by a query like this:

```sql
SELECT sum(sign) * any(_sample_factor) FROM sessions_v2 SAMPLE 20_000_000 INNER JOIN (SELECT DISTINCT session_id FROM EVENTS SAMPLE 20_000_000);
```

Adding `_sample_factor` to the SELECT part of the right side seems to fix the bug:
```sql
SELECT sum(sign) * any(_sample_factor) FROM sessions_v2 SAMPLE 20_000_000 INNER JOIN (SELECT DISTINCT session_id, _sample_factor FROM EVENTS SAMPLE 20_000_000);
```

This is very hard to test with unit tests, the fix was confirmed using real data with >10m records.

Passing `_sample_factor` from the right side to left seems to help Clickhouse keep the sampling context intact and inflate the numbers correctly on the other side of the join.

In the future we should review our approach on sampling with some Clickhouse experts, but I'd like to get this change in since it fixes a bug that customers are experiencing.