### PR TITLE
Silence undefined plan Sentry log for trials

### DIFF
--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -44,6 +44,7 @@ defmodule Plausible.Billing.Quota do
   end
 
   @monthly_pageview_limit_for_free_10k 10_000
+  @monthly_pageview_limit_for_trials :unlimited
 
   @spec monthly_pageview_limit(Plausible.Billing.Subscription.t()) ::
           non_neg_integer() | :unlimited
@@ -62,11 +63,13 @@ defmodule Plausible.Billing.Quota do
         @monthly_pageview_limit_for_free_10k
 
       _any ->
-        Sentry.capture_message("Unknown monthly pageview limit for plan",
-          extra: %{paddle_plan_id: subscription && subscription.paddle_plan_id}
-        )
+        if subscription do
+          Sentry.capture_message("Unknown monthly pageview limit for plan",
+            extra: %{paddle_plan_id: subscription.paddle_plan_id}
+          )
+        end
 
-        :unlimited
+        @monthly_pageview_limit_for_trials
     end
   end
 


### PR DESCRIPTION
This commit removes a Sentry notification triggered when the user plan can't be
found. This error log is spamming on Sentry because of trials, and we should
skip in that case.
