### PR TITLE
Enable sampling in the Stats API

### DIFF
--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -12,7 +12,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   def aggregate(conn, params) do
     site = conn.assigns[:site]
-    params = Map.put(params, "sample_threshold", "infinite")
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
@@ -53,7 +52,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   def breakdown(conn, params) do
     site = conn.assigns[:site]
-    params = Map.put(params, "sample_threshold", "infinite")
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
@@ -172,7 +170,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   def timeseries(conn, params) do
     site = conn.assigns[:site]
-    params = Map.put(params, "sample_threshold", "infinite")
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),


### PR DESCRIPTION
We're currently hardcoding `sample_threshold=infinity` in the Stats API. This PR removes the hardcoding so it can be configured, and applies a standard sampling threshold of 20m.