### PR TITLE
Dump plan information to PostgreSQL

### DIFF
--- a/lib/mix/tasks/dump_plans.ex
+++ b/lib/mix/tasks/dump_plans.ex
@@ -1,0 +1,43 @@
+defmodule Mix.Tasks.DumpPlans do
+  @moduledoc """
+  This task dumps plan information from the JSON files to the `plans` table in
+  PostgreSQL for internal use. This task deletes existing records and
+  (re)inserts the list of plans.
+  """
+
+  use Mix.Task
+  require Logger
+
+  @table "plans"
+
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    Plausible.Repo.delete_all(@table)
+
+    plans =
+      Plausible.Billing.Plans.all()
+      |> Plausible.Billing.Plans.with_prices()
+      |> Enum.map(&Map.from_struct/1)
+      |> Enum.map(&prepare_for_dump/1)
+
+    {count, _} = Plausible.Repo.insert_all(@table, plans)
+
+    Logger.info("Inserted #{count} plans")
+  end
+
+  defp prepare_for_dump(plan) do
+    monthly_cost = plan.monthly_cost && Money.to_decimal(plan.monthly_cost)
+    yearly_cost = plan.yearly_cost && Money.to_decimal(plan.yearly_cost)
+    {:ok, features} = Plausible.Billing.Ecto.FeatureList.dump(plan.features)
+    {:ok, team_member_limit} = Plausible.Billing.Ecto.Limit.dump(plan.team_member_limit)
+
+    plan
+    |> Map.drop([:id])
+    |> Map.put(:kind, Atom.to_string(plan.kind))
+    |> Map.put(:monthly_cost, monthly_cost)
+    |> Map.put(:yearly_cost, yearly_cost)
+    |> Map.put(:features, features)
+    |> Map.put(:team_member_limit, team_member_limit)
+  end
+end

--- a/lib/plausible/billing/ecto/limit.ex
+++ b/lib/plausible/billing/ecto/limit.ex
@@ -11,6 +11,7 @@ defmodule Plausible.Billing.Ecto.Limit do
 
   def cast(-1), do: {:ok, :unlimited}
   def cast(:unlimited), do: {:ok, :unlimited}
+  def cast("unlimited"), do: {:ok, :unlimited}
   def cast(other), do: Ecto.Type.cast(:integer, other)
 
   def load(-1), do: {:ok, :unlimited}

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -16,10 +16,9 @@ defmodule Plausible.Billing.Plans do
     path = Application.app_dir(:plausible, ["priv", "#{f}.json"])
 
     plans_list =
-      path
-      |> File.read!()
-      |> Jason.decode!(keys: :atoms!)
-      |> Enum.map(&Plan.build!(&1, f))
+      for attrs <- path |> File.read!() |> Jason.decode!() do
+        %Plan{} |> Plan.changeset(attrs) |> Ecto.Changeset.apply_action!(nil)
+      end
 
     Module.put_attribute(__MODULE__, f, plans_list)
 

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -260,7 +260,7 @@ defmodule Plausible.Billing.Plans do
     end
   end
 
-  defp all() do
+  def all() do
     @legacy_plans ++ @plans_v1 ++ @plans_v2 ++ @plans_v3 ++ @plans_v4 ++ sandbox_plans()
   end
 

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -245,12 +245,11 @@ defmodule Plausible.Billing.Quota do
         from g in Plausible.Goal, where: g.site_id == ^site.id and not is_nil(g.currency)
       )
 
-    used_features =
-      [
-        {Props, props_exist},
-        {Funnels, funnels_exist},
-        {RevenueGoals, revenue_goals_exist}
-      ]
+    used_features = [
+      {Props, props_exist},
+      {Funnels, funnels_exist},
+      {RevenueGoals, revenue_goals_exist}
+    ]
 
     for {f_mod, used?} <- used_features, used?, f_mod.enabled?(site), do: f_mod
   end

--- a/priv/repo/migrations/20231121131602_create_plans_table.exs
+++ b/priv/repo/migrations/20231121131602_create_plans_table.exs
@@ -1,0 +1,21 @@
+defmodule Plausible.Repo.Migrations.CreatePlansTable do
+  use Ecto.Migration
+
+  def change do
+    if !Application.get_env(:plausible, :is_selfhost) do
+      create table(:plans) do
+        add :generation, :integer, null: false
+        add :kind, :string, null: false
+        add :features, {:array, :string}, null: false
+        add :monthly_pageview_limit, :integer, null: false
+        add :site_limit, :integer, null: false
+        add :team_member_limit, :integer, null: false
+        add :volume, :string, null: false
+        add :monthly_cost, :decimal, null: true
+        add :monthly_product_id, :string, null: true
+        add :yearly_cost, :decimal, null: true
+        add :yearly_product_id, :string, null: true
+      end
+    end
+  end
+end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -517,9 +517,9 @@ defmodule Plausible.Billing.QuotaTest do
       user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
       user_on_v3 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v3_plan_id))
 
-      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v1)
-      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v2)
-      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user_on_v3)
+      assert [Goals, Props, StatsAPI] == Quota.allowed_features_for(user_on_v1)
+      assert [Goals, Props, StatsAPI] == Quota.allowed_features_for(user_on_v2)
+      assert [Goals, Props, StatsAPI] == Quota.allowed_features_for(user_on_v3)
     end
 
     test "returns [Goals, Props, StatsAPI] when user is on free_10k plan" do
@@ -560,7 +560,7 @@ defmodule Plausible.Billing.QuotaTest do
           subscription: build(:subscription, paddle_plan_id: @v1_plan_id)
         )
 
-      assert [Goals, StatsAPI, Props] == Quota.allowed_features_for(user)
+      assert [Goals, Props, StatsAPI] == Quota.allowed_features_for(user)
     end
 
     test "returns all features for enterprise users who have not upgraded yet and are on trial" do


### PR DESCRIPTION
This pull request creates a new internal table called `plans` used for analytical purposes, and a `mix dump_plans` task to seeds the table with plan information. This task can be run multiple times if needed. I also refactored the casting of plans from the JSON files to use Ecto for data casting and validation.

An example of how it looks on the database:

```
| id | generation | kind     | features                                      | monthly_pageview_limit | site_limit | team_member_limit | volume | monthly_cost | monthly_product_id | yearly_cost | yearly_product_id |
|----|------------|----------|-----------------------------------------------|------------------------|------------|-------------------|--------|--------------|--------------------|-------------|-------------------|
| 67 |          4 | business | {goals,props,revenue_goals,funnels,stats_api} |                1000000 |         50 |                10 | 1M     |         79.0 | 63854              |       700.0 | 63871             |
| 68 |          4 | business | {goals,props,revenue_goals,funnels,stats_api} |                2000000 |         50 |                10 | 2M     |         99.0 | 63855              |       900.0 | 63872             |
| 69 |          4 | business | {goals,props,revenue_goals,funnels,stats_api} |                5000000 |         50 |                10 | 5M     |        139.0 | 63856              |        1300 | 63873             |
| 70 |          4 | business | {goals,props,revenue_goals,funnels,stats_api} |               10000000 |         50 |                10 | 10M    |        179.0 | 63857              |        1700 | 63874             |
```
