### PR TITLE
Always enable e-mail verification on full build

### DIFF
--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -67,7 +67,7 @@ defmodule Plausible.Auth.User do
     |> validate_password_strength()
     |> hash_password()
     |> start_trial()
-    |> change_email_verification_status()
+    |> set_email_verification_status()
     |> unique_constraint(:email)
   end
 
@@ -85,7 +85,7 @@ defmodule Plausible.Auth.User do
     |> validate_email_changed()
     |> check_password()
     |> unique_constraint(:email)
-    |> change_email_verification_status()
+    |> set_email_verification_status()
     |> put_change(:previous_email, user.email)
   end
 
@@ -259,7 +259,7 @@ defmodule Plausible.Auth.User do
     end
   end
 
-  defp change_email_verification_status(user) do
+  defp set_email_verification_status(user) do
     on_full_build do
       change(user, email_verified: false)
     else

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -66,8 +66,8 @@ defmodule Plausible.Auth.User do
     |> validate_confirmation(:password, required: true)
     |> validate_password_strength()
     |> hash_password()
-    |> start_trial
-    |> set_email_verified
+    |> start_trial()
+    |> change_email_verification_status()
     |> unique_constraint(:email)
   end
 
@@ -85,7 +85,7 @@ defmodule Plausible.Auth.User do
     |> validate_email_changed()
     |> check_password()
     |> unique_constraint(:email)
-    |> set_email_verified()
+    |> change_email_verification_status()
     |> put_change(:previous_email, user.email)
   end
 
@@ -259,11 +259,13 @@ defmodule Plausible.Auth.User do
     end
   end
 
-  defp set_email_verified(user) do
-    if Keyword.fetch!(Application.get_env(:plausible, :selfhost), :enable_email_verification) do
+  defp change_email_verification_status(user) do
+    on_full_build do
       change(user, email_verified: false)
     else
-      change(user, email_verified: true)
+      selfhosted_config = Application.get_env(:plausible, :selfhost)
+      enable? = Keyword.fetch!(selfhosted_config, :enable_email_verification)
+      change(user, email_verified: !enable?)
     end
   end
 end

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -264,8 +264,8 @@ defmodule Plausible.Auth.User do
       change(user, email_verified: false)
     else
       selfhosted_config = Application.get_env(:plausible, :selfhost)
-      enable? = Keyword.fetch!(selfhosted_config, :enable_email_verification)
-      change(user, email_verified: !enable?)
+      must_verify? = Keyword.fetch!(selfhosted_config, :enable_email_verification)
+      change(user, email_verified: not must_verify?)
     end
   end
 end

--- a/test/plausible_web/controllers/auth_controller_sync_test.exs
+++ b/test/plausible_web/controllers/auth_controller_sync_test.exs
@@ -8,6 +8,7 @@ defmodule PlausibleWeb.AuthControllerSyncTest do
   describe "PUT /settings/email" do
     setup [:create_user, :log_in]
 
+    @tag :small_build_only
     test "updates email but DOES NOT force reverification when feature disabled", %{
       conn: conn,
       user: user


### PR DESCRIPTION
### Changes

There is no point in ever disabling it on full build.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
