### PR TITLE
Expose 9009 for native clickhouse protocol (dev mode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: ## Run the initial setup
 server: ## Start the web server
 	mix phx.server
 
-CH_FLAGS ?= --detach -p 8123:8123 --ulimit nofile=262144:262144 --name plausible_clickhouse
+CH_FLAGS ?= --detach -p 8123:8123 -p 9009:9000 --ulimit nofile=262144:262144 --name plausible_clickhouse
 
 clickhouse: ## Start a container with a recent version of clickhouse
 	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:22.9-alpine


### PR DESCRIPTION
### Changes

The port we normally expose is HTTP, I'd like to use the native one for development.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
