### PR TITLE
drop IPs classified as datacenter

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -24,6 +24,7 @@ defmodule Plausible.Ingestion.Event do
           | :spam_referrer
           | GateKeeper.policy()
           | :invalid
+          | :dc_ip
 
   @type t() :: %__MODULE__{
           domain: String.t() | nil,
@@ -92,6 +93,7 @@ defmodule Plausible.Ingestion.Event do
 
   defp pipeline() do
     [
+      &put_ip_classification/1,
       &put_user_agent/1,
       &put_basic_info/1,
       &put_referrer/1,
@@ -136,6 +138,16 @@ defmodule Plausible.Ingestion.Event do
 
   defp update_attrs(%__MODULE__{} = event, %{} = attrs) do
     struct!(event, clickhouse_event_attrs: Map.merge(event.clickhouse_event_attrs, attrs))
+  end
+
+  defp put_ip_classification(%__MODULE__{} = event) do
+    case event.request.ip_classification do
+      "dc_ip" ->
+        drop(event, :dc_ip)
+
+      _any ->
+        event
+    end
   end
 
   defp put_user_agent(%__MODULE__{} = event) do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -143,7 +143,8 @@ defmodule Plausible.Ingestion.Event do
   defp put_ip_classification(%__MODULE__{} = event) do
     case event.request.ip_classification do
       "dc_ip" ->
-        drop(event, :dc_ip)
+        emit_telemetry_dropped(event, :dc_ip)
+        event
 
       _any ->
         event

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -36,6 +36,7 @@ defmodule Plausible.Ingestion.Request do
     field :hostname, :string
     field :referrer, :string
     field :domains, {:array, :string}
+    field :ip_classification, :string
     field :hash_mode, :integer
     field :pathname, :string
     field :props, :map
@@ -63,6 +64,7 @@ defmodule Plausible.Ingestion.Request do
     case parse_body(conn) do
       {:ok, request_body} ->
         changeset
+        |> put_ip_classification(conn)
         |> put_remote_ip(conn)
         |> put_uri(request_body)
         |> put_hostname()
@@ -270,6 +272,15 @@ defmodule Plausible.Ingestion.Request do
       _any ->
         changeset
     end
+  end
+
+  defp put_ip_classification(changeset, %Plug.Conn{} = conn) do
+    value =
+      conn
+      |> Plug.Conn.get_req_header("x-plausible-ip-type")
+      |> List.first()
+
+    Changeset.put_change(changeset, :ip_classification, value)
   end
 
   defp put_user_agent(changeset, %Plug.Conn{} = conn) do

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -100,6 +100,23 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :throttle
   end
 
+  test "event pipeline drops a request when header x-plausible-ip-type is dc_ip" do
+    site = insert(:site)
+
+    payload = %{
+      name: "pageview",
+      url: "http://dummy.site",
+      domain: site.domain
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+    conn = Plug.Conn.put_req_header(conn, "x-plausible-ip-type", "dc_ip")
+    assert {:ok, request} = Request.build(conn)
+
+    assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(request)
+    assert dropped.drop_reason == :dc_ip
+  end
+
   test "saves revenue amount" do
     site = insert(:site)
     _goal = insert(:goal, event_name: "checkout", currency: "USD", site: site)

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -100,23 +100,6 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :throttle
   end
 
-  test "event pipeline drops a request when header x-plausible-ip-type is dc_ip" do
-    site = insert(:site)
-
-    payload = %{
-      name: "pageview",
-      url: "http://dummy.site",
-      domain: site.domain
-    }
-
-    conn = build_conn(:post, "/api/events", payload)
-    conn = Plug.Conn.put_req_header(conn, "x-plausible-ip-type", "dc_ip")
-    assert {:ok, request} = Request.build(conn)
-
-    assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(request)
-    assert dropped.drop_reason == :dc_ip
-  end
-
   test "saves revenue amount" do
     site = insert(:site)
     _goal = insert(:goal, event_name: "checkout", currency: "USD", site: site)

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -457,7 +457,8 @@ defmodule Plausible.Ingestion.RequestTest do
              "remote_ip" => "127.0.0.1",
              "revenue_source" => %{"amount" => "12.3", "currency" => "USD"},
              "uri" => "https://dummy.site/pictures/index.html?foo=bar&baz=bam",
-             "user_agent" => "Mozilla"
+             "user_agent" => "Mozilla",
+             "ip_classification" => nil
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])


### PR DESCRIPTION
We can efficiently classify IP addresses (or other request data) on our load balancer and enrich the event with an additional header.

To start, the header `x-plausible-ip-type: dc_ip` is added when an IP address in the `X-Forwarded-For` header matches an IP in the datacenter list.

The changes in this PR will parse the header and, based on the classification, drop it and add telemetry information with the drop reason.

_Note_: This PR does not drop the event yet, it just adds the telemetry information so that we can see the possible impact before finally enabling this feature. The changes in 9086b84 will need to be reverted to finally drop.