### PR TITLE
Limit Custom Properties access in Stats API

### DIFF
--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -16,6 +16,51 @@ defmodule Plausible.Props do
   @max_prop_value_length 2000
   def max_prop_value_length, do: @max_prop_value_length
 
+  @internal_keys ~w(url path)
+  @doc """
+  Lists prop keys used internally.
+
+  These props should be allowed by default, and should not be displayed in the
+  props settings page. For example, `url` is a special prop key used for file
+  downloads and outbound links. It doesn't make sense to remove this prop key
+  from the allow list, or to suggest users to add this prop key.
+  """
+  def internal_keys, do: @internal_keys
+
+  @doc """
+  Returns the custom props allowed in queries for the given site. There are
+  two factors deciding whether a custom property is allowed for a site.
+
+  ### 1. Subscription plan including the props feature.
+
+  Internally used keys (i.e. `#{inspect @internal_keys}`) are always allowed,
+  even for plans that don't include props. But for anything other than those,
+  props feature access is needed.
+
+  ### 2. The site having an `allowed_event_props` list configured.
+
+  For customers with a configured `allowed_event_props` list, this function
+  returns that list (+ internally used keys). That helps to filter out garbage
+  props which people might not want to see in their dashboards.
+
+  Since `allowed_event_props` was added after the props feature had already
+  been used for a while, there are sites with `allowed_event_props = nil`. For
+  those sites, all custom properties that exist in the database are allowed to
+  be queried.
+  """
+  @spec allowed_for(Plausible.Site.t()) :: [prop()] | :all
+  def allowed_for(site) do
+    site = Plausible.Repo.preload(site, :owner)
+    props_enabled? = Plausible.Billing.Feature.Props.check_availability(site.owner) == :ok
+    internal_keys = Plausible.Props.internal_keys()
+
+    case {props_enabled?, site.allowed_event_props} do
+      {true, nil} -> :all
+      {true, props_list} -> props_list ++ internal_keys
+      {false, _} -> internal_keys
+    end
+  end
+
   @spec allow(Plausible.Site.t(), [prop()] | prop()) ::
           {:ok, Plausible.Site.t()} | {:error, Ecto.Changeset.t()} | {:error, :upgrade_required}
   @doc """
@@ -84,17 +129,6 @@ defmodule Plausible.Props do
 
     allow(site, props_to_allow)
   end
-
-  @internal_keys ~w(url path)
-  @doc """
-  Lists prop keys used internally.
-
-  These props should be allowed by default, and should not be displayed in the
-  props settings page. For example, `url` is a special prop key used for file
-  downloads and outbound links. It doesn't make sense to remove this prop key
-  from the allow list, or to suggest users to add this prop key.
-  """
-  def internal_keys, do: @internal_keys
 
   def ensure_prop_key_accessible(prop_key, user) do
     if prop_key in @internal_keys do

--- a/lib/plausible/stats/custom_props.ex
+++ b/lib/plausible/stats/custom_props.ex
@@ -33,15 +33,15 @@ defmodule Plausible.Stats.CustomProps do
           select: meta.key,
           distinct: true
         )
-        |> maybe_allowed_props_only(site.allowed_event_props)
+        |> maybe_allowed_props_only(site)
         |> ClickhouseRepo.all()
     end
   end
 
-  def maybe_allowed_props_only(q, allowed_props) when is_list(allowed_props) do
-    props = allowed_props ++ Plausible.Props.internal_keys()
-    from [..., m] in q, where: m.key in ^props
+  def maybe_allowed_props_only(q, site) do
+    case Plausible.Props.allowed_for(site) do
+      :all -> q
+      allowed_props -> from [..., m] in q, where: m.key in ^allowed_props
+    end
   end
-
-  def maybe_allowed_props_only(q, nil), do: q
 end

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -142,7 +142,7 @@ defmodule Plausible.Stats.FilterSuggestions do
       order_by: [desc: fragment("count(*)")],
       limit: 25
     )
-    |> Plausible.Stats.CustomProps.maybe_allowed_props_only(site.allowed_event_props)
+    |> Plausible.Stats.CustomProps.maybe_allowed_props_only(site)
     |> ClickhouseRepo.all()
     |> wrap_suggestions()
   end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -11,12 +11,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def aggregate(conn, params) do
-    site = conn.assigns[:site]
+    site = conn.assigns[:site] |> Repo.preload(:owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          query <- Query.from(site, params),
-         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
+         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query),
+         :ok <- ensure_custom_props_access(site, query) do
       results =
         if params["compare"] == "previous_period" do
           {:ok, prev_query} = Plausible.Stats.Comparisons.compare(site, query, "previous_period")
@@ -43,22 +44,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
       json(conn, %{results: results})
     else
-      {:error, msg} ->
-        conn
-        |> put_status(400)
-        |> json(%{error: msg})
+      err_tuple -> send_json_error_response(conn, err_tuple)
     end
   end
 
   def breakdown(conn, params) do
-    site = conn.assigns[:site]
+    site = conn.assigns[:site] |> Repo.preload(:owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          {:ok, property} <- validate_property(params),
          query <- Query.from(site, params),
          {:ok, metrics} <- parse_and_validate_metrics(params, property, query),
-         {:ok, limit} <- validate_or_default_limit(params) do
+         {:ok, limit} <- validate_or_default_limit(params),
+         :ok <- ensure_custom_props_access(site, query, property) do
       page = String.to_integer(Map.get(params, "page", "1"))
       results = Plausible.Stats.breakdown(site, query, property, metrics, {limit, page})
 
@@ -75,10 +74,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
       json(conn, %{results: results})
     else
-      {:error, msg} ->
-        conn
-        |> put_status(400)
-        |> json(%{error: msg})
+      err_tuple -> send_json_error_response(conn, err_tuple)
     end
   end
 
@@ -129,6 +125,35 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
+  @spec ensure_custom_props_access(Plausible.Site.t(), Query.t(), String.t() | nil) ::
+          :ok | {:error, {402, String.t()}}
+  defp ensure_custom_props_access(site, query, property \\ nil) do
+    allowed_props = Plausible.Props.allowed_for(site, bypass_setup?: true)
+    prop_filter = Query.get_filter_by_prefix(query, "event:props:")
+
+    query_allowed? =
+      case {prop_filter, property, allowed_props} do
+        {_, _, :all} ->
+          true
+
+        {{"event:props:" <> prop, _}, _property, allowed_props} ->
+          prop in allowed_props
+
+        {_filter, "event:props:" <> prop, allowed_props} ->
+          prop in allowed_props
+
+        _ ->
+          true
+      end
+
+    if query_allowed? do
+      :ok
+    else
+      msg = "The owner of this site does not have access to the custom properties feature"
+      {:error, {402, msg}}
+    end
+  end
+
   defp validate_all_metrics(metrics, property, query) do
     Enum.reduce_while(metrics, [], fn metric, acc ->
       case validate_metric(metric, property, query) do
@@ -172,21 +197,19 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def timeseries(conn, params) do
-    site = conn.assigns[:site]
+    site = conn.assigns[:site] |> Repo.preload(:owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          :ok <- validate_interval(params),
          query <- Query.from(site, params),
-         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query) do
+         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query),
+         :ok <- ensure_custom_props_access(site, query) do
       graph = Plausible.Stats.timeseries(site, query, metrics)
 
       json(conn, %{results: graph})
     else
-      {:error, msg} ->
-        conn
-        |> put_status(400)
-        |> json(%{error: msg})
+      err_tuple -> send_json_error_response(conn, err_tuple)
     end
   end
 
@@ -257,4 +280,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_interval(_), do: :ok
+
+  defp send_json_error_response(conn, {:error, {status, msg}}) do
+    conn
+    |> put_status(status)
+    |> json(%{error: msg})
+  end
+
+  defp send_json_error_response(conn, {:error, msg}) do
+    conn
+    |> put_status(400)
+    |> json(%{error: msg})
+  end
 end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -5,13 +5,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   alias Plausible.Stats.{Query, CustomProps}
 
   def realtime_visitors(conn, _params) do
-    site = conn.assigns[:site]
+    site = conn.assigns.site
     query = Query.from(site, %{"period" => "realtime"})
     json(conn, Plausible.Stats.Clickhouse.current_visitors(site, query))
   end
 
   def aggregate(conn, params) do
-    site = conn.assigns[:site] |> Repo.preload(:owner)
+    site = Repo.preload(conn.assigns.site, :owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
@@ -49,7 +49,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def breakdown(conn, params) do
-    site = conn.assigns[:site] |> Repo.preload(:owner)
+    site = Repo.preload(conn.assigns.site, :owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
@@ -197,7 +197,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def timeseries(conn, params) do
-    site = conn.assigns[:site] |> Repo.preload(:owner)
+    site = Repo.preload(conn.assigns.site, :owner)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -1,9 +1,47 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
   use PlausibleWeb.ConnCase
   import Plausible.TestUtils
+  alias Plausible.Billing.Feature
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
   @user_id 123
+
+  describe "feature access" do
+    test "cannot filter by a custom prop without access to the props feature", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      ep = insert(:enterprise_plan, features: [Feature.StatsAPI], user_id: user.id)
+      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "filters" => "event:props:author==Uku"
+        })
+
+      assert json_response(conn, 402)["error"] ==
+               "The owner of this site does not have access to the custom properties feature"
+    end
+
+    test "can filter by an internal prop key without access to the props feature", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      ep = insert(:enterprise_plan, features: [Feature.StatsAPI], user_id: user.id)
+      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "filters" => "event:props:url==https://site.com"
+        })
+
+      assert json_response(conn, 200)["results"]
+    end
+  end
 
   describe "param validation" do
     test "validates that date can be parsed", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -1,7 +1,49 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
   use PlausibleWeb.ConnCase
+  alias Plausible.Billing.Feature
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
+
+  describe "feature access" do
+    test "cannot filter by a custom prop without access to the props feature", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      ep = insert(:enterprise_plan, features: [Feature.StatsAPI], user_id: user.id)
+      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "month",
+          "date" => "2021-01-01",
+          "filters" => "event:props:author==Uku"
+        })
+
+      assert json_response(conn, 402)["error"] ==
+               "The owner of this site does not have access to the custom properties feature"
+    end
+
+    test "can filter by an internal prop without access to the props feature", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      ep = insert(:enterprise_plan, features: [Feature.StatsAPI], user_id: user.id)
+      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "month",
+          "date" => "2021-01-01",
+          "filters" => "event:props:path==/404"
+        })
+
+      assert json_response(conn, 200)["results"]
+    end
+  end
 
   describe "param validation" do
     test "validates that date can be parsed", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Starting from the v4 generation of subscription plans, Stats API and Custom Properties are both considered premium features. However, there are two possible cases where the user might have access to Stats API, but not Custom Properties.

1. Enterprise plans with the Stats API feature allowed, but props disallowed
2. An invited user on trial / business plan /grandfathered plan is querying with their own API key, but the site owner does not have access to props

These cases in mind, extra checks are required to ensure that the queried breakdown property, or the used filters do not contain custom properties that the site owner does not have access to. Internal prop keys such as `url` and `path` should always be allowed.

 This PR also build a single function `allowed_for` that acts as a gateway to custom properties, and documents the difficult aspects of why some sites have `allowed_event_props` set to `nil` and so on.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
