### PR TITLE
Dynamically set up session domain

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -233,7 +233,7 @@ if byte_size(websocket_url) > 0 and
   Cross-domain websocket authentication is not supported for this server.
 
   WEBSOCKET_URL=#{websocket_url} - host must be: '#{base_url.host}',
-  because BASE_URL=#{base_url} so the host is ``.
+  because BASE_URL=#{base_url}.
   """
 end
 

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -9,6 +9,7 @@ defmodule PlausibleWeb.Endpoint do
     # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
     max_age: 60 * 60 * 24 * 365 * 5,
     extra: "SameSite=Lax"
+    # domain added dynamically via RuntimeSessionAdapter, see below
   ]
 
   # Serve at "/" the static files from "priv/static" directory.
@@ -52,7 +53,7 @@ defmodule PlausibleWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
 
-  plug Plug.Session, @session_options
+  plug PlausibleWeb.Plugs.RuntimeSessionAdapter, @session_options
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [

--- a/lib/plausible_web/plugs/runtime_session_adapter.ex
+++ b/lib/plausible_web/plugs/runtime_session_adapter.ex
@@ -1,0 +1,30 @@
+defmodule PlausibleWeb.Plugs.RuntimeSessionAdapter do
+  @moduledoc """
+  A `Plug.Session` adapter that allows configuration at runtime.
+  Sadly, the plug being wrapped has no MFA option for dynamic
+  configuration.
+
+  This is currently used so we can dynamically pass the :domain
+  and have cookies planted across one root domain.
+  """
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    Plug.Session.init(opts)
+  end
+
+  @impl true
+  def call(conn, opts) do
+    Plug.Session.call(conn, patch_cookie_domain(opts))
+  end
+
+  defp patch_cookie_domain(%{cookie_opts: cookie_opts} = runtime_opts) do
+    Map.replace(
+      runtime_opts,
+      :cookie_opts,
+      Keyword.put_new(cookie_opts, :domain, PlausibleWeb.Endpoint.host())
+    )
+  end
+end


### PR DESCRIPTION
### Changes

A follow-up to #3087 - turns out we have to pass the domain explicitly to the Endpoint/Session plug configuration as well. Because, with the existing interface, it can be done only at compile time, we can't rely on the `BASE_URL` that's currently configured in `runtime.exs`.

Another way of tackling this would be to have multiple static configs per `MIX_ENV`, but I think we have enough configuration complexity to deal with.

This PR will inject `:domain` option, at runtime, to the `Plug.Session` calls.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
