### PR TITLE
remove views_per_visit_metric flag

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -324,10 +324,8 @@ defmodule PlausibleWeb.StatsController do
 
   defp shared_link_cookie_name(slug), do: "shared-link-" <> slug
 
-  defp get_flags(user) do
-    %{
-      views_per_visit_metric: FunWithFlags.enabled?(:views_per_visit_metric, for: user)
-    }
+  defp get_flags(_user) do
+    %{}
   end
 
   defp is_dbip() do


### PR DESCRIPTION
### Changes

This PR removes `views_per_visit_metric` flag: https://github.com/plausible/analytics/pull/2996#discussion_r1213557200

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
