### PR TITLE
Tidy up openapi schema

### DIFF
--- a/lib/plausible_web/plugins/api/schemas/error.ex
+++ b/lib/plausible_web/plugins/api/schemas/error.ex
@@ -11,6 +11,6 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Error do
     """,
     type: :object,
     required: [:detail],
-    properties: %{detail: %OpenApiSpex.Schema{type: :string}}
+    properties: %{detail: %Schema{type: :string}}
   })
 end

--- a/lib/plausible_web/plugins/api/schemas/goal/list_response.ex
+++ b/lib/plausible_web/plugins/api/schemas/goal/list_response.ex
@@ -14,15 +14,12 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Goal.ListResponse do
         items: Schemas.Goal,
         type: :array
       },
-      meta: %OpenApiSpex.Schema{
+      meta: %Schema{
         required: [:pagination],
-        properties: %{
-          pagination: %OpenApiSpex.Reference{
-            "$ref": "#/components/schemas/PaginationMetadata"
-          }
-        },
         type: :object,
-        items: Schemas.PaginationMetadata
+        properties: %{
+          pagination: Schemas.PaginationMetadata
+        }
       }
     }
   })

--- a/lib/plausible_web/plugins/api/schemas/link.ex
+++ b/lib/plausible_web/plugins/api/schemas/link.ex
@@ -8,6 +8,6 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Link do
     title: "Link",
     type: :object,
     required: [:url],
-    properties: %{url: %OpenApiSpex.Schema{type: :string}}
+    properties: %{url: %Schema{type: :string}}
   })
 end

--- a/lib/plausible_web/plugins/api/schemas/not_found.ex
+++ b/lib/plausible_web/plugins/api/schemas/not_found.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.NotFound do
     title: "NotFoundError",
     required: [:errors],
     properties: %{
-      errors: %OpenApiSpex.Schema{
+      errors: %Schema{
         items: Schemas.Error,
         type: :array
       }

--- a/lib/plausible_web/plugins/api/schemas/pagination_metadata.ex
+++ b/lib/plausible_web/plugins/api/schemas/pagination_metadata.ex
@@ -13,7 +13,6 @@ defmodule PlausibleWeb.Plugins.API.Schemas.PaginationMetadata do
       has_next_page: %Schema{type: :boolean},
       has_prev_page: %Schema{type: :boolean},
       links: %Schema{
-        items: Schemas.Link,
         properties: %{
           next: Schemas.Link,
           prev: Schemas.Link

--- a/lib/plausible_web/plugins/api/schemas/pagination_metadata.ex
+++ b/lib/plausible_web/plugins/api/schemas/pagination_metadata.ex
@@ -10,13 +10,13 @@ defmodule PlausibleWeb.Plugins.API.Schemas.PaginationMetadata do
     type: :object,
     required: [:has_next_page, :has_prev_page],
     properties: %{
-      has_next_page: %OpenApiSpex.Schema{type: :boolean},
-      has_prev_page: %OpenApiSpex.Schema{type: :boolean},
-      links: %OpenApiSpex.Schema{
+      has_next_page: %Schema{type: :boolean},
+      has_prev_page: %Schema{type: :boolean},
+      links: %Schema{
         items: Schemas.Link,
         properties: %{
-          next: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Link"},
-          prev: %OpenApiSpex.Reference{"$ref": "#/components/schemas/Link"}
+          next: Schemas.Link,
+          prev: Schemas.Link
         },
         type: :object
       }

--- a/lib/plausible_web/plugins/api/schemas/payment_required.ex
+++ b/lib/plausible_web/plugins/api/schemas/payment_required.ex
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.PaymentRequired do
     title: "PaymentRequiredError",
     required: [:errors],
     properties: %{
-      errors: %OpenApiSpex.Schema{
+      errors: %Schema{
         items: Schemas.Error,
         type: :array
       }

--- a/lib/plausible_web/plugins/api/schemas/shared_link/list_response.ex
+++ b/lib/plausible_web/plugins/api/schemas/shared_link/list_response.ex
@@ -14,15 +14,12 @@ defmodule PlausibleWeb.Plugins.API.Schemas.SharedLink.ListResponse do
         items: Schemas.SharedLink,
         type: :array
       },
-      meta: %OpenApiSpex.Schema{
+      meta: %Schema{
         required: [:pagination],
-        properties: %{
-          pagination: %OpenApiSpex.Reference{
-            "$ref": "#/components/schemas/PaginationMetadata"
-          }
-        },
         type: :object,
-        items: Schemas.PaginationMetadata
+        properties: %{
+          pagination: Schemas.PaginationMetadata
+        }
       }
     }
   })

--- a/lib/plausible_web/plugins/api/schemas/unauthorized.ex
+++ b/lib/plausible_web/plugins/api/schemas/unauthorized.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Unauthorized do
     title: "UnauthorizedError",
     required: [:errors],
     properties: %{
-      errors: %OpenApiSpex.Schema{
+      errors: %Schema{
         items: Schemas.Error,
         type: :array
       }

--- a/lib/plausible_web/plugins/api/schemas/unprocessable_entity.ex
+++ b/lib/plausible_web/plugins/api/schemas/unprocessable_entity.ex
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.UnprocessableEntity do
     title: "UnprocessableEntityError",
     required: [:errors],
     properties: %{
-      errors: %OpenApiSpex.Schema{
+      errors: %Schema{
         items: Schemas.Error,
         type: :array
       }


### PR DESCRIPTION
### Changes

This PR only cleans up the OpenAPI schema - no tests should be harmed and it resolves the errors when using PHP code generator.