### PR TITLE
Add notice to revenue goals UI

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -30,7 +30,7 @@ defmodule Plausible.Goal do
         {"#{code} - #{Cldr.Currency.display_name!(code)}", code}
       end
 
-    [{"", nil}] ++ options
+    [{"Select reporting currency", nil}] ++ options
   end
 
   def changeset(goal, attrs \\ %{}) do

--- a/lib/plausible_web/templates/site/new_goal.html.eex
+++ b/lib/plausible_web/templates/site/new_goal.html.eex
@@ -18,13 +18,11 @@
         <%= error_tag f, :event_name %>
       </div>
 
-      <%= if FunWithFlags.enabled?(:revenue_goals, for: @current_user) do %>
-        <div class="mt-3">
-          <%= label f, :currency, "Reporting currency for revenue tracking (optional)", class: "block text-sm font-bold dark:text-gray-100" %>
-          <%= select f, :currency, Plausible.Goal.currency_options(), class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500" %>
-          <%= error_tag f, :currency %>
-        </div>
-      <% end %>
+      <div class="mt-3">
+        <%= label f, :currency, "Reporting currency for revenue tracking (optional)", class: "block text-sm font-bold dark:text-gray-100" %>
+        <%= select f, :currency, Plausible.Goal.currency_options(), class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500" %>
+        <%= error_tag f, :currency %>
+      </div>
     </div>
     <div id="pageview-fields" class="hidden">
       <%= label f, :page_path, class: "block text-sm font-bold dark:text-gray-100" %>

--- a/lib/plausible_web/templates/site/new_goal.html.eex
+++ b/lib/plausible_web/templates/site/new_goal.html.eex
@@ -1,37 +1,67 @@
 <%= form_for @changeset, "/#{URI.encode_www_form(@site.domain)}/goals", [class: "max-w-md w-full mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8"], fn f -> %>
   <h2 class="text-xl font-black dark:text-gray-100">Add goal for <%= @site.domain %></h2>
-  <div class="mt-6 text-sm font-bold dark:text-gray-100">Goal trigger</div>
+  <div class="mt-6 font-medium dark:text-gray-100">Goal trigger</div>
   <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
     <div class="w-1/2 text-center py-2 border-r border-gray-300 dark:border-gray-500 shadow-inner font-bold cursor-pointer text-white dark:text-gray-100 bg-indigo-600" id="event-tab">Custom event</div>
     <div class="w-1/2 text-center py-2 cursor-pointer dark:text-gray-100" id="pageview-tab">Pageview</div>
   </div>
   <div class="my-6">
     <div id="event-fields">
-      <div class="pb-6 text-xs text-gray-700 dark:text-gray-200 text-justify rounded-md bg">
+      <div class="pb-6 text-xs text-gray-700 dark:text-gray-200 text-justify rounded-md">
         Custom events are not tracked by default - you have to configure them on your site to be sent to Plausible. See examples and learn more in
         <a class="text-indigo-500 hover:underline" target="_blank" rel="noreferrer" href="https://plausible.io/docs/custom-event-goals"> our docs</a>.
       </div>
 
       <div>
-        <%= label f, :event_name, class: "block text-sm font-bold dark:text-gray-100" %>
+        <%= label f, :event_name, class: "block font-medium dark:text-gray-100" %>
         <%= text_input f, :event_name, class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", placeholder: "Signup" %>
         <%= error_tag f, :event_name %>
       </div>
 
-      <div class="mt-3">
-        <%= label f, :currency, "Reporting currency for revenue tracking (optional)", class: "block text-sm font-bold dark:text-gray-100" %>
-        <%= select f, :currency, Plausible.Goal.currency_options(), class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500" %>
-        <%= error_tag f, :currency %>
+      <div class="mt-6 space-y-3" x-data="<%= Jason.encode!(%{active: !!Ecto.Changeset.get_field(@changeset, :currency), currency: Ecto.Changeset.get_field(@changeset, :currency)}) %>">
+        <div class="flex items-center w-max cursor-pointer" x-on:click="active = !active; currency = ''">
+          <button 
+            class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
+            x-bind:class="active ? 'bg-indigo-600' : 'bg-gray-200'" 
+            x-bind:aria-checked="active"
+            aria-labelledby="enable-revenue-tracking"
+            role="switch" 
+            type="button"
+          >
+            <span 
+              aria-hidden="true" 
+              class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+              x-bind:class="active ? 'translate-x-5' : 'translate-x-0'"
+            />
+          </button>
+          <span class="ml-3 font-medium text-gray-900 dark:text-gray-200" id="enable-revenue-tracking">
+            Enable revenue tracking
+          </span>
+        </div>
+
+        <div class="rounded-md bg-yellow-50 p-4" x-show="active">
+          <p class="text-xs text-yellow-700 text-justify">
+            Revenue tracking is an upcoming premium feature that's free-to-use
+            during the private preview. Pricing will be announced soon. See
+            examples and learn more in <a class="font-medium text-yellow underline hover:text-yellow-600" href="https://plausible.io/docs/ecommerce-revenue-tracking">our docs</a>.
+          </p>
+        </div>
+
+        <div x-show="active">
+          <%= label f, :currency, "Reporting currency", class: "hidden" %>
+          <%= select f, :currency, Plausible.Goal.currency_options(), class: "transition bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", "x-model": "currency", "x-bind:required": "active" %>
+          <%= error_tag f, :currency %>
+        </div>
       </div>
     </div>
     <div id="pageview-fields" class="hidden">
-      <%= label f, :page_path, class: "block text-sm font-bold dark:text-gray-100" %>
+      <%= label f, :page_path, class: "block font-medium dark:text-gray-100" %>
       <%= text_input f, :page_path, class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", placeholder: "/success" %>
       <%= error_tag f, :page_path %>
     </div>
   </div>
 
-  <%= submit "Add goal →", class: "button mt-4 w-full" %>
+  <%= submit "Add goal →", class: "button text-base font-bold w-full" %>
 <% end %>
 
 <script>

--- a/lib/plausible_web/templates/site/new_goal.html.heex
+++ b/lib/plausible_web/templates/site/new_goal.html.heex
@@ -18,7 +18,7 @@
         <%= error_tag f, :event_name %>
       </div>
 
-      <div class="mt-6 space-y-3" x-data="<%= Jason.encode!(%{active: !!Ecto.Changeset.get_field(@changeset, :currency), currency: Ecto.Changeset.get_field(@changeset, :currency)}) %>">
+      <div class="mt-6 space-y-3" x-data={Jason.encode!(%{active: !!Ecto.Changeset.get_field(@changeset, :currency), currency: Ecto.Changeset.get_field(@changeset, :currency)})}>
         <div class="flex items-center w-max cursor-pointer" x-on:click="active = !active; currency = ''">
           <button 
             class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"

--- a/lib/plausible_web/templates/site/new_goal.html.heex
+++ b/lib/plausible_web/templates/site/new_goal.html.heex
@@ -80,10 +80,10 @@
         </div>
 
         <div x-show="active">
-          <%= label(f, :currency, "Reporting currency", class: "hidden") %>
           <%= select(f, :currency, Plausible.Goal.currency_options(),
             class:
               "transition bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500",
+            "aria-label": "Reporting currency",
             "x-model": "currency",
             "x-bind:required": "active"
           ) %>

--- a/lib/plausible_web/templates/site/new_goal.html.heex
+++ b/lib/plausible_web/templates/site/new_goal.html.heex
@@ -68,8 +68,8 @@
           </span>
         </div>
 
-        <div class="rounded-md bg-yellow-50 p-4" x-show="active">
-          <p class="text-xs text-yellow-700 text-justify">
+        <div class="rounded-md bg-yellow-50 dark:bg-yellow-900 p-4" x-show="active">
+          <p class="text-xs text-yellow-700 dark:text-yellow-50 text-justify">
             Revenue tracking is an upcoming premium feature that's free-to-use
             during the private preview. Pricing will be announced soon. See
             examples and learn more in <a

--- a/lib/plausible_web/templates/site/new_goal.html.heex
+++ b/lib/plausible_web/templates/site/new_goal.html.heex
@@ -2,39 +2,68 @@
   <h2 class="text-xl font-black dark:text-gray-100">Add goal for <%= @site.domain %></h2>
   <div class="mt-6 font-medium dark:text-gray-100">Goal trigger</div>
   <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
-    <div class="w-1/2 text-center py-2 border-r border-gray-300 dark:border-gray-500 shadow-inner font-bold cursor-pointer text-white dark:text-gray-100 bg-indigo-600" id="event-tab">Custom event</div>
-    <div class="w-1/2 text-center py-2 cursor-pointer dark:text-gray-100" id="pageview-tab">Pageview</div>
+    <div
+      class="w-1/2 text-center py-2 border-r border-gray-300 dark:border-gray-500 shadow-inner font-bold cursor-pointer text-white dark:text-gray-100 bg-indigo-600"
+      id="event-tab"
+    >
+      Custom event
+    </div>
+    <div class="w-1/2 text-center py-2 cursor-pointer dark:text-gray-100" id="pageview-tab">
+      Pageview
+    </div>
   </div>
   <div class="my-6">
     <div id="event-fields">
       <div class="pb-6 text-xs text-gray-700 dark:text-gray-200 text-justify rounded-md">
-        Custom events are not tracked by default - you have to configure them on your site to be sent to Plausible. See examples and learn more in
-        <a class="text-indigo-500 hover:underline" target="_blank" rel="noreferrer" href="https://plausible.io/docs/custom-event-goals"> our docs</a>.
+        Custom events are not tracked by default - you have to configure them on your site to be sent to Plausible. See examples and learn more in <a
+          class="text-indigo-500 hover:underline"
+          target="_blank"
+          rel="noreferrer"
+          href="https://plausible.io/docs/custom-event-goals"
+        > our docs</a>.
       </div>
 
       <div>
-        <%= label f, :event_name, class: "block font-medium dark:text-gray-100" %>
-        <%= text_input f, :event_name, class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", placeholder: "Signup" %>
-        <%= error_tag f, :event_name %>
+        <%= label(f, :event_name, class: "block font-medium dark:text-gray-100") %>
+        <%= text_input(f, :event_name,
+          class:
+            "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500",
+          placeholder: "Signup"
+        ) %>
+        <%= error_tag(f, :event_name) %>
       </div>
 
-      <div class="mt-6 space-y-3" x-data={Jason.encode!(%{active: !!Ecto.Changeset.get_field(@changeset, :currency), currency: Ecto.Changeset.get_field(@changeset, :currency)})}>
-        <div class="flex items-center w-max cursor-pointer" x-on:click="active = !active; currency = ''">
-          <button 
+      <div
+        class="mt-6 space-y-3"
+        x-data={
+          Jason.encode!(%{
+            active: !!Ecto.Changeset.get_field(@changeset, :currency),
+            currency: Ecto.Changeset.get_field(@changeset, :currency)
+          })
+        }
+      >
+        <div
+          class="flex items-center w-max cursor-pointer"
+          x-on:click="active = !active; currency = ''"
+        >
+          <button
             class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
-            x-bind:class="active ? 'bg-indigo-600' : 'bg-gray-200'" 
+            x-bind:class="active ? 'bg-indigo-600' : 'bg-gray-200'"
             x-bind:aria-checked="active"
             aria-labelledby="enable-revenue-tracking"
-            role="switch" 
+            role="switch"
             type="button"
           >
-            <span 
-              aria-hidden="true" 
+            <span
+              aria-hidden="true"
               class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
               x-bind:class="active ? 'translate-x-5' : 'translate-x-0'"
             />
           </button>
-          <span class="ml-3 font-medium text-gray-900 dark:text-gray-200" id="enable-revenue-tracking">
+          <span
+            class="ml-3 font-medium text-gray-900 dark:text-gray-200"
+            id="enable-revenue-tracking"
+          >
             Enable revenue tracking
           </span>
         </div>
@@ -43,25 +72,37 @@
           <p class="text-xs text-yellow-700 text-justify">
             Revenue tracking is an upcoming premium feature that's free-to-use
             during the private preview. Pricing will be announced soon. See
-            examples and learn more in <a class="font-medium text-yellow underline hover:text-yellow-600" href="https://plausible.io/docs/ecommerce-revenue-tracking">our docs</a>.
+            examples and learn more in <a
+              class="font-medium text-yellow underline hover:text-yellow-600"
+              href="https://plausible.io/docs/ecommerce-revenue-tracking"
+            >our docs</a>.
           </p>
         </div>
 
         <div x-show="active">
-          <%= label f, :currency, "Reporting currency", class: "hidden" %>
-          <%= select f, :currency, Plausible.Goal.currency_options(), class: "transition bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", "x-model": "currency", "x-bind:required": "active" %>
-          <%= error_tag f, :currency %>
+          <%= label(f, :currency, "Reporting currency", class: "hidden") %>
+          <%= select(f, :currency, Plausible.Goal.currency_options(),
+            class:
+              "transition bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500",
+            "x-model": "currency",
+            "x-bind:required": "active"
+          ) %>
+          <%= error_tag(f, :currency) %>
         </div>
       </div>
     </div>
     <div id="pageview-fields" class="hidden">
-      <%= label f, :page_path, class: "block font-medium dark:text-gray-100" %>
-      <%= text_input f, :page_path, class: "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500", placeholder: "/success" %>
-      <%= error_tag f, :page_path %>
+      <%= label(f, :page_path, class: "block font-medium dark:text-gray-100") %>
+      <%= text_input(f, :page_path,
+        class:
+          "transition mt-3 bg-gray-100 dark:bg-gray-900 outline-none appearance-none border border-transparent rounded w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-none focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500",
+        placeholder: "/success"
+      ) %>
+      <%= error_tag(f, :page_path) %>
     </div>
   </div>
 
-  <%= submit "Add goal →", class: "button text-base font-bold w-full" %>
+  <%= submit("Add goal →", class: "button text-base font-bold w-full") %>
 <% end %>
 
 <script>

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,6 @@
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 Application.ensure_all_started(:double)
-FunWithFlags.enable(:revenue_goals)
 FunWithFlags.enable(:funnels)
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 ExUnit.configure(exclude: [:slow])


### PR DESCRIPTION
This pull request changes the UI for revenue goals, replaces the select box with a toggle, and adds a notice. It also polishes up the goal creation UI in general to have the same font sizes and weights compared to the rest of the page.

https://github.com/plausible/analytics/assets/5093045/d43b8d88-b8e3-470b-b33d-e620e94fee55

Thanks to @RobertJoonas for pairing up with me on this one! 