### PR TITLE
Refactor: Standardize API metrics used internally

### DIFF
--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -52,17 +52,17 @@ export default class Conversions extends React.Component {
         <div className="flex items-center justify-between my-2">
           <span className="flex-1">
             <Bar
-              count={goal.unique_conversions}
+              count={goal.visitors}
               all={this.state.goals}
               bg="bg-red-50 dark:bg-gray-500 dark:bg-opacity-15"
-              plot="unique_conversions"
+              plot="visitors"
             >
               <Link to={url.setQuery('goal', escapeFilterValue(goal.name))} className="block px-2 py-1.5 hover:underline relative z-9 break-all lg:truncate dark:text-gray-200">{goal.name}</Link>
             </Bar>
           </span>
           <div className="dark:text-gray-200">
-            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.unique_conversions)}</span>
-            <span className="hidden md:inline-block md:w-20 font-medium text-right">{numberFormatter(goal.total_conversions)}</span>
+            <span className="inline-block w-20 font-medium text-right">{numberFormatter(goal.visitors)}</span>
+            <span className="hidden md:inline-block md:w-20 font-medium text-right">{numberFormatter(goal.events)}</span>
             <span className="inline-block w-20 font-medium text-right">{goal.conversion_rate}%</span>
             {renderRevenueColumn && <span className="hidden md:inline-block md:w-20 font-medium text-right"><Money formatted={goal.total_revenue} /></span>}
             {renderRevenueColumn && <span className="hidden md:inline-block md:w-20 font-medium text-right"><Money formatted={goal.average_revenue} /></span>}

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -90,8 +90,8 @@ class EntryPagesModal extends React.Component {
           </Link>
         </td>
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_visitors)}</td>}
-        <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.unique_entrances)}</td>
-        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_entrances)}</td>}
+        <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visitors)}</td>
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visits)}</td>}
         {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{durationFormatter(page.visit_duration)}</td>}
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.conversion_rate)}%</td>}
       </tr>

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -72,8 +72,8 @@ class ExitPagesModal extends React.Component {
           <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
         </td>
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_visitors)}</td>}
-        <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.unique_exits)}</td>
-        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_exits)}</td>}
+        <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visitors)}</td>
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visits)}</td>}
         {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatPercentage(page.exit_rate)}</td>}
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.conversion_rate)}%</td>}
       </tr>

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -4,7 +4,7 @@ import * as storage from '../../util/storage'
 import * as url from '../../util/url'
 import * as api from '../../api'
 import ListReport from './../reports/list'
-import { VISITORS_METRIC, UNIQUE_ENTRANCES_METRIC, UNIQUE_EXITS_METRIC, maybeWithCR } from './../reports/metrics';
+import { VISITORS_METRIC, maybeWithCR } from './../reports/metrics';
 
 function EntryPages({query, site}) {
   function fetchData() {
@@ -24,7 +24,7 @@ function EntryPages({query, site}) {
       fetchData={fetchData}
       getFilterFor={getFilterFor}
       keyLabel="Entry page"
-      metrics={maybeWithCR([UNIQUE_ENTRANCES_METRIC], query)}
+      metrics={maybeWithCR([{...VISITORS_METRIC, label: 'Unique Entrances'}], query)}
       detailsLink={url.sitePath(site, '/entry-pages')}
       query={query}
       externalLinkDest={externalLinkDest}
@@ -51,7 +51,7 @@ function ExitPages({query, site}) {
       fetchData={fetchData}
       getFilterFor={getFilterFor}
       keyLabel="Exit page"
-      metrics={maybeWithCR([UNIQUE_EXITS_METRIC], query)}
+      metrics={maybeWithCR([{...VISITORS_METRIC, label: "Unique Exits"}], query)}
       detailsLink={url.sitePath(site, '/exit-pages')}
       query={query}
       externalLinkDest={externalLinkDest}

--- a/assets/js/dashboard/stats/reports/metrics.js
+++ b/assets/js/dashboard/stats/reports/metrics.js
@@ -7,16 +7,6 @@ export const VISITORS_METRIC = {
   realtimeLabel: 'Current visitors',
   goalFilterLabel: 'Conversions'
 }
-export const UNIQUE_ENTRANCES_METRIC = {
-  ...VISITORS_METRIC,
-  name: 'unique_entrances',
-  label: 'Unique Entrances'
-}
-export const UNIQUE_EXITS_METRIC = {
-  ...VISITORS_METRIC,
-  name: 'unique_exits',
-  label: 'Unique Exits'
-}
 export const PERCENTAGE_METRIC = { name: 'percentage', label: '%' }
 export const CR_METRIC = { name: 'conversion_rate', label: 'CR' }
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1134,17 +1134,21 @@ defmodule PlausibleWeb.Api.StatsController do
     conversions =
       site
       |> Stats.breakdown(query, "event:goal", metrics, {100, 1})
-      |> transform_keys(%{goal: :name, visitors: :unique_conversions, events: :total_conversions})
+      |> transform_keys(%{goal: :name})
       |> Enum.map(fn goal ->
         goal
         |> Map.put(:prop_names, CustomProps.props_for_goal(site, query))
-        |> Map.put(:conversion_rate, calculate_cr(total_visitors, goal[:unique_conversions]))
+        |> Map.put(:conversion_rate, calculate_cr(total_visitors, goal[:visitors]))
         |> Enum.map(&format_revenue_metric/1)
         |> Map.new()
       end)
 
     if params["csv"] do
-      to_csv(conversions, [:name, :unique_conversions, :total_conversions])
+      to_csv(conversions, [:name, :visitors, :events], [
+        :name,
+        :unique_conversions,
+        :total_conversions
+      ])
     else
       json(conn, conversions)
     end

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -748,11 +748,11 @@ defmodule Plausible.ImportedTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "/page2",
-                 "unique_exits" => 3,
-                 "total_exits" => 4,
+                 "visitors" => 3,
+                 "visits" => 4,
                  "exit_rate" => 80.0
                },
-               %{"name" => "/page1", "unique_exits" => 2, "total_exits" => 2, "exit_rate" => 66}
+               %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66}
              ]
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -35,15 +35,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 3,
+                 "visitors" => 2,
+                 "events" => 3,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                },
                %{
                  "name" => "Visit /register",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                }
@@ -84,8 +84,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 2,
+                 "visitors" => 1,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                }
@@ -125,8 +125,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 66.7
                }
@@ -164,8 +164,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 3,
+                 "visitors" => 2,
+                 "events" => 3,
                  "prop_names" => [],
                  "conversion_rate" => 66.7
                }
@@ -205,8 +205,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 3,
+                 "visitors" => 2,
+                 "events" => 3,
                  "prop_names" => [],
                  "conversion_rate" => 66.7
                }
@@ -256,8 +256,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 5,
-                 "total_conversions" => 5,
+                 "visitors" => 5,
+                 "events" => 5,
                  "prop_names" => [],
                  "conversion_rate" => 100.0,
                  "average_revenue" => %{"short" => "€166.7M", "long" => "€166,733,566.75"},
@@ -294,27 +294,27 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "conversion_rate" => 33.3,
                  "name" => "Payment",
                  "prop_names" => [],
-                 "total_conversions" => 1,
+                 "events" => 1,
                  "total_revenue" => %{"long" => "€10.00", "short" => "€10.0"},
-                 "unique_conversions" => 1
+                 "visitors" => 1
                },
                %{
                  "average_revenue" => nil,
                  "conversion_rate" => 66.7,
                  "name" => "Signup",
                  "prop_names" => [],
-                 "total_conversions" => 2,
+                 "events" => 2,
                  "total_revenue" => nil,
-                 "unique_conversions" => 2
+                 "visitors" => 2
                },
                %{
                  "average_revenue" => nil,
                  "conversion_rate" => 33.3,
                  "name" => "Visit /checkout",
                  "prop_names" => [],
-                 "total_conversions" => 1,
+                 "events" => 1,
                  "total_revenue" => nil,
-                 "unique_conversions" => 1
+                 "visitors" => 1
                }
              ] == Enum.sort_by(response, & &1["name"])
     end
@@ -334,8 +334,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 100.0
                }
@@ -370,8 +370,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => ["variant"],
                  "conversion_rate" => 33.3
                }
@@ -408,8 +408,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Payment",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => ["logged_in"],
                  "conversion_rate" => 66.7
                }
@@ -573,15 +573,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                },
                %{
                  "name" => "Visit /register",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 16.7
                }
@@ -614,15 +614,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "CTA",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 16.7
                },
                %{
                  "name" => "Visit /register",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 16.7
                }
@@ -650,15 +650,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Visit /blog/**",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 66.7
                },
                %{
                  "name" => "Visit /billing/upgrade",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                }
@@ -690,15 +690,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Visit /blog**",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                },
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 16.7
                }
@@ -731,15 +731,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Visit /ano**",
-                 "unique_conversions" => 2,
-                 "total_conversions" => 2,
+                 "visitors" => 2,
+                 "events" => 2,
                  "prop_names" => [],
                  "conversion_rate" => 33.3
                },
                %{
                  "name" => "CTA",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 16.7
                }
@@ -769,8 +769,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Visit /register",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => [],
                  "conversion_rate" => 25
                }
@@ -802,8 +802,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "Signup",
-                 "unique_conversions" => 1,
-                 "total_conversions" => 1,
+                 "visitors" => 1,
+                 "events" => 1,
                  "prop_names" => ["variant"],
                  "conversion_rate" => 50
                }
@@ -870,58 +870,58 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "conversion_rate" => 100.0,
-                 "unique_conversions" => 8,
+                 "visitors" => 8,
                  "name" => "Visit /**",
-                 "total_conversions" => 8,
+                 "events" => 8,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 37.5,
-                 "unique_conversions" => 3,
+                 "visitors" => 3,
                  "name" => "Visit /signup/**",
-                 "total_conversions" => 3,
+                 "events" => 3,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 37.5,
-                 "unique_conversions" => 3,
+                 "visitors" => 3,
                  "name" => "Visit /*",
-                 "total_conversions" => 3,
+                 "events" => 3,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 25.0,
-                 "unique_conversions" => 2,
+                 "visitors" => 2,
                  "name" => "Visit /billing**/success",
-                 "total_conversions" => 2,
+                 "events" => 2,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 25.0,
-                 "unique_conversions" => 2,
+                 "visitors" => 2,
                  "name" => "Visit /reg*",
-                 "total_conversions" => 2,
+                 "events" => 2,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 12.5,
-                 "unique_conversions" => 1,
+                 "visitors" => 1,
                  "name" => "Visit /signup/*",
-                 "total_conversions" => 1,
+                 "events" => 1,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 12.5,
-                 "unique_conversions" => 1,
+                 "visitors" => 1,
                  "name" => "Visit /billing*/success",
-                 "total_conversions" => 1,
+                 "events" => 1,
                  "prop_names" => []
                },
                %{
                  "conversion_rate" => 12.5,
-                 "unique_conversions" => 1,
+                 "visitors" => 1,
                  "name" => "Visit /register",
-                 "total_conversions" => 1,
+                 "events" => 1,
                  "prop_names" => []
                }
              ]
@@ -956,9 +956,9 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert json_response(conn, 200) == [
                %{
                  "conversion_rate" => 100.0,
-                 "unique_conversions" => 2,
+                 "visitors" => 2,
                  "name" => "Visit /register**",
-                 "total_conversions" => 2,
+                 "events" => 2,
                  "prop_names" => ["logged_in", "author"]
                }
              ]

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -903,14 +903,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "unique_entrances" => 2,
-                 "total_entrances" => 2,
+                 "visitors" => 2,
+                 "visits" => 2,
                  "name" => "/page1",
                  "visit_duration" => 0
                },
                %{
-                 "unique_entrances" => 1,
-                 "total_entrances" => 2,
+                 "visitors" => 1,
+                 "visits" => 2,
                  "name" => "/page2",
                  "visit_duration" => 450
                }
@@ -959,14 +959,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "unique_entrances" => 1,
-                 "total_entrances" => 1,
+                 "visitors" => 1,
+                 "visits" => 1,
                  "name" => "/blog",
                  "visit_duration" => 60
                },
                %{
-                 "unique_entrances" => 1,
-                 "total_entrances" => 1,
+                 "visitors" => 1,
+                 "visits" => 1,
                  "name" => "/blog/john-2",
                  "visit_duration" => 0
                }
@@ -1014,14 +1014,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "unique_entrances" => 2,
-                 "total_entrances" => 2,
+                 "visitors" => 2,
+                 "visits" => 2,
                  "name" => "/page1",
                  "visit_duration" => 0
                },
                %{
-                 "unique_entrances" => 1,
-                 "total_entrances" => 2,
+                 "visitors" => 1,
+                 "visits" => 2,
                  "name" => "/page2",
                  "visit_duration" => 450
                }
@@ -1035,14 +1035,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200) == [
                %{
-                 "unique_entrances" => 3,
-                 "total_entrances" => 5,
+                 "visitors" => 3,
+                 "visits" => 5,
                  "name" => "/page2",
                  "visit_duration" => 240.0
                },
                %{
-                 "unique_entrances" => 2,
-                 "total_entrances" => 2,
+                 "visitors" => 2,
+                 "visits" => 2,
                  "name" => "/page1",
                  "visit_duration" => 0
                }
@@ -1094,16 +1094,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       assert json_response(conn, 200) == [
                %{
                  "total_visitors" => 2,
-                 "unique_entrances" => 1,
-                 "total_entrances" => 1,
+                 "visitors" => 1,
+                 "visits" => 1,
                  "name" => "/page1",
                  "visit_duration" => 0,
                  "conversion_rate" => 50.0
                },
                %{
                  "total_visitors" => 1,
-                 "unique_entrances" => 1,
-                 "total_entrances" => 1,
+                 "visitors" => 1,
+                 "visits" => 1,
                  "name" => "/page2",
                  "visit_duration" => 900,
                  "conversion_rate" => 100.0
@@ -1140,8 +1140,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/exit-pages?period=day&date=2021-01-01")
 
       assert json_response(conn, 200) == [
-               %{"name" => "/page1", "unique_exits" => 2, "total_exits" => 2, "exit_rate" => 66},
-               %{"name" => "/page2", "unique_exits" => 1, "total_exits" => 1, "exit_rate" => 100}
+               %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66},
+               %{"name" => "/page2", "visitors" => 1, "visits" => 1, "exit_rate" => 100}
              ]
     end
 
@@ -1180,7 +1180,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
         )
 
       assert json_response(conn, 200) == [
-               %{"name" => "/", "unique_exits" => 1, "total_exits" => 1}
+               %{"name" => "/", "visitors" => 1, "visits" => 1}
              ]
     end
 
@@ -1224,8 +1224,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/exit-pages?period=day&date=2021-01-01")
 
       assert json_response(conn, 200) == [
-               %{"name" => "/page1", "unique_exits" => 2, "total_exits" => 2, "exit_rate" => 66},
-               %{"name" => "/page2", "unique_exits" => 1, "total_exits" => 1, "exit_rate" => 100}
+               %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66},
+               %{"name" => "/page2", "visitors" => 1, "visits" => 1, "exit_rate" => 100}
              ]
 
       conn =
@@ -1237,11 +1237,11 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "/page2",
-                 "unique_exits" => 3,
-                 "total_exits" => 4,
+                 "visitors" => 3,
+                 "visits" => 4,
                  "exit_rate" => 80.0
                },
-               %{"name" => "/page1", "unique_exits" => 2, "total_exits" => 2, "exit_rate" => 66}
+               %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66}
              ]
     end
 
@@ -1288,16 +1288,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       assert json_response(conn, 200) == [
                %{
                  "name" => "/exit1",
-                 "unique_exits" => 1,
+                 "visitors" => 1,
                  "total_visitors" => 1,
-                 "total_exits" => 1,
+                 "visits" => 1,
                  "conversion_rate" => 100.0
                },
                %{
                  "name" => "/exit2",
-                 "unique_exits" => 1,
+                 "visitors" => 1,
                  "total_visitors" => 1,
-                 "total_exits" => 1,
+                 "visits" => 1,
                  "conversion_rate" => 100.0
                }
              ]
@@ -1341,8 +1341,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
         )
 
       assert json_response(conn, 200) == [
-               %{"name" => "/exit1", "unique_exits" => 1, "total_exits" => 1},
-               %{"name" => "/exit2", "unique_exits" => 1, "total_exits" => 1}
+               %{"name" => "/exit1", "visitors" => 1, "visits" => 1},
+               %{"name" => "/exit2", "visitors" => 1, "visits" => 1}
              ]
     end
   end


### PR DESCRIPTION
### Changes

just a small consistency improvement - as it's clear what the `visitors`, `visits` and `events` metrics mean internally, there's no need to rename it for different reports or according to the filters being used.

This PR only changes the metric atoms being used internally, without changing any actual behavior.

### Tests
- [x] This PR does not require new tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
