### PR TITLE
Fix breakdown pagination when filtering by goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fixed [IPv6 problems](https://github.com/plausible/analytics/issues/3173) in data migration plausible/analytics#3179
 - Fixed [long URLs display](https://github.com/plausible/analytics/issues/3158) in Outbound Link breakdown view
 - Fixed [Sentry reports](https://github.com/plausible/analytics/discussions/3166) for ingestion requests plausible/analytics#3182
+- Fix breakdown pagination bug in the dashboard details view when filtering by goals
 
 ## v2.0.0 - 2023-07-12
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1399,8 +1399,9 @@ defmodule PlausibleWeb.Api.StatsController do
       |> Query.put_filter(filter_name, {:member, items})
       |> Query.remove_event_filters([:goal, :props])
 
-    # Because we are doing yet another query with a different filter, we should only keep
-    # the limit and keep the offset default to retrieve the first page always.
+    # Here, we're always only interested in the first page of results 
+    # - the :member filter makes sure that the results always match with 
+    # the items in the given breakdown_results list
     pagination = {elem(pagination, 0), 1}
 
     res_without_goal =

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1399,6 +1399,10 @@ defmodule PlausibleWeb.Api.StatsController do
       |> Query.put_filter(filter_name, {:member, items})
       |> Query.remove_event_filters([:goal, :props])
 
+    # Because we are doing yet another query with a different filter, we should only keep
+    # the limit and keep the offset default to retrieve the first page always.
+    pagination = {elem(pagination, 0), 1}
+
     res_without_goal =
       Stats.breakdown(site, query_without_goal, filter_name, [:visitors], pagination)
 


### PR DESCRIPTION
### Changes

This PR addresses a crash on CR calculation when filtering by goals and using the details view.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
