### PR TITLE
Pass cached site struct down the ingestion pipeline

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -10,7 +10,7 @@ defmodule Plausible.Ingestion.Event do
   alias Plausible.Site.GateKeeper
 
   defstruct domain: nil,
-            site_id: nil,
+            site: nil,
             clickhouse_event_attrs: %{},
             clickhouse_event: nil,
             dropped?: false,
@@ -27,7 +27,7 @@ defmodule Plausible.Ingestion.Event do
 
   @type t() :: %__MODULE__{
           domain: String.t() | nil,
-          site_id: pos_integer() | nil,
+          site: %Plausible.Site{} | nil,
           clickhouse_event_attrs: map(),
           clickhouse_event: %ClickhouseEventV2{} | nil,
           dropped?: boolean(),
@@ -45,10 +45,10 @@ defmodule Plausible.Ingestion.Event do
       else
         Enum.reduce(domains, [], fn domain, acc ->
           case GateKeeper.check(domain) do
-            {:allow, site_id} ->
+            {:allow, site} ->
               processed =
                 domain
-                |> new(site_id, request)
+                |> new(site, request)
                 |> process_unless_dropped(pipeline())
 
               [processed | acc]
@@ -120,8 +120,8 @@ defmodule Plausible.Ingestion.Event do
     struct!(__MODULE__, domain: domain, request: request)
   end
 
-  defp new(domain, site_id, request) do
-    struct!(__MODULE__, domain: domain, site_id: site_id, request: request)
+  defp new(domain, site, request) do
+    struct!(__MODULE__, domain: domain, site: site, request: request)
   end
 
   defp drop(%__MODULE__{} = event, reason, attrs \\ []) do
@@ -163,7 +163,7 @@ defmodule Plausible.Ingestion.Event do
   defp put_basic_info(%__MODULE__{} = event) do
     update_attrs(event, %{
       domain: event.domain,
-      site_id: event.site_id,
+      site_id: event.site.id,
       timestamp: event.request.timestamp,
       name: event.request.event_name,
       hostname: event.request.hostname,
@@ -208,7 +208,7 @@ defmodule Plausible.Ingestion.Event do
   defp put_props(%__MODULE__{} = event), do: event
 
   defp put_revenue(%__MODULE__{request: %{revenue_source: %Money{} = revenue_source}} = event) do
-    revenue_goals = Plausible.Site.Cache.get(event.domain).revenue_goals || []
+    revenue_goals = event.site.revenue_goals || []
 
     matching_goal =
       Enum.find(revenue_goals, &(&1.event_name == event.clickhouse_event_attrs.name))

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -208,10 +208,8 @@ defmodule Plausible.Ingestion.Event do
   defp put_props(%__MODULE__{} = event), do: event
 
   defp put_revenue(%__MODULE__{request: %{revenue_source: %Money{} = revenue_source}} = event) do
-    revenue_goals = event.site.revenue_goals || []
-
     matching_goal =
-      Enum.find(revenue_goals, &(&1.event_name == event.clickhouse_event_attrs.name))
+      Enum.find(event.site.revenue_goals, &(&1.event_name == event.clickhouse_event_attrs.name))
 
     cond do
       is_nil(matching_goal) ->

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -102,9 +102,9 @@ defmodule Plausible.Site.Cache do
   @spec refresh_updated_recently(Keyword.t()) :: :ok
   def refresh_updated_recently(opts \\ []) do
     recently_updated_sites_query =
-      from [s, mg] in sites_by_domain_query(),
+      from [s, _rg] in sites_by_domain_query(),
         order_by: [asc: s.updated_at],
-        where: s.updated_at > ago(^15, "minute") or mg.updated_at > ago(^15, "minute")
+        where: s.updated_at > ago(^15, "minute")
 
     refresh(
       :updated_recently,
@@ -115,13 +115,13 @@ defmodule Plausible.Site.Cache do
 
   defp sites_by_domain_query do
     from s in Site,
-      left_join: mg in assoc(s, :revenue_goals),
+      left_join: rg in assoc(s, :revenue_goals),
       select: {
         s.domain,
         s.domain_changed_from,
         %{struct(s, ^@cached_schema_fields) | from_cache?: true}
       },
-      preload: [revenue_goals: mg]
+      preload: [revenue_goals: rg]
   end
 
   @spec merge(new_items :: [Site.t()], opts :: Keyword.t()) :: :ok

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -21,11 +21,15 @@ defmodule Plausible.GoalsTest do
   test "create/2 sets site.updated_at for revenue goal" do
     site_1 = insert(:site, updated_at: DateTime.add(DateTime.utc_now(), -3600))
     {:ok, _goal_1} = Goals.create(site_1, %{"event_name" => "Checkout", "currency" => "BRL"})
-    assert NaiveDateTime.compare(site_1.updated_at, reload(site_1).updated_at) == :lt
+
+    assert NaiveDateTime.compare(site_1.updated_at, Plausible.Repo.reload!(site_1).updated_at) ==
+             :lt
 
     site_2 = insert(:site, updated_at: DateTime.add(DateTime.utc_now(), -3600))
     {:ok, _goal_2} = Goals.create(site_2, %{"event_name" => "Read Article", "currency" => nil})
-    assert NaiveDateTime.compare(site_2.updated_at, reload(site_2).updated_at) == :eq
+
+    assert NaiveDateTime.compare(site_2.updated_at, Plausible.Repo.reload!(site_2).updated_at) ==
+             :eq
   end
 
   test "for_site2 returns trimmed input even if it was saved with trailing whitespace" do

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -18,6 +18,16 @@ defmodule Plausible.GoalsTest do
     assert {"should be at most %{count} character(s)", _} = changeset.errors[:event_name]
   end
 
+  test "create/2 sets site.updated_at for revenue goal" do
+    site_1 = insert(:site, updated_at: DateTime.add(DateTime.utc_now(), -3600))
+    {:ok, _goal_1} = Goals.create(site_1, %{"event_name" => "Checkout", "currency" => "BRL"})
+    assert NaiveDateTime.compare(site_1.updated_at, reload(site_1).updated_at) == :lt
+
+    site_2 = insert(:site, updated_at: DateTime.add(DateTime.utc_now(), -3600))
+    {:ok, _goal_2} = Goals.create(site_2, %{"event_name" => "Read Article", "currency" => nil})
+    assert NaiveDateTime.compare(site_2.updated_at, reload(site_2).updated_at) == :eq
+  end
+
   test "for_site2 returns trimmed input even if it was saved with trailing whitespace" do
     site = insert(:site)
     insert(:goal, %{site: site, event_name: " Signup "})

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -62,9 +62,14 @@ defmodule Plausible.Site.CacheTest do
         )
 
       %{id: site_id} = site = insert(:site, domain: "site1.example.com")
-      insert(:goal, site: site, event_name: "Purchase", currency: :BRL)
-      insert(:goal, site: site, event_name: "Add to Cart", currency: :USD)
-      insert(:goal, site: site, event_name: "Click", currency: nil)
+
+      {:ok, _goal} =
+        Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => :BRL})
+
+      {:ok, _goal} =
+        Plausible.Goals.create(site, %{"event_name" => "Add to Cart", "currency" => :USD})
+
+      {:ok, _goal} = Plausible.Goals.create(site, %{"event_name" => "Click", "currency" => nil})
 
       :ok = Cache.refresh_all(cache_name: test)
 
@@ -76,6 +81,47 @@ defmodule Plausible.Site.CacheTest do
       assert [
                %Goal{event_name: "Add to Cart", currency: :USD},
                %Goal{event_name: "Purchase", currency: :BRL}
+             ] = Enum.sort_by(cached_goals, & &1.event_name)
+    end
+
+    test "cache caches revenue goals with event refresh", %{test: test} do
+      {:ok, _} =
+        Supervisor.start_link(
+          [{Cache, [cache_name: test, child_id: :test_revenue_goals_event_refresh]}],
+          strategy: :one_for_one,
+          name: Test.Supervisor.Cache
+        )
+
+      yesterday = DateTime.utc_now() |> DateTime.add(-1 * 60 * 60 * 24)
+
+      # the site was added yesterday so full refresh will pick it up
+      %{id: site_id} = site = insert(:site, domain: "site1.example.com", updated_at: yesterday)
+      # the goal was added yesterday so full refresh will pick it up
+      Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => :BRL}, yesterday)
+      # this goal is added "just now"
+      Plausible.Goals.create(site, %{"event_name" => "Add to Cart", "currency" => :USD})
+      # and this one does not matter
+      Plausible.Goals.create(site, %{"event_name" => "Click", "currency" => nil})
+
+      # at this point, we have 3 goals associated with the cached struct
+      :ok = Cache.refresh_all(cache_name: test)
+
+      # the goal was added 70 seconds ago so partial refresh should pick it up and merge with the rest of goals
+      Plausible.Goals.create(
+        site,
+        %{"event_name" => "Purchase2", "currency" => :BRL},
+        DateTime.add(DateTime.utc_now(), -70)
+      )
+
+      :ok = Cache.refresh_updated_recently(cache_name: test)
+
+      assert %Site{from_cache?: true, id: ^site_id, revenue_goals: cached_goals} =
+               Cache.get("site1.example.com", force?: true, cache_name: test)
+
+      assert [
+               %Goal{event_name: "Add to Cart", currency: :USD},
+               %Goal{event_name: "Purchase", currency: :BRL},
+               %Goal{event_name: "Purchase2", currency: :BRL}
              ] = Enum.sort_by(cached_goals, & &1.event_name)
     end
 

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -55,7 +55,8 @@ defmodule Plausible.Site.CacheTest do
 
     test "cache caches revenue goals", %{test: test} do
       {:ok, _} =
-        Supervisor.start_link([{Cache, [cache_name: test, child_id: :test_cache_caches_id]}],
+        Supervisor.start_link(
+          [{Cache, [cache_name: test, child_id: :test_cache_caches_revenue_goals]}],
           strategy: :one_for_one,
           name: Test.Supervisor.Cache
         )

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -34,8 +34,4 @@ defmodule Plausible.DataCase do
 
     :ok
   end
-
-  def reload(%schema{id: id}) do
-    Plausible.Repo.get(schema, id)
-  end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -34,4 +34,8 @@ defmodule Plausible.DataCase do
 
     :ok
   end
+
+  def reload(%schema{id: id}) do
+    Plausible.Repo.get(schema, id)
+  end
 end


### PR DESCRIPTION
Revenue goals need the cached site struct during ingestion to get the goals name and currency. This cache lookup is not necessary as `GateKeeper.check/1`, which is called first in the ingestion pipeline, could already return the site struct from the cache.

This commit changes `GateKeeper.check/1` to return the site struct instead of the site ID. Moreover, this commit changes the ingestion pipeline to avoid calling the sites cache twice.

Related: https://github.com/plausible/analytics/pull/2957#discussion_r1203921549