### PR TITLE
Fix unique constraint validation on weekly/monthly reports

### DIFF
--- a/lib/plausible/site/monthly_report.ex
+++ b/lib/plausible/site/monthly_report.ex
@@ -3,8 +3,8 @@ defmodule Plausible.Site.MonthlyReport do
   import Ecto.Changeset
 
   schema "monthly_reports" do
-    field :recipients, {:array, :string}
-    belongs_to :site, Plausible.Site
+    field(:recipients, {:array, :string})
+    belongs_to(:site, Plausible.Site)
 
     timestamps()
   end
@@ -13,7 +13,7 @@ defmodule Plausible.Site.MonthlyReport do
     settings
     |> cast(attrs, [:site_id, :recipients])
     |> validate_required([:site_id, :recipients])
-    |> unique_constraint(:site)
+    |> unique_constraint(:site_id)
   end
 
   def add_recipient(report, recipient) do

--- a/lib/plausible/site/monthly_report.ex
+++ b/lib/plausible/site/monthly_report.ex
@@ -3,8 +3,8 @@ defmodule Plausible.Site.MonthlyReport do
   import Ecto.Changeset
 
   schema "monthly_reports" do
-    field(:recipients, {:array, :string})
-    belongs_to(:site, Plausible.Site)
+    field :recipients, {:array, :string}
+    belongs_to :site, Plausible.Site
 
     timestamps()
   end

--- a/lib/plausible/site/weekly_report.ex
+++ b/lib/plausible/site/weekly_report.ex
@@ -3,8 +3,8 @@ defmodule Plausible.Site.WeeklyReport do
   import Ecto.Changeset
 
   schema "weekly_reports" do
-    field(:recipients, {:array, :string})
-    belongs_to(:site, Plausible.Site)
+    field :recipients, {:array, :string}
+    belongs_to :site, Plausible.Site
 
     timestamps()
   end

--- a/lib/plausible/site/weekly_report.ex
+++ b/lib/plausible/site/weekly_report.ex
@@ -3,8 +3,8 @@ defmodule Plausible.Site.WeeklyReport do
   import Ecto.Changeset
 
   schema "weekly_reports" do
-    field :recipients, {:array, :string}
-    belongs_to :site, Plausible.Site
+    field(:recipients, {:array, :string})
+    belongs_to(:site, Plausible.Site)
 
     timestamps()
   end
@@ -13,7 +13,7 @@ defmodule Plausible.Site.WeeklyReport do
     settings
     |> cast(attrs, [:site_id, :recipients])
     |> validate_required([:site_id, :recipients])
-    |> unique_constraint(:site)
+    |> unique_constraint(:site_id)
   end
 
   def add_recipient(report, recipient) do

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -3,21 +3,18 @@ defmodule PlausibleWeb.SiteController do
   use Plausible.Repo
   alias Plausible.{Sites, Goals}
 
-  plug(PlausibleWeb.RequireAccountPlug)
+  plug PlausibleWeb.RequireAccountPlug
 
-  plug(
-    PlausibleWeb.AuthorizeSiteAccess,
-    [:owner, :admin, :super_admin] when action not in [:index, :new, :create_site]
-  )
+  plug PlausibleWeb.AuthorizeSiteAccess,
+       [:owner, :admin, :super_admin] when action not in [:index, :new, :create_site]
 
   def index(conn, params) do
     user = conn.assigns[:current_user]
 
     invitations =
       Repo.all(
-        from(i in Plausible.Auth.Invitation,
+        from i in Plausible.Auth.Invitation,
           where: i.email == ^user.email
-        )
       )
       |> Repo.preload(:site)
 
@@ -112,11 +109,10 @@ defmodule PlausibleWeb.SiteController do
 
     is_first_site =
       !Repo.exists?(
-        from(sm in Plausible.Site.Membership,
+        from sm in Plausible.Site.Membership,
           where:
             sm.user_id == ^user.id and
               sm.site_id != ^site.id
-        )
       )
 
     conn
@@ -257,7 +253,7 @@ defmodule PlausibleWeb.SiteController do
 
   def settings_visibility(conn, _params) do
     site = conn.assigns[:site] |> Repo.preload(:custom_domain)
-    shared_links = Repo.all(from(l in Plausible.Site.SharedLink, where: l.site_id == ^site.id))
+    shared_links = Repo.all(from l in Plausible.Site.SharedLink, where: l.site_id == ^site.id)
 
     conn
     |> assign(:skip_plausible_tracking, true)
@@ -472,7 +468,7 @@ defmodule PlausibleWeb.SiteController do
 
   def disable_weekly_report(conn, _params) do
     site = conn.assigns[:site]
-    Repo.delete_all(from(wr in Plausible.Site.WeeklyReport, where: wr.site_id == ^site.id))
+    Repo.delete_all(from wr in Plausible.Site.WeeklyReport, where: wr.site_id == ^site.id)
 
     conn
     |> put_flash(:success, "You will not receive weekly email reports going forward")
@@ -526,7 +522,7 @@ defmodule PlausibleWeb.SiteController do
 
   def disable_monthly_report(conn, _params) do
     site = conn.assigns[:site]
-    Repo.delete_all(from(mr in Plausible.Site.MonthlyReport, where: mr.site_id == ^site.id))
+    Repo.delete_all(from mr in Plausible.Site.MonthlyReport, where: mr.site_id == ^site.id)
 
     conn
     |> put_flash(:success, "You will not receive monthly email reports going forward")
@@ -586,7 +582,7 @@ defmodule PlausibleWeb.SiteController do
 
   def disable_spike_notification(conn, _params) do
     site = conn.assigns[:site]
-    Repo.delete_all(from(mr in Plausible.Site.SpikeNotification, where: mr.site_id == ^site.id))
+    Repo.delete_all(from mr in Plausible.Site.SpikeNotification, where: mr.site_id == ^site.id)
 
     conn
     |> put_flash(:success, "Spike notification disabled")
@@ -702,10 +698,9 @@ defmodule PlausibleWeb.SiteController do
     site_id = site.id
 
     case Repo.delete_all(
-           from(l in Plausible.Site.SharedLink,
+           from l in Plausible.Site.SharedLink,
              where: l.slug == ^slug,
              where: l.site_id == ^site_id
-           )
          ) do
       {1, _} ->
         conn
@@ -724,10 +719,9 @@ defmodule PlausibleWeb.SiteController do
     site_id = site.id
 
     case Repo.delete_all(
-           from(d in Plausible.Site.CustomDomain,
+           from d in Plausible.Site.CustomDomain,
              where: d.site_id == ^site_id,
              where: d.id == ^domain_id
-           )
          ) do
       {1, _} ->
         conn
@@ -918,11 +912,10 @@ defmodule PlausibleWeb.SiteController do
     cond do
       site.imported_data ->
         Oban.cancel_all_jobs(
-          from(j in Oban.Job,
+          from j in Oban.Job,
             where:
               j.queue == "google_analytics_imports" and
                 fragment("(? ->> 'site_id')::int", j.args) == ^site.id
-          )
         )
 
         Plausible.Imported.forget(site)

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -853,7 +853,21 @@ defmodule PlausibleWeb.SiteControllerTest do
       site: site,
       user: user
     } do
+      conn = post(conn, "/sites/#{site.domain}/weekly-report/enable")
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) =~ "You will receive an email report"
+
+      report = Repo.get_by(Plausible.Site.WeeklyReport, site_id: site.id)
+      assert report.recipients == [user.email]
+    end
+
+    test "creates a weekly report record twice (e.g. from a second tab)", %{
+      conn: conn,
+      site: site,
+      user: user
+    } do
       post(conn, "/sites/#{site.domain}/weekly-report/enable")
+      conn = post(conn, "/sites/#{site.domain}/weekly-report/enable")
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) =~ "You will receive an email report"
 
       report = Repo.get_by(Plausible.Site.WeeklyReport, site_id: site.id)
       assert report.recipients == [user.email]
@@ -929,8 +943,22 @@ defmodule PlausibleWeb.SiteControllerTest do
       site: site,
       user: user
     } do
-      post(conn, "/sites/#{site.domain}/monthly-report/enable")
+      conn = post(conn, "/sites/#{site.domain}/monthly-report/enable")
 
+      report = Repo.get_by(Plausible.Site.MonthlyReport, site_id: site.id)
+      assert report.recipients == [user.email]
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) =~ "You will receive an email report"
+    end
+
+    test "enable monthly report twice (e.g. from a second tab)", %{
+      conn: conn,
+      site: site,
+      user: user
+    } do
+      post(conn, "/sites/#{site.domain}/monthly-report/enable")
+      conn = post(conn, "/sites/#{site.domain}/monthly-report/enable")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) =~ "You will receive an email report"
       report = Repo.get_by(Plausible.Site.MonthlyReport, site_id: site.id)
       assert report.recipients == [user.email]
     end


### PR DESCRIPTION
### Changes

Small fix to how changeset constraint errors are handled on enabling e-mail reports. Based on user report submitted via sentry.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
