### PR TITLE
Bugfix: Allow breakdown by internally used prop keys for Growth plans

### DIFF
--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -96,6 +96,14 @@ defmodule Plausible.Props do
   """
   def internal_keys, do: @internal_keys
 
+  def ensure_prop_key_accessible(prop_key, user) do
+    if prop_key in @internal_keys do
+      :ok
+    else
+      Plausible.Billing.Feature.Props.check_availability(user)
+    end
+  end
+
   @spec suggest_keys_to_allow(Plausible.Site.t(), non_neg_integer()) :: [String.t()]
   @doc """
   Queries the events table to fetch the #{@max_props} most frequent prop keys

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1185,12 +1185,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def custom_prop_values(conn, params) do
     site = Plausible.Repo.preload(conn.assigns.site, :owner)
+    prop_key = Map.fetch!(params, "prop_key")
 
-    with prop_key <- Map.fetch!(params, "prop_key"),
-         :ok <- Plausible.Props.ensure_prop_key_accessible(prop_key, site.owner) do
-      props = breakdown_custom_prop_values(site, params)
-      json(conn, props)
-    else
+    case Plausible.Props.ensure_prop_key_accessible(prop_key, site.owner) do
+      :ok ->
+        props = breakdown_custom_prop_values(site, params)
+        json(conn, props)
+
       {:error, :upgrade_required} ->
         H.payment_required(
           conn,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1186,11 +1186,11 @@ defmodule PlausibleWeb.Api.StatsController do
   def custom_prop_values(conn, params) do
     site = Plausible.Repo.preload(conn.assigns.site, :owner)
 
-    case Plausible.Billing.Feature.Props.check_availability(site.owner) do
-      :ok ->
-        props = breakdown_custom_prop_values(site, params)
-        json(conn, props)
-
+    with prop_key <- Map.fetch!(params, "prop_key"),
+         :ok <- Plausible.Props.ensure_prop_key_accessible(prop_key, site.owner) do
+      props = breakdown_custom_prop_values(site, params)
+      json(conn, props)
+    else
       {:error, :upgrade_required} ->
         H.payment_required(
           conn,


### PR DESCRIPTION
### Changes

In the `StatsController.custom_prop_values` action, allow breakdown by prop keys such as `url` and `path` (used with special goals such as 404s or outbound links)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
