### PR TITLE
Stop expecting `trial_expiry_date` to exist on upgrade

### DIFF
--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -208,13 +208,14 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
   end
 
   defp usage_within_plan_limits?(%{usage: usage, user: user, plan_to_render: plan}) do
-    # At this point, the user is guaranteed to have a `trial_expiry_date`.
-    # Otherwise, they'd be ineligible for an upgrade and this function
-    # would never be called.
-    %Date{} = user.trial_expiry_date
+    # At this point, the user is *not guaranteed* to have a `trial_expiry_date`,
+    # because in the past we've let users upgrade without that constraint, as
+    # well as transfer sites to those accounts. to these accounts we won't be
+    # offering an extra pageview limit allowance margin though.
+    invited_user? = is_nil(user.trial_expiry_date)
 
     trial_active_or_ended_recently? =
-      Timex.diff(Timex.today(), user.trial_expiry_date, :days) <= 10
+      not invited_user? && Timex.diff(Timex.today(), user.trial_expiry_date, :days) <= 10
 
     limit_checking_opts =
       cond do

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -754,6 +754,21 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       refute enterprise_box =~ "10+ team members"
       refute enterprise_box =~ "Unlimited team members"
     end
+
+    test "allows to upgrade without a trial_expiry_date when the user owns a site", %{
+      conn: conn,
+      user: user
+    } do
+      user
+      |> Plausible.Auth.User.changeset(%{trial_expiry_date: nil})
+      |> Repo.update!()
+
+      {:ok, lv, _doc} = get_liveview(conn)
+      doc = set_slider(lv, "100k")
+
+      refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+      refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+    end
   end
 
   describe "for a free_10k subscription" do


### PR DESCRIPTION
### Changes

Fixes a regression caused by https://github.com/plausible/analytics/pull/3683. Explained in the code comment.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
