### PR TITLE
remove dockerhub credentials from pull

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,9 +18,6 @@ jobs:
     services:
       postgres:
         image: postgres:${{ matrix.postgres_version }}
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 5432:5432
         env:
@@ -33,9 +30,6 @@ jobs:
 
       clickhouse:
         image: clickhouse/clickhouse-server:23.3.7.5-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 8123:8123
         env:


### PR DESCRIPTION
I previously introduced using the dockerhub credentials when pulling images from dockerhub. But this leads to problems when creating PRs from a fork.
And it is not so clear if we really need to use the dockerhub creds, as it seems that there were no problems before.
