### PR TITLE
Fix the interval selection in the all time view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Fix bug when using multiple [wildcard goal filters](https://github.com/plausible/analytics/pull/3015)
 - Fix a bug where realtime would fail with imported data
 - Fix a bug where the country name was not shown when [filtering through the map](https://github.com/plausible/analytics/issues/3086)
+- Fix [broken interval selection](https://github.com/plausible/analytics/issues/3086) in the all time view
 
 ### Changed
 - Treat page filter as entry page filter for `bounce_rate`

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -15,7 +15,7 @@ defmodule Plausible.Stats.Query do
 
   def from(site, params) do
     query_by_period(site, params)
-    |> maybe_put_interval(params)
+    |> put_interval(params)
     |> put_parsed_filters(params)
     |> put_imported_opts(site, params)
     |> put_sample_threshold(params)
@@ -118,12 +118,9 @@ defmodule Plausible.Stats.Query do
     now = today(site.timezone)
     start_date = Plausible.Site.local_start_date(site) || now
 
-    date_range = Date.range(start_date, now)
-
     %__MODULE__{
       period: "all",
-      date_range: date_range,
-      interval: Interval.default_for_date_range(date_range)
+      date_range: Date.range(start_date, now)
     }
   end
 
@@ -151,12 +148,15 @@ defmodule Plausible.Stats.Query do
     query_by_period(site, Map.merge(params, %{"period" => "30d"}))
   end
 
-  defp maybe_put_interval(%{interval: nil} = query, params) do
-    interval = Map.get(params, "interval", Interval.default_for_period(query.period))
+  defp put_interval(%{:period => "all"} = query, params) do
+    interval = Map.get(params, "interval", Interval.default_for_date_range(query.date_range))
     Map.put(query, :interval, interval)
   end
 
-  defp maybe_put_interval(query, _), do: query
+  defp put_interval(query, params) do
+    interval = Map.get(params, "interval", Interval.default_for_period(query.period))
+    Map.put(query, :interval, interval)
+  end
 
   defp put_parsed_filters(query, params) do
     Map.put(query, :filters, FilterParser.parse_filters(params["filters"]))

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -130,6 +130,16 @@ defmodule Plausible.Stats.QueryTest do
     assert q.interval == "month"
   end
 
+  test "all time uses passed interval different from the default interval" do
+    site = Map.put(@site, :stats_start_date, Timex.now() |> Timex.shift(months: -1))
+    q = Query.from(site, %{"period" => "all", "interval" => "week"})
+
+    assert q.date_range.first == Timex.today() |> Timex.shift(months: -1)
+    assert q.date_range.last == Timex.today()
+    assert q.period == "all"
+    assert q.interval == "week"
+  end
+
   test "defaults to 30 days format" do
     assert Query.from(@site, %{}) == Query.from(@site, %{"period" => "30d"})
   end


### PR DESCRIPTION
Previously, the interval was always overwritten with the default value, which is determined based on the age of the site. It should not be overwritten when the interval is explicitly passed by the user

Fixes issue #2982 

### Changes

The way the query is build for the given params has been edited so that the default interval for the "all" period is only set when there is no interval in the passed params

### Tests
- [X] Automated tests have been added

### Changelog
- [X] Entry has been added to changelog

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
