### PR TITLE
Remove onClick handler from details link in ListReport

### DIFF
--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -306,8 +306,8 @@ export default function ListReport(props) {
     const moreResultsAvailable = state.list.length >= MAX_ITEMS
     const hideDetails = props.maybeHideDetails && !moreResultsAvailable
 
-    const showDetails = props.detailsLink && !state.loading && !hideDetails 
-    return showDetails && <MoreLink className={'mt-2'} url={props.detailsLink} list={state.list} onClick={props.onClick}/>
+    const showDetails = props.detailsLink && !state.loading && !hideDetails
+    return showDetails && <MoreLink className={'mt-2'} url={props.detailsLink} list={state.list} />
   }
 
   return (


### PR DESCRIPTION
### Changes

Fixes issue where the UI would unexpectedly tab-switch when the user clicks on details.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] No changelog entry needed

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
