### PR TITLE
refactor LazyLoader and fix bug

### DIFF
--- a/assets/js/dashboard/components/lazy-loader.js
+++ b/assets/js/dashboard/components/lazy-loader.js
@@ -1,40 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
 
-export default class extends React.Component {
-  componentDidMount() {
-    if ('IntersectionObserver' in window) {
-      this.attachObserver()
-    } else {
-      this.props.onVisible && this.props.onVisible()
+export default function LazyLoader(props) {
+  const [hasBecomeVisibleYet, setHasBecomeVisibleYet] = useState(false)
+  const { ref, inView } = useInView({
+    threshold: 0,
+  })
+
+  useEffect(() => {
+    if (inView && !hasBecomeVisibleYet) {
+      setHasBecomeVisibleYet(true)
+      props.onVisible && props.onVisible()
     }
-  }
+  }, [inView])
 
-  attachObserver() {
-    this.observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        this.props.onVisible && this.props.onVisible()
-        this.observer.unobserve(this.element);
-      }
-    }, {
-      threshold: 0
-    });
-
-    this.observer.observe(this.element);
-  }
-
-  componentWillUnmount() {
-    this.observer && this.observer.unobserve(this.element);
-  }
-
-  render() {
-    return (
-      <div
-        ref={(el) => { this.element = el }}
-        className={this.props.className}
-        style={this.props.style}
-      >
-        {this.props.children}
-      </div>
-    );
-  }
+  return (
+    <div ref={ref}>
+      {props.children}
+    </div>
+  )
 }

--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -40,7 +40,7 @@ export default class Conversions extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.query !== prevProps.query) {
-      const height = this.htmlNode.current.element.offsetHeight
+      const height = this.htmlNode.current.offsetHeight
       this.setState({ loading: true, goals: null, prevHeight: height })
       this.fetchConversions()
     }
@@ -108,9 +108,11 @@ export default class Conversions extends React.Component {
 
   renderConversions() {
     return (
-      <LazyLoader ref={this.htmlNode} style={{ minHeight: '132px', height: this.state.prevHeight ?? 'auto' }} onVisible={this.onVisible}>
-        {this.renderInner()}
-      </LazyLoader>
+      <div ref={this.htmlNode} style={{ minHeight: '132px', height: this.state.prevHeight ?? 'auto' }} >
+        <LazyLoader onVisible={this.onVisible}>
+          {this.renderInner()}
+        </LazyLoader>
+      </div>
     )
   }
 

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -163,8 +163,8 @@ export default class Referrers extends React.Component {
 
   render() {
     return (
-      <div>
-        <LazyLoader onVisible={this.onVisible} className="flex flex-col flex-grow">
+      <div className="flex flex-col flex-grow">
+        <LazyLoader onVisible={this.onVisible}>
           <h3 className="font-bold dark:text-gray-100">Top Referrers</h3>
           {this.state.loading && <div className="mx-auto loading mt-44"><div></div></div>}
           <FadeIn show={!this.state.loading}>

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -116,8 +116,8 @@ class AllSources extends React.Component {
 
   render() {
     return (
-      <div>
-        <LazyLoader className="flex flex-col flex-grow" onVisible={this.onVisible}>
+      <div className="flex flex-col flex-grow">
+        <LazyLoader onVisible={this.onVisible}>
           <div id="sources" className="flex justify-between w-full">
             <h3 className="font-bold dark:text-gray-100">Top Sources</h3>
             {this.props.renderTabs()}

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -44,6 +44,7 @@
         "react-dom": "^16.13.1",
         "react-flatpickr": "3.10.5",
         "react-flip-move": "^3.0.4",
+        "react-intersection-observer": "^9.5.2",
         "react-popper": "^2.3.0",
         "react-router-dom": "^5.2.0",
         "react-transition-group": "^4.4.2",
@@ -69,10 +70,10 @@
         "webpack-bundle-analyzer": "^4.4.2"
       }
     },
-    "../../../../../../deps/phoenix": {
+    "../../../../../deps/phoenix": {
       "extraneous": true
     },
-    "../../../../../../deps/phoenix_html": {
+    "../../../../../deps/phoenix_html": {
       "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
@@ -7668,6 +7669,14 @@
       "peerDependencies": {
         "react": ">=16.3.x",
         "react-dom": ">=16.3.x"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -15322,6 +15331,12 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.5.tgz",
       "integrity": "sha512-Mf4XpbkUNZy9eu80iXXFIjToDvw+bnHxmKHVoositbMpV87O/EQswnXUqVovRHoTx/F+4dE+p//PyJnAT7OtPA==",
+      "requires": {}
+    },
+    "react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
       "requires": {}
     },
     "react-is": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^16.13.1",
     "react-flatpickr": "3.10.5",
     "react-flip-move": "^3.0.4",
+    "react-intersection-observer": "^9.5.2",
     "react-popper": "^2.3.0",
     "react-router-dom": "^5.2.0",
     "react-transition-group": "^4.4.2",


### PR DESCRIPTION
### Changes

* Refactors LazyLoader to a function component using https://www.npmjs.com/package/react-intersection-observer
* Fixes a bug where the currently used `LazyLoader` did not call the `onVisible` function on page refresh when being scrolled down on the dashboard (screencast of the bug below). Note that the bug happened for me only on Chrome.

https://github.com/plausible/analytics/assets/56999674/3b9e6b2b-ddc8-47fc-ad98-446dad2cd35d

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
