### PR TITLE
Open docs links in new window

### DIFF
--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -165,6 +165,8 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
               during the private preview. Pricing will be announced soon. See
               examples and learn more in <a
                 class="font-medium text-yellow underline hover:text-yellow-600"
+                target="_blank"
+                rel="noreferrer"
                 href="https://plausible.io/docs/ecommerce-revenue-tracking"
               >our docs</a>.
             </p>

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -4,6 +4,8 @@
     during the private preview. Pricing will be announced soon. See
     examples and learn more in <a
       class="font-medium text-yellow underline hover:text-yellow-600"
+      target="_blank"
+      rel="noreferrer"
       href="https://plausible.io/docs/funnel-analysis"
     >our docs</a>.
   </PlausibleWeb.Components.Generic.notice>

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -5,7 +5,7 @@
     be grandfathered and will keep having access to custom properties without
     any change to their plan. See examples and learn more in <.link
       class="font-medium text-yellow underline hover:text-yellow-600"
-      href="https://plausible.io/docs/custom-pageview-props"
+      href="https://plausible.io/docs/custom-props/introduction"
       target="_blank"
       rel="noreferrer"
     >our docs</.link>.

--- a/lib/plausible_web/templates/site/settings_search_console.html.eex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.eex
@@ -22,7 +22,7 @@
             </p>
           <% else %>
             <p class="text-gray-700 dark:text-gray-300 mt-6">
-            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://plausible.io/docs/google-search-console-integration", class: "text-indigo-500") %> on Search Console first.
+            Select the Google Search Console property you would like to pull keyword data from. If you don't see your domain, <%= link("set it up and verify", to: "https://plausible.io/docs/google-search-console-integration", class: "text-indigo-500", target: "_blank", rel: "noreferrer") %> on Search Console first.
             </p>
           <% end %>
 


### PR DESCRIPTION
A fix to open some of the docs links within the app in new window and a change to the URL of one of the links