### PR TITLE
No longer require domain to seek Plugins API Tokens

### DIFF
--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -18,15 +18,14 @@ defmodule Plausible.Plugins.API.Tokens do
     end
   end
 
-  @spec find(String.t(), String.t()) :: {:ok, Token.t()} | {:error, :not_found}
-  def find(domain, raw) do
+  @spec find(String.t()) :: {:ok, Token.t()} | {:error, :not_found}
+  def find(raw) do
     found =
       Repo.one(
         from(t in Token,
           inner_join: s in Site,
           on: s.id == t.site_id,
           where: t.token_hash == ^Token.hash(raw),
-          where: s.domain == ^domain or s.domain_changed_from == ^domain,
           preload: [:site]
         )
       )

--- a/lib/plausible_web/plugins/api/spec.ex
+++ b/lib/plausible_web/plugins/api/spec.ex
@@ -28,8 +28,9 @@ defmodule PlausibleWeb.Plugins.API.Spec do
             type: "http",
             scheme: "basic",
             description: """
-            HTTP basic access authentication using your Site domain as the
+            HTTP basic access authentication using your Site Domain as the
             username and the Plugins API Token contents as the password.
+            Note that Site Domain is optional, a password alone suffices.
 
             For more information see
             https://en.wikipedia.org/wiki/Basic_access_authentication

--- a/lib/plausible_web/plugs/authorize_plugins_api.ex
+++ b/lib/plausible_web/plugs/authorize_plugins_api.ex
@@ -10,14 +10,14 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPI do
   def init(opts), do: opts
 
   def call(conn, _opts \\ []) do
-    with {:ok, domain, token} <- extract_token(conn),
-         {:ok, conn} <- authorize(conn, domain, token) do
+    with {:ok, token} <- extract_token(conn),
+         {:ok, conn} <- authorize(conn, token) do
       conn
     end
   end
 
-  defp authorize(conn, domain, token_value) do
-    case Tokens.find(domain, token_value) do
+  defp authorize(conn, token_value) do
+    case Tokens.find(token_value) do
       {:ok, token} ->
         {:ok, Plug.Conn.assign(conn, :authorized_site, token.site)}
 
@@ -28,8 +28,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPI do
 
   defp extract_token(conn) do
     case Plug.BasicAuth.parse_basic_auth(conn) do
-      {token_identifier, token_value} ->
-        {:ok, token_identifier, token_value}
+      {_token_identifier, token_value} ->
+        {:ok, token_value}
 
       :error ->
         Errors.unauthorized(conn)

--- a/test/plausible/plugins/api/tokens_test.exs
+++ b/test/plausible/plugins/api/tokens_test.exs
@@ -31,26 +31,13 @@ defmodule Plausible.Plugins.API.TokensTest do
     test "finds the right token" do
       site = insert(:site)
       assert {:ok, _, raw} = Tokens.create(site, "My test token")
-      assert {:ok, found} = Tokens.find(site.domain, raw)
+      assert {:ok, found} = Tokens.find(raw)
       assert found.id == found.id
-    end
-
-    test "finds the right token after domain change" do
-      site = insert(:site, domain: "foo1.example.com")
-      assert {:ok, _, raw} = Tokens.create(site, "My test token")
-
-      {:ok, _} = Plausible.Site.Domain.change(site, "foo2.example.com")
-
-      assert {:ok, found} = Tokens.find("foo1.example.com", raw)
-      assert {:ok, ^found} = Tokens.find("foo2.example.com", raw)
+      assert found.site_id == site.id
     end
 
     test "fails to find the token" do
-      site = insert(:site)
-      assert {:ok, _, _} = Tokens.create(site, "My test token")
-
-      assert {:error, :not_found} = Tokens.find(site.domain, "non-existing")
-      assert {:error, :not_found} = Tokens.find("non-existing", "non-existing")
+      assert {:error, :not_found} = Tokens.find("non-existing")
     end
   end
 end

--- a/test/plausible_web/plugs/authorize_plugins_api_test.exs
+++ b/test/plausible_web/plugs/authorize_plugins_api_test.exs
@@ -21,6 +21,21 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
     assert %Plausible.Site{id: ^site_id} = conn.assigns.authorized_site
   end
 
+  test "plug passes when a token is found, no domain provided" do
+    %{id: site_id} = site = insert(:site, domain: "pass.example.com")
+    {:ok, _, raw} = Tokens.create(site, "Some token")
+
+    credentials = "Basic " <> Base.encode64(":#{raw}")
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", credentials)
+      |> AuthorizePluginsAPI.call()
+
+    refute conn.halted
+    assert %Plausible.Site{id: ^site_id} = conn.assigns.authorized_site
+  end
+
   test "plug halts when a token is not found" do
     site = insert(:site, domain: "pass.example.com")
 

--- a/test/plausible_web/plugs/authorize_plugins_api_test.exs
+++ b/test/plausible_web/plugs/authorize_plugins_api_test.exs
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
     %{id: site_id} = site = insert(:site, domain: "pass.example.com")
     {:ok, _, raw} = Tokens.create(site, "Some token")
 
-    credentials = "Basic " <> Base.encode64(":#{raw}")
+    credentials = "Basic " <> Base.encode64(raw)
 
     conn =
       build_conn()


### PR DESCRIPTION
### Changes

This makes it easier to integrate with -- in case data-domain is different than the actual site domain. Tokens are already associated with a single site anyway.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
