### PR TITLE
Reject event goals with reserved names

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -33,6 +33,8 @@ defmodule Plausible.Goal do
     [{"Select reporting currency", nil}] ++ options
   end
 
+  @reserved_event_names ["404", "Outbound Link: Click", "File Download"]
+
   def changeset(goal, attrs \\ %{}) do
     goal
     |> cast(attrs, [:id, :site_id, :event_name, :page_path, :currency])
@@ -41,6 +43,7 @@ defmodule Plausible.Goal do
     |> validate_event_name_and_page_path()
     |> update_change(:event_name, &String.trim/1)
     |> update_change(:page_path, &String.trim/1)
+    |> validate_exclusion(:event_name, @reserved_event_names)
     |> validate_length(:event_name, max: 120)
     |> maybe_drop_currency()
   end

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -32,6 +32,19 @@ defmodule Plausible.GoalsTest do
              :eq
   end
 
+  test "create/2 rejects event goals with reserved names" do
+    site = insert(:site)
+    {:error, %Ecto.Changeset{errors: errors}} = Goals.create(site, %{"event_name" => "404"})
+
+    {:error, %Ecto.Changeset{errors: ^errors}} =
+      Goals.create(site, %{"event_name" => "  File Download "})
+
+    {:error, %Ecto.Changeset{errors: ^errors}} =
+      Goals.create(site, %{"event_name" => "Outbound Link: Click"})
+
+    assert {"is reserved", _} = errors[:event_name]
+  end
+
   test "for_site2 returns trimmed input even if it was saved with trailing whitespace" do
     site = insert(:site)
     insert(:goal, %{site: site, event_name: " Signup "})


### PR DESCRIPTION
This commit adds a validation to the `%Goal{}` creation changeset to reject goals with internally used names, e.g. `404`, `File Download`, and `Outbound Link: Click`