### PR TITLE
Migration: Add `accept_traffic_until` to "sites"

### DIFF
--- a/priv/repo/migrations/20231211092344_add_accept_traffic_until_to_sites.exs
+++ b/priv/repo/migrations/20231211092344_add_accept_traffic_until_to_sites.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddAcceptTrafficUntilToSites do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites) do
+      add :accept_traffic_until, :naive_datetime
+    end
+  end
+end


### PR DESCRIPTION
### Changes

We need to start dropping metrics for sites whose trial has expired or subscription was cancelled. The per-site timestamp gives us flexibility in treating each case separately.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
