### PR TITLE
Evaluate ephemeral funnels before saving

### DIFF
--- a/assets/js/dashboard/stats/behaviours/funnel-tooltip.js
+++ b/assets/js/dashboard/stats/behaviours/funnel-tooltip.js
@@ -56,7 +56,7 @@ export default function FunnelTooltip(palette, funnel) {
               </td>
               <td class="text-right text-sm">
                 <span>
-                  ${dataIndex == 0 ? formatPercentage(funnel.entering_visitors_percentage) : formatPercentage(currentStep.conversion_rate_step)}%
+                  ${dataIndex == 0 ? funnel.entering_visitors_percentage : currentStep.conversion_rate_step}%
                 </span>
               </td>
             </tr>
@@ -73,7 +73,7 @@ export default function FunnelTooltip(palette, funnel) {
                 <span>${dataIndex == 0 ? funnel.never_entering_visitors.toLocaleString() : currentStep.dropoff.toLocaleString()}</span>
               </td >
               <td class="text-right text-sm">
-                <span>${dataIndex == 0 ? formatPercentage(funnel.never_entering_visitors_percentage) : formatPercentage(currentStep.dropoff_percentage)}%</span>
+                <span>${dataIndex == 0 ? funnel.never_entering_visitors_percentage : currentStep.dropoff_percentage}%</span>
               </td>
             </tr >
           </table >
@@ -82,9 +82,4 @@ export default function FunnelTooltip(palette, funnel) {
     }
     tooltipEl.style.display = null
   }
-}
-
-const formatPercentage = (value) => {
-  const decimalNumber = parseFloat(value);
-  return decimalNumber % 1 === 0 ? decimalNumber.toFixed(0) : value;
 }

--- a/assets/js/dashboard/stats/behaviours/funnel.js
+++ b/assets/js/dashboard/stats/behaviours/funnel.js
@@ -97,7 +97,7 @@ export default function Funnel(props) {
   const formatDataLabel = (visitors, ctx) => {
     if (ctx.dataset.label === 'Visitors') {
       const conversionRate = funnel.steps[ctx.dataIndex].conversion_rate
-      return `${formatPercentage(conversionRate)}% \n(${numberFormatter(visitors)} Visitors)`
+      return `${conversionRate}% \n(${numberFormatter(visitors)} Visitors)`
     } else {
       return null
     }
@@ -337,11 +337,6 @@ export default function Funnel(props) {
         </FlipMove>
       </>
     )
-  }
-
-  const formatPercentage = (value) => {
-    const decimalNumber = parseFloat(value);
-    return decimalNumber % 1 === 0 ? decimalNumber.toFixed(0) : value;
   }
 
   return (

--- a/lib/plausible/stats/funnel.ex
+++ b/lib/plausible/stats/funnel.ex
@@ -169,14 +169,22 @@ defmodule Plausible.Stats.Funnel do
   end
 
   defp percentage(x, y) when x in [0, nil] or y in [0, nil] do
-    "0.00"
+    "0"
   end
 
   defp percentage(x, y) do
-    x
-    |> Decimal.div(y)
-    |> Decimal.mult(100)
-    |> Decimal.round(2)
-    |> Decimal.to_string()
+    result =
+      x
+      |> Decimal.div(y)
+      |> Decimal.mult(100)
+      |> Decimal.round(2)
+      |> Decimal.to_string()
+
+    case result do
+      <<compact::binary-size(1), ".00">> -> compact
+      <<compact::binary-size(2), ".00">> -> compact
+      <<compact::binary-size(3), ".00">> -> compact
+      decimal -> decimal
+    end
   end
 end

--- a/lib/plausible_web/live/funnel_settings/form.ex
+++ b/lib/plausible_web/live/funnel_settings/form.ex
@@ -31,14 +31,15 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
        form: to_form(Plausible.Funnels.create_changeset(site, "", [])),
        goals: goals,
        site: site,
-       selections_made: Map.new()
+       selections_made: Map.new(),
+       evaluation_result: nil
      )}
   end
 
   def render(assigns) do
     ~H"""
-    <div id="funnel-form" class="grid grid-cols-4 gap-6 mt-6">
-      <div class="col-span-4 sm:col-span-2">
+    <div id="funnel-form" class="grid grid-cols-2 gap-6 mt-6">
+      <div class="col-span-2 sm:col-span-2">
         <.form
           :let={f}
           for={@form}
@@ -58,7 +59,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
             ) %>
 
             <div :for={step_idx <- @step_ids} class="flex">
-              <div class="w-full flex-1">
+              <div class="w-2/5 flex-1">
                 <.live_component
                   submit_name="funnel[steps][][goal_id]"
                   module={PlausibleWeb.Live.FunnelSettings.ComboBox}
@@ -67,7 +68,17 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
                 />
               </div>
 
-              <.remove_step_button :if={length(@step_ids) > Funnel.min_steps()} step_idx={step_idx} />
+              <div class="w-min inline-flex items-center align-middle">
+                <.remove_step_button :if={length(@step_ids) > Funnel.min_steps()} step_idx={step_idx} />
+              </div>
+
+              <div class="w-2/5 inline-flex items-center ml-2 mb-3 text-gray-500 dark:text-gray-400">
+                <.evaluation
+                  :if={@evaluation_result}
+                  result={@evaluation_result}
+                  at={Enum.find_index(@step_ids, &(&1 == step_idx))}
+                />
+              </div>
             </div>
 
             <.add_step_button :if={
@@ -76,7 +87,19 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
             } />
 
             <div class="mt-6">
-              <%= if has_steps_errors?(f) do %>
+              <p id="funnel-eval" class="text-gray-500 dark:text-gray-400 text-sm mt-2 mb-2">
+                <%= if @evaluation_result do %>
+                  Last month conversion rate: <strong><%= List.last(@evaluation_result.steps).conversion_rate %></strong>%
+                <% else %>
+                  <span class="text-red-600 text-sm">
+                    Choose minimum <%= Funnel.min_steps() %> steps to evaluate funnel.
+                  </span>
+                <% end %>
+              </p>
+            </div>
+
+            <div class="mt-6">
+              <%= if has_steps_errors?(f) or map_size(@selections_made) < Funnel.min_steps() or length(@step_ids) > map_size(@selections_made) do %>
                 <.submit_button_inactive />
               <% else %>
                 <.submit_button />
@@ -103,7 +126,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
         name={@field.name}
         value={@field.value}
         phx-debounce="300"
-        class="focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-900 dark:text-gray-300 block w-full rounded-md sm:text-sm border-gray-300 dark:border-gray-500"
+        class="focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-900 dark:text-gray-300 block w-7/12 rounded-md sm:text-sm border-gray-300 dark:border-gray-500"
       />
 
       <.error :for={{msg, _} <- @field.errors}>Funnel name <%= msg %></.error>
@@ -123,7 +146,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
 
   def remove_step_button(assigns) do
     ~H"""
-    <div class="inline-flex items-center ml-2 mb-2 text-red-600">
+    <div class="inline-flex items-center ml-2 mb-4 text-red-600">
       <svg
         id={"remove-step-#{@step_idx}"}
         class="feather feather-sm cursor-pointer"
@@ -187,6 +210,28 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
     """
   end
 
+  attr(:at, :integer, required: true)
+  attr(:result, :map, required: true)
+
+  def evaluation(assigns) do
+    ~H"""
+    <span class="text-xs">
+      <% step = Enum.at(@result.steps, @at) %>
+      <span :if={step && @at == 0}>
+        <span
+          class="border-dotted border-b border-gray-400 "
+          tooltip="Sample calculation for last month"
+        >
+          Entering Visitors: <strong><%= @result.entering_visitors %></strong>
+        </span>
+      </span>
+      <span :if={step && @at > 0}>
+        Dropoff: <strong><%= Map.get(step, :dropoff_percentage) %>%</strong>
+      </span>
+    </span>
+    """
+  end
+
   def handle_event("add-step", _value, socket) do
     step_ids = socket.assigns.step_ids
 
@@ -203,6 +248,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
     idx = String.to_integer(idx)
     step_ids = List.delete(socket.assigns.step_ids, idx)
     selections_made = drop_selection(socket.assigns.selections_made, idx)
+    send(self(), :evaluate_funnel)
 
     {:noreply, assign(socket, step_ids: step_ids, selections_made: selections_made)}
   end
@@ -240,10 +286,53 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
   def handle_info({:selection_made, %{submit_value: goal_id, by: combo_box}}, socket) do
     selections_made = store_selection(socket.assigns, combo_box, goal_id)
 
+    send(self(), :evaluate_funnel)
+
     {:noreply,
      assign(socket,
        selections_made: selections_made
      )}
+  end
+
+  def handle_info(:evaluate_funnel, socket) do
+    {:noreply, assign(socket, evaluation_result: evaluate_funnel(socket))}
+  end
+
+  defp evaluate_funnel(socket) do
+    if map_size(socket.assigns.selections_made) >= Funnel.min_steps() do
+      site = socket.assigns.site
+
+      steps =
+        socket.assigns.selections_made
+        |> Enum.sort_by(&elem(&1, 0))
+        |> Enum.map(fn {_, goal} ->
+          %{
+            "goal_id" => goal.id,
+            "goal" => %{
+              "id" => goal.id,
+              "event_name" => goal.event_name,
+              "page_path" => goal.page_path
+            }
+          }
+        end)
+
+      definition =
+        Plausible.Funnels.ephemeral_definition(
+          site,
+          "Test funnel",
+          steps
+        )
+
+      query = Plausible.Stats.Query.from(site, %{"period" => "all"})
+
+      case Plausible.Stats.funnel(site, query, definition) do
+        {:ok, funnel} ->
+          funnel
+
+        _ ->
+          nil
+      end
+    end
   end
 
   defp find_sequence_break(input) do

--- a/test/plausible/funnels_test.exs
+++ b/test/plausible/funnels_test.exs
@@ -178,26 +178,26 @@ defmodule Plausible.FunnelsTest do
                   %{
                     label: "Visit /go/to/blog/**",
                     visitors: 2,
-                    conversion_rate: "100.00",
-                    conversion_rate_step: "0.00",
+                    conversion_rate: "100",
+                    conversion_rate_step: "0",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   },
                   %{
                     label: "Signup",
                     visitors: 2,
-                    conversion_rate: "100.00",
-                    conversion_rate_step: "100.00",
+                    conversion_rate: "100",
+                    conversion_rate_step: "100",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   },
                   %{
                     label: "Visit /checkout",
                     visitors: 1,
-                    conversion_rate: "50.00",
-                    conversion_rate_step: "50.00",
+                    conversion_rate: "50",
+                    conversion_rate_step: "50",
                     dropoff: 1,
-                    dropoff_percentage: "50.00"
+                    dropoff_percentage: "50"
                   }
                 ]
               }} = funnel_data
@@ -230,32 +230,32 @@ defmodule Plausible.FunnelsTest do
               %{
                 all_visitors: 2,
                 entering_visitors: 2,
-                entering_visitors_percentage: "100.00",
+                entering_visitors_percentage: "100",
                 never_entering_visitors: 0,
-                never_entering_visitors_percentage: "0.00",
+                never_entering_visitors_percentage: "0",
                 steps: [
                   %{
                     label: "Visit /go/to/blog/**",
                     visitors: 2,
-                    conversion_rate: "100.00",
-                    conversion_rate_step: "0.00",
+                    conversion_rate: "100",
+                    conversion_rate_step: "0",
                     dropoff: 0
                   },
                   %{
                     label: "Signup",
                     visitors: 2,
-                    conversion_rate: "100.00",
-                    conversion_rate_step: "100.00",
+                    conversion_rate: "100",
+                    conversion_rate_step: "100",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   },
                   %{
                     label: "Visit /checkout",
                     visitors: 1,
-                    conversion_rate: "50.00",
-                    conversion_rate_step: "50.00",
+                    conversion_rate: "50",
+                    conversion_rate_step: "50",
                     dropoff: 1,
-                    dropoff_percentage: "50.00"
+                    dropoff_percentage: "50"
                   }
                 ]
               }} = funnel_data
@@ -280,33 +280,33 @@ defmodule Plausible.FunnelsTest do
               %{
                 all_visitors: 0,
                 entering_visitors: 0,
-                entering_visitors_percentage: "0.00",
+                entering_visitors_percentage: "0",
                 never_entering_visitors: 0,
-                never_entering_visitors_percentage: "0.00",
+                never_entering_visitors_percentage: "0",
                 steps: [
                   %{
                     label: "Visit /go/to/blog/**",
                     visitors: 0,
-                    conversion_rate: "0.00",
-                    conversion_rate_step: "0.00",
+                    conversion_rate: "0",
+                    conversion_rate_step: "0",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   },
                   %{
                     label: "Signup",
                     visitors: 0,
-                    conversion_rate: "0.00",
-                    conversion_rate_step: "0.00",
+                    conversion_rate: "0",
+                    conversion_rate_step: "0",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   },
                   %{
                     label: "Visit /checkout",
                     visitors: 0,
-                    conversion_rate: "0.00",
-                    conversion_rate_step: "0.00",
+                    conversion_rate: "0",
+                    conversion_rate_step: "0",
                     dropoff: 0,
-                    dropoff_percentage: "0.00"
+                    dropoff_percentage: "0"
                   }
                 ]
               }} = funnel_data

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -41,34 +41,34 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
                "never_entering_visitors_percentage" => "33.33",
                "steps" => [
                  %{
-                   "conversion_rate" => "100.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "100",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Visit /blog/announcement",
                    "visitors" => 2
                  },
                  %{
-                   "conversion_rate" => "100.00",
-                   "conversion_rate_step" => "100.00",
+                   "conversion_rate" => "100",
+                   "conversion_rate_step" => "100",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Signup",
                    "visitors" => 2
                  },
                  %{
-                   "conversion_rate" => "50.00",
-                   "conversion_rate_step" => "50.00",
+                   "conversion_rate" => "50",
+                   "conversion_rate_step" => "50",
                    "dropoff" => 1,
-                   "dropoff_percentage" => "50.00",
+                   "dropoff_percentage" => "50",
                    "label" => "Visit /cart/add/product",
                    "visitors" => 1
                  },
                  %{
-                   "conversion_rate" => "50.00",
-                   "conversion_rate_step" => "100.00",
+                   "conversion_rate" => "50",
+                   "conversion_rate_step" => "100",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Purchase",
                    "visitors" => 1
                  }
@@ -128,39 +128,39 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
                "name" => "Test funnel",
                "all_visitors" => 1,
                "entering_visitors" => 1,
-               "entering_visitors_percentage" => "100.00",
+               "entering_visitors_percentage" => "100",
                "never_entering_visitors" => 0,
-               "never_entering_visitors_percentage" => "0.00",
+               "never_entering_visitors_percentage" => "0",
                "steps" => [
                  %{
-                   "conversion_rate" => "100.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "100",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Visit /blog/announcement",
                    "visitors" => 1
                  },
                  %{
-                   "conversion_rate" => "100.00",
-                   "conversion_rate_step" => "100.00",
+                   "conversion_rate" => "100",
+                   "conversion_rate_step" => "100",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Signup",
                    "visitors" => 1
                  },
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 1,
-                   "dropoff_percentage" => "100.00",
+                   "dropoff_percentage" => "100",
                    "label" => "Visit /cart/add/product",
                    "visitors" => 0
                  },
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Purchase",
                    "visitors" => 0
                  }
@@ -180,39 +180,39 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
                "name" => "Test funnel",
                "all_visitors" => 0,
                "entering_visitors" => 0,
-               "entering_visitors_percentage" => "0.00",
+               "entering_visitors_percentage" => "0",
                "never_entering_visitors" => 0,
-               "never_entering_visitors_percentage" => "0.00",
+               "never_entering_visitors_percentage" => "0",
                "steps" => [
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Visit /blog/announcement",
                    "visitors" => 0
                  },
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Signup",
                    "visitors" => 0
                  },
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Visit /cart/add/product",
                    "visitors" => 0
                  },
                  %{
-                   "conversion_rate" => "0.00",
-                   "conversion_rate_step" => "0.00",
+                   "conversion_rate" => "0",
+                   "conversion_rate_step" => "0",
                    "dropoff" => 0,
-                   "dropoff_percentage" => "0.00",
+                   "dropoff_percentage" => "0",
                    "label" => "Purchase",
                    "visitors" => 0
                  }

--- a/test/plausible_web/live/funnel_settings/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings/funnel_settings_test.exs
@@ -164,10 +164,14 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
 
       assert lv = find_live_child(lv, "funnels-form")
 
+      lv
+      |> element("li#dropdown-step-1-option-0 a")
+      |> render_click()
+
       doc =
         lv
-        |> element("form")
-        |> render_change(%{funnel: %{name: "My test funnel"}})
+        |> element("li#dropdown-step-2-option-0 a")
+        |> render_click()
 
       save_inactive = ~s/form button#save.cursor-not-allowed/
       save_active = ~s/form button#save[type="submit"]/

--- a/test/plausible_web/live/funnel_settings/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings/funnel_settings_test.exs
@@ -217,10 +217,10 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
       assert text_of_element(doc, ~s/#step-eval-0/) =~ "Entering Visitors: 0"
 
       doc = lv |> element("#step-eval-1") |> render()
-      assert text_of_element(doc, ~s/#step-eval-1/) =~ "Dropoff: 0.00%"
+      assert text_of_element(doc, ~s/#step-eval-1/) =~ "Dropoff: 0%"
 
       doc = lv |> element("#funnel-eval") |> render()
-      assert text_of_element(doc, ~s/#funnel-eval/) =~ "Last month conversion rate: 0.00%"
+      assert text_of_element(doc, ~s/#funnel-eval/) =~ "Last month conversion rate: 0%"
     end
 
     test "cancel buttons renders the funnel list", %{


### PR DESCRIPTION
### Changes

This PR introduces funnel evaluation during funnel creation, so that it's easier to get a grasp of whether the funnel has been configured properly. The funnel form will now show data similar to the funnel chart with every step selection change updating the result. 

By the way, percentage compaction (i.e. `0` instead of `0.00`) was moved server-side, so that it's consistent across the whole stack. Primitives used for percentage calculation are available in the API anyway, in case clients want to use their own representation.

https://github.com/plausible/analytics/assets/173738/398a8e89-3135-47e1-8d11-b6420464e77f

Dark mode:

![image](https://github.com/plausible/analytics/assets/173738/b5166954-2b76-4a77-96ea-f0c2df1a94d8)


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
