### PR TITLE
Add `custom_props.csv` back to CSV export for Growth plans

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1214,21 +1214,32 @@ defmodule PlausibleWeb.Api.StatsController do
 
     prop_names = Plausible.Stats.CustomProps.fetch_prop_names(site, query)
 
-    values =
-      prop_names
-      |> Enum.map(fn prop_key ->
-        breakdown_custom_prop_values(site, Map.put(params, "prop_key", prop_key))
-        |> Enum.map(&Map.put(&1, :property, prop_key))
-        |> transform_keys(%{:name => :value})
-      end)
-      |> Enum.concat()
+    prop_names =
+      if Plausible.Billing.Feature.Props.enabled?(site) do
+        prop_names
+      else
+        prop_names |> Enum.filter(& &1 in Plausible.Props.internal_keys())
+      end
 
-    percent_or_cr =
-      if query.filters["event:goal"],
-        do: :conversion_rate,
-        else: :percentage
+    if prop_names == [] do
+      nil
+    else
+      values =
+        prop_names
+        |> Enum.map(fn prop_key ->
+          breakdown_custom_prop_values(site, Map.put(params, "prop_key", prop_key))
+          |> Enum.map(&Map.put(&1, :property, prop_key))
+          |> transform_keys(%{:name => :value})
+        end)
+        |> Enum.concat()
 
-    to_csv(values, [:property, :value, :visitors, :events, percent_or_cr])
+      percent_or_cr =
+        if query.filters["event:goal"],
+          do: :conversion_rate,
+          else: :percentage
+
+      to_csv(values, [:property, :value, :visitors, :events, percent_or_cr])
+    end
   end
 
   defp breakdown_custom_prop_values(site, %{"prop_key" => prop_key} = params) do

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1221,9 +1221,7 @@ defmodule PlausibleWeb.Api.StatsController do
         prop_names |> Enum.filter(&(&1 in Plausible.Props.internal_keys()))
       end
 
-    if prop_names == [] do
-      nil
-    else
+   if not Enum.empty?(prop_names) do
       values =
         prop_names
         |> Enum.map(fn prop_key ->

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1218,7 +1218,7 @@ defmodule PlausibleWeb.Api.StatsController do
       if Plausible.Billing.Feature.Props.enabled?(site) do
         prop_names
       else
-        prop_names |> Enum.filter(& &1 in Plausible.Props.internal_keys())
+        prop_names |> Enum.filter(&(&1 in Plausible.Props.internal_keys()))
       end
 
     if prop_names == [] do

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1221,7 +1221,7 @@ defmodule PlausibleWeb.Api.StatsController do
         prop_names |> Enum.filter(&(&1 in Plausible.Props.internal_keys()))
       end
 
-   if not Enum.empty?(prop_names) do
+    if not Enum.empty?(prop_names) do
       values =
         prop_names
         |> Enum.map(fn prop_key ->

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -159,17 +159,9 @@ defmodule PlausibleWeb.StatsController do
         ~c"operating_systems.csv" => fn -> Api.StatsController.operating_systems(conn, params) end,
         ~c"devices.csv" => fn -> Api.StatsController.screen_sizes(conn, params) end,
         ~c"conversions.csv" => fn -> Api.StatsController.conversions(conn, params) end,
-        ~c"referrers.csv" => fn -> Api.StatsController.referrers(conn, params) end
+        ~c"referrers.csv" => fn -> Api.StatsController.referrers(conn, params) end,
+        ~c"custom_props.csv" => fn -> Api.StatsController.all_custom_prop_values(conn, params) end
       }
-
-      csvs =
-        if Plausible.Billing.Feature.Props.enabled?(site) do
-          Map.put(csvs, ~c"custom_props.csv", fn ->
-            Api.StatsController.all_custom_prop_values(conn, params)
-          end)
-        else
-          csvs
-        end
 
       csv_values =
         Map.values(csvs)
@@ -178,6 +170,7 @@ defmodule PlausibleWeb.StatsController do
       csvs =
         Map.keys(csvs)
         |> Enum.zip(csv_values)
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
       csvs = [{~c"visitors.csv", visitors} | csvs]
 


### PR DESCRIPTION
### Changes

This PR fixes a bug where `custom_props.csv` file was not included in the CSV export for Growth plans using the `url` or `path` props (e.g. with outbound link or file download goals). These props should not be considered a premium feature.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
