### PR TITLE
Fix upgrade page for legacy trials + bug fixes

### DIFF
--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -27,7 +27,7 @@ defmodule Plausible.Billing.Plans do
     Module.put_attribute(__MODULE__, :external_resource, path)
   end
 
-  @business_tier_launch ~N[2023-11-07 12:00:00]
+  @business_tier_launch ~N[2023-12-01 12:00:00]
 
   @spec growth_plans_for(User.t()) :: [Plan.t()]
   @doc """

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -44,7 +44,9 @@ defmodule Plausible.Billing.Plans do
 
     cond do
       Application.get_env(:plausible, :environment) == "dev" -> @sandbox_plans
-      !owned_plan -> if v4_available, do: @plans_v4, else: @plans_v3
+      is_nil(owned_plan) && Timex.before?(user.inserted_at, @business_tier_launch) -> @plans_v3
+      is_nil(owned_plan) && v4_available -> @plans_v4
+      is_nil(owned_plan) -> @plans_v3
       owned_plan.kind == :business -> @plans_v4
       owned_plan.generation == 1 -> @plans_v1
       owned_plan.generation == 2 -> @plans_v2
@@ -60,6 +62,7 @@ defmodule Plausible.Billing.Plans do
 
     cond do
       Application.get_env(:plausible, :environment) == "dev" -> @sandbox_plans
+      is_nil(owned_plan) && Timex.before?(user.inserted_at, @business_tier_launch) -> @plans_v3
       owned_plan && owned_plan.generation < 4 -> @plans_v3
       true -> @plans_v4
     end

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -245,6 +245,10 @@ defmodule Plausible.Billing.Plans do
   end
 
   defp all() do
-    @legacy_plans ++ @plans_v1 ++ @plans_v2 ++ @plans_v3 ++ @plans_v4
+    @legacy_plans ++ @plans_v1 ++ @plans_v2 ++ @plans_v3 ++ @plans_v4 ++ sandbox_plans()
+  end
+
+  defp sandbox_plans() do
+    if Application.get_env(:plausible, :environment) == "dev", do: @sandbox_plans, else: []
   end
 end

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -27,7 +27,7 @@ defmodule Plausible.Billing.Plans do
     Module.put_attribute(__MODULE__, :external_resource, path)
   end
 
-  @business_tier_launch ~D[2023-11-07]
+  @business_tier_launch ~N[2023-11-07 12:00:00]
 
   @spec growth_plans_for(User.t()) :: [Plan.t()]
   @doc """

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -230,7 +230,7 @@ defmodule Plausible.Billing.Quota do
     case Plans.get_subscription_plan(user.subscription) do
       %EnterprisePlan{} -> Feature.list()
       %Plan{features: features} -> features
-      :free_10k -> [Goals]
+      :free_10k -> [Goals, Props, StatsAPI]
       nil -> Feature.list()
     end
   end

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -215,7 +215,7 @@ defmodule Plausible.Billing.Quota do
           {:team_members, :team_member_limit},
           {:sites, :site_limit}
         ],
-        !below_limit?(Map.get(usage, usage_field), Map.get(plan, limit_field)) do
+        !within_limit?(Map.get(usage, usage_field), Map.get(plan, limit_field)) do
       limit_field
     end
   end
@@ -248,5 +248,14 @@ defmodule Plausible.Billing.Quota do
   """
   def below_limit?(usage, limit) do
     if limit == :unlimited, do: true, else: usage < limit
+  end
+
+  @spec within_limit?(non_neg_integer(), non_neg_integer() | :unlimited) :: boolean()
+  @doc """
+  Returns whether the usage is within the limit or not.
+  Returns true if usage is equal to the limit.
+  """
+  def within_limit?(usage, limit) do
+    if limit == :unlimited, do: true, else: usage <= limit
   end
 end

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -215,7 +215,7 @@ defmodule Plausible.Billing.Quota do
           {:team_members, :team_member_limit},
           {:sites, :site_limit}
         ],
-        !within_limit?(Map.get(usage, usage_field), Map.get(plan, limit_field)) do
+        !below_limit?(Map.get(usage, usage_field), Map.get(plan, limit_field)) do
       limit_field
     end
   end
@@ -241,11 +241,12 @@ defmodule Plausible.Billing.Quota do
       select: %{site_id: sm.site_id}
   end
 
-  @spec within_limit?(non_neg_integer(), non_neg_integer() | :unlimited) :: boolean()
+  @spec below_limit?(non_neg_integer(), non_neg_integer() | :unlimited) :: boolean()
   @doc """
-  Returns whether the limit has been exceeded or not.
+  Returns whether the usage is below the limit or not.
+  Returns false if usage is equal to the limit.
   """
-  def within_limit?(usage, limit) do
+  def below_limit?(usage, limit) do
     if limit == :unlimited, do: true, else: usage < limit
   end
 end

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -117,14 +117,14 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
     site_usage = Plausible.Repo.aggregate(Quota.team_member_usage_query(site.owner, site), :count)
     usage_after_transfer = current_usage + site_usage
 
-    Quota.within_limit?(usage_after_transfer, limit)
+    Quota.below_limit?(usage_after_transfer, limit)
   end
 
   defp within_site_limit_after_transfer?(new_owner) do
     limit = Quota.site_limit(new_owner)
     usage_after_transfer = Quota.site_usage(new_owner) + 1
 
-    Quota.within_limit?(usage_after_transfer, limit)
+    Quota.below_limit?(usage_after_transfer, limit)
   end
 
   defp has_access_to_site_features?(site, new_owner) do
@@ -174,7 +174,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
     limit = Quota.team_member_limit(site.owner)
     usage = Quota.team_member_usage(site.owner)
 
-    if Quota.within_limit?(usage, limit),
+    if Quota.below_limit?(usage, limit),
       do: :ok,
       else: {:error, {:over_limit, limit}}
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -87,7 +87,7 @@ defmodule Plausible.Sites do
       limit = Quota.site_limit(user)
       usage = Quota.site_usage(user)
 
-      if Quota.within_limit?(usage, limit), do: {:ok, usage}, else: {:error, limit}
+      if Quota.below_limit?(usage, limit), do: {:ok, usage}, else: {:error, limit}
     end)
     |> Ecto.Multi.insert(:site, site_changeset)
     |> Ecto.Multi.insert(:site_membership, fn %{site: site} ->

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -13,12 +13,12 @@ defmodule PlausibleWeb.SiteController do
 
     limit = Plausible.Billing.Quota.site_limit(current_user)
     usage = Plausible.Billing.Quota.site_usage(current_user)
-    within_limit? = Plausible.Billing.Quota.within_limit?(usage, limit)
+    below_limit? = Plausible.Billing.Quota.below_limit?(usage, limit)
 
     render(conn, "new.html",
       changeset: Plausible.Site.changeset(%Plausible.Site{}),
       is_first_site: usage == 0,
-      is_at_limit: !within_limit?,
+      is_at_limit: !below_limit?,
       site_limit: limit,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -396,11 +396,15 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   end
 
   defp change_plan_link(assigns) do
+    confirmed =
+      if assigns.confirm_message, do: "confirm(\"#{assigns.confirm_message}\")", else: "true"
+
+    assigns = assign(assigns, :confirmed, confirmed)
+
     ~H"""
-    <.link
+    <button
       id={"#{@kind}-checkout"}
-      onclick={if @confirm_message, do: "if (!confirm(\"#{@confirm_message}\")) {e.preventDefault()}"}
-      href={Routes.billing_path(PlausibleWeb.Endpoint, :change_plan_preview, @paddle_product_id)}
+      onclick={"if (#{@confirmed}) {window.location = '#{Routes.billing_path(PlausibleWeb.Endpoint, :change_plan_preview, @paddle_product_id)}'}"}
       class={[
         "w-full mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-white",
         !@checkout_disabled && "bg-indigo-600 hover:bg-indigo-500",
@@ -408,7 +412,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       ]}
     >
       <%= @change_plan_link_text %>
-    </.link>
+    </button>
     """
   end
 

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -285,7 +285,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
           <.contact_button class="bg-indigo-600 hover:bg-indigo-500 text-white" />
         <% end %>
       </div>
-      <%= if @kind == :growth && @plan_to_render.generation < 4 do %>
+      <%= if @owned && @kind == :growth && @plan_to_render.generation < 4 do %>
         <.growth_grandfathering_notice />
       <% else %>
         <ul

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Workers.CheckUsage do
     site_limit = check_site_limit_for_enterprise(subscriber)
 
     case {pageview_limit, site_limit} do
-      {{:within_limit, _}, {:within_limit, _}} ->
+      {{:below_limit, _}, {:below_limit, _}} ->
         nil
 
       {{_, {last_cycle, last_cycle_usage}}, {_, {site_usage, site_allowance}}} ->
@@ -126,15 +126,15 @@ defmodule Plausible.Workers.CheckUsage do
     {last_last_cycle_usage, last_cycle_usage} =
       billing_mod.last_two_billing_months_usage(subscriber)
 
-    exceeded_last_cycle? = not Plausible.Billing.Quota.within_limit?(last_cycle_usage, limit)
+    exceeded_last_cycle? = not Plausible.Billing.Quota.below_limit?(last_cycle_usage, limit)
 
     exceeded_last_last_cycle? =
-      not Plausible.Billing.Quota.within_limit?(last_last_cycle_usage, limit)
+      not Plausible.Billing.Quota.below_limit?(last_last_cycle_usage, limit)
 
     if exceeded_last_last_cycle? && exceeded_last_cycle? do
       {:over_limit, {last_cycle, last_cycle_usage}}
     else
-      {:within_limit, {last_cycle, last_cycle_usage}}
+      {:below_limit, {last_cycle, last_cycle_usage}}
     end
   end
 
@@ -142,8 +142,8 @@ defmodule Plausible.Workers.CheckUsage do
     limit = subscriber.enterprise_plan.site_limit
     usage = Plausible.Billing.Quota.site_usage(subscriber)
 
-    if Plausible.Billing.Quota.within_limit?(usage, limit) do
-      {:within_limit, {usage, limit}}
+    if Plausible.Billing.Quota.below_limit?(usage, limit) do
+      {:below_limit, {usage, limit}}
     else
       {:over_limit, {usage, limit}}
     end

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -5,6 +5,7 @@ defmodule Plausible.Billing.PlansTest do
   @legacy_plan_id "558746"
   @v1_plan_id "558018"
   @v2_plan_id "654177"
+  @v3_plan_id "749342"
   @v4_plan_id "857097"
   @v3_business_plan_id "857481"
   @v4_business_plan_id "857105"
@@ -25,8 +26,13 @@ defmodule Plausible.Billing.PlansTest do
       assert List.first(Plans.growth_plans_for(user)).monthly_product_id == @v2_plan_id
     end
 
-    test "growth_plans_for/1 returns v4 plans for everyone else" do
-      user = insert(:user)
+    test "growth_plans_for/1 shows v3 pricing for users who signed up before the business tier" do
+      user = insert(:user, inserted_at: ~U[2023-10-01T00:00:00Z])
+      assert List.first(Plans.growth_plans_for(user)).monthly_product_id == @v3_plan_id
+    end
+
+    test "growth_plans_for/1 shows v4 plans for everyone else" do
+      user = insert(:user, inserted_at: ~U[2024-01-01T00:00:00Z])
       assert List.first(Plans.growth_plans_for(user)).monthly_product_id == @v4_plan_id
     end
 
@@ -60,8 +66,13 @@ defmodule Plausible.Billing.PlansTest do
       assert List.first(business_plans).monthly_product_id == @v3_business_plan_id
     end
 
+    test "business_plans_for/1 returns v3 business plans for users who signed up before the business tier release" do
+      user = insert(:user, inserted_at: ~U[2023-10-01T00:00:00Z])
+      assert List.first(Plans.business_plans_for(user)).monthly_product_id == @v3_business_plan_id
+    end
+
     test "business_plans_for/1 returns v4 business plans for everyone else" do
-      user = insert(:user)
+      user = insert(:user, inserted_at: ~U[2024-01-01T00:00:00Z])
       business_plans = Plans.business_plans_for(user)
 
       assert Enum.all?(business_plans, &(&1.kind == :business))

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -127,6 +127,18 @@ defmodule Plausible.Billing.QuotaTest do
 
       assert Quota.exceeded_limits(usage, plan) == [:monthly_pageview_limit, :site_limit]
     end
+
+    test "if limits are reached, they're not exceeded" do
+      usage = %{
+        monthly_pageviews: 10_000,
+        team_members: 2,
+        sites: 50
+      }
+
+      plan = Plans.find(@v3_plan_id)
+
+      assert Quota.exceeded_limits(usage, plan) == []
+    end
   end
 
   describe "monthly_pageview_limit/1" do

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -474,9 +474,9 @@ defmodule Plausible.Billing.QuotaTest do
       assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v3)
     end
 
-    test "returns [Goals] when user is on free_10k plan" do
+    test "returns [Goals, Props, StatsAPI] when user is on free_10k plan" do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: "free_10k"))
-      assert [Goals] == Quota.allowed_features_for(user)
+      assert [Goals, Props, StatsAPI] == Quota.allowed_features_for(user)
     end
 
     test "returns all features when user is on an enterprise plan" do

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -97,21 +97,21 @@ defmodule Plausible.Billing.QuotaTest do
     assert Quota.site_usage(user) == 3
   end
 
-  describe "within_limit?/2" do
+  describe "below_limit?/2" do
     test "returns true when quota is not exceeded" do
-      assert Quota.within_limit?(3, 5)
+      assert Quota.below_limit?(3, 5)
     end
 
     test "returns true when limit is :unlimited" do
-      assert Quota.within_limit?(10_000, :unlimited)
+      assert Quota.below_limit?(10_000, :unlimited)
     end
 
     test "returns false when usage is at limit" do
-      refute Quota.within_limit?(3, 3)
+      refute Quota.below_limit?(3, 3)
     end
 
     test "returns false when usage exceeds the limit" do
-      refute Quota.within_limit?(10, 3)
+      refute Quota.below_limit?(10, 3)
     end
   end
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -30,6 +30,37 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
   @enterprise_plan_box "#enterprise-plan-box"
 
+  describe "for a legacy trial (user registered before business tiers release)" do
+    setup %{conn: conn} do
+      user = insert(:user, inserted_at: ~N[2023-10-25 12:00:00])
+      {:ok, conn: conn} = log_in(%{conn: conn, user: user})
+      {:ok, conn: conn, user: user}
+    end
+
+    test "renders v3 plan benefits, but no grandfathering notice", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      growth_box = text_of_element(doc, @growth_plan_box)
+      business_box = text_of_element(doc, @business_plan_box)
+
+      assert growth_box =~ "Unlimited team members"
+      assert growth_box =~ "Up to 50 sites"
+      assert growth_box =~ "Intuitive, fast and privacy-friendly dashboard"
+      assert growth_box =~ "Email/Slack reports"
+      assert growth_box =~ "Google Analytics import"
+      assert growth_box =~ "Goals and custom events"
+      assert growth_box =~ "Stats API"
+      assert growth_box =~ "Custom Properties"
+
+      assert business_box =~ "Everything in Growth"
+      assert business_box =~ "Funnels"
+      assert business_box =~ "Ecommerce revenue attribution"
+      assert business_box =~ "Priority support"
+
+      refute growth_box =~ "Your subscription has been grandfathered"
+    end
+  end
+
   describe "for a user with no subscription" do
     setup [:create_user, :log_in]
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -385,16 +385,16 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       growth_checkout_button = find(doc, @growth_checkout_button)
 
-      assert text_of_attr(growth_checkout_button, "href") =~
-               Routes.billing_path(conn, :change_plan_preview, @v4_growth_200k_yearly_plan_id)
+      assert text_of_attr(growth_checkout_button, "onclick") =~
+               "if (true) {window.location = '#{Routes.billing_path(conn, :change_plan_preview, @v4_growth_200k_yearly_plan_id)}'}"
 
       element(lv, @slider_input) |> render_change(%{slider: 6})
       doc = element(lv, @monthly_interval_button) |> render_click()
 
       business_checkout_button = find(doc, @business_checkout_button)
 
-      assert text_of_attr(business_checkout_button, "href") =~
-               Routes.billing_path(conn, :change_plan_preview, @v4_business_5m_monthly_plan_id)
+      assert text_of_attr(business_checkout_button, "onclick") =~
+               "if (true) {window.location = '#{Routes.billing_path(conn, :change_plan_preview, @v4_business_5m_monthly_plan_id)}'}"
     end
   end
 
@@ -480,7 +480,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, _lv, doc} = get_liveview(conn)
 
       assert text_of_attr(find(doc, @growth_checkout_button), "onclick") =~
-               "if (!confirm(\"This plan does not support Custom Properties, Revenue Goals and Stats API, which you are currently using. Please note that by subscribing to this plan you will lose access to these features.\")) {e.preventDefault()}"
+               "if (confirm(\"This plan does not support Custom Properties, Revenue Goals and Stats API, which you are currently using. Please note that by subscribing to this plan you will lose access to these features.\")) {window.location = "
     end
   end
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -448,6 +448,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
           build(:site_membership, user: user, role: :owner),
           build(:site_membership, user: build(:user)),
           build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
           build(:site_membership, user: build(:user))
         ]
       )

--- a/test/support/paddle_api_mock.ex
+++ b/test/support/paddle_api_mock.ex
@@ -39,7 +39,7 @@ defmodule Plausible.PaddleApi.Mock do
          "currency" => "EUR",
          "date" => "2023-12-05"
        },
-       "plan_id" => 63852,
+       "plan_id" => 63_852,
        "subscription_id" => 600_279,
        "user_id" => 666_317
      }}

--- a/test/support/paddle_api_mock.ex
+++ b/test/support/paddle_api_mock.ex
@@ -26,6 +26,25 @@ defmodule Plausible.PaddleApi.Mock do
      }}
   end
 
+  def update_subscription_preview(_user, _new_plan_id) do
+    {:ok,
+     %{
+       "immediate_payment" => %{
+         "amount" => -72.6,
+         "currency" => "EUR",
+         "date" => "2023-11-05"
+       },
+       "next_payment" => %{
+         "amount" => 47.19,
+         "currency" => "EUR",
+         "date" => "2023-12-05"
+       },
+       "plan_id" => 63852,
+       "subscription_id" => 600_279,
+       "user_id" => 666_317
+     }}
+  end
+
   def get_invoices(nil), do: {:error, :no_invoices}
   def get_invoices(%{paddle_subscription_id: nil}), do: {:error, :no_invoices}
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -35,7 +35,7 @@ defmodule Plausible.TestUtils do
   end
 
   def create_user(_) do
-    {:ok, user: Factory.insert(:user)}
+    {:ok, user: Factory.insert(:user, inserted_at: ~U[2024-01-01T00:00:00Z])}
   end
 
   def create_site(%{user: user}) do


### PR DESCRIPTION
### Changes

> Legacy trials = users who signed up before the business tier release.

* Include `StatsAPI` and `Props` as allowed features for a `free_10k` subscription plan
* Return v3 plans (both Growth and Business) to legacy trials. This allows them to subscribe to a plan with the terms that they signed up for (e.g. unlimited team members)
* Display Growth benefits list instead of grandfathering notice on the upgrade page when the user is a legacy trial

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
