### PR TITLE
Update Workflow Concurrency

### DIFF
--- a/.github/workflows/build-private-images.yml
+++ b/.github/workflows/build-private-images.yml
@@ -8,6 +8,10 @@ on:
     branches: [master]
     types: [synchronize, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'deploy-to-staging') }}

--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ['v*']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: buildjet-16vcpu-ubuntu-2204

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, stable]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, stable]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test

--- a/.github/workflows/terraform-e2e.yml
+++ b/.github/workflows/terraform-e2e.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - 'test/e2e/**.tf'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   terraform:
     concurrency: terraform_checkly

--- a/.github/workflows/tracker.yml
+++ b/.github/workflows/tracker.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'tracker/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     timeout-minutes: 15


### PR DESCRIPTION
Ensures that only one workflow is running per branch at a time.

If you are working on a branch and push several commits in succession, any workflows in progress will be cancelled and only the last one will run.