### PR TITLE
Render funnel name in bold only when funnels tab active

### DIFF
--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -82,7 +82,7 @@ export default function Behaviours(props) {
                       className={classNames(
                         active ? 'bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-200 cursor-pointer' : 'text-gray-700 dark:text-gray-200',
                         'block px-4 py-2 text-sm',
-                        selectedFunnel === funnelName ? 'font-bold text-gray-500' : ''
+                        (mode === FUNNELS && selectedFunnel === funnelName) ? 'font-bold text-gray-500' : ''
                       )}
                     >
                       {funnelName}


### PR DESCRIPTION
### Changes

This PR fixes small bug when the most recently selected funnel name is rendered in bold even though the user is activating the picker from goals.

Before:

![image](https://github.com/plausible/analytics/assets/173738/f18a4f2d-b1bf-41d5-b10a-162c3748d424)

After:

![image](https://github.com/plausible/analytics/assets/173738/dfa8dcb4-fed7-4d47-9f7b-c000f84890fa)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
