### PR TITLE
Improvements to the Properties feature

### DIFF
--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -166,7 +166,7 @@ export default function PlausibleCombobox(props) {
 
   const containerClass = classNames('relative w-full', {
     [props.className]: !!props.className,
-    'opacity-20 cursor-default pointer-events-none': props.isDisabled
+    'opacity-30 cursor-default pointer-events-none': props.isDisabled
   })
 
   function renderSingleOptionContent() {

--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -22,6 +22,7 @@ export default function Conversions(props) {
       fetchData={fetchConversions}
       getFilterFor={getFilterFor}
       keyLabel="Goal"
+      onClick={props.onGoalFilterClick}
       metrics={[
         {name: 'visitors', label: "Uniques", plot: true},
         {name: 'events', label: "Total", hiddenOnMobile: true},

--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -5,7 +5,7 @@ import { CR_METRIC } from "../reports/metrics"
 import * as url from "../../util/url"
 import * as api from "../../api"
 
-const SPECIAL_GOALS = {
+export const SPECIAL_GOALS = {
   '404': {title: '404 Pages', prop: 'path'},
   'Outbound Link: Click': {title: 'Outbound Links', prop: 'url'},
   'Cloaked Link: Click': {title: 'Cloaked Links', prop: 'url'},
@@ -60,6 +60,6 @@ export default function GoalConversions(props) {
   if (SPECIAL_GOALS[query.filters.goal]) {
     return <SpecialPropBreakdown site={site} query={props.query} />
   } else {
-    return <Conversions site={site} query={props.query} />
+    return <Conversions site={site} query={props.query} onGoalFilterClick={props.onGoalFilterClick}/>
   }
 }

--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -13,11 +13,11 @@ export default function Properties(props) {
   const propKeyStorageName = `prop_key__${site.domain}`
   const propKeyStorageNameForGoal = `${query.filters.goal}__prop_key__${site.domain}`
   
-  const [propKey, setPropKey] = useState(getPropKeyFromStorage())
+  const [propKey, setPropKey] = useState(choosePropKey())
 
   useEffect(() => {
-    setPropKey(getPropKeyFromStorage())
-  }, [query.filters.goal])
+    setPropKey(choosePropKey())
+  }, [query.filters.goal, query.filters.props])
 
   function singleGoalFilterApplied() {
     const goalFilter = query.filters.goal
@@ -29,6 +29,13 @@ export default function Properties(props) {
     }
   }
 
+  function choosePropKey() {
+    if (query.filters.props) {
+      return Object.keys(query.filters.props)[0]
+    } else {
+      return getPropKeyFromStorage()
+    }
+  }
 
   function getPropKeyFromStorage() {
     if (singleGoalFilterApplied()) {
@@ -91,7 +98,7 @@ export default function Properties(props) {
   return (
     <div className="w-full mt-4">
         <div className="w-56">
-          <Combobox boxClass={boxClass} fetchOptions={fetchPropKeyOptions()} singleOption={true} values={comboboxValues} onSelect={onPropKeySelect()} placeholder={'Select a property'} />
+          <Combobox isDisabled={!!query.filters.props} boxClass={boxClass} fetchOptions={fetchPropKeyOptions()} singleOption={true} values={comboboxValues} onSelect={onPropKeySelect()} placeholder={'Select a property'} />
         </div>
       { propKey && renderBreakdown() }
     </div>

--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -97,7 +97,7 @@ export default function Properties(props) {
 
   return (
     <div className="w-full mt-4">
-        <div className="w-56">
+        <div>
           <Combobox isDisabled={!!query.filters.props} boxClass={boxClass} fetchOptions={fetchPropKeyOptions()} singleOption={true} values={comboboxValues} onSelect={onPropKeySelect()} placeholder={'Select a property'} />
         </div>
       { propKey && renderBreakdown() }

--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -5,7 +5,8 @@ import * as api from '../../api'
 import * as url from '../../util/url'
 import { CR_METRIC, PERCENTAGE_METRIC } from "../reports/metrics";
 import * as storage from "../../util/storage";
-import { parsePrefix } from "../../util/filters"
+import { parsePrefix, escapeFilterValue } from "../../util/filters"
+
 
 export default function Properties(props) {
   const { site, query } = props
@@ -83,7 +84,7 @@ export default function Properties(props) {
     )
   }
 
-  const getFilterFor = (listItem) => { return {'props': JSON.stringify({[propKey]: listItem['name']})} }
+  const getFilterFor = (listItem) => { return {'props': JSON.stringify({[propKey]: escapeFilterValue(listItem.name)})} }
   const comboboxValues = propKey ? [{value: propKey, label: propKey}] : []
   const boxClass = 'pl-2 pr-8 py-1 bg-transparent dark:text-gray-300 rounded-md shadow-sm border border-gray-300 dark:border-gray-500'
 

--- a/assets/js/dashboard/stats/modals/conversions.js
+++ b/assets/js/dashboard/stats/modals/conversions.js
@@ -8,6 +8,7 @@ import * as api from '../../api'
 import * as url from "../../util/url";
 import numberFormatter from '../../util/number-formatter'
 import {parseQuery} from '../../query'
+import { escapeFilterValue } from '../../util/filters'
 
 function ConversionsModal(props) {
   const site = props.site
@@ -49,7 +50,7 @@ function ConversionsModal(props) {
 
   function filterSearchLink(listItem) {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set('goal', listItem.name)
+    searchParams.set('goal', escapeFilterValue(listItem.name))
     return searchParams.toString()
   }
 

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -9,6 +9,7 @@ import * as url from "../../util/url";
 import numberFormatter from '../../util/number-formatter'
 import { parseQuery } from '../../query'
 import { specialTitleWhenGoalFilter } from "../behaviours/goal-conversions";
+import { escapeFilterValue } from "../../util/filters"
 
 function PropsModal(props) {
   const site = props.site
@@ -51,7 +52,7 @@ function PropsModal(props) {
 
   function filterSearchLink(listItem) {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set('props', JSON.stringify({ [propKey]: listItem['name'] }))
+    searchParams.set('props', JSON.stringify({ [propKey]: escapeFilterValue(listItem.name) }))
     return searchParams.toString()
   }
 

--- a/assets/js/dashboard/stats/more-link.js
+++ b/assets/js/dashboard/stats/more-link.js
@@ -20,7 +20,7 @@ function detailsIcon() {
   )
 }
 
-export default function MoreLink({url, site, list, endpoint, className}) {
+export default function MoreLink({url, site, list, endpoint, className, onClick}) {
   if (list.length > 0) {
     return (
       <div className={`w-full text-center ${className ? className : ''}`}>
@@ -28,6 +28,7 @@ export default function MoreLink({url, site, list, endpoint, className}) {
           to={url || `/${encodeURIComponent(site.domain)}/${endpoint}${window.location.search}`}
           // eslint-disable-next-line max-len
           className="leading-snug font-bold text-sm text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition tracking-wide"
+          onClick={onClick}
         >
           { detailsIcon() }
           DETAILS

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -307,7 +307,7 @@ export default function ListReport(props) {
     const hideDetails = props.maybeHideDetails && !moreResultsAvailable
 
     const showDetails = props.detailsLink && !state.loading && !hideDetails 
-    return showDetails && <MoreLink className={'mt-2'} url={props.detailsLink} list={state.list} />
+    return showDetails && <MoreLink className={'mt-2'} url={props.detailsLink} list={state.list} onClick={props.onClick}/>
   }
 
   return (

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -51,7 +51,7 @@ export function toFilterQuery(type, clauses) {
   return prefix + result;
 }
 
-function parsePrefix(rawValue) {
+export function parsePrefix(rawValue) {
   const type = Object.keys(FILTER_PREFIXES)
     .find(type => FILTER_PREFIXES[type] === rawValue[0]) || FILTER_TYPES.is;
 


### PR DESCRIPTION
### Changes

This PR fixes several issues with the new Properties feature behaviour:

* Make the property selector component take up the full width in order to be able to display longer values (far from ideal design, open to alternative suggestions)
* Automatically switch the view from Conversions -> Props, when a goal filter is applied by clicking on an item in the Goal Conversions list. The automatic navigation does not happen in the following scenarios:
  * no props configured for the site (or feature disabled)
  * the goal clicked is a pageview goal
  * the goal clicked is a special goal (404, Outbound Link, File Download, Cloaked Link: Click)
* Start saving prop keys per goal filter in localStorage. This way you don't always have to select a property manually when applying different goal filters that have different properties. As soon as you select a property for a goal - it will be saved as your preference and be shown automatically for this goal the next time)
* Disallow the property selector component when a property filter is already applied (missed this before - doesn't make sense to allow picking any other properties, since they will always only display the `(none)` value)

...Also fixes a small bug related to the pipe character 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] [Another PR](https://github.com/plausible/analytics/pull/3242) open for updating the changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
