### PR TITLE
Allow admins to initiate ownership transfer from the CRM

### DIFF
--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -112,8 +112,9 @@ defmodule Plausible.Auth do
   end
 
   def is_super_admin?(nil), do: false
+  def is_super_admin?(%Plausible.Auth.User{id: id}), do: is_super_admin?(id)
 
-  def is_super_admin?(user_id) do
+  def is_super_admin?(user_id) when is_integer(user_id) do
     user_id in Application.get_env(:plausible, :super_admin_user_ids)
   end
 

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -53,7 +53,7 @@ defmodule Plausible.SiteAdmin do
     ]
   end
 
-  def list_actions(conn) do
+  def list_actions(_conn) do
     [
       transfer_ownership: %{
         name: "Transfer ownership",

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -74,11 +74,10 @@ defmodule Plausible.SiteAdmin do
     inviter = conn.assigns[:current_user]
 
     if new_owner do
-      Repo.transaction(fn ->
-        for site <- sites do
-          Plausible.Sites.invite(site, inviter, new_owner.email, :owner)
-        end
-      end)
+      {:ok, _} =
+        Plausible.Sites.bulk_transfer_ownership(sites, inviter, new_owner.email,
+          check_permissions: false
+        )
 
       :ok
     else

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -93,8 +93,7 @@ defmodule Plausible.Sites do
     end
   end
 
-  defp check_invitation_permissions(site, inviter, requested_role, check_permissions: false),
-    do: :ok
+  defp check_invitation_permissions(_, _, _, check_permissions: false), do: :ok
 
   defp check_invitation_permissions(site, inviter, requested_role, _) do
     required_roles = if requested_role == :owner, do: [:owner], else: [:admin, :owner]

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -101,17 +101,21 @@ defmodule Plausible.Sites do
     end
   end
 
-  defp check_invitation_permissions(_, _, _, check_permissions: false), do: :ok
+  defp check_invitation_permissions(site, inviter, requested_role, opts) do
+    check_permissions? = Keyword.get(opts, :check_permissions, true)
 
-  defp check_invitation_permissions(site, inviter, requested_role, _) do
-    required_roles = if requested_role == :owner, do: [:owner], else: [:admin, :owner]
+    if check_permissions? do
+      required_roles = if requested_role == :owner, do: [:owner], else: [:admin, :owner]
 
-    membership_query =
-      from(m in Plausible.Site.Membership,
-        where: m.user_id == ^inviter.id and m.site_id == ^site.id and m.role in ^required_roles
-      )
+      membership_query =
+        from(m in Plausible.Site.Membership,
+          where: m.user_id == ^inviter.id and m.site_id == ^site.id and m.role in ^required_roles
+        )
 
-    if Repo.exists?(membership_query), do: :ok, else: {:error, :forbidden}
+      if Repo.exists?(membership_query), do: :ok, else: {:error, :forbidden}
+    else
+      :ok
+    end
   end
 
   defp send_invitation_email(invitation, invitee) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -92,7 +92,11 @@ defmodule Plausible.Sites do
       from m in Plausible.Site.Membership,
         where: m.user_id == ^inviter.id and m.site_id == ^site.id and m.role in ^required_roles
 
-    if Repo.exists?(membership_query), do: :ok, else: {:error, :forbidden}
+    cond do
+      Plausible.Auth.is_super_admin?(inviter) -> :ok
+      Repo.exists?(membership_query) -> :ok
+      true -> {:error, :forbidden}
+    end
   end
 
   defp send_invitation_email(invitation, invitee) do

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -1,0 +1,57 @@
+defmodule Plausible.Site.AdminTest do
+  use Plausible.DataCase, async: true
+  use Bamboo.Test
+
+  setup do
+    admin_user = insert(:user)
+    conn = %Plug.Conn{assigns: %{current_user: admin_user}}
+    action = Plausible.SiteAdmin.list_actions(conn)[:transfer_ownership][:action]
+
+    Application.put_env(:plausible, :super_admin_user_ids, [admin_user.id])
+
+    {:ok,
+     %{
+       action: action,
+       conn: conn
+     }}
+  end
+
+  describe "bulk transferring site ownership" do
+    test "user has to select at least one site", %{conn: conn, action: action} do
+      assert action.(conn, [], %{}) == {:error, "Please select at least one site from the list"}
+    end
+
+    test "new owner must be an existing user", %{conn: conn, action: action} do
+      site = insert(:site)
+
+      assert action.(conn, [site], %{"email" => "random@email.com"}) ==
+               {:error, "User could not be found"}
+    end
+
+    test "initiates ownership transfer for multiple sites in one action", %{
+      conn: conn,
+      action: action
+    } do
+      current_owner = insert(:user)
+      new_owner = insert(:user)
+
+      site1 =
+        insert(:site, memberships: [build(:site_membership, user: current_owner, role: :owner)])
+
+      site2 =
+        insert(:site, memberships: [build(:site_membership, user: current_owner, role: :owner)])
+
+      assert :ok = action.(conn, [site1, site2], %{"email" => new_owner.email})
+
+      assert_email_delivered_with(
+        to: [nil: new_owner.email],
+        subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
+      )
+
+      assert_email_delivered_with(
+        to: [nil: new_owner.email],
+        subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
+      )
+    end
+  end
+end

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -48,10 +48,27 @@ defmodule Plausible.Site.AdminTest do
         subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
       )
 
+      assert Repo.exists?(
+               from i in Plausible.Auth.Invitation,
+                 where:
+                   i.site_id == ^site1.id and i.email == ^new_owner.email and i.role == :owner
+             )
+
+      assert_invitation_exists(site1, new_owner.email, :owner)
+
       assert_email_delivered_with(
         to: [nil: new_owner.email],
         subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
       )
+
+      assert_invitation_exists(site2, new_owner.email, :owner)
     end
+  end
+
+  defp assert_invitation_exists(site, email, role) do
+    assert Repo.exists?(
+             from i in Plausible.Auth.Invitation,
+               where: i.site_id == ^site.id and i.email == ^email and i.role == ^role
+           )
   end
 end

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -7,8 +7,6 @@ defmodule Plausible.Site.AdminTest do
     conn = %Plug.Conn{assigns: %{current_user: admin_user}}
     action = Plausible.SiteAdmin.list_actions(conn)[:transfer_ownership][:action]
 
-    Application.put_env(:plausible, :super_admin_user_ids, [admin_user.id])
-
     {:ok,
      %{
        action: action,
@@ -48,27 +46,10 @@ defmodule Plausible.Site.AdminTest do
         subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
       )
 
-      assert Repo.exists?(
-               from i in Plausible.Auth.Invitation,
-                 where:
-                   i.site_id == ^site1.id and i.email == ^new_owner.email and i.role == :owner
-             )
-
-      assert_invitation_exists(site1, new_owner.email, :owner)
-
       assert_email_delivered_with(
         to: [nil: new_owner.email],
         subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
       )
-
-      assert_invitation_exists(site2, new_owner.email, :owner)
     end
-  end
-
-  defp assert_invitation_exists(site, email, role) do
-    assert Repo.exists?(
-             from i in Plausible.Auth.Invitation,
-               where: i.site_id == ^site.id and i.email == ^email and i.role == ^role
-           )
   end
 end

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -209,6 +209,38 @@ defmodule Plausible.SitesTest do
     end
   end
 
+  describe "bulk_transfer_ownership/4" do
+    test "initiates ownership transfer for multiple sites in one action" do
+      admin_user = insert(:user)
+      new_owner = insert(:user)
+
+      site1 = insert(:site)
+      site2 = insert(:site)
+
+      assert {:ok, _} = Sites.bulk_transfer_ownership([site1, site2], admin_user, new_owner.email)
+
+      assert_email_delivered_with(
+        to: [nil: new_owner.email],
+        subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
+      )
+
+      assert Repo.exists?(
+               from i in Plausible.Auth.Invitation,
+                 where:
+                   i.site_id == ^site1.id and i.email == ^new_owner.email and i.role == :owner
+             )
+
+      assert_invitation_exists(site1, new_owner.email, :owner)
+
+      assert_email_delivered_with(
+        to: [nil: new_owner.email],
+        subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
+      )
+
+      assert_invitation_exists(site2, new_owner.email, :owner)
+    end
+  end
+
   describe "get_for_user/2" do
     test "get site for super_admin" do
       user1 = insert(:user)
@@ -222,5 +254,12 @@ defmodule Plausible.SitesTest do
       assert is_nil(Sites.get_for_user(user2.id, domain))
       assert %{id: ^site_id} = Sites.get_for_user(user2.id, domain, [:super_admin])
     end
+  end
+
+  defp assert_invitation_exists(site, email, role) do
+    assert Repo.exists?(
+             from i in Plausible.Auth.Invitation,
+               where: i.site_id == ^site.id and i.email == ^email and i.role == ^role
+           )
   end
 end


### PR DESCRIPTION
### Changes

Adds an action in the CRM to initiate ownership transfers. Uses the `Sites.invite` function that @vinibrsl recently extracted.


### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

