### PR TITLE
Use tags rather than context to annotate support hashes in Sentry

### DIFF
--- a/lib/plausible_web/plugs/error_handler.ex
+++ b/lib/plausible_web/plugs/error_handler.ex
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Plugs.ErrorHandler do
       @impl Plug.ErrorHandler
       def handle_errors(conn, %{kind: kind, reason: reason}) do
         hash = Hahash.name({kind, reason})
-        Sentry.Context.set_extra_context(%{hash: hash})
+        Sentry.Context.set_tags_context(%{hash: hash})
         json(conn, %{error: "internal server error", support_hash: hash})
       end
     end


### PR DESCRIPTION
Correction to #3661 

`set_tags_context` is more applicable here, as we can search by it. Per Sentry moduledoc:


```
  Merges new fields into the `:tags` context, specific to the current process.

  This is used to set fields which should display when looking at a specific
  instance of an error. These fields can also be used to search and filter on.
```


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
