### PR TITLE
Fix spacing between two notices in funnel settings

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -4,9 +4,9 @@ defmodule PlausibleWeb.Components.Generic do
   """
   use Phoenix.Component
 
-  attr(:title, :string, default: "Notice")
-  attr(:class, :string)
-  slot(:inner_block)
+  attr :title, :string, default: "Notice"
+  attr :class, :string, default: ""
+  slot :inner_block
 
   def notice(assigns) do
     ~H"""

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -4,12 +4,16 @@ defmodule PlausibleWeb.Components.Generic do
   """
   use Phoenix.Component
 
-  attr :title, :string, default: "Notice"
-  slot :inner_block
+  attr(:title, :string, default: "Notice")
+  attr(:class, :string)
+  slot(:inner_block)
 
   def notice(assigns) do
     ~H"""
-    <div class="rounded-md bg-yellow-50 p-4 dark:bg-transparent dark:border border-yellow-200">
+    <div class={[
+      "rounded-md bg-yellow-50 p-4 dark:bg-transparent dark:border border-yellow-200",
+      @class
+    ]}>
       <div class="flex">
         <div class="flex-shrink-0">
           <svg

--- a/lib/plausible_web/live/funnel_settings.ex
+++ b/lib/plausible_web/live/funnel_settings.ex
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
         </div>
 
         <div :if={@goal_count < Funnel.min_steps()}>
-          <PlausibleWeb.Components.Generic.notice>
+          <PlausibleWeb.Components.Generic.notice class="mt-4" title="Not enough goals">
             You need to define at least two goals to create a funnel. Go ahead and <%= link(
               "add goals",
               to: PlausibleWeb.Router.Helpers.site_path(@socket, :new_goal, @domain),


### PR DESCRIPTION
### Changes

Before:

![image](https://github.com/plausible/analytics/assets/173738/caf587cd-e6a7-409c-a5aa-86f4aa00c33d)


After:

![image](https://github.com/plausible/analytics/assets/173738/bd58185c-1ebc-4559-ab80-ca61c75be463)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
