### PR TITLE
Fix props availability check when listing stats filters in dropdown

### DIFF
--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -95,7 +95,7 @@ function DropdownContent({ history, site, query, wrapped }) {
 
   if (wrapped === 0 || addingFilter) {
     let filterGroups = {...FILTER_GROUPS}
-    if (!site.propsEnabled) delete filterGroups.props
+    if (!site.propsAvailable) delete filterGroups.props
 
     return Object.keys(filterGroups).map((option) => filterDropdownOption(site, option))
   }


### PR DESCRIPTION
### Changes

Fixes props site property check when rendering filters dropdown which was missed when changing `propsEnabled` => `propsAvailable` in https://github.com/plausible/analytics/pull/3646.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
