### PR TITLE
Add eventually/1 call to flaky test

### DIFF
--- a/test/workers/import_google_analytics_test.exs
+++ b/test/workers/import_google_analytics_test.exs
@@ -158,7 +158,10 @@ defmodule Plausible.Workers.ImportGoogleAnalyticsTest do
       api_stub
     )
 
-    assert Plausible.Stats.Clickhouse.imported_pageview_count(site) == 0
+    assert eventually(fn ->
+             count = Plausible.Stats.Clickhouse.imported_pageview_count(site)
+             {count == 0, count}
+           end)
   end
 
   test "sends email to owner after failed import" do


### PR DESCRIPTION
This commit tries to fix a flaky test that's failing often on CI. ClickHouse deletes are asynchronous and can take some time before it takes effect. The `eventually/1` function retries the assertion with a backoff.