### PR TITLE
Randomize user_id in session collapse tests

### DIFF
--- a/test/plausible/session/cache_store_test.exs
+++ b/test/plausible/session/cache_store_test.exs
@@ -1,5 +1,5 @@
 defmodule Plausible.Session.CacheStoreTest do
-  use Plausible.DataCase
+  use Plausible.DataCase, asyc: true
   alias Plausible.Session.CacheStore
 
   defmodule FakeBuffer do
@@ -123,8 +123,16 @@ defmodule Plausible.Session.CacheStoreTest do
       Plausible.Session.WriteBuffer.flush()
     end
 
+    defp random_user_id() do
+      SipHash.hash!(:crypto.strong_rand_bytes(16), Ecto.UUID.generate())
+    end
+
     test "across parts" do
-      e = build(:event, name: "pageview")
+      e =
+        build(:event,
+          name: "pageview",
+          user_id: random_user_id()
+        )
 
       flush([%{e | pathname: "/"}])
       flush([%{e | pathname: "/exit"}])
@@ -138,7 +146,11 @@ defmodule Plausible.Session.CacheStoreTest do
     end
 
     test "within parts" do
-      e = build(:event, name: "pageview")
+      e =
+        build(:event,
+          name: "pageview",
+          user_id: random_user_id()
+        )
 
       flush([
         %{e | pathname: "/"},
@@ -154,7 +166,7 @@ defmodule Plausible.Session.CacheStoreTest do
     end
 
     test "across and within parts" do
-      e = build(:event, name: "pageview")
+      e = build(:event, name: "pageview", user_id: random_user_id())
 
       flush([
         %{e | pathname: "/"},


### PR DESCRIPTION
### Changes

This is a blind stab at https://github.com/plausible/analytics/actions/runs/7192271123/job/19588394230 introduced via #3622 - to prevent `Cachex` lookups clash.
### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
