### PR TITLE
Use autocomplete=new-password for shared link password field

### DIFF
--- a/lib/plausible_web/templates/site/new_shared_link.html.eex
+++ b/lib/plausible_web/templates/site/new_shared_link.html.eex
@@ -10,7 +10,7 @@
   <div class="my-4">
     <%= label f, :password, "Password (optional)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <div class="mt-1">
-      <%= password_input f, :password, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-900 dark:border-gray-500 dark:text-gray-300 dark:focus:bg-gray-800 dark:focus:border-gray-500", autocomplete: "off" %>
+      <%= password_input f, :password, class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md dark:bg-gray-900 dark:border-gray-500 dark:text-gray-300 dark:focus:bg-gray-800 dark:focus:border-gray-500", autocomplete: "new-password" %>
       <%= error_tag f, :password %>
       <p class="mt-2 text-sm text-gray-500 dark:text-gray-200">
         Password protection is optional. Please make sure you save it in a secure place. Once the link is created, we cannot reveal the password.


### PR DESCRIPTION
### Changes

This PR tries to address problem of password managers automatically filling password field on page load when creating new shared link. 

It follows the method described in https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password. 

I have tested it with Bitwarden browser extension (with autofill on page load temporarily enabled) and it behaves as expected, _not_ autopopulating the field with existing credentials.

It must be noted this is merely a hint though. When triggering auto-fill manually (by selecting credentials from the list in extension pane), the field is still going to be populated. That requires a deliberate action though. Browser compatbility for that property value is also limited.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
