### PR TITLE
Restrict subscribing to a plan when exceeding its limits + warning for losing feature access

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -1,7 +1,7 @@
 defmodule Plausible.Billing do
   use Plausible.Repo
   require Plausible.Billing.Subscription.Status
-  alias Plausible.Billing.Subscription
+  alias Plausible.Billing.{Subscription, Plans, Quota}
 
   @spec active_subscription_for(integer()) :: Subscription.t() | nil
   def active_subscription_for(user_id) do
@@ -40,6 +40,13 @@ defmodule Plausible.Billing do
   def change_plan(user, new_plan_id) do
     subscription = active_subscription_for(user.id)
 
+    case Quota.ensure_can_subscribe_to_plan(user, Plans.find(new_plan_id)) do
+      :ok -> do_change_plan(subscription, new_plan_id)
+      error -> error
+    end
+  end
+
+  defp do_change_plan(subscription, new_plan_id) do
     res =
       paddle_api().update_subscription(subscription.paddle_subscription_id, %{
         plan_id: new_plan_id

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -79,9 +79,9 @@ defmodule Plausible.Billing.Plans do
         do: yearly_product_id
   end
 
-  defp find(nil), do: nil
+  def find(nil), do: nil
 
-  defp find(product_id) do
+  def find(product_id) do
     Enum.find(all(), fn plan ->
       product_id in [plan.monthly_product_id, plan.yearly_product_id]
     end)

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -166,6 +166,21 @@ defmodule Plausible.Billing.Quota do
     end)
   end
 
+  def ensure_can_subscribe_to_plan(user, %Plan{} = plan) do
+    usage = %{
+      monthly_pageviews: monthly_pageview_usage(user),
+      team_members: team_member_usage(user),
+      sites: site_usage(user)
+    }
+
+    case exceeded_limits(usage, plan) do
+      [] -> :ok
+      exceeded_limits -> {:error, %{exceeded_limits: exceeded_limits}}
+    end
+  end
+
+  def ensure_can_subscribe_to_plan(_user, nil), do: :ok
+
   def exceeded_limits(usage, %Plan{} = plan) do
     for {usage_field, limit_field} <- [
           {:monthly_pageviews, :monthly_pageview_limit},

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -166,6 +166,17 @@ defmodule Plausible.Billing.Quota do
     end)
   end
 
+  def exceeded_limits(usage, %Plan{} = plan) do
+    for {usage_field, limit_field} <- [
+          {:monthly_pageviews, :monthly_pageview_limit},
+          {:team_members, :team_member_limit},
+          {:sites, :site_limit}
+        ],
+        !within_limit?(Map.get(usage, usage_field), Map.get(plan, limit_field)) do
+      limit_field
+    end
+  end
+
   @doc """
   Returns a list of features the user can use. Trial users have the
   ability to use all features during their trial.

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -162,7 +162,7 @@ defmodule Plausible.Billing.Quota do
     ]
 
     Enum.reduce(queries, [], fn {feature, query}, acc ->
-      if Plausible.Repo.exists?(query), do: [feature | acc], else: acc
+      if Plausible.Repo.exists?(query), do: acc ++ [feature], else: acc
     end)
   end
 

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -283,13 +283,19 @@ defmodule PlausibleWeb.Components.Billing do
   attr :paddle_product_id, :string, required: true
   attr :checkout_disabled, :boolean, default: false
   attr :user, :any, required: true
+  attr :confirm_message, :any, default: nil
   slot :inner_block, required: true
 
   def paddle_button(assigns) do
+    confirmed =
+      if assigns.confirm_message, do: "confirm(\"#{assigns.confirm_message}\")", else: "true"
+
+    assigns = assign(assigns, :confirmed, confirmed)
+
     ~H"""
     <button
       id={@id}
-      onclick={"Paddle.Checkout.open(#{Jason.encode!(%{product: @paddle_product_id, email: @user.email, disableLogout: true, passthrough: @user.id, success: Routes.billing_path(PlausibleWeb.Endpoint, :upgrade_success), theme: "none"})})"}
+      onclick={"if (#{@confirmed}) {Paddle.Checkout.open(#{Jason.encode!(%{product: @paddle_product_id, email: @user.email, disableLogout: true, passthrough: @user.id, success: Routes.billing_path(PlausibleWeb.Endpoint, :upgrade_success), theme: "none"})})}"}
       class={[
         "w-full mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-white",
         !@checkout_disabled && "bg-indigo-600 hover:bg-indigo-500",

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -279,12 +279,22 @@ defmodule PlausibleWeb.Components.Billing do
     |> String.replace(".00", "")
   end
 
+  attr :id, :string, required: true
+  attr :paddle_product_id, :string, required: true
+  attr :checkout_disabled, :boolean, default: false
+  attr :user, :any, required: true
+  slot :inner_block, required: true
+
   def paddle_button(assigns) do
     ~H"""
     <button
       id={@id}
       onclick={"Paddle.Checkout.open(#{Jason.encode!(%{product: @paddle_product_id, email: @user.email, disableLogout: true, passthrough: @user.id, success: Routes.billing_path(PlausibleWeb.Endpoint, :upgrade_success), theme: "none"})})"}
-      class="w-full mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-white bg-indigo-600 hover:bg-indigo-500"
+      class={[
+        "w-full mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-white",
+        !@checkout_disabled && "bg-indigo-600 hover:bg-indigo-500",
+        @checkout_disabled && "pointer-events-none bg-gray-400 dark:bg-gray-600"
+      ]}
     >
       <%= render_slot(@inner_block) %>
     </button>

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -126,7 +126,15 @@ defmodule PlausibleWeb.BillingController do
   def change_plan_preview(conn, %{"plan_id" => new_plan_id}) do
     with {:ok, {subscription, preview_info}} <-
            preview_subscription(conn.assigns.current_user, new_plan_id) do
+      back_action =
+        if FunWithFlags.enabled?(:business_tier, for: conn.assigns.current_user) do
+          :choose_plan
+        else
+          :change_plan_form
+        end
+
       render(conn, "change_plan_preview.html",
+        back_link: Routes.billing_path(conn, back_action),
         skip_plausible_tracking: true,
         subscription: subscription,
         preview_info: preview_info,

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -240,6 +240,9 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   end
 
   defp plan_box(assigns) do
+    paddle_product_id = get_paddle_product_id(assigns.plan_to_render, assigns.selected_interval)
+    assigns = assign(assigns, :paddle_product_id, paddle_product_id)
+
     ~H"""
     <div
       id={"#{@kind}-plan-box"}
@@ -266,7 +269,6 @@ defmodule PlausibleWeb.Live.ChoosePlan do
             <.contact_button class="bg-indigo-600 hover:bg-indigo-500 text-white" />
           <% @owned_plan && Plausible.Billing.Subscriptions.resumable?(@user.subscription) -> %>
             <.render_change_plan_link
-              paddle_product_id={get_paddle_product_id(@plan_to_render, @selected_interval)}
               text={
                 change_plan_link_text(
                   @owned_plan,
@@ -278,13 +280,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
               {assigns}
             />
           <% true -> %>
-            <.paddle_button
-              id={"#{@kind}-checkout"}
-              paddle_product_id={get_paddle_product_id(@plan_to_render, @selected_interval)}
-              {assigns}
-            >
-              Upgrade
-            </.paddle_button>
+            <.paddle_button id={"#{@kind}-checkout"} {assigns}>Upgrade</.paddle_button>
         <% end %>
       </div>
       <%= if @kind == :growth && @plan_to_render.generation < 4 do %>

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -243,6 +243,10 @@ defmodule PlausibleWeb.Live.ChoosePlan do
     paddle_product_id = get_paddle_product_id(assigns.plan_to_render, assigns.selected_interval)
     change_plan_link_text = change_plan_link_text(assigns)
 
+    exceeds_pageview_limit =
+      assigns.available &&
+        !Quota.within_limit?(assigns.usage, assigns.plan_to_render.monthly_pageview_limit)
+
     billing_details_expired =
       assigns.user.subscription &&
         assigns.user.subscription.status in [
@@ -254,6 +258,9 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       cond do
         change_plan_link_text == "Currently on this plan" ->
           {true, nil}
+
+        exceeds_pageview_limit ->
+          {true, "Your usage exceeds this plan"}
 
         billing_details_expired ->
           {true, "Please update your billing details first"}

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -362,7 +362,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
     </.link>
     <p
       :if={@billing_details_expired && !@plan_already_owned}
-      class="text-center text-sm text-red-700 dark:text-red-500"
+      class="h-0 text-center text-sm text-red-700 dark:text-red-500"
     >
       Please update your billing details first
     </p>

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -291,25 +291,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
     paddle_product_id = get_paddle_product_id(assigns.plan_to_render, assigns.selected_interval)
     change_plan_link_text = change_plan_link_text(assigns)
 
-    exceeds_pageview_limit =
-      !Quota.within_limit?(
-        assigns.usage.monthly_pageviews,
-        assigns.plan_to_render.monthly_pageview_limit
-      )
-
-    exceeds_team_member_limit =
-      !Quota.within_limit?(
-        assigns.usage.team_members,
-        assigns.plan_to_render.team_member_limit
-      )
-
-    exceeds_site_limit =
-      !Quota.within_limit?(
-        assigns.usage.sites,
-        assigns.plan_to_render.site_limit
-      )
-
-    exceeds_some_limit = exceeds_pageview_limit || exceeds_team_member_limit || exceeds_site_limit
+    exceeds_some_limit = Quota.exceeded_limits(assigns.usage, assigns.plan_to_render) != []
 
     billing_details_expired =
       assigns.user.subscription &&

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -25,7 +25,8 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:usage, fn %{user: user} ->
         %{
           monthly_pageviews: Quota.monthly_pageview_usage(user),
-          team_members: Quota.team_member_usage(user)
+          team_members: Quota.team_member_usage(user),
+          sites: Quota.site_usage(user)
         }
       end)
       |> assign_new(:owned_plan, fn %{user: %{subscription: subscription}} ->
@@ -259,7 +260,13 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         assigns.plan_to_render.team_member_limit
       )
 
-    exceeds_some_limit = exceeds_pageview_limit || exceeds_team_member_limit
+    exceeds_site_limit =
+      !Quota.within_limit?(
+        assigns.usage.sites,
+        assigns.plan_to_render.site_limit
+      )
+
+    exceeds_some_limit = exceeds_pageview_limit || exceeds_team_member_limit || exceeds_site_limit
 
     billing_details_expired =
       assigns.user.subscription &&

--- a/lib/plausible_web/templates/billing/change_plan_preview.html.eex
+++ b/lib/plausible_web/templates/billing/change_plan_preview.html.eex
@@ -66,7 +66,7 @@
 
     <div class="flex items-center justify-between mt-10">
       <span class="flex rounded-md shadow-sm">
-        <a href="<%= Routes.billing_path(@conn, :change_plan_form) %>" type="button" class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:border-blue-300 focus:ring active:text-gray-800 dark:active:text-gray-200 active:bg-gray-50 transition ease-in-out duration-150">
+        <a href="<%= @back_link %>" type="button" class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:text-gray-500 dark:hover:text-gray-200 focus:outline-none focus:border-blue-300 focus:ring active:text-gray-800 dark:active:text-gray-200 active:bg-gray-50 transition ease-in-out duration-150">
           Back
         </a>
       </span>

--- a/lib/plausible_web/views/text_helpers.ex
+++ b/lib/plausible_web/views/text_helpers.ex
@@ -1,0 +1,33 @@
+defmodule PlausibleWeb.TextHelpers do
+  @moduledoc false
+
+  @spec pretty_join([String.t()]) :: String.t()
+
+  @doc """
+  Turns a list of strings into a string and replaces the last comma
+  with the word "and".
+
+  ### Examples:
+
+      iex> ["one"] |> PlausibleWeb.TextHelpers.pretty_join()
+      "one"
+
+      iex> ["one", "two"] |> PlausibleWeb.TextHelpers.pretty_join()
+      "one and two"
+
+      iex> ["one", "two", "three"] |> PlausibleWeb.TextHelpers.pretty_join()
+      "one, two and three"
+  """
+  def pretty_join([str]), do: str
+
+  def pretty_join(list) do
+    [last_string | rest] = Enum.reverse(list)
+
+    rest_string =
+      rest
+      |> Enum.reverse()
+      |> Enum.join(", ")
+
+    "#{rest_string} and #{last_string}"
+  end
+end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -427,7 +427,7 @@ defmodule Plausible.Billing.QuotaTest do
       steps = Enum.map(goals, &%{"goal_id" => &1.id})
       Plausible.Funnels.create(site, "dummy", steps)
 
-      assert [RevenueGoals, Funnels, Props] == Quota.features_usage(user)
+      assert [Props, Funnels, RevenueGoals] == Quota.features_usage(user)
     end
 
     test "accounts only for sites the user owns" do

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -1,6 +1,6 @@
 defmodule Plausible.Billing.QuotaTest do
   use Plausible.DataCase, async: true
-  alias Plausible.Billing.Quota
+  alias Plausible.Billing.{Quota, Plans}
   alias Plausible.Billing.Feature.{Goals, RevenueGoals, Funnels, Props, StatsAPI}
 
   @legacy_plan_id "558746"
@@ -112,6 +112,20 @@ defmodule Plausible.Billing.QuotaTest do
 
     test "returns false when usage exceeds the limit" do
       refute Quota.within_limit?(10, 3)
+    end
+  end
+
+  describe "exceeded_limits/2" do
+    test "returns limits that are exceeded" do
+      usage = %{
+        monthly_pageviews: 10_001,
+        team_members: 2,
+        sites: 51
+      }
+
+      plan = Plans.find(@v3_plan_id)
+
+      assert Quota.exceeded_limits(usage, plan) == [:monthly_pageview_limit, :site_limit]
     end
   end
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -200,6 +200,23 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert get_paddle_checkout_params(find(doc, @business_checkout_button))["product"] ==
                @v4_business_5m_monthly_plan_id
     end
+
+    test "checkout is disabled when pageview usage exceeds rendered plan limit", %{
+      conn: conn,
+      user: user
+    } do
+      site = insert(:site, members: [user])
+      generate_usage_for(site, 10_001)
+
+      {:ok, lv, _doc} = get_liveview(conn)
+
+      doc = lv |> element(@slider_input) |> render_change(%{slider: 0})
+
+      assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+      assert text_of_element(doc, @business_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+    end
   end
 
   describe "for a user with a v4 growth subscription plan" do

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -37,7 +37,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, _lv, doc} = get_liveview(conn)
 
       assert doc =~ "Upgrade your account"
-      assert doc =~ "You have used <b>0</b>\nbillable pageviews in the last 30 days"
+      assert doc =~ "You have used"
+      assert doc =~ "<b>0</b>"
+      assert doc =~ "billable pageviews in the last 30 days"
       assert doc =~ "Questions?"
       assert doc =~ "What happens if I go over my page views limit?"
       assert doc =~ "Enterprise"
@@ -274,7 +276,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       ])
 
       {:ok, _lv, doc} = get_liveview(conn)
-      assert doc =~ "You have used <b>2</b>\nbillable pageviews in the last 30 days"
+      assert doc =~ "You have used"
+      assert doc =~ "<b>2</b>"
+      assert doc =~ "billable pageviews in the last 30 days"
     end
 
     test "gets default selected interval from current subscription plan", %{conn: conn} do
@@ -389,6 +393,25 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @business_checkout_button) == "Downgrade"
       assert text_of_element(doc, @growth_checkout_button) == "Downgrade to Growth"
+    end
+
+    test "checkout is disabled when team member usage exceeds rendered plan limit", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user))
+        ]
+      )
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
     end
   end
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -413,6 +413,18 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
     end
+
+    test "checkout is disabled when sites usage exceeds rendered plan limit", %{
+      conn: conn,
+      user: user
+    } do
+      for _ <- 1..11, do: insert(:site, members: [user])
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+    end
   end
 
   describe "for a user with a v3 business (unlimited team members) subscription plan" do

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -219,6 +219,16 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert text_of_element(doc, @business_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
     end
+
+    test "warns about losing access to a feature", %{conn: conn, user: user} do
+      site = insert(:site, members: [user])
+      Plausible.Props.allow(site, ["author"])
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_attr(find(doc, @growth_checkout_button), "onclick") =~
+               "if (confirm(\"This plan does not support Custom Properties, which you are currently using. Please note that by subscribing to this plan you will lose access to this feature.\")) {Paddle.Checkout.open"
+    end
   end
 
   describe "for a user with a v4 growth subscription plan" do
@@ -424,6 +434,18 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+    end
+
+    test "warns about losing access to a feature", %{conn: conn, user: user} do
+      site = insert(:site, members: [user])
+      Plausible.Props.allow(site, ["author"])
+
+      insert(:goal, currency: :USD, site: site, event_name: "Purchase")
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_attr(find(doc, @growth_checkout_button), "onclick") =~
+               "if (!confirm(\"This plan does not support Custom Properties and Revenue Goals, which you are currently using. Please note that by subscribing to this plan you will lose access to these features.\")) {e.preventDefault()}"
     end
   end
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -139,6 +139,12 @@ defmodule Plausible.TestUtils do
     |> Plug.Conn.fetch_session()
   end
 
+  def generate_usage_for(site, i) do
+    events = for _i <- 1..i, do: Factory.build(:pageview)
+    populate_stats(site, events)
+    :ok
+  end
+
   def populate_stats(site, events) do
     Enum.map(events, fn event ->
       case event do


### PR DESCRIPTION
### Changes

* On the new upgrade page, disable the upgrade/change-plan link and render an error message beneath it saying "Your usage exceeds this plan", if the user's usage exceeds any of the following limits:
  * monthly pageview limit (based on the last 30 days)
  * team member limit
  * site limit

* On the new upgrade page, use the built-in browser confirmation popup for displaying a warning about losing access to features.

* Also, on the API level, restrict subscribing to a plan that does not accommodate usage (also based on all the three limits mentioned above)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
