### PR TITLE
Trigger email reverification on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add `custom_props.csv` to CSV export (almost the same as the old `prop_breakdown.csv`, but has different column headers, and includes props for pageviews too, not only custom events)
 - Add `referrers.csv` to CSV export
 - Improve password validation in registration and password reset forms
+- Enforce email reverification on update
 
 ### Removed
 - Removed the nested custom event property breakdown UI when filtering by a goal in Goal Conversions

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -28,6 +28,7 @@ defmodule Plausible.Auth.User do
     field :trial_expiry_date, :date
     field :theme, Ecto.Enum, values: [:system, :light, :dark]
     field :email_verified, :boolean
+    field :previous_email, :string
     embeds_one :grace_period, Plausible.Auth.GracePeriod, on_replace: :update
 
     has_many :site_memberships, Plausible.Site.Membership
@@ -59,6 +60,30 @@ defmodule Plausible.Auth.User do
     |> cast(attrs, [:email, :name, :theme])
     |> validate_required([:email, :name, :theme])
     |> unique_constraint(:email)
+  end
+
+  def email_changeset(user, attrs \\ %{}) do
+    user
+    |> cast(attrs, [:email, :password])
+    |> validate_required([:email, :password])
+    |> check_password()
+    |> unique_constraint(:email)
+    |> put_change(:email_verified, false)
+    |> put_change(:previous_email, user.email)
+  end
+
+  def cancel_email_changeset(user) do
+    if user.previous_email do
+      user
+      |> change()
+      |> put_change(:email_verified, true)
+      |> put_change(:email, user.previous_email)
+      |> put_change(:previous_email, nil)
+    else
+      user
+      |> change()
+      |> add_error(:previous_email, "can't be blank", validation: :required)
+    end
   end
 
   def changeset(user, attrs \\ %{}) do
@@ -125,6 +150,18 @@ defmodule Plausible.Auth.User do
   catch
     _kind, _value ->
       %{suggestions: [], warning: "", score: 3}
+  end
+
+  defp check_password(changeset) do
+    if password = get_change(changeset, :password) do
+      if Plausible.Auth.Password.match?(password, changeset.data.password_hash) do
+        changeset
+      else
+        add_error(changeset, :password, "is invalid", validation: :check_password)
+      end
+    else
+      changeset
+    end
   end
 
   defp validate_password_strength(changeset) do

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -12,6 +12,7 @@ defmodule Plausible.Auth.UserAdmin do
     [
       name: nil,
       email: nil,
+      previous_email: nil,
       trial_expiry_date: nil
     ]
   end

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -12,6 +12,15 @@ defmodule Plausible.Site.Memberships do
   defdelegate reject_invitation(invitation_id, user), to: Memberships.RejectInvitation
   defdelegate remove_invitation(invitation_id, site), to: Memberships.RemoveInvitation
 
+  @spec any?(String.t()) :: boolean()
+  def any?(user_id) do
+    Repo.exists?(
+      from(m in Plausible.Site.Membership,
+        where: m.user_id == ^user_id
+      )
+    )
+  end
+
   @spec has_any_invitations?(String.t()) :: boolean()
   def has_any_invitations?(email) do
     Repo.exists?(

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -3,9 +3,21 @@ defmodule Plausible.Site.Memberships do
   API for site memberships and invitations
   """
 
+  import Ecto.Query, only: [from: 2]
+
+  alias Plausible.Repo
   alias Plausible.Site.Memberships
 
   defdelegate accept_invitation(invitation_id, user), to: Memberships.AcceptInvitation
   defdelegate reject_invitation(invitation_id, user), to: Memberships.RejectInvitation
   defdelegate remove_invitation(invitation_id, site), to: Memberships.RemoveInvitation
+
+  @spec has_any_invitations?(String.t()) :: boolean()
+  def has_any_invitations?(email) do
+    Repo.exists?(
+      from(i in Plausible.Auth.Invitation,
+        where: i.email == ^email
+      )
+    )
+  end
 end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -260,6 +260,15 @@ defmodule Plausible.Sites do
     role(user_id, site) in [:admin, :owner]
   end
 
+  @spec has_any_sites?(String.t()) :: boolean()
+  def has_any_sites?(user_id) do
+    Repo.exists?(
+      from(m in Plausible.Site.Membership,
+        where: m.user_id == ^user_id
+      )
+    )
+  end
+
   def locked?(%Site{locked: locked}) do
     locked
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -260,15 +260,6 @@ defmodule Plausible.Sites do
     role(user_id, site) in [:admin, :owner]
   end
 
-  @spec has_any_sites?(String.t()) :: boolean()
-  def has_any_sites?(user_id) do
-    Repo.exists?(
-      from(m in Plausible.Site.Membership,
-        where: m.user_id == ^user_id
-      )
-    )
-  end
-
   def locked?(%Site{locked: locked}) do
     locked
   end

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -26,6 +26,15 @@ defmodule Plausible.Users do
     )
   end
 
+  @spec has_email_code?(String.t()) :: boolean()
+  def has_email_code?(user_id) do
+    Repo.exists?(
+      from(c in "email_verification_codes",
+        where: c.user_id == ^user_id
+      )
+    )
+  end
+
   defp last_subscription_query(user_id) do
     from(subscription in Plausible.Billing.Subscription,
       where: subscription.user_id == ^user_id,

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -366,9 +366,9 @@ defmodule PlausibleWeb.AuthController do
     changeset = Auth.User.cancel_email_changeset(conn.assigns.current_user)
 
     case Repo.update(changeset) do
-      {:ok, _user} ->
+      {:ok, user} ->
         conn
-        |> put_flash(:success, "Email update cancelled")
+        |> put_flash(:success, "Email changed back to #{user.email}")
         |> redirect(to: Routes.auth_path(conn, :user_settings) <> "#change-email-address")
 
       {:error, _} ->

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -82,7 +82,7 @@ defmodule PlausibleWeb.AuthController do
     render(conn, "activate.html",
       has_email_code?: Plausible.Users.has_email_code?(user.id),
       has_any_invitations?: Plausible.Site.Memberships.has_any_invitations?(user.email),
-      has_any_sites?: Plausible.Sites.has_any_sites?(user.id),
+      has_any_memberships?: Plausible.Site.Memberships.any?(user.id),
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )
   end
@@ -91,14 +91,14 @@ defmodule PlausibleWeb.AuthController do
     user = conn.assigns[:current_user]
 
     has_any_invitations? = Plausible.Site.Memberships.has_any_invitations?(user.email)
-    has_any_sites? = Plausible.Sites.has_any_sites?(user.id)
+    has_any_memberships? = Plausible.Site.Memberships.any?(user.id)
 
     {code, ""} = Integer.parse(code)
 
     case Auth.verify_email(user, code) do
       :ok ->
         cond do
-          has_any_sites? ->
+          has_any_memberships? ->
             conn
             |> put_flash(:success, "Email updated successfully")
             |> redirect(to: Routes.auth_path(conn, :user_settings) <> "#change-email-address")
@@ -115,7 +115,7 @@ defmodule PlausibleWeb.AuthController do
           error: "Incorrect activation code",
           has_email_code?: true,
           has_any_invitations?: has_any_invitations?,
-          has_any_sites?: has_any_sites?,
+          has_any_memberships?: has_any_memberships?,
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
 
@@ -124,7 +124,7 @@ defmodule PlausibleWeb.AuthController do
           error: "Code is expired, please request another one",
           has_email_code?: false,
           has_any_invitations?: has_any_invitations?,
-          has_any_sites?: has_any_sites?,
+          has_any_memberships?: has_any_memberships?,
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
     end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -155,6 +155,7 @@ defmodule PlausibleWeb.AuthController do
           error: "Code is expired, please request another one",
           has_pin: false,
           has_invitation: has_invitation,
+          has_memberships: has_memberships,
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
     end
@@ -403,7 +404,10 @@ defmodule PlausibleWeb.AuthController do
 
       {:error, _} ->
         conn
-        |> put_flash(:error, "Could not cancel email update")
+        |> put_flash(
+          :error,
+          "Could not cancel email update because previous email has already been taken"
+        )
         |> redirect(to: Routes.auth_path(conn, :activate_form))
     end
   end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -7,6 +7,7 @@ defmodule PlausibleWeb.AuthController do
   plug(
     PlausibleWeb.RequireLoggedOutPlug
     when action in [
+           :register_form,
            :register,
            :register_from_invitation,
            :login_form,
@@ -19,8 +20,15 @@ defmodule PlausibleWeb.AuthController do
     when action in [
            :user_settings,
            :save_settings,
+           :update_email,
+           :cancel_update_email,
+           :new_api_key,
+           :create_api_key,
+           :delete_api_key,
            :delete_me,
-           :activate_form
+           :activate_form,
+           :activate,
+           :request_activation_code
          ]
   )
 
@@ -28,13 +36,6 @@ defmodule PlausibleWeb.AuthController do
 
   defp assign_is_selfhost(conn, _opts) do
     assign(conn, :is_selfhost, Plausible.Release.selfhost?())
-  end
-
-  def register_form(conn, _params) do
-    render(conn, "register_form.html",
-      connect_live_socket: true,
-      layout: {PlausibleWeb.LayoutView, "focus.html"}
-    )
   end
 
   def register(conn, %{"user" => %{"email" => email, "password" => password}}) do

--- a/lib/plausible_web/plugs/require_account.ex
+++ b/lib/plausible_web/plugs/require_account.ex
@@ -1,6 +1,13 @@
 defmodule PlausibleWeb.RequireAccountPlug do
   import Plug.Conn
 
+  @unverified_email_exceptions [
+    ["settings", "email", "cancel"],
+    ["activate"],
+    ["activate", "request-code"],
+    ["me"]
+  ]
+
   def init(options) do
     options
   end
@@ -14,7 +21,8 @@ defmodule PlausibleWeb.RequireAccountPlug do
         |> Phoenix.Controller.redirect(to: "/login")
         |> halt
 
-      not user.email_verified and conn.path_info not in [["activate"], ["me"]] ->
+      not user.email_verified and
+          conn.path_info not in @unverified_email_exceptions ->
         conn
         |> Phoenix.Controller.redirect(to: "/activate")
         |> halt

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -187,6 +187,8 @@ defmodule PlausibleWeb.Router do
     get "/logout", AuthController, :logout
     get "/settings", AuthController, :user_settings
     put "/settings", AuthController, :save_settings
+    put "/settings/email", AuthController, :update_email
+    post "/settings/email/cancel", AuthController, :cancel_update_email
     delete "/me", AuthController, :delete_me
     get "/settings/api-keys/new", AuthController, :new_api_key
     post "/settings/api-keys", AuthController, :create_api_key

--- a/lib/plausible_web/templates/auth/activate.html.eex
+++ b/lib/plausible_web/templates/auth/activate.html.eex
@@ -1,7 +1,13 @@
 <div class="w-full max-w-3xl mt-4 mx-auto flex">
   <%= if @has_pin do %>
     <%= form_for @conn, "/activate", [class: "w-full max-w-lg mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mb-4 mt-8"], fn f -> %>
-      <h2 class="text-xl font-black dark:text-gray-100">Activate your account</h2>
+      <h2 class="text-xl font-black dark:text-gray-100">
+        <%= if @has_memberships do %>
+        Verify your email address
+        <% else %>
+        Activate your account
+        <% end %>
+      </h2>
 
       <div class="mt-2 text-sm text-gray-500 dark:text-gray-200 leading-tight">
         Please enter the 4-digit code we sent to <b><%= @conn.assigns[:current_user].email %></b>
@@ -31,9 +37,15 @@
         Entered the wrong email address?
       </div>
       <ul class="list-disc text-xs text-gray-500 leading-tight mt-1">
+        <%= if @has_memberships do %>
+        <li>
+          <%= link("Change email back to", class: "underline text-indigo-600", to: "/settings/email/cancel", method: "post") %> to <%= @conn.assigns[:current_user].previous_email %>
+        </li>
+        <% else %>
         <li>
           <%= link("Delete this account", class: "underline text-indigo-600", to: "/me?redirect=/register", method: "delete", data: [confirm: "Deleting your account cannot be reversed. Are you sure?"]) %> and start over
         </li>
+        <% end %>
       </ul>
     <% end %>
   <% else %>
@@ -51,7 +63,7 @@
     </div>
   <% end %>
 
-  <%= if !@has_invitation do %>
+  <%= if !@has_invitation and !@has_memberships do %>
     <div class="pt-12 pl-8 hidden md:block">
       <%= render(PlausibleWeb.AuthView, "_onboarding_steps.html", current_step: 1) %>
     </div>

--- a/lib/plausible_web/templates/auth/activate.html.eex
+++ b/lib/plausible_web/templates/auth/activate.html.eex
@@ -1,8 +1,8 @@
 <div class="w-full max-w-3xl mt-4 mx-auto flex">
-  <%= if @has_pin do %>
+  <%= if @has_email_code? do %>
     <%= form_for @conn, "/activate", [class: "w-full max-w-lg mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mb-4 mt-8"], fn f -> %>
       <h2 class="text-xl font-black dark:text-gray-100">
-        <%= if @has_memberships do %>
+        <%= if @has_any_sites? do %>
         Verify your email address
         <% else %>
         Activate your account
@@ -37,7 +37,7 @@
         Entered the wrong email address?
       </div>
       <ul class="list-disc text-xs text-gray-500 leading-tight mt-1">
-        <%= if @has_memberships do %>
+        <%= if @has_any_sites? do %>
         <li>
           <%= link("Change email back to", class: "underline text-indigo-600", to: "/settings/email/cancel", method: "post") %> to <%= @conn.assigns[:current_user].previous_email %>
         </li>
@@ -63,7 +63,7 @@
     </div>
   <% end %>
 
-  <%= if !@has_invitation and !@has_memberships do %>
+  <%= if !@has_any_invitations? and !@has_any_sites? do %>
     <div class="pt-12 pl-8 hidden md:block">
       <%= render(PlausibleWeb.AuthView, "_onboarding_steps.html", current_step: 1) %>
     </div>

--- a/lib/plausible_web/templates/auth/activate.html.eex
+++ b/lib/plausible_web/templates/auth/activate.html.eex
@@ -2,7 +2,7 @@
   <%= if @has_email_code? do %>
     <%= form_for @conn, "/activate", [class: "w-full max-w-lg mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 py-6 mb-4 mt-8"], fn f -> %>
       <h2 class="text-xl font-black dark:text-gray-100">
-        <%= if @has_any_sites? do %>
+        <%= if @has_any_memberships? do %>
         Verify your email address
         <% else %>
         Activate your account
@@ -37,7 +37,7 @@
         Entered the wrong email address?
       </div>
       <ul class="list-disc text-xs text-gray-500 leading-tight mt-1">
-        <%= if @has_any_sites? do %>
+        <%= if @has_any_memberships? do %>
         <li>
           <%= link("Change email back to", class: "underline text-indigo-600", to: "/settings/email/cancel", method: "post") %> to <%= @conn.assigns[:current_user].previous_email %>
         </li>
@@ -63,7 +63,7 @@
     </div>
   <% end %>
 
-  <%= if !@has_any_invitations? and !@has_any_sites? do %>
+  <%= if !@has_any_invitations? and !@has_any_memberships? do %>
     <div class="pt-12 pl-8 hidden md:block">
       <%= render(PlausibleWeb.AuthView, "_onboarding_steps.html", current_step: 1) %>
     </div>

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -222,7 +222,7 @@
 
   <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
 
-  <%= form_for @changeset, "/settings", [class: "max-w-sm"], fn f -> %>
+  <%= form_for @settings_changeset, "/settings", [class: "max-w-sm"], fn f -> %>
     <div class="col-span-4 sm:col-span-2">
       <%= label(f, :theme, "Theme Selection",
         class: "block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300"
@@ -237,11 +237,11 @@
 </div>
 
 <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-indigo-100 rounded rounded-t-none shadow-md dark:bg-gray-800 dark:border-indigo-500">
-  <h2 class="text-xl font-black dark:text-gray-100">Account settings</h2>
+  <h2 id="account-settings" class="text-xl font-black dark:text-gray-100">Account settings</h2>
 
   <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
 
-  <%= form_for @changeset, "/settings", [class: "max-w-sm"], fn f -> %>
+  <%= form_for @settings_changeset, "/settings#account-settings", [class: "max-w-sm"], fn f -> %>
     <div class="my-4">
       <%= label(f, :name, class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
       <div class="mt-1">
@@ -250,16 +250,6 @@
             "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
         ) %>
         <%= error_tag(f, :name) %>
-      </div>
-    </div>
-    <div class="my-4">
-      <%= label(f, :email, class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
-      <div class="mt-1">
-        <%= email_input(f, :email,
-          class:
-            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md"
-        ) %>
-        <%= error_tag(f, :email) %>
       </div>
     </div>
     <%= submit("Save changes", class: "button mt-4") %>
@@ -328,6 +318,49 @@
       </div>
     </div>
   </div>
+</div>
+
+<div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">
+  <h2 id="change-email-address" class="text-xl font-black dark:text-gray-100">Change email address</h2>
+
+  <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
+
+  <%= form_for @email_changeset, "/settings/email#change-email-address", [class: "max-w-sm"], fn f -> %>
+    <div class="my-4">
+      <%= label(f, :password, "Account password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
+      <div class="mt-1">
+        <%= password_input(f, :password,
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
+        ) %>
+        <%= error_tag(f, :password) %>
+      </div>
+    </div>
+    <div class="my-4">
+      <%= label(f, :current_email, "Current email", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
+      <div class="mt-1">
+        <%= email_input(f, :current_email,
+          readonly: true,
+          value: f.source.data.email,
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800 bg-gray-100"
+        ) %>
+      </div>
+    </div>
+    <div class="my-4">
+      <%= label(f, :email, "New email", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
+      <div class="mt-1">
+        <%= email_input(f, :email,
+          value: f.source.changes[:email],
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md"
+        ) %>
+        <%= error_tag(f, :email) %>
+      </div>
+    </div>
+
+    <%= submit("Change my email", class: "inline-block mt-4 px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-red-700 bg-white dark:bg-gray-800 hover:text-red-500 dark:hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150") %>
+  <% end %>
 </div>
 
 <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 mb-24 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -237,11 +237,13 @@
 </div>
 
 <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-indigo-100 rounded rounded-t-none shadow-md dark:bg-gray-800 dark:border-indigo-500">
-  <h2 id="account-settings" class="text-xl font-black dark:text-gray-100">Account settings</h2>
+  <h2 id="change-account-name" class="text-xl font-black dark:text-gray-100">
+    Change account name
+  </h2>
 
   <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
 
-  <%= form_for @settings_changeset, "/settings#account-settings", [class: "max-w-sm"], fn f -> %>
+  <%= form_for @settings_changeset, "/settings#change-account-name", [class: "max-w-sm"], fn f -> %>
     <div class="my-4">
       <%= label(f, :name, class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
       <div class="mt-1">
@@ -252,7 +254,61 @@
         <%= error_tag(f, :name) %>
       </div>
     </div>
-    <%= submit("Save changes", class: "button mt-4") %>
+    <%= submit("Save", class: "button mt-4") %>
+  <% end %>
+</div>
+
+<div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">
+  <h2 id="change-email-address" class="text-xl font-black dark:text-gray-100">
+    Change email address
+  </h2>
+
+  <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
+
+  <%= form_for @email_changeset, "/settings/email#change-email-address", [class: "max-w-sm"], fn f -> %>
+    <div class="my-4">
+      <%= label(f, :password, "Account password",
+        class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+      ) %>
+      <div class="mt-1">
+        <%= password_input(f, :password,
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
+        ) %>
+        <%= error_tag(f, :password) %>
+      </div>
+    </div>
+    <div class="my-4">
+      <%= label(f, :current_email, "Current email",
+        class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+      ) %>
+      <div class="mt-1">
+        <%= email_input(f, :current_email,
+          readonly: true,
+          value: f.data.email,
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800 bg-gray-100"
+        ) %>
+      </div>
+    </div>
+    <div class="my-4">
+      <%= label(f, :email, "New email",
+        class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+      ) %>
+      <div class="mt-1">
+        <%= email_input(f, :email,
+          value: f.params["email"],
+          class:
+            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md"
+        ) %>
+        <%= error_tag(f, :email) %>
+      </div>
+    </div>
+
+    <%= submit("Change my email",
+      class:
+        "inline-block mt-4 px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-red-700 bg-white dark:bg-gray-800 hover:text-red-500 dark:hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150"
+    ) %>
   <% end %>
 </div>
 
@@ -318,49 +374,6 @@
       </div>
     </div>
   </div>
-</div>
-
-<div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">
-  <h2 id="change-email-address" class="text-xl font-black dark:text-gray-100">Change email address</h2>
-
-  <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
-
-  <%= form_for @email_changeset, "/settings/email#change-email-address", [class: "max-w-sm"], fn f -> %>
-    <div class="my-4">
-      <%= label(f, :password, "Account password", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
-      <div class="mt-1">
-        <%= password_input(f, :password,
-          class:
-            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
-        ) %>
-        <%= error_tag(f, :password) %>
-      </div>
-    </div>
-    <div class="my-4">
-      <%= label(f, :current_email, "Current email", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
-      <div class="mt-1">
-        <%= email_input(f, :current_email,
-          readonly: true,
-          value: f.source.data.email,
-          class:
-            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800 bg-gray-100"
-        ) %>
-      </div>
-    </div>
-    <div class="my-4">
-      <%= label(f, :email, "New email", class: "block text-sm font-medium text-gray-700 dark:text-gray-300") %>
-      <div class="mt-1">
-        <%= email_input(f, :email,
-          value: f.source.changes[:email],
-          class:
-            "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md"
-        ) %>
-        <%= error_tag(f, :email) %>
-      </div>
-    </div>
-
-    <%= submit("Change my email", class: "inline-block mt-4 px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-red-700 bg-white dark:bg-gray-800 hover:text-red-500 dark:hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150") %>
-  <% end %>
 </div>
 
 <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 mb-24 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -52,7 +52,7 @@ seeded_token = Plausible.Plugins.API.Token.generate("seed-token")
 {:ok, goal2} = Plausible.Goals.create(site, %{"page_path" => "/register"})
 {:ok, goal3} = Plausible.Goals.create(site, %{"page_path" => "/login"})
 {:ok, goal4} = Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => "USD"})
-{:ok, goal5} = Plausible.Goals.create(site, %{"page_path" => Enum.random(long_random_paths)})
+{:ok, _goal5} = Plausible.Goals.create(site, %{"page_path" => Enum.random(long_random_paths)})
 {:ok, outbound} = Plausible.Goals.create(site, %{"event_name" => "Outbound Link: Click"})
 
 {:ok, _funnel} =

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -688,6 +688,135 @@ defmodule PlausibleWeb.AuthControllerTest do
     end
   end
 
+  describe "PUT /settings/email" do
+    setup [:create_user, :log_in]
+
+    test "updates email and forces reverification", %{conn: conn, user: user} do
+      password = "very-long-very-secret-123"
+
+      user
+      |> User.set_password(password)
+      |> Repo.update!()
+
+      assert user.email_verified
+
+      conn =
+        put(conn, "/settings/email", %{
+          "user" => %{"email" => "new" <> user.email, "password" => password}
+        })
+
+      assert redirected_to(conn, 302) == Routes.auth_path(conn, :activate)
+
+      updated_user = Repo.reload!(user)
+
+      assert updated_user.email == "new" <> user.email
+      assert updated_user.previous_email == user.email
+      refute updated_user.email_verified
+
+      assert_delivered_email_matches(%{to: [{_, user_email}], subject: subject})
+      assert user_email == updated_user.email
+      assert subject =~ "is your Plausible email verification code"
+    end
+
+    test "renders form with error on no fields filled", %{conn: conn} do
+      conn = put(conn, "/settings/email", %{"user" => %{}})
+
+      assert html_response(conn, 200) =~ "can&#39;t be blank"
+    end
+
+    test "renders form with error on invalid password", %{conn: conn, user: user} do
+      conn =
+        put(conn, "/settings/email", %{
+          "user" => %{"password" => "invalid", "email" => "new" <> user.email}
+        })
+
+      assert html_response(conn, 200) =~ "is invalid"
+    end
+
+    test "renders form with error on already taken email", %{conn: conn, user: user} do
+      other_user = insert(:user)
+
+      password = "very-long-very-secret-123"
+
+      user
+      |> User.set_password(password)
+      |> Repo.update!()
+
+      conn =
+        put(conn, "/settings/email", %{
+          "user" => %{"password" => password, "email" => other_user.email}
+        })
+
+      assert html_response(conn, 200) =~ "has already been taken"
+    end
+  end
+
+  describe "POST /settings/email/cancel" do
+    setup [:create_user, :log_in]
+
+    test "cancels email reverification in progress", %{conn: conn, user: user} do
+      user =
+        user
+        |> Ecto.Changeset.change(
+          email_verified: false,
+          email: "new" <> user.email,
+          previous_email: user.email
+        )
+        |> Repo.update!()
+
+      conn = post(conn, "/settings/email/cancel")
+
+      assert redirected_to(conn, 302) ==
+               Routes.auth_path(conn, :user_settings) <> "#change-email-address"
+
+      updated_user = Repo.reload!(user)
+
+      assert updated_user.email_verified
+      assert updated_user.email == user.previous_email
+      refute updated_user.previous_email
+    end
+
+    test "fails to cancel reverification when previous email is already retaken", %{
+      conn: conn,
+      user: user
+    } do
+      user =
+        user
+        |> Ecto.Changeset.change(
+          email_verified: false,
+          email: "new" <> user.email,
+          previous_email: user.email
+        )
+        |> Repo.update!()
+
+      _other_user = insert(:user, email: user.previous_email)
+
+      conn = post(conn, "/settings/email/cancel")
+
+      assert redirected_to(conn, 302) == Routes.auth_path(conn, :activate_form)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "Could not cancel email update"
+    end
+
+    test "crashes when previous email is empty on cancel (should not happen)", %{
+      conn: conn,
+      user: user
+    } do
+      user
+      |> Ecto.Changeset.change(
+        email_verified: false,
+        email: "new" <> user.email,
+        previous_email: nil
+      )
+      |> Repo.update!()
+
+      assert_raise RuntimeError, ~r/Previous email is empty for user/, fn ->
+        post(conn, "/settings/email/cancel")
+      end
+    end
+  end
+
   describe "DELETE /me" do
     setup [:create_user, :log_in, :create_new_site]
     use Plausible.Repo

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -749,6 +749,24 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       assert html_response(conn, 200) =~ "has already been taken"
     end
+
+    test "renders form with error when email is identical with the current one", %{
+      conn: conn,
+      user: user
+    } do
+      password = "very-long-very-secret-123"
+
+      user
+      |> User.set_password(password)
+      |> Repo.update!()
+
+      conn =
+        put(conn, "/settings/email", %{
+          "user" => %{"password" => password, "email" => user.email}
+        })
+
+      assert html_response(conn, 200) =~ "can&#39;t be the same"
+    end
   end
 
   describe "POST /settings/email/cancel" do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -440,7 +440,9 @@ defmodule PlausibleWeb.AuthControllerTest do
 
     test "shows the form", %{conn: conn} do
       conn = get(conn, "/settings")
-      assert html_response(conn, 200) =~ "Account settings"
+      assert resp = html_response(conn, 200)
+      assert resp =~ "Change account name"
+      assert resp =~ "Change email address"
     end
 
     test "shows subscription", %{conn: conn, user: user} do


### PR DESCRIPTION
### Changes

[email_reverification.webm](https://github.com/plausible/analytics/assets/588351/69c2d8eb-3b4a-4bc2-8da4-1f2a4c64d7b0)

Email now must be reverified on change. In order to intiate the change, current user password must be provided.

The settings form was slightly reorganized in the process.

There's ability to cancel reverification from activation view.

Draft of documentation update is prepared in https://github.com/plausible/docs/pull/438

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
