### PR TITLE
Fix flaky test

### DIFF
--- a/test/plausible/session/cache_store_test.exs
+++ b/test/plausible/session/cache_store_test.exs
@@ -118,13 +118,20 @@ defmodule Plausible.Session.CacheStoreTest do
   end
 
   describe "collapse order" do
+    defp new_site_id() do
+      [[site_id]] =
+        Plausible.ClickhouseRepo.query!("select max(site_id) + rand() from sessions_v2 FINAL").rows
+
+      site_id
+    end
+
     defp flush(events) do
       for e <- events, do: CacheStore.on_event(e, nil)
       Plausible.Session.WriteBuffer.flush()
     end
 
     test "across parts" do
-      e = build(:event, name: "pageview")
+      e = build(:event, name: "pageview", site_id: new_site_id())
 
       flush([%{e | pathname: "/"}])
       flush([%{e | pathname: "/exit"}])
@@ -138,7 +145,7 @@ defmodule Plausible.Session.CacheStoreTest do
     end
 
     test "within parts" do
-      e = build(:event, name: "pageview")
+      e = build(:event, name: "pageview", site_id: new_site_id())
 
       flush([
         %{e | pathname: "/"},
@@ -154,7 +161,7 @@ defmodule Plausible.Session.CacheStoreTest do
     end
 
     test "across and within parts" do
-      e = build(:event, name: "pageview")
+      e = build(:event, name: "pageview", site_id: new_site_id())
 
       flush([
         %{e | pathname: "/"},


### PR DESCRIPTION
### Changes

The test flakiness introduced via #3622 was reproducible locally by running the `across parts` tests hundred times with a macro generator. This patch no longer leads to failures.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
