### PR TITLE
Fix SiteLocker for case of user without trial expiry date but with active subscription

### DIFF
--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -58,6 +58,13 @@ defmodule Plausible.BillingTest do
       assert Billing.check_needs_to_upgrade(user) == {:needs_to_upgrade, :no_trial}
     end
 
+    test "is false for user with empty trial expiry date but with an active subscription" do
+      user = insert(:user, trial_expiry_date: nil)
+      insert(:subscription, user: user)
+
+      assert Billing.check_needs_to_upgrade(user) == :no_upgrade_needed
+    end
+
     test "is false for a user with an expired trial but an active subscription" do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user)


### PR DESCRIPTION
This PR addresses a problem where a site owned by a user who does not have trial expiry date set (e.g. they were invited to a site without previously having their own site) who was promoted to an owner.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
