### PR TITLE
Refine ComboBox.StaticSearch

### DIFF
--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -252,16 +252,15 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
         socket
       end
 
-    if input_len > 0 do
-      suggestions =
-        input
-        |> suggest_mod.suggest(options)
-        |> Enum.take(suggestions_limit(socket.assigns))
+    suggestions =
+      if input_len > 0 do
+        suggest_mod.suggest(input, options)
+      else
+        options
+      end
+      |> Enum.take(suggestions_limit(socket.assigns))
 
-      {:noreply, assign(socket, %{suggestions: suggestions})}
-    else
-      {:noreply, assign(socket, %{suggestions: options})}
-    end
+    {:noreply, assign(socket, %{suggestions: suggestions})}
   end
 
   defp do_select(socket, submit_value, display_value) do

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -260,7 +260,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
 
       {:noreply, assign(socket, %{suggestions: suggestions})}
     else
-      {:noreply, socket}
+      {:noreply, assign(socket, %{suggestions: options})}
     end
   end
 

--- a/lib/plausible_web/live/components/combo_box/static_search.ex
+++ b/lib/plausible_web/live/components/combo_box/static_search.ex
@@ -19,15 +19,16 @@ defmodule PlausibleWeb.Live.Components.ComboBox.StaticSearch do
   end
 
   defp weight(value, input) do
-    cond do
-      value == input ->
+    value = to_string(value)
+
+    case {value, input} do
+      {value, input} when value == input ->
         3
 
-      String.length(input) > String.length(value) ->
+      {value, input} when byte_size(input) > byte_size(value) ->
         0
 
-      true ->
-        value = to_string(value)
+      {value, input} ->
         input = String.downcase(input)
         value = String.downcase(value)
         weight = if String.contains?(value, input), do: 1, else: 0

--- a/test/plausible_web/live/components/combo_box/static_search_test.exs
+++ b/test/plausible_web/live/components/combo_box/static_search_test.exs
@@ -24,9 +24,12 @@ defmodule PlausibleWeb.Live.Components.ComboBox.StaticSearchTest do
 
     test "allows fuzzy matching" do
       options = fake_options(["/url/0xC0FFEE", "/url/0xDEADBEEF", "/url/other"])
+      assert [{_, "/url/0xC0FFEE"}] = StaticSearch.suggest("0x FF", options)
+    end
 
-      assert [{_, "/url/0xC0FFEE"}, {_, "/url/0xDEADBEEF"}, {_, "/url/other"}] =
-               StaticSearch.suggest("0x FF", options)
+    test "filters out bad matches" do
+      options = fake_options(["OS", "Version", "Logged In"])
+      assert [] = StaticSearch.suggest("cow", options)
     end
   end
 

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -191,6 +191,14 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
       refute element_exists?(doc, suggestion_li(8))
       refute element_exists?(doc, suggestion_li(9))
     end
+
+    test "clearing search input resets to all options", %{conn: conn} do
+      {:ok, lv, _html} = live_isolated(conn, SampleView, session: %{})
+      type_into_combo(lv, "test-component", "Echo me")
+      doc = type_into_combo(lv, "test-component", "")
+
+      for i <- 1..7, do: assert(element_exists?(doc, suggestion_li(i)))
+    end
   end
 
   describe "creatable integration" do

--- a/test/plausible_web/live/funnel_settings/form_test.exs
+++ b/test/plausible_web/live/funnel_settings/form_test.exs
@@ -56,9 +56,6 @@ defmodule PlausibleWeb.Live.FunnelSettings.FormTest do
       doc = type_into_combo(lv, 2, "another")
 
       refute text_of_element(doc, "ul#dropdown-step-1 li") =~ "Another World"
-
-      assert text_of_element(doc, "ul#dropdown-step-2 li") =~ "Hello World"
-      assert text_of_element(doc, "ul#dropdown-step-2 li") =~ "Plausible"
       refute text_of_element(doc, "ul#dropdown-step-2 li") =~ "Another World"
     end
 


### PR DESCRIPTION
### Changes

This commit makes static search more strict by rejecting matches with a score less than `0.6`. Here's an example of suggestion that was matching with a `0.5` score that should not be suggested.

```
iex> String.jaro_distance("author", "uaa")
0.5
```

This makes the suggestion list smaller and more reasonable.

Co-authored by: Robert Joonas <robertjoonas16@gmail.com>

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
