### PR TITLE
Allow optional IPv6 for clickhouse repo

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -282,7 +282,7 @@ maybe_ch_ipv6 =
 ch_transport_opts = [
   keepalive: true,
   show_econnreset: true,
-  inet6: maybe_ch_ipv6,
+  inet6: maybe_ch_ipv6
 ]
 
 config :plausible, Plausible.ClickhouseRepo,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -275,9 +275,14 @@ config :plausible, :google,
   reporting_api_url: "https://analyticsreporting.googleapis.com",
   max_buffer_size: get_int_from_path_or_env(config_dir, "GOOGLE_MAX_BUFFER_SIZE", 10_000)
 
+maybe_ch_ipv6 =
+  get_var_from_path_or_env(config_dir, "ECTO_CH_IPV6", "false")
+  |> String.to_existing_atom()
+
 ch_transport_opts = [
   keepalive: true,
-  show_econnreset: true
+  show_econnreset: true,
+  inet6: maybe_ch_ipv6,
 ]
 
 config :plausible, Plausible.ClickhouseRepo,


### PR DESCRIPTION
### Changes

Adds optional support for connect to clickhouse over ipv6. Same as #1661, but for clickhouse.

### Tests
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
