### PR TITLE
fix CR undefined bug

### DIFF
--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -57,7 +57,7 @@ function Regions({query, site, onClick}) {
       getFilterFor={getFilterFor}
       onClick={onClick}
       keyLabel="Region"
-      metrics={maybeWithCR([VISITORS_METRIC], query)}
+      metrics={[VISITORS_METRIC]}
       detailsLink={sitePath(site, '/regions')}
       query={query}
       renderIcon={renderIcon}
@@ -84,7 +84,7 @@ function Cities({query, site}) {
       fetchData={fetchData}
       getFilterFor={getFilterFor}
       keyLabel="City"
-      metrics={maybeWithCR([VISITORS_METRIC], query)}
+      metrics={[VISITORS_METRIC]}
       detailsLink={sitePath(site, '/cities')}
       query={query}
       renderIcon={renderIcon}


### PR DESCRIPTION
### Changes

Quick fix for the bug introduced in https://github.com/plausible/analytics/pull/3078 - we don't actually return the CR metric for cities and regions. Only countries. This tells the React frontend not to expect this metric to be in the response, which will not render the `undefined` values anymore.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
