### PR TITLE
allow :eof in data mgiration input

### DIFF
--- a/lib/plausible/data_migration.ex
+++ b/lib/plausible/data_migration.ex
@@ -30,7 +30,12 @@ defmodule Plausible.DataMigration do
           end
 
         prompt = IO.ANSI.white() <> message <> choices <> IO.ANSI.reset()
-        answer = String.downcase(String.trim(IO.gets(prompt)))
+
+        answer =
+          case IO.gets(prompt) do
+            answer when is_binary(answer) -> answer |> String.trim() |> String.downcase()
+            :eof -> ""
+          end
 
         skip = fn ->
           IO.puts("    #{IO.ANSI.cyan()}Skipped.#{IO.ANSI.reset()}")


### PR DESCRIPTION
### Changes

This PR fixes the problem encountered in https://github.com/plausible/analytics/discussions/3035

I'm marking it as a draft until the user provides more info on how they run the migration script. I haven't been able to get `:eof` on my self-hosted instance.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
