### PR TITLE
Run SiteLocker right after site ownership transfer

### DIFF
--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -106,9 +106,11 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
     |> downgrade_previous_owner(site, user)
     |> Multi.insert_or_update(:membership, membership)
     |> Multi.run(:update_locked_sites, fn _, _ ->
-      # At this point this function should be guaranteed to unlock
-      # the site, via `Invitations.ensure_can_take_ownership/2`.
-      :unlocked = Billing.SiteLocker.update_sites_for(user, send_email?: false)
+      on_full_build do
+        # At this point this function should be guaranteed to unlock
+        # the site, via `Invitations.ensure_can_take_ownership/2`.
+        :unlocked = Billing.SiteLocker.update_sites_for(user, send_email?: false)
+      end
 
       {:ok, :unlocked}
     end)

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -105,6 +105,13 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
     Multi.new()
     |> downgrade_previous_owner(site, user)
     |> Multi.insert_or_update(:membership, membership)
+    |> Multi.run(:update_locked_sites, fn _, _ ->
+      # At this point this function should be guaranteed to unlock
+      # the site, via `Invitations.ensure_can_take_ownership/2`.
+      :unlocked = Billing.SiteLocker.update_sites_for(user, send_email?: false)
+
+      {:ok, :unlocked}
+    end)
   end
 
   # If there's an existing membership, we DO NOT change the role

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -7,7 +7,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
   alias Plausible.Site.Memberships.AcceptInvitation
 
   describe "transfer_ownership/3" do
-    test "transfers ownership succeeds" do
+    test "transfers ownership successfully" do
       site = insert(:site, memberships: [])
       existing_owner = insert(:user)
 
@@ -30,6 +30,25 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert existing_membership.role == :admin
 
       assert_no_emails_delivered()
+    end
+
+    test "unlocks the site if it was previously locked" do
+      site = insert(:site, locked: true, memberships: [])
+      existing_owner = insert(:user)
+
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user)
+      insert(:growth_subscription, user: new_owner)
+
+      assert {:ok, new_membership} =
+               AcceptInvitation.transfer_ownership(site, new_owner)
+
+      assert new_membership.site_id == site.id
+      assert new_membership.user_id == new_owner.id
+      assert new_membership.role == :owner
+
+      refute Repo.reload!(site).locked
     end
 
     for role <- [:viewer, :admin] do
@@ -293,6 +312,37 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
         subject:
           "[Plausible Analytics] #{new_owner.email} accepted the ownership transfer of #{site.domain}"
       )
+    end
+
+    test "unlocks a previously locked site after transfer" do
+      site = insert(:site, locked: true, memberships: [])
+      existing_owner = insert(:user)
+
+      insert(:site_membership, user: existing_owner, site: site, role: :owner)
+
+      new_owner = insert(:user)
+      insert(:growth_subscription, user: new_owner)
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: existing_owner,
+          email: new_owner.email,
+          role: :owner
+        )
+
+      assert {:ok, new_membership} =
+               AcceptInvitation.accept_invitation(
+                 invitation.invitation_id,
+                 new_owner
+               )
+
+      assert new_membership.site_id == site.id
+      assert new_membership.user_id == new_owner.id
+      assert new_membership.role == :owner
+      refute Repo.reload(invitation)
+
+      refute Repo.reload!(site).locked
     end
 
     for role <- [:viewer, :admin] do

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -32,6 +32,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert_no_emails_delivered()
     end
 
+    @tag :full_build_only
     test "unlocks the site if it was previously locked" do
       site = insert(:site, locked: true, memberships: [])
       existing_owner = insert(:user)
@@ -314,6 +315,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       )
     end
 
+    @tag :full_build_only
     test "unlocks a previously locked site after transfer" do
       site = insert(:site, locked: true, memberships: [])
       existing_owner = insert(:user)


### PR DESCRIPTION
### Changes

This PR ensures that transferred site is unlocked immediately in cases of both, direct transfer and a transfer via invitation.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
