### PR TITLE
Add loading state to site cards

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -236,13 +236,14 @@ defmodule PlausibleWeb.Live.Sites do
 
   def site_stats(assigns) do
     ~H"""
-    <div class="h-[58px]">
-      <div :if={@hourly_stats == :loading} class="text-center pt-6">
-        <span class="animate-pulse text-xs text-gray-600 dark:text-gray-400">crunching numbers</span>
+    <div class="md:h-[78px] h-20 pl-8 pr-8 pt-2">
+      <div :if={@hourly_stats == :loading} class="text-center animate-pulse">
+        <div class="md:h-[34px] h-11 dark:bg-gray-700 bg-gray-200 rounded-md"></div>
+        <div class="md:h-[26px] h-6 mt-1 dark:bg-gray-700 bg-gray-200 rounded-md"></div>
       </div>
       <div
         :if={is_map(@hourly_stats)}
-        class="hidden"
+        class="hidden h-50px"
         phx-mounted={
           Phoenix.LiveView.JS.show(transition: {"ease-in duration-500", "opacity-0", "opacity-100"})
         }
@@ -496,7 +497,6 @@ defmodule PlausibleWeb.Live.Sites do
 
     hourly_stats =
       if connected?(socket) do
-        :timer.sleep(3000)
         Plausible.Stats.Clickhouse.last_24h_visitors_hourly_intervals(sites.entries)
       else
         sites.entries

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -238,8 +238,8 @@ defmodule PlausibleWeb.Live.Sites do
     ~H"""
     <div class="md:h-[78px] h-20 pl-8 pr-8 pt-2">
       <div :if={@hourly_stats == :loading} class="text-center animate-pulse">
-        <div class="md:h-[34px] h-11 dark:bg-gray-700 bg-gray-200 rounded-md"></div>
-        <div class="md:h-[26px] h-6 mt-1 dark:bg-gray-700 bg-gray-200 rounded-md"></div>
+        <div class="md:h-[34px] h-11 dark:bg-gray-700 bg-gray-100 rounded-md"></div>
+        <div class="md:h-[26px] h-6 mt-1 dark:bg-gray-700 bg-gray-100 rounded-md"></div>
       </div>
       <div
         :if={is_map(@hourly_stats)}

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -270,7 +270,7 @@ defmodule PlausibleWeb.Live.Sites do
   def percentage_change(assigns) do
     ~H"""
     <p class="dark:text-gray-100">
-      <span :if={@change == 0} class="font-semibold text-green-500">〰</span>
+      <span :if={@change == 0} class="font-semibold">〰</span>
       <span :if={@change > 0} class="font-semibold text-green-500">↑</span>
       <span :if={@change < 0} class="font-semibold text-red-400">↓</span>
       <%= abs(@change) %>%

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -238,7 +238,7 @@ defmodule PlausibleWeb.Live.Sites do
     ~H"""
     <div class="h-[58px]">
       <div :if={@hourly_stats == :loading} class="text-center pt-6">
-        <span class="animate-pulse text-xs">crunching numbers</span>
+        <span class="animate-pulse text-xs text-gray-600 dark:text-gray-400">crunching numbers</span>
       </div>
       <div
         :if={is_map(@hourly_stats)}
@@ -496,6 +496,7 @@ defmodule PlausibleWeb.Live.Sites do
 
     hourly_stats =
       if connected?(socket) do
+        :timer.sleep(3000)
         Plausible.Stats.Clickhouse.last_24h_visitors_hourly_intervals(sites.entries)
       else
         sites.entries

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -56,7 +56,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       site_card = text_of_element(resp, "li[data-domain=\"#{site.domain}\"]")
 
-      assert site_card =~ "0 visitors in last 24h"
+      assert site_card =~ "crunching numbers"
       assert site_card =~ site.domain
     end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -56,7 +56,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       site_card = text_of_element(resp, "li[data-domain=\"#{site.domain}\"]")
 
-      assert site_card =~ "crunching numbers"
+      refute site_card =~ "0 visitors"
       assert site_card =~ site.domain
     end
 


### PR DESCRIPTION
### Changes

shows loading state, so that "0 visitors" doesn't flash before ws connects.

cc @ukutaht - if you like to test/tweak locally, add :timer.sleep(3000) after `connected?` on line 498
