### PR TITLE
Make stats controller tests synchronous

### DIFF
--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.StatsControllerTest do
-  use PlausibleWeb.ConnCase, async: true
+  use PlausibleWeb.ConnCase, async: false
   use Plausible.Repo
   import Plausible.Test.Support.HTML
 


### PR DESCRIPTION
### Changes

This PR turns StatsControllerTest synchronous so that there's no stale data in clickhouse.
Fixes a failure with seed 483739

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
