### PR TITLE
Bugfix: funnel deletion

### DIFF
--- a/lib/plausible_web/live/funnel_settings.ex
+++ b/lib/plausible_web/live/funnel_settings.ex
@@ -80,11 +80,14 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   end
 
   def handle_event("delete-funnel", %{"funnel-id" => id}, socket) do
+    site =
+      Sites.get_for_user!(socket.assigns.current_user_id, socket.assigns.domain, [:owner, :admin])
+
     id = String.to_integer(id)
-    :ok = Funnels.delete(socket.assigns.site, id)
+    :ok = Funnels.delete(site, id)
     socket = put_flash(socket, :success, "Funnel deleted successfully")
     Process.send_after(self(), :clear_flash, 5000)
-    {:noreply, assign(socket, funnels: Funnels.list(socket.assigns.site))}
+    {:noreply, assign(socket, funnels: Enum.reject(socket.assigns.funnels, &(&1.id == id)))}
   end
 
   def handle_info({:funnel_saved, funnel}, socket) do

--- a/lib/plausible_web/live/funnel_settings/list.ex
+++ b/lib/plausible_web/live/funnel_settings/list.ex
@@ -25,6 +25,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.List do
                 </span>
               </span>
               <button
+                id={"delete-funnel-#{funnel.id}"}
                 phx-click="delete-funnel"
                 phx-value-funnel-id={funnel.id}
                 class="text-sm text-red-600"


### PR DESCRIPTION
Somewhere along the way of rebasing the feature,
the integration tests for deletion were lost.

j/k they were never written 🤡

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
