### PR TITLE
Fix dogfooding

### DIFF
--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -230,7 +230,6 @@ defmodule PlausibleWeb.SiteController do
     site = conn.assigns[:site] |> Repo.preload(:custom_domain)
 
     conn
-    |> assign(:skip_plausible_tracking, true)
     |> render("settings_funnels.html",
       site: site,
       dogfood_page_path: "/:dashboard/settings/funnels",
@@ -243,7 +242,6 @@ defmodule PlausibleWeb.SiteController do
     site = conn.assigns[:site] |> Repo.preload(:custom_domain)
 
     conn
-    |> assign(:skip_plausible_tracking, true)
     |> render("settings_props.html",
       site: site,
       dogfood_page_path: "/:dashboard/settings/properties",

--- a/lib/plausible_web/templates/layout/_tracking.html.heex
+++ b/lib/plausible_web/templates/layout/_tracking.html.heex
@@ -1,5 +1,10 @@
 <%= if !Application.get_env(:plausible, :is_selfhost) && !@conn.assigns[:skip_plausible_tracking] do %>
-  <script defer data-api={dogfood_api_destination()} data-domain={dogfood_domain(@conn)} src={dogfood_script_url()}>
+  <script
+    defer
+    data-api={dogfood_api_destination()}
+    data-domain={dogfood_domain(@conn)}
+    src={dogfood_script_url()}
+  >
   </script>
   <script>
     window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }

--- a/lib/plausible_web/templates/layout/_tracking.html.heex
+++ b/lib/plausible_web/templates/layout/_tracking.html.heex
@@ -1,5 +1,5 @@
 <%= if !Application.get_env(:plausible, :is_selfhost) && !@conn.assigns[:skip_plausible_tracking] do %>
-  <script defer data-domain={dogfood_domain(@conn)} src={dogfood_script_url()}>
+  <script defer data-api={dogfood_api_destination()} data-domain={dogfood_domain(@conn)} src={dogfood_script_url()}>
   </script>
   <script>
     window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -29,6 +29,16 @@ defmodule PlausibleWeb.LayoutView do
     end
   end
 
+  @doc """
+  Temporary override to do more testing of the new ingest.plausible.io endpoint for accepting events. In staging and locally
+  will fall back to staging.plausible.io/api/event and localhost:8000/api/event respectively.
+  """
+  def dogfood_api_destination() do
+    if Application.get_env(:plausible, :environment) == "prod" do
+      "https://ingest.plausible.io/api/event"
+    end
+  end
+
   def home_dest(conn) do
     if conn.assigns[:current_user] do
       "/sites"


### PR DESCRIPTION
### Changes

1. Removes the `skip_plausible_tracking` assign from 2 pages that should be tracked
2. Starts sending our own events to `ingest.plausible.io` for further testing of that endpoint