### PR TITLE
Update gitignore with docker volume dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ plausible-report.xml
 
 # Auto-generated tracker files
 /priv/tracker/js/*.js
+
+# Docker volumes
+.clickhouse_db_vol*
+plausible_db*


### PR DESCRIPTION
### Changes

This PR updates .gitignore with docker volume dirs so they don't pollute git status.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
