### PR TITLE
Refactor: Add 'goals' feature to JSON plan files

### DIFF
--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -32,7 +32,7 @@ defmodule Plausible.Billing.Feature do
   @callback toggle_field() :: atom()
 
   @doc """
-  Toggles the feature on and off for a site. Returns 
+  Toggles the feature on and off for a site. Returns
   `{:error, :upgrade_required}` when toggling a feature the site owner does not
   have access to.
   """
@@ -94,7 +94,7 @@ defmodule Plausible.Billing.Feature do
         cond do
           is_nil(extra_feature) -> :ok
           not FunWithFlags.enabled?(:business_tier, for: user) -> :ok
-          extra_feature in Quota.extra_features_limit(user) -> :ok
+          extra_feature in Quota.allowed_features_for(user) -> :ok
           true -> {:error, :upgrade_required}
         end
       end

--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -9,17 +9,24 @@ defmodule Plausible.Billing.Feature do
   When defining new features, the following options are expected by the
   `__using__` macro:
 
+    * `:name` - an atom representing the feature name in the plan JSON
+    file (see also Plausible.Billing.Plan).
+
     * `:display_name` - human-readable display name of the feature
 
     * `:toggle_field` - the field in the %Plausible.Site{} schema that toggles
     the feature. If `nil` or not set, toggle/2 silently returns `:ok`
 
-    * `:extra_feature` - an atom representing the feature name in the plan JSON
-    file (see also Plausible.Billing.Plan). If `nil` or not set,
-    `check_availability/1` silently returns `:ok`
+    * `:free` - if set to `true`, makes the `check_availability/1` function
+    always return `:ok` (no matter the user's subscription status)
 
   Functions defined by `__using__` can be overridden if needed.
   """
+
+  @doc """
+  Returns the atom representing the feature name in the plan JSON file.
+  """
+  @callback name() :: atom()
 
   @doc """
   Returns the human-readable display name of the feature.
@@ -51,9 +58,10 @@ defmodule Plausible.Billing.Feature do
               :ok | {:error, :upgrade_required} | {:error, :not_implemented}
 
   @features [
-    Plausible.Billing.Feature.Funnels,
     Plausible.Billing.Feature.Goals,
+    Plausible.Billing.Feature.StatsAPI,
     Plausible.Billing.Feature.Props,
+    Plausible.Billing.Feature.Funnels,
     Plausible.Billing.Feature.RevenueGoals
   ]
 
@@ -69,6 +77,9 @@ defmodule Plausible.Billing.Feature do
     quote location: :keep do
       @behaviour Plausible.Billing.Feature
       alias Plausible.Billing.Quota
+
+      @impl true
+      def name, do: Keyword.get(unquote(opts), :name)
 
       @impl true
       def display_name, do: Keyword.get(unquote(opts), :display_name)
@@ -89,12 +100,10 @@ defmodule Plausible.Billing.Feature do
 
       @impl true
       def check_availability(%Plausible.Auth.User{} = user) do
-        extra_feature = Keyword.get(unquote(opts), :extra_feature)
-
         cond do
-          is_nil(extra_feature) -> :ok
           not FunWithFlags.enabled?(:business_tier, for: user) -> :ok
-          extra_feature in Quota.allowed_features_for(user) -> :ok
+          Keyword.get(unquote(opts), :free) -> :ok
+          __MODULE__ in Quota.allowed_features_for(user) -> :ok
           true -> {:error, :upgrade_required}
         end
       end
@@ -122,36 +131,38 @@ end
 defmodule Plausible.Billing.Feature.Funnels do
   @moduledoc false
   use Plausible.Billing.Feature,
+    name: :funnels,
     display_name: "Funnels",
-    toggle_field: :funnels_enabled,
-    extra_feature: :funnels
+    toggle_field: :funnels_enabled
 end
 
 defmodule Plausible.Billing.Feature.RevenueGoals do
   @moduledoc false
   use Plausible.Billing.Feature,
-    display_name: "Revenue Goals",
-    extra_feature: :revenue_goals
+    name: :revenue_goals,
+    display_name: "Revenue Goals"
 end
 
 defmodule Plausible.Billing.Feature.Goals do
   @moduledoc false
   use Plausible.Billing.Feature,
+    name: :goals,
     display_name: "Goals",
-    toggle_field: :conversions_enabled
+    toggle_field: :conversions_enabled,
+    free: true
 end
 
 defmodule Plausible.Billing.Feature.Props do
   @moduledoc false
   use Plausible.Billing.Feature,
+    name: :props,
     display_name: "Custom Properties",
-    toggle_field: :props_enabled,
-    extra_feature: :props
+    toggle_field: :props_enabled
 end
 
 defmodule Plausible.Billing.Feature.StatsAPI do
   @moduledoc false
   use Plausible.Billing.Feature,
-    display_name: "Stats API",
-    extra_feature: :stats_api
+    name: :stats_api,
+    display_name: "Stats API"
 end

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -130,11 +130,11 @@ defmodule Plausible.Billing.Quota do
     Plausible.Repo.one(query)
   end
 
-  @spec extra_features_usage(Plausible.Auth.User.t()) :: [atom()]
+  @spec features_usage(Plausible.Auth.User.t()) :: [atom()]
   @doc """
   Returns a list of extra features the given user's sites uses.
   """
-  def extra_features_usage(user) do
+  def features_usage(user) do
     props_usage_query =
       from s in Plausible.Site,
         inner_join: os in subquery(owned_sites_query(user)),

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -167,7 +167,7 @@ defmodule Plausible.Billing.Quota do
   Returns a list of extra features the user can use. Trial users have the
   ability to use all features during their trial.
   """
-  def extra_features_limit(user) do
+  def allowed_features_for(user) do
     user = Plausible.Users.with_subscription(user)
 
     case Plans.get_subscription_plan(user.subscription) do

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -15,7 +15,7 @@ defmodule PlausibleWeb.Components.Billing do
   attr(:rest, :global)
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  def extra_feature_notice(assigns) do
+  def premium_feature_notice(assigns) do
     private_preview? = not FunWithFlags.enabled?(:business_tier, for: assigns.current_user)
     display_upgrade_link? = assigns.current_user.id == assigns.billable_user.id
     has_access? = assigns.feature_mod.check_availability(assigns.billable_user) == :ok

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -381,7 +381,10 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       </p>
       <p class="h-4 mt-1"></p>
       <.contact_button class="" />
-      <ul role="list" class="mt-8 space-y-3 text-sm leading-6 xl:mt-10 text-gray-300 dark:text-gray-100">
+      <ul
+        role="list"
+        class="mt-8 space-y-3 text-sm leading-6 xl:mt-10 text-gray-300 dark:text-gray-100"
+      >
         <li class="flex gap-x-3">
           <.check_icon class="text-white dark:text-green-600" /> Unlimited products
         </li>

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -381,7 +381,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       </p>
       <p class="h-4 mt-1"></p>
       <.contact_button class="" />
-      <ul role="list" class="mt-8 space-y-3 text-sm leading-6 xl:mt-10 text-gray-300">
+      <ul role="list" class="mt-8 space-y-3 text-sm leading-6 xl:mt-10 text-gray-300 dark:text-gray-100">
         <li class="flex gap-x-3">
           <.check_icon class="text-white dark:text-green-600" /> Unlimited products
         </li>

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -192,7 +192,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           </button>
 
           <span x-show="active">
-            <PlausibleWeb.Components.Billing.extra_feature_notice
+            <PlausibleWeb.Components.Billing.premium_feature_notice
               billable_user={@site.owner}
               current_user={@current_user}
               feature_mod={Plausible.Billing.Feature.RevenueGoals}

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -319,7 +319,7 @@
   <h2 class="text-xl font-black dark:text-gray-100">API Keys</h2>
   <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
 
-  <PlausibleWeb.Components.Billing.extra_feature_notice
+  <PlausibleWeb.Components.Billing.premium_feature_notice
     billable_user={@current_user}
     current_user={@current_user}
     feature_mod={Plausible.Billing.Feature.StatsAPI}

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -1,5 +1,5 @@
 <section class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden">
-  <PlausibleWeb.Components.Billing.extra_feature_notice
+  <PlausibleWeb.Components.Billing.premium_feature_notice
     billable_user={@site.owner}
     current_user={@current_user}
     feature_mod={Plausible.Billing.Feature.Funnels}

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -1,5 +1,5 @@
 <section class="shadow bg-white dark:bg-gray-800 sm:rounded-md sm:overflow-hidden">
-  <PlausibleWeb.Components.Billing.extra_feature_notice
+  <PlausibleWeb.Components.Billing.premium_feature_notice
     billable_user={@site.owner}
     current_user={@current_user}
     feature_mod={Plausible.Billing.Feature.Props}

--- a/priv/plans_v1.json
+++ b/priv/plans_v1.json
@@ -6,7 +6,7 @@
     "yearly_product_id":"572810",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -15,7 +15,7 @@
     "yearly_product_id":"590752",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -24,7 +24,7 @@
     "yearly_product_id":"597486",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -33,7 +33,7 @@
     "yearly_product_id":"597488",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -42,7 +42,7 @@
     "yearly_product_id":"597643",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -51,7 +51,7 @@
     "yearly_product_id":"597310",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -60,7 +60,7 @@
     "yearly_product_id":"597312",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -69,7 +69,7 @@
     "yearly_product_id":"642354",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -78,7 +78,7 @@
     "yearly_product_id":"642356",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -87,6 +87,6 @@
     "yearly_product_id":"650653",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   }
 ]

--- a/priv/plans_v2.json
+++ b/priv/plans_v2.json
@@ -6,7 +6,7 @@
     "yearly_product_id":"653232",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -15,7 +15,7 @@
     "yearly_product_id":"653234",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -24,7 +24,7 @@
     "yearly_product_id":"653236",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -33,7 +33,7 @@
     "yearly_product_id":"653239",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -42,7 +42,7 @@
     "yearly_product_id":"653242",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -51,7 +51,7 @@
     "yearly_product_id":"653254",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -60,7 +60,7 @@
     "yearly_product_id":"653256",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -69,7 +69,7 @@
     "yearly_product_id":"653257",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -78,7 +78,7 @@
     "yearly_product_id":"653258",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -87,6 +87,6 @@
     "yearly_product_id":"653259",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   }
 ]

--- a/priv/plans_v3.json
+++ b/priv/plans_v3.json
@@ -6,7 +6,7 @@
     "yearly_product_id":"749343",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -15,7 +15,7 @@
     "yearly_product_id":"749345",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -24,7 +24,7 @@
     "yearly_product_id":"749347",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -33,7 +33,7 @@
     "yearly_product_id":"749349",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -42,7 +42,7 @@
     "yearly_product_id":"749352",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -51,7 +51,7 @@
     "yearly_product_id":"749355",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -60,7 +60,7 @@
     "yearly_product_id":"749357",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -69,6 +69,6 @@
     "yearly_product_id":"749359",
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   }
 ]

--- a/priv/plans_v4.json
+++ b/priv/plans_v4.json
@@ -6,7 +6,7 @@
     "yearly_product_id":"change-me-749343",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -15,7 +15,7 @@
     "yearly_product_id":"change-me-749345",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -24,7 +24,7 @@
     "yearly_product_id":"change-me-749347",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -33,7 +33,7 @@
     "yearly_product_id":"change-me-749349",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -42,7 +42,7 @@
     "yearly_product_id":"change-me-749352",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -51,7 +51,7 @@
     "yearly_product_id":"change-me-749355",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -60,7 +60,7 @@
     "yearly_product_id":"change-me-749357",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"growth",
@@ -69,7 +69,7 @@
     "yearly_product_id":"change-me-749359",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":[]
+    "features":["goals"]
   },
   {
     "kind":"business",
@@ -78,7 +78,7 @@
     "yearly_product_id":"change-me-b749343",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -87,7 +87,7 @@
     "yearly_product_id":"change-me-b749345",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -96,7 +96,7 @@
     "yearly_product_id":"change-me-b749347",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -105,7 +105,7 @@
     "yearly_product_id":"change-me-b749349",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -114,7 +114,7 @@
     "yearly_product_id":"change-me-b749352",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -123,7 +123,7 @@
     "yearly_product_id":"change-me-b749355",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -132,7 +132,7 @@
     "yearly_product_id":"change-me-b749357",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -141,6 +141,6 @@
     "yearly_product_id":"change-me-b749359",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props","revenue_goals","funnels","stats_api"]
+    "features":["goals","props","revenue_goals","funnels","stats_api"]
   }
 ]

--- a/priv/sandbox_plans.json
+++ b/priv/sandbox_plans.json
@@ -6,7 +6,7 @@
     "yearly_product_id":"63859",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -15,7 +15,7 @@
     "yearly_product_id":"63860",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -24,7 +24,7 @@
     "yearly_product_id":"63861",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -33,7 +33,7 @@
     "yearly_product_id":"63862",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -42,7 +42,7 @@
     "yearly_product_id":"63863",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -51,7 +51,7 @@
     "yearly_product_id":"63864",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -60,7 +60,7 @@
     "yearly_product_id":"63865",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"growth",
@@ -69,7 +69,7 @@
     "yearly_product_id":"63866",
     "site_limit":10,
     "team_member_limit":5,
-    "extra_features":["props","stats_api"]
+    "features":["goals","props","stats_api"]
   },
   {
     "kind":"business",
@@ -78,7 +78,7 @@
     "yearly_product_id":"63867",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -87,7 +87,7 @@
     "yearly_product_id":"63868",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -96,7 +96,7 @@
     "yearly_product_id":"63869",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -105,7 +105,7 @@
     "yearly_product_id":"63870",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -114,7 +114,7 @@
     "yearly_product_id":"63871",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -123,7 +123,7 @@
     "yearly_product_id":"63872",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -132,7 +132,7 @@
     "yearly_product_id":"63873",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   },
   {
     "kind":"business",
@@ -141,6 +141,6 @@
     "yearly_product_id":"63874",
     "site_limit":50,
     "team_member_limit":50,
-    "extra_features":["props", "revenue_goals", "funnels","stats_api"]
+    "features":["goals","props", "revenue_goals", "funnels","stats_api"]
   }
 ]

--- a/priv/unlisted_plans_v1.json
+++ b/priv/unlisted_plans_v1.json
@@ -6,6 +6,6 @@
     "monthly_product_id":null,
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props"]
+    "features":["goals","props"]
   }
 ]

--- a/priv/unlisted_plans_v2.json
+++ b/priv/unlisted_plans_v2.json
@@ -6,6 +6,6 @@
     "yearly_product_id":null,
     "site_limit":50,
     "team_member_limit":"unlimited",
-    "extra_features":["props"]
+    "features":["goals","props"]
   }
 ]

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -430,20 +430,20 @@ defmodule Plausible.Billing.QuotaTest do
     end
   end
 
-  describe "extra_features_limit/1" do
+  describe "allowed_features_for/1" do
     test "returns props when user is on an old plan" do
       user_on_v1 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
       user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
       user_on_v3 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v3_plan_id))
 
-      assert [:props, :stats_api] == Quota.extra_features_limit(user_on_v1)
-      assert [:props, :stats_api] == Quota.extra_features_limit(user_on_v2)
-      assert [:props, :stats_api] == Quota.extra_features_limit(user_on_v3)
+      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v1)
+      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v2)
+      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v3)
     end
 
     test "returns an empty list when user is on free_10k plan" do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: "free_10k"))
-      assert [] == Quota.extra_features_limit(user)
+      assert [] == Quota.allowed_features_for(user)
     end
 
     test "returns all extra features when user is on an enterprise plan" do
@@ -459,12 +459,13 @@ defmodule Plausible.Billing.QuotaTest do
       _subscription =
         insert(:subscription, user_id: user.id, paddle_plan_id: enterprise_plan.paddle_plan_id)
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.extra_features_limit(user)
+      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
     end
 
     test "returns all extra features when user in on trial" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: 7))
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.extra_features_limit(user)
+
+      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
     end
 
     test "returns previous plan limits for enterprise users who have not paid yet" do
@@ -474,7 +475,7 @@ defmodule Plausible.Billing.QuotaTest do
           subscription: build(:subscription, paddle_plan_id: @v1_plan_id)
         )
 
-      assert [:props, :stats_api] == Quota.extra_features_limit(user)
+      assert [:props, :stats_api] == Quota.allowed_features_for(user)
     end
 
     test "returns trial limits for enterprise users who have not upgraded yet and are on trial" do
@@ -484,7 +485,7 @@ defmodule Plausible.Billing.QuotaTest do
           subscription: nil
         )
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.extra_features_limit(user)
+      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
     end
 
     test "returns all extra features for enterprise customers" do
@@ -494,7 +495,7 @@ defmodule Plausible.Billing.QuotaTest do
           subscription: build(:subscription, paddle_plan_id: "123321")
         )
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.extra_features_limit(user)
+      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
     end
 
     test "returns all extra features for enterprise customers who are due to change a plan" do
@@ -505,7 +506,7 @@ defmodule Plausible.Billing.QuotaTest do
         )
 
       insert(:enterprise_plan, user_id: user.id, paddle_plan_id: "new-paddle-plan-id")
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.extra_features_limit(user)
+      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
     end
   end
 end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -1,6 +1,7 @@
 defmodule Plausible.Billing.QuotaTest do
   use Plausible.DataCase, async: true
   alias Plausible.Billing.Quota
+  alias Plausible.Billing.Feature.{Goals, RevenueGoals, Funnels, Props, StatsAPI}
 
   @v1_plan_id "558018"
   @v2_plan_id "654177"
@@ -370,7 +371,7 @@ defmodule Plausible.Billing.QuotaTest do
       assert [] == Quota.features_usage(user)
     end
 
-    test "returns :props when user uses custom props" do
+    test "returns [Props] when user uses custom props" do
       user = insert(:user)
 
       insert(:site,
@@ -378,10 +379,10 @@ defmodule Plausible.Billing.QuotaTest do
         memberships: [build(:site_membership, user: user, role: :owner)]
       )
 
-      assert [:props] == Quota.features_usage(user)
+      assert [Props] == Quota.features_usage(user)
     end
 
-    test "returns :funnels when user uses funnels" do
+    test "returns [Funnels] when user uses funnels" do
       user = insert(:user)
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :owner)])
 
@@ -389,18 +390,18 @@ defmodule Plausible.Billing.QuotaTest do
       steps = Enum.map(goals, &%{"goal_id" => &1.id})
       Plausible.Funnels.create(site, "dummy", steps)
 
-      assert [:funnels] == Quota.features_usage(user)
+      assert [Funnels] == Quota.features_usage(user)
     end
 
-    test "returns :revenue_goals when user uses revenue goals" do
+    test "returns [RevenueGoals] when user uses revenue goals" do
       user = insert(:user)
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :owner)])
       insert(:goal, currency: :USD, site: site, event_name: "Purchase")
 
-      assert [:revenue_goals] == Quota.features_usage(user)
+      assert [RevenueGoals] == Quota.features_usage(user)
     end
 
-    test "returns multiple extra features" do
+    test "returns multiple features" do
       user = insert(:user)
 
       site =
@@ -415,7 +416,7 @@ defmodule Plausible.Billing.QuotaTest do
       steps = Enum.map(goals, &%{"goal_id" => &1.id})
       Plausible.Funnels.create(site, "dummy", steps)
 
-      assert [:revenue_goals, :funnels, :props] == Quota.features_usage(user)
+      assert [RevenueGoals, Funnels, Props] == Quota.features_usage(user)
     end
 
     test "accounts only for sites the user owns" do
@@ -431,22 +432,22 @@ defmodule Plausible.Billing.QuotaTest do
   end
 
   describe "allowed_features_for/1" do
-    test "returns props when user is on an old plan" do
+    test "returns all grandfathered features when user is on an old plan" do
       user_on_v1 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
       user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
       user_on_v3 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v3_plan_id))
 
-      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v1)
-      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v2)
-      assert [:props, :stats_api] == Quota.allowed_features_for(user_on_v3)
+      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v1)
+      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v2)
+      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v3)
     end
 
-    test "returns an empty list when user is on free_10k plan" do
+    test "returns [Goals] when user is on free_10k plan" do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: "free_10k"))
-      assert [] == Quota.allowed_features_for(user)
+      assert [Goals] == Quota.allowed_features_for(user)
     end
 
-    test "returns all extra features when user is on an enterprise plan" do
+    test "returns all features when user is on an enterprise plan" do
       user = insert(:user)
 
       enterprise_plan =
@@ -459,13 +460,13 @@ defmodule Plausible.Billing.QuotaTest do
       _subscription =
         insert(:subscription, user_id: user.id, paddle_plan_id: enterprise_plan.paddle_plan_id)
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
+      assert Plausible.Billing.Feature.list() == Quota.allowed_features_for(user)
     end
 
-    test "returns all extra features when user in on trial" do
+    test "returns all features when user in on trial" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.now(), days: 7))
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
+      assert Plausible.Billing.Feature.list() == Quota.allowed_features_for(user)
     end
 
     test "returns previous plan limits for enterprise users who have not paid yet" do
@@ -475,30 +476,30 @@ defmodule Plausible.Billing.QuotaTest do
           subscription: build(:subscription, paddle_plan_id: @v1_plan_id)
         )
 
-      assert [:props, :stats_api] == Quota.allowed_features_for(user)
+      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user)
     end
 
-    test "returns trial limits for enterprise users who have not upgraded yet and are on trial" do
+    test "returns all features for enterprise users who have not upgraded yet and are on trial" do
       user =
         insert(:user,
           enterprise_plan: build(:enterprise_plan, paddle_plan_id: "123321"),
           subscription: nil
         )
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
+      assert Plausible.Billing.Feature.list() == Quota.allowed_features_for(user)
     end
 
-    test "returns all extra features for enterprise customers" do
+    test "returns all features for enterprise customers" do
       user =
         insert(:user,
           enterprise_plan: build(:enterprise_plan, paddle_plan_id: "123321"),
           subscription: build(:subscription, paddle_plan_id: "123321")
         )
 
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
+      assert Plausible.Billing.Feature.list() == Quota.allowed_features_for(user)
     end
 
-    test "returns all extra features for enterprise customers who are due to change a plan" do
+    test "returns all features for enterprise customers who are due to change a plan" do
       user =
         insert(:user,
           enterprise_plan: build(:enterprise_plan, paddle_plan_id: "old-paddle-plan-id"),
@@ -506,7 +507,7 @@ defmodule Plausible.Billing.QuotaTest do
         )
 
       insert(:enterprise_plan, user_id: user.id, paddle_plan_id: "new-paddle-plan-id")
-      assert [:props, :revenue_goals, :funnels, :stats_api] == Quota.allowed_features_for(user)
+      assert Plausible.Billing.Feature.list() == Quota.allowed_features_for(user)
     end
   end
 end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -364,10 +364,10 @@ defmodule Plausible.Billing.QuotaTest do
     end
   end
 
-  describe "extra_features_usage/1" do
+  describe "features_usage/1" do
     test "returns an empty list" do
       user = insert(:user)
-      assert [] == Quota.extra_features_usage(user)
+      assert [] == Quota.features_usage(user)
     end
 
     test "returns :props when user uses custom props" do
@@ -378,7 +378,7 @@ defmodule Plausible.Billing.QuotaTest do
         memberships: [build(:site_membership, user: user, role: :owner)]
       )
 
-      assert [:props] == Quota.extra_features_usage(user)
+      assert [:props] == Quota.features_usage(user)
     end
 
     test "returns :funnels when user uses funnels" do
@@ -389,7 +389,7 @@ defmodule Plausible.Billing.QuotaTest do
       steps = Enum.map(goals, &%{"goal_id" => &1.id})
       Plausible.Funnels.create(site, "dummy", steps)
 
-      assert [:funnels] == Quota.extra_features_usage(user)
+      assert [:funnels] == Quota.features_usage(user)
     end
 
     test "returns :revenue_goals when user uses revenue goals" do
@@ -397,7 +397,7 @@ defmodule Plausible.Billing.QuotaTest do
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :owner)])
       insert(:goal, currency: :USD, site: site, event_name: "Purchase")
 
-      assert [:revenue_goals] == Quota.extra_features_usage(user)
+      assert [:revenue_goals] == Quota.features_usage(user)
     end
 
     test "returns multiple extra features" do
@@ -415,7 +415,7 @@ defmodule Plausible.Billing.QuotaTest do
       steps = Enum.map(goals, &%{"goal_id" => &1.id})
       Plausible.Funnels.create(site, "dummy", steps)
 
-      assert [:revenue_goals, :funnels, :props] == Quota.extra_features_usage(user)
+      assert [:revenue_goals, :funnels, :props] == Quota.features_usage(user)
     end
 
     test "accounts only for sites the user owns" do
@@ -426,7 +426,7 @@ defmodule Plausible.Billing.QuotaTest do
         memberships: [build(:site_membership, user: user, role: :admin)]
       )
 
-      assert [] == Quota.extra_features_usage(user)
+      assert [] == Quota.features_usage(user)
     end
   end
 

--- a/test/plausible_web/components/billing_test.exs
+++ b/test/plausible_web/components/billing_test.exs
@@ -6,10 +6,10 @@ defmodule PlausibleWeb.Components.BillingTest do
   @v4_growth_plan_id "change-me-749342"
   @v4_business_plan_id "change-me-b749342"
 
-  test "extra_feature_notice/1 renders a message when user is on trial" do
+  test "premium_feature_notice/1 renders a message when user is on trial" do
     me = insert(:user)
 
-    assert render_component(&Billing.extra_feature_notice/1,
+    assert render_component(&Billing.premium_feature_notice/1,
              billable_user: me,
              current_user: me,
              feature_mod: Plausible.Billing.Feature.Props
@@ -17,11 +17,11 @@ defmodule PlausibleWeb.Components.BillingTest do
              "Custom Properties is part of the Plausible Business plan. You can access it during your trial"
   end
 
-  test "extra_feature_notice/1 renders an upgrade link when user is the site owner and does not have access to the feature" do
+  test "premium_feature_notice/1 renders an upgrade link when user is the site owner and does not have access to the feature" do
     me = insert(:user, subscription: build(:subscription, paddle_plan_id: @v4_growth_plan_id))
 
     rendered =
-      render_component(&Billing.extra_feature_notice/1,
+      render_component(&Billing.premium_feature_notice/1,
         billable_user: me,
         current_user: me,
         feature_mod: Plausible.Billing.Feature.Props
@@ -32,12 +32,12 @@ defmodule PlausibleWeb.Components.BillingTest do
     assert rendered =~ "/billing/upgrade"
   end
 
-  test "extra_feature_notice/1 does not render an upgrade link when user is not the site owner" do
+  test "premium_feature_notice/1 does not render an upgrade link when user is not the site owner" do
     me = insert(:user)
     owner = insert(:user, subscription: build(:subscription, paddle_plan_id: @v4_growth_plan_id))
 
     rendered =
-      render_component(&Billing.extra_feature_notice/1,
+      render_component(&Billing.premium_feature_notice/1,
         billable_user: owner,
         current_user: me,
         feature_mod: Plausible.Billing.Feature.Funnels
@@ -49,11 +49,11 @@ defmodule PlausibleWeb.Components.BillingTest do
     refute rendered =~ "/billing/upgrade"
   end
 
-  test "extra_feature_notice/1 does not render a notice when the user has access to the feature" do
+  test "premium_feature_notice/1 does not render a notice when the user has access to the feature" do
     me = insert(:user, subscription: build(:subscription, paddle_plan_id: @v4_business_plan_id))
 
     rendered =
-      render_component(&Billing.extra_feature_notice/1,
+      render_component(&Billing.premium_feature_notice/1,
         billable_user: me,
         current_user: me,
         feature_mod: Plausible.Billing.Feature.Funnels


### PR DESCRIPTION
### Changes

This refactoring PR is meant to prepare for adding the feature gates and limits information to the new `/billing/choose-plan` page. It will consider `Goals` a feature that is also listed in the JSON files, and removes the abstraction of "extra_features", replacing it with just "features" or "allowed_features" depending on the context.

Reviewing commit by commit might be easier to follow.

### Tests
- [x] Automated tests have been updated

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
