### PR TITLE
Bump funnel max size to 8 steps

### DIFF
--- a/assets/js/dashboard/stats/behaviours/funnel.js
+++ b/assets/js/dashboard/stats/behaviours/funnel.js
@@ -51,7 +51,7 @@ export default function Funnel(props) {
   }, [funnel, visible])
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(max-width: 600px)')
+    const mediaQuery = window.matchMedia('(max-width: 768px)')
     setSmallScreen(mediaQuery.matches)
     const handleScreenChange = (e) => {
       setSmallScreen(e.matches);
@@ -164,6 +164,14 @@ export default function Funnel(props) {
     const dropOffData = funnel.steps.map((step) => step.dropoff)
     const ctx = canvasRef.current.getContext("2d")
 
+    const calcBarThickness = (ctx) => {
+      if (ctx.dataset.data.length <= 3) {
+        return 160
+      } else {
+        return Math.floor(650 / ctx.dataset.data.length)
+      }
+    }
+
     // passing those verbatim to make sure canvas rendering picks them up
     var fontFamily = 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"'
 
@@ -199,7 +207,7 @@ export default function Funnel(props) {
       data: data,
       options: {
         responsive: true,
-        barThickness: 120,
+        barThickness: calcBarThickness,
         plugins: {
           legend: {
             display: false,

--- a/lib/plausible/funnel.ex
+++ b/lib/plausible/funnel.ex
@@ -1,6 +1,6 @@
 defmodule Plausible.Funnel do
   @min_steps 2
-  @max_steps 5
+  @max_steps 8
 
   @moduledoc """
   A funnel is a marketing term used to capture and describe the journey

--- a/test/plausible/funnels_test.exs
+++ b/test/plausible/funnels_test.exs
@@ -14,12 +14,15 @@ defmodule Plausible.FunnelsTest do
     {:ok, g4} = Goals.create(site, %{"event_name" => "Leave feedback"})
     {:ok, g5} = Goals.create(site, %{"page_path" => "/recommend"})
     {:ok, g6} = Goals.create(site, %{"event_name" => "Extra event"})
+    {:ok, g7} = Goals.create(site, %{"event_name" => "Extra event 2"})
+    {:ok, g8} = Goals.create(site, %{"event_name" => "Extra event 3"})
+    {:ok, g9} = Goals.create(site, %{"event_name" => "Extra event 4"})
 
     {:ok,
      %{
        site: site,
        goals: [g1, g2, g3],
-       steps: [g1, g2, g3, g4, g5, g6] |> Enum.map(&%{"goal_id" => &1.id})
+       steps: [g1, g2, g3, g4, g5, g6, g7, g8, g9] |> Enum.map(&%{"goal_id" => &1.id})
      }}
   end
 
@@ -84,7 +87,14 @@ defmodule Plausible.FunnelsTest do
                )
     end
 
-    test "a funnel can be made of 5 steps maximum", %{site: site, steps: too_many_steps} do
+    test "a funnel can be made of 8 steps maximum", %{site: site, steps: too_many_steps} do
+      assert {:ok, _} =
+               Funnels.create(
+                 site,
+                 "Lorem ipsum",
+                 Enum.take(too_many_steps, 8)
+               )
+
       assert {:error, :invalid_funnel_size} =
                Funnels.create(
                  site,


### PR DESCRIPTION
### Changes

This PR enables funnels as large as 8 steps maximum.

https://github.com/plausible/analytics/assets/173738/9ec46399-b0ca-4ae2-8be6-6db04f1d7993

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
