### PR TITLE
Fix CSV export reading props feature flag

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -149,7 +149,7 @@ defmodule PlausibleWeb.StatsController do
       }
 
       csvs =
-        if FunWithFlags.enabled?(:props) do
+        if FunWithFlags.enabled?(:props, for: conn.assigns[:current_user]) do
           Map.put(csvs, 'custom_props.csv', fn ->
             Api.StatsController.all_custom_prop_values(conn, params)
           end)


### PR DESCRIPTION
Just a quick follow-up change for https://github.com/plausible/analytics/pull/3167. We're not only interested in the global state of the feature flag, but also per user.