### PR TITLE
Avoid suggesting plan for trials switching to enterprise plans

### DIFF
--- a/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
@@ -1,12 +1,12 @@
 Thanks for exploring Plausible, a simple and privacy-friendly alternative to Google Analytics. Your free 30-day trial is ending <%= @day %>, but you can keep using Plausible by upgrading to a paid plan.
 <br /><br />
 In the last month, your account has used <%= PlausibleWeb.AuthView.delimit_integer(@usage) %> billable pageviews<%= if @custom_events > 0, do: " and custom events in total", else: "" %>.
-<%= if @usage <= 10_000_000 do %>
+<%= if @suggested_plan == :enterprise do %>
+This is more than our standard plans, so please reply back to this email to get a quote for your volume.
+<% else %>
 Based on that we recommend you select the <%= @suggested_plan.volume %>/mo plan.
 <br /><br />
 <%= link("Upgrade now", to: "#{plausible_url()}/billing/upgrade") %>
 <br /><br />
 Have a question, feedback or need some guidance? Just reply to this email to get in touch!
-<% else %>
-This is more than our standard plans, so please reply back to this email to get a quote for your volume.
 <% end %>

--- a/test/workers/send_trial_notifications_test.exs
+++ b/test/workers/send_trial_notifications_test.exs
@@ -206,5 +206,13 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {20_000_000, 0})
       assert email.html_body =~ "please reply back to this email to get a quote for your volume"
     end
+
+    test "does not suggest a plan when user is switching to an enterprise plan" do
+      user = insert(:user)
+      insert(:enterprise_plan, user: user, paddle_plan_id: "enterprise-plan-id")
+
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {10_000, 0})
+      assert email.html_body =~ "please reply back to this email to get a quote for your volume"
+    end
   end
 end


### PR DESCRIPTION
This commit fixes a bug where the SendTrialNotifications job tried to suggest a plan for users switching to enterprise plans, resulting in the exception below:

```
UndefinedFunctionError: function :enterprise.volume/0 is undefined (module :enterprise is not available)
  Module "enterprise", in :enterprise.volume/0
  File "lib/plausible_web/templates/email/trial_upgrade_email.html.eex", line 5, in PlausibleWeb.EmailView."trial_upgrade_email.html"/1
  File "lib/phoenix_view.ex", line 381, in Phoenix.View.render_within/3
  File "lib/phoenix_view.ex", line 557, in Phoenix.View.render_to_iodata/3
  File "lib/phoenix_view.ex", line 564, in Phoenix.View.render_to_string/3
  File "lib/bamboo_phoenix.ex", line 291, in Bamboo.Phoenix.render_text_or_html_email/1
  File "lib/workers/send_trial_notifications.ex", line 67, in Plausible.Workers.SendTrialNotifications.send_today_reminder/1
  File "lib/workers/send_trial_notifications.ex", line 36, in anonymous fn/2 in Plausible.Workers.SendTrialNotifications.perform/1
```