### PR TITLE
Plot revenue metrics on main graph

### DIFF
--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -10,6 +10,8 @@ export const METRIC_MAPPING = {
   'Total visits': 'visits',
   'Bounce rate': 'bounce_rate',
   'Unique conversions': 'conversions',
+  'Average revenue': 'average_revenue',
+  'Total revenue': 'total_revenue',
 }
 
 export const METRIC_LABELS = {
@@ -20,6 +22,8 @@ export const METRIC_LABELS = {
   'bounce_rate': 'Bounce Rate',
   'visit_duration': 'Visit Duration',
   'conversions': 'Converted Visitors',
+  'average_revenue': 'Average Revenue',
+  'total_revenue': 'Total Revenue',
 }
 
 export const METRIC_FORMATTER = {
@@ -30,6 +34,8 @@ export const METRIC_FORMATTER = {
   'bounce_rate': (number) => (`${number}%`),
   'visit_duration': durationFormatter,
   'conversions': numberFormatter,
+  'total_revenue': numberFormatter,
+  'average_revenue': numberFormatter,
 }
 
 export const LoadingState = {
@@ -79,7 +85,7 @@ const buildMainPlotDataset = function(plot, presentIndex) {
   }]
 }
 
-export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) => {
+export const buildDataSet = (plot, comparisonPlot, present_index, ctx, metric) => {
   var gradient = ctx.createLinearGradient(0, 0, 0, 300);
   var prev_gradient = ctx.createLinearGradient(0, 0, 0, 300);
   gradient.addColorStop(0, 'rgba(101,116,205, 0.2)');
@@ -87,12 +93,21 @@ export const buildDataSet = (plot, comparisonPlot, present_index, ctx, label) =>
   prev_gradient.addColorStop(0, 'rgba(101,116,205, 0.075)');
   prev_gradient.addColorStop(1, 'rgba(101,116,205, 0)');
 
+  const label = METRIC_LABELS[metric]
   const defaultOptions = { label, borderWidth: 3, pointBorderColor: "transparent", pointHoverRadius: 4, backgroundColor: gradient, fill: true }
 
+  let mappedPlot = [...plot]
+  let mappedComparisonPlot = comparisonPlot && [...comparisonPlot]
+
+  if (['average_revenue', 'total_revenue'].includes(metric)) {
+    mappedPlot = mappedPlot.map(({ amount }) => amount)
+    mappedComparisonPlot = mappedComparisonPlot && mappedComparisonPlot.map(({ amount }) => amount)
+  }
+
   const dataset = [
-    ...buildMainPlotDataset(plot, present_index),
-    ...buildDashedDataset(plot, present_index),
-    ...buildComparisonDataset(comparisonPlot)
+    ...buildMainPlotDataset(mappedPlot, present_index),
+    ...buildDashedDataset(mappedPlot, present_index),
+    ...buildComparisonDataset(mappedComparisonPlot)
   ]
 
   return dataset.map((item) => Object.assign(item, defaultOptions))

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -90,10 +90,13 @@ export default class TopStats extends React.Component {
   }
 
   canMetricBeGraphed(stat) {
-    const isTotalUniqueVisitors = this.props.query.filters.goal && stat.name === 'Unique visitors'
-    const isKnownMetric = Object.keys(METRIC_MAPPING).includes(stat.name)
+    const goalFilteredMetrics = ['Unique visitors', 'Average revenue', 'Total revenue']
 
-    return isKnownMetric && !isTotalUniqueVisitors
+    if (goalFilteredMetrics.includes(stat.name)) {
+      return Boolean(this.props.query.filters.goal)
+    } else {
+      return Object.keys(METRIC_MAPPING).includes(stat.name)
+    }
   }
 
   maybeUpdateMetric(stat) {

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -43,7 +43,8 @@ class LineGraph extends React.Component {
     const { graphData, metric, query } = this.props
     const graphEl = document.getElementById("main-graph-canvas")
     this.ctx = graphEl.getContext('2d');
-    const dataSet = buildDataSet(graphData.plot, graphData.comparison_plot, graphData.present_index, this.ctx, METRIC_LABELS[metric])
+
+    const dataSet = buildDataSet(graphData.plot, graphData.comparison_plot, graphData.present_index, this.ctx , metric)
 
     return new Chart(this.ctx, {
       type: 'line',

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -23,10 +23,12 @@ defmodule Plausible.Stats.Breakdown do
 
     event_results =
       if Enum.any?(event_goals) do
+        revenue_goals = Enum.filter(event_goals, &Plausible.Goal.revenue?/1)
+
         site
         |> breakdown(event_query, "event:name", metrics, pagination)
         |> transform_keys(%{name: :goal})
-        |> cast_revenue_metrics_to_money(event_goals)
+        |> cast_revenue_metrics_to_money(revenue_goals)
       else
         []
       end
@@ -155,26 +157,6 @@ defmodule Plausible.Stats.Breakdown do
   def breakdown(site, query, property, metrics, pagination) do
     trace(query, property, metrics)
     breakdown_sessions(site, query, property, metrics, pagination)
-  end
-
-  defp cast_revenue_metrics_to_money(event_results, goals) do
-    cast_and_put = fn map, key, currency ->
-      if decimal = Map.get(map, key),
-        do: Map.put(map, key, Money.new!(currency, decimal)),
-        else: map
-    end
-
-    revenue_goals = Enum.filter(goals, &Plausible.Goal.revenue?/1)
-
-    Enum.map(event_results, fn result ->
-      if matching_goal = Enum.find(revenue_goals, &(&1.event_name == result.goal)) do
-        result
-        |> cast_and_put.(:total_revenue, matching_goal.currency)
-        |> cast_and_put.(:average_revenue, matching_goal.currency)
-      else
-        result
-      end
-    end)
   end
 
   defp zip_results(event_result, session_result, property, metrics) do

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -3,6 +3,8 @@ defmodule Plausible.Stats.Util do
   Utilities for modifying stat results
   """
 
+  import Ecto.Query
+
   @doc """
   `__internal_visits` is fetched when querying bounce rate and visit duration, as it
   is needed to calculate these from imported data. This function removes that metric
@@ -20,4 +22,65 @@ defmodule Plausible.Stats.Util do
   def remove_internal_visits_metric(result) when is_map(result) do
     Map.delete(result, :__internal_visits)
   end
+
+  @revenue_metrics [:average_revenue, :total_revenue]
+
+  @spec get_revenue_tracking_currency(%Plausible.Site{}, %Plausible.Stats.Query{}, [atom()]) ::
+          {atom() | nil, [atom()]}
+  @doc """
+  Returns the common currency for the goal filters in a query. If there are no
+  goal filters, or multiple currencies, `nil` is returned and revenue metrics
+  are dropped.
+
+  Aggregating revenue data works only for same currency goals. If the query is
+  filtered by goals with different currencies, for example, one USD and other
+  EUR, revenue metrics are dropped.
+  """
+  def get_revenue_tracking_currency(site, query, metrics) do
+    goal_filters =
+      case query.filters do
+        %{"event:goal" => {:is, {_, goal_name}}} -> [goal_name]
+        %{"event:goal" => {:member, list}} -> Enum.map(list, fn {_, goal_name} -> goal_name end)
+        _any -> []
+      end
+
+    if Enum.any?(metrics, &(&1 in @revenue_metrics)) && Enum.any?(goal_filters) do
+      revenue_goals_currencies =
+        Plausible.Repo.all(
+          from rg in Ecto.assoc(site, :revenue_goals),
+            where: rg.event_name in ^goal_filters,
+            select: rg.currency,
+            distinct: true
+        )
+
+      if length(revenue_goals_currencies) == 1,
+        do: {List.first(revenue_goals_currencies), metrics},
+        else: {nil, metrics -- @revenue_metrics}
+    else
+      {nil, metrics -- @revenue_metrics}
+    end
+  end
+
+  def cast_revenue_metrics_to_money([%{goal: _goal} | _rest] = results, revenue_goals)
+      when is_list(revenue_goals) do
+    for result <- results do
+      if matching_goal = Enum.find(revenue_goals, &(&1.event_name == result.goal)) do
+        cast_revenue_metrics_to_money(result, matching_goal.currency)
+      else
+        result
+      end
+    end
+  end
+
+  def cast_revenue_metrics_to_money(results, currency) when is_map(results) do
+    for {metric, value} <- results, into: %{} do
+      if metric in @revenue_metrics && currency do
+        {metric, Money.new!(value || 0, currency)}
+      else
+        {metric, value}
+      end
+    end
+  end
+
+  def cast_revenue_metrics_to_money(results, _), do: results
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -145,7 +145,13 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp plot_timeseries(timeseries, metric) do
-    Enum.map(timeseries, fn row -> row[metric] || 0 end)
+    Enum.map(timeseries, fn row ->
+      case row[metric] do
+        nil -> 0
+        %Money{} = money -> format_money(money)
+        value -> value
+      end
+    end)
   end
 
   defp label_timeseries(main_result, nil) do
@@ -1152,7 +1158,8 @@ defmodule PlausibleWeb.Api.StatsController do
       %Money{} ->
         %{
           short: Money.to_string!(value, format: :short, fractional_digits: 1),
-          long: Money.to_string!(value)
+          long: Money.to_string!(value),
+          amount: Decimal.to_float(value.amount)
         }
 
       _any ->

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -260,8 +260,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "total_conversions" => 5,
                  "prop_names" => [],
                  "conversion_rate" => 100.0,
-                 "average_revenue" => %{"short" => "€166.7M", "long" => "€166,733,566.75"},
-                 "total_revenue" => %{"short" => "€500.2M", "long" => "€500,200,700.25"}
+                 "average_revenue" => %{
+                   "short" => "€166.7M",
+                   "long" => "€166,733,566.75",
+                   "amount" => 166_733_566.748
+                 },
+                 "total_revenue" => %{
+                   "short" => "€500.2M",
+                   "long" => "€500,200,700.25",
+                   "amount" => 500_200_700.246
+                 }
                }
              ]
     end
@@ -290,12 +298,12 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       assert [
                %{
-                 "average_revenue" => %{"long" => "€10.00", "short" => "€10.0"},
+                 "average_revenue" => %{"long" => "€10.00", "short" => "€10.0", "amount" => 10.0},
                  "conversion_rate" => 33.3,
                  "name" => "Payment",
                  "prop_names" => [],
                  "total_conversions" => 1,
-                 "total_revenue" => %{"long" => "€10.00", "short" => "€10.0"},
+                 "total_revenue" => %{"long" => "€10.00", "short" => "€10.0", "amount" => 10.0},
                  "unique_conversions" => 1
                },
                %{

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -929,4 +929,168 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert 0 == Enum.sum(comparison_plot)
     end
   end
+
+  describe "GET /api/stats/main-graph - total_revenue plot" do
+    setup [:create_user, :log_in, :create_new_site, :add_imported_data]
+
+    test "plots total_revenue for a month", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("13.29"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("19.90"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-05 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("10.31"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-31 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("20.0"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-31 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!(%{goal: "Payment"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=total_revenue&filters=#{filters}"
+        )
+
+      assert %{"plot" => plot} = json_response(conn, 200)
+
+      assert plot == [
+               %{"amount" => 13.29, "long" => "$13.29", "short" => "$13.3"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 19.9, "long" => "$19.90", "short" => "$19.9"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 30.31, "long" => "$30.31", "short" => "$30.3"}
+             ]
+    end
+  end
+
+  describe "GET /api/stats/main-graph - average_revenue plot" do
+    setup [:create_user, :log_in, :create_new_site, :add_imported_data]
+
+    test "plots total_revenue for a month", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("13.29"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("50.50"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("19.90"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-05 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("10.31"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-31 00:00:00]
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("20.0"),
+          revenue_reporting_currency: "USD",
+          timestamp: ~N[2021-01-31 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!(%{goal: "Payment"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=average_revenue&filters=#{filters}"
+        )
+
+      assert %{"plot" => plot} = json_response(conn, 200)
+
+      assert plot == [
+               %{"amount" => 31.895, "long" => "$31.90", "short" => "$31.9"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 19.9, "long" => "$19.90", "short" => "$19.9"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 0.0, "long" => "$0.00", "short" => "$0.0"},
+               %{"amount" => 15.155, "long" => "$15.16", "short" => "$15.2"}
+             ]
+    end
+  end
 end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -724,12 +724,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$1,659.50", "short" => "$1.7K"}
+               "value" => %{"long" => "$1,659.50", "short" => "$1.7K", "amount" => 1659.5}
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$3,319.00", "short" => "$3.3K"}
+               "value" => %{"long" => "$3,319.00", "short" => "$3.3K", "amount" => 3319.0}
              } in top_stats
     end
 
@@ -780,12 +780,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$1,659.50", "short" => "$1.7K"}
+               "value" => %{"long" => "$1,659.50", "short" => "$1.7K", "amount" => 1659.5}
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$6,638.00", "short" => "$6.6K"}
+               "value" => %{"long" => "$6,638.00", "short" => "$6.6K", "amount" => 6638.0}
              } in top_stats
     end
 


### PR DESCRIPTION
### Changes

This pull request plots revenue metrics on main graph. Previously, revenue metrics were not clickable from top stats. Here's a preview:

<img width="1135" alt="Screenshot 2023-07-06 at 21 32 35" src="https://github.com/plausible/analytics/assets/5093045/46c12864-b139-4177-be0e-6c50da2b196c">


### Tests
- [X] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
