### PR TITLE
Props into CSV export

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -166,10 +166,6 @@ defmodule Plausible.Site do
     )
   end
 
-  def set_allowed_event_props(site, list) do
-    change(site, allowed_event_props: list)
-  end
-
   @togglable_features ~w[conversions_enabled funnels_enabled props_enabled]a
   def feature_toggle_change(site, property, opts \\ [])
       when property in @togglable_features do

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -85,7 +85,7 @@ defmodule Plausible.SiteAdmin do
         props -> String.split(props, ~r/\s*,\s*/)
       end
 
-    Plausible.Sites.set_allowed_event_props(site, props_list)
+    Plausible.Sites.set_allowed_event_props!(site, props_list)
 
     :ok
   end

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -85,8 +85,7 @@ defmodule Plausible.SiteAdmin do
         props -> String.split(props, ~r/\s*,\s*/)
       end
 
-    Plausible.Site.set_allowed_event_props(site, props_list)
-    |> Repo.update!()
+    Plausible.Sites.set_allowed_event_props(site, props_list)
 
     :ok
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -178,7 +178,7 @@ defmodule Plausible.Sites do
     )
   end
 
-  def set_allowed_event_props(site, props) do
+  def set_allowed_event_props!(site, props) do
     Ecto.Changeset.change(site, allowed_event_props: props)
     |> Repo.update!()
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -177,4 +177,9 @@ defmodule Plausible.Sites do
         where: sm.role == :owner
     )
   end
+
+  def set_allowed_event_props(site, props) do
+    Ecto.Changeset.change(site, allowed_event_props: props)
+    |> Repo.update!()
+  end
 end

--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -34,7 +34,7 @@ defmodule Plausible.Stats.CustomProps do
     end
   end
 
-  defp fetch_prop_names(site, query) do
+  def fetch_prop_names(site, query) do
     case Query.get_filter_by_prefix(query, "event:props:") do
       {"event:props:" <> key, _} ->
         [key]

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1211,9 +1211,10 @@ defmodule PlausibleWeb.Api.StatsController do
       end)
       |> Enum.concat()
 
-    percent_or_cr = if query.filters["event:goal"],
-      do: :conversion_rate,
-      else: :percentage
+    percent_or_cr =
+      if query.filters["event:goal"],
+        do: :conversion_rate,
+        else: :percentage
 
     to_csv(values, [:property, :value, :visitors, :events, percent_or_cr])
   end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -148,6 +148,15 @@ defmodule PlausibleWeb.StatsController do
         'prop_breakdown.csv' => fn -> Api.StatsController.all_props_breakdown(conn, params) end
       }
 
+      csvs =
+        if FunWithFlags.enabled?(:props) do
+          Map.put(csvs, 'custom_props.csv', fn ->
+            Api.StatsController.all_custom_prop_values(conn, params)
+          end)
+        else
+          csvs
+        end
+
       csv_values =
         Map.values(csvs)
         |> Plausible.ClickhouseRepo.parallel_tasks()

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/custom_props.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/custom_props.csv
@@ -1,0 +1,2 @@
+property,value,visitors,events,conversion_rate
+variant,A,1,1,25.0

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/custom_props.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/custom_props.csv
@@ -1,0 +1,1 @@
+property,value,visitors,events,percentage

--- a/test/plausible_web/controllers/CSVs/30d/custom_props.csv
+++ b/test/plausible_web/controllers/CSVs/30d/custom_props.csv
@@ -1,0 +1,3 @@
+property,value,visitors,events,percentage
+variant,(none),3,4,75.0
+variant,A,1,1,25.0

--- a/test/plausible_web/controllers/CSVs/6m/custom_props.csv
+++ b/test/plausible_web/controllers/CSVs/6m/custom_props.csv
@@ -1,0 +1,3 @@
+property,value,visitors,events,percentage
+variant,(none),4,5,80.0
+variant,A,1,1,20.0

--- a/test/plausible_web/controllers/api/internal_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller_test.exs
@@ -100,6 +100,16 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
       assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
     end
 
+    test "when the logged-in user is an super-admin", %{conn: conn, user: user} do
+      site = insert(:site)
+      patch_env(:super_admin_user_ids, [user.id])
+
+      conn = put(conn, "/api/#{site.domain}/disable-feature", %{"feature" => "conversions"})
+
+      assert json_response(conn, 200) == "ok"
+      assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
+    end
+
     test "returns 401 when the logged-in user is a viewer of the site", %{conn: conn, user: user} do
       site = insert(:site)
       insert(:site_membership, user: user, site: site, role: :viewer)
@@ -137,27 +147,6 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
              }
 
       assert %{conversions_enabled: true} = Plausible.Sites.get_by_domain(site.domain)
-    end
-  end
-end
-
-# We need to be separate tests calling `patch_env` in an `async: false` test
-# module, because `Application.env` is a shared state.
-defmodule PlausibleWeb.Api.InternalControllerSyncTest do
-  use PlausibleWeb.ConnCase, async: false
-  use Plausible.Repo
-
-  describe "PUT /api/:domain/disable-feature" do
-    setup [:create_user, :log_in]
-
-    test "when the logged-in user is an super-admin", %{conn: conn, user: user} do
-      site = insert(:site)
-      patch_env(:super_admin_user_ids, [user.id])
-
-      conn = put(conn, "/api/#{site.domain}/disable-feature", %{"feature" => "conversions"})
-
-      assert json_response(conn, 200) == "ok"
-      assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
     end
   end
 end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -455,7 +455,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
          } do
       site =
         site
-        |> Plausible.Sites.set_allowed_event_props(["author"])
+        |> Plausible.Sites.set_allowed_event_props!(["author"])
 
       populate_stats(site, [
         build(:event,
@@ -490,7 +490,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
          } do
       site =
         site
-        |> Plausible.Sites.set_allowed_event_props(["author", "logged_in"])
+        |> Plausible.Sites.set_allowed_event_props!(["author", "logged_in"])
 
       populate_stats(site, [
         build(:event,

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -455,8 +455,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
          } do
       site =
         site
-        |> Plausible.Site.set_allowed_event_props(["author"])
-        |> Plausible.Repo.update!()
+        |> Plausible.Sites.set_allowed_event_props(["author"])
 
       populate_stats(site, [
         build(:event,
@@ -491,8 +490,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
          } do
       site =
         site
-        |> Plausible.Site.set_allowed_event_props(["author", "logged_in"])
-        |> Plausible.Repo.update!()
+        |> Plausible.Sites.set_allowed_event_props(["author", "logged_in"])
 
       populate_stats(site, [
         build(:event,

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -284,7 +284,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
     } do
       site =
         site
-        |> Plausible.Sites.set_allowed_event_props(["author"])
+        |> Plausible.Sites.set_allowed_event_props!(["author"])
 
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -284,8 +284,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
     } do
       site =
         site
-        |> Plausible.Site.set_allowed_event_props(["author"])
-        |> Plausible.Repo.update!()
+        |> Plausible.Sites.set_allowed_event_props(["author"])
 
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -140,7 +140,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "exports allowed event props", %{conn: conn, site: site} do
-      site = Plausible.Sites.set_allowed_event_props(site, ["author", "logged_in"])
+      site = Plausible.Sites.set_allowed_event_props!(site, ["author", "logged_in"])
 
       populate_stats(site, [
         build(:pageview, "meta.key": ["author"], "meta.value": ["uku"]),
@@ -246,7 +246,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       conn: conn,
       site: site
     } do
-      site = Plausible.Sites.set_allowed_event_props(site, ["author", "logged_in"])
+      site = Plausible.Sites.set_allowed_event_props!(site, ["author", "logged_in"])
 
       populate_stats(site, [
         build(:pageview, "meta.key": ["author"], "meta.value": ["uku"]),
@@ -364,7 +364,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       conn: conn,
       site: site
     } do
-      site = Plausible.Sites.set_allowed_event_props(site, ["author", "logged_in"])
+      site = Plausible.Sites.set_allowed_event_props!(site, ["author", "logged_in"])
 
       populate_stats(site, [
         build(:event, name: "Newsletter Signup", "meta.key": ["author"], "meta.value": ["uku"]),

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -149,12 +149,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       {_filename, visitors} =
         Enum.find(zip, fn {filename, _data} -> filename == 'visitors.csv' end)
 
-      parsed_csv =
-        visitors
-        |> String.split("\r\n")
-        |> Enum.map(&String.split(&1, ","))
-
-      assert parsed_csv == [
+      assert parse_csv(visitors) == [
                [
                  "date",
                  "visitors",
@@ -172,6 +167,12 @@ defmodule PlausibleWeb.StatsControllerTest do
                [""]
              ]
     end
+  end
+
+  defp parse_csv(file_content) when is_binary(file_content) do
+    file_content
+    |> String.split("\r\n")
+    |> Enum.map(&String.split(&1, ","))
   end
 
   describe "GET /:website/export - via shared link" do

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -124,6 +124,37 @@ defmodule PlausibleWeb.StatsControllerTest do
   describe "GET /:website/export" do
     setup [:create_user, :create_new_site, :log_in]
 
+    test "exports all the necessary CSV files", %{conn: conn, site: site} do
+      conn = get(conn, "/" <> site.domain <> "/export")
+
+      assert {"content-type", "application/zip; charset=utf-8"} =
+               List.keyfind(conn.resp_headers, "content-type", 0)
+
+      {:ok, zip} = :zip.unzip(response(conn, 200), [:memory])
+
+      zip = Enum.map(zip, fn {filename, _} -> filename end)
+
+      assert 'visitors.csv' in zip
+      assert 'browsers.csv' in zip
+      assert 'cities.csv' in zip
+      assert 'conversions.csv' in zip
+      assert 'countries.csv' in zip
+      assert 'custom_props.csv' in zip
+      assert 'devices.csv' in zip
+      assert 'entry_pages.csv' in zip
+      assert 'exit_pages.csv' in zip
+      assert 'operating_systems.csv' in zip
+      assert 'pages.csv' in zip
+      assert 'prop_breakdown.csv' in zip
+      assert 'regions.csv' in zip
+      assert 'sources.csv' in zip
+      assert 'utm_campaigns.csv' in zip
+      assert 'utm_contents.csv' in zip
+      assert 'utm_mediums.csv' in zip
+      assert 'utm_sources.csv' in zip
+      assert 'utm_terms.csv' in zip
+    end
+
     test "exports data in zipped csvs", %{conn: conn, site: site} do
       populate_exported_stats(site)
       conn = get(conn, "/" <> site.domain <> "/export?date=2021-10-20")

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -160,14 +160,14 @@ defmodule PlausibleWeb.StatsControllerTest do
         Enum.find(zip, fn {filename, _data} -> filename == 'custom_props.csv' end)
 
       assert parse_csv(result) == [
-        ["property", "value", "visitors", "events", "percentage"],
-        ["author", "(none)", "3", "4", "50.0"],
-        ["author", "uku", "2", "2", "33.3"],
-        ["author", "marko", "1", "1", "16.7"],
-        ["logged_in", "(none)", "5", "5", "83.3"],
-        ["logged_in", "true", "1", "2", "16.7"],
-        [""]
-      ]
+               ["property", "value", "visitors", "events", "percentage"],
+               ["author", "(none)", "3", "4", "50.0"],
+               ["author", "uku", "2", "2", "33.3"],
+               ["author", "marko", "1", "1", "16.7"],
+               ["logged_in", "(none)", "5", "5", "83.3"],
+               ["logged_in", "true", "1", "2", "16.7"],
+               [""]
+             ]
     end
 
     test "exports data grouped by interval", %{conn: conn, site: site} do
@@ -242,14 +242,18 @@ defmodule PlausibleWeb.StatsControllerTest do
   describe "GET /:website/export - with a custom prop filter" do
     setup [:create_user, :create_new_site, :log_in]
 
-    test "custom-props.csv only returns the prop and its value in filter", %{conn: conn, site: site} do
+    test "custom-props.csv only returns the prop and its value in filter", %{
+      conn: conn,
+      site: site
+    } do
       site = Plausible.Sites.set_allowed_event_props(site, ["author", "logged_in"])
 
       populate_stats(site, [
         build(:pageview, "meta.key": ["author"], "meta.value": ["uku"]),
         build(:pageview, "meta.key": ["author"], "meta.value": ["marko"]),
-        build(:pageview, "meta.key": ["logged_in"], "meta.value": ["true"]),
+        build(:pageview, "meta.key": ["logged_in"], "meta.value": ["true"])
       ])
+
       filters = Jason.encode!(%{props: %{author: "marko"}})
       conn = get(conn, "/" <> site.domain <> "/export?period=day&filters=#{filters}")
 
@@ -259,10 +263,10 @@ defmodule PlausibleWeb.StatsControllerTest do
         Enum.find(zip, fn {filename, _data} -> filename == 'custom_props.csv' end)
 
       assert parse_csv(result) == [
-        ["property", "value", "visitors", "events", "percentage"],
-        ["author", "marko", "1", "1", "100.0"],
-        [""]
-      ]
+               ["property", "value", "visitors", "events", "percentage"],
+               ["author", "marko", "1", "1", "100.0"],
+               [""]
+             ]
     end
   end
 
@@ -356,15 +360,19 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert_zip(conn, "30d-filter-goal")
     end
 
-    test "custom-props.csv only returns the prop names for the goal in filter", %{conn: conn, site: site} do
+    test "custom-props.csv only returns the prop names for the goal in filter", %{
+      conn: conn,
+      site: site
+    } do
       site = Plausible.Sites.set_allowed_event_props(site, ["author", "logged_in"])
 
       populate_stats(site, [
         build(:event, name: "Newsletter Signup", "meta.key": ["author"], "meta.value": ["uku"]),
         build(:event, name: "Newsletter Signup", "meta.key": ["author"], "meta.value": ["marko"]),
         build(:event, name: "Newsletter Signup", "meta.key": ["author"], "meta.value": ["marko"]),
-        build(:pageview, "meta.key": ["logged_in"], "meta.value": ["true"]),
+        build(:pageview, "meta.key": ["logged_in"], "meta.value": ["true"])
       ])
+
       filters = Jason.encode!(%{goal: "Newsletter Signup"})
       conn = get(conn, "/" <> site.domain <> "/export?period=day&filters=#{filters}")
 
@@ -374,11 +382,11 @@ defmodule PlausibleWeb.StatsControllerTest do
         Enum.find(zip, fn {filename, _data} -> filename == 'custom_props.csv' end)
 
       assert parse_csv(result) == [
-        ["property", "value", "visitors", "events", "conversion_rate"],
-        ["author", "marko", "2", "2", "50.0"],
-        ["author", "uku", "1", "1", "25.0"],
-        [""]
-      ]
+               ["property", "value", "visitors", "events", "conversion_rate"],
+               ["author", "marko", "2", "2", "50.0"],
+               ["author", "uku", "1", "1", "25.0"],
+               [""]
+             ]
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,6 @@
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 Application.ensure_all_started(:double)
 FunWithFlags.enable(:funnels)
+FunWithFlags.enable(:props)
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 ExUnit.configure(exclude: [:slow])


### PR DESCRIPTION
### Changes

This PR starts including a new CSV file in the export zip - `custom_props.csv`. This file will only be included in the zip, if the `props` feature flag is enabled for the user triggering the export.

There's also the existing `prop_breakdown.csv` file which will be kept until the `props` feature is globally enabled. This will be a breaking change.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not require a changelog update **yet**

### Documentation
- [x] This change does not need a documentation update **yet**

### Dark mode
- [x] This PR does not change the UI
