### PR TITLE
new time on page

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -161,15 +161,16 @@ defmodule Plausible.Stats.Aggregate do
                ),
              timestamp: e.timestamp,
              pathname: e.pathname,
-             session_id: e.session_id
+             user_id: e.user_id
            }
 
     timed_pages_q =
       from e in Ecto.Query.subquery(windowed_pages_q),
-        group_by: [e.pathname, e.session_id],
+        group_by: [e.pathname, e.user_id],
         where: ^Plausible.Stats.Base.dynamic_filter_condition(query, "event:page", :pathname),
         where: e.next_timestamp != 0,
-        select: %{duration: sum(e.next_timestamp - e.timestamp)}
+        having: selected_as(:duration) > 0,
+        select: %{duration: selected_as(sum(e.next_timestamp - e.timestamp), :duration)}
 
     time_on_page_q =
       from e in Ecto.Query.subquery(timed_pages_q),

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -438,7 +438,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert Enum.at(results, 2) == %{
              "page" => "/",
              "pageviews" => 5537,
-             "time_on_page" => 17.677262055264585,
+             "time_on_page" => 263.82479784366575,
              "visitors" => 371,
              "visits" => 212,
              "bounce_rate" => 54.0,
@@ -450,7 +450,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.last(results) == %{
              "page" => "/5-dobrih-razloga-zasto-zapoceti-dan-zobenom-kasom/",
              "pageviews" => 2,
-             "time_on_page" => 10.0,
+             "time_on_page" => 20.0,
              "visitors" => 1,
              "visits" => 1,
              "bounce_rate" => nil,

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -424,30 +424,30 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
                |> Enum.find(&(&1["name"] == "Time on page"))
     end
 
-    test "averages time on page across sessions", %{
+    test "averages time on page across active visitors", %{
       conn: conn,
       site: site
     } do
-      # ┌─p──┬─p2─┬─minus(t2, t)─┬──s─┐
-      # │ /a │ /b │          100 │ s1 │
-      # │ /a │ /d │          100 │ s2 │
-      # │ /a │ /d │            0 │ s2 │
+      # ┌─p──┬─p2─┬─minus(t2, t)─┬──u─┐
+      # │ /a │ /b │          100 │ u1 │
+      # │ /a │ /d │          100 │ u2 │
+      # │ /a │ /d │            0 │ u2 │
       # └────┴────┴──────────────┴────┘
-      # so that time_on_page(a)=(100+100+0)/count(sessions)=200/2=100
+      # so that time_on_page(a)=(100+100+0)/count(active_visitors)=200/2=100
 
-      s1 = @user_id
-      s2 = @user_id + 1
+      u1 = @user_id
+      u2 = @user_id + 1
 
       now = ~N[2021-01-01 00:00:00]
       later = fn seconds -> NaiveDateTime.add(now, seconds) end
 
       populate_stats(site, [
-        build(:pageview, user_id: s1, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s1, timestamp: later.(100), pathname: "/b"),
-        build(:pageview, user_id: s2, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d")
+        build(:pageview, session_id: u1, user_id: u1, timestamp: now, pathname: "/a"),
+        build(:pageview, session_id: u1, user_id: u1, timestamp: later.(100), pathname: "/b"),
+        build(:pageview, session_id: u2, user_id: u2, timestamp: now, pathname: "/a"),
+        build(:pageview, session_id: u2, user_id: u2, timestamp: later.(100), pathname: "/d"),
+        build(:pageview, session_id: u2, user_id: u2, timestamp: later.(100), pathname: "/a"),
+        build(:pageview, session_id: u2, user_id: u2, timestamp: later.(100), pathname: "/d")
       ])
 
       filters = Jason.encode!(%{page: "/a"})


### PR DESCRIPTION
### Changes

This PR changes how **Time on Page** statistic is calculated.

Before it was:

```js
sum(duration(page)) / count(unique(page, next_page, session))
```

Now it is:

```js
avg(sum(duration(page) per user) > 0)
```

### TODOs

- [ ] filter by "active visitors" `sum(duration(sessions) per user) > 0` and not "active pages" `sum(duration(page)) per user > 0`?

### Tests
- [x] Automated tests have been updated

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
