### PR TITLE
remove fetch.min.js shim from waiting_first_pageview page

### DIFF
--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.eex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.eex
@@ -1,4 +1,3 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/3.0.0/fetch.min.js" integrity="sha256-E1M+0f/hvoNVoV8K5RSn1gwe4EFwlvORnOrFzghX0wM=" crossorigin="anonymous"></script>
 <script>
   function updateStatus() {
     fetch("/api/<%= URI.encode_www_form(@site.domain) %>/status")


### PR DESCRIPTION
### Changes

This PR removes `fetch.min.js` shim since it's no longer necessary.

Related discussion: https://github.com/plausible/analytics/discussions/2987

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
