### PR TITLE
Migration: add funnel related tables

### DIFF
--- a/priv/repo/migrations/20230417095029_init_funnels.exs
+++ b/priv/repo/migrations/20230417095029_init_funnels.exs
@@ -1,0 +1,21 @@
+defmodule Plausible.Repo.Migrations.InitFunnels do
+  use Ecto.Migration
+
+  def change do
+    create table(:funnels) do
+      add :name, :string, null: false
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+      timestamps()
+    end
+
+    create table(:funnel_steps) do
+      add :goal_id, references(:goals, on_delete: :delete_all), null: false
+      add :funnel_id, references(:funnels, on_delete: :delete_all), null: false
+      add :step_order, :integer, null: false
+      timestamps()
+    end
+
+    create unique_index(:funnel_steps, [:goal_id, :funnel_id])
+    create unique_index(:funnels, [:name, :site_id])
+  end
+end


### PR DESCRIPTION
### Changes

This PR adds `funnels` and `funnel_steps` tables.
Steps reference `goals` and define their order within a funnel.


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
