### PR TITLE
Improve ownership transfers

### DIFF
--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -118,6 +118,7 @@ defmodule Plausible.Billing.Quota do
       from i in Plausible.Auth.Invitation,
         inner_join: os in subquery(owned_sites_query),
         on: i.site_id == os.site_id,
+        where: i.role != :owner,
         select: %{email: i.email},
         union: ^team_members_query
 

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -97,15 +97,9 @@ defmodule PlausibleWeb.Site.MembershipController do
   def transfer_ownership(conn, %{"email" => email}) do
     site_domain = conn.assigns[:site].domain
     site = Sites.get_for_user!(conn.assigns[:current_user].id, site_domain)
-    user = Plausible.Auth.find_user_by(email: email)
 
     case Sites.invite(site, conn.assigns.current_user, email, :owner) do
-      {:ok, invitation} ->
-        invitation
-        |> Repo.preload([:site, :inviter])
-        |> PlausibleWeb.Email.ownership_transfer_request(user)
-        |> Plausible.Mailer.send()
-
+      {:ok, _invitation} ->
         conn
         |> put_flash(:success, "Site transfer request has been sent to #{email}")
         |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -14,7 +14,6 @@ defmodule PlausibleWeb.Site.MembershipController do
   use Plausible.Repo
   alias Plausible.Sites
   alias Plausible.Site.Membership
-  alias Plausible.Auth.Invitation
 
   @only_owner_is_allowed_to [:transfer_ownership_form, :transfer_ownership]
 
@@ -100,41 +99,32 @@ defmodule PlausibleWeb.Site.MembershipController do
     site = Sites.get_for_user!(conn.assigns[:current_user].id, site_domain)
     user = Plausible.Auth.find_user_by(email: email)
 
-    invite_result =
-      Invitation.new(%{
-        email: email,
-        role: :owner,
-        site_id: site.id,
-        inviter_id: conn.assigns[:current_user].id
-      })
-      |> Repo.insert()
+    case Sites.invite(site, conn.assigns.current_user, email, :owner) do
+      {:ok, invitation} ->
+        invitation
+        |> Repo.preload([:site, :inviter])
+        |> PlausibleWeb.Email.ownership_transfer_request(user)
+        |> Plausible.Mailer.send()
 
-    conn =
-      case invite_result do
-        {:ok, invitation} ->
-          invitation
-          |> Repo.preload([:site, :inviter])
-          |> PlausibleWeb.Email.ownership_transfer_request(user)
-          |> Plausible.Mailer.send()
+        conn
+        |> put_flash(:success, "Site transfer request has been sent to #{email}")
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
 
-          put_flash(conn, :success, "Site transfer request has been sent to #{email}")
+      {:error, changeset} ->
+        errors = Plausible.ChangesetHelpers.traverse_errors(changeset)
 
-        {:error, changeset} ->
-          errors = Plausible.ChangesetHelpers.traverse_errors(changeset)
+        message =
+          case errors do
+            %{invitation: ["already sent" | _]} -> "Invitation has already been sent"
+            _other -> "Site transfer request to #{email} has failed"
+          end
 
-          message =
-            case errors do
-              %{invitation: ["already sent" | _]} -> "Invitation has already been sent"
-              _other -> "Site transfer request to #{email} has failed"
-            end
-
-          conn
-          |> put_flash(:ttl, :timer.seconds(5))
-          |> put_flash(:error_title, "Transfer error")
-          |> put_flash(:error, message)
-      end
-
-    redirect(conn, to: Routes.site_path(conn, :settings_people, site.domain))
+        conn
+        |> put_flash(:ttl, :timer.seconds(5))
+        |> put_flash(:error_title, "Transfer error")
+        |> put_flash(:error, message)
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
+    end
   end
 
   @doc """

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -166,7 +166,7 @@
                   <% end %>
                   <%= if Plausible.Billing.on_trial?(@current_user) do %>
                     <br/><br />
-                    Your 30-day free trial will end immediately and you will have to enter your card details to keep using Plausible.
+                    NB: Your 30-day free trial will end immediately and <strong>you will have to enter your card details</strong> to keep using Plausible.
                   <% end %>
                   </p>
                 </div>

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -282,6 +282,15 @@ defmodule Plausible.Billing.QuotaTest do
       assert Quota.team_member_usage(me) == 3
     end
 
+    test "does not count ownership transfer as a team member" do
+      me = insert(:user)
+      site_i_own = insert(:site, memberships: [build(:site_membership, user: me, role: :owner)])
+
+      insert(:invitation, site: site_i_own, inviter: me, role: :owner)
+
+      assert Quota.team_member_usage(me) == 0
+    end
+
     test "returns zero when user does not have any site" do
       me = insert(:user)
       assert Quota.team_member_usage(me) == 0

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -169,6 +169,16 @@ defmodule Plausible.SitesTest do
       assert {:error, :forbidden} = Sites.invite(site, inviter, "vini@plausible.test", :owner)
     end
 
+    test "does not check for limits when transferring ownership" do
+      inviter = insert(:user)
+
+      memberships =
+        [build(:site_membership, user: inviter, role: :owner)] ++ build_list(5, :site_membership)
+
+      site = insert(:site, memberships: memberships)
+      assert {:ok, _invitation} = Sites.invite(site, inviter, "newowner@plausible.test", :owner)
+    end
+
     test "does not allow viewers to invite users" do
       inviter = insert(:user)
 

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -142,6 +142,19 @@ defmodule Plausible.SitesTest do
       site = insert(:site, memberships: memberships)
       assert {:error, {:over_limit, 5}} = Sites.invite(site, inviter, invitee.email, :viewer)
     end
+
+    test "sends ownership transfer email when invitee role is owner" do
+      inviter = insert(:user)
+      site = insert(:site, memberships: [build(:site_membership, user: inviter, role: :owner)])
+
+      assert {:ok, %Plausible.Auth.Invitation{}} =
+               Sites.invite(site, inviter, "vini@plausible.test", :owner)
+
+      assert_email_delivered_with(
+        to: [nil: "vini@plausible.test"],
+        subject: "[Plausible Analytics] Request to transfer ownership of #{site.domain}"
+      )
+    end
   end
 
   describe "get_for_user/2" do


### PR DESCRIPTION
### Changes

This pull request introduces a series of improvements to ownership transfers
including:

- Refactoring the duplicated code between regular invitations and ownership transfers
- Improving test coverage
- Changing team member limits queries to not count pending transfers as team members

### Tests
- [X] Automated tests have been added

### Changelog
- [X] This PR does not make a user-facing change

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
