### PR TITLE
[migration] Data fix: rewrite goals for which `event_name` and `page_path` both exist

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -43,6 +43,10 @@ defmodule Plausible.Goal do
     |> update_change(:event_name, &String.trim/1)
     |> update_change(:page_path, &String.trim/1)
     |> validate_length(:event_name, max: 120)
+    |> check_constraint(:event_name,
+      name: :check_event_name_or_page_path,
+      message: "cannot co-exist with page_path"
+    )
     |> maybe_drop_currency()
   end
 

--- a/priv/repo/migrations/20230918084301_fix_broken_goals.exs
+++ b/priv/repo/migrations/20230918084301_fix_broken_goals.exs
@@ -1,0 +1,25 @@
+defmodule Plausible.Repo.Migrations.FixBrokenGoals do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE goals SET page_path = NULL WHERE page_path IS NOT NULL AND event_name IS NOT NULL
+    """
+
+    execute("""
+     ALTER TABLE goals
+     ADD CONSTRAINT check_event_name_or_page_path
+     CHECK (
+       (event_name IS NOT NULL AND page_path IS NULL) OR
+       (event_name IS NULL AND page_path IS NOT NULL)
+     );
+    """)
+  end
+
+  def down do
+    execute """
+    ALTER TABLE goals
+    DROP CONSTRAINT check_event_name_or_page_path;
+    """
+  end
+end

--- a/priv/repo/migrations/20230918084301_fix_broken_goals.exs
+++ b/priv/repo/migrations/20230918084301_fix_broken_goals.exs
@@ -2,9 +2,9 @@ defmodule Plausible.Repo.Migrations.FixBrokenGoals do
   use Ecto.Migration
 
   def up do
-    execute """
+    execute("""
     UPDATE goals SET page_path = NULL WHERE page_path IS NOT NULL AND event_name IS NOT NULL
-    """
+    """)
 
     execute("""
      ALTER TABLE goals
@@ -12,14 +12,15 @@ defmodule Plausible.Repo.Migrations.FixBrokenGoals do
      CHECK (
        (event_name IS NOT NULL AND page_path IS NULL) OR
        (event_name IS NULL AND page_path IS NOT NULL)
-     );
+     )
+     NOT VALID;
     """)
   end
 
   def down do
-    execute """
+    execute("""
     ALTER TABLE goals
     DROP CONSTRAINT check_event_name_or_page_path;
-    """
+    """)
   end
 end

--- a/priv/repo/migrations/20230918084301_fix_broken_goals.exs
+++ b/priv/repo/migrations/20230918084301_fix_broken_goals.exs
@@ -1,6 +1,9 @@
 defmodule Plausible.Repo.Migrations.FixBrokenGoals do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up do
     execute("""
     UPDATE goals SET page_path = NULL WHERE page_path IS NOT NULL AND event_name IS NOT NULL

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -174,4 +174,13 @@ defmodule Plausible.GoalsTest do
 
     assert [^g3, ^g2] = Goals.for_site(site)
   end
+
+  test "must be either page_path or event_name" do
+    site = insert(:site)
+
+    assert {:error, changeset} =
+             Goals.create(site, %{"page_path" => "/foo", "event_name" => "/foo"})
+
+    assert {"cannot co-exist with page_path", _} = changeset.errors[:event_name]
+  end
 end


### PR DESCRIPTION
### Changes

See https://github.com/plausible/analytics/commit/118795c1c86d9f45b819b935c69f1da1bafa7ab9 for explanation.

We've decided to favour `event_name` over `page_path`.


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
