### PR TITLE
Add revenue metrics to top stats

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -19,13 +19,13 @@ export default class TopStats extends React.Component {
     const formattedComparison = numberFormatter(Math.abs(comparison))
 
     const defaultClassName = classNames({
-       "text-xs dark:text-gray-100": !forceDarkBg,
-       "text-xs text-gray-100": forceDarkBg
+       "pl-2 text-xs dark:text-gray-100": !forceDarkBg,
+       "pl-2 text-xs text-gray-100": forceDarkBg
      })
 
      const noChangeClassName = classNames({
-       "text-xs text-gray-700 dark:text-gray-300": !forceDarkBg,
-       "text-xs text-gray-300": forceDarkBg
+       "pl-2 text-xs text-gray-700 dark:text-gray-300": !forceDarkBg,
+       "pl-2 text-xs text-gray-300": forceDarkBg
      })
 
     if (comparison > 0) {
@@ -46,6 +46,8 @@ export default class TopStats extends React.Component {
       return durationFormatter(value)
     } else if (['bounce rate', 'conversion rate'].includes(name.toLowerCase())) {
       return value + '%'
+    } else if (['average revenue', 'total revenue'].includes(name.toLowerCase())) {
+      return value?.short
     } else {
       return numberFormatter(value)
     }
@@ -56,6 +58,8 @@ export default class TopStats extends React.Component {
       return durationFormatter(value)
     } else if (['bounce rate', 'conversion rate'].includes(name.toLowerCase())) {
       return value + '%'
+    } else if (['average revenue', 'total revenue'].includes(name.toLowerCase())) {
+      return value?.long
     } else {
       return (value || 0).toLocaleString()
     }

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -3,10 +3,24 @@ defmodule Plausible.Stats.Aggregate do
   use Plausible.ClickhouseRepo
   import Plausible.Stats.{Base, Imported, Util}
 
-  @event_metrics [:visitors, :pageviews, :events, :sample_percent]
+  @event_metrics [
+    :visitors,
+    :pageviews,
+    :events,
+    :sample_percent,
+    :average_revenue,
+    :total_revenue
+  ]
   @session_metrics [:visits, :bounce_rate, :visit_duration, :views_per_visit, :sample_percent]
+  @revenue_metrics [:average_revenue, :total_revenue]
 
   def aggregate(site, query, metrics) do
+    # Aggregating revenue data works only for same currency goals. If the query
+    # is filtered by goals with different currencies, for example, one USD and
+    # other EUR, revenue metrics are dropped.
+    currency = get_revenue_tracking_currency(site, query)
+    metrics = if currency, do: metrics, else: metrics -- @revenue_metrics
+
     event_metrics = Enum.filter(metrics, &(&1 in @event_metrics))
     event_task = fn -> aggregate_events(site, query, event_metrics) end
     session_metrics = Enum.filter(metrics, &(&1 in @session_metrics))
@@ -22,6 +36,7 @@ defmodule Plausible.Stats.Aggregate do
     Plausible.ClickhouseRepo.parallel_tasks([session_task, event_task, time_on_page_task])
     |> Enum.reduce(%{}, fn aggregate, task_result -> Map.merge(aggregate, task_result) end)
     |> Enum.map(&maybe_round_value/1)
+    |> Enum.map(&cast_revenue_metric_to_money(&1, currency))
     |> Enum.map(fn {metric, value} -> {metric, %{value: value}} end)
     |> Enum.into(%{})
   end
@@ -134,4 +149,38 @@ defmodule Plausible.Stats.Aggregate do
   end
 
   defp maybe_round_value(entry), do: entry
+
+  defp get_revenue_tracking_currency(site, query) do
+    goal_filters =
+      case query.filters do
+        %{"event:goal" => {:is, {_, goal_name}}} -> [goal_name]
+        %{"event:goal" => {:member, list}} -> Enum.map(list, fn {_, goal_name} -> goal_name end)
+        _any -> []
+      end
+
+    revenue_goals = Plausible.Site.Cache.get(site.domain).revenue_goals
+
+    revenue_goals_currencies =
+      Enum.reduce(goal_filters, [], fn filter, acc ->
+        revenue_goal = Enum.find(revenue_goals, &(&1.event_name == filter))
+
+        if revenue_goal && revenue_goal.currency not in acc do
+          [revenue_goal.currency | acc]
+        else
+          acc
+        end
+      end)
+
+    if length(revenue_goals_currencies) == 1,
+      do: List.first(revenue_goals_currencies),
+      else: nil
+  end
+
+  defp cast_revenue_metric_to_money({metric, value}, currency) do
+    if metric in @revenue_metrics and is_atom(currency) do
+      {metric, Money.new!(value, currency)}
+    else
+      {metric, value}
+    end
+  end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -36,6 +36,7 @@ site =
 {:ok, goal1} = Plausible.Goals.create(site, %{"page_path" => "/"})
 {:ok, goal2} = Plausible.Goals.create(site, %{"page_path" => "/register"})
 {:ok, goal3} = Plausible.Goals.create(site, %{"page_path" => "/login"})
+{:ok, goal4} = Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => "USD"})
 
 {:ok, _funnel} =
   Plausible.Funnels.create(site, "From homepage to login", [
@@ -126,6 +127,35 @@ native_stats_range
     ]
     |> Keyword.merge(geolocation)
     |> then(&Plausible.Factory.build(:pageview, &1))
+  end)
+end)
+|> Plausible.TestUtils.populate_stats()
+
+native_stats_range
+|> Enum.with_index()
+|> Enum.flat_map(fn {date, index} ->
+  Enum.map(0..Enum.random(1..50), fn _ ->
+    geolocation = Enum.random(geolocations)
+
+    [
+      name: goal4.event_name,
+      site_id: site.id,
+      hostname: site.domain,
+      timestamp: put_random_time.(date, index),
+      referrer_source: Enum.random(["", "Facebook", "Twitter", "DuckDuckGo", "Google"]),
+      browser: Enum.random(["Edge", "Chrome", "Safari", "Firefox", "Vivaldi"]),
+      browser_version: to_string(Enum.random(0..50)),
+      screen_size: Enum.random(["Mobile", "Tablet", "Desktop", "Laptop"]),
+      operating_system: Enum.random(["Windows", "macOS", "Linux"]),
+      operating_system_version: to_string(Enum.random(0..15)),
+      pathname:
+        Enum.random(["/", "/login", "/settings", "/register", "/docs", "/docs/1", "/docs/2"]),
+      user_id: Enum.random(1..1200),
+      revenue_reporting_amount: Decimal.new(Enum.random(100..10000)),
+      revenue_reporting_currency: "USD"
+    ]
+    |> Keyword.merge(geolocation)
+    |> then(&Plausible.Factory.build(:event, &1))
   end)
 end)
 |> Plausible.TestUtils.populate_stats()

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -721,8 +721,16 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       filters = Jason.encode!(%{goal: "Payment"})
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
       assert %{"top_stats" => top_stats} = json_response(conn, 200)
-      assert %{"name" => "Average revenue", "value" => "$1,659.50"} in top_stats
-      assert %{"name" => "Total revenue", "value" => "$3,319.00"} in top_stats
+
+      assert %{
+               "name" => "Average revenue",
+               "value" => %{"long" => "$1,659.50", "short" => "$1.7K"}
+             } in top_stats
+
+      assert %{
+               "name" => "Total revenue",
+               "value" => %{"long" => "$3,319.00", "short" => "$3.3K"}
+             } in top_stats
     end
 
     test "returns average and total when filtering by many revenue goals with same currency", %{
@@ -769,8 +777,16 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       filters = Jason.encode!(%{goal: "Payment|Payment2"})
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
       assert %{"top_stats" => top_stats} = json_response(conn, 200)
-      assert %{"name" => "Average revenue", "value" => "$1,659.50"} in top_stats
-      assert %{"name" => "Total revenue", "value" => "$6,638.00"} in top_stats
+
+      assert %{
+               "name" => "Average revenue",
+               "value" => %{"long" => "$1,659.50", "short" => "$1.7K"}
+             } in top_stats
+
+      assert %{
+               "name" => "Total revenue",
+               "value" => %{"long" => "$6,638.00", "short" => "$6.6K"}
+             } in top_stats
     end
 
     test "does not return average and total when filtering by many revenue goals with different currencies",

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -690,6 +690,125 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{"name" => "Conversion rate", "value" => 33.3} in res["top_stats"]
     end
+
+    test "returns average and total when filtering by a revenue goal", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "AddToCart", currency: "EUR")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(13_29),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(19_90),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(10_31),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(20_00),
+          revenue_reporting_currency: "EUR"
+        )
+      ])
+
+      filters = Jason.encode!(%{goal: "Payment"})
+      conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
+      assert %{"top_stats" => top_stats} = json_response(conn, 200)
+      assert %{"name" => "Average revenue", "value" => "$1,659.50"} in top_stats
+      assert %{"name" => "Total revenue", "value" => "$3,319.00"} in top_stats
+    end
+
+    test "returns average and total when filtering by many revenue goals with same currency", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "Payment2", currency: "USD")
+      insert(:goal, site: site, event_name: "AddToCart", currency: "EUR")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(13_29),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(19_90),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment2",
+          revenue_reporting_amount: Decimal.new(13_29),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment2",
+          revenue_reporting_amount: Decimal.new(19_90),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(10_31),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(20_00),
+          revenue_reporting_currency: "EUR"
+        )
+      ])
+
+      filters = Jason.encode!(%{goal: "Payment|Payment2"})
+      conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
+      assert %{"top_stats" => top_stats} = json_response(conn, 200)
+      assert %{"name" => "Average revenue", "value" => "$1,659.50"} in top_stats
+      assert %{"name" => "Total revenue", "value" => "$6,638.00"} in top_stats
+    end
+
+    test "does not return average and total when filtering by many revenue goals with different currencies",
+         %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "AddToCart", currency: "EUR")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(13_29),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new(19_90),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(10_31),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "AddToCart",
+          revenue_reporting_amount: Decimal.new(20_00),
+          revenue_reporting_currency: "EUR"
+        )
+      ])
+
+      filters = Jason.encode!(%{goal: "Payment|AddToCart"})
+      conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
+      assert %{"top_stats" => top_stats} = json_response(conn, 200)
+
+      metrics = Enum.map(top_stats, & &1["name"])
+      refute "Average revenue" in metrics
+      refute "Total revenue" in metrics
+    end
   end
 
   describe "GET /api/stats/top-stats - with comparisons" do


### PR DESCRIPTION
### Changes

This PR adds revenue data to top stats. Average and total are displayed when filtering by a revenue goal (or many if they have the same currency set).

<img width="1133" alt="Screenshot 2023-06-19 at 18 50 50" src="https://github.com/plausible/analytics/assets/5093045/b63ca2fd-a4ca-43a4-be57-ee15d617df7c">

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
