### PR TITLE
s/superadmin/super_admin

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -149,21 +149,21 @@ defmodule Plausible.Sites do
   end
 
   def get_for_user!(user_id, domain, roles \\ [:owner, :admin, :viewer]) do
-    if :superadmin in roles and Plausible.Auth.is_super_admin?(domain) do
+    if :super_admin in roles and Plausible.Auth.is_super_admin?(user_id) do
       get_by_domain!(domain)
     else
       user_id
-      |> get_for_user_q(domain, List.delete(roles, :superadmin))
+      |> get_for_user_q(domain, List.delete(roles, :super_admin))
       |> Repo.one!()
     end
   end
 
   def get_for_user(user_id, domain, roles \\ [:owner, :admin, :viewer]) do
-    if :superadmin in roles and Plausible.Auth.is_super_admin?(domain) do
+    if :super_admin in roles and Plausible.Auth.is_super_admin?(user_id) do
       get_by_domain(domain)
     else
       user_id
-      |> get_for_user_q(domain, List.delete(roles, :superadmin))
+      |> get_for_user_q(domain, List.delete(roles, :super_admin))
       |> Repo.one()
     end
   end

--- a/lib/plausible_web/live/funnel_settings.ex
+++ b/lib/plausible_web/live/funnel_settings.ex
@@ -16,7 +16,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
       ) do
     true = Plausible.Funnels.enabled_for?("user:#{user_id}")
 
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :superadmin])
+    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
 
     funnels = Funnels.list(site)
     goal_count = Goals.count(site)

--- a/lib/plausible_web/live/funnel_settings/form.ex
+++ b/lib/plausible_web/live/funnel_settings/form.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
   alias Plausible.{Sites, Goals}
 
   def mount(_params, %{"current_user_id" => user_id, "domain" => domain}, socket) do
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :superadmin])
+    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
 
     # We'll have the options trimmed to only the data we care about, to keep
     # it minimal at the socket assigns, yet, we want to retain specific %Goal{}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
         %{"site_id" => _site_id, "domain" => domain, "current_user_id" => user_id},
         socket
       ) do
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :superadmin])
+    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
 
     goals = Goals.for_site(site, preload_funnels?: true)
 

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -20,7 +20,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       ) do
     form = to_form(Plausible.Goal.changeset(%Plausible.Goal{}))
 
-    site = Plausible.Sites.get_for_user!(user_id, domain, [:owner, :admin, :superadmin])
+    site = Plausible.Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
 
     {:ok,
      assign(socket,

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -143,4 +143,19 @@ defmodule Plausible.SitesTest do
       assert {:error, {:over_limit, 5}} = Sites.invite(site, inviter, invitee.email, :viewer)
     end
   end
+
+  describe "get_for_user/2" do
+    test "get site for super_admin" do
+      user1 = insert(:user)
+      user2 = insert(:user)
+      patch_env(:super_admin_user_ids, [user2.id])
+
+      %{id: site_id, domain: domain} = insert(:site, members: [user1])
+      assert %{id: ^site_id} = Sites.get_for_user(user1.id, domain)
+      assert %{id: ^site_id} = Sites.get_for_user(user1.id, domain, [:owner])
+
+      assert is_nil(Sites.get_for_user(user2.id, domain))
+      assert %{id: ^site_id} = Sites.get_for_user(user2.id, domain, [:super_admin])
+    end
+  end
 end


### PR DESCRIPTION
I guess ideally we need compile-time checks around roles and tests that don't require application env patching. Relying on arbitrary atoms leads to stupid mistakes that easily slip through reviews.