### PR TITLE
Fix event name validation

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -1,3 +1,16 @@
+defmodule Plausible.Ecto.EventName do
+  use Ecto.Type
+  def type, do: :string
+
+  def cast(val) when is_binary(val), do: {:ok, val}
+  def cast(val) when is_integer(val), do: {:ok, Integer.to_string(val)}
+
+  # Everything else is a failure though
+  def cast(_), do: :error
+  def load(val), do: {:ok, val}
+  def dump(val), do: {:ok, val}
+end
+
 defmodule Plausible.Ingestion.Request do
   @moduledoc """
   The %Plausible.Ingestion.Request{} struct stores all needed fields
@@ -13,12 +26,12 @@ defmodule Plausible.Ingestion.Request do
   embedded_schema do
     field :remote_ip, :string
     field :user_agent, :string
-    field :event_name, :string
+    field :event_name, Plausible.Ecto.EventName
     field :uri, :map
     field :hostname, :string
     field :referrer, :string
     field :domains, {:array, :string}
-    field :hash_mode, :string
+    field :hash_mode, :integer
     field :pathname, :string
     field :props, :map
     field :query_params, :map
@@ -88,10 +101,13 @@ defmodule Plausible.Ingestion.Request do
   end
 
   defp put_request_params(changeset, %{} = request_body) do
-    Changeset.change(
+    Changeset.cast(
       changeset,
-      event_name: request_body["n"] || request_body["name"],
-      hash_mode: request_body["h"] || request_body["hashMode"]
+      %{
+        event_name: request_body["n"] || request_body["name"],
+        hash_mode: request_body["h"] || request_body["hashMode"]
+      },
+      [:event_name, :hash_mode]
     )
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -1,4 +1,9 @@
 defmodule Plausible.Ecto.EventName do
+  @moduledoc """
+    Custom type for event name. Accepts Strings and Integers and stores them as String. Returns
+    cast error if any other type is provided. Accepting integers is important for 404 tracking.
+  """
+
   use Ecto.Type
   def type, do: :string
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -10,7 +10,6 @@ defmodule Plausible.Ecto.EventName do
   def cast(val) when is_binary(val), do: {:ok, val}
   def cast(val) when is_integer(val), do: {:ok, Integer.to_string(val)}
 
-  # Everything else is a failure though
   def cast(_), do: :error
   def load(val), do: {:ok, val}
   def dump(val), do: {:ok, val}

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -119,59 +119,6 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert NaiveDateTime.compare(e1.timestamp, e2.timestamp) == :gt
     end
 
-    test "can send custom event name", %{conn: conn, site: site} do
-      params = %{
-        name: "custom event",
-        url: "http://www.example.com/path ",
-        domain: site.domain
-      }
-
-      post(conn, "/api/event", params)
-
-      event = get_event(site)
-
-      assert event.name == "custom event"
-    end
-
-    test "numeric names are cast to string", %{conn: conn, site: site} do
-      params = %{
-        name: 404,
-        url: "http://www.example.com/path ",
-        domain: site.domain
-      }
-
-      post(conn, "/api/event", params)
-
-      event = get_event(site)
-
-      assert event.name == "404"
-    end
-
-    test "responds with validation error if name is blank", %{conn: conn, site: site} do
-      params = %{
-        name: nil,
-        url: "http://www.example.com/path ",
-        domain: site.domain
-      }
-
-      conn = post(conn, "/api/event", params)
-      assert json_response(conn, 400) == %{"errors" => %{"event_name" => ["can't be blank"]}}
-    end
-
-    test "responds with validation error if name cannot be cast to string", %{
-      conn: conn,
-      site: site
-    } do
-      params = %{
-        name: ["list", "of", "things"],
-        url: "http://www.example.com/path ",
-        domain: site.domain
-      }
-
-      conn = post(conn, "/api/event", params)
-      assert json_response(conn, 400) == %{"errors" => %{"event_name" => ["is invalid"]}}
-    end
-
     test "www. is stripped from domain", %{conn: conn, site: site} do
       params = %{
         name: "custom event",

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -119,6 +119,59 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert NaiveDateTime.compare(e1.timestamp, e2.timestamp) == :gt
     end
 
+    test "can send custom event name", %{conn: conn, site: site} do
+      params = %{
+        name: "custom event",
+        url: "http://www.example.com/path ",
+        domain: site.domain
+      }
+
+      post(conn, "/api/event", params)
+
+      event = get_event(site)
+
+      assert event.name == "custom event"
+    end
+
+    test "numeric names are cast to string", %{conn: conn, site: site} do
+      params = %{
+        name: 404,
+        url: "http://www.example.com/path ",
+        domain: site.domain
+      }
+
+      post(conn, "/api/event", params)
+
+      event = get_event(site)
+
+      assert event.name == "404"
+    end
+
+    test "responds with validation error if name is blank", %{conn: conn, site: site} do
+      params = %{
+        name: nil,
+        url: "http://www.example.com/path ",
+        domain: site.domain
+      }
+
+      conn = post(conn, "/api/event", params)
+      assert json_response(conn, 400) == %{"errors" => %{"event_name" => ["can't be blank"]}}
+    end
+
+    test "responds with validation error if name cannot be cast to string", %{
+      conn: conn,
+      site: site
+    } do
+      params = %{
+        name: ["list", "of", "things"],
+        url: "http://www.example.com/path ",
+        domain: site.domain
+      }
+
+      conn = post(conn, "/api/event", params)
+      assert json_response(conn, 400) == %{"errors" => %{"event_name" => ["is invalid"]}}
+    end
+
     test "www. is stripped from domain", %{conn: conn, site: site} do
       params = %{
         name: "custom event",


### PR DESCRIPTION
### Changes

Currently when an event is sent with a `name` field that is not a String, we run into an Ecto error:

```
CaseClauseError anonymous fn/5 in Ecto.Changeset.validate_length/3
```

This PR makes 2 changes:
1. Accept numeric event names (like `404`)2. 
2. Return validation error if event name is not a String or Integer