### PR TITLE
APP-47C: Filter out GA imported data with no visitors recorded

### DIFF
--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -114,6 +114,7 @@ defmodule Plausible.Stats.Imported do
         group_by: field(i, ^dim),
         where: i.site_id == ^site.id,
         where: i.date >= ^query.date_range.first and i.date <= ^query.date_range.last,
+        where: i.visitors > 0,
         select: %{}
       )
       |> select_imported_metrics(metrics)

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -130,6 +130,27 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
              ]
     end
 
+    test "skips breakdown when visitors=0 (possibly due to 'Enable Users Metric' in GA)", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:imported_browsers, browser: "Chrome", visitors: 0, visits: 14),
+        build(:imported_browsers, browser: "Firefox", visitors: 0, visits: 14),
+        build(:imported_browsers,
+          browser: "''",
+          visitors: 0,
+          visits: 14,
+          visit_duration: 0,
+          bounces: 14
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+
+      assert json_response(conn, 200) == []
+    end
+
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,


### PR DESCRIPTION
### Changes

Sentry error was indicating division by zero at percentage calculation at https://github.com/plausible/analytics/blob/df3a5d6de90f372adad779f3b84444a46ed02fb2/lib/plausible_web/controllers/api/stats_controller.ex#L1270 - this PR ensures no imported data is retrieved if the number of visitors stored is 0 (we probably shouldn't be doing it in the first place but it's kind of late for that 😥).

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
