### PR TITLE
Disallow funny business on timezone entry

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -68,6 +68,7 @@ defmodule Plausible.Site do
     |> cast(attrs, [:domain, :timezone])
     |> clean_domain()
     |> validate_required([:domain, :timezone])
+    |> validate_timezone()
     |> validate_domain_format()
     |> validate_domain_reserved_characters()
     |> unique_constraint(:domain,
@@ -263,6 +264,16 @@ defmodule Plausible.Site do
       )
     else
       changeset
+    end
+  end
+
+  defp validate_timezone(changeset) do
+    tz = get_field(changeset, :timezone)
+
+    if Timex.is_valid_timezone?(tz) do
+      changeset
+    else
+      add_error(changeset, :timezone, "is invalid")
     end
   end
 end

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -12,6 +12,15 @@ defmodule Plausible.SitesTest do
       assert {:ok, %{site: %{domain: "example.com", timezone: "Europe/London"}}} =
                Sites.create(user, params)
     end
+
+    test "fails on invalid timezone" do
+      user = insert(:user)
+
+      params = %{"domain" => "example.com", "timezone" => "blah"}
+
+      assert {:error, :site, %{errors: [timezone: {"is invalid", []}]}, %{}} =
+               Sites.create(user, params)
+    end
   end
 
   describe "is_member?" do

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -26,6 +26,18 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                }
       end
 
+      test "timezone is validated", %{conn: conn} do
+        conn =
+          post(conn, "/api/v1/sites", %{
+            "domain" => "some-site.domain",
+            "timezone" => "d"
+          })
+
+        assert json_response(conn, 400) == %{
+                 "error" => "timezone: is invalid"
+               }
+      end
+
       test "timezone defaults to Etc/UTC", %{conn: conn} do
         conn =
           post(conn, "/api/v1/sites", %{


### PR DESCRIPTION
### Changes

Ensures timezone is within the set known to Timex

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
