### PR TITLE
Fix `class` in `styled_link` and remove existing uses of `class`

### DIFF
--- a/lib/plausible_web/components/billing.ex
+++ b/lib/plausible_web/components/billing.ex
@@ -273,7 +273,6 @@ defmodule PlausibleWeb.Components.Billing do
         }
         id="#upgrade-or-change-plan-link"
         href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
-        class="text-sm font-medium"
       >
         <%= change_plan_or_upgrade_text(@subscription) %>
       </.styled_link>
@@ -296,7 +295,6 @@ defmodule PlausibleWeb.Components.Billing do
         <.styled_link
           :if={Subscription.Status.active?(@subscription)}
           href={Routes.billing_path(PlausibleWeb.Endpoint, :change_plan_form)}
-          class="text-sm font-medium"
         >
           Change plan
         </.styled_link>
@@ -310,10 +308,7 @@ defmodule PlausibleWeb.Components.Billing do
         </span>
       <% else %>
         <div class="py-2 text-xl font-medium dark:text-gray-100">Free trial</div>
-        <.styled_link
-          href={Routes.billing_path(PlausibleWeb.Endpoint, :upgrade)}
-          class="text-sm font-medium"
-        >
+        <.styled_link href={Routes.billing_path(PlausibleWeb.Endpoint, :upgrade)}>
           Upgrade
         </.styled_link>
       <% end %>

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -144,7 +144,7 @@ defmodule PlausibleWeb.Components.Generic do
     <.unstyled_link
       new_tab={@new_tab}
       href={@href}
-      class="text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600"
+      class={"text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 " <> @class}
     >
       <%= render_slot(@inner_block) %>
     </.unstyled_link>

--- a/lib/plausible_web/templates/site/change_domain.html.heex
+++ b/lib/plausible_web/templates/site/change_domain.html.heex
@@ -25,7 +25,7 @@
     </p>
     <p class="text-sm text-gray-700 dark:text-gray-300 mt-4">
       Visit our
-      <.styled_link new_tab class="text-sm" href="https://plausible.io/docs/change-domain-name/">
+      <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
         documentation
       </.styled_link>
       for details.
@@ -36,10 +36,7 @@
     </PlausibleWeb.Components.Generic.button>
 
     <div class="text-center mt-4">
-      <.styled_link
-        href={Routes.site_path(@conn, :settings_general, @site.domain)}
-        class="w-full text-center"
-      >
+      <.styled_link href={Routes.site_path(@conn, :settings_general, @site.domain)}>
         Back to Site Settings
       </.styled_link>
     </div>

--- a/lib/plausible_web/templates/site/snippet.html.heex
+++ b/lib/plausible_web/templates/site/snippet.html.heex
@@ -43,18 +43,14 @@
     <div class="mt-2 dark:text-gray-100">
       <p class="text-sm">
         On WordPress? We have
-        <.styled_link
-          new_tab
-          class="text-sm"
-          href="https://plausible.io/wordpress-analytics-plugin"
-        >
+        <.styled_link new_tab href="https://plausible.io/wordpress-analytics-plugin">
           a plugin
         </.styled_link>
       </p>
 
       <p class="text-sm">
         See more
-        <.styled_link new_tab class="text-sm" href="https://plausible.io/docs/integration-guides">
+        <.styled_link new_tab href="https://plausible.io/docs/integration-guides">
           integration guides
         </.styled_link>
       </p>


### PR DESCRIPTION
### Changes

Make it possible to add custom classes to the `styled_link` component. The class attribute was given in several cases, but it was not used by the component.