### PR TITLE
Filter out empty entries when listing stats for UTM props

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -443,9 +443,10 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:utm_medium") do
     from(
       s in q,
+      where: fragment("not empty(?)", s.utm_medium),
       group_by: s.utm_medium,
       select_merge: %{
-        utm_medium: fragment("if(empty(?), ?, ?)", s.utm_medium, @no_ref, s.utm_medium)
+        utm_medium: s.utm_medium
       }
     )
   end
@@ -453,9 +454,10 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:utm_source") do
     from(
       s in q,
+      where: fragment("not empty(?)", s.utm_source),
       group_by: s.utm_source,
       select_merge: %{
-        utm_source: fragment("if(empty(?), ?, ?)", s.utm_source, @no_ref, s.utm_source)
+        utm_source: s.utm_source
       }
     )
   end
@@ -463,9 +465,10 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:utm_campaign") do
     from(
       s in q,
+      where: fragment("not empty(?)", s.utm_campaign),
       group_by: s.utm_campaign,
       select_merge: %{
-        utm_campaign: fragment("if(empty(?), ?, ?)", s.utm_campaign, @no_ref, s.utm_campaign)
+        utm_campaign: s.utm_campaign
       }
     )
   end
@@ -473,9 +476,10 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:utm_content") do
     from(
       s in q,
+      where: fragment("not empty(?)", s.utm_content),
       group_by: s.utm_content,
       select_merge: %{
-        utm_content: fragment("if(empty(?), ?, ?)", s.utm_content, @no_ref, s.utm_content)
+        utm_content: s.utm_content
       }
     )
   end
@@ -483,9 +487,10 @@ defmodule Plausible.Stats.Breakdown do
   defp do_group_by(q, "visit:utm_term") do
     from(
       s in q,
+      where: fragment("not empty(?)", s.utm_term),
       group_by: s.utm_term,
       select_merge: %{
-        utm_term: fragment("if(empty(?), ?, ?)", s.utm_term, @no_ref, s.utm_term)
+        utm_term: s.utm_term
       }
     )
   end

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -142,8 +142,9 @@ defmodule Plausible.Stats.Imported do
 
         :utm_medium ->
           imported_q
+          |> where([i], fragment("not empty(?)", i.utm_medium))
           |> select_merge([i], %{
-            utm_medium: fragment("if(empty(?), ?, ?)", i.utm_medium, @no_ref, i.utm_medium)
+            utm_medium: i.utm_medium
           })
 
         :utm_source ->
@@ -154,20 +155,23 @@ defmodule Plausible.Stats.Imported do
 
         :utm_campaign ->
           imported_q
+          |> where([i], fragment("not empty(?)", i.utm_campaign))
           |> select_merge([i], %{
-            utm_campaign: fragment("if(empty(?), ?, ?)", i.utm_campaign, @no_ref, i.utm_campaign)
+            utm_campaign: i.utm_campaign
           })
 
         :utm_term ->
           imported_q
+          |> where([i], fragment("not empty(?)", i.utm_term))
           |> select_merge([i], %{
-            utm_term: fragment("if(empty(?), ?, ?)", i.utm_term, @no_ref, i.utm_term)
+            utm_term: i.utm_term
           })
 
         :utm_content ->
           imported_q
+          |> where([i], fragment("not empty(?)", i.utm_content))
           |> select_merge([i], %{
-            utm_content: fragment("if(empty(?), ?, ?)", i.utm_content, @no_ref, i.utm_content)
+            utm_content: i.utm_content
           })
 
         :page ->

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -147,12 +147,6 @@ defmodule Plausible.Stats.Imported do
             utm_medium: i.utm_medium
           })
 
-        :utm_source ->
-          imported_q
-          |> select_merge([i], %{
-            utm_source: fragment("if(empty(?), ?, ?)", i.utm_source, @no_ref, i.utm_source)
-          })
-
         :utm_campaign ->
           imported_q
           |> where([i], fragment("not empty(?)", i.utm_campaign))

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -306,12 +306,6 @@ defmodule Plausible.ImportedTest do
                  "name" => "social",
                  "visit_duration" => 20,
                  "visitors" => 3
-               },
-               %{
-                 "bounce_rate" => 100.0,
-                 "name" => "Direct / None",
-                 "visit_duration" => 60.0,
-                 "visitors" => 1
                }
              ]
     end
@@ -395,12 +389,6 @@ defmodule Plausible.ImportedTest do
                  "visitors" => 2,
                  "bounce_rate" => 100.0,
                  "visit_duration" => 50.0
-               },
-               %{
-                 "bounce_rate" => 0.0,
-                 "name" => "Direct / None",
-                 "visit_duration" => 100.0,
-                 "visitors" => 1
                }
              ]
     end
@@ -485,12 +473,6 @@ defmodule Plausible.ImportedTest do
                  "visitors" => 2,
                  "bounce_rate" => 100.0,
                  "visit_duration" => 50.0
-               },
-               %{
-                 "bounce_rate" => 0.0,
-                 "name" => "Direct / None",
-                 "visit_duration" => 100.0,
-                 "visitors" => 1
                }
              ]
     end
@@ -574,12 +556,6 @@ defmodule Plausible.ImportedTest do
                  "visitors" => 2,
                  "bounce_rate" => 100.0,
                  "visit_duration" => 50.0
-               },
-               %{
-                 "bounce_rate" => 0.0,
-                 "name" => "Direct / None",
-                 "visit_duration" => 100.0,
-                 "visitors" => 1
                }
              ]
     end

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_campaigns.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_campaigns.csv
@@ -1,2 +1,1 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_contents.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_contents.csv
@@ -1,2 +1,1 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_mediums.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_mediums.csv
@@ -1,2 +1,1 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_sources.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_sources.csv
@@ -1,2 +1,1 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_terms.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/utm_terms.csv
@@ -1,2 +1,1 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/utm_campaigns.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/utm_campaigns.csv
@@ -1,2 +1,1 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,1,0,60

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/utm_contents.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/utm_contents.csv
@@ -1,2 +1,1 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,1,0,60

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/utm_mediums.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/utm_mediums.csv
@@ -1,2 +1,1 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,1,0,60

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/utm_sources.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/utm_sources.csv
@@ -1,2 +1,1 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,1,0,60

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/utm_terms.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/utm_terms.csv
@@ -1,2 +1,1 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,1,0,60

--- a/test/plausible_web/controllers/CSVs/30d/utm_campaigns.csv
+++ b/test/plausible_web/controllers/CSVs/30d/utm_campaigns.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 ads,1,100,0

--- a/test/plausible_web/controllers/CSVs/30d/utm_contents.csv
+++ b/test/plausible_web/controllers/CSVs/30d/utm_contents.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 content,1,100,0

--- a/test/plausible_web/controllers/CSVs/30d/utm_mediums.csv
+++ b/test/plausible_web/controllers/CSVs/30d/utm_mediums.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 search,1,100,0

--- a/test/plausible_web/controllers/CSVs/30d/utm_sources.csv
+++ b/test/plausible_web/controllers/CSVs/30d/utm_sources.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 google,1,100,0

--- a/test/plausible_web/controllers/CSVs/30d/utm_terms.csv
+++ b/test/plausible_web/controllers/CSVs/30d/utm_terms.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 term,1,100,0

--- a/test/plausible_web/controllers/CSVs/6m/utm_campaigns.csv
+++ b/test/plausible_web/controllers/CSVs/6m/utm_campaigns.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,3,67,20
 ads,2,100,0

--- a/test/plausible_web/controllers/CSVs/6m/utm_contents.csv
+++ b/test/plausible_web/controllers/CSVs/6m/utm_contents.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,4,75,15
 content,1,100,0

--- a/test/plausible_web/controllers/CSVs/6m/utm_mediums.csv
+++ b/test/plausible_web/controllers/CSVs/6m/utm_mediums.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,4,75,15
 search,1,100,0

--- a/test/plausible_web/controllers/CSVs/6m/utm_sources.csv
+++ b/test/plausible_web/controllers/CSVs/6m/utm_sources.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,4,75,15
 google,1,100,0

--- a/test/plausible_web/controllers/CSVs/6m/utm_terms.csv
+++ b/test/plausible_web/controllers/CSVs/6m/utm_terms.csv
@@ -1,3 +1,2 @@
 name,visitors,bounce_rate,visit_duration
-Direct / None,4,75,15
 term,1,100,0

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -243,8 +243,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"utm_medium" => "Search", "visitors" => 2},
-               %{"utm_medium" => "Direct / None", "visitors" => 1}
+               %{"utm_medium" => "Search", "visitors" => 2}
              ]
            }
   end
@@ -275,8 +274,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"utm_source" => "Google", "visitors" => 2},
-               %{"utm_source" => "Direct / None", "visitors" => 1}
+               %{"utm_source" => "Google", "visitors" => 2}
              ]
            }
   end
@@ -307,8 +305,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"utm_campaign" => "ads", "visitors" => 2},
-               %{"utm_campaign" => "Direct / None", "visitors" => 1}
+               %{"utm_campaign" => "ads", "visitors" => 2}
              ]
            }
   end
@@ -339,8 +336,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"utm_content" => "Content1", "visitors" => 2},
-               %{"utm_content" => "Direct / None", "visitors" => 1}
+               %{"utm_content" => "Content1", "visitors" => 2}
              ]
            }
   end
@@ -371,8 +367,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     assert json_response(conn, 200) == %{
              "results" => [
-               %{"utm_term" => "Term1", "visitors" => 2},
-               %{"utm_term" => "Direct / None", "visitors" => 1}
+               %{"utm_term" => "Term1", "visitors" => 2}
              ]
            }
   end


### PR DESCRIPTION
### Changes

This PR effectively removes "Direct / None" entry from all UTM props reports across native UI, CSV exports and external API.

Entries with empty respective UTM prop are filtered out when querying stats. This applies to natively collected stats as well as the ones imported from Google Analytics.

Additionally, [a dead code path](https://github.com/plausible/analytics/pull/3339/files#diff-4bd4f25d18935ddee49a41d09209e22b918a05424ba9ed6368314841aa8108e2L149) was removed from imported stats logic - there's a clause of the same function that explicitly skips processing from `utm_source` property, as it's apparently not exposed by GA (or at least it wasn't at the time it was implemented - we might revise that).


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
