### PR TITLE
Fix flaky log assertion

### DIFF
--- a/test/workers/expire_domain_change_transitions_test.exs
+++ b/test/workers/expire_domain_change_transitions_test.exs
@@ -12,7 +12,7 @@ defmodule Plausible.Workers.ExpireDomainChangeTransitionsTest do
         assert :ok = ExpireDomainChangeTransitions.perform(nil)
       end)
 
-    assert log == ""
+    refute log =~ "Expired"
   end
 
   test "expires domains selectively after change and logs the result" do


### PR DESCRIPTION
### Changes

Fixes CI random failure seen at @vinibrsl's PR: https://github.com/plausible/analytics/actions/runs/5674130039/job/15377104359?pr=3191

I haven't gotten deep into details, it looks like some `Logger` race condition - the message comes from another test after all.

I thought that maybe Elixir v.1.15.4 will magically fix it, alas, the error was still observable randomly with the same seed.

The value of that test is minor anyway.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
