### PR TITLE
Implement limits for team members

### DIFF
--- a/lib/plausible/auth/invitation.ex
+++ b/lib/plausible/auth/invitation.ex
@@ -2,6 +2,8 @@ defmodule Plausible.Auth.Invitation do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t() :: %__MODULE__{}
+
   @derive {Jason.Encoder, only: [:invitation_id, :role, :site]}
   @required [:email, :role, :site_id, :inviter_id]
   schema "invitations" do

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -3,6 +3,7 @@ defmodule Plausible.Billing.Quota do
   This module provides functions to work with plans usage and limits.
   """
 
+  import Ecto.Query
   alias Plausible.Billing.Plans
 
   @limit_sites_since ~D[2021-05-05]
@@ -77,6 +78,57 @@ defmodule Plausible.Billing.Quota do
     user
     |> Plausible.Billing.usage_breakdown()
     |> Tuple.sum()
+  end
+
+  @team_member_limit_for_trials 5
+  @spec team_member_limit(Plausible.Auth.User.t()) :: non_neg_integer()
+  @doc """
+  Returns the limit of team members a user can have in their sites.
+  """
+  def team_member_limit(user) do
+    user = Plausible.Users.with_subscription(user)
+
+    case Plans.get_subscription_plan(user.subscription) do
+      %Plausible.Billing.EnterprisePlan{} -> :unlimited
+      %Plausible.Billing.Plan{team_member_limit: limit} -> limit
+      :free_10k -> :unlimited
+      nil -> @team_member_limit_for_trials
+    end
+  end
+
+  @spec team_member_usage(Plausible.Auth.User.t()) :: integer()
+  @doc """
+  Returns the total count of team members and pending invitations associated
+  with the user's sites.
+  """
+  def team_member_usage(user) do
+    owned_sites_query =
+      from s in Plausible.Site,
+        inner_join: sm in assoc(s, :memberships),
+        where: sm.role == :owner and sm.user_id == ^user.id,
+        select: %{site_id: s.id}
+
+    team_members_query =
+      from os in subquery(owned_sites_query),
+        inner_join: s in Plausible.Site,
+        on: s.id == os.site_id,
+        inner_join: sm in assoc(s, :memberships),
+        inner_join: u in assoc(sm, :user),
+        select: %{email: u.email}
+
+    invitations_and_team_members_query =
+      from i in Plausible.Auth.Invitation,
+        inner_join: os in subquery(owned_sites_query),
+        on: i.site_id == os.site_id,
+        select: %{email: i.email},
+        union_all: ^team_members_query
+
+    query =
+      from itm in subquery(invitations_and_team_members_query),
+        where: itm.email != ^user.email,
+        select: count(itm.email, :distinct)
+
+    Plausible.Repo.one(query)
   end
 
   @spec within_limit?(non_neg_integer(), non_neg_integer() | :unlimited) :: boolean()

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -27,10 +27,18 @@ defmodule PlausibleWeb.Components.Billing do
     <tr {@rest}>
       <td class={["py-4 text-sm whitespace-nowrap text-left", @pad && "pl-6"]}><%= @title %></td>
       <td class="py-4 text-sm whitespace-nowrap text-right">
-        <%= Cldr.Number.to_string!(@usage) %>
-        <%= if is_number(@limit), do: "/ #{Cldr.Number.to_string!(@limit)}" %>
+        <%= render_quota(@usage) %>
+        <%= if @limit, do: "/ #{render_quota(@limit)}" %>
       </td>
     </tr>
     """
+  end
+
+  defp render_quota(quota) do
+    case quota do
+      quota when is_number(quota) -> Cldr.Number.to_string!(quota)
+      :unlimited -> "∞"
+      nil -> ""
+    end
   end
 end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -498,6 +498,8 @@ defmodule PlausibleWeb.AuthController do
       subscription: user.subscription,
       invoices: Plausible.Billing.paddle_api().get_invoices(user.subscription),
       theme: user.theme || "system",
+      team_member_limit: Plausible.Billing.Quota.team_member_limit(user),
+      team_member_usage: Plausible.Billing.Quota.team_member_usage(user),
       site_limit: Plausible.Billing.Quota.site_limit(user),
       site_usage: Plausible.Billing.Quota.site_usage(user),
       total_pageview_limit: Plausible.Billing.Quota.monthly_pageview_limit(user.subscription),

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -59,6 +59,15 @@ defmodule PlausibleWeb.Site.MembershipController do
           skip_plausible_tracking: true
         )
 
+      {:error, {:over_limit, limit}} ->
+        render(conn, "invite_member_form.html",
+          error:
+            "Your account is limited to #{limit} team members. You can upgrade your plan to increase this limit.",
+          site: site,
+          layout: {PlausibleWeb.LayoutView, "focus.html"},
+          skip_plausible_tracking: true
+        )
+
       {:error, %Ecto.Changeset{} = changeset} ->
         error_msg =
           case changeset.errors[:invitation] do

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -151,6 +151,11 @@
           usage={@site_usage}
           limit={@site_limit}
         />
+        <PlausibleWeb.Components.Billing.usage_and_limits_row
+          title="Team members"
+          usage={@team_member_usage}
+          limit={@team_member_limit}
+        />
       </PlausibleWeb.Components.Billing.usage_and_limits_table>
     </article>
 

--- a/priv/plans_v1.json
+++ b/priv/plans_v1.json
@@ -6,7 +6,8 @@
     "monthly_product_id":"558018",
     "yearly_cost":"$48",
     "yearly_product_id":"572810",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -15,7 +16,8 @@
     "monthly_product_id":"558745",
     "yearly_cost":"$96",
     "yearly_product_id":"590752",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -24,7 +26,8 @@
     "monthly_product_id":"597485",
     "yearly_cost":"$144",
     "yearly_product_id":"597486",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -33,7 +36,8 @@
     "monthly_product_id":"597487",
     "yearly_cost":"$216",
     "yearly_product_id":"597488",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -42,7 +46,8 @@
     "monthly_product_id":"597642",
     "yearly_cost":"$384",
     "yearly_product_id":"597643",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -51,7 +56,8 @@
     "monthly_product_id":"597309",
     "yearly_cost":"$552",
     "yearly_product_id":"597310",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -60,7 +66,8 @@
     "monthly_product_id":"597311",
     "yearly_cost":"$792",
     "yearly_product_id":"597312",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -69,7 +76,8 @@
     "monthly_product_id":"642352",
     "yearly_cost":"$1200",
     "yearly_product_id":"642354",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -78,7 +86,8 @@
     "monthly_product_id":"642355",
     "yearly_cost":"$1800",
     "yearly_product_id":"642356",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -87,6 +96,7 @@
     "monthly_product_id":"650652",
     "yearly_cost":"$2640",
     "yearly_product_id":"650653",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/priv/plans_v2.json
+++ b/priv/plans_v2.json
@@ -6,7 +6,8 @@
     "monthly_product_id":"654177",
     "yearly_cost":"$60",
     "yearly_product_id":"653232",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -15,7 +16,8 @@
     "monthly_product_id":"654178",
     "yearly_cost":"$120",
     "yearly_product_id":"653234",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -24,7 +26,8 @@
     "monthly_product_id":"653237",
     "yearly_cost":"$200",
     "yearly_product_id":"653236",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -33,7 +36,8 @@
     "monthly_product_id":"653238",
     "yearly_cost":"$300",
     "yearly_product_id":"653239",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -42,7 +46,8 @@
     "monthly_product_id":"653240",
     "yearly_cost":"$500",
     "yearly_product_id":"653242",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -51,7 +56,8 @@
     "monthly_product_id":"653253",
     "yearly_cost":"$700",
     "yearly_product_id":"653254",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -60,7 +66,8 @@
     "monthly_product_id":"653255",
     "yearly_cost":"$1000",
     "yearly_product_id":"653256",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -69,7 +76,8 @@
     "monthly_product_id":"654181",
     "yearly_cost":"$1500",
     "yearly_product_id":"653257",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -78,7 +86,8 @@
     "monthly_product_id":"654182",
     "yearly_cost":"$2250",
     "yearly_product_id":"653258",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -87,6 +96,7 @@
     "monthly_product_id":"654183",
     "yearly_cost":"$3300",
     "yearly_product_id":"653259",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/priv/plans_v3.json
+++ b/priv/plans_v3.json
@@ -6,7 +6,8 @@
     "monthly_product_id":"749342",
     "yearly_cost":"$90",
     "yearly_product_id":"749343",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -15,7 +16,8 @@
     "monthly_product_id":"749344",
     "yearly_cost":"$190",
     "yearly_product_id":"749345",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -24,7 +26,8 @@
     "monthly_product_id":"749346",
     "yearly_cost":"$290",
     "yearly_product_id":"749347",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -33,7 +36,8 @@
     "monthly_product_id":"749348",
     "yearly_cost":"$490",
     "yearly_product_id":"749349",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -42,7 +46,8 @@
     "monthly_product_id":"749350",
     "yearly_cost":"$690",
     "yearly_product_id":"749352",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -51,7 +56,8 @@
     "monthly_product_id":"749353",
     "yearly_cost":"$890",
     "yearly_product_id":"749355",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -60,7 +66,8 @@
     "monthly_product_id":"749356",
     "yearly_cost":"$1290",
     "yearly_product_id":"749357",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -69,6 +76,7 @@
     "monthly_product_id":"749358",
     "yearly_cost":"$1690",
     "yearly_product_id":"749359",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/priv/sandbox_plans.json
+++ b/priv/sandbox_plans.json
@@ -6,7 +6,8 @@
     "yearly_product_id":"20127",
     "monthly_cost":"$6",
     "yearly_cost":"$60",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   },
   {
     "kind":"growth",
@@ -15,6 +16,7 @@
     "yearly_product_id":"20658",
     "monthly_cost":"$12.34",
     "yearly_cost":"$120.34",
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/priv/unlisted_plans_v1.json
+++ b/priv/unlisted_plans_v1.json
@@ -6,6 +6,7 @@
     "yearly_cost":"$4800",
     "monthly_product_id":null,
     "monthly_cost":null,
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/priv/unlisted_plans_v2.json
+++ b/priv/unlisted_plans_v2.json
@@ -6,6 +6,7 @@
     "monthly_cost":"$250",
     "yearly_product_id":null,
     "yearly_cost":null,
-    "site_limit":50
+    "site_limit":50,
+    "team_member_limit":"unlimited"
   }
 ]

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -41,9 +41,6 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns 50 when user in on trial" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: 7))
       assert 50 == Quota.site_limit(user)
-
-      user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: -7))
-      assert 50 == Quota.site_limit(user)
     end
 
     test "returns the subscription limit for enterprise users who have not paid yet" do
@@ -191,6 +188,157 @@ defmodule Plausible.Billing.QuotaTest do
       )
 
       assert Quota.monthly_pageview_usage(user) == 0
+    end
+  end
+
+  describe "team_member_usage/1" do
+    test "returns the number of members in all of the sites the user owns" do
+      me = insert(:user)
+
+      _site_i_own_1 =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner),
+            build(:site_membership, user: build(:user), role: :viewer)
+          ]
+        )
+
+      _site_i_own_2 =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner),
+            build(:site_membership, user: build(:user), role: :admin),
+            build(:site_membership, user: build(:user), role: :viewer)
+          ]
+        )
+
+      _site_i_own_3 =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner)
+          ]
+        )
+
+      _site_i_have_access =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :viewer),
+            build(:site_membership, user: build(:user), role: :viewer),
+            build(:site_membership, user: build(:user), role: :viewer),
+            build(:site_membership, user: build(:user), role: :viewer)
+          ]
+        )
+
+      assert Quota.team_member_usage(me) == 3
+    end
+
+    test "counts the same email address as one team member" do
+      me = insert(:user)
+      joe = insert(:user, email: "joe@plausible.test")
+
+      _site_i_own_1 =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner),
+            build(:site_membership, user: joe, role: :viewer)
+          ]
+        )
+
+      _site_i_own_2 =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner),
+            build(:site_membership, user: build(:user), role: :admin),
+            build(:site_membership, user: joe, role: :viewer)
+          ]
+        )
+
+      site_i_own_3 = insert(:site, memberships: [build(:site_membership, user: me, role: :owner)])
+
+      insert(:invitation, site: site_i_own_3, inviter: me, email: "joe@plausible.test")
+
+      assert Quota.team_member_usage(me) == 2
+    end
+
+    test "counts pending invitations as team members" do
+      me = insert(:user)
+      member = insert(:user)
+
+      site_i_own =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: me, role: :owner),
+            build(:site_membership, user: member, role: :admin)
+          ]
+        )
+
+      site_i_have_access =
+        insert(:site, memberships: [build(:site_membership, user: me, role: :admin)])
+
+      insert(:invitation, site: site_i_own, inviter: me)
+      insert(:invitation, site: site_i_own, inviter: member)
+      insert(:invitation, site: site_i_have_access, inviter: me)
+
+      assert Quota.team_member_usage(me) == 3
+    end
+
+    test "returns zero when user does not have any site" do
+      me = insert(:user)
+      assert Quota.team_member_usage(me) == 0
+    end
+
+    test "does not count email report recipients as team members" do
+      me = insert(:user)
+      site = insert(:site, memberships: [build(:site_membership, user: me, role: :owner)])
+
+      insert(:weekly_report,
+        site: site,
+        recipients: ["adam@plausible.test", "vini@plausible.test"]
+      )
+
+      assert Quota.team_member_usage(me) == 0
+    end
+  end
+
+  describe "team_member_limit/1" do
+    test "returns unlimited when user is on an old plan" do
+      user_on_v1 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
+      user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
+      user_on_v3 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v3_plan_id))
+
+      assert :unlimited == Quota.team_member_limit(user_on_v1)
+      assert :unlimited == Quota.team_member_limit(user_on_v2)
+      assert :unlimited == Quota.team_member_limit(user_on_v3)
+    end
+
+    test "returns unlimited when user is on free_10k plan" do
+      user = insert(:user, subscription: build(:subscription, paddle_plan_id: "free_10k"))
+      assert :unlimited == Quota.team_member_limit(user)
+    end
+
+    test "returns unlimited when user is on an enterprise plan" do
+      user = insert(:user)
+      enterprise_plan = insert(:enterprise_plan, user_id: user.id)
+
+      _subscription =
+        insert(:subscription, user_id: user.id, paddle_plan_id: enterprise_plan.paddle_plan_id)
+
+      assert :unlimited == Quota.team_member_limit(user)
+    end
+
+    test "returns 5 when user in on trial" do
+      user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: 7))
+      assert 5 == Quota.team_member_limit(user)
+    end
+
+    test "is unlimited for enterprise customers" do
+      user =
+        insert(:user,
+          enterprise_plan: build(:enterprise_plan, paddle_plan_id: "123321"),
+          subscription: build(:subscription, paddle_plan_id: "123321")
+        )
+
+      assert :unlimited == Quota.team_member_limit(user)
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -32,7 +32,10 @@ defmodule Plausible.Factory do
   end
 
   def site_membership_factory do
-    %Plausible.Site.Membership{}
+    %Plausible.Site.Membership{
+      user: build(:user),
+      role: :viewer
+    }
   end
 
   def ch_session_factory do


### PR DESCRIPTION
This pull request implements the team member limit, adds it to the Usage & Limits section and applies the limit when inviting new members.

I'll tackle ownership transfers in a separate pull request, as we need to consider not only team members but the total of sites as well.