### PR TITLE
Prevent robots from looking too much into public dashboards

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -67,7 +67,7 @@ defmodule PlausibleWeb.StatsController do
           funnels: Plausible.Funnels.list(site),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
-          title: "Plausible · " <> site.domain,
+          title: title(conn, site),
           offer_email_report: offer_email_report,
           demo: demo,
           flags: get_flags(conn.assigns[:current_user]),
@@ -295,7 +295,7 @@ defmodule PlausibleWeb.StatsController do
           funnels: Plausible.Funnels.list(shared_link.site),
           stats_start_date: shared_link.site.stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
-          title: "Plausible · " <> shared_link.site.domain,
+          title: title(conn, shared_link.site),
           offer_email_report: false,
           demo: false,
           skip_plausible_tracking: true,
@@ -342,5 +342,13 @@ defmodule PlausibleWeb.StatsController do
       end
 
     !!is_or_nil
+  end
+
+  defp title(%{path_info: ["plausible.io"]}, _) do
+    "Plausible Analytics: Live Demo"
+  end
+
+  defp title(_conn, site) do
+    "Plausible · " <> site.domain
   end
 end

--- a/lib/plausible_web/plugs/no_robots.ex
+++ b/lib/plausible_web/plugs/no_robots.ex
@@ -4,12 +4,10 @@ defmodule PlausibleWeb.Plugs.NoRobots do
 
   We're adding `x-robots-tag` to the response header and annotate the conn
   with "noindex, nofollow" under `private.robots` key.
-  In case a robot is detected anyways, we'll send 403 Forbidden.
 
   The only exception is, if the request is trying to access our live demo
   at plausible.io/plausible.io - in which case we'll allow indexing, but deny
   following links and skip the bot detection, in kind robots we trust.
-  Note that even then, sibling URLs will be checked against bot intrusion still.
   """
   @behaviour Plug
   import Plug.Conn
@@ -26,28 +24,6 @@ defmodule PlausibleWeb.Plugs.NoRobots do
         put_private(conn, :robots, "noindex, nofollow")
       end
 
-    conn = put_resp_header(conn, "x-robots-tag", conn.private.robots)
-
-    if forbid?(conn) do
-      conn
-      |> put_resp_header("x-plausible-forbidden-reason", "robot")
-      |> put_status(403)
-      |> halt()
-    else
-      conn
-    end
-  end
-
-  defp forbid?(conn) do
-    with ua <- List.first(get_req_header(conn, "user-agent")),
-         true <- is_binary(ua),
-         "noindex" <> _ <- conn.private.robots,
-         {ok, %UAInspector.Result.Bot{}} when ok in [:ok, :commit] <-
-           Cachex.fetch(:user_agents, ua, &UAInspector.parse/1) do
-      true
-    else
-      _ ->
-        false
-    end
+    put_resp_header(conn, "x-robots-tag", conn.private.robots)
   end
 end

--- a/lib/plausible_web/plugs/no_robots.ex
+++ b/lib/plausible_web/plugs/no_robots.ex
@@ -1,0 +1,36 @@
+defmodule PlausibleWeb.Plugs.NoRobots do
+  @moduledoc """
+  Rejects bot requests by any means available.
+  """
+  @behaviour Plug
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts \\ nil) do
+    conn = put_resp_header(conn, "x-robots-tag", "noindex, nofollow")
+
+    if bot?(conn) do
+      conn
+      |> put_resp_header("x-plausible-forbidden-reason", "robot")
+      |> put_status(403)
+      |> halt()
+    else
+      conn
+    end
+  end
+
+  defp bot?(conn) do
+    with ua <- List.first(get_req_header(conn, "user-agent")),
+         true <- is_binary(ua),
+         {ok, %UAInspector.Result.Bot{}} when ok in [:ok, :commit] <-
+           Cachex.fetch(:user_agents, ua, &UAInspector.parse/1) do
+      true
+    else
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/plausible_web/plugs/no_robots.ex
+++ b/lib/plausible_web/plugs/no_robots.ex
@@ -1,6 +1,15 @@
 defmodule PlausibleWeb.Plugs.NoRobots do
   @moduledoc """
   Rejects bot requests by any means available.
+
+  We're adding `x-robots-tag` to the response header and annotate the conn
+  with "noindex, nofollow" under `private.robots` key.
+  In case a robot is detected anyways, we'll send 403 Forbidden.
+
+  The only exception is, if the request is trying to access our live demo
+  at plausible.io/plausible.io - in which case we'll allow indexing, but deny
+  following links and skip the bot detection, in kind robots we trust.
+  Note that even then, sibling URLs will be checked against bot intrusion still.
   """
   @behaviour Plug
   import Plug.Conn
@@ -10,9 +19,16 @@ defmodule PlausibleWeb.Plugs.NoRobots do
 
   @impl true
   def call(conn, _opts \\ nil) do
-    conn = put_resp_header(conn, "x-robots-tag", "noindex, nofollow")
+    conn =
+      if conn.path_info == ["plausible.io"] do
+        put_private(conn, :robots, "index, nofollow")
+      else
+        put_private(conn, :robots, "noindex, nofollow")
+      end
 
-    if bot?(conn) do
+    conn = put_resp_header(conn, "x-robots-tag", conn.private.robots)
+
+    if forbid?(conn) do
       conn
       |> put_resp_header("x-plausible-forbidden-reason", "robot")
       |> put_status(403)
@@ -22,9 +38,10 @@ defmodule PlausibleWeb.Plugs.NoRobots do
     end
   end
 
-  defp bot?(conn) do
+  defp forbid?(conn) do
     with ua <- List.first(get_req_header(conn, "user-agent")),
          true <- is_binary(ua),
+         "noindex" <> _ <- conn.private.robots,
          {ok, %UAInspector.Result.Bot{}} when ok in [:ok, :commit] <-
            Cachex.fetch(:user_agents, ua, &UAInspector.parse/1) do
       true

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.Router do
 
   scope "/api/stats", PlausibleWeb.Api do
     pipe_through :internal_stats_api
-    get "/:domain//funnels/:id", StatsController, :funnel
+    get "/:domain/funnels/:id", StatsController, :funnel
     get "/:domain/current-visitors", StatsController, :current_visitors
     get "/:domain/main-graph", StatsController, :main_graph
     get "/:domain/top-stats", StatsController, :top_stats

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -8,6 +8,7 @@ defmodule PlausibleWeb.Router do
     plug :fetch_session
     plug :fetch_live_flash
     plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
     plug PlausibleWeb.FirstLaunchPlug, redirect_to: "/register"
     plug PlausibleWeb.SessionTimeoutPlug, timeout_after_seconds: @two_weeks_in_seconds
     plug PlausibleWeb.AuthPlug
@@ -17,6 +18,7 @@ defmodule PlausibleWeb.Router do
   pipeline :shared_link do
     plug :accepts, ["html"]
     plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
   end
 
   pipeline :csrf do
@@ -33,6 +35,7 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["json"]
     plug :fetch_session
     plug PlausibleWeb.AuthorizeSiteAccess
+    plug PlausibleWeb.Plugs.NoRobots
   end
 
   pipeline :public_api do
@@ -42,6 +45,7 @@ defmodule PlausibleWeb.Router do
   pipeline :flags do
     plug :accepts, ["html"]
     plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
     plug :fetch_session
     plug PlausibleWeb.CRMAuthPlug
   end
@@ -50,7 +54,9 @@ defmodule PlausibleWeb.Router do
     forward "/sent-emails", Bamboo.SentEmailViewerPlug
   end
 
-  use Kaffy.Routes, scope: "/crm", pipe_through: [PlausibleWeb.CRMAuthPlug]
+  use Kaffy.Routes,
+    scope: "/crm",
+    pipe_through: [PlausibleWeb.Plugs.NoRobots, PlausibleWeb.CRMAuthPlug]
 
   scope path: "/flags" do
     pipe_through :flags

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -8,7 +8,7 @@
     <%= if Plausible.Funnels.enabled_for?(@conn.assigns[:current_user]) do %>
     <meta name="csrf-token" content="<%= Plug.CSRFProtection.get_csrf_token() %>" />
     <meta name="websocket-url" content="<%= websocket_url() %>" />
-    <meta name="robots" content="noindex, nofollow" />
+    <meta name="robots" content="<%= @conn.private.robots %>" />
     <% end %>
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">
     <link rel="apple-touch-icon" href="/images/icon/apple-touch-icon.png">

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -8,6 +8,7 @@
     <%= if Plausible.Funnels.enabled_for?(@conn.assigns[:current_user]) do %>
     <meta name="csrf-token" content="<%= Plug.CSRFProtection.get_csrf_token() %>" />
     <meta name="websocket-url" content="<%= websocket_url() %>" />
+    <meta name="robots" content="noindex, nofollow" />
     <% end %>
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">
     <link rel="apple-touch-icon" href="/images/icon/apple-touch-icon.png">

--- a/lib/plausible_web/templates/layout/focus.html.eex
+++ b/lib/plausible_web/templates/layout/focus.html.eex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="A lightweight, non-intrusive alternative to Google Analytics."/>
-    <meta name="robots" content="noindex, nofollow" />
+    <meta name="robots" content="<%= @conn.private.robots %>" />
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">
     <title><%= assigns[:title] || "Plausible · Web analytics" %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>

--- a/lib/plausible_web/templates/layout/focus.html.eex
+++ b/lib/plausible_web/templates/layout/focus.html.eex
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="A lightweight, non-intrusive alternative to Google Analytics."/>
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">
     <title><%= assigns[:title] || "Plausible · Web analytics" %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>

--- a/test/plausible_web/controllers/api/internal_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller_test.exs
@@ -20,6 +20,21 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
 
       assert json_response(conn, 200) == "READY"
     end
+
+    test "is WAITING when unauthenticated", %{user: user} do
+      site = insert(:site, members: [user])
+      Plausible.TestUtils.create_pageviews([%{site: site}])
+
+      conn = get(build_conn(), "/api/#{site.domain}/status")
+
+      assert json_response(conn, 200) == "WAITING"
+    end
+
+    test "is WAITING when non-existing site", %{conn: conn} do
+      conn = get(conn, "/api/example.com/status")
+
+      assert json_response(conn, 200) == "WAITING"
+    end
   end
 
   describe "GET /api/sites" do

--- a/test/plausible_web/plugs/no_robots_test.exs
+++ b/test/plausible_web/plugs/no_robots_test.exs
@@ -1,0 +1,39 @@
+defmodule PlausibleWeb.Plugs.NoRobotsTest do
+  use Plausible.DataCase, async: true
+  use Plug.Test
+
+  alias PlausibleWeb.Plugs.NoRobots
+
+  @sample_non_robot "Mozilla/5.0 (Linux; Android 10; MED-LX9N; HMSCore 5.2.0.318) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 HuaweiBrowser/10.1.2.320 Mobile Safari/537.36"
+  @sample_bot "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/103.0.5060.134 Safari/537.36"
+
+  test "non-bots pass - when no user agent is supplied" do
+    conn = conn(:get, "/") |> NoRobots.call()
+    assert get_resp_header(conn, "x-robots-tag") == ["noindex, nofollow"]
+    assert get_resp_header(conn, "x-plausible-forbidden-reason") == []
+
+    refute conn.halted
+    refute conn.status
+  end
+
+  test "non-bots pass - when user agent is supplied" do
+    conn = conn(:get, "/") |> put_req_header("user-agent", @sample_non_robot) |> NoRobots.call()
+    assert get_resp_header(conn, "x-robots-tag") == ["noindex, nofollow"]
+    assert get_resp_header(conn, "x-plausible-forbidden-reason") == []
+
+    refute conn.halted
+    refute conn.status
+  end
+
+  test "bots receive 403" do
+    conn = conn(:get, "/") |> put_req_header("user-agent", @sample_bot) |> NoRobots.call()
+
+    for _ <- [:cache_commit, :cache_ok] do
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex, nofollow"]
+      assert get_resp_header(conn, "x-plausible-forbidden-reason") == ["robot"]
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR attempts to cut off robots from browsing dashboard and internal APIs.
We're adding the `meta="robots"` HTML tag to dashboard layouts, `x-robots-tag` to HTTP responses ~~and we're checking the user agent against UAInspector DB with Cachex on top (we're already doing it during the ingestion phase, so the plug isn't installed there)~~.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
