### PR TITLE
Create `site_user_preferences` table and apply LV fix

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -474,6 +474,14 @@ defmodule PlausibleWeb.Live.Sites do
     """
   end
 
+  def handle_event(
+        "filter",
+        %{"filter_text" => filter_text},
+        %{assigns: %{filter_text: filter_text}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
   def handle_event("filter", %{"filter_text" => filter_text}, socket) do
     socket =
       socket

--- a/priv/repo/migrations/20231109090334_add_site_user_preferences.exs
+++ b/priv/repo/migrations/20231109090334_add_site_user_preferences.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Repo.Migrations.AddSiteUserPreferences do
+  use Ecto.Migration
+
+  def change do
+    create table(:site_user_preferences) do
+      add :pinned_at, :naive_datetime
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+      timestamps()
+    end
+
+    create unique_index(:site_user_preferences, [:user_id, :site_id])
+  end
+end


### PR DESCRIPTION
### Changes

Changes extracted from #3469 - the migration has to be deployed and run before the changes in logic.

There's also a fix to sites LV which should address problem of excessive DB queries due to firing `phx-change` events on reconnecting websockets. More context: https://hexdocs.pm/phoenix_live_view/form-bindings.html#recovery-following-crashes-or-disconnects

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
