### PR TITLE
Ensure that `User.password_strength/1` always returns a value

### DIFF
--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -122,6 +122,9 @@ defmodule Plausible.Auth.User do
             %{suggestions: [], warning: "", score: 3}
         end
     end
+  catch
+    _kind, _value ->
+      %{suggestions: [], warning: "", score: 3}
   end
 
   defp validate_password_strength(changeset) do


### PR DESCRIPTION
### Changes

This change ensures that password strength check never crashes, always prioritising not breaking affected flows (especially registration and invites). Minimum password length is still enforced anyway,

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests (or rather, there's no known input that would let me test it)

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
