### PR TITLE
Connect to live socket only on specific pages

### DIFF
--- a/assets/js/liveview/live_socket.js
+++ b/assets/js/liveview/live_socket.js
@@ -4,8 +4,7 @@ import { LiveSocket } from "phoenix_live_view"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']")
 let websocketUrl = document.querySelector("meta[name='websocket-url']")
-let connectLiveSocket = document.querySelector("meta[name='connect-live-socket']")
-if (connectLiveSocket && connectLiveSocket.getAttribute("content") == "true" && csrfToken && websocketUrl) {
+if (csrfToken && websocketUrl) {
   let token = csrfToken.getAttribute("content")
   let url = websocketUrl.getAttribute("content")
   let liveUrl = (url === "") ? "/live" : new URL("/live", url).href;

--- a/assets/js/liveview/live_socket.js
+++ b/assets/js/liveview/live_socket.js
@@ -4,7 +4,8 @@ import { LiveSocket } from "phoenix_live_view"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']")
 let websocketUrl = document.querySelector("meta[name='websocket-url']")
-if (csrfToken && websocketUrl) {
+let connectLiveSocket = document.querySelector("meta[name='connect-live-socket']")
+if (connectLiveSocket && connectLiveSocket.getAttribute("content") == "true" && csrfToken && websocketUrl) {
   let token = csrfToken.getAttribute("content")
   let url = websocketUrl.getAttribute("content")
   let liveUrl = (url === "") ? "/live" : new URL("/live", url).href;

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -285,6 +285,7 @@ defmodule PlausibleWeb.SiteController do
       |> assign(:skip_plausible_tracking, true)
       |> render("settings_funnels.html",
         site: site,
+        connect_live_socket: true,
         layout: {PlausibleWeb.LayoutView, "site_settings.html"}
       )
     else
@@ -298,7 +299,8 @@ defmodule PlausibleWeb.SiteController do
       |> assign(:skip_plausible_tracking, true)
       |> render("settings_props.html",
         site: conn.assigns.site,
-        layout: {PlausibleWeb.LayoutView, "site_settings.html"}
+        layout: {PlausibleWeb.LayoutView, "site_settings.html"},
+        connect_live_socket: true
       )
     else
       conn |> Plug.Conn.put_status(401) |> Plug.Conn.halt()

--- a/lib/plausible_web/live/flash.ex
+++ b/lib/plausible_web/live/flash.ex
@@ -24,6 +24,7 @@ defmodule PlausibleWeb.Live.Flash do
         </.flash>
       </div>
       <div
+        :if={Application.get_env(:plausible, :environment) == "dev"}
         id="live-view-connection-status"
         class="hidden"
         phx-disconnected={JS.show()}
@@ -37,7 +38,7 @@ defmodule PlausibleWeb.Live.Flash do
             Oops, a server blip
           </:title>
           <:message>
-            Please wait while we're trying to reconnect...
+            Live socket disconnected.
           </:message>
         </.flash>
       </div>

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -8,6 +8,7 @@
     <%= if Plausible.Funnels.enabled_for?(@conn.assigns[:current_user]) do %>
     <meta name="csrf-token" content="<%= Plug.CSRFProtection.get_csrf_token() %>" />
     <meta name="websocket-url" content="<%= websocket_url() %>" />
+    <meta name="connect-live-socket" content="<%= Map.get(@conn.assigns, :connect_live_socket, false) %>" />
     <meta name="robots" content="<%= @conn.private.robots %>" />
     <% end %>
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -5,12 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="Plausible is a lightweight and open-source web analytics tool. Your website data is 100% yours and the privacy of your visitors is respected."/>
-    <%= if Plausible.Funnels.enabled_for?(@conn.assigns[:current_user]) do %>
+    <%= if @conn.assigns[:connect_live_socket] do %>
     <meta name="csrf-token" content="<%= Plug.CSRFProtection.get_csrf_token() %>" />
     <meta name="websocket-url" content="<%= websocket_url() %>" />
-    <meta name="connect-live-socket" content="<%= Map.get(@conn.assigns, :connect_live_socket, false) %>" />
-    <meta name="robots" content="<%= @conn.private.robots %>" />
     <% end %>
+    <meta name="robots" content="<%= @conn.private.robots %>" />
     <link rel="icon" type="image/png" sizes="32x32" href="<%= PlausibleWeb.Router.Helpers.static_path(@conn, "/images/icon/plausible_favicon.png") %>">
     <link rel="apple-touch-icon" href="/images/icon/apple-touch-icon.png">
     <title><%= assigns[:title] || "Plausible · Simple, privacy-friendly alternative to Google Analytics" %></title>


### PR DESCRIPTION
And disable the "server blip" message on non-dev
environments. It's non actionable for our customers.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
