### PR TITLE
Ignore unkown device type

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -372,6 +372,9 @@ defmodule Plausible.Ingestion.Event do
       %Device{type: t} when t in @desktop_types ->
         "Desktop"
 
+      %Device{type: "unknown"} ->
+        nil
+
       %Device{type: type} ->
         Sentry.capture_message("Could not determine device type from UAInspector",
           extra: %{type: type}


### PR DESCRIPTION
### Changes

The ua_inspector library has many device types that it reports. We have our own grouping rules to categorize them. For example, "smartphone", "wearable", and "portable media player" are  categorised as "Mobile" in Plausible.

Originally I added a fallback clause that reports any unknown device type to Sentry so that we can add it to our grouping rules if necessary. I wasn't sure if our rules were exhaustive or not, and the library might introduce new ones over time.

Turns out the library sometimes returns "unknown" as the device type. It is not helpful to report this to Sentry since we will never add a grouping rule for it. Since this gets triggered a lot, it's better to ignore the "unknown" device type completely which this PR does.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
