### PR TITLE
Set CLICKHOUSE_MAX_BUFFER_SIZE_BYTES to 1M on dev

### DIFF
--- a/config/.env.dev
+++ b/config/.env.dev
@@ -2,6 +2,7 @@ BASE_URL=http://localhost:8000
 SECURE_COOKIE=false
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_dev
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_events_db
+CLICKHOUSE_MAX_BUFFER_SIZE_BYTES=1000000
 SECRET_KEY_BASE=/njrhntbycvastyvtk1zycwfm981vpo/0xrvwjjvemdakc/vsvbrevlwsc6u8rcg
 TOTP_VAULT_KEY=Q3BD4nddbkVJIPXgHuo5NthGKSIH0yesRfG05J88HIo=
 ENVIRONMENT=dev


### PR DESCRIPTION
Completes full `mix ecto.reset` in around 30s 🤘

Thanks @ruslandoga for the quality of life improvement :)