### PR TITLE
Trim prop list to 30 items during ingestion

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -183,11 +183,13 @@ defmodule Plausible.Ingestion.Request do
     Changeset.put_change(changeset, :hostname, sanitize_hostname(host))
   end
 
+  @max_props 30
   defp put_props(changeset, %{} = request_body) do
     props =
       (request_body["m"] || request_body["meta"] || request_body["p"] || request_body["props"])
       |> decode_props_or_fallback()
       |> Enum.reject(fn {_k, v} -> is_nil(v) || is_list(v) || is_map(v) || v == "" end)
+      |> Enum.take(@max_props)
       |> Map.new()
 
     changeset

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -316,17 +316,20 @@ defmodule Plausible.Ingestion.RequestTest do
              changeset.errors[:props]
   end
 
-  test "does not fail when sending many props" do
+  test "trims prop list to 30 items when sending too many items" do
     payload = %{
       name: "pageview",
       domain: "dummy.site",
-      url: "https://dummy.site/",
-      props: for(i <- 1..100, do: {"key_#{i}", "value"}, into: %{})
+      url: "http://dummy.site/index.html",
+      referrer: "https://example.com",
+      hashMode: 1,
+      props: for(i <- 1..50, do: {"#{i}", "foo"}, into: %{})
     }
 
     conn = build_conn(:post, "/api/events", payload)
+
     assert {:ok, request} = Request.build(conn)
-    assert map_size(request.props) == 100
+    assert map_size(request.props) == 30
   end
 
   test "malicious input, technically valid json" do


### PR DESCRIPTION
### Changes

This commit adds an upper bound limit to custom props. It fails silently and trims the list instead of dropping the event.

Documentation update PR: https://github.com/plausible/docs/pull/402

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [X] This PR does not change the UI
