### PR TITLE
add landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 - Ability to change domain for existing site (requires numeric IDs data migration, instructions will be provided separately) UI + API (`PUT /api/v1/sites`)
 - Add `LOG_FAILED_LOGIN_ATTEMPTS` environment variable to enable failed login attempts logs plausible/analytics#2936
 - Add `MAILER_NAME` environment variable support plausible/analytics#2937
-- Add `MAILGUN_BASE_URI` support for `Bamboo.MailgunAdapter` plausible/analytics#2935 
+- Add `MAILGUN_BASE_URI` support for `Bamboo.MailgunAdapter` plausible/analytics#2935
+- Add a landing page for self-hosters plausible/analytics#2989
 
 ### Fixed
 - Fix tracker bug - call callback function even when event is ignored

--- a/lib/plausible_web/controllers/page_controller.ex
+++ b/lib/plausible_web/controllers/page_controller.ex
@@ -5,11 +5,13 @@ defmodule PlausibleWeb.PageController do
   @doc """
   The root path is never accessible in Plausible.Cloud because it is handled by the upstream reverse proxy.
 
-  This controller action is only ever triggered in self-hosted Plausible. It redirects the user to /login where `PlausibleWeb.RequireLoggedOutPlug` plug kicks in. If they are already logged in, they are redirected to /sites, otherwise they'll see the /login page.
+  This controller action is only ever triggered in self-hosted Plausible.
   """
   def index(conn, _params) do
-    conn
-    |> put_session(:login_dest, conn.request_path)
-    |> redirect(to: "/login")
+    render(conn, "index.html",
+      # TODO compile in
+      version: "v2.0.0-rc.1",
+      layout: {PlausibleWeb.LayoutView, "focus.html"}
+    )
   end
 end

--- a/lib/plausible_web/controllers/page_controller.ex
+++ b/lib/plausible_web/controllers/page_controller.ex
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.PageController do
   use PlausibleWeb, :controller
   use Plausible.Repo
 
+  plug PlausibleWeb.RequireLoggedOutPlug
+
   @doc """
   The root path is never accessible in Plausible.Cloud because it is handled by the upstream reverse proxy.
 

--- a/lib/plausible_web/controllers/page_controller.ex
+++ b/lib/plausible_web/controllers/page_controller.ex
@@ -8,10 +8,6 @@ defmodule PlausibleWeb.PageController do
   This controller action is only ever triggered in self-hosted Plausible.
   """
   def index(conn, _params) do
-    render(conn, "index.html",
-      # TODO compile in
-      version: "v2.0.0-rc.1",
-      layout: {PlausibleWeb.LayoutView, "focus.html"}
-    )
+    render(conn, "index.html", layout: {PlausibleWeb.LayoutView, "focus.html"})
   end
 end

--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,0 +1,14 @@
+<div class="bg-white px-8 py-6 mx-auto max-w-xl rounded shadow">
+  <p class="font-semibold leading-10 text-gray-900">
+    Welcome to Plausible <a href="https://github.com/plausible/analytics/tree/v2.0.0-rc.1"><small class="bg-gray-300 rounded-full ml-0.5 px-2 py-0.5 font-medium leading-6"><%= @version %></small></a>
+  </p>
+  <ul>
+    <li><a href="/login">Login</a></li>
+    <li><a href="/register">Register</a></li>
+    <li><a href="https://plausible.io/docs/self-hosting">Guides &amp; Docs</a></li>
+    <li><a href="https://github.com/plausible/analytics">Source Code
+    <li><a href="https://github.com/plausible/analytics/discussions">Discuss</a></li>
+    <li><a href="https://github.com/plausible/analytics/blob/<%= @version %>/CHANGELOG.md">Changelog</a></li>
+    <li><a href="https://twitter.com/PlausibleHQ">Follow on Twitter</a></li>
+  </ul>
+</div>

--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,38 +1,34 @@
-<div class="max-w-xl mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mb-4 mt-8">
+<div class="w-full md:max-w-xl md:mx-auto bg-white dark:bg-gray-800 md:shadow-md md:rounded px-8 py-6">
   <p class="text-gray-900 text-xl font-black dark:text-gray-100">
     Welcome to Plausible Analytics!
   </p>
   <p class="mt-4 text-gray-600 dark:text-gray-200">
   <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">Plausible Analytics</a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
   </p>
-  <div class="mt-6 flex text-gray-700 dark:text-gray-300">
-    <ul class="w-1/2 space-y-1">
-      <li>
-        <%= link to: Routes.auth_path(@conn, :login), class: "flex items-center" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-log-in h-4 w-4"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path><polyline points="10 17 15 12 10 7"></polyline><line x1="15" y1="12" x2="3" y2="12"></line></svg>
-          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Login</span>
-        <% end %>
-      </li>
-      <li>
-        <%= link to: Routes.auth_path(@conn, :register), class: "flex items-center" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-user-plus h-4 w-4"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
-          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Register</span>
-        <% end %>
-      </li>
-    </ul>
-    <ul class="w-1/2 space-y-1">
-      <li>
-        <a href="https://plausible.io/docs" class="flex items-center">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-book-open h-4 w-4"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
-          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Guides &amp; Docs</span>
-        </a>
-      </li>
-      <li>
-        <a href="" class="flex items-center">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-twitter h-4 w-4"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path></svg>
-          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Follow on Twitter</span>
-        </a>
-      </li>
-    </ul>
-  </div>
+  <ul class="mt-6 flex flex-wrap text-gray-700 dark:text-gray-300 space-y-1 md:space-y-0">
+    <li class="w-full md:w-1/2 md:order-1">
+      <%= link to: Routes.auth_path(@conn, :login), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-log-in h-4 w-4"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path><polyline points="10 17 15 12 10 7"></polyline><line x1="15" y1="12" x2="3" y2="12"></line></svg>
+        <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Login</span>
+      <% end %>
+    </li>
+    <li class="w-full md:mt-1 md:w-1/2 md:order-3">
+      <%= link to: Routes.auth_path(@conn, :register), class: "flex items-center" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-user-plus h-4 w-4"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
+        <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Register</span>
+      <% end %>
+    </li>
+    <li class="w-full md:w-1/2 md:order-2">
+      <a href="https://plausible.io/docs" class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-book-open h-4 w-4"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+        <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Guides &amp; Docs</span>
+      </a>
+    </li>
+    <li class="w-full md:mt-1 md:w-1/2 md:order-4">
+      <a href="" class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-twitter h-4 w-4"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path></svg>
+        <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Follow on Twitter</span>
+      </a>
+    </li>
+  </ul>
 </div>

--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,14 +1,38 @@
-<div class="bg-white px-8 py-6 mx-auto max-w-xl rounded shadow">
-  <p class="font-semibold leading-10 text-gray-900">
-    Welcome to Plausible <a href="https://github.com/plausible/analytics/tree/v2.0.0-rc.1"><small class="bg-gray-300 rounded-full ml-0.5 px-2 py-0.5 font-medium leading-6"><%= @version %></small></a>
+<div class="max-w-xl mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mb-4 mt-8">
+  <p class="text-gray-900 text-xl font-black dark:text-gray-100">
+    Welcome to Plausible Analytics!
   </p>
-  <ul>
-    <li><a href="/login">Login</a></li>
-    <li><a href="/register">Register</a></li>
-    <li><a href="https://plausible.io/docs/self-hosting">Guides &amp; Docs</a></li>
-    <li><a href="https://github.com/plausible/analytics">Source Code
-    <li><a href="https://github.com/plausible/analytics/discussions">Discuss</a></li>
-    <li><a href="https://github.com/plausible/analytics/blob/<%= @version %>/CHANGELOG.md">Changelog</a></li>
-    <li><a href="https://twitter.com/PlausibleHQ">Follow on Twitter</a></li>
-  </ul>
+  <p class="mt-4 text-gray-600 dark:text-gray-200">
+  <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">Plausible Analytics</a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
+  </p>
+  <div class="mt-6 flex text-gray-700 dark:text-gray-300">
+    <ul class="w-1/2 space-y-1">
+      <li>
+        <%= link to: Routes.auth_path(@conn, :login), class: "flex items-center" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-log-in h-4 w-4"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path><polyline points="10 17 15 12 10 7"></polyline><line x1="15" y1="12" x2="3" y2="12"></line></svg>
+          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Login</span>
+        <% end %>
+      </li>
+      <li>
+        <%= link to: Routes.auth_path(@conn, :register), class: "flex items-center" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-user-plus h-4 w-4"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
+          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Register</span>
+        <% end %>
+      </li>
+    </ul>
+    <ul class="w-1/2 space-y-1">
+      <li>
+        <a href="https://plausible.io/docs" class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-book-open h-4 w-4"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Guides &amp; Docs</span>
+        </a>
+      </li>
+      <li>
+        <a href="" class="flex items-center">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-twitter h-4 w-4"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path></svg>
+          <span class="ml-2 font-semibold underline text-indigo-700 dark:text-indigo-400">Follow on Twitter</span>
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/lib/plausible_web/views/page_view.ex
+++ b/lib/plausible_web/views/page_view.ex
@@ -1,0 +1,3 @@
+defmodule PlausibleWeb.PageView do
+  use PlausibleWeb, :view
+end

--- a/test/plausible_web/controllers/page_controller_test.exs
+++ b/test/plausible_web/controllers/page_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule PlausibleWeb.PageControllerTest do
+  use PlausibleWeb.ConnCase, async: true
+
+  describe "GET /" do
+    test "shows landing page when user not authenticated", %{conn: conn} do
+      assert conn |> get("/") |> html_response(200) =~ "Welcome to Plausible Analytics!"
+    end
+
+    test "redirects to /sites if user is authenticated", %{conn: conn} do
+      user = insert(:user)
+
+      assert conn
+             |> init_test_session(%{current_user_id: user.id})
+             |> get("/")
+             |> redirected_to(302) == "/sites"
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR adds a landing page in dev and self-hosted setups.

That page shows up when the user is not logged in and makes a `GET /` request.

<img width="400" alt="Screenshot 2023-05-31 at 18 14 37" src="https://github.com/plausible/analytics/assets/67764432/2230a463-5ee4-4464-bb00-0e24d58c2c01">
<img width="400" alt="Screenshot 2023-05-31 at 18 14 31" src="https://github.com/plausible/analytics/assets/67764432/73996b5f-8921-4265-967c-9b2998eda83b">
<img width="400" alt="Screenshot 2023-05-31 at 18 14 06" src="https://github.com/plausible/analytics/assets/67764432/32576a1d-f391-4b50-8f14-fbc73086f75e">
<img width="400" alt="Screenshot 2023-05-31 at 18 14 13" src="https://github.com/plausible/analytics/assets/67764432/c87c6292-110f-4d96-9df0-868e636af4d8">

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
