### PR TITLE
Add revenue metrics to prop breakdown

### DIFF
--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -68,7 +68,7 @@ export default class Conversions extends React.Component {
             {renderRevenueColumn && <span className="hidden md:inline-block md:w-20 font-medium text-right"><Money formatted={goal.average_revenue} /></span>}
           </div>
         </div>
-        { renderProps && !goal.total_revenue && <PropBreakdown site={this.props.site} query={this.props.query} goal={goal} /> }
+        { renderProps && <PropBreakdown site={this.props.site} query={this.props.query} goal={goal} renderRevenueColumn={renderRevenueColumn } /> }
       </div>
     )
   }

--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -9,14 +9,7 @@ import * as api from '../../api'
 import * as url from '../../util/url'
 import { escapeFilterValue } from '../../util/filters'
 import LazyLoader from '../../components/lazy-loader'
-
-function Money({ formatted }) {
-  if (formatted) {
-    return <span tooltip={formatted.long}>{formatted.short}</span>
-  } else {
-    return "-"
-  }
-}
+import Money from './money'
 
 export default class Conversions extends React.Component {
   constructor(props) {

--- a/assets/js/dashboard/stats/behaviours/money.js
+++ b/assets/js/dashboard/stats/behaviours/money.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function Money({ formatted }) {
+  if (formatted) {
+    return <span tooltip={formatted.long}>{formatted.short}</span>
+  } else {
+    return "-"
+  }
+}
+

--- a/assets/js/dashboard/stats/behaviours/prop-breakdown.js
+++ b/assets/js/dashboard/stats/behaviours/prop-breakdown.js
@@ -72,11 +72,6 @@ export default class PropertyBreakdown extends React.Component {
     this.setState({ viewport: window.innerWidth });
   }
 
-  getBarMaxWidth() {
-    const { viewport } = this.state;
-    return viewport > MOBILE_UPPER_WIDTH ? "16rem" : "10rem";
-  }
-
   fetch({concat}) {
     if (!this.props.query.filters['goal']) return
 
@@ -136,15 +131,16 @@ export default class PropertyBreakdown extends React.Component {
 
     return (
       <div className="flex items-center justify-between my-2" key={value.name}>
-        <Bar
-          count={value.unique_conversions}
-          plot="unique_conversions"
-          all={this.state.breakdown}
-          bg="bg-red-50 dark:bg-gray-500 dark:bg-opacity-15"
-          maxWidthDeduction={this.getBarMaxWidth()}
-        >
-          {this.renderPropContent(value, query)}
-        </Bar>
+        <div className="flex-1">
+          <Bar
+            count={value.unique_conversions}
+            plot="unique_conversions"
+            all={this.state.breakdown}
+            bg="bg-red-50 dark:bg-gray-500 dark:bg-opacity-15"
+          >
+            {this.renderPropContent(value, query)}
+          </Bar>
+        </div>
         <div className="dark:text-gray-200">
           <span className="font-medium inline-block w-20 text-right">{numberFormatter(value.unique_conversions)}</span>
           {
@@ -158,6 +154,8 @@ export default class PropertyBreakdown extends React.Component {
             : null
           }
           <span className="font-medium inline-block w-20 text-right">{numberFormatter(value.conversion_rate)}%</span>
+          {this.props.renderRevenueColumn && <span className="hidden md:inline-block md:w-20 font-medium text-right"><Money formatted={value.total_revenue} /></span>}
+          {this.props.renderRevenueColumn && <span className="hidden md:inline-block md:w-20 font-medium text-right"><Money formatted={value.average_revenue} /></span>}
         </div>
       </div>
     )

--- a/assets/js/dashboard/stats/behaviours/prop-breakdown.js
+++ b/assets/js/dashboard/stats/behaviours/prop-breakdown.js
@@ -5,6 +5,7 @@ import * as storage from '../../util/storage'
 import Bar from '../bar'
 import numberFormatter from '../../util/number-formatter'
 import * as api from '../../api'
+import Money from './money'
 
 const MOBILE_UPPER_WIDTH = 767
 const DEFAULT_WIDTH = 1080

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -69,6 +69,7 @@ defmodule Plausible.Stats.Breakdown do
 
   def breakdown(site, query, "event:props:" <> custom_prop = property, metrics, pagination) do
     {limit, _} = pagination
+    {currency, metrics} = get_revenue_tracking_currency(site, query, metrics)
 
     none_result =
       if include_none_result?(query.filters[property]) do
@@ -90,6 +91,7 @@ defmodule Plausible.Stats.Breakdown do
     results =
       breakdown_events(site, query, "event:props:" <> custom_prop, metrics, pagination)
       |> Kernel.++(none_result)
+      |> Enum.map(&cast_revenue_metrics_to_money(&1, currency))
       |> Enum.sort_by(& &1[sorting_key(metrics)], :desc)
 
     if Enum.find_index(results, fn value -> value[custom_prop] == "(none)" end) == limit do


### PR DESCRIPTION
### Changes

This pull request enables prop breakdown for revenue goals. Revenue metrics are queries when filtering by a revenue goal. Preview:

<img width="1129" alt="Screenshot 2023-07-13 at 16 43 06" src="https://github.com/plausible/analytics/assets/5093045/682a9cf1-8a49-4821-b457-3fb2fa74d8e8">

### Tests
- [X] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] The UI has been tested both in dark and light mode
