### PR TITLE
Fix filter labels when filtering on clicks from ModalTable

### DIFF
--- a/assets/js/dashboard/router.js
+++ b/assets/js/dashboard/router.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import {BrowserRouter, Switch, Route, useLocation} from "react-router-dom";
+import { BrowserRouter, Switch, Route, useLocation } from "react-router-dom";
 
 import Dash from './index'
 import SourcesModal from './stats/modals/sources'
@@ -26,14 +26,14 @@ function ScrollToTop() {
   return null;
 }
 
-export default function Router({site, loggedIn, currentUserRole}) {
+export default function Router({ site, loggedIn, currentUserRole }) {
   return (
     <BrowserRouter>
       <Route path="/:domain">
         <ScrollToTop />
         <Dash site={site} loggedIn={loggedIn} currentUserRole={currentUserRole} />
         <Switch>
-          <Route exact path={["/:domain/sources", "/:domain/utm_mediums", "/:domain/utm_sources", "/:domain/utm_campaigns", "/:domain/utm_contents", "/:domain/utm_terms" ]}>
+          <Route exact path={["/:domain/sources", "/:domain/utm_mediums", "/:domain/utm_sources", "/:domain/utm_campaigns", "/:domain/utm_contents", "/:domain/utm_terms"]}>
             <SourcesModal site={site} />
           </Route>
           <Route exact path="/:domain/referrers/Google">
@@ -52,19 +52,19 @@ export default function Router({site, loggedIn, currentUserRole}) {
             <ExitPagesModal site={site} />
           </Route>
           <Route path="/:domain/countries">
-            <ModalTable title="Top countries" site={site} endpoint={url.apiPath(site, '/countries')} filter={{country: 'code', country_name: 'name'}} keyLabel="Country" renderIcon={renderCountryIcon} />
+            <ModalTable title="Top countries" site={site} endpoint={url.apiPath(site, '/countries')} filter={{ country: 'code', country_labels: 'name' }} keyLabel="Country" renderIcon={renderCountryIcon} />
           </Route>
           <Route path="/:domain/regions">
-            <ModalTable title="Top regions" site={site} endpoint={url.apiPath(site, '/regions')} filter={{region: 'code', region_name: 'name'}} keyLabel="Region" renderIcon={renderRegionIcon} />
+            <ModalTable title="Top regions" site={site} endpoint={url.apiPath(site, '/regions')} filter={{ region: 'code', region_labels: 'name' }} keyLabel="Region" renderIcon={renderRegionIcon} />
           </Route>
           <Route path="/:domain/cities">
-            <ModalTable title="Top cities" site={site} endpoint={url.apiPath(site, '/cities')} filter={{city: 'code', city_name: 'name'}} keyLabel="City" renderIcon={renderCityIcon} />
+            <ModalTable title="Top cities" site={site} endpoint={url.apiPath(site, '/cities')} filter={{ city: 'code', city_labels: 'name' }} keyLabel="City" renderIcon={renderCityIcon} />
           </Route>
           <Route path="/:domain/custom-prop-values/:prop_key">
-            <PropsModal site={site}/>
+            <PropsModal site={site} />
           </Route>
           <Route path="/:domain/conversions">
-            <ConversionsModal site={site}/>
+            <ConversionsModal site={site} />
           </Route>
           <Route path={["/:domain/filter/:field"]}>
             <FilterModal site={site} />


### PR DESCRIPTION
### Changes

This PR fixes a regression causing filtering locations from details view render empty filter labels.


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
