### PR TITLE
Enable superadmin access to funnel settings

### DIFF
--- a/lib/plausible_web/live/funnel_settings.ex
+++ b/lib/plausible_web/live/funnel_settings.ex
@@ -15,7 +15,13 @@ defmodule PlausibleWeb.Live.FunnelSettings do
         socket
       ) do
     true = Plausible.Funnels.enabled_for?("user:#{user_id}")
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin])
+
+    site =
+      if Plausible.Auth.is_super_admin?(user_id) do
+        Sites.get_by_domain(domain)
+      else
+        Sites.get_for_user!(user_id, domain, [:owner, :admin])
+      end
 
     funnels = Funnels.list(site)
     goal_count = Goals.count(site)

--- a/lib/plausible_web/live/funnel_settings/form.ex
+++ b/lib/plausible_web/live/funnel_settings/form.ex
@@ -12,7 +12,12 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
   alias Plausible.{Sites, Goals}
 
   def mount(_params, %{"current_user_id" => user_id, "domain" => domain}, socket) do
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin])
+    site =
+      if Plausible.Auth.is_super_admin?(user_id) do
+        Sites.get_by_domain(domain)
+      else
+        Sites.get_for_user!(user_id, domain, [:owner, :admin])
+      end
 
     # We'll have the options trimmed to only the data we care about, to keep
     # it minimal at the socket assigns, yet, we want to retain specific %Goal{}


### PR DESCRIPTION
### Changes

Doesn't make the lv crash when superadmin accesses it. This is only extra measure, the main mount point is already guarded via `PlausibleWeb.AuthorizeSiteAccess` plug in the controller.
I'm allowing myself to skip tests on that one, because it requires env patching.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
