### PR TITLE
fix(tracker): handle `pageshow` events from bfcache

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -162,6 +162,10 @@
     } else {
       page()
     }
+
+    document.addEventListener('pageshow', (ev) => {
+      if (ev.persisted) page();
+    })
   {{/unless}}
 
   {{#if (any outbound_links file_downloads tagged_events)}}


### PR DESCRIPTION
### Changes

Adds a `pageshow` event handler to the tracker in order to handle navigations via the [back/forward cache](https://web.dev/bfcache/#how-bfcache-affects-analytics-and-performance-measurement)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
