### PR TITLE
Fix invalid subscription preload in SiteLocker email submission routine

### DIFF
--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -68,7 +68,6 @@ defmodule Plausible.Billing.SiteLocker do
 
   @spec send_grace_period_end_email(Plausible.Auth.User.t()) :: Plausible.Mailer.result()
   def send_grace_period_end_email(user) do
-    user = Repo.preload(user, :subscription)
     {_, last_cycle} = Plausible.Billing.last_two_billing_cycles(user)
     {_, last_cycle_usage} = Plausible.Billing.last_two_billing_months_usage(user)
     suggested_plan = Plausible.Billing.Plans.suggest(user, last_cycle_usage)

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -40,7 +40,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
       case Repo.transaction(multi) do
         {:ok, changes} ->
           if changes[:site_locker] == {:locked, :grace_period_ended_now} do
-            Billing.SiteLocker.send_grace_period_end_email(changes.user)
+            user = Plausible.Users.with_subscription(changes.user)
+            Billing.SiteLocker.send_grace_period_end_email(user)
           end
 
           notify_invitation_accepted(invitation)


### PR DESCRIPTION
### Changes

Fixes invalid preload of subscription on user in a corner case of sending email about grace period ending right around accepting ownership transfer.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
