### PR TITLE
Redirect to People Settings after removing pending invitation

### DIFF
--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -131,6 +131,6 @@ defmodule PlausibleWeb.InvitationController do
 
     conn
     |> put_flash(:success, "You have removed the invitation for #{invitation.email}")
-    |> redirect(to: Routes.site_path(conn, :settings_general, invitation.site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_people, invitation.site.domain))
   end
 end

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -264,10 +264,13 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
           role: :admin
         )
 
-      delete(
-        conn,
-        Routes.invitation_path(conn, :remove_invitation, site.domain, invitation.invitation_id)
-      )
+      conn =
+        delete(
+          conn,
+          Routes.invitation_path(conn, :remove_invitation, site.domain, invitation.invitation_id)
+        )
+
+      assert redirected_to(conn, 302) == "/#{site.domain}/settings/people"
 
       refute Repo.exists?(
                from i in Plausible.Auth.Invitation, where: i.email == "jane@example.com"


### PR DESCRIPTION
This PR addresses getting redirected to Site Settings page after removing pending invitation in People Settings.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
