### PR TITLE
Fix test flakiness due to shared state in asynchronous run

### DIFF
--- a/test/plausible_web/controllers/api/internal_controller/sync_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/sync_test.exs
@@ -1,0 +1,18 @@
+defmodule PlausibleWeb.Api.InternalController.SyncTest do
+  use PlausibleWeb.ConnCase, async: false
+  use Plausible.Repo
+
+  describe "PUT /api/:domain/disable-feature" do
+    setup [:create_user, :log_in]
+
+    test "when the logged-in user is an super-admin", %{conn: conn, user: user} do
+      site = insert(:site)
+      patch_env(:super_admin_user_ids, [user.id])
+
+      conn = put(conn, "/api/#{site.domain}/disable-feature", %{"feature" => "conversions"})
+
+      assert json_response(conn, 200) == "ok"
+      assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/internal_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller_test.exs
@@ -100,16 +100,6 @@ defmodule PlausibleWeb.Api.InternalControllerTest do
       assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
     end
 
-    test "when the logged-in user is an super-admin", %{conn: conn, user: user} do
-      site = insert(:site)
-      patch_env(:super_admin_user_ids, [user.id])
-
-      conn = put(conn, "/api/#{site.domain}/disable-feature", %{"feature" => "conversions"})
-
-      assert json_response(conn, 200) == "ok"
-      assert %{conversions_enabled: false} = Plausible.Sites.get_by_domain(site.domain)
-    end
-
     test "returns 401 when the logged-in user is a viewer of the site", %{conn: conn, user: user} do
       site = insert(:site)
       insert(:site_membership, user: user, site: site, role: :viewer)

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -11,6 +11,10 @@ defmodule Plausible.TestUtils do
 
   defmacro patch_env(env_key, value) do
     quote do
+      if __MODULE__.__info__(:attributes)[:ex_unit_async] == [true] do
+        raise "Patching env is unsafe in asynchronous tests. maybe extract the case elsewhere?"
+      end
+
       original_env = Application.get_env(:plausible, unquote(env_key))
       Application.put_env(:plausible, unquote(env_key), unquote(value))
 


### PR DESCRIPTION
### Changes

This PR extracts a single test where the application env was patched to its own module. We'll also throw a runtime error in case this is done ever again.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
