### PR TITLE
Fix bug showing invitation popups

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -455,7 +455,7 @@ defmodule PlausibleWeb.Live.Sites do
                       x-text="selectedInvitation && selectedInvitation.role"
                     >Admin</b>.
                   </p>
-                  <p
+                  <div
                     x-show="selectedInvitation && selectedInvitation.role === 'owner'"
                     class="mt-2 text-sm text-gray-500 dark:text-gray-200"
                   >
@@ -472,7 +472,7 @@ defmodule PlausibleWeb.Live.Sites do
                       <strong>you will have to enter your card details</strong>
                       to keep using Plausible.
                     </div>
-                  </p>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Apparently using the `<p>` element breaks x-show/styles cascading. Swapping it with `<div>` renders `x-show` correctly including children elements.

Before:

![image](https://github.com/plausible/analytics/assets/173738/16210110-dded-402d-95c8-2ad165910c8a)

![image](https://github.com/plausible/analytics/assets/173738/4c3d8431-9cce-41a5-8d48-8a7e79113716)


After:

![image](https://github.com/plausible/analytics/assets/173738/0efc2dea-8588-4eca-b241-29435f415697)

![image](https://github.com/plausible/analytics/assets/173738/5df17935-9c5f-4d01-809f-ba494f378fe3)


