### PR TITLE
Move back to GitHub managed actions runner

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: Build and test
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -22,9 +22,6 @@ jobs:
     services:
       postgres:
         image: postgres:${{ matrix.postgres_version }}
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
         ports:
           - 5432:5432
         env:
@@ -37,9 +34,6 @@ jobs:
 
       clickhouse:
         image: clickhouse/clickhouse-server:23.3.7.5-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
         ports:
           - 8123:8123
         env:


### PR DESCRIPTION
This fixes CI for PRs coming from external repos/contributors 