### PR TITLE
ignore only pv limit exceeded on subscribe

### DIFF
--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -190,8 +190,17 @@ defmodule Plausible.Billing.Quota do
 
   def ensure_can_subscribe_to_plan(user, %Plan{} = plan) do
     case exceeded_limits(usage(user), plan) do
-      [] -> :ok
-      exceeded_limits -> {:error, %{exceeded_limits: exceeded_limits}}
+      [] ->
+        :ok
+
+      [:monthly_pageview_limit] ->
+        # This is a quick fix. Need to figure out how to handle this case. Only
+        # checking the last 30 days usage is not accurate enough. Needs to be
+        # in sync with the actual locking system.
+        :ok
+
+      exceeded_limits ->
+        {:error, %{exceeded_limits: exceeded_limits}}
     end
   end
 


### PR DESCRIPTION
### Changes

This is a dirty quick fix to allow subscribing to a plan with exceeded pageview limit. We need to figure out how to handle this case more gracefully.
 
### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
