### PR TITLE
Reconfigure live websocket

### DIFF
--- a/assets/js/dashboard/stats/behaviours/funnel.js
+++ b/assets/js/dashboard/stats/behaviours/funnel.js
@@ -13,7 +13,6 @@ import LazyLoader from '../../components/lazy-loader'
 
 
 export default function Funnel(props) {
-  console.info('funnah')
   const [loading, setLoading] = useState(true)
   const [visible, setVisible] = useState(false)
   const [error, setError] = useState(undefined)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -227,6 +227,16 @@ log_failed_login_attempts =
 
 websocket_url = get_var_from_path_or_env(config_dir, "WEBSOCKET_URL", "")
 
+if byte_size(websocket_url) > 0 and
+     not String.ends_with?(URI.new!(websocket_url).host, base_url.host) do
+  raise """
+  Cross-domain websocket authentication is not supported for this server.
+
+  WEBSOCKET_URL=#{websocket_url} - host must be: '#{base_url.host}',
+  because BASE_URL=#{base_url} so the host is ``.
+  """
+end
+
 config :plausible,
   environment: env,
   mailer_email: mailer_email,

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -54,7 +54,8 @@ defmodule PlausibleWeb.Endpoint do
 
   plug Plug.Session, @session_options
 
-  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: {__MODULE__, :patch_session_opts, []}]]
 
   plug CORSPlug
   plug PlausibleWeb.Router
@@ -63,5 +64,13 @@ defmodule PlausibleWeb.Endpoint do
     :plausible
     |> Application.fetch_env!(__MODULE__)
     |> Keyword.fetch!(:websocket_url)
+  end
+
+  def patch_session_opts() do
+    # `host()` provided by Phoenix.Endpoint's compilation hooks
+    # is used to inject the domain - this way we can authenticate
+    # websocket requests within single root domain, in case websocket_url()
+    # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
+    Keyword.put(@session_options, :domain, host())
   end
 end

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -55,7 +55,10 @@ defmodule PlausibleWeb.Endpoint do
   plug Plug.Session, @session_options
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: {__MODULE__, :patch_session_opts, []}]]
+    websocket: [
+      check_origin: true,
+      connect_info: [session: {__MODULE__, :patch_session_opts, []}]
+    ]
 
   plug CORSPlug
   plug PlausibleWeb.Router
@@ -71,6 +74,7 @@ defmodule PlausibleWeb.Endpoint do
     # is used to inject the domain - this way we can authenticate
     # websocket requests within single root domain, in case websocket_url()
     # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
-    Keyword.put(@session_options, :domain, host())
+    @session_options
+    |> Keyword.put(:domain, host())
   end
 end

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -74,7 +74,6 @@ defmodule PlausibleWeb.Endpoint do
     # is used to inject the domain - this way we can authenticate
     # websocket requests within single root domain, in case websocket_url()
     # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
-    @session_options
-    |> Keyword.put(:domain, host())
+    Keyword.put(@session_options, :domain, host())
   end
 end


### PR DESCRIPTION
### Changes

This is an attempt of enforcing the websocket session authentication within the same root domain, otherwise the socket was unable to retrieve the cookie. Ref #3082 - in case we like to provide a fully qualified `wss://` URL.

I have tested it with the following steps:

1. Remove `BASE_URL` from `config/.env.dev` - otherwise it'll override environment variables 😥
2. Adding the following `/etc/hosts` entries:

  ```
  127.0.0.1 plausible.local
  127.0.0.1 ws.plausible.local
  ```

3. Running `BASE_URL=http://plausible.local:8000 WEBSOCKET_URL=ws://ws.plausible.local:8000 iex -S mix`
4. Accessing funnel settings via `http://plausible.local:8000`

![image](https://github.com/plausible/analytics/assets/173738/a02266cf-240f-438c-9fdf-46e7ea30074d)

Additionally, this PR sets origin check for the live websocket alone, to prevent Cross-Site WebSocket Hijacking (CSWSH) attacks. The setting has been verified by accessing the funnel settings via yet another origin:

![image](https://github.com/plausible/analytics/assets/173738/446d2c3a-a37d-457b-b525-2934b2d17a55)

Endpoint configuration remains intact for now. The expectation is not to break anything for proxy clients and self-hosters.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
