### PR TITLE
remove action=register_form check

### DIFF
--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -7,7 +7,6 @@ defmodule PlausibleWeb.AuthController do
   plug(
     PlausibleWeb.RequireLoggedOutPlug
     when action in [
-           :register_form,
            :register,
            :register_from_invitation,
            :login_form,


### PR DESCRIPTION
### Changes

This PR removes `:register_form` plug check since there is no such action in this auth_controller anymore.

### Tests
- x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
