### PR TITLE
[pg migration] Delete account with multiple subscriptions

### DIFF
--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -87,7 +87,6 @@ defmodule Plausible.Auth do
       user =
         user
         |> Repo.preload(site_memberships: :site)
-        |> Repo.preload(:subscription)
 
       for membership <- user.site_memberships do
         Repo.delete!(membership)
@@ -97,7 +96,6 @@ defmodule Plausible.Auth do
         end
       end
 
-      if user.subscription, do: Repo.delete!(user.subscription)
       Repo.delete!(user)
     end)
   end

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -14,6 +14,10 @@ defmodule Plausible.Auth.UserAdmin do
     ]
   end
 
+  def delete(_conn, %{data: user}) do
+    Plausible.Auth.delete_user(user)
+  end
+
   def index(_) do
     [
       name: nil,

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -76,6 +76,7 @@ defmodule Plausible.Billing do
   def needs_to_upgrade?(%Plausible.Auth.User{trial_expiry_date: nil}), do: {true, :no_trial}
 
   def needs_to_upgrade?(user) do
+    user = Plausible.Users.with_subscription(user)
     trial_is_over = Timex.before?(user.trial_expiry_date, Timex.today())
     subscription_active = subscription_is_active?(user.subscription)
 
@@ -99,6 +100,7 @@ defmodule Plausible.Billing do
   def on_trial?(%Plausible.Auth.User{trial_expiry_date: nil}), do: false
 
   def on_trial?(user) do
+    user = Plausible.Users.with_subscription(user)
     !subscription_is_active?(user.subscription) && trial_days_left(user) >= 0
   end
 

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -37,7 +37,7 @@ defmodule Plausible.Billing.Plans do
           | :enterprise
 
   def plans_for(user) do
-    user = Repo.preload(user, :subscription)
+    user = Plausible.Users.with_subscription(user)
     sandbox_plans = plans_sandbox()
     v1_plans = plans_v1()
     v2_plans = plans_v2()

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -2,6 +2,8 @@ defmodule Plausible.Billing.SiteLocker do
   use Plausible.Repo
 
   def check_sites_for(user) do
+    user = Plausible.Users.with_subscription(user)
+
     case Plausible.Billing.needs_to_upgrade?(user) do
       {true, :grace_period_ended} ->
         set_lock_status_for(user, true)

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -1,0 +1,36 @@
+defmodule Plausible.Users do
+  @moduledoc """
+  User context
+  """
+
+  import Ecto.Query
+
+  alias Plausible.Auth.User
+  alias Plausible.Billing.Subscription
+  alias Plausible.Repo
+
+  def with_subscription(%User{id: user_id} = user) do
+    Repo.preload(user, subscription: last_subscription_query(user_id))
+  end
+
+  def with_subscription(user_id) when is_integer(user_id) do
+    Repo.one(
+      from(user in User,
+        left_join: last_subscription in subquery(last_subscription_query(user_id)),
+        on: last_subscription.user_id == user.id,
+        left_join: subscription in Subscription,
+        on: subscription.id == last_subscription.id,
+        where: user.id == ^user_id,
+        preload: [subscription: subscription]
+      )
+    )
+  end
+
+  defp last_subscription_query(user_id) do
+    from(subscription in Plausible.Billing.Subscription,
+      where: subscription.user_id == ^user_id,
+      order_by: [desc: subscription.inserted_at],
+      limit: 1
+    )
+  end
+end

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -8,33 +8,12 @@ defmodule PlausibleWeb.AuthPlug do
 
   def call(conn, _opts) do
     with id when is_integer(id) <- get_session(conn, :current_user_id),
-         %Plausible.Auth.User{} = user <- find_user(id) do
+         %Plausible.Auth.User{} = user <- Plausible.Users.with_subscription(id) do
       Plausible.OpenTelemetry.add_user_attributes(user)
       Sentry.Context.set_user_context(%{id: user.id, name: user.name, email: user.email})
       assign(conn, :current_user, user)
     else
       nil -> conn
     end
-  end
-
-  defp find_user(user_id) do
-    last_subscription_query =
-      from(subscription in Plausible.Billing.Subscription,
-        where: subscription.user_id == ^user_id,
-        order_by: [desc: subscription.inserted_at],
-        limit: 1
-      )
-
-    user_query =
-      from(user in Plausible.Auth.User,
-        left_join: last_subscription in subquery(last_subscription_query),
-        on: last_subscription.user_id == user.id,
-        left_join: subscription in Plausible.Billing.Subscription,
-        on: subscription.id == last_subscription.id,
-        where: user.id == ^user_id,
-        preload: [subscription: subscription]
-      )
-
-    Repo.one(user_query)
   end
 end

--- a/lib/workers/send_site_setup_emails.ex
+++ b/lib/workers/send_site_setup_emails.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
     for site <- Repo.all(q) do
       owner =
         Plausible.Sites.owner_for(site)
-        |> Repo.preload(:subscription)
+        |> Plausible.Users.with_subscription()
 
       setup_completed = Plausible.Sites.has_stats?(site)
       hours_passed = Timex.diff(Timex.now(), site.inserted_at, :hours)
@@ -66,7 +66,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
     for site <- Repo.all(q) do
       owner =
         Plausible.Sites.owner_for(site)
-        |> Repo.preload(:subscription)
+        |> Plausible.Users.with_subscription()
 
       if Plausible.Sites.has_stats?(site) do
         send_setup_success_email(owner, site)

--- a/priv/repo/migrations/20230802081520_cascade_delete_user.exs
+++ b/priv/repo/migrations/20230802081520_cascade_delete_user.exs
@@ -1,0 +1,43 @@
+defmodule Plausible.Repo.Migrations.CascadeDeleteUser do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:subscriptions, "subscriptions_user_id_fkey"))
+
+    alter table(:subscriptions) do
+      modify(:user_id, references(:users, on_delete: :delete_all), null: false)
+    end
+
+    drop(constraint(:site_memberships, "site_memberships_user_id_fkey"))
+
+    alter table(:site_memberships) do
+      modify(:user_id, references(:users, on_delete: :delete_all), null: false)
+    end
+
+    drop(constraint(:google_auth, "google_auth_user_id_fkey"))
+
+    alter table(:google_auth) do
+      modify(:user_id, references(:users, on_delete: :delete_all), null: false)
+    end
+  end
+
+  def down do
+    drop(constraint(:subscriptions, "subscriptions_user_id_fkey"))
+
+    alter table(:subscriptions) do
+      modify(:user_id, references(:users), null: false)
+    end
+
+    drop(constraint(:site_memberships, "site_memberships_user_id_fkey"))
+
+    alter table(:site_memberships) do
+      modify(:user_id, references(:users), null: false)
+    end
+
+    drop(constraint(:google_auth, "google_auth_user_id_fkey"))
+
+    alter table(:google_auth) do
+      modify(:user_id, references(:users), null: false)
+    end
+  end
+end

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -199,15 +199,13 @@ defmodule Plausible.BillingTest do
 
   describe "on_trial?" do
     test "is true with >= 0 trial days left" do
-      user = insert(:user) |> Repo.preload(:subscription)
+      user = insert(:user)
 
       assert Billing.on_trial?(user)
     end
 
     test "is false with < 0 trial days left" do
-      user =
-        insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: -1))
-        |> Repo.preload(:subscription)
+      user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: -1))
 
       refute Billing.on_trial?(user)
     end
@@ -222,14 +220,11 @@ defmodule Plausible.BillingTest do
   describe "needs_to_upgrade?" do
     test "is false for a trial user" do
       user = insert(:user)
-      user = Repo.preload(user, :subscription)
-
       refute Billing.needs_to_upgrade?(user)
     end
 
     test "is true for a user with an expired trial" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
-      user = Repo.preload(user, :subscription)
 
       assert Billing.needs_to_upgrade?(user)
     end
@@ -237,7 +232,6 @@ defmodule Plausible.BillingTest do
     test "is false for a user with an expired trial but an active subscription" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user)
-      user = Repo.preload(user, :subscription)
 
       refute Billing.needs_to_upgrade?(user)
     end
@@ -245,7 +239,6 @@ defmodule Plausible.BillingTest do
     test "is false for a user with a cancelled subscription IF the billing cycle isn't completed yet" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user, status: "deleted", next_bill_date: Timex.today())
-      user = Repo.preload(user, :subscription)
 
       refute Billing.needs_to_upgrade?(user)
     end
@@ -259,15 +252,12 @@ defmodule Plausible.BillingTest do
         next_bill_date: Timex.shift(Timex.today(), days: -1)
       )
 
-      user = Repo.preload(user, :subscription)
-
       assert Billing.needs_to_upgrade?(user)
     end
 
     test "is false for a deleted subscription if not next_bill_date specified" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user, status: "deleted", next_bill_date: nil)
-      user = Repo.preload(user, :subscription)
 
       assert Billing.needs_to_upgrade?(user)
     end

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -20,13 +20,13 @@ defmodule Plausible.Billing.PlansTest do
     end
 
     test "shows v2 pricing for users who signed up in 2021" do
-      user = insert(:user, inserted_at: ~N[2021-12-31 00:00:00]) |> Repo.preload(:subscription)
+      user = insert(:user, inserted_at: ~N[2021-12-31 00:00:00])
 
       assert List.first(Plans.plans_for(user))[:monthly_product_id] == @v2_plan_id
     end
 
     test "shows v3 pricing for everyone else" do
-      user = insert(:user) |> Repo.preload(:subscription)
+      user = insert(:user)
 
       assert List.first(Plans.plans_for(user))[:monthly_product_id] == @v3_plan_id
     end

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -5,9 +5,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
   describe "check_sites_for/1" do
     test "does not lock sites if user is on trial" do
-      user =
-        insert(:user, trial_expiry_date: Timex.today())
-        |> Repo.preload(:subscription)
+      user = insert(:user, trial_expiry_date: Timex.today())
 
       site = insert(:site, locked: true, members: [user])
 
@@ -19,7 +17,6 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock if user has an active subscription" do
       user = insert(:user)
       insert(:subscription, status: "active", user: user)
-      user = Repo.preload(user, :subscription)
       site = insert(:site, locked: true, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -30,7 +27,6 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock user who is past due" do
       user = insert(:user)
       insert(:subscription, status: "past_due", user: user)
-      user = Repo.preload(user, :subscription)
       site = insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -41,7 +37,6 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock user who cancelled subscription but it hasn't expired yet" do
       user = insert(:user)
       insert(:subscription, status: "deleted", user: user)
-      user = Repo.preload(user, :subscription)
       site = insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -59,7 +54,6 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      user = Repo.preload(user, :subscription)
       site = insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -78,8 +72,6 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       site = insert(:site, members: [user])
 
-      user = Repo.preload(user, :subscription)
-
       SiteLocker.check_sites_for(user)
 
       refute Repo.reload!(site).locked
@@ -95,7 +87,6 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      user = Repo.preload(user, :subscription)
       site = insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -113,7 +104,6 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      user = Repo.preload(user, :subscription)
       insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -135,7 +125,6 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      user = Repo.preload(user, :subscription)
       insert(:site, members: [user])
 
       SiteLocker.check_sites_for(user)
@@ -145,16 +134,14 @@ defmodule Plausible.Billing.SiteLockerTest do
         subject: "[Action required] Your Plausible dashboard is now locked"
       )
 
-      user = Repo.reload!(user) |> Repo.preload(:subscription)
+      user = Repo.reload!(user)
       SiteLocker.check_sites_for(user)
 
       assert_no_emails_delivered()
     end
 
     test "locks all sites if user has no trial or active subscription" do
-      user =
-        insert(:user, trial_expiry_date: Timex.today() |> Timex.shift(days: -1))
-        |> Repo.preload(:subscription)
+      user = insert(:user, trial_expiry_date: Timex.today() |> Timex.shift(days: -1))
 
       site = insert(:site, locked: true, members: [user])
 
@@ -164,9 +151,7 @@ defmodule Plausible.Billing.SiteLockerTest do
     end
 
     test "only locks sites that the user owns" do
-      user =
-        insert(:user, trial_expiry_date: Timex.today() |> Timex.shift(days: -1))
-        |> Repo.preload(:subscription)
+      user = insert(:user, trial_expiry_date: Timex.today() |> Timex.shift(days: -1))
 
       owner_site =
         insert(:site,

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -689,11 +689,13 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       insert(:google_auth, site: site, user: user)
       insert(:subscription, user: user, status: "deleted")
+      insert(:subscription, user: user, status: "active")
 
       conn = delete(conn, "/me")
       assert redirected_to(conn) == "/"
       assert Repo.reload(site) == nil
       assert Repo.reload(user) == nil
+      assert Repo.all(Plausible.Billing.Subscription) == []
     end
 
     test "deletes sites that the user owns", %{conn: conn, user: user, site: owner_site} do


### PR DESCRIPTION
### Changes

There were some cascading deletes missing in postgres schema, this PR takes care of that via a migration. Additionally, all subscription preloads are now done through an unified interface to minimize the risk of preloading a subscription that's not latest (explicit ordering is provided).

BTW CRM user deletion is fixed too.

I think it's fine to deploy this migration with the code in one shot.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
