### PR TITLE
Implement direct site ownership transfer without invite via CRM

### DIFF
--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -8,6 +8,7 @@ defmodule Plausible.Site.Memberships do
   alias Plausible.Repo
   alias Plausible.Site.Memberships
 
+  defdelegate transfer_ownership(site, user), to: Memberships.AcceptInvitation
   defdelegate accept_invitation(invitation_id, user), to: Memberships.AcceptInvitation
   defdelegate reject_invitation(invitation_id, user), to: Memberships.RejectInvitation
   defdelegate remove_invitation(invitation_id, site), to: Memberships.RemoveInvitation

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -4,7 +4,174 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
   alias Plausible.Site.Memberships.AcceptInvitation
 
-  describe "invitations" do
+  describe "transfer_ownership/3" do
+    for {label, opts} <- [{"cloud", []}, {"selfhosted", [selfhost?: true]}] do
+      test "transfers ownership on #{label} instance" do
+        site = insert(:site, memberships: [])
+        existing_owner = insert(:user)
+
+        existing_membership =
+          insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+        new_owner = insert(:user)
+
+        assert {:ok, new_membership} =
+                 AcceptInvitation.transfer_ownership(site, new_owner, unquote(opts))
+
+        assert new_membership.site_id == site.id
+        assert new_membership.user_id == new_owner.id
+        assert new_membership.role == :owner
+
+        existing_membership = Repo.reload!(existing_membership)
+        assert existing_membership.user_id == existing_owner.id
+        assert existing_membership.site_id == site.id
+        assert existing_membership.role == :admin
+
+        assert_no_emails_delivered()
+      end
+    end
+
+    for role <- [:viewer, :admin] do
+      test "upgrades existing #{role} membership into an owner" do
+        existing_owner = insert(:user)
+        new_owner = insert(:user)
+
+        site =
+          insert(:site,
+            memberships: [
+              build(:site_membership, user: existing_owner, role: :owner),
+              build(:site_membership, user: new_owner, role: unquote(role))
+            ]
+          )
+
+        assert {:ok, %{id: membership_id}} = AcceptInvitation.transfer_ownership(site, new_owner)
+
+        assert %{role: :admin} =
+                 Plausible.Repo.get_by(Plausible.Site.Membership, user_id: existing_owner.id)
+
+        assert %{id: ^membership_id, role: :owner} =
+                 Plausible.Repo.get_by(Plausible.Site.Membership, user_id: new_owner.id)
+      end
+    end
+
+    test "does not degrade or alter trial when accepting ownership transfer by self" do
+      owner = insert(:user, trial_expiry_date: nil)
+      site = insert(:site, memberships: [build(:site_membership, user: owner, role: :owner)])
+
+      assert {:ok, %{id: membership_id}} = AcceptInvitation.transfer_ownership(site, owner)
+
+      assert %{id: ^membership_id, role: :owner} =
+               Plausible.Repo.get_by(Plausible.Site.Membership, user_id: owner.id)
+
+      assert Repo.reload!(owner).trial_expiry_date == nil
+    end
+
+    test "locks the site if the new owner has no active subscription or trial" do
+      existing_owner = insert(:user)
+
+      site =
+        insert(:site,
+          locked: false,
+          memberships: [build(:site_membership, user: existing_owner, role: :owner)]
+        )
+
+      new_owner = insert(:user, trial_expiry_date: Date.add(Date.utc_today(), -1))
+
+      assert {:ok, _membership} = AcceptInvitation.transfer_ownership(site, new_owner)
+
+      assert Repo.reload!(site).locked
+    end
+
+    test "does not lock the site or set trial expiry date if the instance is selfhosted" do
+      existing_owner = insert(:user)
+
+      site =
+        insert(:site,
+          locked: false,
+          memberships: [build(:site_membership, user: existing_owner, role: :owner)]
+        )
+
+      new_owner = insert(:user, trial_expiry_date: nil)
+
+      assert {:ok, _membership} =
+               AcceptInvitation.transfer_ownership(site, new_owner, selfhost?: true)
+
+      assert Repo.reload!(new_owner).trial_expiry_date == nil
+      refute Repo.reload!(site).locked
+    end
+
+    test "ends trial of the new owner immediately" do
+      existing_owner = insert(:user)
+
+      site =
+        insert(:site,
+          locked: false,
+          memberships: [build(:site_membership, user: existing_owner, role: :owner)]
+        )
+
+      new_owner = insert(:user, trial_expiry_date: Date.add(Date.utc_today(), 7))
+
+      assert {:ok, _membership} = AcceptInvitation.transfer_ownership(site, new_owner)
+
+      assert Repo.reload!(new_owner).trial_expiry_date == Date.add(Date.utc_today(), -1)
+      assert Repo.reload!(site).locked
+    end
+
+    test "sets user's trial expiry date to yesterday if they don't have one" do
+      existing_owner = insert(:user)
+
+      site =
+        insert(:site,
+          locked: false,
+          memberships: [build(:site_membership, user: existing_owner, role: :owner)]
+        )
+
+      new_owner = insert(:user, trial_expiry_date: nil)
+
+      assert {:ok, _membership} = AcceptInvitation.transfer_ownership(site, new_owner)
+
+      assert Repo.reload!(new_owner).trial_expiry_date == Date.add(Date.utc_today(), -1)
+      assert Repo.reload!(site).locked
+    end
+
+    test "ends grace period and sends an email about it if new owner is past grace period" do
+      existing_owner = insert(:user)
+
+      site =
+        insert(:site,
+          locked: false,
+          memberships: [build(:site_membership, user: existing_owner, role: :owner)]
+        )
+
+      new_owner = insert(:user, trial_expiry_date: Date.add(Date.utc_today(), -1))
+      insert(:subscription, user: new_owner, next_bill_date: Timex.today())
+
+      new_owner =
+        new_owner
+        |> Plausible.Auth.GracePeriod.start_changeset(100)
+        |> then(fn changeset ->
+          grace_period =
+            changeset
+            |> get_field(:grace_period)
+            |> Map.put(:end_date, Date.add(Date.utc_today(), -1))
+
+          change(changeset, grace_period: grace_period)
+        end)
+        |> Repo.update!()
+
+      assert {:ok, _membership} = AcceptInvitation.transfer_ownership(site, new_owner)
+
+      assert Repo.reload!(new_owner).grace_period.is_over
+      assert Repo.reload!(site).locked
+
+      assert_email_delivered_with(
+        to: [{"Jane Smith", new_owner.email}],
+        subject: "[Action required] Your Plausible dashboard is now locked"
+      )
+    end
+  end
+
+  describe "accept_invitation/3 - invitations" do
     test "converts an invitation into a membership" do
       inviter = insert(:user)
       invitee = insert(:user)
@@ -91,7 +258,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
     end
   end
 
-  describe "ownership transfers" do
+  describe "accept_invitation/3 - ownership transfers" do
     for {label, opts} <- [{"cloud", []}, {"selfhosted", [selfhost?: true]}] do
       test "converts an ownership transfer into a membership on #{label} instance" do
         site = insert(:site, memberships: [])


### PR DESCRIPTION
### Changes

Additional action for bulk transfer of ownership of multiple sites to a new owner without issuing invites.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
