### PR TITLE
Support `contains`/`matches` for custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ### Added
+- Allow filtering with `contains`/`matches` operator for custom properties
 - Add `referrers.csv` to CSV export
 - Add a new Properties section in the dashboard to break down by custom properties
 - Add `custom_props.csv` to CSV export (almost the same as the old `prop_breakdown.csv`, but has different column headers, and includes props for pageviews too, not only custom events)

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -40,11 +40,15 @@ function PropFilterModal(props) {
 
   const fetchPropValueOptions = useCallback(() => {
     return (input) => {
+      if (formState.prop_value?.type === FILTER_TYPES.contains) {
+        return Promise.resolve([])
+      }
+
       const propKey = formState.prop_key?.value
       const updatedQuery = { ...query, filters: { ...query.filters, props: {[propKey]: '!(none)'} } }
       return api.get(apiPath(props.site, "/suggestions/prop_value"), updatedQuery, { q: input.trim() })
     }
-  }, [formState.prop_key])
+  }, [formState.prop_key, formState.prop_value])
 
   function onPropKeySelect() {
     return (selectedOptions) => {

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -86,7 +86,14 @@ function PropFilterModal(props) {
           <FilterTypeSelector isDisabled={!formState.prop_key} forFilter={'prop_value'} onSelect={onFilterTypeSelect()} selectedType={selectedFilterType()} />
         </div>
         <div className="col-span-4">
-          <Combobox isDisabled={!formState.prop_key} fetchOptions={fetchPropValueOptions()} values={formState.prop_value.clauses} onSelect={onPropValueSelect()} placeholder={'Value'} />
+          <Combobox
+            isDisabled={!formState.prop_key}
+            fetchOptions={fetchPropValueOptions()}
+            values={formState.prop_value.clauses}
+            onSelect={onPropValueSelect()}
+            placeholder={'Value'}
+            freeChoice={selectedFilterType() == FILTER_TYPES.contains}
+          />
         </div>
       </div>
     )

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -10,6 +10,10 @@ export const FILTER_GROUPS = {
   'props': ['prop_key', 'prop_value']
 }
 
+export const ALLOW_FREE_CHOICE = new Set(
+  FILTER_GROUPS['page'].concat(FILTER_GROUPS['utm']).concat(['prop_value'])
+)
+
 export const FILTER_TYPES = {
   isNot: 'is not',
   contains: 'contains',
@@ -27,7 +31,7 @@ export function supportsIsNot(filterName) {
 }
 
 export function isFreeChoiceFilter(filterName) {
-  return FILTER_GROUPS['page'].concat(FILTER_GROUPS['utm']).includes(filterName)
+  return ALLOW_FREE_CHOICE.has(filterName)
 }
 
 // As of March 2023, Safari does not support negative lookbehind regexes. In case it throws an error, falls back to plain | matching. This means

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -142,6 +142,16 @@ defmodule Plausible.Stats.Base do
             )
           end
 
+        {"event:props:" <> prop_name, {:matches, value}} ->
+          regex = page_regex(value)
+
+          from(
+            e in q,
+            left_array_join: meta in "meta",
+            as: :meta,
+            where: meta.key == ^prop_name and fragment("match(?, ?)", meta.value, ^regex)
+          )
+
         {"event:props:" <> prop_name, {:member, values}} ->
           none_value_included = Enum.member?(values, "(none)")
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -189,6 +189,7 @@ defmodule Plausible.Stats.Breakdown do
   defp include_none_result?({:is_not, "(none)"}), do: false
   defp include_none_result?({:member, values}), do: Enum.member?(values, "(none)")
   defp include_none_result?({:not_member, values}), do: !Enum.member?(values, "(none)")
+  defp include_none_result?({:matches, _}), do: false
   defp include_none_result?(_), do: true
 
   defp breakdown_sessions(_, _, _, [], _), do: []

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -75,6 +75,43 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    test "returns top pages with :matches filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          pathname: "/1",
+          "meta.key": ["prop"],
+          "meta.value": ["bar"]
+        ),
+        build(:pageview,
+          pathname: "/2",
+          "meta.key": ["prop"],
+          "meta.value": ["foobar"]
+        ),
+        build(:pageview,
+          pathname: "/3",
+          "meta.key": ["prop"],
+          "meta.value": ["baar"]
+        ),
+        build(:pageview,
+          pathname: "/4",
+          "meta.key": ["another"],
+          "meta.value": ["bar"]
+        ),
+        build(:pageview, pathname: "/5")
+      ])
+
+      filters = Jason.encode!(%{props: %{"prop" => "~bar"}})
+      conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200) == [
+               %{"visitors" => 1, "name" => "/1"},
+               %{"visitors" => 1, "name" => "/2"}
+             ]
+    end
+
     test "calculates bounce_rate and time_on_page with :is filter on custom pageview props",
          %{conn: conn, site: site} do
       populate_stats(site, [


### PR DESCRIPTION
### Changes

This PR a filtering with `contains`/`matches` for custom properties, e.g. "Filter where (custom property) url contains foo"

![image](https://github.com/plausible/analytics/assets/148820/ab409050-e4ce-4e15-81ac-0cf017e26023)

First PR :raised_hands: 

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
