### PR TITLE
Add last_bill_date to new subscriptions

### DIFF
--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -116,6 +116,7 @@ defmodule Plausible.BillingTest do
   @plan_id_100k "654178"
 
   @subscription_created_params %{
+    "event_time" => "2019-05-01 01:03:52",
     "alert_name" => "subscription_created",
     "passthrough" => "",
     "email" => "",
@@ -153,6 +154,7 @@ defmodule Plausible.BillingTest do
       subscription = Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
       assert subscription.paddle_subscription_id == @subscription_id
       assert subscription.next_bill_date == ~D[2019-06-01]
+      assert subscription.last_bill_date == ~D[2019-05-01]
       assert subscription.next_bill_amount == "6.00"
       assert subscription.currency_code == "EUR"
     end
@@ -166,6 +168,7 @@ defmodule Plausible.BillingTest do
       subscription = Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
       assert subscription.paddle_subscription_id == @subscription_id
       assert subscription.next_bill_date == ~D[2019-06-01]
+      assert subscription.last_bill_date == ~D[2019-05-01]
       assert subscription.next_bill_amount == "6.00"
     end
 
@@ -222,6 +225,7 @@ defmodule Plausible.BillingTest do
       subscription = Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
       assert subscription.paddle_plan_id == @plan_id_10k
       assert subscription.next_bill_amount == "12.00"
+      assert subscription.last_bill_date == "wat"
     end
 
     test "unlocks sites if subscription is changed from past_due to active" do


### PR DESCRIPTION
### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
