### PR TITLE
Track tokens usage

### DIFF
--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -71,6 +71,7 @@ defmodule Plausible.Plugins.API.Token do
   end
 
   @spec last_used_humanize(t()) :: String.t()
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def last_used_humanize(token) do
     diff =
       if token.last_used_at do

--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -85,7 +85,7 @@ defmodule Plausible.Plugins.API.Token do
       diff < 70 -> "An hour ago"
       diff < 24 * 60 -> "Hours ago"
       diff < 24 * 60 * 2 -> "Yesterday"
-      diff < 24 * 60 * 7 -> "Some time this week"
+      diff < 24 * 60 * 7 -> "Sometime this week"
       true -> "Long time ago"
     end
   end

--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Plugins.API.Token do
     field(:token_hash, :binary)
     field(:description, :string)
     field(:hint, :string)
-    field(:last_seen_at, :naive_datetime)
+    field(:last_used_at, :naive_datetime)
 
     belongs_to(:site, Site)
   end
@@ -73,9 +73,9 @@ defmodule Plausible.Plugins.API.Token do
   @spec last_seen_humanize(t()) :: String.t()
   def last_seen_humanize(token) do
     diff =
-      if token.last_seen_at do
+      if token.last_used_at do
         now = NaiveDateTime.utc_now()
-        Timex.diff(now, token.last_seen_at, :minutes)
+        Timex.diff(now, token.last_used_at, :minutes)
       end
 
     cond do

--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -23,6 +23,7 @@ defmodule Plausible.Plugins.API.Token do
     field(:token_hash, :binary)
     field(:description, :string)
     field(:hint, :string)
+    field(:last_seen_at, :naive_datetime)
 
     belongs_to(:site, Site)
   end
@@ -66,6 +67,26 @@ defmodule Plausible.Plugins.API.Token do
       {true, _} -> "plausible-plugin-selfhost"
       {false, "prod"} -> "plausible-plugin"
       {false, env} -> "plausible-plugin-#{env}"
+    end
+  end
+
+  @spec last_seen_humanize(t()) :: String.t()
+  def last_seen_humanize(token) do
+    diff =
+      if token.last_seen_at do
+        now = NaiveDateTime.utc_now()
+        Timex.diff(now, token.last_seen_at, :minutes)
+      end
+
+    cond do
+      is_nil(diff) -> "Not yet"
+      diff < 5 -> "Just recently"
+      diff < 30 -> "Several minutes ago"
+      diff < 70 -> "An hour ago"
+      diff < 24 * 60 -> "Hours ago"
+      diff < 24 * 60 * 2 -> "Yesterday"
+      diff < 24 * 60 * 7 -> "Some time this week"
+      true -> "Long time ago"
     end
   end
 

--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -70,8 +70,8 @@ defmodule Plausible.Plugins.API.Token do
     end
   end
 
-  @spec last_seen_humanize(t()) :: String.t()
-  def last_seen_humanize(token) do
+  @spec last_used_humanize(t()) :: String.t()
+  def last_used_humanize(token) do
     diff =
       if token.last_used_at do
         now = NaiveDateTime.utc_now()

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -45,7 +45,9 @@ defmodule Plausible.Plugins.API.Tokens do
 
   @spec list(Site.t()) :: {:ok, [Token.t()]}
   def list(site) do
-    Repo.all(from(t in Token, where: t.site_id == ^site.id, order_by: [desc: t.inserted_at, desc: t.id]))
+    Repo.all(
+      from(t in Token, where: t.site_id == ^site.id, order_by: [desc: t.inserted_at, desc: t.id])
+    )
   end
 
   @spec any?(Site.t()) :: boolean()
@@ -56,11 +58,11 @@ defmodule Plausible.Plugins.API.Tokens do
   @spec update_last_seen(Token.t(), NaiveDateTime.t()) :: {:ok, Token.t()}
   def update_last_seen(token, now \\ NaiveDateTime.utc_now()) do
     now = NaiveDateTime.truncate(now, :second)
-    last_seen = token.last_seen_at
+    last_seen = token.last_used_at
 
     if is_nil(last_seen) or Timex.diff(now, last_seen, :minutes) > 5 do
       token
-      |> Ecto.Changeset.change(%{last_seen_at: now})
+      |> Ecto.Changeset.change(%{last_used_at: now})
       |> Repo.update()
     else
       {:ok, token}

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -58,9 +58,9 @@ defmodule Plausible.Plugins.API.Tokens do
   @spec update_last_seen(Token.t(), NaiveDateTime.t()) :: {:ok, Token.t()}
   def update_last_seen(token, now \\ NaiveDateTime.utc_now()) do
     now = NaiveDateTime.truncate(now, :second)
-    last_seen = token.last_used_at
+    last_used = token.last_used_at
 
-    if is_nil(last_seen) or Timex.diff(now, last_seen, :minutes) > 5 do
+    if is_nil(last_used) or Timex.diff(now, last_used, :minutes) > 5 do
       token
       |> Ecto.Changeset.change(%{last_used_at: now})
       |> Repo.update()

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -39,13 +39,13 @@ defmodule Plausible.Plugins.API.Tokens do
 
   @spec delete(Site.t(), String.t()) :: :ok
   def delete(site, token_id) do
-    Repo.delete_all(from t in Token, where: t.site_id == ^site.id and t.id == ^token_id)
+    Repo.delete_all(from(t in Token, where: t.site_id == ^site.id and t.id == ^token_id))
     :ok
   end
 
   @spec list(Site.t()) :: {:ok, [Token.t()]}
   def list(site) do
-    Repo.all(from t in Token, where: t.site_id == ^site.id, order_by: [desc: t.id])
+    Repo.all(from(t in Token, where: t.site_id == ^site.id, order_by: [desc: t.inserted_at]))
   end
 
   @spec any?(Site.t()) :: boolean()

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -57,6 +57,9 @@ defmodule Plausible.Plugins.API.Tokens do
 
   @spec update_last_seen(Token.t(), NaiveDateTime.t()) :: {:ok, Token.t()}
   def update_last_seen(token, now \\ NaiveDateTime.utc_now()) do
+    # we don't need very precise timestamp tracking, and to spare postgres we only
+    # update that timestamp in 5m windows - this is mostly to help users reason
+    # about what token they have, in case of rotations
     now = NaiveDateTime.truncate(now, :second)
     last_used = token.last_used_at
 

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -45,7 +45,7 @@ defmodule Plausible.Plugins.API.Tokens do
 
   @spec list(Site.t()) :: {:ok, [Token.t()]}
   def list(site) do
-    Repo.all(from(t in Token, where: t.site_id == ^site.id, order_by: [desc: t.inserted_at]))
+    Repo.all(from(t in Token, where: t.site_id == ^site.id, order_by: [desc: t.inserted_at, desc: t.id]))
   end
 
   @spec any?(Site.t()) :: boolean()

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -52,4 +52,18 @@ defmodule Plausible.Plugins.API.Tokens do
   def any?(site) do
     Repo.exists?(from(t in Token, where: t.site_id == ^site.id))
   end
+
+  @spec update_last_seen(Token.t(), NaiveDateTime.t()) :: {:ok, Token.t()}
+  def update_last_seen(token, now \\ NaiveDateTime.utc_now()) do
+    now = NaiveDateTime.truncate(now, :second)
+    last_seen = token.last_seen_at
+
+    if is_nil(last_seen) or Timex.diff(now, last_seen, :minutes) > 5 do
+      token
+      |> Ecto.Changeset.change(%{last_seen_at: now})
+      |> Repo.update()
+    else
+      {:ok, token}
+    end
+  end
 end

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -67,23 +67,23 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
             <tr>
               <th
                 scope="col"
-                class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-gray-100"
+                class="px-6 py-3 text-xs font-medium text-left text-gray-500 uppercase dark:text-gray-100"
               >
                 Description
               </th>
               <th
                 scope="col"
-                class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-gray-100"
+                class="px-6 py-3 text-xs font-medium text-left text-gray-500 uppercase dark:text-gray-100"
               >
                 Hint
               </th>
               <th
                 scope="col"
-                class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-gray-100"
+                class="px-6 py-3 text-xs font-medium text-left text-gray-500 uppercase dark:text-gray-100"
               >
                 Last used
               </th>
-              <th scope="col" class="relative px-6 py-3">
+              <th scope="col" class="px-6 py-3">
                 <span class="sr-only">Revoke</span>
               </th>
             </tr>
@@ -91,16 +91,18 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
           <tbody>
             <%= for token <- @displayed_tokens do %>
               <tr class="bg-white dark:bg-gray-800">
-                <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
-                  <span class="token-description"><%= token.description %></span>
+                <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                  <span class="token-description">
+                    <%= token.description %>
+                  </span>
                 </td>
-                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-100 whitespace-nowrap font-mono">
+                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-100 font-mono">
                   **********<%= token.hint %>
                 </td>
                 <td class="px-6 py-4 text-sm font-normal whitespace-nowrap">
                   <%= Plausible.Plugins.API.Token.last_seen_humanize(token) %>
                 </td>
-                <td class="px-6 py-4 text-sm font-medium text-right whitespace-nowrap">
+                <td class="px-6 py-4 text-sm font-medium text-right">
                   <button
                     id={"revoke-token-#{token.id}"}
                     phx-click="revoke-token"

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -81,7 +81,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
                 scope="col"
                 class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-gray-100"
               >
-                Last seen
+                Last used
               </th>
               <th scope="col" class="relative px-6 py-3">
                 <span class="sr-only">Revoke</span>

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -100,7 +100,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
                   **********<%= token.hint %>
                 </td>
                 <td class="px-6 py-4 text-sm font-normal whitespace-nowrap">
-                  <%= Plausible.Plugins.API.Token.last_seen_humanize(token) %>
+                  <%= Plausible.Plugins.API.Token.last_used_humanize(token) %>
                 </td>
                 <td class="px-6 py-4 text-sm font-medium text-right">
                   <button

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -77,6 +77,12 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
               >
                 Hint
               </th>
+              <th
+                scope="col"
+                class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-gray-100"
+              >
+                Last seen
+              </th>
               <th scope="col" class="relative px-6 py-3">
                 <span class="sr-only">Revoke</span>
               </th>
@@ -90,6 +96,9 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
                 </td>
                 <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-100 whitespace-nowrap font-mono">
                   **********<%= token.hint %>
+                </td>
+                <td class="px-6 py-4 text-sm font-normal whitespace-nowrap">
+                  <%= Plausible.Plugins.API.Token.last_seen_humanize(token) %>
                 </td>
                 <td class="px-6 py-4 text-sm font-medium text-right whitespace-nowrap">
                   <button

--- a/lib/plausible_web/plugs/authorize_plugins_api.ex
+++ b/lib/plausible_web/plugs/authorize_plugins_api.ex
@@ -20,6 +20,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPI do
   defp authorize(conn, token_value) do
     case Tokens.find(token_value) do
       {:ok, token} ->
+        {:ok, token} = Tokens.update_last_seen(token)
         {:ok, Plug.Conn.assign(conn, :authorized_site, token.site)}
 
       {:error, :not_found} ->

--- a/priv/repo/migrations/20231018081657_add_last_used_at_to_plugins_api_tokens.exs
+++ b/priv/repo/migrations/20231018081657_add_last_used_at_to_plugins_api_tokens.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddLastUsedAtToPluginsApiTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table("plugins_api_tokens") do
+      add(:last_seen_at, :naive_datetime)
+    end
+  end
+end

--- a/priv/repo/migrations/20231018081657_add_last_used_at_to_plugins_api_tokens.exs
+++ b/priv/repo/migrations/20231018081657_add_last_used_at_to_plugins_api_tokens.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Repo.Migrations.AddLastUsedAtToPluginsApiTokens do
 
   def change do
     alter table("plugins_api_tokens") do
-      add(:last_seen_at, :naive_datetime)
+      add(:last_used_at, :naive_datetime)
     end
   end
 end

--- a/test/plausible/plugins/api/token_test.exs
+++ b/test/plausible/plugins/api/token_test.exs
@@ -75,7 +75,7 @@ defmodule Plausible.Plugins.API.TokenTest do
     now = NaiveDateTime.utc_now()
 
     last_seen = fn shift ->
-      Token.last_seen_humanize(%Token{last_seen_at: Timex.shift(now, shift)})
+      Token.last_seen_humanize(%Token{last_used_at: Timex.shift(now, shift)})
     end
 
     assert Token.last_seen_humanize(%Token{}) == "Not yet"

--- a/test/plausible/plugins/api/token_test.exs
+++ b/test/plausible/plugins/api/token_test.exs
@@ -86,7 +86,7 @@ defmodule Plausible.Plugins.API.TokenTest do
     assert last_seen.(hours: -1) == "An hour ago"
     assert last_seen.(hours: -7) == "Hours ago"
     assert last_seen.(days: -1) == "Yesterday"
-    assert last_seen.(days: -3) == "Some time this week"
+    assert last_seen.(days: -3) == "Sometime this week"
     assert last_seen.(months: -1) == "Long time ago"
   end
 end

--- a/test/plausible/plugins/api/token_test.exs
+++ b/test/plausible/plugins/api/token_test.exs
@@ -71,14 +71,14 @@ defmodule Plausible.Plugins.API.TokenTest do
     end
   end
 
-  test "last_seen_humanize/1" do
+  test "last_used_humanize/1" do
     now = NaiveDateTime.utc_now()
 
     last_seen = fn shift ->
-      Token.last_seen_humanize(%Token{last_used_at: Timex.shift(now, shift)})
+      Token.last_used_humanize(%Token{last_used_at: Timex.shift(now, shift)})
     end
 
-    assert Token.last_seen_humanize(%Token{}) == "Not yet"
+    assert Token.last_used_humanize(%Token{}) == "Not yet"
 
     assert last_seen.(minutes: -1) == "Just recently"
     assert last_seen.(minutes: -4) == "Just recently"

--- a/test/plausible/plugins/api/token_test.exs
+++ b/test/plausible/plugins/api/token_test.exs
@@ -70,4 +70,23 @@ defmodule Plausible.Plugins.API.TokenTest do
       assert Ecto.Changeset.get_field(changeset, :site).id == 1_892_787
     end
   end
+
+  test "last_seen_humanize/1" do
+    now = NaiveDateTime.utc_now()
+
+    last_seen = fn shift ->
+      Token.last_seen_humanize(%Token{last_seen_at: Timex.shift(now, shift)})
+    end
+
+    assert Token.last_seen_humanize(%Token{}) == "Not yet"
+
+    assert last_seen.(minutes: -1) == "Just recently"
+    assert last_seen.(minutes: -4) == "Just recently"
+    assert last_seen.(minutes: -6) == "Several minutes ago"
+    assert last_seen.(hours: -1) == "An hour ago"
+    assert last_seen.(hours: -7) == "Hours ago"
+    assert last_seen.(days: -1) == "Yesterday"
+    assert last_seen.(days: -3) == "Some time this week"
+    assert last_seen.(months: -1) == "Long time ago"
+  end
 end

--- a/test/plausible/plugins/api/tokens_test.exs
+++ b/test/plausible/plugins/api/tokens_test.exs
@@ -84,11 +84,11 @@ defmodule Plausible.Plugins.API.TokensTest do
       {:ok, token1} = Tokens.update_last_seen(token0, now)
       {:ok, token2} = Tokens.update_last_seen(token1, Timex.shift(now, minutes: 2))
 
-      assert token1.last_seen_at == token2.last_seen_at
+      assert token1.last_used_at == token2.last_used_at
 
       {:ok, token3} = Tokens.update_last_seen(token2, Timex.shift(now, minutes: 6))
 
-      assert NaiveDateTime.compare(token3.last_seen_at, token2.last_seen_at) == :gt
+      assert NaiveDateTime.compare(token3.last_used_at, token2.last_used_at) == :gt
     end
   end
 end

--- a/test/plausible/plugins/api/tokens_test.exs
+++ b/test/plausible/plugins/api/tokens_test.exs
@@ -73,4 +73,22 @@ defmodule Plausible.Plugins.API.TokensTest do
       assert Tokens.any?(site2)
     end
   end
+
+  describe "update_last_seen/1" do
+    test "updates in 5m window" do
+      site = insert(:site)
+      assert {:ok, token0, _} = Tokens.create(site, "My test token")
+
+      now = NaiveDateTime.utc_now()
+
+      {:ok, token1} = Tokens.update_last_seen(token0, now)
+      {:ok, token2} = Tokens.update_last_seen(token1, Timex.shift(now, minutes: 2))
+
+      assert token1.last_seen_at == token2.last_seen_at
+
+      {:ok, token3} = Tokens.update_last_seen(token2, Timex.shift(now, minutes: 6))
+
+      assert NaiveDateTime.compare(token3.last_seen_at, token2.last_seen_at) == :gt
+    end
+  end
 end

--- a/test/plausible_web/live/plugins_api_tokens_test.exs
+++ b/test/plausible_web/live/plugins_api_tokens_test.exs
@@ -46,6 +46,10 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
 
       assert resp =~ "test-token-1"
       assert resp =~ "test-token-2"
+
+      assert resp =~ "Last used"
+      assert resp =~ "Not yet"
+
       assert resp =~ "**********" <> t1.hint
       assert resp =~ "**********" <> t2.hint
       refute resp =~ "test-token-3"

--- a/test/plausible_web/plugs/authorize_plugins_api_test.exs
+++ b/test/plausible_web/plugs/authorize_plugins_api_test.exs
@@ -1,8 +1,9 @@
 defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
   use PlausibleWeb.ConnCase, async: true
 
-  alias Plausible.Plugins.API.Tokens
+  alias Plausible.Plugins.API.{Token, Tokens}
   alias PlausibleWeb.Plugs.AuthorizePluginsAPI
+  alias Plausible.Repo
 
   import Plug.Conn
 
@@ -67,5 +68,23 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
                %{"detail" => "Plugins API: unauthorized"}
              ]
            }
+  end
+
+  test "plug updates last seen timestamp" do
+    site = insert(:site, domain: "pass.example.com")
+    {:ok, token, raw} = Tokens.create(site, "Some token")
+
+    refute token.last_seen_at
+    assert Token.last_seen_humanize(token) == "Not yet"
+
+    credentials = "Basic " <> Base.encode64(raw)
+
+    build_conn()
+    |> put_req_header("authorization", credentials)
+    |> AuthorizePluginsAPI.call()
+
+    token = Repo.reload!(token)
+    assert token.last_seen_at
+    assert Token.last_seen_humanize(token) == "Just recently"
   end
 end

--- a/test/plausible_web/plugs/authorize_plugins_api_test.exs
+++ b/test/plausible_web/plugs/authorize_plugins_api_test.exs
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
     site = insert(:site, domain: "pass.example.com")
     {:ok, token, raw} = Tokens.create(site, "Some token")
 
-    refute token.last_seen_at
+    refute token.last_used_at
     assert Token.last_seen_humanize(token) == "Not yet"
 
     credentials = "Basic " <> Base.encode64(raw)
@@ -84,7 +84,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
     |> AuthorizePluginsAPI.call()
 
     token = Repo.reload!(token)
-    assert token.last_seen_at
+    assert token.last_used_at
     assert Token.last_seen_humanize(token) == "Just recently"
   end
 end

--- a/test/plausible_web/plugs/authorize_plugins_api_test.exs
+++ b/test/plausible_web/plugs/authorize_plugins_api_test.exs
@@ -75,7 +75,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
     {:ok, token, raw} = Tokens.create(site, "Some token")
 
     refute token.last_used_at
-    assert Token.last_seen_humanize(token) == "Not yet"
+    assert Token.last_used_humanize(token) == "Not yet"
 
     credentials = "Basic " <> Base.encode64(raw)
 
@@ -85,6 +85,6 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPITest do
 
     token = Repo.reload!(token)
     assert token.last_used_at
-    assert Token.last_seen_humanize(token) == "Just recently"
+    assert Token.last_used_humanize(token) == "Just recently"
   end
 end


### PR DESCRIPTION
### Changes

Migration is included, but can be deployed along with this PR - there's very little Plugins API usage still.

PR is built on top of #3427 - needs that one merged first, so that base is switched.

We'll now track and display "last used" for Plugins API Tokens:

![image](https://github.com/plausible/analytics/assets/173738/f820a953-8185-4614-8dac-39780b06e01d)



### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
