### PR TITLE
Fix email update flow for selfhosted setup with verification disabled

### DIFF
--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Auth.User do
     |> validate_email_changed()
     |> check_password()
     |> unique_constraint(:email)
-    |> put_change(:email_verified, false)
+    |> set_email_verified()
     |> put_change(:previous_email, user.email)
   end
 

--- a/test/plausible_web/controllers/auth_controller_sync_test.exs
+++ b/test/plausible_web/controllers/auth_controller_sync_test.exs
@@ -1,0 +1,42 @@
+defmodule PlausibleWeb.AuthControllerSyncTest do
+  use PlausibleWeb.ConnCase
+  use Bamboo.Test
+  use Plausible.Repo
+
+  alias Plausible.Auth.User
+
+  describe "PUT /settings/email" do
+    setup [:create_user, :log_in]
+
+    test "updates email but DOES NOT force reverification when feature disabled", %{
+      conn: conn,
+      user: user
+    } do
+      patch_env(:selfhost, enable_email_verification: false)
+
+      password = "very-long-very-secret-123"
+
+      user
+      |> User.set_password(password)
+      |> Repo.update!()
+
+      assert user.email_verified
+
+      conn =
+        put(conn, "/settings/email", %{
+          "user" => %{"email" => "new" <> user.email, "password" => password}
+        })
+
+      assert redirected_to(conn, 302) ==
+               Routes.auth_path(conn, :user_settings) <> "#change-email-address"
+
+      updated_user = Repo.reload!(user)
+
+      assert updated_user.email == "new" <> user.email
+      assert updated_user.previous_email == user.email
+      assert updated_user.email_verified
+
+      assert_no_emails_delivered()
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Follow-up to #3388 that fixes regression in cases of self-hosted setups with email verification disabled.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
