### PR TITLE
fix: site permission check

### DIFF
--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -24,11 +24,11 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
 
       role =
         cond do
-          user_id && membership_role ->
-            membership_role
-
           Plausible.Auth.is_super_admin?(user_id) ->
             :super_admin
+         
+          user_id && membership_role ->
+            membership_role
 
           site.public ->
             :public

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -26,7 +26,7 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
         cond do
           Plausible.Auth.is_super_admin?(user_id) ->
             :super_admin
-         
+
           user_id && membership_role ->
             membership_role
 


### PR DESCRIPTION
### Changes

This pull request correct the role of super_admin in `Plausible.AuthorizeSiteAccess`.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
