### PR TITLE
Plugins API: handle Revenue Goals creation wrt Business Tier

### DIFF
--- a/lib/plausible/plugins/api/goals.ex
+++ b/lib/plausible/plugins/api/goals.ex
@@ -18,7 +18,10 @@ defmodule Plausible.Plugins.API.Goals do
   @spec create(
           Plausible.Site.t(),
           create_request() | list(create_request())
-        ) :: {:ok, list(Plausible.Goal.t())} | {:error, Ecto.Changeset.t()}
+        ) ::
+          {:ok, list(Plausible.Goal.t())}
+          | {:error, Ecto.Changeset.t()}
+          | {:error, :upgrade_required}
   def create(site, goal_or_goals) do
     Repo.transaction(fn -> find_or_create(site, goal_or_goals) end)
   end

--- a/lib/plausible_web/plugins/api/controllers/goals.ex
+++ b/lib/plausible_web/plugins/api/controllers/goals.ex
@@ -58,11 +58,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.Goals do
         |> render("goal.json", goal: goal, authorized_site: site)
 
       {:error, :upgrade_required} ->
-        Errors.error(
-          conn,
-          402,
-          "#{Plausible.Billing.Feature.RevenueGoals.display_name()} is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
-        )
+        payment_required(conn)
 
       {:error, changeset} ->
         Errors.error(conn, 422, changeset)
@@ -84,6 +80,9 @@ defmodule PlausibleWeb.Plugins.API.Controllers.Goals do
         |> put_view(Views.Goal)
         |> put_status(:created)
         |> render("index.json", goals: goals, authorized_site: site)
+
+      {:error, :upgrade_required} ->
+        payment_required(conn)
 
       {:error, changeset} ->
         Errors.error(conn, 422, changeset)
@@ -164,5 +163,13 @@ defmodule PlausibleWeb.Plugins.API.Controllers.Goals do
       {:error, :not_found} ->
         send_resp(conn, :no_content, "")
     end
+  end
+
+  defp payment_required(conn) do
+    Errors.error(
+      conn,
+      402,
+      "#{Plausible.Billing.Feature.RevenueGoals.display_name()} is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
+    )
   end
 end

--- a/lib/plausible_web/plugins/api/controllers/goals.ex
+++ b/lib/plausible_web/plugins/api/controllers/goals.ex
@@ -36,6 +36,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.Goals do
            oneOf: [Schemas.Goal.ListResponse, Schemas.Goal]
          }},
       unauthorized: {"Unauthorized", "application/json", Schemas.Unauthorized},
+      payment_required: {"Payment required", "application/json", Schemas.PaymentRequired},
       unprocessable_entity:
         {"Unprocessable entity", "application/json", Schemas.UnprocessableEntity}
     }
@@ -55,6 +56,13 @@ defmodule PlausibleWeb.Plugins.API.Controllers.Goals do
         |> put_status(:created)
         |> put_resp_header("location", goals_url(base_uri(), :get, goal.id))
         |> render("goal.json", goal: goal, authorized_site: site)
+
+      {:error, :upgrade_required} ->
+        Errors.error(
+          conn,
+          402,
+          "#{Plausible.Billing.Feature.RevenueGoals.display_name()} is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
+        )
 
       {:error, changeset} ->
         Errors.error(conn, 422, changeset)

--- a/lib/plausible_web/plugins/api/schemas/payment_required.ex
+++ b/lib/plausible_web/plugins/api/schemas/payment_required.ex
@@ -1,0 +1,23 @@
+defmodule PlausibleWeb.Plugins.API.Schemas.PaymentRequired do
+  @moduledoc """
+  OpenAPI schema for a generic 402 response
+  """
+
+  use PlausibleWeb, :open_api_schema
+
+  OpenApiSpex.schema(%{
+    description: """
+    The response that is returned when the user makes a request that cannot be
+    processed due to their subscription limitations.
+    """,
+    type: :object,
+    title: "PaymentRequiredError",
+    required: [:errors],
+    properties: %{
+      errors: %OpenApiSpex.Schema{
+        items: Schemas.Error,
+        type: :array
+      }
+    }
+  })
+end

--- a/test/plausible_web/plugins/api/controllers/goals_test.exs
+++ b/test/plausible_web/plugins/api/controllers/goals_test.exs
@@ -44,6 +44,35 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
     end
   end
 
+  describe "buisness tier" do
+    test "fails on revenue goal creation attempt with insufficient plan", %{
+      site: site,
+      token: token,
+      conn: conn
+    } do
+      site = Plausible.Repo.preload(site, :owner)
+      FunWithFlags.enable(:business_tier, for_actor: site.owner)
+
+      insert(:subscription, paddle_plan_id: "free_10k", user: site.owner)
+
+      url = Routes.goals_url(base_uri(), :create)
+
+      payload = %{
+        goal_type: "Goal.Revenue",
+        goal: %{event_name: "Purchase", currency: "EUR"}
+      }
+
+      assert_request_schema(payload, "Goal.CreateRequest.Revenue", spec())
+
+      conn
+      |> authenticate(site.domain, token)
+      |> put_req_header("content-type", "application/json")
+      |> put(url, payload)
+      |> json_response(402)
+      |> assert_schema("PaymentRequiredError", spec())
+    end
+  end
+
   describe "put /goals - create a single goal" do
     test "validates input according to the schema", %{conn: conn, token: token, site: site} do
       url = Routes.goals_url(base_uri(), :create)

--- a/test/plausible_web/plugins/api/controllers/goals_test.exs
+++ b/test/plausible_web/plugins/api/controllers/goals_test.exs
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
     end
   end
 
-  describe "buisness tier" do
+  describe "business tier" do
     test "fails on revenue goal creation attempt with insufficient plan", %{
       site: site,
       token: token,

--- a/test/plausible_web/plugins/api/controllers/goals_test.exs
+++ b/test/plausible_web/plugins/api/controllers/goals_test.exs
@@ -52,8 +52,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
     } do
       site = Plausible.Repo.preload(site, :owner)
       FunWithFlags.enable(:business_tier, for_actor: site.owner)
-
-      insert(:subscription, paddle_plan_id: "free_10k", user: site.owner)
+      insert(:growth_subscription, user: site.owner)
 
       url = Routes.goals_url(base_uri(), :create)
 
@@ -79,8 +78,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
     } do
       site = Plausible.Repo.preload(site, :owner)
       FunWithFlags.enable(:business_tier, for_actor: site.owner)
-
-      insert(:subscription, paddle_plan_id: "free_10k", user: site.owner)
+      insert(:growth_subscription, user: site.owner)
 
       url = Routes.goals_url(base_uri(), :create)
 

--- a/test/plausible_web/plugins/api/controllers/goals_test.exs
+++ b/test/plausible_web/plugins/api/controllers/goals_test.exs
@@ -71,6 +71,43 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
       |> json_response(402)
       |> assert_schema("PaymentRequiredError", spec())
     end
+
+    test "fails on bulk revenue goal creation attempt with insufficient plan", %{
+      site: site,
+      token: token,
+      conn: conn
+    } do
+      site = Plausible.Repo.preload(site, :owner)
+      FunWithFlags.enable(:business_tier, for_actor: site.owner)
+
+      insert(:subscription, paddle_plan_id: "free_10k", user: site.owner)
+
+      url = Routes.goals_url(base_uri(), :create)
+
+      payload = %{
+        goals: [
+          %{
+            goal_type: "Goal.CustomEvent",
+            goal: %{event_name: "Signup"}
+          },
+          %{
+            goal_type: "Goal.Revenue",
+            goal: %{event_name: "Purchase", currency: "EUR"}
+          },
+          %{
+            goal_type: "Goal.Pageview",
+            goal: %{path: "/checkout"}
+          }
+        ]
+      }
+
+      conn
+      |> authenticate(site.domain, token)
+      |> put_req_header("content-type", "application/json")
+      |> put(url, payload)
+      |> json_response(402)
+      |> assert_schema("PaymentRequiredError", spec())
+    end
   end
 
   describe "put /goals - create a single goal" do


### PR DESCRIPTION
### Changes

This PR enables error handling on revenue goal creation constrained by subscription/business tier rules.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
