### PR TITLE
Disable deduplication for improted_* tables in CH

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -63,7 +63,7 @@ jobs:
             _build
             priv/plts
           key: ${{ runner.os }}-mix-v5-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-v500-
+          restore-keys: ${{ runner.os }}-mix-v5-
       - name: Install dependencies
         run: mix deps.get && npm install --prefix ./tracker
       - name: Check Formatting

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -56,7 +56,7 @@ jobs:
           elixir-version: ${{steps.versions.outputs.elixir}}
           otp-version: ${{ steps.versions.outputs.erlang}}
       - name: Restore dependencies cache
-        uses: buildjet/cache@v3
+        uses: buildjet/cache@v300
         with:
           path: |
             deps

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -56,14 +56,14 @@ jobs:
           elixir-version: ${{steps.versions.outputs.elixir}}
           otp-version: ${{ steps.versions.outputs.erlang}}
       - name: Restore dependencies cache
-        uses: buildjet/cache@v300
+        uses: buildjet/cache@v3
         with:
           path: |
             deps
             _build
             priv/plts
           key: ${{ runner.os }}-mix-v5-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-v5-
+          restore-keys: ${{ runner.os }}-mix-v500-
       - name: Install dependencies
         run: mix deps.get && npm install --prefix ./tracker
       - name: Check Formatting

--- a/priv/ingest_repo/migrations/20231017073642_disable_deduplication_window_for_imports.exs
+++ b/priv/ingest_repo/migrations/20231017073642_disable_deduplication_window_for_imports.exs
@@ -1,0 +1,26 @@
+defmodule Plausible.IngestRepo.Migrations.DisableDeduplicationWindowForImports do
+  use Ecto.Migration
+
+  @import_tables ~w(
+    imported_visitors 
+    imported_sources 
+    imported_pages 
+    imported_entry_pages 
+    imported_exit_pages 
+    imported_locations 
+    imported_devices 
+    imported_browsers 
+    imported_operating_systems
+  )
+
+  def change do
+    for table <- @import_tables do
+      execute """
+              ALTER TABLE #{table} MODIFY SETTING replicated_deduplication_window = 0
+              """,
+              """
+              ALTER TABLE #{table} MODIFY SETTING replicated_deduplication_window = 100
+              """
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Disable deduplication of inserted parts for imported tables to improve behavior on reimporting.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
