### PR TITLE
Improve LiveView flash messages

### DIFF
--- a/lib/plausible_web/live/flash.ex
+++ b/lib/plausible_web/live/flash.ex
@@ -46,7 +46,10 @@ defmodule PlausibleWeb.Live.Flash do
   def flash_messages(assigns) do
     ~H"""
     <div id="liveview-flash">
-      <div :if={@flash != %{}} class="">
+      <div
+        :if={@flash != %{} or Application.get_env(:plausible, :environment) == "dev"}
+        class="inset-0 z-50 fixed flex flex-col-reverse items-center sm:items-end justify-start sm:justify-end px-4 py-6 pointer-events-none sm:p-6"
+      >
         <.flash :if={Flash.get(@flash, :success)} key="success">
           <:icon>
             <.icon_success />
@@ -69,15 +72,14 @@ defmodule PlausibleWeb.Live.Flash do
             <%= Flash.get(@flash, :error) %>
           </:message>
         </.flash>
-      </div>
-      <div
-        :if={Application.get_env(:plausible, :environment) == "dev"}
-        id="live-view-connection-status"
-        class="hidden"
-        phx-disconnected={JS.show()}
-        phx-connected={JS.hide()}
-      >
-        <.flash on_close={JS.hide(to: "#live-view-connection-status")}>
+        <.flash
+          :if={Application.get_env(:plausible, :environment) == "dev"}
+          id="live-view-connection-status"
+          class="hidden"
+          phx-disconnected={JS.show()}
+          phx-connected={JS.hide()}
+          on_close={JS.hide()}
+        >
           <:icon>
             <.icon_error />
           </:icon>
@@ -98,26 +100,32 @@ defmodule PlausibleWeb.Live.Flash do
   slot(:message, required: true)
   attr(:key, :string, default: nil)
   attr(:on_close, :any, default: "lv:clear-flash")
+  attr(:class, :string, default: "")
+  attr(:rest, :global)
 
   def flash(assigns) do
     ~H"""
-    <div class="inset-0 z-50 fixed flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
-      <div class="max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto">
-        <div class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-          <div class="p-4">
-            <div class="flex items-start">
-              <%= render_slot(@icon) %>
-              <div class="ml-3 w-0 flex-1 pt-0.5">
-                <p class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
-                  <%= render_slot(@title) %>
-                </p>
-                <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
-                  <%= render_slot(@message) %>
-                </p>
-              </div>
-              <div class="ml-4 flex-shrink-0 flex">
-                <.clear_flash_button on_close={@on_close} key={@key} />
-              </div>
+    <div
+      class={[
+        @class,
+        "mb-4 max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto"
+      ]}
+      {@rest}
+    >
+      <div class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
+        <div class="p-4">
+          <div class="flex items-start">
+            <%= render_slot(@icon) %>
+            <div class="ml-3 w-0 flex-1 pt-0.5">
+              <p class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
+                <%= render_slot(@title) %>
+              </p>
+              <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
+                <%= render_slot(@message) %>
+              </p>
+            </div>
+            <div class="ml-4 flex-shrink-0 flex">
+              <.clear_flash_button on_close={@on_close} key={@key} />
             </div>
           </div>
         </div>

--- a/lib/plausible_web/live/funnel_settings.ex
+++ b/lib/plausible_web/live/funnel_settings.ex
@@ -4,6 +4,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   """
   use Phoenix.LiveView
   use Phoenix.HTML
+  use PlausibleWeb.Live.Flash
 
   use Plausible.Funnel
 
@@ -41,7 +42,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   def render(assigns) do
     ~H"""
     <div id="funnel-settings-main">
-      <.live_component id="embedded_liveview_flash" module={PlausibleWeb.Live.Flash} flash={@flash} />
+      <.flash_messages flash={@flash} />
       <%= if @add_funnel? do %>
         <%= live_render(
           @socket,
@@ -101,8 +102,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
 
     id = String.to_integer(id)
     :ok = Funnels.delete(site, id)
-    socket = put_flash(socket, :success, "Funnel deleted successfully")
-    Process.send_after(self(), :clear_flash, 5000)
+    socket = put_live_flash(socket, :success, "Funnel deleted successfully")
 
     {:noreply,
      assign(socket,
@@ -112,8 +112,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   end
 
   def handle_info({:funnel_saved, funnel}, socket) do
-    socket = put_flash(socket, :success, "Funnel saved successfully")
-    Process.send_after(self(), :clear_flash, 5000)
+    socket = put_live_flash(socket, :success, "Funnel saved successfully")
 
     {:noreply,
      assign(socket,
@@ -125,9 +124,5 @@ defmodule PlausibleWeb.Live.FunnelSettings do
 
   def handle_info(:cancel_add_funnel, socket) do
     {:noreply, assign(socket, add_funnel?: false)}
-  end
-
-  def handle_info(:clear_flash, socket) do
-    {:noreply, clear_flash(socket)}
   end
 end

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -4,6 +4,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
   """
   use Phoenix.LiveView
   use Phoenix.HTML
+  use PlausibleWeb.Live.Flash
 
   use Plausible.Funnel
 
@@ -39,7 +40,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
   def render(assigns) do
     ~H"""
     <div id="goal-settings-main">
-      <.live_component id="embedded_liveview_flash" module={PlausibleWeb.Live.Flash} flash={@flash} />
+      <.flash_messages flash={@flash} />
       <%= if @add_goal? do %>
         <%= live_render(
           @socket,
@@ -89,13 +90,12 @@ defmodule PlausibleWeb.Live.GoalSettings do
       :ok ->
         socket =
           socket
-          |> put_flash(:success, "Goal deleted successfully")
+          |> put_live_flash(:success, "Goal deleted successfully")
           |> assign(
             all_goals: Enum.reject(socket.assigns.all_goals, &(&1.id == goal_id)),
             displayed_goals: Enum.reject(socket.assigns.displayed_goals, &(&1.id == goal_id))
           )
 
-        Process.send_after(self(), :clear_flash, 5000)
         {:noreply, socket}
 
       _ ->
@@ -116,12 +116,8 @@ defmodule PlausibleWeb.Live.GoalSettings do
         all_goals: [goal | socket.assigns.all_goals],
         displayed_goals: [goal | socket.assigns.all_goals]
       )
-      |> put_flash(:success, "Goal saved successfully")
+      |> put_live_flash(:success, "Goal saved successfully")
 
     {:noreply, socket}
-  end
-
-  def handle_info(:clear_flash, socket) do
-    {:noreply, clear_flash(socket)}
   end
 end

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -4,6 +4,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
   """
   use Phoenix.LiveView
   use Phoenix.HTML
+  use PlausibleWeb.Live.Flash
 
   alias Plausible.Sites
   alias Plausible.Plugins.API.Tokens
@@ -33,7 +34,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
 
   def render(assigns) do
     ~H"""
-    <.live_component id="embedded_liveview_flash" module={PlausibleWeb.Live.Flash} flash={@flash} />
+    <.flash_messages flash={@flash} />
 
     <%= if @add_token? do %>
       <%= live_render(
@@ -139,9 +140,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
   def handle_info({:token_added, token}, socket) do
     displayed_tokens = [token | socket.assigns.displayed_tokens]
 
-    socket = put_flash(socket, :success, "Plugins API Token created successfully")
-
-    Process.send_after(self(), :clear_flash, 5000)
+    socket = put_live_flash(socket, :success, "Plugins API Token created successfully")
 
     {:noreply,
      assign(socket,
@@ -149,9 +148,5 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
        add_token?: false,
        token_description: ""
      )}
-  end
-
-  def handle_info(:clear_flash, socket) do
-    {:noreply, clear_flash(socket)}
   end
 end

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -5,6 +5,8 @@ defmodule PlausibleWeb.Live.PropsSettings do
 
   use Phoenix.LiveView
   use Phoenix.HTML
+  use PlausibleWeb.Live.Flash
+
   alias PlausibleWeb.Live.Components.ComboBox
 
   def mount(
@@ -37,7 +39,7 @@ defmodule PlausibleWeb.Live.PropsSettings do
   def render(assigns) do
     ~H"""
     <section id="props-settings-main">
-      <.live_component id="embedded_liveview_flash" module={PlausibleWeb.Live.Flash} flash={@flash} />
+      <.flash_messages flash={@flash} />
       <%= if @add_prop? do %>
         <%= live_render(
           @socket,
@@ -105,14 +107,13 @@ defmodule PlausibleWeb.Live.PropsSettings do
 
     socket =
       socket
-      |> put_flash(:success, "Property removed successfully")
+      |> put_live_flash(:success, "Property removed successfully")
       |> assign(
         all_props: Enum.reject(socket.assigns.all_props, &(&1 == prop)),
         displayed_props: Enum.reject(socket.assigns.displayed_props, &(&1 == prop)),
         site: site
       )
 
-    Process.send_after(self(), :clear_flash, 5000)
     {:noreply, socket}
   end
 
@@ -139,7 +140,7 @@ defmodule PlausibleWeb.Live.PropsSettings do
         displayed_props: props,
         site: %{socket.assigns.site | allowed_event_props: props}
       )
-      |> put_flash(:success, "Properties added successfully")
+      |> put_live_flash(:success, "Properties added successfully")
 
     {:noreply, socket}
   end
@@ -160,13 +161,9 @@ defmodule PlausibleWeb.Live.PropsSettings do
         displayed_props: allowed_event_props,
         site: %{site | allowed_event_props: allowed_event_props}
       )
-      |> put_flash(:success, "Property added successfully")
+      |> put_live_flash(:success, "Property added successfully")
 
     {:noreply, socket}
-  end
-
-  def handle_info(:clear_flash, socket) do
-    {:noreply, clear_flash(socket)}
   end
 
   defp new_form(site) do

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -4,6 +4,8 @@ defmodule PlausibleWeb.Live.Sites do
   """
 
   use Phoenix.LiveView
+  use PlausibleWeb.Live.Flash
+
   alias Phoenix.LiveView.JS
   use Phoenix.HTML
 
@@ -59,7 +61,7 @@ defmodule PlausibleWeb.Live.Sites do
     assigns = assign(assigns, :invitations, invitations)
 
     ~H"""
-    <.live_component id="embedded_liveview_flash" module={PlausibleWeb.Live.Flash} flash={@flash} />
+    <.flash_messages flash={@flash} />
     <div
       x-data={"{selectedInvitation: null, invitationOpen: false, invitations: #{Enum.map(@invitations, &({&1.invitation_id, &1})) |> Enum.into(%{}) |> Jason.encode!}}"}
       x-on:keydown.escape.window="invitationOpen = false"
@@ -593,7 +595,7 @@ defmodule PlausibleWeb.Live.Sites do
               end
 
             socket
-            |> put_flash(:success, flash_message)
+            |> put_live_flash(:success, flash_message)
             |> load_sites()
             |> push_event("js-exec", %{
               to: "#site-card-#{hash_domain(site.domain)}",
@@ -606,20 +608,14 @@ defmodule PlausibleWeb.Live.Sites do
                 "Please unpin one of your pinned sites to make room for new pins"
 
             socket
-            |> put_flash(:error, flash_message)
+            |> put_live_flash(:error, flash_message)
             |> push_event("js-exec", %{
               to: "#site-card-#{hash_domain(site.domain)}",
               attr: "data-pin-failed"
             })
         end
 
-      if flash_timer = socket.assigns[:flash_timer] do
-        Process.cancel_timer(flash_timer)
-      end
-
-      flash_timer = Process.send_after(self(), :clear_flash, 5000)
-
-      {:noreply, assign(socket, :flash_timer, flash_timer)}
+      {:noreply, socket}
     else
       Sentry.capture_message("Attempting to toggle pin for invalid domain.",
         extra: %{domain: domain, user: socket.assigns.user.id}
@@ -653,10 +649,6 @@ defmodule PlausibleWeb.Live.Sites do
       |> set_filter_text("")
 
     {:noreply, socket}
-  end
-
-  def handle_info(:clear_flash, socket) do
-    {:noreply, clear_flash(socket)}
   end
 
   defp load_sites(%{assigns: assigns} = socket) do

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -613,9 +613,13 @@ defmodule PlausibleWeb.Live.Sites do
             })
         end
 
-      Process.send_after(self(), :clear_flash, 5000)
+      if flash_timer = socket.assigns[:flash_timer] do
+        Process.cancel_timer(flash_timer)
+      end
 
-      {:noreply, socket}
+      flash_timer = Process.send_after(self(), :clear_flash, 5000)
+
+      {:noreply, assign(socket, :flash_timer, flash_timer)}
     else
       Sentry.capture_message("Attempting to toggle pin for invalid domain.",
         extra: %{domain: domain, user: socket.assigns.user.id}


### PR DESCRIPTION
### Changes

This PR abstracts LiveView flash logic and ensures that success and error flash messages are treated independently, each with it's own timer for hiding. Also timer for each flash type is reset when a new flash message is created while the previous one hasn't disappeared yet.

Styling of flash messages is fixed so that notification boxes are stacking vertically without overlapping.

[flashes.webm](https://github.com/plausible/analytics/assets/588351/455cee32-e4ce-4d4a-a0ee-6ed4ca417fd9)

[flashes_small.webm](https://github.com/plausible/analytics/assets/588351/38a79e1b-3ac1-4ef5-bec5-400c46f0befc)


Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
