### PR TITLE
Fix calendar picker for comparisons on small screens

### DIFF
--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -183,7 +183,7 @@ const ComparisonInput = function({ site, query, history }) {
             </Transition>
 
             { uiMode == "datepicker" &&
-            <div className="h-0 absolute">
+            <div className="h-0 md:absolute">
               <Flatpickr ref={calendar} options={flatpickrOptions} className="invisible" />
             </div> }
           </Menu>


### PR DESCRIPTION
### Changes

Fixes https://github.com/plausible/analytics/issues/3304

Before:

<img width="438" alt="image" src="https://github.com/plausible/analytics/assets/588351/f97fc8cf-cf89-4205-a76d-f261c4d33c81">

After:

<img width="444" alt="image" src="https://github.com/plausible/analytics/assets/588351/a5bd7b67-f0a7-4d83-bbe0-bb9420ad113c">

Using `md` makes sure the picker button does not jump out of line on larger screen sizes (hence the need for `absolute`).

Verified to work on actual mobile display too - Sunday is visible and selectable on iPhone 12 mini.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
