### PR TITLE
Move input range bubble to JavaScript

### DIFF
--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -225,18 +225,6 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   end
 
   defp slider(assigns) do
-    selected_index =
-      Enum.find_index(assigns.available_volumes, &(&1 == assigns.selected_volume)) ||
-        length(assigns.available_volumes)
-
-    slider_percentage = selected_index / length(assigns.available_volumes) * 100
-    bubble_position = "left: calc(#{slider_percentage}% + #{13.87 - slider_percentage * 0.26}px)"
-
-    assigns =
-      assigns
-      |> assign(:selected_index, selected_index)
-      |> assign(:bubble_position, bubble_position)
-
     ~H"""
     <form class="max-w-md lg:max-w-none w-full lg:w-1/2 lg:order-2">
       <div class="flex items-baseline space-x-2">
@@ -244,22 +232,40 @@ defmodule PlausibleWeb.Live.ChoosePlan do
           <%= format_volume(List.first(@available_volumes), @available_volumes) %>
         </span>
         <div class="flex-1 relative">
+          <script>
+            const VOLUMES = <%= @available_volumes |> Enum.map(&format_volume(&1, @available_volumes)) |> Jason.encode!() |> raw() %>
+
+            function repositionBubble() {
+              const input = document.getElementById("slider")
+              const percentage = Number((input.value / input.max) * 100)
+              const bubble = document.getElementById("slider-bubble")
+
+              bubble.innerHTML = input.value == input.max ? `${VOLUMES[input.value - 1]}+` : VOLUMES[input.value]
+              bubble.style.left = `calc(${percentage}% + (${13.87 - percentage * 0.26}px))`
+            }
+
+            document.addEventListener("DOMContentLoaded", repositionBubble)
+          </script>
           <input
             phx-change="slide"
+            id="slider"
             name="slider"
             class="shadow mt-8 dark:bg-gray-600 dark:border-none"
             type="range"
             min="0"
             max={length(@available_volumes)}
             step="1"
-            value={@selected_index}
+            value={
+              Enum.find_index(assigns.available_volumes, &(&1 == assigns.selected_volume)) ||
+                length(assigns.available_volumes)
+            }
+            oninput="repositionBubble()"
           />
           <output
+            id="slider-bubble"
             class="absolute bottom-[35px] py-[4px] px-[12px] -translate-x-1/2 rounded-md text-white bg-indigo-600 position text-xs font-medium"
-            style={@bubble_position}
-          >
-            <%= format_volume(@selected_volume, @available_volumes) %>
-          </output>
+            phx-update="ignore"
+          />
         </div>
         <span class="text-xs font-medium text-gray-600 dark:text-gray-200">
           <%= format_volume(List.last(@available_volumes), @available_volumes) <> "+" %>


### PR DESCRIPTION
This commit switches the input range bubble on the choose plan page from
LiveView to JavaScript. The reason for this change is the input range
is a regular HTML input rendered by the browser, not LV, therefore
bubble was not in sync when sliding the input.
