### PR TITLE
Improve domain cleanup on site creation

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -221,12 +221,12 @@ defmodule Plausible.Site do
   defp clean_domain(changeset) do
     clean_domain =
       (get_field(changeset, :domain) || "")
+      |> String.downcase()
       |> String.trim()
       |> String.replace_leading("http://", "")
       |> String.replace_leading("https://", "")
+      |> String.trim("/")
       |> String.replace_leading("www.", "")
-      |> String.replace_trailing("/", "")
-      |> String.downcase()
 
     change(changeset, %{domain: clean_domain})
   end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -235,17 +235,19 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert Repo.get_by(Plausible.Site, domain: "example.com")
     end
 
-    test "cleans up the url", %{conn: conn} do
-      conn =
-        post(conn, "/sites", %{
-          "site" => %{
-            "domain" => "https://www.Example.com/",
-            "timezone" => "Europe/London"
-          }
-        })
+    for url <- ["https://Example.com/", "HTTPS://EXAMPLE.COM/", "/Example.com/", "//Example.com/"] do
+      test "cleans up an url like #{url}", %{conn: conn} do
+        conn =
+          post(conn, "/sites", %{
+            "site" => %{
+              "domain" => unquote(url),
+              "timezone" => "Europe/London"
+            }
+          })
 
-      assert redirected_to(conn) == "/example.com/snippet"
-      assert Repo.get_by(Plausible.Site, domain: "example.com")
+        assert redirected_to(conn) == "/example.com/snippet"
+        assert Repo.get_by(Plausible.Site, domain: "example.com")
+      end
     end
 
     test "renders form again when domain is missing", %{conn: conn} do


### PR DESCRIPTION
### Changes

As in the title. Any extra leading slashes are removed from the name in the process as it does not work well with local HTTP redirects.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
