### PR TITLE
Add a `last_bill_date` to existing subscriptions (migration only)

### DIFF
--- a/priv/repo/migrations/20231204151831_backfill_last_bill_date_to_subscriptions.exs
+++ b/priv/repo/migrations/20231204151831_backfill_last_bill_date_to_subscriptions.exs
@@ -1,0 +1,11 @@
+defmodule Plausible.Repo.Migrations.BackfillLastBillDateToSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    execute """
+    UPDATE subscriptions
+    SET last_bill_date = inserted_at::date
+    WHERE last_bill_date IS NULL AND paddle_plan_id != 'free_10k';
+    """
+  end
+end


### PR DESCRIPTION
### Changes

There was a bug in our system, where the `last_bill_date` was not saved upon creating a subscription, and only changed from `nil` to a real date after the second payment on the same subscription. This was fixed for all new/upcoming subscriptions in https://github.com/plausible/analytics/pull/3588.

This PR only contains a migration file that executes SQL to backfill the `last_bill_date` to all existing subscriptions - that means, for all subscriptions that don't have a `last_bill_date`, we will set it to the date when the subscription itself was inserted into our database, i.e. `inserted_at`.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
