### PR TITLE
Fix and refactor invitation logic

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -73,12 +73,14 @@ defmodule Plausible.Billing do
     end
   end
 
-  @spec needs_to_upgrade?(Plausible.Auth.User.t()) ::
+  @spec check_needs_to_upgrade(Plausible.Auth.User.t()) ::
           {true, :no_trial | :no_active_subscription | :grace_period_ended | nil}
           | {false, nil}
-  def needs_to_upgrade?(%Plausible.Auth.User{trial_expiry_date: nil}), do: {true, :no_trial}
+  def check_needs_to_upgrade(%Plausible.Auth.User{trial_expiry_date: nil}) do
+    {true, :no_trial}
+  end
 
-  def needs_to_upgrade?(user) do
+  def check_needs_to_upgrade(user) do
     user = Plausible.Users.with_subscription(user)
     trial_is_over = Timex.before?(user.trial_expiry_date, Timex.today())
     subscription_active = subscription_is_active?(user.subscription)

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -83,7 +83,7 @@ defmodule Plausible.Billing do
     cond do
       trial_is_over && !subscription_active -> {true, :no_active_subscription}
       Plausible.Auth.GracePeriod.expired?(user) -> {true, :grace_period_ended}
-      true -> false
+      true -> {false, nil}
     end
   end
 

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -283,13 +283,8 @@ defmodule Plausible.Billing do
 
     user
     |> maybe_remove_grace_period()
-    |> update_lock_status()
+    |> tap(&Plausible.Billing.SiteLocker.update_sites_for/1)
     |> maybe_adjust_api_key_limits()
-  end
-
-  defp update_lock_status(user) do
-    Plausible.Billing.SiteLocker.update_sites_for(user)
-    user
   end
 
   defp maybe_adjust_api_key_limits(user) do

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -74,10 +74,10 @@ defmodule Plausible.Billing do
   end
 
   @spec check_needs_to_upgrade(Plausible.Auth.User.t()) ::
-          {true, :no_trial | :no_active_subscription | :grace_period_ended | nil}
-          | {false, nil}
+          {:needs_to_upgrade, :no_trial | :no_active_subscription | :grace_period_ended}
+          | :no_upgrade_needed
   def check_needs_to_upgrade(%Plausible.Auth.User{trial_expiry_date: nil}) do
-    {true, :no_trial}
+    {:needs_to_upgrade, :no_trial}
   end
 
   def check_needs_to_upgrade(user) do
@@ -86,9 +86,9 @@ defmodule Plausible.Billing do
     subscription_active = subscription_is_active?(user.subscription)
 
     cond do
-      trial_is_over && !subscription_active -> {true, :no_active_subscription}
-      Plausible.Auth.GracePeriod.expired?(user) -> {true, :grace_period_ended}
-      true -> {false, nil}
+      trial_is_over && !subscription_active -> {:needs_to_upgrade, :no_active_subscription}
+      Plausible.Auth.GracePeriod.expired?(user) -> {:needs_to_upgrade, :grace_period_ended}
+      true -> :no_upgrade_needed
     end
   end
 

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -1,7 +1,13 @@
 defmodule Plausible.Billing.SiteLocker do
   use Plausible.Repo
 
-  def check_sites_for(user, opts \\ []) do
+  @type update_opt() :: {:send_email?, boolean()}
+
+  @type lock_reason() :: :grace_period_ended_now | :grace_period_ended_already
+
+  @spec update_sites_for(Plausible.Auth.User.t(), [update_opt()]) ::
+          {:locked, lock_reason()} | {:unlocked, nil}
+  def update_sites_for(user, opts \\ []) do
     send_email? = Keyword.get(opts, :send_email?, true)
 
     user = Plausible.Users.with_subscription(user)
@@ -34,6 +40,7 @@ defmodule Plausible.Billing.SiteLocker do
     end
   end
 
+  @spec set_lock_status_for(Plausible.Auth.User.t(), boolean()) :: {:ok, non_neg_integer()}
   def set_lock_status_for(user, status) do
     site_ids =
       Repo.all(
@@ -50,9 +57,12 @@ defmodule Plausible.Billing.SiteLocker do
         where: s.id in ^site_ids
       )
 
-    Repo.update_all(site_q, set: [locked: status])
+    {num_updated, _} = Repo.update_all(site_q, set: [locked: status])
+
+    {:ok, num_updated}
   end
 
+  @spec send_grace_period_end_email(Plausible.Auth.User.t()) :: Plausible.Mailer.result()
   def send_grace_period_end_email(user) do
     {_, last_cycle} = Plausible.Billing.last_two_billing_cycles(user)
     {_, last_cycle_usage} = Plausible.Billing.last_two_billing_months_usage(user)

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -1,33 +1,47 @@
 defmodule Plausible.Billing.SiteLocker do
   use Plausible.Repo
 
-  def check_sites_for(user) do
+  def check_sites_for(user, opts \\ []) do
+    send_email? = Keyword.get(opts, :send_email?, true)
+
     user = Plausible.Users.with_subscription(user)
 
     case Plausible.Billing.needs_to_upgrade?(user) do
       {true, :grace_period_ended} ->
         set_lock_status_for(user, true)
 
-        if !user.grace_period.is_over do
-          send_grace_period_end_email(user)
-          Plausible.Auth.GracePeriod.end_changeset(user) |> Repo.update()
+        if user.grace_period.is_over != true do
+          user
+          |> Plausible.Auth.GracePeriod.end_changeset()
+          |> Repo.update!()
+
+          if send_email? do
+            send_grace_period_end_email(user)
+          end
+
+          {:locked, :grace_period_ended_now}
+        else
+          {:locked, :grace_period_ended_already}
         end
 
-      {true, _} ->
+      {true, reason} ->
         set_lock_status_for(user, true)
+        {:locked, reason}
 
-      _ ->
+      {false, _} ->
         set_lock_status_for(user, false)
+        {:unlocked, nil}
     end
   end
 
   def set_lock_status_for(user, status) do
     site_ids =
       Repo.all(
-        from s in Plausible.Site.Membership,
+        from(s in Plausible.Site.Membership,
           where: s.user_id == ^user.id,
           where: s.role == :owner,
           select: s.site_id
+        )
       )
 
     site_q =
@@ -39,7 +53,7 @@ defmodule Plausible.Billing.SiteLocker do
     Repo.update_all(site_q, set: [locked: status])
   end
 
-  defp send_grace_period_end_email(user) do
+  def send_grace_period_end_email(user) do
     {_, last_cycle} = Plausible.Billing.last_two_billing_cycles(user)
     {_, last_cycle_usage} = Plausible.Billing.last_two_billing_months_usage(user)
     suggested_plan = Plausible.Billing.Plans.suggest(user, last_cycle_usage)

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -64,6 +64,7 @@ defmodule Plausible.Billing.SiteLocker do
 
   @spec send_grace_period_end_email(Plausible.Auth.User.t()) :: Plausible.Mailer.result()
   def send_grace_period_end_email(user) do
+    user = Repo.preload(user, :subscription)
     {_, last_cycle} = Plausible.Billing.last_two_billing_cycles(user)
     {_, last_cycle_usage} = Plausible.Billing.last_two_billing_months_usage(user)
     suggested_plan = Plausible.Billing.Plans.suggest(user, last_cycle_usage)

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -12,7 +12,7 @@ defmodule Plausible.Billing.SiteLocker do
 
     user = Plausible.Users.with_subscription(user)
 
-    case Plausible.Billing.needs_to_upgrade?(user) do
+    case Plausible.Billing.check_needs_to_upgrade(user) do
       {true, :grace_period_ended} ->
         set_lock_status_for(user, true)
 

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -10,7 +10,7 @@ defmodule Plausible.Billing.SiteLocker do
           | :no_active_subscription
 
   @spec update_sites_for(Plausible.Auth.User.t(), [update_opt()]) ::
-          {:locked, lock_reason()} | {:unlocked, nil}
+          {:locked, lock_reason()} | :unlocked
   def update_sites_for(user, opts \\ []) do
     send_email? = Keyword.get(opts, :send_email?, true)
 
@@ -40,7 +40,7 @@ defmodule Plausible.Billing.SiteLocker do
 
       :no_upgrade_needed ->
         set_lock_status_for(user, false)
-        {:unlocked, nil}
+        :unlocked
     end
   end
 

--- a/lib/plausible/mailer.ex
+++ b/lib/plausible/mailer.ex
@@ -2,7 +2,9 @@ defmodule Plausible.Mailer do
   use Bamboo.Mailer, otp_app: :plausible
   require Logger
 
-  @spec send(Bamboo.Email.t()) :: :ok | {:error, :hard_bounce} | {:error, :unknown_error}
+  @type result() :: :ok | {:error, :hard_bounce} | {:error, :unknown_error}
+
+  @spec send(Bamboo.Email.t()) :: result()
   def send(email) do
     case deliver_now(email) do
       {:ok, _email} -> :ok

--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -2,6 +2,8 @@ defmodule Plausible.Site.Membership do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t() :: %__MODULE__{}
+
   schema "site_memberships" do
     field :role, Ecto.Enum, values: [:owner, :admin, :viewer]
     belongs_to :site, Plausible.Site

--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -10,9 +10,15 @@ defmodule Plausible.Site.Membership do
     timestamps()
   end
 
-  def changeset(schema, attrs) do
-    schema
-    |> cast(attrs, [:user_id, :site_id, :role])
-    |> validate_required([:user_id, :site_id])
+  def new(site, user) do
+    %__MODULE__{}
+    |> change()
+    |> put_assoc(:site, site)
+    |> put_assoc(:user, user)
+  end
+
+  def set_role(changeset, role) do
+    changeset
+    |> cast(%{role: role}, [:role])
   end
 end

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -1,0 +1,9 @@
+defmodule Plausible.Site.Memberships do
+  @moduledoc """
+  API for site memberships and invitations
+  """
+
+  alias Plausible.Site.Memberships
+
+  defdelegate accept_invitation(invitation_id, user), to: Memberships.AcceptInvitation
+end

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -6,4 +6,6 @@ defmodule Plausible.Site.Memberships do
   alias Plausible.Site.Memberships
 
   defdelegate accept_invitation(invitation_id, user), to: Memberships.AcceptInvitation
+  defdelegate reject_invitation(invitation_id, user), to: Memberships.RejectInvitation
+  defdelegate remove_invitation(invitation_id, site), to: Memberships.RemoveInvitation
 end

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -59,7 +59,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
     |> Multi.insert_or_update(:membership, membership)
     |> Multi.delete(:invitation, invitation)
     |> Multi.run(:site_locker, fn _, %{user: updated_user} ->
-      {:ok, Billing.SiteLocker.check_sites_for(updated_user, send_email?: false)}
+      {:ok, Billing.SiteLocker.update_sites_for(updated_user, send_email?: false)}
     end)
   end
 

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -110,7 +110,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
 
     case previous_owner do
       %{user_id: ^new_owner_id} ->
-        Multi.put(multi, :previous_owner, previous_owner)
+        Multi.put(multi, :previous_owner_membership, previous_owner)
 
       nil ->
         Logger.warn(
@@ -118,10 +118,14 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
             ", new owner ID: #{new_owner_id}"
         )
 
-        Multi.put(multi, :previous_owner, nil)
+        Multi.put(multi, :previous_owner_membership, nil)
 
       previous_owner ->
-        Multi.update(multi, :previous_owner, Site.Membership.set_role(previous_owner, :admin))
+        Multi.update(
+          multi,
+          :previous_owner_membership,
+          Site.Membership.set_role(previous_owner, :admin)
+        )
     end
   end
 
@@ -135,7 +139,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
 
       Billing.on_trial?(new_owner) or is_nil(new_owner.trial_expiry_date) ->
         Multi.update(multi, :user, fn
-          %{previous_owner: %{id: ^new_owner_id}} ->
+          %{previous_owner_membership: %{user_id: ^new_owner_id}} ->
             Ecto.Changeset.change(new_owner)
 
           _ ->

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -86,6 +86,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
     |> Site.Membership.set_role(invitation.role)
   end
 
+  # If the new owner is the same as old owner, we do not downgrade them
+  # to avoid leaving site without an owner!
   defp downgrade_previous_owner(multi, site, new_owner) do
     new_owner_id = new_owner.id
 
@@ -115,7 +117,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
     end
   end
 
-  # If new owner is the same as the old owner, it's a no-op
+  # If the new owner is the same as the old owner, it's a no-op
   defp maybe_end_trial_of_new_owner(multi, new_owner) do
     new_owner_id = new_owner.id
 

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -15,6 +15,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   alias Ecto.Multi
   alias Plausible.Auth
   alias Plausible.Billing
+  alias Plausible.Memberships.Invitations
   alias Plausible.Repo
   alias Plausible.Site
   alias Plausible.Site.Memberships.Invitations
@@ -24,7 +25,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   @spec accept_invitation(String.t(), Auth.User.t()) ::
           {:ok, Site.Membership.t()} | {:error, :invitation_not_found | Ecto.Changeset.t()}
   def accept_invitation(invitation_id, user) do
-    with {:ok, invitation} <- find_invitation(invitation_id) do
+    with {:ok, invitation} <- Invitations.find_for_user(invitation_id, user) do
       membership = get_or_create_membership(invitation, user)
 
       multi =
@@ -133,19 +134,6 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
 
       true ->
         Multi.put(multi, :user, new_owner)
-    end
-  end
-
-  defp find_invitation(invitation_id) do
-    invitation =
-      Auth.Invitation
-      |> Repo.get_by(invitation_id: invitation_id)
-      |> Repo.preload([:site, :inviter])
-
-    if invitation do
-      {:ok, invitation}
-    else
-      {:error, :invitation_not_found}
     end
   end
 

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -1,0 +1,112 @@
+defmodule Plausible.Site.Memberships.AcceptInvitation do
+  @moduledoc """
+  Service for accepting invitations, including ownership transfers
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Multi
+  alias Plausible.Auth
+  alias Plausible.Billing
+  alias Plausible.Repo
+  alias Plausible.Site
+
+  def accept_invitation(invitation_id, user) do
+    with {:ok, invitation} <- find_invitation(invitation_id) do
+      membership = get_or_create_membership(invitation, user)
+
+      multi =
+        Multi.new()
+        |> maybe_prepare_ownership_transfer(invitation, user)
+        |> Multi.insert_or_update(:membership, membership)
+        |> Multi.delete(:invitation, invitation)
+        |> Multi.run(:site_locker, fn _, %{user: updated_user} ->
+          {:ok,
+           Billing.SiteLocker.check_sites_for(Repo.reload!(updated_user), send_email?: false)}
+        end)
+
+      case Repo.transaction(multi) do
+        {:ok, changes} ->
+          if changes.site_locker == {:locked, :grace_period_ended_now} do
+            Billing.SiteLocker.send_grace_period_end_email(changes.user)
+          end
+
+          notify_invitation_accepted(invitation)
+
+          membership = Repo.preload(changes.membership, [:site, :user])
+
+          {:ok, membership}
+
+        {:error, _operation, error, _changes} ->
+          {:error, error}
+      end
+    end
+  end
+
+  defp get_or_create_membership(invitation, user) do
+    case Repo.get_by(Site.Membership, user_id: user.id, site_id: invitation.site.id) do
+      nil -> Site.Membership.new(invitation.site, user)
+      membership -> membership
+    end
+    |> Site.Membership.set_role(invitation.role)
+  end
+
+  defp maybe_prepare_ownership_transfer(multi, %{role: :owner} = invitation, user) do
+    multi
+    |> downgrade_previous_owner(invitation.site)
+    |> maybe_end_trial_of_new_owner(user)
+  end
+
+  defp maybe_prepare_ownership_transfer(multi, _invitation, user),
+    do: Multi.put(multi, :user, user)
+
+  defp downgrade_previous_owner(multi, site) do
+    previous_owner =
+      from(
+        sm in Site.Membership,
+        where: sm.site_id == ^site.id,
+        where: sm.role == :owner
+      )
+
+    Multi.update_all(multi, :previous_owner, previous_owner, set: [role: :admin])
+  end
+
+  defp maybe_end_trial_of_new_owner(multi, new_owner) do
+    if Application.get_env(:plausible, :is_selfhost) do
+      Multi.put(multi, :user, new_owner)
+    else
+      end_trial_of_new_owner(multi, new_owner)
+    end
+  end
+
+  defp end_trial_of_new_owner(multi, new_owner) do
+    if Billing.on_trial?(new_owner) || is_nil(new_owner.trial_expiry_date) do
+      Multi.update(multi, :user, Auth.User.end_trial(new_owner))
+    else
+      Multi.put(multi, :user, new_owner)
+    end
+  end
+
+  defp find_invitation(invitation_id) do
+    invitation =
+      Auth.Invitation
+      |> Repo.get_by(invitation_id: invitation_id)
+      |> Repo.preload([:site, :inviter])
+
+    if invitation do
+      {:ok, invitation}
+    else
+      {:error, :invitation_not_found}
+    end
+  end
+
+  defp notify_invitation_accepted(%Auth.Invitation{role: :owner} = invitation) do
+    PlausibleWeb.Email.ownership_transfer_accepted(invitation)
+    |> Plausible.Mailer.send()
+  end
+
+  defp notify_invitation_accepted(invitation) do
+    PlausibleWeb.Email.invitation_accepted(invitation)
+    |> Plausible.Mailer.send()
+  end
+end

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -1,6 +1,13 @@
 defmodule Plausible.Site.Memberships.AcceptInvitation do
   @moduledoc """
-  Service for accepting invitations, including ownership transfers
+  Service for accepting invitations, including ownership transfers.
+
+  Accepting invitation accounts for the fact that it's possible
+  that accepting user has an existing membership for the site and
+  acts permissively to not unnecesarily disrupt the flow while
+  also maintaining integrity of site memberships. This also applies
+  to cases where users update their email address between issuing
+  the invitation and accepting it.
   """
 
   import Ecto.Query, only: [from: 2]

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
 
   Accepting invitation accounts for the fact that it's possible
   that accepting user has an existing membership for the site and
-  acts permissively to not unnecesarily disrupt the flow while
+  acts permissively to not unnecessarily disrupt the flow while
   also maintaining integrity of site memberships. This also applies
   to cases where users update their email address between issuing
   the invitation and accepting it.

--- a/lib/plausible/site/memberships/invitations.ex
+++ b/lib/plausible/site/memberships/invitations.ex
@@ -1,0 +1,36 @@
+defmodule Plausible.Site.Memberships.Invitations do
+  @moduledoc false
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+
+  @spec find_for_user(String.t(), Auth.User.t()) ::
+          {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
+  def find_for_user(invitation_id, user) do
+    invitation =
+      Auth.Invitation
+      |> Repo.get_by(invitation_id: invitation_id, email: user.email)
+      |> Repo.preload([:site, :inviter])
+
+    if invitation do
+      {:ok, invitation}
+    else
+      {:error, :invitation_not_found}
+    end
+  end
+
+  @spec find_for_site(String.t(), Plausible.Site.t()) ::
+          {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
+  def find_for_site(invitation_id, site) do
+    invitation =
+      Auth.Invitation
+      |> Repo.get_by(invitation_id: invitation_id, site_id: site.id)
+      |> Repo.preload([:site, :inviter])
+
+    if invitation do
+      {:ok, invitation}
+    else
+      {:error, :invitation_not_found}
+    end
+  end
+end

--- a/lib/plausible/site/memberships/invitations.ex
+++ b/lib/plausible/site/memberships/invitations.ex
@@ -1,6 +1,8 @@
 defmodule Plausible.Site.Memberships.Invitations do
   @moduledoc false
 
+  import Ecto.Query, only: [from: 2]
+
   alias Plausible.Auth
   alias Plausible.Repo
 
@@ -32,5 +34,12 @@ defmodule Plausible.Site.Memberships.Invitations do
     else
       {:error, :invitation_not_found}
     end
+  end
+
+  @spec delete_invitation(Auth.Invitation.t()) :: :ok
+  def delete_invitation(invitation) do
+    Repo.delete_all(from(i in Auth.Invitation, where: i.id == ^invitation.id))
+
+    :ok
   end
 end

--- a/lib/plausible/site/memberships/reject_invitation.ex
+++ b/lib/plausible/site/memberships/reject_invitation.ex
@@ -1,0 +1,30 @@
+defmodule Plausible.Site.Memberships.RejectInvitation do
+  @moduledoc """
+  Service for rejecting invitations.
+  """
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+  alias Plausible.Site.Memberships.Invitations
+
+  @spec reject_invitation(String.t(), Auth.User.t()) ::
+          {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
+  def reject_invitation(invitation_id, user) do
+    with {:ok, invitation} <- Invitations.find_for_user(invitation_id, user) do
+      Repo.delete!(invitation)
+      notify_invitation_rejected(invitation)
+
+      {:ok, invitation}
+    end
+  end
+
+  defp notify_invitation_rejected(%Auth.Invitation{role: :owner} = invitation) do
+    PlausibleWeb.Email.ownership_transfer_rejected(invitation)
+    |> Plausible.Mailer.send()
+  end
+
+  defp notify_invitation_rejected(invitation) do
+    PlausibleWeb.Email.invitation_rejected(invitation)
+    |> Plausible.Mailer.send()
+  end
+end

--- a/lib/plausible/site/memberships/reject_invitation.ex
+++ b/lib/plausible/site/memberships/reject_invitation.ex
@@ -4,14 +4,13 @@ defmodule Plausible.Site.Memberships.RejectInvitation do
   """
 
   alias Plausible.Auth
-  alias Plausible.Repo
   alias Plausible.Site.Memberships.Invitations
 
   @spec reject_invitation(String.t(), Auth.User.t()) ::
           {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
   def reject_invitation(invitation_id, user) do
     with {:ok, invitation} <- Invitations.find_for_user(invitation_id, user) do
-      Repo.delete!(invitation)
+      Invitations.delete_invitation(invitation)
       notify_invitation_rejected(invitation)
 
       {:ok, invitation}

--- a/lib/plausible/site/memberships/remove_invitation.ex
+++ b/lib/plausible/site/memberships/remove_invitation.ex
@@ -1,0 +1,19 @@
+defmodule Plausible.Site.Memberships.RemoveInvitation do
+  @moduledoc """
+  Service for removing invitations.
+  """
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+  alias Plausible.Site.Memberships.Invitations
+
+  @spec remove_invitation(String.t(), Plausible.Site.t()) ::
+          {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
+  def remove_invitation(invitation_id, site) do
+    with {:ok, invitation} <- Invitations.find_for_site(invitation_id, site) do
+      Repo.delete!(invitation)
+
+      {:ok, invitation}
+    end
+  end
+end

--- a/lib/plausible/site/memberships/remove_invitation.ex
+++ b/lib/plausible/site/memberships/remove_invitation.ex
@@ -4,14 +4,13 @@ defmodule Plausible.Site.Memberships.RemoveInvitation do
   """
 
   alias Plausible.Auth
-  alias Plausible.Repo
   alias Plausible.Site.Memberships.Invitations
 
   @spec remove_invitation(String.t(), Plausible.Site.t()) ::
           {:ok, Auth.Invitation.t()} | {:error, :invitation_not_found}
   def remove_invitation(invitation_id, site) do
     with {:ok, invitation} <- Invitations.find_for_site(invitation_id, site) do
-      Repo.delete!(invitation)
+      Invitations.delete_invitation(invitation)
 
       {:ok, invitation}
     end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -28,14 +28,8 @@ defmodule Plausible.Sites do
       if Quota.within_limit?(usage, limit), do: {:ok, usage}, else: {:error, limit}
     end)
     |> Ecto.Multi.insert(:site, site_changeset)
-    |> Ecto.Multi.run(:site_membership, fn repo, %{site: site} ->
-      membership_changeset =
-        Site.Membership.changeset(%Site.Membership{}, %{
-          site_id: site.id,
-          user_id: user.id
-        })
-
-      repo.insert(membership_changeset)
+    |> Ecto.Multi.insert(:site_membership, fn %{site: site} ->
+      Site.Membership.new(site, user)
     end)
     |> maybe_start_trial(user)
     |> Repo.transaction()

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -6,6 +6,7 @@ defmodule Plausible.Sites do
   @type invite_error() ::
           Ecto.Changeset.t()
           | :already_a_member
+          | :transfer_to_self
           | {:over_limit, non_neg_integer()}
           | :forbidden
 
@@ -85,6 +86,7 @@ defmodule Plausible.Sites do
     with :ok <- check_invitation_permissions(site, inviter, role, opts),
          :ok <- check_team_member_limit(site, role),
          invitee <- Plausible.Auth.find_user_by(email: invitee_email),
+         :ok <- ensure_transfer_valid(site, invitee, role),
          :ok <- ensure_new_membership(site, invitee, role),
          %Ecto.Changeset{} = changeset <- Plausible.Auth.Invitation.new(attrs),
          {:ok, invitation} <- Repo.insert(changeset) do
@@ -123,6 +125,18 @@ defmodule Plausible.Sites do
       end
 
     Plausible.Mailer.send(email)
+  end
+
+  defp ensure_transfer_valid(site, invitee, :owner) do
+    if invitee && role(invitee.id, site) == :owner do
+      {:error, :transfer_to_self}
+    else
+      :ok
+    end
+  end
+
+  defp ensure_transfer_valid(_site, _invitee, _role) do
+    :ok
   end
 
   defp ensure_new_membership(_site, _invitee, :owner) do

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -31,9 +31,8 @@ defmodule PlausibleWeb.InvitationController do
         end
 
       membership_changeset =
-        (existing_membership ||
-           %Membership{user_id: user.id, site_id: invitation.site.id})
-        |> Membership.changeset(%{role: invitation.role})
+        (existing_membership || Membership.new(invitation.site, user))
+        |> Membership.set_role(invitation.role)
 
       multi =
         multi

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -1,13 +1,9 @@
 defmodule PlausibleWeb.InvitationController do
   use PlausibleWeb, :controller
-  use Plausible.Repo
-  alias Plausible.Auth.Invitation
 
   plug PlausibleWeb.RequireAccountPlug
 
-  @require_owner [:remove_invitation]
-
-  plug PlausibleWeb.AuthorizeSiteAccess, [:owner, :admin] when action in @require_owner
+  plug PlausibleWeb.AuthorizeSiteAccess, [:owner, :admin] when action in [:remove_invitation]
 
   def accept_invitation(conn, %{"invitation_id" => invitation_id}) do
     case Plausible.Site.Memberships.accept_invitation(invitation_id, conn.assigns.current_user) do
@@ -29,37 +25,30 @@ defmodule PlausibleWeb.InvitationController do
   end
 
   def reject_invitation(conn, %{"invitation_id" => invitation_id}) do
-    invitation =
-      Repo.get_by!(Invitation, invitation_id: invitation_id)
-      |> Repo.preload([:site, :inviter])
+    case Plausible.Site.Memberships.reject_invitation(invitation_id, conn.assigns.current_user) do
+      {:ok, invitation} ->
+        conn
+        |> put_flash(:success, "You have rejected the invitation to #{invitation.site.domain}")
+        |> redirect(to: "/sites")
 
-    Repo.delete!(invitation)
-    notify_invitation_rejected(invitation)
-
-    conn
-    |> put_flash(:success, "You have rejected the invitation to #{invitation.site.domain}")
-    |> redirect(to: "/sites")
-  end
-
-  defp notify_invitation_rejected(%Invitation{role: :owner} = invitation) do
-    PlausibleWeb.Email.ownership_transfer_rejected(invitation)
-    |> Plausible.Mailer.send()
-  end
-
-  defp notify_invitation_rejected(invitation) do
-    PlausibleWeb.Email.invitation_rejected(invitation)
-    |> Plausible.Mailer.send()
+      {:error, :invitation_not_found} ->
+        conn
+        |> put_flash(:error, "Invitation missing or already accepted")
+        |> redirect(to: "/sites")
+    end
   end
 
   def remove_invitation(conn, %{"invitation_id" => invitation_id}) do
-    invitation =
-      Repo.get_by!(Invitation, invitation_id: invitation_id, site_id: conn.assigns[:site].id)
-      |> Repo.preload(:site)
+    case Plausible.Site.Memberships.remove_invitation(invitation_id, conn.assigns.site) do
+      {:ok, invitation} ->
+        conn
+        |> put_flash(:success, "You have removed the invitation for #{invitation.email}")
+        |> redirect(to: Routes.site_path(conn, :settings_people, invitation.site.domain))
 
-    Repo.delete!(invitation)
-
-    conn
-    |> put_flash(:success, "You have removed the invitation for #{invitation.email}")
-    |> redirect(to: Routes.site_path(conn, :settings_people, invitation.site.domain))
+      {:error, :invitation_not_found} ->
+        conn
+        |> put_flash(:error, "Invitation missing or already removed")
+        |> redirect(to: Routes.site_path(conn, :settings_people, conn.assigns.site.domain))
+    end
   end
 end

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -1,90 +1,30 @@
 defmodule PlausibleWeb.InvitationController do
   use PlausibleWeb, :controller
   use Plausible.Repo
-  alias Ecto.Multi
   alias Plausible.Auth.Invitation
-  alias Plausible.Site.Membership
 
   plug PlausibleWeb.RequireAccountPlug
 
   @require_owner [:remove_invitation]
 
-  plug PlausibleWeb.AuthorizeSiteAccess,
-       [:owner, :admin] when action in @require_owner
+  plug PlausibleWeb.AuthorizeSiteAccess, [:owner, :admin] when action in @require_owner
 
   def accept_invitation(conn, %{"invitation_id" => invitation_id}) do
-    invitation =
-      Repo.get_by(Invitation, invitation_id: invitation_id)
-      |> Repo.preload([:site, :inviter])
+    case Plausible.Site.Memberships.accept_invitation(invitation_id, conn.assigns.current_user) do
+      {:ok, membership} ->
+        conn
+        |> put_flash(:success, "You now have access to #{membership.site.domain}")
+        |> redirect(to: "/#{URI.encode_www_form(membership.site.domain)}")
 
-    if invitation do
-      user = conn.assigns[:current_user]
-      existing_membership = Repo.get_by(Membership, user_id: user.id, site_id: invitation.site.id)
+      {:error, :invitation_not_found} ->
+        conn
+        |> put_flash(:error, "Invitation missing or already accepted")
+        |> redirect(to: "/sites")
 
-      multi =
-        if invitation.role == :owner do
-          Multi.new()
-          |> downgrade_previous_owner(invitation.site)
-          |> maybe_end_trial_of_new_owner(user)
-        else
-          Multi.new()
-        end
-
-      membership_changeset =
-        (existing_membership || Membership.new(invitation.site, user))
-        |> Membership.set_role(invitation.role)
-
-      multi =
-        multi
-        |> Multi.insert_or_update(:membership, membership_changeset)
-        |> Multi.delete(:invitation, invitation)
-
-      case Repo.transaction(multi) do
-        {:ok, changes} ->
-          updated_user = Map.get(changes, :user, user)
-          notify_invitation_accepted(invitation)
-          Plausible.Billing.SiteLocker.check_sites_for(updated_user)
-
-          conn
-          |> put_flash(:success, "You now have access to #{invitation.site.domain}")
-          |> redirect(to: "/#{URI.encode_www_form(invitation.site.domain)}")
-
-        {:error, _operation, _value, _changes} ->
-          conn
-          |> put_flash(:error, "Something went wrong, please try again")
-          |> redirect(to: "/sites")
-      end
-    else
-      conn
-      |> put_flash(:error, "Invitation missing or already accepted")
-      |> redirect(to: "/sites")
-    end
-  end
-
-  defp downgrade_previous_owner(multi, site) do
-    prev_owner =
-      from(
-        sm in Plausible.Site.Membership,
-        where: sm.site_id == ^site.id,
-        where: sm.role == :owner
-      )
-
-    Multi.update_all(multi, :prev_owner, prev_owner, set: [role: :admin])
-  end
-
-  defp maybe_end_trial_of_new_owner(multi, new_owner) do
-    if Application.get_env(:plausible, :is_selfhost) do
-      multi
-    else
-      end_trial_of_new_owner(multi, new_owner)
-    end
-  end
-
-  defp end_trial_of_new_owner(multi, new_owner) do
-    if Plausible.Billing.on_trial?(new_owner) || is_nil(new_owner.trial_expiry_date) do
-      Ecto.Multi.update(multi, :user, Plausible.Auth.User.end_trial(new_owner))
-    else
-      multi
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Something went wrong, please try again")
+        |> redirect(to: "/sites")
     end
   end
 
@@ -99,16 +39,6 @@ defmodule PlausibleWeb.InvitationController do
     conn
     |> put_flash(:success, "You have rejected the invitation to #{invitation.site.domain}")
     |> redirect(to: "/sites")
-  end
-
-  defp notify_invitation_accepted(%Invitation{role: :owner} = invitation) do
-    PlausibleWeb.Email.ownership_transfer_accepted(invitation)
-    |> Plausible.Mailer.send()
-  end
-
-  defp notify_invitation_accepted(invitation) do
-    PlausibleWeb.Email.invitation_accepted(invitation)
-    |> Plausible.Mailer.send()
   end
 
   defp notify_invitation_rejected(%Invitation{role: :owner} = invitation) do

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -149,7 +149,8 @@ defmodule PlausibleWeb.Site.MembershipController do
     if can_grant_role? do
       membership =
         membership
-        |> Membership.changeset(%{role: new_role})
+        |> Ecto.Changeset.change()
+        |> Membership.set_role(new_role)
         |> Repo.update!()
 
       redirect_target =

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -104,6 +104,13 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> put_flash(:success, "Site transfer request has been sent to #{email}")
         |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
 
+      {:error, :transfer_to_self} ->
+        conn
+        |> put_flash(:ttl, :timer.seconds(5))
+        |> put_flash(:error_title, "Transfer error")
+        |> put_flash(:error, "Can't transfer ownership to existing owner")
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
+
       {:error, changeset} ->
         errors = Plausible.ChangesetHelpers.traverse_errors(changeset)
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.SiteController do
       sites: sites,
       visitors: visitors,
       pagination: pagination,
-      needs_to_upgrade: user_owns_sites && Plausible.Billing.needs_to_upgrade?(user)
+      needs_to_upgrade: user_owns_sites && Plausible.Billing.check_needs_to_upgrade(user)
     )
   end
 

--- a/lib/plausible_web/templates/site/index.html.eex
+++ b/lib/plausible_web/templates/site/index.html.eex
@@ -1,6 +1,6 @@
 <div x-data="{selectedInvitation: null, invitationOpen: false, invitations: <%= Enum.map(@invitations, &({&1.invitation_id, &1})) |> Enum.into(%{}) |> Jason.encode! %>}" @keydown.escape.window="invitationOpen = false" class="container pt-6">
 
-  <%= if @needs_to_upgrade == {true, :no_active_subscription} do %>
+  <%= if @needs_to_upgrade == {:needs_to_upgrade, :no_active_subscription} do %>
     <div class="rounded-md bg-yellow-100 p-4">
       <div class="flex">
         <div class="flex-shrink-0">

--- a/lib/workers/lock_sites.ex
+++ b/lib/workers/lock_sites.ex
@@ -8,7 +8,7 @@ defmodule Plausible.Workers.LockSites do
     users = Repo.all(from u in Plausible.Auth.User, preload: [subscription: ^subscription_q])
 
     for user <- users do
-      Plausible.Billing.SiteLocker.check_sites_for(user)
+      Plausible.Billing.SiteLocker.update_sites_for(user)
     end
 
     :ok

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -125,31 +125,31 @@ defmodule Plausible.BillingTest do
     end
   end
 
-  describe "needs_to_upgrade?" do
+  describe "check_needs_to_upgrade" do
     test "is false for a trial user" do
       user = insert(:user)
-      assert Billing.needs_to_upgrade?(user) == {false, nil}
+      assert Billing.check_needs_to_upgrade(user) == {false, nil}
     end
 
     # FIXME: reason result is not consistent with expectation, why?
     test "is true for a user with an expired trial" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
 
-      assert Billing.needs_to_upgrade?(user) == {true, :no_active_subscription}
+      assert Billing.check_needs_to_upgrade(user) == {true, :no_active_subscription}
     end
 
     test "is false for a user with an expired trial but an active subscription" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user)
 
-      assert Billing.needs_to_upgrade?(user) == {false, nil}
+      assert Billing.check_needs_to_upgrade(user) == {false, nil}
     end
 
     test "is false for a user with a cancelled subscription IF the billing cycle isn't completed yet" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user, status: "deleted", next_bill_date: Timex.today())
 
-      assert Billing.needs_to_upgrade?(user) == {false, nil}
+      assert Billing.check_needs_to_upgrade(user) == {false, nil}
     end
 
     test "is true for a user with a cancelled subscription IF the billing cycle is complete" do
@@ -161,7 +161,7 @@ defmodule Plausible.BillingTest do
         next_bill_date: Timex.shift(Timex.today(), days: -1)
       )
 
-      assert Billing.needs_to_upgrade?(user) == {true, :no_active_subscription}
+      assert Billing.check_needs_to_upgrade(user) == {true, :no_active_subscription}
     end
 
     # FIXME: revise if that makes sense
@@ -169,7 +169,7 @@ defmodule Plausible.BillingTest do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user, status: "deleted", next_bill_date: nil)
 
-      assert Billing.needs_to_upgrade?(user) == {true, :no_active_subscription}
+      assert Billing.check_needs_to_upgrade(user) == {true, :no_active_subscription}
     end
 
     # FIXME: missing grace period test

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -3,13 +3,13 @@ defmodule Plausible.Billing.SiteLockerTest do
   use Bamboo.Test, shared: true
   alias Plausible.Billing.SiteLocker
 
-  describe "check_sites_for/1" do
+  describe "update_sites_for/1" do
     test "does not lock sites if user is on trial" do
       user = insert(:user, trial_expiry_date: Timex.today())
 
       site = insert(:site, locked: true, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -19,7 +19,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "active", user: user)
       site = insert(:site, locked: true, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -29,7 +29,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "past_due", user: user)
       site = insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -39,7 +39,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "deleted", user: user)
       site = insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -56,7 +56,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "active", user: user)
       site = insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -72,7 +72,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       site = insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       refute Repo.reload!(site).locked
     end
@@ -89,7 +89,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "active", user: user)
       site = insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       assert Repo.reload!(site).locked
     end
@@ -106,7 +106,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "active", user: user)
       insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       assert_email_delivered_with(
         to: [user],
@@ -127,7 +127,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       insert(:subscription, status: "active", user: user)
       insert(:site, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       assert_email_delivered_with(
         to: [user],
@@ -135,7 +135,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       )
 
       user = Repo.reload!(user)
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       assert_no_emails_delivered()
     end
@@ -145,7 +145,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       site = insert(:site, locked: true, members: [user])
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       assert Repo.reload!(site).locked
     end
@@ -167,7 +167,7 @@ defmodule Plausible.Billing.SiteLockerTest do
           ]
         )
 
-      SiteLocker.check_sites_for(user)
+      SiteLocker.update_sites_for(user)
 
       owner_site = Repo.reload!(owner_site)
       viewer_site = Repo.reload!(viewer_site)

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -7,9 +7,15 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock sites if user is on trial" do
       user = insert(:user, trial_expiry_date: Timex.today())
 
-      site = insert(:site, locked: true, members: [user])
+      site =
+        insert(:site,
+          locked: true,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
 
-      SiteLocker.update_sites_for(user)
+      assert SiteLocker.update_sites_for(user) == :unlocked
 
       refute Repo.reload!(site).locked
     end
@@ -17,9 +23,16 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock if user has an active subscription" do
       user = insert(:user)
       insert(:subscription, status: "active", user: user)
-      site = insert(:site, locked: true, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      site =
+        insert(:site,
+          locked: true,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == :unlocked
 
       refute Repo.reload!(site).locked
     end
@@ -27,9 +40,15 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock user who is past due" do
       user = insert(:user)
       insert(:subscription, status: "past_due", user: user)
-      site = insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == :unlocked
 
       refute Repo.reload!(site).locked
     end
@@ -37,9 +56,15 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "does not lock user who cancelled subscription but it hasn't expired yet" do
       user = insert(:user)
       insert(:subscription, status: "deleted", user: user)
-      site = insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == :unlocked
 
       refute Repo.reload!(site).locked
     end
@@ -54,15 +79,21 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      site = insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == :unlocked
 
       refute Repo.reload!(site).locked
     end
 
     test "locks user who cancelled subscription and the cancelled subscription has expired" do
-      user = insert(:user)
+      user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
 
       insert(:subscription,
         status: "deleted",
@@ -70,11 +101,16 @@ defmodule Plausible.Billing.SiteLockerTest do
         user: user
       )
 
-      site = insert(:site, members: [user])
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
 
-      SiteLocker.update_sites_for(user)
+      assert SiteLocker.update_sites_for(user) == {:locked, :no_active_subscription}
 
-      refute Repo.reload!(site).locked
+      assert Repo.reload!(site).locked
     end
 
     test "locks all sites if user has active subscription but grace period has ended" do
@@ -87,9 +123,15 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      site = insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == {:locked, :grace_period_ended_now}
 
       assert Repo.reload!(site).locked
     end
@@ -104,9 +146,14 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner)
+        ]
+      )
+
+      assert SiteLocker.update_sites_for(user) == {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
         to: [user],
@@ -125,9 +172,14 @@ defmodule Plausible.Billing.SiteLockerTest do
         )
 
       insert(:subscription, status: "active", user: user)
-      insert(:site, members: [user])
 
-      SiteLocker.update_sites_for(user)
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner)
+        ]
+      )
+
+      assert SiteLocker.update_sites_for(user) == {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
         to: [user],
@@ -135,7 +187,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       )
 
       user = Repo.reload!(user)
-      SiteLocker.update_sites_for(user)
+      assert SiteLocker.update_sites_for(user) == {:locked, :grace_period_ended_already}
 
       assert_no_emails_delivered()
     end
@@ -143,9 +195,29 @@ defmodule Plausible.Billing.SiteLockerTest do
     test "locks all sites if user has no trial or active subscription" do
       user = insert(:user, trial_expiry_date: Timex.today() |> Timex.shift(days: -1))
 
-      site = insert(:site, locked: true, members: [user])
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
 
-      SiteLocker.update_sites_for(user)
+      assert SiteLocker.update_sites_for(user) == {:locked, :no_active_subscription}
+
+      assert Repo.reload!(site).locked
+    end
+
+    test "locks sites for user with empty trial - shouldn't happen under normal circumstances" do
+      user = insert(:user, trial_expiry_date: nil)
+
+      site =
+        insert(:site,
+          memberships: [
+            build(:site_membership, user: user, role: :owner)
+          ]
+        )
+
+      assert SiteLocker.update_sites_for(user) == {:locked, :no_trial}
 
       assert Repo.reload!(site).locked
     end
@@ -167,7 +239,7 @@ defmodule Plausible.Billing.SiteLockerTest do
           ]
         )
 
-      SiteLocker.update_sites_for(user)
+      assert SiteLocker.update_sites_for(user) == {:locked, :no_active_subscription}
 
       owner_site = Repo.reload!(owner_site)
       viewer_site = Repo.reload!(viewer_site)

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -1,0 +1,235 @@
+defmodule Plausible.Site.Memberships.AcceptInvitationTest do
+  use Plausible.DataCase, async: true
+  use Bamboo.Test
+
+  alias Plausible.Site.Memberships.AcceptInvitation
+
+  describe "invitations" do
+    test "converts an invitation into a membership" do
+      inviter = insert(:user)
+      invitee = insert(:user)
+      site = insert(:site, members: [inviter])
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: inviter,
+          email: invitee.email,
+          role: :admin
+        )
+
+      assert {:ok, membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, invitee)
+
+      assert membership.site_id == site.id
+      assert membership.user_id == invitee.id
+      assert membership.role == :admin
+      refute Repo.reload(invitation)
+
+      assert_email_delivered_with(
+        to: [nil: inviter.email],
+        subject:
+          "[Plausible Analytics] #{invitee.email} accepted your invitation to #{site.domain}"
+      )
+    end
+
+    test "handles accepting invitation as already a member gracefully" do
+      inviter = insert(:user)
+      invitee = insert(:user)
+      site = insert(:site, members: [inviter])
+      existing_membership = insert(:site_membership, user: invitee, site: site, role: :admin)
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: inviter,
+          email: invitee.email,
+          role: :viewer
+        )
+
+      assert {:ok, new_membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, invitee)
+
+      assert existing_membership.id == new_membership.id
+      assert existing_membership.user_id == new_membership.user_id
+      assert existing_membership.site_id == new_membership.site_id
+      assert existing_membership.role == new_membership.role
+      assert new_membership.role == :admin
+      refute Repo.reload(invitation)
+    end
+
+    test "returns an error on non-existent inviation" do
+      invitee = insert(:user)
+
+      assert {:error, :invitation_not_found} =
+               AcceptInvitation.accept_invitation("does_not_exist", invitee)
+    end
+  end
+
+  describe "ownership transfers" do
+    for {label, opts} <- [{"cloud", []}, {"selfhosted", [selfhost?: true]}] do
+      test "converts an ownership transfer into a membership on #{label} instance" do
+        site = insert(:site)
+        existing_owner = insert(:user)
+
+        existing_membership =
+          insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+        new_owner = insert(:user)
+
+        invitation =
+          insert(:invitation,
+            site_id: site.id,
+            inviter: existing_owner,
+            email: new_owner.email,
+            role: :owner
+          )
+
+        assert {:ok, new_membership} =
+                 AcceptInvitation.accept_invitation(
+                   invitation.invitation_id,
+                   new_owner,
+                   unquote(opts)
+                 )
+
+        assert new_membership.site_id == site.id
+        assert new_membership.user_id == new_owner.id
+        assert new_membership.role == :owner
+        refute Repo.reload(invitation)
+
+        existing_membership = Repo.reload!(existing_membership)
+        assert existing_membership.user_id == existing_owner.id
+        assert existing_membership.site_id == site.id
+        assert existing_membership.role == :admin
+
+        assert_email_delivered_with(
+          to: [nil: existing_owner.email],
+          subject:
+            "[Plausible Analytics] #{new_owner.email} accepted the ownership transfer of #{site.domain}"
+        )
+      end
+    end
+
+    for role <- [:viewer, :admin] do
+      test "upgrades existing #{role} membership into an owner" do
+        site = insert(:site)
+        owner = insert(:user)
+        owner_membership = insert(:site_membership, user: owner, site: site, role: :owner)
+        new_owner = insert(:user)
+
+        new_owner_membership =
+          insert(:site_membership, user: new_owner, site: site, role: unquote(role))
+
+        invitation =
+          insert(:invitation,
+            site_id: site.id,
+            inviter: owner,
+            email: new_owner.email,
+            role: :owner
+          )
+
+        assert {:ok, membership} =
+                 AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
+
+        assert membership.id == new_owner_membership.id
+        assert membership.role == :owner
+
+        assert Repo.reload!(owner_membership).role == :admin
+        refute Repo.reload(invitation)
+      end
+    end
+
+    test "locks the site if the new owner has no active subscription or trial" do
+      site = insert(:site, locked: false)
+
+      existing_owner = insert(:user)
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user, trial_expiry_date: Date.add(Date.utc_today(), -1))
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: existing_owner,
+          email: new_owner.email,
+          role: :owner
+        )
+
+      assert {:ok, _membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
+
+      assert Repo.reload!(site).locked
+    end
+
+    test "does not lock the site or set trial expiry date if the instance is selfhosted" do
+      site = insert(:site, locked: false)
+
+      existing_owner = insert(:user)
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user, trial_expiry_date: nil)
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: existing_owner,
+          email: new_owner.email,
+          role: :owner
+        )
+
+      assert {:ok, _membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner,
+                 selfhost?: true
+               )
+
+      assert Repo.reload!(new_owner).trial_expiry_date == nil
+      refute Repo.reload!(site).locked
+    end
+
+    test "ends trial of the new owner immediately" do
+      site = insert(:site, locked: false)
+
+      existing_owner = insert(:user)
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user, trial_expiry_date: Date.add(Date.utc_today(), 7))
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: existing_owner,
+          email: new_owner.email,
+          role: :owner
+        )
+
+      assert {:ok, _membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
+
+      assert Repo.reload!(new_owner).trial_expiry_date == Date.add(Date.utc_today(), -1)
+      assert Repo.reload!(site).locked
+    end
+
+    test "sets user's trial expiry date to yesterday if they don't have one" do
+      site = insert(:site, locked: false)
+
+      existing_owner = insert(:user)
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user, trial_expiry_date: nil)
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: existing_owner,
+          email: new_owner.email,
+          role: :owner
+        )
+
+      assert {:ok, _membership} =
+               AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
+
+      assert Repo.reload!(new_owner).trial_expiry_date == Date.add(Date.utc_today(), -1)
+      assert Repo.reload!(site).locked
+    end
+  end
+end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -82,7 +82,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       refute Repo.reload(invitation)
     end
 
-    test "returns an error on non-existent inviation" do
+    test "returns an error on non-existent invitation" do
       invitee = insert(:user)
 
       assert {:error, :invitation_not_found} =

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -279,7 +279,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert Repo.reload!(site).locked
     end
 
-    test "ends grace period and sends an email about it if new owner is in grace period" do
+    test "ends grace period and sends an email about it if new owner is past grace period" do
       site = insert(:site, locked: false)
 
       existing_owner = insert(:user)

--- a/test/plausible/site/memberships/reject_invitation_test.exs
+++ b/test/plausible/site/memberships/reject_invitation_test.exs
@@ -1,0 +1,58 @@
+defmodule Plausible.Site.Memberships.RejectInvitationTest do
+  use Plausible.DataCase, async: true
+  use Bamboo.Test
+
+  alias Plausible.Site.Memberships.RejectInvitation
+
+  test "rejects invitation and sends email to inviter" do
+    inviter = insert(:user)
+    invitee = insert(:user)
+    site = insert(:site, members: [inviter])
+
+    invitation =
+      insert(:invitation,
+        site_id: site.id,
+        inviter: inviter,
+        email: invitee.email,
+        role: :admin
+      )
+
+    assert {:ok, rejected_invitation} =
+             RejectInvitation.reject_invitation(invitation.invitation_id, invitee)
+
+    assert rejected_invitation.id == invitation.id
+    refute Repo.reload(rejected_invitation)
+
+    assert_email_delivered_with(
+      to: [nil: inviter.email],
+      subject: "[Plausible Analytics] #{invitee.email} rejected your invitation to #{site.domain}"
+    )
+  end
+
+  test "returns error for non-existent invitation" do
+    invitee = insert(:user)
+
+    assert {:error, :invitation_not_found} =
+             RejectInvitation.reject_invitation("does_not_exist", invitee)
+  end
+
+  test "does not allow rejecting invitation by anyone other than invitee" do
+    inviter = insert(:user)
+    invitee = insert(:user)
+    other_user = insert(:user)
+    site = insert(:site, members: [inviter])
+
+    invitation =
+      insert(:invitation,
+        site_id: site.id,
+        inviter: inviter,
+        email: invitee.email,
+        role: :admin
+      )
+
+    assert {:error, :invitation_not_found} =
+             RejectInvitation.reject_invitation(invitation.invitation_id, other_user)
+
+    assert Repo.reload(invitation)
+  end
+end

--- a/test/plausible/site/memberships/remove_invitation_test.exs
+++ b/test/plausible/site/memberships/remove_invitation_test.exs
@@ -1,0 +1,52 @@
+defmodule Plausible.Site.Memberships.RemoveInvitationTest do
+  use Plausible.DataCase, async: true
+
+  alias Plausible.Site.Memberships.RemoveInvitation
+
+  test "removes invitation" do
+    inviter = insert(:user)
+    invitee = insert(:user)
+    site = insert(:site, members: [inviter])
+
+    invitation =
+      insert(:invitation,
+        site_id: site.id,
+        inviter: inviter,
+        email: invitee.email,
+        role: :admin
+      )
+
+    assert {:ok, removed_invitation} =
+             RemoveInvitation.remove_invitation(invitation.invitation_id, site)
+
+    assert removed_invitation.id == invitation.id
+    refute Repo.reload(removed_invitation)
+  end
+
+  test "returns error for non-existent invitation" do
+    site = insert(:site)
+
+    assert {:error, :invitation_not_found} =
+             RemoveInvitation.remove_invitation("does_not_exist", site)
+  end
+
+  test "does not allow removing invitation from another site" do
+    inviter = insert(:user)
+    invitee = insert(:user)
+    site = insert(:site, members: [inviter])
+    other_site = insert(:site, members: [inviter])
+
+    invitation =
+      insert(:invitation,
+        site_id: site.id,
+        inviter: inviter,
+        email: invitee.email,
+        role: :admin
+      )
+
+    assert {:error, :invitation_not_found} =
+             RemoveInvitation.remove_invitation(invitation.invitation_id, other_site)
+
+    assert Repo.reload(invitation)
+  end
+end

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -47,7 +47,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
 
   test "locked site - returns 402", %{conn: conn, api_key: api_key, user: user} do
     site = insert(:site, members: [user])
-    {1, _} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
+    {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
 
     conn
     |> with_api_key(api_key)
@@ -88,7 +88,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
       user: user
     } do
       site = insert(:site, members: [user])
-      {1, _} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
+      {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
 
       conn
       |> with_api_key(api_key)

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -132,6 +132,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Repo.reload!(site).locked
     end
 
+    # FIXME: test started failing after changes
     test "will end the trial of the new owner immediately", %{
       conn: conn,
       user: user

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Site.InvitationControllerTest do
-  use PlausibleWeb.ConnCase
+  use PlausibleWeb.ConnCase, async: true
   use Plausible.Repo
   use Bamboo.Test
 

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -53,43 +53,9 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Phoenix.Flash.get(c2.assigns.flash, :error) ==
                "Invitation missing or already accepted"
     end
-
-    test "notifies the original inviter", %{conn: conn, user: user} do
-      inviter = insert(:user)
-      site = insert(:site)
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :admin)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      assert_email_delivered_with(
-        to: [nil: inviter.email],
-        subject: "[Plausible Analytics] #{user.email} accepted your invitation to #{site.domain}"
-      )
-    end
   end
 
   describe "POST /sites/invitations/:invitation_id/accept - ownership transfer" do
-    test "notifies the original inviter with a different email", %{
-      conn: conn,
-      user: user
-    } do
-      inviter = insert(:user)
-      site = insert(:site, members: [inviter])
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      assert_email_delivered_with(
-        to: [nil: inviter.email],
-        subject:
-          "[Plausible Analytics] #{user.email} accepted the ownership transfer of #{site.domain}"
-      )
-    end
-
     test "downgrades previous owner to admin", %{conn: conn, user: user} do
       old_owner = insert(:user)
       site = insert(:site, members: [old_owner])
@@ -100,112 +66,6 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
 
       refute Repo.exists?(from(i in Plausible.Auth.Invitation, where: i.email == ^user.email))
-
-      old_owner_membership =
-        Repo.get_by(Plausible.Site.Membership, user_id: old_owner.id, site_id: site.id)
-
-      assert old_owner_membership.role == :admin
-
-      new_owner_membership =
-        Repo.get_by(Plausible.Site.Membership, user_id: user.id, site_id: site.id)
-
-      assert new_owner_membership.role == :owner
-    end
-
-    test "will lock the site if new owner does not have an active subscription or trial",
-         %{
-           conn: conn,
-           user: user
-         } do
-      Repo.update_all(from(u in Plausible.Auth.User, where: u.id == ^user.id),
-        set: [trial_expiry_date: Timex.today() |> Timex.shift(days: -1)]
-      )
-
-      inviter = insert(:user)
-      site = insert(:site, members: [inviter], locked: false)
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      assert Repo.reload!(site).locked
-    end
-
-    test "will end the trial of the new owner immediately", %{
-      conn: conn,
-      user: user
-    } do
-      Repo.update_all(from(u in Plausible.Auth.User, where: u.id == ^user.id),
-        set: [trial_expiry_date: Timex.today() |> Timex.shift(days: 7)]
-      )
-
-      inviter = insert(:user)
-      site = insert(:site, members: [inviter], locked: false)
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      assert Timex.before?(Repo.reload!(user).trial_expiry_date, Timex.today())
-      assert Repo.reload!(site).locked
-    end
-
-    test "if new owner does not have a trial - will set trial_expiry_date to yesterday",
-         %{
-           conn: conn,
-           user: user
-         } do
-      Repo.update_all(from(u in Plausible.Auth.User, where: u.id == ^user.id),
-        set: [trial_expiry_date: nil]
-      )
-
-      inviter = insert(:user)
-      site = insert(:site, members: [inviter], locked: false)
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      assert Timex.before?(Repo.reload!(user).trial_expiry_date, Timex.today())
-      assert Repo.reload!(site).locked
-    end
-
-    test "can upgrade admin to owner", %{conn: conn, user: user} do
-      old_owner = insert(:user)
-      site = insert(:site, members: [old_owner])
-      insert(:site_membership, site: site, user: user, role: :admin)
-
-      invitation =
-        insert(:invitation, site_id: site.id, inviter: old_owner, email: user.email, role: :owner)
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-
-      refute Repo.exists?(from(i in Plausible.Auth.Invitation, where: i.email == ^user.email))
-
-      new_owner_membership =
-        Repo.get_by(Plausible.Site.Membership, user_id: user.id, site_id: site.id)
-
-      assert new_owner_membership.role == :owner
-    end
-
-    test "works in self-hosted", %{conn: conn, user: user} do
-      patch_env(:is_selfhost, true)
-
-      old_owner = insert(:user)
-      site = insert(:site, members: [old_owner])
-
-      invitation =
-        insert(:invitation,
-          site_id: site.id,
-          inviter: old_owner,
-          email: user.email,
-          role: :owner
-        )
-
-      post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
 
       old_owner_membership =
         Repo.get_by(Plausible.Site.Membership, user_id: old_owner.id, site_id: site.id)

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -76,7 +76,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       user: user
     } do
       inviter = insert(:user)
-      site = insert(:site)
+      site = insert(:site, members: [inviter])
 
       invitation =
         insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
@@ -122,7 +122,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       )
 
       inviter = insert(:user)
-      site = insert(:site, locked: false)
+      site = insert(:site, members: [inviter], locked: false)
 
       invitation =
         insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
@@ -132,7 +132,6 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Repo.reload!(site).locked
     end
 
-    # FIXME: test started failing after changes
     test "will end the trial of the new owner immediately", %{
       conn: conn,
       user: user
@@ -142,7 +141,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       )
 
       inviter = insert(:user)
-      site = insert(:site, locked: false)
+      site = insert(:site, members: [inviter], locked: false)
 
       invitation =
         insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)
@@ -163,7 +162,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       )
 
       inviter = insert(:user)
-      site = insert(:site, locked: false)
+      site = insert(:site, members: [inviter], locked: false)
 
       invitation =
         insert(:invitation, site_id: site.id, inviter: inviter, email: user.email, role: :owner)


### PR DESCRIPTION
This PR refactors and fixes a number of issues with invitation flow:

- invitation accepting, rejecting and removing logic moved to dedicated "service" modules
- accepting logic significantly refactored for readability and clearer sepration between ownership transfer and invite flows
- fixed a bug where it was possible to accept transfer ownership on an owner, degrading them to admin and leaving site without an owner
- fix a bug where it was possible to degrade existing member's role with an invite
- fix grace period end handling in invitation acceptance due to a missing relationship preload in SiteLocker
- improve naming and test coverage of surrounding logic
- prevent issuing transfer ownership on owner's email at the time of issuing the invitation
- make acceptance of invitation and transfer ownerships in problematic cases graceful, without degrading roles and corrupting data integrity (can happen when users update their emails between issuing the invitation and accepting it)
- do not lock sites on transfer ownership on selfhosted instances
- prevent ability to remove invitation from another site on service logic level
- prevent ability to reject invitation by anyone else than invitee

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
