### PR TITLE
Notice across the app about Funnels and Revenue goals private preview end

### DIFF
--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -318,7 +318,7 @@ defmodule PlausibleWeb.Components.Billing do
 
         _free_10k_or_enterprise_or_growth ->
           used_features = Plausible.Billing.Quota.features_usage(assigns.user)
-          for f_mod <- [Funnels, RevenueGoals], f_mod in used_features, do: f_mod
+          Enum.filter([Funnels, RevenueGoals], &(&1 in used_features))
       end
 
     assigns = assign(assigns, :features_to_lose, features_to_lose)

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -113,7 +113,7 @@ defmodule PlausibleWeb.Components.Billing do
         """
 
       true ->
-        ~H"please contact support@plausible.io about the Enterprise plan"
+        ~H"please contact hello@plausible.io to upgrade your subscription"
     end
   end
 

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -330,7 +330,7 @@ defmodule PlausibleWeb.Components.Billing do
     >
       <.notice
         class="rounded-t-md rounded-b-none"
-        dismissable_id="premium_features_private_preview_end"
+        dismissable_id={"premium_features_private_preview_end__#{@user.id}"}
       >
         Business plans are now live! The private preview of <%= PlausibleWeb.TextHelpers.pretty_join(
           Enum.map(@features_to_lose, & &1.display_name())

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -4,9 +4,10 @@ defmodule PlausibleWeb.Components.Billing do
   use Phoenix.Component
   import PlausibleWeb.Components.Generic
   require Plausible.Billing.Subscription.Status
+  alias Plausible.Billing.Feature.{RevenueGoals, Funnels}
   alias Plausible.Billing.Feature.{Props, StatsAPI}
   alias PlausibleWeb.Router.Helpers, as: Routes
-  alias Plausible.Billing.{Subscription, Plans, Subscriptions}
+  alias Plausible.Billing.{Subscription, Plans, Plan, Subscriptions}
 
   attr(:billable_user, Plausible.Auth.User, required: true)
   attr(:current_user, Plausible.Auth.User, required: true)
@@ -17,15 +18,10 @@ defmodule PlausibleWeb.Components.Billing do
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def premium_feature_notice(assigns) do
-    billable_user = Plausible.Users.with_subscription(assigns.billable_user)
-    plan = Plans.get_regular_plan(billable_user.subscription, only_non_expired: true)
-    business? = plan && plan.kind == :business
-
     legacy_feature_access? =
       Timex.before?(assigns.billable_user.inserted_at, Plans.business_tier_launch()) &&
         assigns.feature_mod in [StatsAPI, Props]
 
-    private_preview? = FunWithFlags.enabled?(:premium_features_private_preview)
     has_access? = assigns.feature_mod.check_availability(assigns.billable_user) == :ok
 
     cond do
@@ -36,14 +32,6 @@ defmodule PlausibleWeb.Components.Billing do
         ~H"""
         <.notice class="rounded-t-md rounded-b-none" size={@size} {@rest}>
           <%= @feature_mod.display_name() %> is part of the Plausible Business plan. You can access it during your trial, but you'll need to subscribe to the Business plan to retain access after the trial ends."
-        </.notice>
-        """
-
-      private_preview? && !business? ->
-        ~H"""
-        <.notice class="rounded-t-md rounded-b-none" size={@size} {@rest}>
-          Business plans are now live! The private preview of <%= @feature_mod.display_name() %> ends <%= private_preview_days_remaining() %>. If you wish to continue using this feature,
-          <.upgrade_call_to_action current_user={@current_user} billable_user={@billable_user} />.
         </.notice>
         """
 
@@ -60,7 +48,7 @@ defmodule PlausibleWeb.Components.Billing do
     end
   end
 
-  defp private_preview_days_remaining do
+  defp private_preview_end do
     private_preview_ends_at = Timex.shift(Plausible.Billing.Plans.business_tier_launch(), days: 8)
 
     days_remaining = Timex.diff(private_preview_ends_at, NaiveDateTime.utc_now(), :day)
@@ -316,6 +304,48 @@ defmodule PlausibleWeb.Components.Billing do
   end
 
   def subscription_paused_notice(assigns), do: ~H""
+
+  def private_preview_end_notice(assigns) do
+    user = assigns.user |> Plausible.Users.with_subscription()
+
+    features_to_lose =
+      case Plans.get_subscription_plan(user.subscription) do
+        nil ->
+          []
+
+        %Plan{kind: :business} ->
+          []
+
+        _free_10k_or_enterprise_or_growth ->
+          used_features = Plausible.Billing.Quota.features_usage(assigns.user)
+          for f_mod <- [Funnels, RevenueGoals], f_mod in used_features, do: f_mod
+      end
+
+    assigns = assign(assigns, :features_to_lose, features_to_lose)
+
+    ~H"""
+    <div
+      :if={FunWithFlags.enabled?(:premium_features_private_preview) && @features_to_lose != []}
+      class="container mt-2"
+    >
+      <.notice
+        class="rounded-t-md rounded-b-none"
+        dismissable_id="premium_features_private_preview_end"
+      >
+        Business plans are now live! The private preview of <%= PlausibleWeb.TextHelpers.pretty_join(
+          Enum.map(@features_to_lose, & &1.display_name())
+        ) %> ends <b><%= private_preview_end() %></b>. If you wish to continue using <%= if length(
+                                                                                              @features_to_lose
+                                                                                            ) == 1,
+                                                                                            do:
+                                                                                              "this feature",
+                                                                                            else:
+                                                                                              "these features" %>,
+        <.upgrade_call_to_action current_user={@user} billable_user={@user} />.
+      </.notice>
+    </div>
+    """
+  end
 
   def present_enterprise_plan(assigns) do
     ~H"""

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -329,7 +329,7 @@ defmodule PlausibleWeb.Components.Billing do
       class="container mt-2"
     >
       <.notice
-        class="rounded-t-md rounded-b-none"
+        class="shadow-md dark:shadow-none"
         dismissable_id={"premium_features_private_preview_end__#{@user.id}"}
       >
         Business plans are now live! The private preview of <%= PlausibleWeb.TextHelpers.pretty_join(

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.Components.Generic do
           class="absolute right-0 top-0 m-2 text-yellow-800 dark:text-yellow-900"
           onclick={"localStorage['notice_dismissed__#{@dismissable_id}'] = 'true'; document.getElementById('#{@dismissable_id}').classList.add('hidden')"}
         >
-          <.x_icon class="h-4 w-4 font-semibold" />
+          <Heroicons.x_mark class="h-4 w-4 hover:stroke-2" />
         </button>
         <div class="flex">
           <div :if={@size !== :xs} class="flex-shrink-0">
@@ -237,22 +237,5 @@ defmodule PlausibleWeb.Components.Generic do
     else
       ["w-4 h-4"]
     end
-  end
-
-  attr(:class, :string, default: "")
-
-  defp x_icon(assigns) do
-    ~H"""
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke-width="1.5"
-      stroke="currentColor"
-      class={@class}
-    >
-      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-    </svg>
-    """
   end
 end

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -61,13 +61,14 @@ defmodule PlausibleWeb.Components.Generic do
   attr(:title, :string, default: "Notice")
   attr(:size, :atom, default: :sm)
   attr(:dismissable_id, :any, default: nil)
+  attr(:class, :string, default: "")
   attr(:rest, :global)
   slot(:inner_block)
 
   def notice(assigns) do
     ~H"""
     <div id={@dismissable_id} class={@dismissable_id && "hidden"}>
-      <div class="rounded-md bg-yellow-50 dark:bg-yellow-100 p-4 relative" {@rest}>
+      <div class={"rounded-md bg-yellow-50 dark:bg-yellow-100 p-4 relative #{@class}"} {@rest}>
         <button
           :if={@dismissable_id}
           class="absolute right-0 top-0 m-2 text-yellow-800 dark:text-yellow-900"

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -60,42 +60,60 @@ defmodule PlausibleWeb.Components.Generic do
 
   attr(:title, :string, default: "Notice")
   attr(:size, :atom, default: :sm)
+  attr(:dismissable_id, :any, default: nil)
   attr(:rest, :global)
   slot(:inner_block)
 
   def notice(assigns) do
     ~H"""
-    <div class="rounded-md bg-yellow-50 dark:bg-yellow-100 p-4" {@rest}>
-      <div class="flex">
-        <div :if={@size !== :xs} class="flex-shrink-0">
-          <svg
-            class="h-5 w-5 text-yellow-400"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-              clip-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div class="ml-3">
-          <h3
-            :if={@size !== :xs}
-            class={"text-#{@size} font-medium text-yellow-800 dark:text-yellow-900 mb-2"}
-          >
-            <%= @title %>
-          </h3>
-          <div class={"text-#{@size} text-yellow-700 dark:text-yellow-800"}>
-            <p>
-              <%= render_slot(@inner_block) %>
-            </p>
+    <div id={@dismissable_id} class={@dismissable_id && "hidden"}>
+      <div class="rounded-md bg-yellow-50 dark:bg-yellow-100 p-4 relative" {@rest}>
+        <button
+          :if={@dismissable_id}
+          class="absolute right-0 top-0 m-2 text-yellow-800 dark:text-yellow-900"
+          onclick={"localStorage['notice_dismissed__#{@dismissable_id}'] = 'true'; document.getElementById('#{@dismissable_id}').classList.add('hidden')"}
+        >
+          <.x_icon class="h-4 w-4 font-semibold" />
+        </button>
+        <div class="flex">
+          <div :if={@size !== :xs} class="flex-shrink-0">
+            <svg
+              class="h-5 w-5 text-yellow-400"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </div>
+          <div class="ml-3">
+            <h3
+              :if={@size !== :xs}
+              class={"text-#{@size} font-medium text-yellow-800 dark:text-yellow-900 mb-2"}
+            >
+              <%= @title %>
+            </h3>
+            <div class={"text-#{@size} text-yellow-700 dark:text-yellow-800"}>
+              <p>
+                <%= render_slot(@inner_block) %>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
+    <script data-key={@dismissable_id}>
+      const dismissId = document.currentScript.dataset.key
+      const localStorageKey = `notice_dismissed__${dismissId}`
+
+      if (localStorage[localStorageKey] !== 'true') {
+        document.getElementById(dismissId).classList.remove('hidden')
+      }
+    </script>
     """
   end
 
@@ -218,5 +236,22 @@ defmodule PlausibleWeb.Components.Generic do
     else
       ["w-4 h-4"]
     end
+  end
+
+  attr(:class, :string, default: "")
+
+  defp x_icon(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class={@class}
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+    """
   end
 end

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -95,12 +95,16 @@
   </div>
 <% end %>
 
-<.subscription_past_due_notice
-  subscription={@conn.assigns[:current_user] && @conn.assigns[:current_user].subscription}
-  class="container"
-/>
+<%= if @conn.assigns[:current_user] do %>
+  <.subscription_past_due_notice
+    subscription={@conn.assigns.current_user.subscription}
+    class="container"
+  />
 
-<.subscription_paused_notice
-  subscription={@conn.assigns[:current_user] && @conn.assigns[:current_user].subscription}
-  class="container"
-/>
+  <.subscription_paused_notice
+    subscription={@conn.assigns.current_user.subscription}
+    class="container"
+  />
+
+  <.private_preview_end_notice user={@conn.assigns.current_user} />
+<% end %>

--- a/test/plausible_web/components/billing_test.exs
+++ b/test/plausible_web/components/billing_test.exs
@@ -120,7 +120,7 @@ defmodule PlausibleWeb.Components.BillingTest do
       )
 
     assert rendered =~ "Your account is limited to 10 users."
-    assert rendered =~ "please contact support@plausible.io about the Enterprise plan"
+    assert rendered =~ "please contact hello@plausible.io to upgrade your subscription"
   end
 
   test "limit_exceeded_notice/1 when billable user is on a business plan displays support email" do
@@ -135,6 +135,6 @@ defmodule PlausibleWeb.Components.BillingTest do
       )
 
     assert rendered =~ "Your account is limited to 10 users."
-    assert rendered =~ "please contact support@plausible.io about the Enterprise plan"
+    assert rendered =~ "please contact hello@plausible.io to upgrade your subscription"
   end
 end


### PR DESCRIPTION
### Changes
 

* Change the upgrade CTA to say "contact us to upgrade your subscription" instead of "contact us about your enterprise plan" (which is not a good message for Business subscriptions who've hit some limit)
* Implement a `dismissable_id` option to `PlausibleWeb.Components.Generic.notice` which saves the user's preference in their localStorage that a notice with this `dismissable_id` has been dismissed.
* show a notice about losing access to Funnels and Revenue goals (to the site owners that are using either of these features) across the app (i.e. on `/settings`, `/sites`, dashboard, and site settings pages)
* Since we don't want to display the same notice twice, also remove the current private preview end notices from the relevant sections of site settings (i.e. the `PlausibleWeb.Components.Billing.premium_feature_notice` component)
* Fix a bug applying classnames to the `notice` component

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
