### PR TITLE
Fix /sites cut-off for 0 visitors plot

### DIFF
--- a/lib/plausible_web/live/components/visitors.ex
+++ b/lib/plausible_web/live/components/visitors.ex
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Live.Components.Visitors do
       |> assign(:id, Ecto.UUID.generate())
 
     ~H"""
-    <svg viewBox={"0 -1 #{(@points_len - 1) * @tick} #{@height + 1}"} class="chart w-full mb-2">
+    <svg viewBox={"0 -1 #{(@points_len - 1) * @tick} #{@height + 2}"} class="chart w-full mb-2">
       <defs>
         <clipPath id={"gradient-cut-off-#{@id}"}>
           <polyline points={@clip_points} />


### PR DESCRIPTION
### Changes

before:

![image](https://github.com/plausible/analytics/assets/173738/ff496c0d-630b-40f9-b3a9-d80bbcb681f0)


after:

![image](https://github.com/plausible/analytics/assets/173738/67943710-7592-4f3e-909c-26b45227e0e7)
