### PR TITLE
Trim long URLs, paths and other list items uniformly

### DIFF
--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { Link , withRouter } from 'react-router-dom'
+import { Link, withRouter } from 'react-router-dom'
 
 
 import Modal from './modal'
 import * as api from '../../api'
 import numberFormatter, { durationFormatter } from '../../util/number-formatter'
-import {parseQuery} from '../../query'
+import { parseQuery } from '../../query'
+import { trimURL } from '../../util/url'
 
 class EntryPagesModal extends React.Component {
   constructor(props) {
@@ -24,12 +25,12 @@ class EntryPagesModal extends React.Component {
   }
 
   loadPages() {
-    const {query, page} = this.state;
+    const { query, page } = this.state;
 
     api.get(
       `/api/stats/${encodeURIComponent(this.props.site.domain)}/entry-pages`,
       query,
-      {limit: 100, page}
+      { limit: 100, page }
     )
       .then(
         (res) => this.setState((state) => ({
@@ -42,11 +43,11 @@ class EntryPagesModal extends React.Component {
 
   loadMore() {
     const { page } = this.state;
-    this.setState({loading: true, page: page + 1}, this.loadPages.bind(this))
+    this.setState({ loading: true, page: page + 1 }, this.loadPages.bind(this))
   }
 
   formatBounceRate(page) {
-    if (typeof(page.bounce_rate) === 'number') {
+    if (typeof (page.bounce_rate) === 'number') {
       return `${page.bounce_rate}%`;
     }
     return '-';
@@ -78,7 +79,7 @@ class EntryPagesModal extends React.Component {
 
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
-        <td className="p-2">
+        <td className="p-2 truncate">
           <Link
             to={{
               pathname: `/${encodeURIComponent(this.props.site.domain)}`,
@@ -86,7 +87,7 @@ class EntryPagesModal extends React.Component {
             }}
             className="hover:underline"
           >
-            {page.name}
+            {trimURL(page.name, 40)}
           </Link>
         </td>
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_visitors)}</td>}
@@ -130,13 +131,13 @@ class EntryPagesModal extends React.Component {
                   </th>
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Total Visitors </th>}
                   <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >{this.label()} </th>
-                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Total Entrances </th> }
-                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Visit Duration </th> }
+                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Total Entrances </th>}
+                  {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >Visit Duration </th>}
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right" >CR </th>}
                 </tr>
               </thead>
               <tbody>
-                { this.state.pages.map(this.renderPage.bind(this)) }
+                {this.state.pages.map(this.renderPage.bind(this))}
               </tbody>
             </table>
           </main>
@@ -148,8 +149,8 @@ class EntryPagesModal extends React.Component {
   render() {
     return (
       <Modal site={this.props.site}>
-        { this.renderBody() }
-        { this.renderLoading() }
+        {this.renderBody()}
+        {this.renderLoading()}
       </Modal>
     )
   }

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -5,8 +5,8 @@ import { withRouter } from 'react-router-dom'
 import Modal from './modal'
 import * as api from '../../api'
 import numberFormatter from '../../util/number-formatter'
-import {parseQuery} from '../../query'
-
+import { parseQuery } from '../../query'
+import { trimURL } from '../../util/url'
 class ExitPagesModal extends React.Component {
   constructor(props) {
     super(props)
@@ -24,18 +24,18 @@ class ExitPagesModal extends React.Component {
   }
 
   loadPages() {
-    const {query, page} = this.state;
+    const { query, page } = this.state;
 
-    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/exit-pages`, query, {limit: 100, page})
-      .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
+    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/exit-pages`, query, { limit: 100, page })
+      .then((res) => this.setState((state) => ({ loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100 })))
   }
 
   loadMore() {
-    this.setState({loading: true, page: this.state.page + 1}, this.loadPages.bind(this))
+    this.setState({ loading: true, page: this.state.page + 1 }, this.loadPages.bind(this))
   }
 
   formatPercentage(number) {
-    if (typeof(number) === 'number') {
+    if (typeof (number) === 'number') {
       return number + '%'
     } else {
       return '-'
@@ -68,8 +68,8 @@ class ExitPagesModal extends React.Component {
 
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
-        <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline">{page.name}</Link>
+        <td className="p-2 truncate">
+          <Link to={{ pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString() }} className="hover:underline">{trimURL(page.name, 40)}</Link>
         </td>
         {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.total_visitors)}</td>}
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visitors)}</td>
@@ -114,7 +114,7 @@ class ExitPagesModal extends React.Component {
                 </tr>
               </thead>
               <tbody>
-                { this.state.pages.map(this.renderPage.bind(this)) }
+                {this.state.pages.map(this.renderPage.bind(this))}
               </tbody>
             </table>
           </main>
@@ -126,8 +126,8 @@ class ExitPagesModal extends React.Component {
   render() {
     return (
       <Modal site={this.props.site}>
-        { this.renderBody() }
-        { this.renderLoading() }
+        {this.renderBody()}
+        {this.renderLoading()}
       </Modal>
     )
   }

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -4,8 +4,9 @@ import { withRouter } from 'react-router-dom'
 
 import Modal from './modal'
 import * as api from '../../api'
-import numberFormatter, {durationFormatter} from '../../util/number-formatter'
-import {parseQuery} from '../../query'
+import numberFormatter, { durationFormatter } from '../../util/number-formatter'
+import { parseQuery } from '../../query'
+import { trimURL } from '../../util/url'
 
 class PagesModal extends React.Component {
   constructor(props) {
@@ -25,14 +26,14 @@ class PagesModal extends React.Component {
 
   loadPages() {
     const detailed = this.showExtra()
-    const {query, page} = this.state;
+    const { query, page } = this.state;
 
-    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, {limit: 100, page, detailed})
-      .then((res) => this.setState((state) => ({loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100})))
+    api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, { limit: 100, page, detailed })
+      .then((res) => this.setState((state) => ({ loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100 })))
   }
 
   loadMore() {
-    this.setState({loading: true, page: this.state.page + 1}, this.loadPages.bind(this))
+    this.setState({ loading: true, page: this.state.page + 1 }, this.loadPages.bind(this))
   }
 
   showExtra() {
@@ -48,7 +49,7 @@ class PagesModal extends React.Component {
   }
 
   formatBounceRate(page) {
-    if (typeof(page.bounce_rate) === 'number') {
+    if (typeof (page.bounce_rate) === 'number') {
       return page.bounce_rate + '%'
     } else {
       return '-'
@@ -63,14 +64,14 @@ class PagesModal extends React.Component {
     return (
       <tr className="text-sm dark:text-gray-200" key={page.name}>
         <td className="p-2">
-          <Link to={{pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString()}} className="hover:underline block truncate">{page.name}</Link>
+          <Link to={{ pathname: `/${encodeURIComponent(this.props.site.domain)}`, search: query.toString() }} className="hover:underline block truncate">{trimURL(page.name, 50)}</Link>
         </td>
-        {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.total_visitors}</td> }
+        {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.total_visitors}</td>}
         <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.visitors)}</td>
-        {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td> }
-        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td> }
-        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td> }
-        {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.conversion_rate}%</td> }
+        {this.showPageviews() && <td className="p-2 w-32 font-medium" align="right">{numberFormatter(page.pageviews)}</td>}
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{this.formatBounceRate(page)}</td>}
+        {this.showExtra() && <td className="p-2 w-32 font-medium" align="right">{timeOnPage}</td>}
+        {this.showConversionRate() && <td className="p-2 w-32 font-medium" align="right">{page.conversion_rate}%</td>}
       </tr>
     )
   }
@@ -114,7 +115,7 @@ class PagesModal extends React.Component {
                 <tr>
                   <th className="p-2 w-48 md:w-56 lg:w-1/3 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="left">Page url</th>
                   {this.showConversionRate() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Total visitors</th>}
-                  <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">{ this.label() }</th>
+                  <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">{this.label()}</th>
                   {this.showPageviews() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Pageviews</th>}
                   {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Bounce rate</th>}
                   {this.showExtra() && <th className="p-2 w-32 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400" align="right">Time on Page</th>}
@@ -122,7 +123,7 @@ class PagesModal extends React.Component {
                 </tr>
               </thead>
               <tbody>
-                { this.state.pages.map(this.renderPage.bind(this)) }
+                {this.state.pages.map(this.renderPage.bind(this))}
               </tbody>
             </table>
           </main>
@@ -134,8 +135,8 @@ class PagesModal extends React.Component {
   render() {
     return (
       <Modal site={this.props.site}>
-        { this.renderBody() }
-        { this.renderLoading() }
+        {this.renderBody()}
+        {this.renderLoading()}
       </Modal>
     )
   }

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -7,7 +7,7 @@ import Modal from './modal'
 import * as api from '../../api'
 import * as url from "../../util/url";
 import numberFormatter from '../../util/number-formatter'
-import {parseQuery} from '../../query'
+import { parseQuery } from '../../query'
 
 function PropsModal(props) {
   const site = props.site
@@ -24,7 +24,7 @@ function PropsModal(props) {
   }, [])
 
   function fetchData() {
-    api.get(url.apiPath(site, `/custom-prop-values/${propKey}`), query, {limit: 100, page})
+    api.get(url.apiPath(site, `/custom-prop-values/${propKey}`), query, { limit: 100, page })
       .then((res) => {
         setLoading(false)
         setList(list.concat(res))
@@ -50,7 +50,7 @@ function PropsModal(props) {
 
   function filterSearchLink(listItem) {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set('props', JSON.stringify({[propKey]: listItem['name']}))
+    searchParams.set('props', JSON.stringify({ [propKey]: listItem['name'] }))
     return searchParams.toString()
   }
 
@@ -59,17 +59,17 @@ function PropsModal(props) {
       <tr className="text-sm dark:text-gray-200" key={listItem.name}>
         <td className="p-2">
           <Link
-            to={{pathname: url.siteBasePath(site), search: filterSearchLink(listItem)}}
+            to={{ pathname: url.siteBasePath(site), search: filterSearchLink(listItem) }}
             className="hover:underline block truncate">
-              {listItem.name}
+            {url.trimURL(listItem.name, 30)}
           </Link>
         </td>
         <td className="p-2 w-24 font-medium" align="right">{numberFormatter(listItem.visitors)}</td>
         <td className="p-2 w-24 font-medium" align="right">{numberFormatter(listItem.events)}</td>
-        { query.filters.goal && <td className="p-2 w-24 font-medium" align="right">{listItem.conversion_rate}%</td> }
-        { !query.filters.goal && <td className="p-2 w-24 font-medium" align="right">{listItem.percentage}</td> }
-        { hasRevenue && <td className="p-2 w-24 font-medium" align="right"><Money formatted={listItem.total_revenue}/></td> }
-        { hasRevenue && <td className="p-2 w-24 font-medium" align="right"><Money formatted={listItem.average_revenue}/></td> }
+        {query.filters.goal && <td className="p-2 w-24 font-medium" align="right">{listItem.conversion_rate}%</td>}
+        {!query.filters.goal && <td className="p-2 w-24 font-medium" align="right">{listItem.percentage}</td>}
+        {hasRevenue && <td className="p-2 w-24 font-medium" align="right"><Money formatted={listItem.total_revenue} /></td>}
+        {hasRevenue && <td className="p-2 w-24 font-medium" align="right"><Money formatted={listItem.average_revenue} /></td>}
       </tr>
     )
   }
@@ -99,7 +99,7 @@ function PropsModal(props) {
               </tr>
             </thead>
             <tbody>
-              { list.map((item) => renderListItem(item, hasRevenue)) }
+              {list.map((item) => renderListItem(item, hasRevenue))}
             </tbody>
           </table>
         </main>
@@ -109,9 +109,9 @@ function PropsModal(props) {
 
   return (
     <Modal site={site}>
-      { renderBody() }
-      { loading && renderLoading() }
-      { !loading && moreResultsAvailable && renderLoadMore() }
+      {renderBody()}
+      {loading && renderLoading()}
+      {!loading && moreResultsAvailable && renderLoadMore()}
     </Modal>
   )
 }

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -6,9 +6,9 @@ import * as api from '../../api'
 import ListReport from './../reports/list'
 import { VISITORS_METRIC, maybeWithCR } from './../reports/metrics';
 
-function EntryPages({query, site}) {
+function EntryPages({ query, site }) {
   function fetchData() {
-    return api.get(url.apiPath(site, '/entry-pages'), query, {limit: 9})
+    return api.get(url.apiPath(site, '/entry-pages'), query, { limit: 9 })
   }
 
   function externalLinkDest(page) {
@@ -16,7 +16,7 @@ function EntryPages({query, site}) {
   }
 
   function getFilterFor(listItem) {
-    return { entry_page: listItem['name']}
+    return { entry_page: listItem['name'] }
   }
 
   return (
@@ -24,7 +24,7 @@ function EntryPages({query, site}) {
       fetchData={fetchData}
       getFilterFor={getFilterFor}
       keyLabel="Entry page"
-      metrics={maybeWithCR([{...VISITORS_METRIC, label: 'Unique Entrances'}], query)}
+      metrics={maybeWithCR([{ ...VISITORS_METRIC, label: 'Unique Entrances' }], query)}
       detailsLink={url.sitePath(site, '/entry-pages')}
       query={query}
       externalLinkDest={externalLinkDest}
@@ -33,9 +33,9 @@ function EntryPages({query, site}) {
   )
 }
 
-function ExitPages({query, site}) {
+function ExitPages({ query, site }) {
   function fetchData() {
-    return api.get(url.apiPath(site, '/exit-pages'), query, {limit: 9})
+    return api.get(url.apiPath(site, '/exit-pages'), query, { limit: 9 })
   }
 
   function externalLinkDest(page) {
@@ -43,7 +43,7 @@ function ExitPages({query, site}) {
   }
 
   function getFilterFor(listItem) {
-    return { exit_page: listItem['name']}
+    return { exit_page: listItem['name'] }
   }
 
   return (
@@ -51,7 +51,7 @@ function ExitPages({query, site}) {
       fetchData={fetchData}
       getFilterFor={getFilterFor}
       keyLabel="Exit page"
-      metrics={maybeWithCR([{...VISITORS_METRIC, label: "Unique Exits"}], query)}
+      metrics={maybeWithCR([{ ...VISITORS_METRIC, label: "Unique Exits" }], query)}
       detailsLink={url.sitePath(site, '/exit-pages')}
       query={query}
       externalLinkDest={externalLinkDest}
@@ -60,9 +60,9 @@ function ExitPages({query, site}) {
   )
 }
 
-function TopPages({query, site}) {
+function TopPages({ query, site }) {
   function fetchData() {
-    return api.get(url.apiPath(site, '/pages'), query, {limit: 9})
+    return api.get(url.apiPath(site, '/pages'), query, { limit: 9 })
   }
 
   function externalLinkDest(page) {
@@ -88,15 +88,15 @@ function TopPages({query, site}) {
 }
 
 const labelFor = {
-	'pages': 'Top Pages',
-	'entry-pages': 'Entry Pages',
-	'exit-pages': 'Exit Pages',
+  'pages': 'Top Pages',
+  'entry-pages': 'Entry Pages',
+  'exit-pages': 'Exit Pages',
 }
 
 export default class Pages extends React.Component {
   constructor(props) {
     super(props)
-    this.tabKey = `pageTab__${  props.site.domain}`
+    this.tabKey = `pageTab__${props.site.domain}`
     const storedTab = storage.getItem(this.tabKey)
     this.state = {
       mode: storedTab || 'pages'
@@ -106,19 +106,19 @@ export default class Pages extends React.Component {
   setMode(mode) {
     return () => {
       storage.setItem(this.tabKey, mode)
-      this.setState({mode})
+      this.setState({ mode })
     }
   }
 
   renderContent() {
-    switch(this.state.mode) {
-    case "entry-pages":
-      return <EntryPages site={this.props.site} query={this.props.query} />
-    case "exit-pages":
-      return <ExitPages site={this.props.site} query={this.props.query} />
-    case "pages":
-    default:
-      return <TopPages site={this.props.site} query={this.props.query} />
+    switch (this.state.mode) {
+      case "entry-pages":
+        return <EntryPages site={this.props.site} query={this.props.query} />
+      case "exit-pages":
+        return <ExitPages site={this.props.site} query={this.props.query} />
+      case "pages":
+      default:
+        return <TopPages site={this.props.site} query={this.props.query} />
     }
   }
 
@@ -155,13 +155,13 @@ export default class Pages extends React.Component {
             {labelFor[this.state.mode] || 'Page Visits'}
           </h3>
           <div className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
-            { this.renderPill('Top Pages', 'pages') }
-            { this.renderPill('Entry Pages', 'entry-pages') }
-            { this.renderPill('Exit Pages', 'exit-pages') }
+            {this.renderPill('Top Pages', 'pages')}
+            {this.renderPill('Entry Pages', 'entry-pages')}
+            {this.renderPill('Exit Pages', 'exit-pages')}
           </div>
         </div>
         {/* Main Contents */}
-        { this.renderContent() }
+        {this.renderContent()}
       </div>
     )
   }

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -8,7 +8,7 @@ import MoreLink from '../more-link'
 import Bar from '../bar'
 import LazyLoader from '../../components/lazy-loader'
 import classNames from 'classnames'
-
+import { trimURL } from '../../util/url'
 const MAX_ITEMS = 9
 const MIN_HEIGHT = 380
 const ROW_HEIGHT = 32
@@ -16,27 +16,27 @@ const ROW_GAP_HEIGHT = 4
 const DATA_CONTAINER_HEIGHT = (ROW_HEIGHT + ROW_GAP_HEIGHT) * (MAX_ITEMS - 1) + ROW_HEIGHT
 const COL_MIN_WIDTH = 70
 
-function FilterLink({filterQuery, onClick, children}) {
+function FilterLink({ filterQuery, onClick, children }) {
   const className = classNames('max-w-max w-full flex md:overflow-hidden', {
     'hover:underline': !!filterQuery
   })
-  
+
   if (filterQuery) {
     return (
       <Link
-        to={{search: filterQuery.toString()}}
+        to={{ search: filterQuery.toString() }}
         onClick={onClick}
         className={className}
-        >
-        { children }
+      >
+        {children}
       </Link>
     )
   } else {
-    return <span className={className}>{ children }</span>
+    return <span className={className}>{children}</span>
   }
 }
 
-function ExternalLink({item, externalLinkDest}) {
+function ExternalLink({ item, externalLinkDest }) {
   const dest = externalLinkDest && externalLinkDest(item)
   if (dest) {
     return (
@@ -103,7 +103,7 @@ function ExternalLink({item, externalLinkDest}) {
 //   * `color` - color of the comparison bars in light-mode
 
 export default function ListReport(props) {
-  const [state, setState] = useState({loading: true, list: null})
+  const [state, setState] = useState({ loading: true, list: null })
   const [visible, setVisible] = useState(false)
   const metrics = props.metrics
   const colMinWidth = props.colMinWidth || COL_MIN_WIDTH
@@ -112,12 +112,12 @@ export default function ListReport(props) {
   const goalFilterApplied = !!props.query.filters.goal
 
   const fetchData = useCallback(() => {
-      if (!isRealtime) {
-        setState({loading: true, list: null})
-      }
-      props.fetchData()
-        .then((res) => setState({loading: false, list: res}))
-    }, [props.keyLabel, props.query])
+    if (!isRealtime) {
+      setState({ loading: true, list: null })
+    }
+    props.fetchData()
+      .then((res) => setState({ loading: false, list: res }))
+  }, [props.keyLabel, props.query])
 
   const onVisible = () => { setVisible(true) }
 
@@ -126,7 +126,7 @@ export default function ListReport(props) {
       // When a goal filter is applied or removed, we always want the component to go into a
       // loading state, even in realtime mode, because the metrics list will change. We can
       // only read the new metrics once the new list is loaded.
-      setState({loading: true, list: null})
+      setState({ loading: true, list: null })
     }
   }, [goalFilterApplied]);
 
@@ -160,15 +160,15 @@ export default function ListReport(props) {
     if (state.list && state.list.length > 0) {
       return (
         <div className="h-full flex flex-col">
-          <div style={{height: ROW_HEIGHT}}>
-            { renderReportHeader() }
+          <div style={{ height: ROW_HEIGHT }}>
+            {renderReportHeader()}
           </div>
 
-          <div style={{minHeight: DATA_CONTAINER_HEIGHT}}>
-            { renderReportBody() }
+          <div style={{ minHeight: DATA_CONTAINER_HEIGHT }}>
+            {renderReportBody()}
           </div>
 
-          { maybeRenderMoreLink() }
+          {maybeRenderMoreLink()}
         </div>
       )
     }
@@ -181,17 +181,17 @@ export default function ListReport(props) {
         <div
           key={metric.name}
           className={`text-right ${hiddenOnMobileClass(metric)}`}
-          style={{minWidth: colMinWidth}}
+          style={{ minWidth: colMinWidth }}
         >
-            { metricLabelFor(metric, props.query) }
+          {metricLabelFor(metric, props.query)}
         </div>
       )
     })
-    
+
     return (
       <div className="pt-3 w-full text-xs font-bold tracking-wide text-gray-500 flex items-center dark:text-gray-400">
-        <span className="flex-grow truncate">{ props.keyLabel }</span>
-        { metricLabels }
+        <span className="flex-grow truncate">{props.keyLabel}</span>
+        {metricLabels}
       </div>
     )
   }
@@ -206,10 +206,10 @@ export default function ListReport(props) {
 
   function renderRow(listItem) {
     return (
-      <div key={listItem.name} style={{minHeight: ROW_HEIGHT}}>
-        <div className="flex w-full" style={{marginTop: ROW_GAP_HEIGHT}}>
-          { renderBarFor(listItem) }
-          { renderMetricValuesFor(listItem) }
+      <div key={listItem.name} style={{ minHeight: ROW_HEIGHT }}>
+        <div className="flex w-full" style={{ marginTop: ROW_GAP_HEIGHT }}>
+          {renderBarFor(listItem)}
+          {renderMetricValuesFor(listItem)}
         </div>
       </div>
     )
@@ -218,7 +218,7 @@ export default function ListReport(props) {
   function getFilterQuery(listItem) {
     const filter = props.getFilterFor(listItem)
     if (!filter) { return null }
-    
+
     const query = new URLSearchParams(window.location.search)
     Object.entries(filter).forEach((([key, value]) => {
       query.set(key, value)
@@ -227,9 +227,9 @@ export default function ListReport(props) {
     return query
   }
 
-  function renderBarFor(listItem) {    
+  function renderBarFor(listItem) {
     const lightBackground = props.color || 'bg-green-50'
-    const noop = () => {}
+    const noop = () => { }
     const metricToPlot = metrics.find(m => m.plot).name
 
     return (
@@ -245,7 +245,7 @@ export default function ListReport(props) {
               {maybeRenderIconFor(listItem)}
 
               <span className="w-full md:truncate">
-                {listItem.name}
+                {trimURL(listItem.name, 60)}
               </span>
             </FilterLink>
             <ExternalLink item={listItem} externalLinkDest={props.externalLinkDest} />
@@ -271,10 +271,10 @@ export default function ListReport(props) {
         <div
           key={`${listItem.name}__${metric.name}`}
           className={`text-right ${hiddenOnMobileClass(metric)}`}
-          style={{width: colMinWidth, minWidth: colMinWidth}}
+          style={{ width: colMinWidth, minWidth: colMinWidth }}
         >
           <span className="font-medium text-sm dark:text-gray-200 text-right">
-            { displayMetricValue(listItem[metric.name], metric) }
+            {displayMetricValue(listItem[metric.name], metric)}
           </span>
         </div>
       )
@@ -283,7 +283,7 @@ export default function ListReport(props) {
 
   function renderLoading() {
     return (
-      <div className="w-full flex flex-col justify-center" style={{minHeight: `${MIN_HEIGHT}px`}}>
+      <div className="w-full flex flex-col justify-center" style={{ minHeight: `${MIN_HEIGHT}px` }}>
         <div className="mx-auto loading"><div></div></div>
       </div>
     )
@@ -291,23 +291,23 @@ export default function ListReport(props) {
 
   function renderNoDataYet() {
     return (
-      <div className="w-full h-full flex flex-col justify-center" style={{minHeight: `${MIN_HEIGHT}px`}}>
+      <div className="w-full h-full flex flex-col justify-center" style={{ minHeight: `${MIN_HEIGHT}px` }}>
         <div className="mx-auto font-medium text-gray-500 dark:text-gray-400">No data yet</div>
       </div>
     )
   }
 
   function maybeRenderMoreLink() {
-    return props.detailsLink && !state.loading && <MoreLink url={props.detailsLink} list={state.list}/>
+    return props.detailsLink && !state.loading && <MoreLink url={props.detailsLink} list={state.list} />
   }
 
   return (
     <LazyLoader onVisible={onVisible} >
-      <div className="w-full" style={{minHeight: `${MIN_HEIGHT}px`}}>
-        { state.loading && renderLoading() }  
-        { !state.loading && <FadeIn show={!state.loading} className="h-full">
-          { renderReport() }
-        </FadeIn> }
+      <div className="w-full" style={{ minHeight: `${MIN_HEIGHT}px` }}>
+        {state.loading && renderLoading()}
+        {!state.loading && <FadeIn show={!state.loading} className="h-full">
+          {renderReport()}
+        </FadeIn>}
       </div>
     </LazyLoader>
   )

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -245,7 +245,7 @@ export default function ListReport(props) {
               {maybeRenderIconFor(listItem)}
 
               <span className="w-full md:truncate">
-                {trimURL(listItem.name, 60)}
+                {trimURL(listItem.name, colMinWidth)}
               </span>
             </FilterLink>
             <ExternalLink item={listItem} externalLinkDest={props.externalLinkDest} />

--- a/assets/js/dashboard/util/url.js
+++ b/assets/js/dashboard/util/url.js
@@ -39,13 +39,15 @@ export function trimURL(url, maxLength) {
     return url;
   }
 
+  const ellipsis = "...";
+
   if (isValidHttpUrl(url)) {
     const [protocol, restURL] = url.split('://');
     const parts = restURL.split('/');
 
     const host = parts.shift();
     if (host.length > maxLength - 5) {
-      return `${protocol}://${host.substr(0, maxLength - 5)}...${restURL.slice(-maxLength + 5)}`;
+      return `${protocol}://${host.substr(0, maxLength - 5)}${ellipsis}${restURL.slice(-maxLength + 5)}`;
     }
 
     let remainingLength = maxLength - host.length - 5;
@@ -64,6 +66,13 @@ export function trimURL(url, maxLength) {
     }
 
     return trimmedURL;
+  } else {
+    const leftSideLength = Math.floor(maxLength / 2);
+    const rightSideLength = maxLength - leftSideLength;
+
+    const leftSide = url.slice(0, leftSideLength);
+    const rightSide = url.slice(-rightSideLength);
+
+    return leftSide + ellipsis + rightSide;
   }
-  return url
 }

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -27,6 +27,17 @@ imported_stats_range =
     Date.add(native_stats_range.first, -1)
   )
 
+long_random_paths =
+  for _ <- 1..100 do
+    l = Enum.random(40..300)
+    "/long/#{l}/path/#{String.duplicate("0x", l)}/end"
+  end
+
+long_random_urls =
+  for path <- long_random_paths do
+    "https://dummy.site#{path}"
+  end
+
 site =
   Plausible.Factory.insert(:site,
     domain: "dummy.site",
@@ -38,6 +49,7 @@ site =
 {:ok, goal2} = Plausible.Goals.create(site, %{"page_path" => "/register"})
 {:ok, goal3} = Plausible.Goals.create(site, %{"page_path" => "/login"})
 {:ok, goal4} = Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => "USD"})
+{:ok, goal5} = Plausible.Goals.create(site, %{"page_path" => Enum.random(long_random_paths)})
 {:ok, outbound} = Plausible.Goals.create(site, %{"event_name" => "Outbound Link: Click"})
 
 {:ok, _funnel} =
@@ -124,7 +136,15 @@ native_stats_range
       operating_system: Enum.random(["Windows", "macOS", "Linux"]),
       operating_system_version: to_string(Enum.random(0..15)),
       pathname:
-        Enum.random(["/", "/login", "/settings", "/register", "/docs", "/docs/1", "/docs/2"]),
+        Enum.random([
+          "/",
+          "/login",
+          "/settings",
+          "/register",
+          "/docs",
+          "/docs/1",
+          "/docs/2" | long_random_paths
+        ]),
       user_id: Enum.random(1..1200)
     ]
     |> Keyword.merge(geolocation)
@@ -151,7 +171,15 @@ native_stats_range
       operating_system: Enum.random(["Windows", "macOS", "Linux"]),
       operating_system_version: to_string(Enum.random(0..15)),
       pathname:
-        Enum.random(["/", "/login", "/settings", "/register", "/docs", "/docs/1", "/docs/2"]),
+        Enum.random([
+          "/",
+          "/login",
+          "/settings",
+          "/register",
+          "/docs",
+          "/docs/1",
+          "/docs/2" | long_random_paths
+        ]),
       user_id: Enum.random(1..1200),
       revenue_reporting_amount: Decimal.new(Enum.random(100..10000)),
       revenue_reporting_currency: "USD"
@@ -182,10 +210,7 @@ native_stats_range
       user_id: Enum.random(1..1200),
       "meta.key": ["url"],
       "meta.value": [
-        Enum.random([
-          "http://dummy.site/long/1/#{String.duplicate("0x", 200)}",
-          "http://dummy.site/random/long/1/#{String.duplicate("0x", Enum.random(1..300))}"
-        ])
+        Enum.random(long_random_urls)
       ]
     ]
     |> Keyword.merge(geolocation)


### PR DESCRIPTION
### Changes

This PR extends the `trimURL` to fall back to regular strings in case page paths are provided. It's now applied on all the lists and modals.

![image](https://github.com/plausible/analytics/assets/173738/7aa253af-ebfb-4c97-9ed9-1a08add65a63)

![image](https://github.com/plausible/analytics/assets/173738/b77ce6cf-ae25-4fe0-9b6f-fb2503235eee)

![image](https://github.com/plausible/analytics/assets/173738/1e8c06f1-4c09-45b6-a42b-07eba8911e44)

![image](https://github.com/plausible/analytics/assets/173738/9ced69f6-db72-4e8f-8912-407fdcf91618)

![image](https://github.com/plausible/analytics/assets/173738/38f812c4-77f2-44a6-a9a3-5bb36a0037df)

![image](https://github.com/plausible/analytics/assets/173738/f8f2c843-13a8-4a7f-a3b9-6bef54fb4829)

![image](https://github.com/plausible/analytics/assets/173738/7c3ff89d-6e41-4061-b81c-002c5ad90936)



### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
