### PR TITLE
Wrap user deletion in DB transaction

### DIFF
--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -82,6 +82,26 @@ defmodule Plausible.Auth do
     Enum.any?(sites, &Plausible.Sites.has_stats?/1)
   end
 
+  def delete_user(user) do
+    Repo.transaction(fn ->
+      user =
+        user
+        |> Repo.preload(site_memberships: :site)
+        |> Repo.preload(:subscription)
+
+      for membership <- user.site_memberships do
+        Repo.delete!(membership)
+
+        if membership.role == :owner do
+          Plausible.Site.Removal.run(membership.site.domain)
+        end
+      end
+
+      if user.subscription, do: Repo.delete!(user.subscription)
+      Repo.delete!(user)
+    end)
+  end
+
   def user_owns_sites?(user) do
     Repo.exists?(
       from(s in Plausible.Site,

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -533,21 +533,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def delete_me(conn, params) do
-    user =
-      conn.assigns[:current_user]
-      |> Repo.preload(site_memberships: :site)
-      |> Repo.preload(:subscription)
-
-    for membership <- user.site_memberships do
-      Repo.delete!(membership)
-
-      if membership.role == :owner do
-        Plausible.Site.Removal.run(membership.site.domain)
-      end
-    end
-
-    if user.subscription, do: Repo.delete!(user.subscription)
-    Repo.delete!(user)
+    Plausible.Auth.delete_user(conn.assigns[:current_user])
 
     logout(conn, params)
   end

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -692,6 +692,8 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       conn = delete(conn, "/me")
       assert redirected_to(conn) == "/"
+      assert Repo.reload(site) == nil
+      assert Repo.reload(user) == nil
     end
 
     test "deletes sites that the user owns", %{conn: conn, user: user, site: owner_site} do


### PR DESCRIPTION
### Changes

Reduces the possibility of reaching an inconsistent state with the database. Extracting the `Plausible.Auth.delete_user/1` function also allows us to easily retry failed deletions manually from iex.