### PR TITLE
Reapply sentry context

### DIFF
--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -2,9 +2,8 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   @moduledoc """
   LiveView allowing listing, creating and deleting funnels.
   """
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
-  use PlausibleWeb.Live.Flash
 
   use Plausible.Funnel
 

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
   to allow building searchable funnel definitions out of list of goals available.
   """
 
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Plausible.Funnel
 
   import PlausibleWeb.Live.Components.Form

--- a/lib/plausible_web.ex
+++ b/lib/plausible_web.ex
@@ -1,4 +1,19 @@
 defmodule PlausibleWeb do
+  def live_view(opts \\ []) do
+    quote do
+      use Plausible
+      use Phoenix.LiveView, global_prefixes: ~w(x-)
+      use PlausibleWeb.Live.Flash
+
+      unless :no_sentry_context in unquote(opts) do
+        use PlausibleWeb.Live.SentryContext
+      end
+
+      alias PlausibleWeb.Router.Helpers, as: Routes
+      alias Phoenix.LiveView.JS
+    end
+  end
+
   def controller do
     quote do
       use Phoenix.Controller, namespace: PlausibleWeb
@@ -85,5 +100,9 @@ defmodule PlausibleWeb do
   """
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
+  end
+
+  defmacro __using__([{which, opts}]) when is_atom(which) do
+    apply(__MODULE__, which, [List.wrap(opts)])
   end
 end

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -17,7 +17,12 @@ defmodule PlausibleWeb.Endpoint do
   socket("/live", Phoenix.LiveView.Socket,
     websocket: [
       check_origin: true,
-      connect_info: [session: {__MODULE__, :runtime_session_opts, []}]
+      connect_info: [
+        :peer_data,
+        :uri,
+        :user_agent,
+        session: {__MODULE__, :runtime_session_opts, []}
+      ]
     ]
   )
 

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   @moduledoc """
   LiveView for upgrading to a plan, or changing an existing plan.
   """
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
 
   require Plausible.Billing.Subscription.Status

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -15,7 +15,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   @contact_link "https://plausible.io/contact"
   @billing_faq_link "https://plausible.io/docs/billing"
 
-  def mount(_params, %{"user_id" => user_id}, socket) do
+  def mount(_params, %{"current_user_id" => user_id}, socket) do
     socket =
       socket
       |> assign_new(:user, fn ->

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -2,9 +2,8 @@ defmodule PlausibleWeb.Live.GoalSettings do
   @moduledoc """
   LiveView allowing listing, creating and deleting goals.
   """
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
-  use PlausibleWeb.Live.Flash
 
   alias Plausible.{Sites, Goals}
 

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -2,8 +2,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   @moduledoc """
   Live view for the goal creation form
   """
-  use Phoenix.LiveView
-  use Plausible
+  use PlausibleWeb, :live_view
   import PlausibleWeb.Live.Components.Form
   alias PlausibleWeb.Live.Components.ComboBox
 

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -268,6 +268,10 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     """
   end
 
+  def handle_info({:selection_made, %{submit_value: _prop}}, socket) do
+    {:noreply, socket}
+  end
+
   def handle_event("switch-tab", _params, socket) do
     {:noreply,
      assign(socket,

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -2,9 +2,9 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
   @moduledoc """
   LiveView allowing listing, creating and revoking Plugins API tokens.
   """
-  use Phoenix.LiveView
+
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
-  use PlausibleWeb.Live.Flash
 
   alias Plausible.Sites
   alias Plausible.Plugins.API.Tokens

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
   @moduledoc """
   Live view for the goal creation form
   """
-  use Phoenix.LiveView
+  use PlausibleWeb, live_view: :no_sentry_context
   import PlausibleWeb.Live.Components.Form
 
   alias Plausible.Repo

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -3,9 +3,8 @@ defmodule PlausibleWeb.Live.PropsSettings do
   LiveView allowing listing, allowing and disallowing custom event properties.
   """
 
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
-  use PlausibleWeb.Live.Flash
 
   alias PlausibleWeb.Live.Components.ComboBox
 

--- a/lib/plausible_web/live/props_settings/form.ex
+++ b/lib/plausible_web/live/props_settings/form.ex
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Live.PropsSettings.Form do
   @moduledoc """
   Live view for the custom props creation form
   """
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   import PlausibleWeb.Live.Components.Form
   alias PlausibleWeb.Live.Components.ComboBox
 

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -3,16 +3,12 @@ defmodule PlausibleWeb.Live.RegisterForm do
   LiveView for registration form.
   """
 
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
-  use Plausible
-
   import PlausibleWeb.Live.Components.Form
 
   alias Plausible.Auth
   alias Plausible.Repo
-
-  alias PlausibleWeb.Router.Helpers, as: Routes
 
   def mount(params, _session, socket) do
     socket =

--- a/lib/plausible_web/live/reset_password_form.ex
+++ b/lib/plausible_web/live/reset_password_form.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Live.ResetPasswordForm do
   LiveView for password reset form.
   """
 
-  use Phoenix.LiveView
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
 
   import PlausibleWeb.Live.Components.Form

--- a/lib/plausible_web/live/sentry_context.ex
+++ b/lib/plausible_web/live/sentry_context.ex
@@ -1,0 +1,76 @@
+defmodule PlausibleWeb.Live.SentryContext do
+  @moduledoc """
+  This module tries to supply LiveViews with some common Sentry context
+  (without it, there is practically none).
+
+  Use via `use PlausibleWeb.Live.SentryContext` in your LiveView module,
+  or preferably via `use PlausibleWeb, :live_view`.
+
+  In case you have multiple LiveViews, there is `use PlausibleWeb, live_view: :no_sentry_context`
+  exposed that allows you to skip using this module. This is because
+  only the root LiveView has access to `connect_info` and an exception will be
+  thrown otherwise.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      on_mount PlausibleWeb.Live.SentryContext
+    end
+  end
+
+  def on_mount(:default, _params, session, socket) do
+    peer = Phoenix.LiveView.get_connect_info(socket, :peer_data)
+    uri = Phoenix.LiveView.get_connect_info(socket, :uri)
+
+    user_agent =
+      Phoenix.LiveView.get_connect_info(socket, :user_agent)
+
+    socket_host =
+      case socket.host_uri do
+        :not_mounted_at_router -> :not_mounted_at_router
+        %URI{host: host} -> host
+      end
+
+    request_context =
+      %{
+        host: socket_host,
+        env: %{
+          "REMOTE_ADDR" => get_ip(peer),
+          "REMOTE_PORT" => peer && peer.port,
+          "SEVER_NAME" => uri && uri.host
+        }
+      }
+
+    request_context =
+      if user_agent do
+        Map.merge(request_context, %{
+          headers: %{
+            "User-Agent" => user_agent
+          }
+        })
+      else
+        request_context
+      end
+
+    Sentry.Context.set_request_context(request_context)
+
+    user_id = session["current_user_id"]
+
+    if user_id do
+      Sentry.Context.set_user_context(%{
+        id: user_id
+      })
+    end
+
+    {:cont, socket}
+  end
+
+  defp get_ip(%{address: addr}) do
+    case :inet.ntoa(addr) do
+      {:error, _} -> ""
+      address -> to_string(address)
+    end
+  end
+
+  defp get_ip(_), do: ""
+end

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -3,11 +3,7 @@ defmodule PlausibleWeb.Live.Sites do
   LiveView for sites index.
   """
 
-  use Phoenix.LiveView, global_prefixes: ~w(x-)
-  use PlausibleWeb.Live.Flash
-  use Plausible
-
-  alias Phoenix.LiveView.JS
+  use PlausibleWeb, :live_view
   use Phoenix.HTML
 
   import PlausibleWeb.Components.Generic
@@ -18,7 +14,6 @@ defmodule PlausibleWeb.Live.Sites do
   alias Plausible.Site
   alias Plausible.Sites
   alias Plausible.Site.Memberships.Invitations
-  alias PlausibleWeb.Router.Helpers, as: Routes
 
   def mount(params, %{"current_user_id" => user_id}, socket) do
     uri =

--- a/lib/plausible_web/templates/billing/choose_plan.html.heex
+++ b/lib/plausible_web/templates/billing/choose_plan.html.heex
@@ -1,4 +1,4 @@
 <%= live_render(@conn, PlausibleWeb.Live.ChoosePlan,
   id: "choose-plan",
-  session: %{"user_id" => @user.id}
+  session: %{"current_user_id" => @user.id}
 ) %>

--- a/test/plausible_web/live/goal_settings/form_test.exs
+++ b/test/plausible_web/live/goal_settings/form_test.exs
@@ -129,6 +129,13 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
 
       refute element_exists?(html, ~s/a[phx-value-display-value="PLN - Polish Zloty"]/)
       assert element_exists?(html, ~s/a[phx-value-display-value="EUR - Euro"]/)
+
+      lv
+      |> element("#dropdown-currency_input-option-1 a")
+      |> render_click()
+
+      # make sure combo's {:selection_made, ...} message is received
+      render(lv)
     end
 
     test "pageview combo works", %{conn: conn, site: site} do

--- a/test/plausible_web/live/sentry_context_test.exs
+++ b/test/plausible_web/live/sentry_context_test.exs
@@ -1,0 +1,78 @@
+defmodule PlausibleWeb.Live.SentryContextTest do
+  use PlausibleWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  defmodule SampleLV do
+    use PlausibleWeb, :live_view
+
+    def mount(_params, %{"test" => test_pid}, socket) do
+      socket = assign(socket, test_pid: test_pid)
+      {:ok, socket}
+    end
+
+    def render(assigns) do
+      ~H"""
+      ok computer
+      """
+    end
+
+    def handle_event("get_sentry_context", _params, socket) do
+      context = Sentry.Context.get_all()
+      send(socket.assigns.test_pid, {:context, context})
+      {:noreply, socket}
+    end
+  end
+
+  describe "sentry context" do
+    test "basic shape", %{conn: conn} do
+      context_hook(conn)
+      assert_receive {:context, context}
+
+      assert %{
+               extra: %{},
+               request: %{
+                 env: %{
+                   "REMOTE_ADDR" => "127.0.0.1",
+                   "REMOTE_PORT" => port,
+                   "SEVER_NAME" => "www.example.com"
+                 },
+                 host: :not_mounted_at_router
+               },
+               user: %{},
+               tags: %{},
+               breadcrumbs: []
+             } = context
+
+      assert is_integer(port)
+    end
+
+    test "user-agent is included", %{conn: conn} do
+      conn
+      |> put_req_header("user-agent", "Firefox")
+      |> context_hook()
+
+      assert_receive {:context, context}
+      assert context.request.headers["User-Agent"] == "Firefox"
+    end
+
+    test "user_id is included", %{conn: conn} do
+      context_hook(conn, %{"current_user_id" => 172})
+
+      assert_receive {:context, context}
+      assert context.user.id == 172
+    end
+  end
+
+  defp context_hook(conn, extra_session \\ %{}) do
+    lv = get_liveview(conn, extra_session)
+    assert render(lv) =~ "ok computer"
+    render_hook(lv, :get_sentry_context, %{})
+  end
+
+  defp get_liveview(conn, extra_session) do
+    {:ok, lv, _html} =
+      live_isolated(conn, SampleLV, session: Map.merge(%{"test" => self()}, extra_session))
+
+    lv
+  end
+end


### PR DESCRIPTION
### Changes

This PR re-applies #3672 with two patches - one fixing a crash on revenue goals selection, and also ensuring the context is only set when the socket is actually connected, so effectively on second mount only.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
