### PR TITLE
Fix weekly interval bug

### DIFF
--- a/lib/plausible/stats/fragments.ex
+++ b/lib/plausible/stats/fragments.ex
@@ -92,7 +92,7 @@ defmodule Plausible.Stats.Fragments do
     quote do
       weekstart_not_before(
         to_timezone(unquote(date), unquote(timezone)),
-        unquote(not_before)
+        to_timezone(unquote(not_before), unquote(timezone))
       )
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -688,6 +688,31 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
              }
     end
 
+    test "returns stats for the first week of the month when site.timezone is ahead of UTC", %{
+      conn: conn,
+      site: site
+    } do
+      site =
+        site
+        |> Plausible.Site.changeset(%{timezone: "Europe/Copenhagen"})
+        |> Plausible.Repo.update!()
+
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2023-03-01 12:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&metric=visitors&date=2023-03-01&interval=week"
+        )
+
+      %{"labels" => labels, "plot" => plot} = json_response(conn, 200)
+
+      assert List.first(plot) == 1
+      assert List.first(labels) == "2023-03-01"
+    end
+
     test "shows half-perfect week-split month on week scale with full week indicators", %{
       conn: conn,
       site: site

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -688,7 +688,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
              }
     end
 
-    test "returns stats for the first week of the month when site.timezone is ahead of UTC", %{
+    test "returns stats for the first week of the month when site timezone is ahead of UTC", %{
       conn: conn,
       site: site
     } do


### PR DESCRIPTION
### Changes

This PR fixes a bug where the main graph weekly interval query sometimes returns 0 visitors for the first week, even when there were visitors.

The bug can be reproduced on any dashboard by looking at the main graph, when the following conditions are met:

1. The site timezone is ahead of UTC
2. The first day of the selected period is not a Monday
3. The `week` interval option is selected

This happened because the start of the month defining the first week was missing the UTC -> site.timezone conversion.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
