### PR TITLE
Recommending a plan

### DIFF
--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -63,9 +63,9 @@ defmodule Plausible.Billing.Plans do
     |> Enum.filter(&(&1.kind == :business))
   end
 
-  def available_plans_with_prices(%User{} = user) do
+  def available_plans_for(%User{} = user, opts \\ []) do
     (growth_plans_for(user) ++ business_plans_for(user))
-    |> with_prices()
+    |> then(fn all -> if opts[:with_prices], do: with_prices(all), else: all end)
     |> Enum.group_by(& &1.kind)
   end
 

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -67,9 +67,16 @@ defmodule Plausible.Billing.Plans do
   end
 
   def available_plans_for(%User{} = user, opts \\ []) do
-    (growth_plans_for(user) ++ business_plans_for(user))
-    |> then(fn all -> if opts[:with_prices], do: with_prices(all), else: all end)
-    |> Enum.group_by(& &1.kind)
+    plans = growth_plans_for(user) ++ business_plans_for(user)
+
+    plans =
+      if Keyword.get(opts, :with_prices) do
+        with_prices(plans)
+      else
+        plans
+      end
+
+    Enum.group_by(plans, & &1.kind)
   end
 
   @spec yearly_product_ids() :: [String.t()]

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -28,6 +28,12 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:owned_plan, fn %{user: %{subscription: subscription}} ->
         Plans.get_regular_plan(subscription, only_non_expired: true)
       end)
+      |> assign_new(:owned_tier, fn %{owned_plan: owned_plan} ->
+        if owned_plan, do: Map.get(owned_plan, :kind), else: nil
+      end)
+      |> assign_new(:recommended_tier, fn %{owned_plan: owned_plan, user: user} ->
+        if owned_plan, do: nil, else: Plans.suggest_tier(user)
+      end)
       |> assign_new(:current_interval, fn %{user: user} ->
         current_user_subscription_interval(user.subscription)
       end)
@@ -101,7 +107,8 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <div class="mt-6 isolate mx-auto grid max-w-md grid-cols-1 gap-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
           <.plan_box
             kind={:growth}
-            owned={@owned_plan && Map.get(@owned_plan, :kind) == :growth}
+            owned={@owned_tier == :growth}
+            recommended={@recommended_tier == :growth}
             plan_to_render={@growth_plan_to_render}
             benefits={@growth_benefits}
             available={!!@selected_growth_plan}
@@ -109,7 +116,8 @@ defmodule PlausibleWeb.Live.ChoosePlan do
           />
           <.plan_box
             kind={:business}
-            owned={@owned_plan && Map.get(@owned_plan, :kind) == :business}
+            owned={@owned_tier == :business}
+            recommended={@recommended_tier == :business}
             plan_to_render={@business_plan_to_render}
             benefits={@business_benefits}
             available={!!@selected_business_plan}
@@ -241,24 +249,33 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   end
 
   defp plan_box(assigns) do
+    highlight =
+      cond do
+        assigns.owned -> "Current"
+        assigns.recommended -> "Recommended"
+        true -> nil
+      end
+
+    assigns = assign(assigns, :highlight, highlight)
+
     ~H"""
     <div
       id={"#{@kind}-plan-box"}
       class={[
         "shadow-lg bg-white rounded-3xl px-6 sm:px-8 py-4 sm:py-6 dark:bg-gray-800",
-        !@owned && "dark:ring-gray-600",
-        @owned && "ring-2 ring-indigo-600 dark:ring-indigo-300"
+        !@highlight && "dark:ring-gray-600",
+        @highlight && "ring-2 ring-indigo-600 dark:ring-indigo-300"
       ]}
     >
       <div class="flex items-center justify-between gap-x-4">
         <h3 class={[
           "text-lg font-semibold leading-8",
-          !@owned && "text-gray-900 dark:text-gray-100",
-          @owned && "text-indigo-600 dark:text-indigo-300"
+          !@highlight && "text-gray-900 dark:text-gray-100",
+          @highlight && "text-indigo-600 dark:text-indigo-300"
         ]}>
           <%= String.capitalize(to_string(@kind)) %>
         </h3>
-        <.current_label :if={@owned} />
+        <.pill :if={@highlight} text={@highlight} />
       </div>
       <div>
         <.render_price_info available={@available} {assigns} />
@@ -444,14 +461,14 @@ defmodule PlausibleWeb.Live.ChoosePlan do
     """
   end
 
-  defp current_label(assigns) do
+  defp pill(assigns) do
     ~H"""
     <div class="flex items-center justify-between gap-x-4">
       <p
-        id="current-label"
+        id="highlight-pill"
         class="rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs font-semibold leading-5 text-indigo-600 dark:text-indigo-300 dark:ring-1 dark:ring-indigo-300/50"
       >
-        Current
+        <%= @text %>
       </p>
     </div>
     """

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -32,7 +32,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         current_user_subscription_interval(user.subscription)
       end)
       |> assign_new(:available_plans, fn %{user: user} ->
-        Plans.available_plans_with_prices(user)
+        Plans.available_plans_for(user, with_prices: true)
       end)
       |> assign_new(:available_volumes, fn %{available_plans: available_plans} ->
         get_available_volumes(available_plans)

--- a/lib/plausible_web/templates/email/dashboard_locked.html.eex
+++ b/lib/plausible_web/templates/email/dashboard_locked.html.eex
@@ -6,7 +6,7 @@ In the last billing cycle (<%= date_format(@last_cycle.first) %> to <%= date_for
 <%= if @suggested_plan == :enterprise do %>
 This is more than our standard plans, so please reply back to this email to get a quote for your volume.
 <% else %>
-Based on that we recommend you select the <%= @suggested_plan.volume %>/mo plan.
+Based on that we recommend you select a <%= @suggested_plan.volume %>/mo plan.
 <br /><br />
 <a href="https://plausible.io/settings">Click here</a> to go to your account settings. You can upgrade your subscription tier by clicking the 'Change plan' link.
 <% end %>

--- a/lib/plausible_web/templates/email/over_limit.html.eex
+++ b/lib/plausible_web/templates/email/over_limit.html.eex
@@ -8,7 +8,7 @@ In the last billing cycle (<%= date_format(@last_cycle.first) %> to <%= date_for
 <%= if @suggested_plan == :enterprise do %>
 This is more than our standard plans, so please reply back to this email to get a quote for your volume.
 <% else %>
-Based on that we recommend you select the <%= @suggested_plan.volume %>/mo plan.
+Based on that we recommend you select a <%= @suggested_plan.volume %>/mo plan.
 <br /><br />
 You can upgrade your subscription using our self-serve platform. The new charge will be prorated to reflect the amount you have already paid and the time until your current subscription is supposed to expire.
 <br /><br />

--- a/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
+++ b/lib/plausible_web/templates/email/trial_upgrade_email.html.eex
@@ -4,7 +4,7 @@ In the last month, your account has used <%= PlausibleWeb.AuthView.delimit_integ
 <%= if @suggested_plan == :enterprise do %>
 This is more than our standard plans, so please reply back to this email to get a quote for your volume.
 <% else %>
-Based on that we recommend you select the <%= @suggested_plan.volume %>/mo plan.
+Based on that we recommend you select a <%= @suggested_plan.volume %>/mo plan.
 <br /><br />
 <%= link("Upgrade now", to: "#{plausible_url()}/billing/upgrade") %>
 <br /><br />

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -68,10 +68,10 @@ defmodule Plausible.Billing.PlansTest do
       assert List.first(business_plans).monthly_product_id == @v4_business_plan_id
     end
 
-    test "available_plans_with_prices/1" do
+    test "available_plans returns all plans for user with prices when asked for" do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
 
-      %{growth: growth_plans, business: business_plans} = Plans.available_plans_with_prices(user)
+      %{growth: growth_plans, business: business_plans} = Plans.available_plans_for(user, with_prices: true)
 
       assert Enum.find(growth_plans, fn plan ->
                (%Money{} = plan.monthly_cost) && plan.monthly_product_id == @v2_plan_id
@@ -80,6 +80,12 @@ defmodule Plausible.Billing.PlansTest do
       assert Enum.find(business_plans, fn plan ->
                (%Money{} = plan.monthly_cost) && plan.monthly_product_id == @v3_business_plan_id
              end)
+    end
+
+    test "available_plans returns all plans without prices by default" do
+      user = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
+
+      assert %{growth: [_ | _], business: [_ | _]} = Plans.available_plans_for(user)
     end
 
     test "latest_enterprise_plan_with_price/1" do

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -71,7 +71,8 @@ defmodule Plausible.Billing.PlansTest do
     test "available_plans returns all plans for user with prices when asked for" do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
 
-      %{growth: growth_plans, business: business_plans} = Plans.available_plans_for(user, with_prices: true)
+      %{growth: growth_plans, business: business_plans} =
+        Plans.available_plans_for(user, with_prices: true)
 
       assert Enum.find(growth_plans, fn plan ->
                (%Money{} = plan.monthly_cost) && plan.monthly_product_id == @v2_plan_id
@@ -229,6 +230,38 @@ defmodule Plausible.Billing.PlansTest do
                "857093",
                "857094"
              ] == Plans.yearly_product_ids()
+    end
+  end
+
+  describe "suggest_tier/1" do
+    test "suggests Business when user has used a premium feature" do
+      user = insert(:user, inserted_at: ~N[2024-01-01 10:00:00])
+      insert(:api_key, user: user)
+
+      assert Plans.suggest_tier(user) == :business
+    end
+
+    test "suggests Growth when no premium features used" do
+      user = insert(:user, inserted_at: ~N[2024-01-01 10:00:00])
+      site = insert(:site, members: [user])
+      insert(:goal, site: site, event_name: "goals_is_not_premium")
+
+      assert Plans.suggest_tier(user) == :growth
+    end
+
+    test "suggests Growth tier for a user who used the Stats API, but signed up before it was considered a premium feature" do
+      user = insert(:user, inserted_at: ~N[2023-10-25 10:00:00])
+      insert(:api_key, user: user)
+
+      assert Plans.suggest_tier(user) == :growth
+    end
+
+    test "suggests Business tier for a user who used the Revenue Goals, even when they signed up before Business tier release" do
+      user = insert(:user, inserted_at: ~N[2023-10-25 10:00:00])
+      site = insert(:site, members: [user])
+      insert(:goal, site: site, currency: :USD, event_name: "Purchase")
+
+      assert Plans.suggest_tier(user) == :business
     end
   end
 end

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -166,7 +166,7 @@ defmodule Plausible.Workers.CheckUsageTest do
     })
 
     # Should find 2 visiors
-    assert html_body =~ ~s(Based on that we recommend you select the 100k/mo plan.)
+    assert html_body =~ ~s(Based on that we recommend you select a 100k/mo plan.)
   end
 
   describe "enterprise customers" do

--- a/test/workers/send_trial_notifications_test.exs
+++ b/test/workers/send_trial_notifications_test.exs
@@ -147,56 +147,56 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {9_000, 0})
-      assert email.html_body =~ "we recommend you select the 10k/mo plan."
+      assert email.html_body =~ "we recommend you select a 10k/mo plan."
     end
 
     test "suggests 100k/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {90_000, 0})
-      assert email.html_body =~ "we recommend you select the 100k/mo plan."
+      assert email.html_body =~ "we recommend you select a 100k/mo plan."
     end
 
     test "suggests 200k/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {180_000, 0})
-      assert email.html_body =~ "we recommend you select the 200k/mo plan."
+      assert email.html_body =~ "we recommend you select a 200k/mo plan."
     end
 
     test "suggests 500k/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {450_000, 0})
-      assert email.html_body =~ "we recommend you select the 500k/mo plan."
+      assert email.html_body =~ "we recommend you select a 500k/mo plan."
     end
 
     test "suggests 1m/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {900_000, 0})
-      assert email.html_body =~ "we recommend you select the 1M/mo plan."
+      assert email.html_body =~ "we recommend you select a 1M/mo plan."
     end
 
     test "suggests 2m/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {1_800_000, 0})
-      assert email.html_body =~ "we recommend you select the 2M/mo plan."
+      assert email.html_body =~ "we recommend you select a 2M/mo plan."
     end
 
     test "suggests 5m/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {4_500_000, 0})
-      assert email.html_body =~ "we recommend you select the 5M/mo plan."
+      assert email.html_body =~ "we recommend you select a 5M/mo plan."
     end
 
     test "suggests 10m/mo plan" do
       user = insert(:user)
 
       email = PlausibleWeb.Email.trial_upgrade_email(user, "today", {9_000_000, 0})
-      assert email.html_body =~ "we recommend you select the 10M/mo plan."
+      assert email.html_body =~ "we recommend you select a 10M/mo plan."
     end
 
     test "does not suggest a plan above that" do


### PR DESCRIPTION
### Changes

This PR implement the recommending of a plan tier for trials, based on the premium features they've used. When recommending the tier, we also take into account if the trials started before or after the Business Tiers release. Therefore, this PR consists of two tests that will become redundant after 30 days have passed from the release.

The styling of the recommendation highlight on the UI side is exactly the same as for the currently owned plan. But since these are used for different user groups (trials vs existing subscribers) - we never show the two highlights on the page at the same time.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode

