### PR TITLE
Make OpenTelemetry sampler ratio configurable via env

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,6 +148,11 @@ google_cid = get_var_from_path_or_env(config_dir, "GOOGLE_CLIENT_ID")
 google_secret = get_var_from_path_or_env(config_dir, "GOOGLE_CLIENT_SECRET")
 postmark_api_key = get_var_from_path_or_env(config_dir, "POSTMARK_API_KEY")
 
+{otel_sampler_ratio, ""} =
+  config_dir
+  |> get_var_from_path_or_env("OTEL_SAMPLER_RATIO", "0.5")
+  |> Float.parse()
+
 cron_enabled =
   config_dir
   |> get_var_from_path_or_env("CRON_ENABLED", "false")
@@ -600,7 +605,7 @@ config :logger,
 if honeycomb_api_key && honeycomb_dataset do
   config :opentelemetry,
     resource: Plausible.OpenTelemetry.resource_attributes(runtime_metadata),
-    sampler: {Plausible.OpenTelemetry.Sampler, nil},
+    sampler: {Plausible.OpenTelemetry.Sampler, %{ratio: otel_sampler_ratio}},
     span_processor: :batch,
     traces_exporter: :otlp
 


### PR DESCRIPTION
### Changes

Makes sampler ratio configurable via `OTEL_SAMPLER_RATIO`

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
