### PR TITLE
Fix Add Property button font weight

### DIFF
--- a/lib/plausible_web/live/props_settings/list.ex
+++ b/lib/plausible_web/live/props_settings/list.ex
@@ -43,7 +43,7 @@ defmodule PlausibleWeb.Live.PropsSettings.List do
           <button
             type="button"
             phx-click="add-prop"
-            class="mt-2 block items-center rounded-md bg-indigo-600 p-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            class="mt-2 block items-center rounded-md bg-indigo-600 p-2 text-sm text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
           >
             + Add Property
           </button>


### PR DESCRIPTION
This sets the Add Property button font-weight to the ones seen in Add Goals and Add Funnels.