### PR TITLE
Set with_imported=false in realtime mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug when combining goal and prop filters plausible/analytics#2654
 - Fix broken favicons when domain includes a slash
 - Fix bug when using multiple [wildcard goal filters](https://github.com/plausible/analytics/pull/3015)
+- Fix a bug where realtime would fail with imported data
 
 ### Changed
 - Treat page filter as entry page filter for `bounce_rate`

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -235,6 +235,7 @@ defmodule Plausible.Stats.Query do
       site.imported_data.status != "ok" -> false
       Timex.after?(query.date_range.first, site.imported_data.end_date) -> false
       Enum.any?(query.filters) -> false
+      query.period == "realtime" -> false
       true -> requested?
     end
   end


### PR DESCRIPTION
This commit fixes a bug where timeseries queries - such as the main graph - would fail with imported data in realtime mode. Realtime mode `date` field is not actually a date, but minutes from now. This would cause the imported tables join to fail with this error:

```
(Ch.Error Code: 53. DB::Exception: Can't infer common type for joined
columns: date: Int64 at left, s1.date: Date at right. There is no
supertype for types Int64, Date because some of them are
Date/Date32/DateTime/DateTime64 and some of them are not.
(TYPE_MISMATCH)
```

This commit removes imported data from realtime queries, as it doesn't make sense to include it. Imported data does not have time precision, and would only appear in the first day the data was imported anyways.