### PR TITLE
Protect against custom props payloads breaking event insertions

### DIFF
--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -78,8 +78,7 @@ defmodule Plausible.ClickhouseEventV2 do
         :revenue_source_currency,
         :revenue_reporting_amount,
         :revenue_reporting_currency
-      ],
-      empty_values: [nil, ""]
+      ]
     )
     |> validate_required([:name, :site_id, :hostname, :pathname, :user_id, :timestamp])
   end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -214,15 +214,11 @@ defmodule Plausible.Ingestion.Event do
 
   defp put_props(%__MODULE__{request: %{props: %{} = props}} = event) do
     # defensive: ensuring the keys/values are always in the same order
-    kvs =
-      Enum.reduce(props, %{keys: [], values: []}, fn
-        {k, v}, %{keys: ks, values: vs} ->
-          %{keys: [k | ks], values: [to_string(v) | vs]}
-      end)
+    {keys, values} = Enum.unzip(props)
 
     update_attrs(event, %{
-      "meta.key": Enum.reverse(kvs.keys),
-      "meta.value": Enum.reverse(kvs.values)
+      "meta.key": keys,
+      "meta.value": Enum.map(values, &to_string/1)
     })
   end
 

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -218,7 +218,7 @@ defmodule Plausible.Ingestion.Event do
 
     update_attrs(event, %{
       "meta.key": keys,
-      "meta.value": Enum.map(values, &to_string/1)
+      "meta.value": values
     })
   end
 

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -213,9 +213,16 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp put_props(%__MODULE__{request: %{props: %{} = props}} = event) do
+    # defensive: ensuring the keys/values are always in the same order
+    kvs =
+      Enum.reduce(props, %{keys: [], values: []}, fn
+        {k, v}, %{keys: ks, values: vs} ->
+          %{keys: [k | ks], values: [to_string(v) | vs]}
+      end)
+
     update_attrs(event, %{
-      "meta.key": Map.keys(props),
-      "meta.value": Enum.map(props, fn {_, v} -> to_string(v) end)
+      "meta.key": Enum.reverse(kvs.keys),
+      "meta.value": Enum.reverse(kvs.values)
     })
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -206,7 +206,14 @@ defmodule Plausible.Ingestion.Request do
     props =
       (request_body["m"] || request_body["meta"] || request_body["p"] || request_body["props"])
       |> Plausible.Helpers.JSON.decode_or_fallback()
-      |> Enum.reject(fn {_k, v} -> is_nil(v) || is_list(v) || is_map(v) || v == "" end)
+      |> Enum.filter(fn {k, v} ->
+        non_empty_key = is_binary(k) and byte_size(k) > 0
+
+        valid_value =
+          (is_binary(v) and byte_size(v) > 0) or is_number(v) or (is_atom(v) and not is_nil(v))
+
+        non_empty_key and valid_value
+      end)
       |> Enum.take(@max_props)
       |> Map.new()
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -566,7 +566,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert Map.get(event, :"meta.value") == ["true", "12"]
     end
 
-    test "immune to props payload causing uneven arrays", %{conn: conn, site: site} do
+    test "filters out bad props", %{conn: conn, site: site} do
       params = %{
         name: "Signup",
         url: "http://gigride.live/",
@@ -574,7 +574,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         props: %{
           false: nil,
           nil: false,
-          good: true
+          good: true,
+          "      ": "    ",
+          "    ": "value",
+          key: "    "
         }
       }
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -566,6 +566,27 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert Map.get(event, :"meta.value") == ["true", "12"]
     end
 
+    test "immune to props payload causing uneven arrays", %{conn: conn, site: site} do
+      params = %{
+        name: "Signup",
+        url: "http://gigride.live/",
+        domain: site.domain,
+        props: %{
+          false: nil,
+          nil: false,
+          good: true
+        }
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      event = get_event(site)
+
+      assert Map.get(event, :"meta.key") == ["good"]
+      assert Map.get(event, :"meta.value") == ["true"]
+    end
+
     test "ignores malformed custom props", %{conn: conn, site: site} do
       params = %{
         name: "Signup",


### PR DESCRIPTION
### Changes

This patch puts the shields up against custom props payloads ending up as uneven arrays insertions.

```
Elements 'meta.key' and 'meta.value' of Nested data structure 'meta' (Array columns) have different array sizes. (SIZES_OF_ARRAYS_DONT_MATCH)
```

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
