### PR TITLE
Simplify TOTP core logic and add email notifications

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -70,7 +70,7 @@ defmodule PlausibleWeb.Email do
 
   def two_factor_enabled_email(user) do
     priority_email()
-    |> to(user.email)
+    |> to(user)
     |> tag("two-factor-enabled-reset-email")
     |> subject("Plausible two-factor authentication enabled")
     |> render("two_factor_enabled_email.html", user: user)
@@ -78,7 +78,7 @@ defmodule PlausibleWeb.Email do
 
   def two_factor_disabled_email(user) do
     priority_email()
-    |> to(user.email)
+    |> to(user)
     |> tag("two-factor-enabled-reset-email")
     |> subject("Plausible two-factor authentication disabled")
     |> render("two_factor_disabled_email.html", user: user)

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -68,6 +68,22 @@ defmodule PlausibleWeb.Email do
     |> render("password_reset_email.html", reset_link: reset_link)
   end
 
+  def two_factor_enabled_email(user) do
+    priority_email()
+    |> to(user.email)
+    |> tag("two-factor-enabled-reset-email")
+    |> subject("Plausible two-factor authentication enabled")
+    |> render("two_factor_enabled_email.html", user: user)
+  end
+
+  def two_factor_disabled_email(user) do
+    priority_email()
+    |> to(user.email)
+    |> tag("two-factor-enabled-reset-email")
+    |> subject("Plausible two-factor authentication disabled")
+    |> render("two_factor_disabled_email.html", user: user)
+  end
+
   def trial_one_week_reminder(user) do
     base_email()
     |> to(user)

--- a/lib/plausible_web/templates/email/two_factor_disabled_email.html.eex
+++ b/lib/plausible_web/templates/email/two_factor_disabled_email.html.eex
@@ -1,0 +1,1 @@
+Two-factor authentication is now disabled on your account.

--- a/lib/plausible_web/templates/email/two_factor_enabled_email.html.eex
+++ b/lib/plausible_web/templates/email/two_factor_enabled_email.html.eex
@@ -1,0 +1,1 @@
+Two-factor authentication is now enabled on your account.

--- a/test/plausible/auth/totp_test.exs
+++ b/test/plausible/auth/totp_test.exs
@@ -49,7 +49,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert TOTP.initiate(user) == {:error, :already_setup}
     end
@@ -67,23 +67,50 @@ defmodule Plausible.Auth.TOTPTest do
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
 
-      assert {:ok, user} = TOTP.enable(user, code)
+      assert {:ok, user, %{recovery_codes: recovery_codes}} = TOTP.enable(user, code)
 
       assert user.totp_enabled
       assert byte_size(user.totp_secret) > 0
+
+      persisted_recovery_codes = Repo.all(RecoveryCode)
+
+      assert length(recovery_codes) == 10
+      assert length(persisted_recovery_codes) == 10
+
+      Enum.each(persisted_recovery_codes, fn recovery_code ->
+        assert recovery_code.user_id == user.id
+        assert byte_size(recovery_code.code_digest) > 0
+      end)
+
+      Enum.each(recovery_codes, fn code_string ->
+        assert byte_size(code_string) > 0
+        assert :ok = TOTP.use_recovery_code(user, code_string)
+      end)
     end
 
     test "succeeds for user who has TOTP enabled already" do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret, time: System.os_time(:second) - 30)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, %{recovery_codes: [recovery_code | recovery_codes]}} = TOTP.enable(user, code)
+      :ok = TOTP.use_recovery_code(user, recovery_code)
 
-      assert {:ok, updated_user} = TOTP.enable(user, code, allow_reuse?: true)
+      assert {:ok, updated_user, %{recovery_codes: new_recovery_codes}} =
+               TOTP.enable(user, code, allow_reuse?: true)
 
       assert updated_user.id == user.id
       assert updated_user.totp_enabled
       assert updated_user.totp_secret == user.totp_secret
+
+      assert Enum.uniq(recovery_codes ++ new_recovery_codes) ==
+               recovery_codes ++ new_recovery_codes
+
+      assert length(new_recovery_codes) == 10
+
+      Enum.each(new_recovery_codes, fn code_string ->
+        assert byte_size(code_string) > 0
+        assert :ok = TOTP.use_recovery_code(user, code_string)
+      end)
     end
 
     test "fails when TOTP setup is not initiated" do
@@ -105,7 +132,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert {:ok, updated_user} = TOTP.disable(user, "VeryStrongVerySecret")
 
@@ -130,7 +157,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert {:error, :invalid_password} = TOTP.disable(user, "invalid")
     end
@@ -138,65 +165,12 @@ defmodule Plausible.Auth.TOTPTest do
 
   describe "generate_recovery_codes/1" do
     test "generates recovery codes for user with enabled TOTP" do
-      user = insert(:user)
-      {:ok, user, _} = TOTP.initiate(user)
-      code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
-
-      assert {:ok, codes} = TOTP.generate_recovery_codes(user)
-
-      persisted_codes = Repo.all(RecoveryCode)
-
-      assert length(codes) == 10
-      assert length(persisted_codes) == 10
-
-      Enum.each(persisted_codes, fn recovery_code ->
-        assert recovery_code.user_id == user.id
-        assert byte_size(recovery_code.code_digest) > 0
-      end)
-
-      Enum.each(codes, fn code ->
-        assert byte_size(code) > 0
-        assert :ok = TOTP.use_recovery_code(user, code)
-      end)
-    end
-
-    test "regenerates recovery codes when generated already" do
-      user = insert(:user)
-      {:ok, user, _} = TOTP.initiate(user)
-      code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
-
-      assert {:ok, [code | codes]} = TOTP.generate_recovery_codes(user)
-      assert :ok = TOTP.use_recovery_code(user, code)
-
-      assert {:ok, new_codes} = TOTP.generate_recovery_codes(user)
-
-      assert Enum.uniq(codes ++ new_codes) == codes ++ new_codes
-
-      assert length(new_codes) == 10
-
-      Enum.each(new_codes, fn code ->
-        assert byte_size(code) > 0
-        assert :ok = TOTP.use_recovery_code(user, code)
-      end)
-    end
-
-    test "fails when user has TOTP disabled" do
-      user = insert(:user)
-
-      assert {:error, :not_enabled} = TOTP.generate_recovery_codes(user)
-    end
-  end
-
-  describe "generate_recovery_codes_protected/1" do
-    test "generates recovery codes for user with enabled TOTP" do
       user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
-      assert {:ok, codes} = TOTP.generate_recovery_codes_protected(user, "VeryStrongVerySecret")
+      assert {:ok, codes} = TOTP.generate_recovery_codes(user, "VeryStrongVerySecret")
 
       persisted_codes = Repo.all(RecoveryCode)
 
@@ -218,16 +192,16 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user, password: "VeryStrongVerySecret")
 
       assert {:error, :not_enabled} =
-               TOTP.generate_recovery_codes_protected(user, "VeryStrongVerySecret")
+               TOTP.generate_recovery_codes(user, "VeryStrongVerySecret")
     end
 
     test "fails when invalid password provided" do
       user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
-      assert {:error, :invalid_password} = TOTP.generate_recovery_codes_protected(user, "invalid")
+      assert {:error, :invalid_password} = TOTP.generate_recovery_codes(user, "invalid")
     end
   end
 
@@ -236,7 +210,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret, time: System.os_time(:second) - 30)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
       new_code = NimbleTOTP.verification_code(user.totp_secret)
 
       # making sure that generated OTP codes are different
@@ -251,7 +225,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret, time: System.os_time(:second) - 30)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert {:error, :invalid_code} = TOTP.validate_code(user, code)
     end
@@ -260,7 +234,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert {:error, :invalid_code} = TOTP.validate_code(user, "1234")
     end
@@ -276,11 +250,11 @@ defmodule Plausible.Auth.TOTPTest do
 
   describe "use_recovery_code/2" do
     test "succeeds when valid recovery code provided but fails when trying to reuse it" do
-      user = insert(:user)
+      user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
-      {:ok, [code | codes]} = TOTP.generate_recovery_codes(user)
+      {:ok, user, _} = TOTP.enable(user, code)
+      {:ok, [code | codes]} = TOTP.generate_recovery_codes(user, "VeryStrongVerySecret")
 
       assert :ok = TOTP.use_recovery_code(user, code)
       assert {:error, :invalid_code} = TOTP.use_recovery_code(user, code)
@@ -289,11 +263,11 @@ defmodule Plausible.Auth.TOTPTest do
     end
 
     test "fails when provided code is invalid" do
-      user = insert(:user)
+      user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
-      {:ok, _} = TOTP.generate_recovery_codes(user)
+      {:ok, user, _} = TOTP.enable(user, code)
+      {:ok, _} = TOTP.generate_recovery_codes(user, "VeryStrongVerySecret")
 
       assert {:error, :invalid_code} = TOTP.use_recovery_code(user, "INVALID")
     end
@@ -302,7 +276,7 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user)
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
+      {:ok, user, _} = TOTP.enable(user, code)
 
       assert {:error, :invalid_code} = TOTP.use_recovery_code(user, "INVALID")
     end
@@ -311,11 +285,11 @@ defmodule Plausible.Auth.TOTPTest do
       user = insert(:user, password: "VeryStrongVerySecret")
       {:ok, user, _} = TOTP.initiate(user)
       code = NimbleTOTP.verification_code(user.totp_secret)
-      {:ok, user} = TOTP.enable(user, code)
-      {:ok, [code | _]} = TOTP.generate_recovery_codes(user)
+      {:ok, user, _} = TOTP.enable(user, code)
+      {:ok, [code | _]} = TOTP.generate_recovery_codes(user, "VeryStrongVerySecret")
       {:ok, user} = TOTP.disable(user, "VeryStrongVerySecret")
 
-      assert {:error, :not_enabled} = TOTP.user_recovery_code(user, code)
+      assert {:error, :not_enabled} = TOTP.use_recovery_code(user, code)
     end
   end
 end

--- a/test/plausible/auth/totp_test.exs
+++ b/test/plausible/auth/totp_test.exs
@@ -8,11 +8,22 @@ defmodule Plausible.Auth.TOTPTest do
 
   describe "enabled?/1" do
     test "Returns user's TOTP state" do
-      assert TOTP.enabled?(insert(:user, totp_enabled: true, totp_secret: "secret"))
       refute TOTP.enabled?(insert(:user, totp_enabled: false, totp_secret: nil))
-      # these shouldn't happen under normal circumstances but we do check
-      # totp_secret presence just to be safe and avoid undefined behavior
       refute TOTP.enabled?(insert(:user, totp_enabled: false, totp_secret: "secret"))
+      assert TOTP.enabled?(insert(:user, totp_enabled: true, totp_secret: "secret"))
+      # this shouldn't happen under normal circumstances but we do check
+      # totp_secret presence just to be safe and avoid undefined behavior
+      refute TOTP.enabled?(insert(:user, totp_enabled: true, totp_secret: nil))
+    end
+  end
+
+  describe "initiated?/1" do
+    test "Returns true only when user's TOTP setup is initiated but not finalized" do
+      refute TOTP.initiated?(insert(:user, totp_enabled: false, totp_secret: nil))
+      refute TOTP.initiated?(insert(:user, totp_enabled: true, totp_secret: "secret"))
+      assert TOTP.initiated?(insert(:user, totp_enabled: false, totp_secret: "secret"))
+      # this shouldn't happen under normal circumstances but we do check
+      # totp_secret presence just to be safe and avoid undefined behavior
       refute TOTP.enabled?(insert(:user, totp_enabled: true, totp_secret: nil))
     end
   end


### PR DESCRIPTION
### Changes

These changes are extracted from https://github.com/plausible/analytics/pull/3541. Tests got slightly improved after extraction and recipient address now includes user's display name.

### Tests
- [x] Automated tests have been added
- [] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
