### PR TITLE
disable registration by default in self-hosted setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Device type is now determined from the User-Agent instead of window.innerWidth plausible/analytics#2711
 - Add padding by default to embedded dashboards so that shadows are not cut off plausible/analytics#2744
 - Update the User Agents database (https://github.com/matomo-org/device-detector/releases/tag/6.1.1)
+- Disable registration in self-hosted setups by default plausible/analytics#3014
 
 ### Removed
 - Remove Firewall plug and `IP_BLOCKLIST` environment variable

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -175,9 +175,17 @@ enable_email_verification =
   |> get_var_from_path_or_env("ENABLE_EMAIL_VERIFICATION", "false")
   |> String.to_existing_atom()
 
+is_selfhost =
+  config_dir
+  |> get_var_from_path_or_env("SELFHOST", "true")
+  |> String.to_existing_atom()
+
+# by default, registration is disabled in self-hosted setups
+disable_registration_default = to_string(is_selfhost)
+
 disable_registration =
   config_dir
-  |> get_var_from_path_or_env("DISABLE_REGISTRATION", "false")
+  |> get_var_from_path_or_env("DISABLE_REGISTRATION", disable_registration_default)
   |> String.to_existing_atom()
 
 if disable_registration not in [true, false, :invite_only] do
@@ -190,11 +198,6 @@ hcaptcha_secret = get_var_from_path_or_env(config_dir, "HCAPTCHA_SECRET")
 log_level =
   config_dir
   |> get_var_from_path_or_env("LOG_LEVEL", "warn")
-  |> String.to_existing_atom()
-
-is_selfhost =
-  config_dir
-  |> get_var_from_path_or_env("SELFHOST", "true")
   |> String.to_existing_atom()
 
 custom_script_name =

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -37,7 +37,10 @@ defmodule PlausibleWeb.AuthController do
         conn
 
       disable_registration in [:invite_only, true] ->
-        conn |> redirect(to: Routes.auth_path(conn, :login_form)) |> halt()
+        conn
+        |> put_flash(:error, "Registration is disabled on this instance")
+        |> redirect(to: Routes.auth_path(conn, :login_form))
+        |> halt()
 
       true ->
         conn


### PR DESCRIPTION
### Changes

This PR disables registration in self-hosted setups. Note that the first user is allowed to register anyway (https://github.com/plausible/analytics/pull/2357).

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated (https://github.com/plausible/docs/pull/399)
- [ ] mention in the release notes

### Dark mode
- [x] Dark mode has been tested
