### PR TITLE
Prevent invited users without sites from subscribing

### DIFF
--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -447,7 +447,7 @@ defmodule PlausibleWeb.Components.Billing do
 
   def subscription_paused_notice(assigns), do: ~H""
 
-  def upgrade_ineligible_notice(%{user: %User{trial_expiry_date: nil}} = assigns) do
+  def upgrade_ineligible_notice(assigns) do
     ~H"""
     <aside id="upgrade-eligible-notice" class="pb-6">
       <PlausibleWeb.Components.Generic.notice
@@ -464,8 +464,6 @@ defmodule PlausibleWeb.Components.Billing do
     </aside>
     """
   end
-
-  def upgrade_ineligible_notice(assigns), do: ~H""
 
   def present_enterprise_plan(assigns) do
     ~H"""

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -447,6 +447,26 @@ defmodule PlausibleWeb.Components.Billing do
 
   def subscription_paused_notice(assigns), do: ~H""
 
+  def upgrade_ineligible_notice(%{user: %User{trial_expiry_date: nil}} = assigns) do
+    ~H"""
+    <aside id="upgrade-eligible-notice" class="pb-6">
+      <PlausibleWeb.Components.Generic.notice
+        title="No sites owned"
+        theme={:yellow}
+        class="shadow-md dark:shadow-none"
+      >
+        You cannot start a subscription as your account doesn't own any sites. The account that owns the sites is responsible for the billing. Please either
+        <.styled_link href="https://plausible.io/docs/transfer-ownership">
+          transfer the sites
+        </.styled_link>
+        to your account or start a subscription from the account that owns your sites.
+      </PlausibleWeb.Components.Generic.notice>
+    </aside>
+    """
+  end
+
+  def upgrade_ineligible_notice(assigns), do: ~H""
+
   def present_enterprise_plan(assigns) do
     ~H"""
     <ul class="w-full py-4">

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -37,8 +37,8 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:owned_tier, fn %{owned_plan: owned_plan} ->
         if owned_plan, do: Map.get(owned_plan, :kind), else: nil
       end)
-      |> assign_new(:recommended_tier, fn %{owned_plan: owned_plan, user: user} ->
-        if owned_plan || is_nil(user.trial_expiry_date), do: nil, else: Plans.suggest_tier(user)
+      |> assign_new(:recommended_tier, fn %{owned_plan: owned_plan, user: user, usage: usage} ->
+        if owned_plan || usage.sites == 0, do: nil, else: Plans.suggest_tier(user)
       end)
       |> assign_new(:current_interval, fn %{user: user} ->
         current_user_subscription_interval(user.subscription)
@@ -99,7 +99,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       <div class="mx-auto max-w-7xl px-6 lg:px-20">
         <.subscription_past_due_notice class="pb-6" subscription={@user.subscription} />
         <.subscription_paused_notice class="pb-6" subscription={@user.subscription} />
-        <.upgrade_ineligible_notice user={@user} />
+        <.upgrade_ineligible_notice :if={@usage.sites == 0} />
         <div class="mx-auto max-w-4xl text-center">
           <p class="text-4xl font-bold tracking-tight lg:text-5xl">
             <%= if @owned_plan,
@@ -362,7 +362,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
 
     {checkout_disabled, disabled_message} =
       cond do
-        is_nil(assigns.user.trial_expiry_date) ->
+        assigns.usage.sites == 0 ->
           {true, nil}
 
         change_plan_link_text == "Currently on this plan" && not subscription_deleted ->

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -718,12 +718,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
   end
 
-  describe "for an invited user (with trial_expiry_date=nil)" do
-    setup context do
-      context
-      |> Map.put(:user, insert(:user, trial_expiry_date: nil))
-      |> log_in()
-    end
+  describe "for a user with no sites" do
+    setup [:create_user, :log_in]
 
     test "does not allow to subscribe and renders notice", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   @slider_volumes ["10k", "100k", "200k", "500k", "1M", "2M", "5M", "10M", "10M+"]
 
   describe "for a user with no subscription" do
-    setup [:create_user, :log_in]
+    setup [:create_user, :create_site, :log_in]
 
     test "displays basic page content", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -206,8 +206,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                @v4_business_5m_monthly_plan_id
     end
 
-    test "warns about losing access to a feature", %{conn: conn, user: user} do
-      site = insert(:site, members: [user])
+    test "warns about losing access to a feature", %{conn: conn, site: site} do
       Plausible.Props.allow(site, ["author"])
 
       {:ok, _lv, doc} = get_liveview(conn)
@@ -224,11 +223,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
 
     @tag :full_build_only
-    test "recommends Business tier when Revenue Goals were used during trial", %{
-      conn: conn,
-      user: user
-    } do
-      site = insert(:site, members: [user])
+    test "recommends Business when Revenue Goals used during trial", %{conn: conn, site: site} do
       insert(:goal, site: site, currency: :USD, event_name: "Purchase")
 
       {:ok, _lv, doc} = get_liveview(conn)
@@ -239,7 +234,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a v4 growth subscription plan" do
-    setup [:create_user, :log_in, :subscribe_v4_growth]
+    setup [:create_user, :create_site, :log_in, :subscribe_v4_growth]
 
     test "displays basic page content", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -285,9 +280,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                "https://plausible.io/white-label-web-analytics"
     end
 
-    test "displays usage", %{conn: conn, user: user} do
-      site = insert(:site, members: [user])
-
+    test "displays usage", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview),
         build(:pageview)
@@ -373,7 +366,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a v4 business subscription plan" do
-    setup [:create_user, :log_in, :subscribe_v4_business]
+    setup [:create_user, :create_site, :log_in, :subscribe_v4_business]
 
     test "gets default pageview limit from current subscription plan", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -448,9 +441,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "checkout is not disabled when pageview usage exceeded but next upgrade allowed by override",
          %{
            conn: conn,
-           user: user
+           user: user,
+           site: site
          } do
-      site = insert(:site, members: [user])
       now = NaiveDateTime.utc_now()
 
       generate_usage_for(site, 11_000, Timex.shift(now, days: -5))
@@ -465,9 +458,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
 
     @tag :full_build_only
-    test "warns about losing access to a feature", %{conn: conn, user: user} do
-      site = insert(:site, members: [user])
-
+    test "warns about losing access to a feature", %{conn: conn, user: user, site: site} do
       Plausible.Props.allow(site, ["author"])
       insert(:goal, currency: :USD, site: site, event_name: "Purchase")
       insert(:api_key, user: user)
@@ -480,7 +471,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a v3 business (unlimited team members) subscription plan" do
-    setup [:create_user, :log_in]
+    setup [:create_user, :create_site, :log_in]
 
     setup %{user: user} = context do
       create_subscription_for(user, paddle_plan_id: @v3_business_10k_monthly_plan_id)
@@ -526,7 +517,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a past_due subscription" do
-    setup [:create_user, :log_in, :create_past_due_subscription]
+    setup [:create_user, :create_site, :log_in, :create_past_due_subscription]
 
     test "renders failed payment notice and link to update billing details", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -556,7 +547,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a paused subscription" do
-    setup [:create_user, :log_in, :create_paused_subscription]
+    setup [:create_user, :create_site, :log_in, :create_paused_subscription]
 
     test "renders subscription paused notice and link to update billing details", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -586,7 +577,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a user with a cancelled subscription" do
-    setup [:create_user, :log_in, :create_cancelled_subscription]
+    setup [:create_user, :create_site, :log_in, :create_cancelled_subscription]
 
     test "checkout buttons are paddle buttons", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -619,7 +610,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a grandfathered user" do
-    setup [:create_user, :log_in]
+    setup [:create_user, :create_site, :log_in]
 
     setup %{user: user} = context do
       create_subscription_for(user, paddle_plan_id: @v1_10k_yearly_plan_id)
@@ -692,7 +683,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   end
 
   describe "for a free_10k subscription" do
-    setup [:create_user, :log_in, :subscribe_free_10k]
+    setup [:create_user, :create_site, :log_in, :subscribe_free_10k]
 
     test "recommends growth tier when no premium features used", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -701,8 +692,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
 
     @tag :full_build_only
-    test "recommends Business tier when premium features used", %{conn: conn, user: user} do
-      site = insert(:site, members: [user])
+    test "recommends Business tier when premium features used", %{conn: conn, site: site} do
       insert(:goal, currency: :USD, site: site, event_name: "Purchase")
 
       {:ok, _lv, doc} = get_liveview(conn)

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -728,6 +728,22 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
   end
 
+  describe "for an invited user (with trial_expiry_date=nil)" do
+    setup context do
+      context
+      |> Map.put(:user, insert(:user, trial_expiry_date: nil))
+      |> log_in()
+    end
+
+    test "does not allow to subscribe and renders notice", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, "#upgrade-eligible-notice") =~ "You cannot start a subscription"
+      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+      assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+    end
+  end
+
   defp subscribe_v4_growth(%{user: user}) do
     create_subscription_for(user, paddle_plan_id: @v4_growth_200k_yearly_plan_id)
   end


### PR DESCRIPTION
### Changes

This PR only contains one addition to the upgrade page - not allowing users with `trial_expiry_date=nil` to upgrade. Those are the users that were invited as an admin or a viewer to another site in Plausible, but don't own any sites themselves.

Preview:
<img width="1176" alt="image" src="https://github.com/plausible/analytics/assets/56999674/af70588e-6ec9-47ba-8e32-84462fcb18e4">

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
