### PR TITLE
Limit width of embedded dashboards by default

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   safelist: [
     // PlausibleWeb.StatsView.stats_container_class/1 uses this class
     // it's not used anywhere else in the templates or scripts
-    "max-w-screen-lg"
+    "max-w-screen-xl"
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
### Changes

Fixes a bug that was introduced in https://github.com/plausible/analytics/pull/2744

Embedded dashboards used to be limited to `max-w-screen-lg` by default. I changed it to `max-w-screen-xl` to provide more space for shadows. But I forgot to update the Tailwind safelist which made the class not apply at all in production.