### PR TITLE
Clean up legacy trials code + displaying limits

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
       {:ok, %{site: site}} ->
         json(conn, site)
 
-      {:error, :limit, limit, _} ->
+      {:error, {:over_limit, limit}} ->
         conn
         |> put_status(402)
         |> json(%{

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -234,7 +234,7 @@ defmodule Plausible.Billing do
     case user.grace_period do
       %GracePeriod{allowance_required: allowance_required} ->
         new_monthly_pageview_limit =
-          Plausible.Billing.Quota.monthly_pageview_limit(user.subscription)
+          Plausible.Billing.Quota.monthly_pageview_limit(user)
 
         if new_monthly_pageview_limit > allowance_required do
           user

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -36,14 +36,13 @@ defmodule Plausible.Billing.Plans do
   As new versions of plans are introduced, users who were on old plans can
   still choose from old plans.
   """
-  def growth_plans_for(%User{} = user, now \\ Timex.now()) do
+  def growth_plans_for(%User{} = user) do
     user = Plausible.Users.with_subscription(user)
     v4_available = FunWithFlags.enabled?(:business_tier, for: user)
     owned_plan = get_regular_plan(user.subscription)
 
     cond do
       Application.get_env(:plausible, :environment) == "dev" -> @sandbox_plans
-      is_nil(owned_plan) && grandfathered_trial?(user.trial_expiry_date, now) -> @plans_v3
       is_nil(owned_plan) && v4_available -> @plans_v4
       is_nil(owned_plan) -> @plans_v3
       user.subscription && Subscriptions.expired?(user.subscription) -> @plans_v4
@@ -56,32 +55,17 @@ defmodule Plausible.Billing.Plans do
     |> Enum.filter(&(&1.kind == :growth))
   end
 
-  def business_plans_for(%User{} = user, now \\ Timex.now()) do
+  def business_plans_for(%User{} = user) do
     user = Plausible.Users.with_subscription(user)
     owned_plan = get_regular_plan(user.subscription)
 
     cond do
       Application.get_env(:plausible, :environment) == "dev" -> @sandbox_plans
-      is_nil(owned_plan) && grandfathered_trial?(user.trial_expiry_date, now) -> @plans_v3
       user.subscription && Subscriptions.expired?(user.subscription) -> @plans_v4
       owned_plan && owned_plan.generation < 4 -> @plans_v3
       true -> @plans_v4
     end
     |> Enum.filter(&(&1.kind == :business))
-  end
-
-  # Takes a Date struct argument representing the trial end date of a user.
-  # If the `trial_expiry` is `nil`, it means that the user has not started
-  # their trial yet (i.e. invited user), and this function returns false.
-  defp grandfathered_trial?(nil, _now), do: false
-
-  defp grandfathered_trial?(trial_expiry, now) do
-    trial_start = Timex.shift(trial_expiry, days: -30)
-
-    joined_before_business_tiers = Timex.before?(trial_start, @business_tier_launch)
-    trial_active_or_expired_less_than_10d_ago = Timex.diff(now, trial_expiry, :days) <= 10
-
-    joined_before_business_tiers && trial_active_or_expired_less_than_10d_ago
   end
 
   def available_plans_for(%User{} = user, opts \\ []) do

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -43,27 +43,15 @@ defmodule Plausible.Billing.Quota do
     end
 
     @site_limit_for_trials 10
-    @site_limit_for_legacy_trials 50
     @site_limit_for_free_10k 50
     defp get_site_limit_from_plan(user) do
       user = Plausible.Users.with_subscription(user)
 
       case Plans.get_subscription_plan(user.subscription) do
-        %EnterprisePlan{} ->
-          :unlimited
-
-        %Plan{site_limit: site_limit} ->
-          site_limit
-
-        :free_10k ->
-          @site_limit_for_free_10k
-
-        nil ->
-          if Timex.before?(user.inserted_at, Plans.business_tier_launch()) do
-            @site_limit_for_legacy_trials
-          else
-            @site_limit_for_trials
-          end
+        %EnterprisePlan{} -> :unlimited
+        %Plan{site_limit: site_limit} -> site_limit
+        :free_10k -> @site_limit_for_free_10k
+        nil -> @site_limit_for_trials
       end
     end
   else
@@ -203,7 +191,6 @@ defmodule Plausible.Billing.Quota do
   end
 
   @team_member_limit_for_trials 3
-  @team_member_limit_for_legacy_trials :unlimited
   @spec team_member_limit(User.t()) :: non_neg_integer()
   @doc """
   Returns the limit of team members a user can have in their sites.
@@ -212,21 +199,10 @@ defmodule Plausible.Billing.Quota do
     user = Plausible.Users.with_subscription(user)
 
     case Plans.get_subscription_plan(user.subscription) do
-      %EnterprisePlan{team_member_limit: limit} ->
-        limit
-
-      %Plan{team_member_limit: limit} ->
-        limit
-
-      :free_10k ->
-        :unlimited
-
-      nil ->
-        if Timex.before?(user.inserted_at, Plans.business_tier_launch()) do
-          @team_member_limit_for_legacy_trials
-        else
-          @team_member_limit_for_trials
-        end
+      %EnterprisePlan{team_member_limit: limit} -> limit
+      %Plan{team_member_limit: limit} -> limit
+      :free_10k -> :unlimited
+      nil -> @team_member_limit_for_trials
     end
   end
 

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -72,11 +72,13 @@ defmodule Plausible.Billing.Quota do
   @monthly_pageview_limit_for_free_10k 10_000
   @monthly_pageview_limit_for_trials :unlimited
 
-  @spec monthly_pageview_limit(Subscription.t()) ::
+  @spec monthly_pageview_limit(User.t() | Subscription.t()) ::
           non_neg_integer() | :unlimited
-  @doc """
-  Returns the limit of pageviews for a subscription.
-  """
+  def monthly_pageview_limit(%User{} = user) do
+    user = Plausible.Users.with_subscription(user)
+    monthly_pageview_limit(user.subscription)
+  end
+
   def monthly_pageview_limit(subscription) do
     case Plans.get_subscription_plan(subscription) do
       %EnterprisePlan{monthly_pageview_limit: limit} ->

--- a/lib/plausible/billing/quota.ex
+++ b/lib/plausible/billing/quota.ex
@@ -223,8 +223,14 @@ defmodule Plausible.Billing.Quota do
 
   @spec team_member_usage(User.t()) :: integer()
   @doc """
-  Returns the total count of team members and pending invitations associated
-  with the user's sites.
+  Returns the total count of team members associated with the user's sites.
+
+  * The given user (i.e. the owner) is not counted as a team member.
+
+  * Pending invitations are counted as team members even before accepted.
+
+  * Users are counted uniquely - i.e. even if an account is associated with
+    many sites owned by the given user, they still count as one team member.
   """
   def team_member_usage(user) do
     Plausible.Repo.aggregate(team_member_usage_query(user), :count)

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -57,6 +57,8 @@ defmodule Plausible.Site do
     timestamps()
   end
 
+  def new(params), do: changeset(%__MODULE__{}, params)
+
   @domain_unique_error """
   This domain cannot be registered. Perhaps one of your colleagues registered it? If that's not the case, please contact support@plausible.io
   """

--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -237,7 +237,7 @@ defmodule PlausibleWeb.Components.Billing do
   end
 
   attr(:title, :string, required: true)
-  attr(:usage, :any, required: true)
+  attr(:usage, :integer, required: true)
   attr(:limit, :integer, default: nil)
   attr(:pad, :boolean, default: false)
   attr(:rest, :global)
@@ -249,19 +249,11 @@ defmodule PlausibleWeb.Components.Billing do
         <%= @title %>
       </td>
       <td class="py-4 text-sm sm:whitespace-nowrap text-right">
-        <%= render_quota(@usage) %>
-        <%= if @limit, do: "/ #{render_quota(@limit)}" %>
+        <%= Cldr.Number.to_string!(@usage) %>
+        <%= if is_number(@limit), do: "/ #{Cldr.Number.to_string!(@limit)}" %>
       </td>
     </tr>
     """
-  end
-
-  defp render_quota(quota) do
-    case quota do
-      quota when is_number(quota) -> Cldr.Number.to_string!(quota)
-      :unlimited -> "∞"
-      nil -> ""
-    end
   end
 
   def monthly_quota_box(%{business_tier: true} = assigns) do

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.AdminController do
     usage = Quota.usage(user, with_features: true)
 
     limits = %{
-      monthly_pageviews: Quota.monthly_pageview_limit(user.subscription),
+      monthly_pageviews: Quota.monthly_pageview_limit(user),
       sites: Quota.site_limit(user),
       team_members: Quota.team_member_limit(user)
     }

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -613,7 +613,7 @@ defmodule PlausibleWeb.AuthController do
       team_member_usage: Quota.team_member_usage(user),
       site_limit: Quota.site_limit(user),
       site_usage: Quota.site_usage(user),
-      pageview_limit: Quota.monthly_pageview_limit(user.subscription),
+      pageview_limit: Quota.monthly_pageview_limit(user),
       pageview_usage: Quota.monthly_pageview_usage(user),
       totp_enabled?: Auth.TOTP.enabled?(user)
     )

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -3,10 +3,10 @@
     <h2 class="text-xl font-black dark:text-gray-100 mb-4">Your website details</h2>
 
     <PlausibleWeb.Components.Billing.limit_exceeded_notice
-      :if={Map.get(assigns, :is_at_limit, false)}
+      :if={Map.get(assigns, :exceeded_limit)}
       current_user={@current_user}
       billable_user={@current_user}
-      limit={Map.get(assigns, :site_limit, 0)}
+      limit={Map.get(assigns, :exceeded_limit)}
       resource="sites"
     />
 
@@ -52,7 +52,7 @@
           class:
             "focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-800 flex-1 block w-full px-3 py-2 rounded-none rounded-r-md sm:text-sm border-gray-300 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300",
           placeholder: "example.com",
-          disabled: Map.get(assigns, :is_at_limit, false)
+          disabled: is_integer(Map.get(assigns, :exceeded_limit))
         ) %>
       </div>
       <%= error_tag(f, :domain) %>
@@ -71,7 +71,7 @@
           selected: "Etc/Greenwich",
           class:
             "mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md",
-          disabled: Map.get(assigns, :is_at_limit, false)
+          disabled: is_integer(Map.get(assigns, :exceeded_limit))
         ) %>
       </div>
     </div>
@@ -93,7 +93,7 @@
 
     <%= submit("Add snippet →",
       class: "button mt-4 w-full disabled:cursor-not-allowed",
-      disabled: Map.get(assigns, :is_at_limit, false)
+      disabled: is_integer(Map.get(assigns, :exceeded_limit))
     ) %>
   <% end %>
 

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -3,10 +3,10 @@
     <h2 class="text-xl font-black dark:text-gray-100 mb-4">Your website details</h2>
 
     <PlausibleWeb.Components.Billing.limit_exceeded_notice
-      :if={Map.get(assigns, :exceeded_limit)}
+      :if={@site_limit_exceeded?}
       current_user={@current_user}
       billable_user={@current_user}
-      limit={Map.get(assigns, :exceeded_limit)}
+      limit={@site_limit}
       resource="sites"
     />
 
@@ -52,7 +52,7 @@
           class:
             "focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-800 flex-1 block w-full px-3 py-2 rounded-none rounded-r-md sm:text-sm border-gray-300 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300",
           placeholder: "example.com",
-          disabled: is_integer(Map.get(assigns, :exceeded_limit))
+          disabled: @site_limit_exceeded?
         ) %>
       </div>
       <%= error_tag(f, :domain) %>
@@ -71,7 +71,7 @@
           selected: "Etc/Greenwich",
           class:
             "mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md",
-          disabled: is_integer(Map.get(assigns, :exceeded_limit))
+          disabled: @site_limit_exceeded?
         ) %>
       </div>
     </div>
@@ -93,11 +93,11 @@
 
     <%= submit("Add snippet →",
       class: "button mt-4 w-full disabled:cursor-not-allowed",
-      disabled: is_integer(Map.get(assigns, :exceeded_limit))
+      disabled: @site_limit_exceeded?
     ) %>
   <% end %>
 
-  <%= if @is_first_site do %>
+  <%= if @first_site? do %>
     <div class="pt-12 pl-8 hidden md:block">
       <%= render(PlausibleWeb.AuthView, "_onboarding_steps.html", current_step: 2) %>
     </div>

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -108,7 +108,7 @@ defmodule Plausible.Workers.CheckUsage do
 
   defp check_pageview_usage(subscriber, quota_mod) do
     usage = quota_mod.monthly_pageview_usage(subscriber)
-    limit = Quota.monthly_pageview_limit(subscriber.subscription)
+    limit = Quota.monthly_pageview_limit(subscriber)
 
     if exceeds_last_two_usage_cycles?(usage, limit) do
       {:over_limit, usage}

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -38,22 +38,6 @@ defmodule Plausible.Billing.PlansTest do
       |> assert_generation(4)
     end
 
-    test "growth_plans_for/1 returns v3 plans for pre business tier trials only if their trial is active or expired less than 10 days ago" do
-      trial_start = ~D[2023-10-27]
-      trial_expiry = Timex.shift(trial_start, days: 30)
-      expiry_datetime = Timex.to_datetime(trial_expiry)
-
-      user = insert(:user, trial_expiry_date: trial_expiry)
-
-      now1 = Timex.shift(expiry_datetime, days: -1)
-      now2 = Timex.shift(expiry_datetime, days: 10)
-      now3 = Timex.shift(expiry_datetime, days: 11)
-
-      Plans.growth_plans_for(user, now1) |> assert_generation(3)
-      Plans.growth_plans_for(user, now2) |> assert_generation(3)
-      Plans.growth_plans_for(user, now3) |> assert_generation(4)
-    end
-
     test "growth_plans_for/1 returns v4 plans for expired legacy subscriptions" do
       subscription =
         build(:subscription,
@@ -112,22 +96,6 @@ defmodule Plausible.Billing.PlansTest do
       insert(:user, trial_expiry_date: ~D[2023-12-24])
       |> Plans.business_plans_for()
       |> assert_generation(4)
-    end
-
-    test "business_plans_for/1 returns v3 plans for pre business tier trials only if their trial is active or expired less than 10 days ago" do
-      trial_start = ~D[2023-10-27]
-      trial_expiry = Timex.shift(trial_start, days: 30)
-      expiry_datetime = Timex.to_datetime(trial_expiry)
-
-      user = insert(:user, trial_expiry_date: trial_expiry)
-
-      now1 = Timex.shift(expiry_datetime, days: -1)
-      now2 = Timex.shift(expiry_datetime, days: 10)
-      now3 = Timex.shift(expiry_datetime, days: 11)
-
-      Plans.business_plans_for(user, now1) |> assert_generation(3)
-      Plans.business_plans_for(user, now2) |> assert_generation(3)
-      Plans.business_plans_for(user, now3) |> assert_generation(4)
     end
 
     test "business_plans_for/1 returns v4 plans for expired legacy subscriptions" do

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -18,6 +18,7 @@ defmodule Plausible.Billing.QuotaTest do
 
   describe "site_limit/1" do
     @describetag :full_build_only
+
     test "returns 50 when user is on an old plan" do
       user_on_v1 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
       user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -33,20 +33,13 @@ defmodule Plausible.Billing.QuotaTest do
       assert 50 == Quota.site_limit(user)
     end
 
-    test "returns unlimited when user is on an enterprise plan" do
+    test "returns the configured site limit for enterprise plan" do
       user = insert(:user)
 
-      enterprise_plan =
-        insert(:enterprise_plan,
-          user_id: user.id,
-          monthly_pageview_limit: 100_000,
-          site_limit: 500
-        )
+      enterprise_plan = insert(:enterprise_plan, user_id: user.id, site_limit: 500)
+      insert(:subscription, user_id: user.id, paddle_plan_id: enterprise_plan.paddle_plan_id)
 
-      _subscription =
-        insert(:subscription, user_id: user.id, paddle_plan_id: enterprise_plan.paddle_plan_id)
-
-      assert :unlimited == Quota.site_limit(user)
+      assert enterprise_plan.site_limit == Quota.site_limit(user)
     end
 
     test "returns 10 when user in on trial" do
@@ -76,27 +69,6 @@ defmodule Plausible.Billing.QuotaTest do
         )
 
       assert 10 == Quota.site_limit(user)
-    end
-
-    test "is unlimited for enterprise customers" do
-      user =
-        insert(:user,
-          enterprise_plan: build(:enterprise_plan, paddle_plan_id: "123321"),
-          subscription: build(:subscription, paddle_plan_id: "123321")
-        )
-
-      assert :unlimited == Quota.site_limit(user)
-    end
-
-    test "is unlimited for enterprise customers who are due to change a plan" do
-      user =
-        insert(:user,
-          enterprise_plan: build(:enterprise_plan, paddle_plan_id: "old-paddle-plan-id"),
-          subscription: build(:subscription, paddle_plan_id: "old-paddle-plan-id")
-        )
-
-      insert(:enterprise_plan, user_id: user.id, paddle_plan_id: "new-paddle-plan-id")
-      assert :unlimited == Quota.site_limit(user)
     end
   end
 

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -361,6 +361,7 @@ defmodule Plausible.Billing.QuotaTest do
   end
 
   describe "team_member_limit/1" do
+    @describetag :full_build_only
     test "returns unlimited when user is on an old plan" do
       user_on_v1 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
       user_on_v2 = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -58,16 +58,6 @@ defmodule Plausible.Billing.QuotaTest do
       assert 10 == Quota.site_limit(user)
     end
 
-    test "returns 50 when user in on trial but registered before the business tier was live" do
-      user =
-        insert(:user,
-          trial_expiry_date: Timex.shift(Timex.now(), days: 7),
-          inserted_at: ~U[2023-10-01T00:00:00Z]
-        )
-
-      assert 50 == Quota.site_limit(user)
-    end
-
     test "returns the subscription limit for enterprise users who have not paid yet" do
       user =
         insert(:user,
@@ -421,16 +411,6 @@ defmodule Plausible.Billing.QuotaTest do
         )
 
       assert 3 == Quota.team_member_limit(user)
-    end
-
-    test "returns unlimited when user in on trial but registered before the business tier was live" do
-      user =
-        insert(:user,
-          trial_expiry_date: Timex.shift(Timex.now(), days: 7),
-          inserted_at: ~U[2023-10-01T00:00:00Z]
-        )
-
-      assert :unlimited == Quota.team_member_limit(user)
     end
 
     test "returns the enterprise plan limit" do

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -66,6 +66,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       )
     end
 
+    @tag :full_build_only
     test "returns error when owner is over their team member limit" do
       [owner, inviter, invitee] = insert_list(3, :user)
 
@@ -186,6 +187,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :admin)
     end
 
+    @tag :full_build_only
     test "does not allow transferring ownership when site does not fit the new owner subscription" do
       old_owner = insert(:user, subscription: build(:business_subscription))
       new_owner = insert(:user, subscription: build(:growth_subscription))

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -863,12 +863,12 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert text_of_element(doc, "#pageviews_current_cycle") =~ "Pageviews 1"
       assert text_of_element(doc, "#custom_events_current_cycle") =~ "Custom events 0"
 
-      assert text_of_element(doc, "#total_pageviews_last_cycle") =~ "Total billable pageviews 1"
+      assert text_of_element(doc, "#total_pageviews_last_cycle") =~ "Total billable pageviews 1 / 10,000"
       assert text_of_element(doc, "#pageviews_last_cycle") =~ "Pageviews 0"
       assert text_of_element(doc, "#custom_events_last_cycle") =~ "Custom events 1"
 
       assert text_of_element(doc, "#total_pageviews_penultimate_cycle") =~
-               "Total billable pageviews 2"
+               "Total billable pageviews 2 / 10,000"
 
       assert text_of_element(doc, "#pageviews_penultimate_cycle") =~ "Pageviews 1"
       assert text_of_element(doc, "#custom_events_penultimate_cycle") =~ "Custom events 1"
@@ -1095,6 +1095,19 @@ defmodule PlausibleWeb.AuthControllerTest do
         |> text_of_element("#team-member-usage-row")
 
       assert team_member_usage_row_text =~ "Team members 0 / 3"
+    end
+
+    @tag :full_build_only
+    test "renders team member usage without limit if it's unlimited", %{conn: conn, user: user} do
+      insert(:subscription, paddle_plan_id: @v3_plan_id, user: user)
+
+      team_member_usage_row_text =
+        conn
+        |> get("/settings")
+        |> html_response(200)
+        |> text_of_element("#team-member-usage-row")
+
+      assert team_member_usage_row_text == "Team members 0"
     end
 
     test "redners 2FA section in disabled state", %{conn: conn} do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -863,7 +863,9 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert text_of_element(doc, "#pageviews_current_cycle") =~ "Pageviews 1"
       assert text_of_element(doc, "#custom_events_current_cycle") =~ "Custom events 0"
 
-      assert text_of_element(doc, "#total_pageviews_last_cycle") =~ "Total billable pageviews 1 / 10,000"
+      assert text_of_element(doc, "#total_pageviews_last_cycle") =~
+               "Total billable pageviews 1 / 10,000"
+
       assert text_of_element(doc, "#pageviews_last_cycle") =~ "Pageviews 0"
       assert text_of_element(doc, "#custom_events_last_cycle") =~ "Custom events 1"
 

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -21,6 +21,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       refute element_exists?(html, ~s/button[type=submit][disabled]/)
     end
 
+    @tag :full_build_only
     test "disables invite form when is over limit", %{conn: conn, user: user} do
       memberships = [
         build(:site_membership, user: user, role: :owner) | build_list(5, :site_membership)
@@ -53,6 +54,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       assert redirected_to(conn) == "/#{URI.encode_www_form(site.domain)}/settings/people"
     end
 
+    @tag :full_build_only
     test "fails to create invitation when is over limit", %{conn: conn, user: user} do
       memberships = [
         build(:site_membership, user: user, role: :owner) | build_list(5, :site_membership)


### PR DESCRIPTION
### Changes

- [x] Remove the special handling for legacy trials which don't exist anymore
- [x] Make `Quota.team_member_limit/1` always return `:unlimited` on self hosted instances
- [x] Make `Quota.site_limit/1` return the real configured site limit for enterprise plans, not `:unlimited`
- [x] In the account settings usage section, instead of displaying ∞, do not render the limit at all if it's `:unlimited` 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
