### PR TITLE
Fix goal filter inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Replace `CLICKHOUSE_MAX_BUFFER_SIZE` with `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES`
 
 ### Fixed
+- Stop returning custom events in goal breakdown with a pageview goal filter and vice versa
 - Only return `(none)` values in custom property breakdown for the first page (pagination) of results
 - Fixed weekly/monthly e-mail report [rendering issues](https://github.com/plausible/analytics/issues/284)
 - Fix [broken interval selection](https://github.com/plausible/analytics/issues/2982) in the all time view plausible/analytics#3110

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -94,31 +94,6 @@ defmodule Plausible.Stats.Base do
 
           from(e in q, where: ^where_clause)
 
-        {:not_matches_member, clauses} ->
-          {events, pages} = split_goals(clauses, &page_regex/1)
-
-          event_clause =
-            if Enum.any?(events) do
-              dynamic([x], fragment("multiMatchAny(?, ?)", x.name, ^events))
-            else
-              dynamic([x], false)
-            end
-
-          page_clause =
-            if Enum.any?(pages) do
-              dynamic([x], fragment("multiMatchAny(?, ?)", x.pathname, ^pages))
-            else
-              dynamic([x], false)
-            end
-
-          where_clause = dynamic([], not (^event_clause or ^page_clause))
-
-          from(e in q, where: ^where_clause)
-
-        {:not_member, clauses} ->
-          {events, pages} = split_goals(clauses)
-          from(e in q, where: e.pathname not in ^pages and e.name not in ^events)
-
         nil ->
           q
       end

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -60,18 +60,24 @@ defmodule Plausible.Stats.Base do
     q =
       case query.filters["event:goal"] do
         {:is, {:page, path}} ->
-          from(e in q, where: e.pathname == ^path)
+          from(e in q, where: e.pathname == ^path and e.name == "pageview")
 
         {:matches, {:page, expr}} ->
           regex = page_regex(expr)
-          from(e in q, where: fragment("match(?, ?)", e.pathname, ^regex))
+
+          from(e in q,
+            where: fragment("match(?, ?)", e.pathname, ^regex) and e.name == "pageview"
+          )
 
         {:is, {:event, event}} ->
           from(e in q, where: e.name == ^event)
 
         {:member, clauses} ->
           {events, pages} = split_goals(clauses)
-          from(e in q, where: e.pathname in ^pages or e.name in ^events)
+
+          from(e in q,
+            where: (e.pathname in ^pages and e.name == "pageview") or e.name in ^events
+          )
 
         {:matches_member, clauses} ->
           {events, pages} = split_goals(clauses, &page_regex/1)
@@ -85,7 +91,10 @@ defmodule Plausible.Stats.Base do
 
           page_clause =
             if Enum.any?(pages) do
-              dynamic([x], fragment("multiMatchAny(?, ?)", x.pathname, ^pages))
+              dynamic(
+                [x],
+                fragment("multiMatchAny(?, ?)", x.pathname, ^pages) and x.name == "pageview"
+              )
             else
               dynamic([x], false)
             end

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -57,7 +57,7 @@ defmodule Plausible.Stats.Breakdown do
               "notEmpty(multiMatchAllIndices(?, ?) as indices)",
               e.pathname,
               ^page_regexes
-            ),
+            ) and e.name == "pageview",
           group_by: fragment("index"),
           select: %{
             index: fragment("arrayJoin(indices) as index"),

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -405,45 +405,6 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
              ]
     end
 
-    test "can filter by multiple negated mixed goals", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/"),
-        build(:pageview, pathname: "/"),
-        build(:pageview, pathname: "/another"),
-        build(:pageview, pathname: "/register"),
-        build(:event, name: "CTA"),
-        build(:event, name: "Signup")
-      ])
-
-      insert(:goal, %{site: site, page_path: "/register"})
-      insert(:goal, %{site: site, page_path: "/another"})
-      insert(:goal, %{site: site, event_name: "CTA"})
-      insert(:goal, %{site: site, event_name: "Signup"})
-
-      filters = Jason.encode!(%{goal: "!Signup|Visit /another"})
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "CTA",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 16.7
-               },
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 16.7
-               }
-             ]
-    end
-
     test "can combine wildcard and no wildcard in matches_member", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, pathname: "/blog/post-1"),
@@ -512,75 +473,6 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "visitors" => 1,
                  "events" => 1,
                  "conversion_rate" => 16.7
-               }
-             ]
-    end
-
-    test "can filter by not_matches_member filter type on goals", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/another"),
-        build(:pageview, pathname: "/another"),
-        build(:pageview, pathname: "/blog/post-1"),
-        build(:pageview, pathname: "/blog/post-2"),
-        build(:event, name: "CTA"),
-        build(:event, name: "Signup")
-      ])
-
-      insert(:goal, %{site: site, page_path: "/blog**"})
-      insert(:goal, %{site: site, page_path: "/ano**"})
-      insert(:goal, %{site: site, event_name: "CTA"})
-      insert(:goal, %{site: site, event_name: "Signup"})
-
-      filters = Jason.encode!(%{goal: "!Signup|Visit /blog**"})
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "Visit /ano**",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 33.3
-               },
-               %{
-                 "name" => "CTA",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 16.7
-               }
-             ]
-    end
-
-    test "can combine wildcard and no wildcard in not_matches_member", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/blog/post-1"),
-        build(:pageview, pathname: "/blog/post-2"),
-        build(:pageview, pathname: "/billing/upgrade"),
-        build(:pageview, pathname: "/register")
-      ])
-
-      insert(:goal, %{site: site, page_path: "/blog/**"})
-      insert(:goal, %{site: site, page_path: "/billing/upgrade"})
-      insert(:goal, %{site: site, page_path: "/register"})
-
-      filters = Jason.encode!(%{goal: "!Visit /blog/**|Visit /billing/upgrade"})
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 25
                }
              ]
     end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -265,16 +265,17 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       conn: conn,
       site: site
     } do
-      populate_stats(site, [
-        build(:event, name: "Signup"),
-        build(:event, name: "Signup"),
+      [
         build(:event,
           name: "Payment",
           pathname: "/checkout",
           revenue_reporting_amount: Decimal.new("10.00"),
           revenue_reporting_currency: "EUR"
         )
-      ])
+      ]
+      |> Enum.concat(build_list(2, :event, name: "Signup"))
+      |> Enum.concat(build_list(3, :pageview, pathname: "/checkout"))
+      |> then(fn events -> populate_stats(site, events) end)
 
       insert(:goal, %{site: site, event_name: "Signup"})
       insert(:goal, %{site: site, page_path: "/checkout"})
@@ -286,7 +287,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       assert [
                %{
                  "average_revenue" => %{"long" => "€10.00", "short" => "€10.0"},
-                 "conversion_rate" => 33.3,
+                 "conversion_rate" => 16.7,
                  "name" => "Payment",
                  "events" => 1,
                  "total_revenue" => %{"long" => "€10.00", "short" => "€10.0"},
@@ -294,7 +295,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                },
                %{
                  "average_revenue" => nil,
-                 "conversion_rate" => 66.7,
+                 "conversion_rate" => 33.3,
                  "name" => "Signup",
                  "events" => 2,
                  "total_revenue" => nil,
@@ -302,11 +303,11 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                },
                %{
                  "average_revenue" => nil,
-                 "conversion_rate" => 33.3,
+                 "conversion_rate" => 50.0,
                  "name" => "Visit /checkout",
-                 "events" => 1,
+                 "events" => 3,
                  "total_revenue" => nil,
-                 "visitors" => 1
+                 "visitors" => 3
                }
              ] == Enum.sort_by(response, & &1["name"])
     end
@@ -337,35 +338,94 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
   describe "GET /api/stats/:domain/conversions - with goal filter" do
     setup [:create_user, :log_in, :create_new_site]
 
-    test "returns only the conversion that is filtered for", %{conn: conn, site: site} do
+    test "does not consider custom event pathname as a pageview goal completion", %{
+      conn: conn,
+      site: site
+    } do
       populate_stats(site, [
         build(:pageview, pathname: "/"),
-        build(:pageview, pathname: "/"),
         build(:pageview, pathname: "/register"),
-        build(:pageview, pathname: "/register"),
-        build(:event, name: "Signup", "meta.key": ["variant"], "meta.value": ["A"]),
-        build(:event, name: "Signup", "meta.key": ["variant"], "meta.value": ["B"])
+        build(:event, pathname: "/register", name: "Signup")
       ])
 
       insert(:goal, %{site: site, page_path: "/register"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      filters = Jason.encode!(%{goal: "Signup"})
+      get_with_filter = fn filters ->
+        path = "/api/stats/#{site.domain}/conversions"
+        query = "?period=day&filters=#{Jason.encode!(filters)}"
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
-        )
+        get(conn, path <> query)
+        |> json_response(200)
+      end
 
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 33.3
-               }
-             ]
+      expected = [
+        %{
+          "name" => "Signup",
+          "visitors" => 1,
+          "events" => 1,
+          "conversion_rate" => 33.3
+        }
+      ]
+
+      # {:is, {:event, event}} filter type
+      assert get_with_filter.(%{goal: "Signup"}) == expected
+
+      # {:member, clauses} filter type
+      assert get_with_filter.(%{goal: "Signup|Whatever"}) == expected
+
+      # {:matches_member, clauses} filter type
+      assert get_with_filter.(%{goal: "Signup|Visit /whatever*"}) == expected
+    end
+
+    test "does not return custom events with the filtered pageview goal pathname", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/register"),
+        build(:event, pathname: "/register", name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, page_path: "/regi**"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      get_with_filter = fn filters ->
+        path = "/api/stats/#{site.domain}/conversions"
+        query = "?period=day&filters=#{Jason.encode!(filters)}"
+
+        get(conn, path <> query)
+        |> json_response(200)
+      end
+
+      expected = [
+        %{
+          "name" => "Visit /register",
+          "visitors" => 1,
+          "events" => 1,
+          "conversion_rate" => 33.3
+        },
+        %{
+          "name" => "Visit /regi**",
+          "visitors" => 1,
+          "events" => 1,
+          "conversion_rate" => 33.3
+        }
+      ]
+
+      # {:is, {:page, path}} filter type
+      assert get_with_filter.(%{goal: "Visit+/register"}) == expected
+
+      # {:matches, {:page, expr}} filter type
+      assert get_with_filter.(%{goal: "Visit+/regi**"}) == expected
+
+      # {:member, clauses} filter type
+      assert get_with_filter.(%{goal: "Visit+/register|Whatever"}) == expected
+
+      # {:matches_member, clauses} filter type
+      assert get_with_filter.(%{goal: "Visit+/register|Visit+/regi**"}) == expected
     end
 
     test "can filter by multiple mixed goals", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

This PR fixes the behaviour where custom event goals are returned in the conversions breakdown with a pageview goal filter, and vice versa. Example from the live demo:

<img width="644" alt="image" src="https://github.com/plausible/analytics/assets/56999674/32683336-3194-403b-8325-2220a969cc14">

<img width="641" alt="image" src="https://github.com/plausible/analytics/assets/56999674/6e73031a-3956-4ba0-be2c-de59a8606e4d">

After this PR, in the two above cases, only the goal in filter would be returned.

This PR also removes some dead code handling the `:not_member` and `:not_matches_member` filter types for the `event:goal` property. As things stand now, these filter types cannot be used for this property.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
