### PR TITLE
Skip breakdown of imported pages with pageviews=0

### DIFF
--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -368,6 +368,7 @@ defmodule Plausible.Stats.Imported do
 
   defp select_imported_metrics(q, [:pageviews | rest]) do
     q
+    |> where([i], i.pageviews > 0)
     |> select_merge([i], %{pageviews: sum(i.pageviews)})
     |> select_imported_metrics(rest)
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -542,6 +542,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         date: ~D[2021-01-01],
         visitors: 1,
         pageviews: 0
+      ),
+      build(:imported_pages,
+        page: "/include-me",
+        date: ~D[2021-01-01],
+        visitors: 1,
+        pageviews: 1
       )
     ])
 
@@ -558,7 +564,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     assert json_response(conn, 200) == %{
              "results" => [
                %{"page" => "/", "pageviews" => 2},
-               %{"page" => "/plausible.io", "pageviews" => 1}
+               %{"page" => "/plausible.io", "pageviews" => 1},
+               %{"page" => "/include-me", "pageviews" => 1}
              ]
            }
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -523,7 +523,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
            }
   end
 
-  test "pageviews breakdown by event:page - imported data having pageviews=0 and visits=n should be bypassed",
+  test "pageviews breakdown by event:page - imported data having pageviews=0 and visitors=n should be bypassed",
        %{conn: conn, site: site} do
     site =
       site
@@ -538,9 +538,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:imported_pages,
-        page: "/some-other-page",
+        page: "/skip-me",
         date: ~D[2021-01-01],
-        time_on_page: 60,
         visitors: 1,
         pageviews: 0
       )


### PR DESCRIPTION
### Changes

Similar to https://github.com/plausible/analytics/pull/3123 - apparently some imported pages google sends us look like: 

```
┌─visitors─┬─pageviews─┬─exits─┬─time_on_page─┐
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
│        1 │         0 │     0 │            0 │
└──────────┴───────────┴───────┴──────────────┘
```

It's questionable whether we should import those records at all, but that's a matter addressable separately. Regardless, we should exclude those from breakdowns to avoid crashing the exit rate calculation via division by zero.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
