### PR TITLE
Limit grandfathering to *active* subscribers and trials

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -281,6 +281,10 @@ defmodule Plausible.Billing do
 
   def paddle_api(), do: Application.fetch_env!(:plausible, :paddle_api)
 
+  def cancelled_subscription_notice_dismiss_id(%Plausible.Auth.User{} = user) do
+    "subscription_cancelled__#{user.id}"
+  end
+
   defp active_subscription_query(user_id) do
     from(s in Subscription,
       where: s.user_id == ^user_id and s.status == ^Subscription.Status.active(),

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -72,11 +72,9 @@ defmodule Plausible.Billing.Plans do
     |> Enum.filter(&(&1.kind == :business))
   end
 
-  @doc """
-  Takes a Date struct argument representing the trial end date of a user.
-  If the `trial_expiry` is `nil`, it means that the user has not started
-  their trial yet (i.e. invited user), and this function returns false.
-  """
+  # Takes a Date struct argument representing the trial end date of a user.
+  # If the `trial_expiry` is `nil`, it means that the user has not started
+  # their trial yet (i.e. invited user), and this function returns false.
   defp grandfathered_trial?(nil, _now), do: false
 
   defp grandfathered_trial?(trial_expiry, now) do

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -77,9 +77,9 @@ defmodule Plausible.Billing.Plans do
   If the `trial_expiry` is `nil`, it means that the user has not started
   their trial yet (i.e. invited user), and this function returns false.
   """
-  def grandfathered_trial?(nil, _now), do: false
+  defp grandfathered_trial?(nil, _now), do: false
 
-  def grandfathered_trial?(trial_expiry, now) do
+  defp grandfathered_trial?(trial_expiry, now) do
     trial_start = Timex.shift(trial_expiry, days: -30)
 
     joined_before_business_tiers = Timex.before?(trial_start, @business_tier_launch)

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -48,6 +48,7 @@ defmodule Plausible.Billing.Plans do
       is_nil(owned_plan) && grandfathered_trial?(user.trial_expiry_date, now) -> @plans_v3
       is_nil(owned_plan) && v4_available -> @plans_v4
       is_nil(owned_plan) -> @plans_v3
+      user.subscription && Subscriptions.expired?(user.subscription) -> @plans_v4
       owned_plan.kind == :business -> @plans_v4
       owned_plan.generation == 1 -> @plans_v1
       owned_plan.generation == 2 -> @plans_v2
@@ -64,6 +65,7 @@ defmodule Plausible.Billing.Plans do
     cond do
       Application.get_env(:plausible, :environment) == "dev" -> @sandbox_plans
       is_nil(owned_plan) && grandfathered_trial?(user.trial_expiry_date, now) -> @plans_v3
+      user.subscription && Subscriptions.expired?(user.subscription) -> @plans_v4
       owned_plan && owned_plan.generation < 4 -> @plans_v3
       true -> @plans_v4
     end

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -222,7 +222,11 @@ defmodule PlausibleWeb.Components.Billing do
       ) do
     ~H"""
     <aside id="subscription-cancelled-notice" class="container">
-      <PlausibleWeb.Components.Generic.notice title="Subscription cancelled" theme={:red}>
+      <PlausibleWeb.Components.Generic.notice
+        title="Subscription cancelled"
+        theme={:red}
+        class="shadow-md dark:shadow-none"
+      >
         <%= if @user.subscription.next_bill_date && Timex.compare(@user.subscription.next_bill_date, Timex.today()) >= 0 do %>
           <p>
             You have access to your stats until <span class="font-semibold inline"><%= Timex.format!(@user.subscription.next_bill_date, "{Mshort} {D}, {YYYY}") %></span>.
@@ -253,7 +257,10 @@ defmodule PlausibleWeb.Components.Billing do
       ) do
     ~H"""
     <aside class={@class}>
-      <PlausibleWeb.Components.Generic.notice title="Payment failed">
+      <PlausibleWeb.Components.Generic.notice
+        title="Payment failed"
+        class="shadow-md dark:shadow-none"
+      >
         There was a problem with your latest payment. Please update your payment information to keep using Plausible.<.link
           href={@subscription.update_url}
           class="whitespace-nowrap font-semibold"
@@ -273,7 +280,11 @@ defmodule PlausibleWeb.Components.Billing do
       ) do
     ~H"""
     <aside class={@class}>
-      <PlausibleWeb.Components.Generic.notice title="Subscription paused" theme={:red}>
+      <PlausibleWeb.Components.Generic.notice
+        title="Subscription paused"
+        theme={:red}
+        class="shadow-md dark:shadow-none"
+      >
         Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.<.link
           href={@subscription.update_url}
           class="whitespace-nowrap font-semibold"

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -300,7 +300,7 @@ defmodule PlausibleWeb.Components.Billing do
     ~H"""
     <div
       :if={FunWithFlags.enabled?(:premium_features_private_preview) && @features_to_lose != []}
-      class="container mt-2"
+      class="container"
     >
       <.notice
         class="shadow-md dark:shadow-none"

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Components.Billing do
 
       not has_access? ->
         ~H"""
-        <.notice class="rounded-t-md rounded-b-none" size={@size} {@rest}>
+        <.notice class="rounded-t-md rounded-b-none" size={@size} {@rest} title="Notice">
           <%= account_label(@current_user, @billable_user) %> does not have access to <%= assigns.feature_mod.display_name() %>. To get access to this feature,
           <.upgrade_call_to_action current_user={@current_user} billable_user={@billable_user} />.
         </.notice>
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.Components.Billing do
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def limit_exceeded_notice(assigns) do
     ~H"""
-    <.notice {@rest}>
+    <.notice {@rest} title="Notice">
       <%= account_label(@current_user, @billable_user) %> is limited to <%= @limit %> <%= @resource %>. To increase this limit,
       <.upgrade_call_to_action current_user={@current_user} billable_user={@billable_user} />.
     </.notice>
@@ -326,6 +326,7 @@ defmodule PlausibleWeb.Components.Billing do
     >
       <.notice
         class="shadow-md dark:shadow-none"
+        title="Notice"
         dismissable_id={"premium_features_private_preview_end__#{@user.id}"}
       >
         Business plans are now live! The private preview of <%= PlausibleWeb.TextHelpers.pretty_join(

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -245,6 +245,9 @@ defmodule PlausibleWeb.Components.Billing do
 
   def subscription_cancelled_notice(assigns), do: ~H""
 
+  attr(:class, :string, default: "")
+  attr(:subscription, :any, default: nil)
+
   def subscription_past_due_notice(
         %{subscription: %Subscription{status: Subscription.Status.past_due()}} = assigns
       ) do
@@ -261,6 +264,9 @@ defmodule PlausibleWeb.Components.Billing do
   end
 
   def subscription_past_due_notice(assigns), do: ~H""
+
+  attr(:class, :string, default: "")
+  attr(:subscription, :any, default: nil)
 
   def subscription_paused_notice(
         %{subscription: %Subscription{status: Subscription.Status.paused()}} = assigns

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -250,38 +250,12 @@ defmodule PlausibleWeb.Components.Billing do
       ) do
     ~H"""
     <aside class={@class}>
-      <div class="shadow-md dark:shadow-none rounded-lg bg-yellow-100 p-4">
-        <div class="flex">
-          <div class="flex-shrink-0">
-            <svg
-              class="w-5 h-5 mt-0.5 text-yellow-800"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </div>
-          <div class="ml-3 flex-1 md:flex md:justify-between">
-            <p class="text-yellow-700">
-              There was a problem with your latest payment. Please update your payment information to keep using Plausible.
-            </p>
-            <.link
-              href={@subscription.update_url}
-              class="whitespace-nowrap font-medium text-yellow-700 hover:text-yellow-600"
-            >
-              Update billing info <span aria-hidden="true"> &rarr;</span>
-            </.link>
-          </div>
-        </div>
-      </div>
+      <PlausibleWeb.Components.Generic.notice title="Payment failed">
+        There was a problem with your latest payment. Please update your payment information to keep using Plausible.<.link
+          href={@subscription.update_url}
+          class="whitespace-nowrap font-semibold"
+        > Update billing info <span aria-hidden="true"> &rarr;</span></.link>
+      </PlausibleWeb.Components.Generic.notice>
     </aside>
     """
   end

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -267,38 +267,12 @@ defmodule PlausibleWeb.Components.Billing do
       ) do
     ~H"""
     <aside class={@class}>
-      <div class="shadow-md dark:shadow-none rounded-lg bg-red-100 p-4">
-        <div class="flex">
-          <div class="flex-shrink-0">
-            <svg
-              class="w-5 h-5 mt-0.5 text-yellow-800"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path
-                d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </div>
-          <div class="ml-3 flex-1 md:flex md:justify-between">
-            <p class="text-red-700">
-              Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.
-            </p>
-            <.link
-              href={@subscription.update_url}
-              class="whitespace-nowrap font-medium text-red-700 hover:text-red-600"
-            >
-              Update billing info <span aria-hidden="true"> &rarr;</span>
-            </.link>
-          </div>
-        </div>
-      </div>
+      <PlausibleWeb.Components.Generic.notice title="Subscription paused" theme={:red}>
+        Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.<.link
+          href={@subscription.update_url}
+          class="whitespace-nowrap font-semibold"
+        > Update billing info <span aria-hidden="true"> &rarr;</span></.link>
+      </PlausibleWeb.Components.Generic.notice>
     </aside>
     """
   end

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -4,13 +4,14 @@ defmodule PlausibleWeb.Components.Billing do
   use Phoenix.Component
   import PlausibleWeb.Components.Generic
   require Plausible.Billing.Subscription.Status
+  alias Plausible.Auth.User
   alias Plausible.Billing.Feature.{RevenueGoals, Funnels}
   alias Plausible.Billing.Feature.{Props, StatsAPI}
   alias PlausibleWeb.Router.Helpers, as: Routes
   alias Plausible.Billing.{Subscription, Plans, Plan, Subscriptions}
 
-  attr(:billable_user, Plausible.Auth.User, required: true)
-  attr(:current_user, Plausible.Auth.User, required: true)
+  attr(:billable_user, User, required: true)
+  attr(:current_user, User, required: true)
   attr(:feature_mod, :atom, required: true, values: Plausible.Billing.Feature.list())
   attr(:grandfathered?, :boolean, default: false)
   attr(:size, :atom, default: :sm)
@@ -56,8 +57,8 @@ defmodule PlausibleWeb.Components.Billing do
     end
   end
 
-  attr(:billable_user, Plausible.Auth.User, required: true)
-  attr(:current_user, Plausible.Auth.User, required: true)
+  attr(:billable_user, User, required: true)
+  attr(:current_user, User, required: true)
   attr(:limit, :integer, required: true)
   attr(:resource, :string, required: true)
   attr(:rest, :global)

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -226,7 +226,7 @@ defmodule PlausibleWeb.Components.Billing do
 
   It also takes a dismissable argument which renders the notice dismissable (with
   the help of JavaScript and localStorage). We show a dismissable notice about a
-  cancelled subscription across the app. But when the user dismisses it. We will
+  cancelled subscription across the app, but when the user dismisses it, we will
   start displaying it in the account settings > subscription section instead.
 
   So it's either shown across the app, or only on the /settings page. Depending

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.Components.Generic do
       body_text: "text-yellow-700 dark:text-yellow-800"
     },
     red: %{
-      bg: "bg-red-50 dark:bg-red-100",
+      bg: "bg-red-100",
       icon: "text-red-700",
       title_text: "text-red-800 dark:text-red-900",
       body_text: "text-red-700 dark:text-red-800"

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -4,6 +4,15 @@ defmodule PlausibleWeb.Components.Generic do
   """
   use Phoenix.Component
 
+  @notice_themes %{
+    yellow: %{
+      bg: "bg-yellow-50 dark:bg-yellow-100",
+      icon: "text-yellow-400",
+      title_text: "text-yellow-800 dark:text-yellow-900",
+      body_text: "text-yellow-700 dark:text-yellow-800"
+    }
+  }
+
   attr(:type, :string, default: "button")
   attr(:class, :string, default: "")
   attr(:disabled, :boolean, default: false)
@@ -60,18 +69,21 @@ defmodule PlausibleWeb.Components.Generic do
 
   attr(:title, :any, default: nil)
   attr(:size, :atom, default: :sm)
+  attr(:theme, :atom, default: :yellow)
   attr(:dismissable_id, :any, default: nil)
   attr(:class, :string, default: "")
   attr(:rest, :global)
   slot(:inner_block)
 
   def notice(assigns) do
+    assigns = assign(assigns, :theme, Map.fetch!(@notice_themes, assigns.theme))
+
     ~H"""
     <div id={@dismissable_id} class={@dismissable_id && "hidden"}>
-      <div class={"rounded-md bg-yellow-50 dark:bg-yellow-100 p-4 relative #{@class}"} {@rest}>
+      <div class={"rounded-md #{@theme.bg} p-4 relative #{@class}"} {@rest}>
         <button
           :if={@dismissable_id}
-          class="absolute right-0 top-0 m-2 text-yellow-800 dark:text-yellow-900"
+          class={"absolute right-0 top-0 m-2 #{@theme.title_text}"}
           onclick={"localStorage['notice_dismissed__#{@dismissable_id}'] = 'true'; document.getElementById('#{@dismissable_id}').classList.add('hidden')"}
         >
           <Heroicons.x_mark class="h-4 w-4 hover:stroke-2" />
@@ -79,7 +91,7 @@ defmodule PlausibleWeb.Components.Generic do
         <div class="flex">
           <div :if={@title} class="flex-shrink-0">
             <svg
-              class="h-5 w-5 text-yellow-400"
+              class={"h-5 w-5 #{@theme.icon}"}
               viewBox="0 0 20 20"
               fill="currentColor"
               aria-hidden="true"
@@ -92,13 +104,10 @@ defmodule PlausibleWeb.Components.Generic do
             </svg>
           </div>
           <div class={@title && "ml-3"}>
-            <h3
-              :if={@title}
-              class={"text-#{@size} font-medium text-yellow-800 dark:text-yellow-900 mb-2"}
-            >
+            <h3 :if={@title} class={"text-#{@size} font-medium #{@theme.title_text} mb-2"}>
               <%= @title %>
             </h3>
-            <div class={"text-#{@size} text-yellow-700 dark:text-yellow-800"}>
+            <div class={"text-#{@size} #{@theme.body_text}"}>
               <p>
                 <%= render_slot(@inner_block) %>
               </p>

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -86,7 +86,7 @@ defmodule PlausibleWeb.Components.Generic do
 
     ~H"""
     <div id={@dismissable_id} class={@dismissable_id && "hidden"}>
-      <div class={"rounded-md #{@theme.bg} p-4 relative #{@class}"} {@rest}>
+      <div class={["rounded-md p-4 relative", @theme.bg, @class]} {@rest}>
         <button
           :if={@dismissable_id}
           class={"absolute right-0 top-0 m-2 #{@theme.title_text}"}

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -107,7 +107,7 @@ defmodule PlausibleWeb.Components.Generic do
         </div>
       </div>
     </div>
-    <script data-key={@dismissable_id}>
+    <script :if={@dismissable_id} data-key={@dismissable_id}>
       const dismissId = document.currentScript.dataset.key
       const localStorageKey = `notice_dismissed__${dismissId}`
 

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -10,6 +10,12 @@ defmodule PlausibleWeb.Components.Generic do
       icon: "text-yellow-400",
       title_text: "text-yellow-800 dark:text-yellow-900",
       body_text: "text-yellow-700 dark:text-yellow-800"
+    },
+    red: %{
+      bg: "bg-red-50 dark:bg-red-100",
+      icon: "text-red-700",
+      title_text: "text-red-800 dark:text-red-900",
+      body_text: "text-red-700 dark:text-red-800"
     }
   }
 

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -109,7 +109,7 @@ defmodule PlausibleWeb.Components.Generic do
               />
             </svg>
           </div>
-          <div class={@title && "ml-3"}>
+          <div class={["w-full", @title && "ml-3"]}>
             <h3 :if={@title} class={"text-#{@size} font-medium #{@theme.title_text} mb-2"}>
               <%= @title %>
             </h3>

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Components.Generic do
     """
   end
 
-  attr(:title, :string, default: "Notice")
+  attr(:title, :any, default: nil)
   attr(:size, :atom, default: :sm)
   attr(:dismissable_id, :any, default: nil)
   attr(:class, :string, default: "")
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.Components.Generic do
           <Heroicons.x_mark class="h-4 w-4 hover:stroke-2" />
         </button>
         <div class="flex">
-          <div :if={@size !== :xs} class="flex-shrink-0">
+          <div :if={@title} class="flex-shrink-0">
             <svg
               class="h-5 w-5 text-yellow-400"
               viewBox="0 0 20 20"
@@ -91,9 +91,9 @@ defmodule PlausibleWeb.Components.Generic do
               />
             </svg>
           </div>
-          <div class="ml-3">
+          <div class={@title && "ml-3"}>
             <h3
-              :if={@size !== :xs}
+              :if={@title}
               class={"text-#{@size} font-medium text-yellow-800 dark:text-yellow-900 mb-2"}
             >
               <%= @title %>

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -25,42 +25,6 @@
 
     <div class="my-4 border-b border-gray-400"></div>
 
-    <div
-      :if={
-        @subscription && @subscription.status == Plausible.Billing.Subscription.Status.deleted()
-      }
-      class="p-2 bg-red-100 rounded-lg sm:p-3"
-    >
-      <div class="flex flex-wrap items-center justify-between">
-        <div class="flex items-center flex-1 w-0">
-          <svg
-            class="w-6 h-6 text-red-800"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 9V11M12 15H12.01M5.07183 19H18.9282C20.4678 19 21.4301 17.3333 20.6603 16L13.7321 4C12.9623 2.66667 11.0378 2.66667 10.268 4L3.33978 16C2.56998 17.3333 3.53223 19 5.07183 19Z"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <p class="ml-3 font-medium text-red-800">
-            <%= if @subscription.next_bill_date && Timex.compare(@subscription.next_bill_date, Timex.today()) >= 0 do %>
-              Your subscription is cancelled but you have access to your stats until <%= Timex.format!(
-                @subscription.next_bill_date,
-                "{Mshort} {D}, {YYYY}"
-              ) %>. Upgrade below to make sure you don't lose access.
-            <% else %>
-              Your subscription is cancelled. Upgrade below to get access to your stats again.
-            <% end %>
-          </p>
-        </div>
-      </div>
-    </div>
-
     <div class="flex flex-col items-center justify-between mt-8 sm:flex-row sm:items-start">
       <PlausibleWeb.Components.Billing.monthly_quota_box
         user={@user}

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -25,6 +25,11 @@
 
     <div class="my-4 border-b border-gray-400"></div>
 
+    <PlausibleWeb.Components.Billing.subscription_cancelled_notice
+      user={@user}
+      dismissable={false}
+    />
+
     <div class="flex flex-col items-center justify-between mt-8 sm:flex-row sm:items-start">
       <PlausibleWeb.Components.Billing.monthly_quota_box
         user={@user}

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -96,6 +96,8 @@
 <% end %>
 
 <%= if @conn.assigns[:current_user] do %>
+  <.subscription_cancelled_notice user={@conn.assigns.current_user} />
+
   <.subscription_past_due_notice
     subscription={@conn.assigns.current_user.subscription}
     class="container"

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -96,17 +96,19 @@
 <% end %>
 
 <%= if @conn.assigns[:current_user] do %>
-  <.subscription_cancelled_notice user={@conn.assigns.current_user} />
+  <div class="flex flex-col gap-y-2">
+    <.subscription_cancelled_notice user={@conn.assigns.current_user} />
 
-  <.subscription_past_due_notice
-    subscription={@conn.assigns.current_user.subscription}
-    class="container"
-  />
+    <.subscription_past_due_notice
+      subscription={@conn.assigns.current_user.subscription}
+      class="container"
+    />
 
-  <.subscription_paused_notice
-    subscription={@conn.assigns.current_user.subscription}
-    class="container"
-  />
+    <.subscription_paused_notice
+      subscription={@conn.assigns.current_user.subscription}
+      class="container"
+    />
 
-  <.private_preview_end_notice user={@conn.assigns.current_user} />
+    <.private_preview_end_notice user={@conn.assigns.current_user} />
+  </div>
 <% end %>

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -54,6 +54,19 @@ defmodule Plausible.Billing.PlansTest do
       Plans.growth_plans_for(user, now3) |> assert_generation(4)
     end
 
+    test "growth_plans_for/1 returns v4 plans for expired legacy subscriptions" do
+      subscription =
+        build(:subscription,
+          paddle_plan_id: @v1_plan_id,
+          status: :deleted,
+          next_bill_date: ~D[2023-11-10]
+        )
+
+      insert(:user, subscription: subscription)
+      |> Plans.growth_plans_for()
+      |> assert_generation(4)
+    end
+
     test "growth_plans_for/1 shows v4 plans for everyone else" do
       insert(:user, inserted_at: ~U[2024-01-01T00:00:00Z])
       |> Plans.growth_plans_for()
@@ -115,6 +128,19 @@ defmodule Plausible.Billing.PlansTest do
       Plans.business_plans_for(user, now1) |> assert_generation(3)
       Plans.business_plans_for(user, now2) |> assert_generation(3)
       Plans.business_plans_for(user, now3) |> assert_generation(4)
+    end
+
+    test "business_plans_for/1 returns v4 plans for expired legacy subscriptions" do
+      subscription =
+        build(:subscription,
+          paddle_plan_id: @v2_plan_id,
+          status: :deleted,
+          next_bill_date: ~D[2023-11-10]
+        )
+
+      insert(:user, subscription: subscription)
+      |> Plans.business_plans_for()
+      |> assert_generation(4)
     end
 
     test "business_plans_for/1 returns v4 business plans for everyone else" do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -16,6 +16,7 @@ defmodule PlausibleWeb.AuthControllerTest do
   setup :verify_on_exit!
 
   @v3_plan_id "749355"
+  @v4_plan_id "857097"
   @configured_enterprise_plan_paddle_plan_id "123"
 
   describe "GET /register" do
@@ -625,6 +626,67 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       assert text_of_attr(change_plan_link, "href") ==
                Routes.billing_path(conn, :choose_plan)
+    end
+
+    test "renders cancelled subscription notice", %{conn: conn, user: user} do
+      insert(:subscription,
+        paddle_plan_id: @v4_plan_id,
+        user: user,
+        status: :deleted,
+        next_bill_date: ~D[2023-01-01]
+      )
+
+      notice_text =
+        get(conn, "/settings")
+        |> html_response(200)
+        |> text_of_element("#subscription-cancelled-notice")
+
+      assert notice_text =~ "Subscription cancelled"
+      assert notice_text =~ "Upgrade your subscription to get access to your stats again"
+    end
+
+    test "renders cancelled subscription notice with some subscription days still left", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:subscription,
+        paddle_plan_id: @v4_plan_id,
+        user: user,
+        status: :deleted,
+        next_bill_date: Timex.shift(Timex.today(), days: 10)
+      )
+
+      notice_text =
+        get(conn, "/settings")
+        |> html_response(200)
+        |> text_of_element("#subscription-cancelled-notice")
+
+      assert notice_text =~ "Subscription cancelled"
+      assert notice_text =~ "You have access to your stats until"
+      assert notice_text =~ "Upgrade your subscription to make sure you don't lose access"
+    end
+
+    test "renders cancelled subscription notice with a warning about losing grandfathering", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:subscription,
+        paddle_plan_id: @v3_plan_id,
+        user: user,
+        status: :deleted,
+        next_bill_date: Timex.shift(Timex.today(), days: 10)
+      )
+
+      notice_text =
+        get(conn, "/settings")
+        |> html_response(200)
+        |> text_of_element("#subscription-cancelled-notice")
+
+      assert notice_text =~ "Subscription cancelled"
+      assert notice_text =~ "You have access to your stats until"
+
+      assert notice_text =~
+               "by letting your subscription expire, you lose access to our grandfathered terms"
     end
 
     test "shows invoices for subscribed user", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -639,7 +639,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       notice_text =
         get(conn, "/settings")
         |> html_response(200)
-        |> text_of_element("#subscription-cancelled-notice")
+        |> text_of_element("#global-subscription-cancelled-notice")
 
       assert notice_text =~ "Subscription cancelled"
       assert notice_text =~ "Upgrade your subscription to get access to your stats again"
@@ -659,7 +659,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       notice_text =
         get(conn, "/settings")
         |> html_response(200)
-        |> text_of_element("#subscription-cancelled-notice")
+        |> text_of_element("#global-subscription-cancelled-notice")
 
       assert notice_text =~ "Subscription cancelled"
       assert notice_text =~ "You have access to your stats until"
@@ -680,7 +680,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       notice_text =
         get(conn, "/settings")
         |> html_response(200)
-        |> text_of_element("#subscription-cancelled-notice")
+        |> text_of_element("#global-subscription-cancelled-notice")
 
       assert notice_text =~ "Subscription cancelled"
       assert notice_text =~ "You have access to your stats until"

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -34,7 +34,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
   describe "for a legacy trial (user registered before business tiers release)" do
     setup %{conn: conn} do
-      user = insert(:user, inserted_at: ~N[2023-10-25 12:00:00])
+      user = insert(:user, trial_expiry_date: ~D[2023-11-24])
       {:ok, conn: conn} = log_in(%{conn: conn, user: user})
       {:ok, conn: conn, user: user}
     end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -35,7 +35,12 @@ defmodule Plausible.TestUtils do
   end
 
   def create_user(_) do
-    {:ok, user: Factory.insert(:user, inserted_at: ~U[2024-01-01T00:00:00Z])}
+    {:ok,
+     user:
+       Factory.insert(:user,
+         inserted_at: ~U[2024-01-01T00:00:00Z],
+         trial_expiry_date: ~D[2024-02-01]
+       )}
   end
 
   def create_site(%{user: user}) do


### PR DESCRIPTION
## Changes

### Grandfathering

* Stop offering grandfathered plans to subscribers who cancelled and let their subscription expire
  * These users will also see a warning (see the first screenshot below)
* Stop offering grandfathered plans to trials who didn't subscribe during, or within the next 10 days after the trial
  * Obviously only applies to those who started the trial **before** the business tiers release
  * The 10 days limit is silent - they won't be notified about having only 10 days to subscribe to get the grandfathered benefits

### Cancelled subscription notices

The current notice looks like this and it's only displayed on the account settings page:

<img width="806" alt="image" src="https://github.com/plausible/analytics/assets/56999674/4cb092dd-0a91-4a6a-906d-4ad5cdede70b">
 

**With this PR:**

* Move the notice across the app (same scope as the "subscription paused/past-due" notices -`_notice.html`)
* Note about grandfathering as mentioned above
* Change the styling by re-using the `Generic.notice` component (added a configurable color theme option for that)

<img width="1059" alt="image" src="https://github.com/plausible/analytics/assets/56999674/0c106b27-fb50-47f7-9648-16c0ccae2bf2">
<img width="1436" alt="image" src="https://github.com/plausible/analytics/assets/56999674/1b9abb0d-b100-4a21-beae-79080ffa8bfb">


### Bonus

Use `Generic.notice` in `subscription_past_due_notice` and `subscription_past_due_notice` for more consistent styling and less code.

Before:
<img width="1012" alt="image" src="https://github.com/plausible/analytics/assets/56999674/0610e14c-65fb-4b76-8f68-0a30859a4f80">
<img width="1014" alt="image" src="https://github.com/plausible/analytics/assets/56999674/da48a3b5-a463-42bb-934e-d7d3ce528137">

After:
<img width="1022" alt="image" src="https://github.com/plausible/analytics/assets/56999674/5656f786-031d-4827-b387-e60443dd51a5">
<img width="1014" alt="image" src="https://github.com/plausible/analytics/assets/56999674/619a0afe-1116-43bc-9d03-c616f731281c">

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
