### PR TITLE
Add constraint enforcing at most one owner membership per site

### DIFF
--- a/priv/repo/migrations/20231010074900_add_unique_index_on_site_memberships_site_id_when_owner.exs
+++ b/priv/repo/migrations/20231010074900_add_unique_index_on_site_memberships_site_id_when_owner.exs
@@ -1,0 +1,13 @@
+defmodule Plausible.Repo.Migrations.AddUniqueIndexOnSiteMembershipsSiteIdWhenOwner do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create_if_not_exists unique_index(:site_memberships, [:site_id],
+                           where: "role = 'owner'",
+                           concurrently: true
+                         )
+  end
+end

--- a/test/plausible/site/membership_test.exs
+++ b/test/plausible/site/membership_test.exs
@@ -1,0 +1,15 @@
+defmodule Plausible.Site.MembershipTest do
+  use Plausible.DataCase
+
+  test "raises on trying to insert two owner memberships for the same site" do
+    user1 = insert(:user)
+    user2 = insert(:user)
+    site = insert(:site)
+
+    insert(:site_membership, site: site, user: user1, role: "owner")
+
+    assert_raise Ecto.ConstraintError, ~r/site_memberships_site_id_index/, fn ->
+      insert(:site_membership, site: site, user: user2, role: "owner")
+    end
+  end
+end


### PR DESCRIPTION
### Changes

As in the title. It ensures better data integrity in case such invalid state slips through application-level validations.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
