### PR TITLE
Fix the country filter label when clicking on a country on the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Fix broken favicons when domain includes a slash
 - Fix bug when using multiple [wildcard goal filters](https://github.com/plausible/analytics/pull/3015)
 - Fix a bug where realtime would fail with imported data
+- Fix a bug where the country name was not shown when [filtering through the map](https://github.com/plausible/analytics/issues/3086)
 
 ### Changed
 - Treat page filter as entry page filter for `bounce_rate`

--- a/assets/js/dashboard/stats/locations/map.js
+++ b/assets/js/dashboard/stats/locations/map.js
@@ -121,7 +121,7 @@ class Countries extends React.Component {
               this.props.query,
               {
                 country: country.code,
-                country_name: country.name
+                country_labels: country.name
               }
             )
           }


### PR DESCRIPTION
### Changes

Fixes the bug as described in #3086 
The filter label takes the value from the `country_labels` field and not `country_name`.
By changing the property to `country_labels`, the correct name shows up in the filter

### Tests
- [X] This PR does not require tests

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
