### PR TITLE
Make FixBrokenGoals migration idempotent

### DIFF
--- a/priv/repo/migrations/20230914071244_fix_broken_goals.exs
+++ b/priv/repo/migrations/20230914071244_fix_broken_goals.exs
@@ -10,6 +10,11 @@ defmodule Plausible.Repo.Migrations.FixBrokenGoals do
     """)
 
     execute("""
+    ALTER TABLE goals
+    DROP CONSTRAINT IF EXISTS check_event_name_or_page_path;
+    """)
+
+    execute("""
      ALTER TABLE goals
      ADD CONSTRAINT check_event_name_or_page_path
      CHECK (
@@ -23,7 +28,7 @@ defmodule Plausible.Repo.Migrations.FixBrokenGoals do
   def down do
     execute("""
     ALTER TABLE goals
-    DROP CONSTRAINT check_event_name_or_page_path;
+    DROP CONSTRAINT IF EXISTS check_event_name_or_page_path;
     """)
   end
 end

--- a/rel/overlays/pending-migrations.sh
+++ b/rel/overlays/pending-migrations.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# lists pending migrations
+
+BIN_DIR=$(dirname "$0")
+
+"${BIN_DIR}"/bin/plausible eval Plausible.Release.pending_migrations


### PR DESCRIPTION
The migration in question was renamed in order to fix order of executing migrations when run from the ground up (via https://github.com/plausible/analytics/pull/3378).

As a side effect, it's executed again on databases that had it applied earlier, with a different timestamp prefix.

As this migration is safe to run multiple times, it was modified to make forward migration work gracefully when constraint already exists.

Tested locally by manually removing migration version from `schema_migrations` and rerunning migrations again - behaves fine.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
