### PR TITLE
Fix dark mode race condition

### DIFF
--- a/assets/js/apply-theme.js
+++ b/assets/js/apply-theme.js
@@ -30,7 +30,7 @@ function reapplyTheme() {
 }
 
 reapplyTheme();
-window.matchMedia('(prefers-color-scheme: dark)').addListener(reapplyTheme);
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', reapplyTheme);
 
 window.onload = function() {
 	reapplyTheme();

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -74,7 +74,8 @@ defmodule PlausibleWeb.StatsController do
           demo: demo,
           flags: get_flags(conn.assigns[:current_user]),
           is_dbip: is_dbip(),
-          dogfood_page_path: dogfood_page_path
+          dogfood_page_path: dogfood_page_path,
+          load_dashboard_js: true
         )
 
       !stats_start_date && can_see_stats? ->
@@ -320,7 +321,8 @@ defmodule PlausibleWeb.StatsController do
           background: conn.params["background"],
           theme: conn.params["theme"],
           flags: get_flags(conn.assigns[:current_user]),
-          is_dbip: is_dbip()
+          is_dbip: is_dbip(),
+          load_dashboard_js: true
         )
 
       Sites.locked?(shared_link.site) ->

--- a/lib/plausible_web/templates/layout/app.html.eex
+++ b/lib/plausible_web/templates/layout/app.html.eex
@@ -33,5 +33,8 @@
       <%= render("_footer.html", assigns) %>
     <% end %>
     <script type="text/javascript" data-pref="<%= @conn.assigns[:theme] || (@conn.assigns[:current_user] && @conn.assigns[:current_user].theme) %>"  src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <%= if @conn.assigns[:load_dashboard_js] do %>
+      <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dashboard.js") %>"></script>
+    <% end %>
   </body>
 </html>

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -58,5 +58,4 @@
       </div>
     </div>
   <% end %>
-  <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dashboard.js") %>"></script>
 </div>


### PR DESCRIPTION
### Changes

Ensure app.js is loaded before dashboard.js - this is assumed in the code for dark mode to work correctly in dashboard components.

PS - is there a nicer way to do this instead of an assign?