### PR TITLE
Populate log_comment column with tags for performance analysis

### DIFF
--- a/lib/plausible/clickhouse_repo.ex
+++ b/lib/plausible/clickhouse_repo.ex
@@ -25,4 +25,34 @@ defmodule Plausible.ClickhouseRepo do
     |> Enum.to_list()
     |> Keyword.values()
   end
+
+  @doc """
+  Automatically adds tags as query log_comment setting for clickhouse queries.
+
+  These tags include information like plausible.site.id and http.route.
+
+  The tags will be exposed in system.query_log table log_comment column and can be used
+  for query performance analysis.
+
+  The tags are indirectly fetched from OpenTelemetry traces to avoid duplicating data.
+  """
+  @impl true
+  def prepare_query(_operation, query, opts) do
+    setting = {:log_comment, Jason.encode!(current_trace_attributes())}
+
+    opts = Keyword.update(opts, :settings, [setting], fn settings -> [setting | settings] end)
+
+    {query, opts}
+  end
+
+  defp current_trace_attributes() do
+    try do
+      :ets.tab2list(:otel_span_table)
+      |> Enum.at(0)
+      |> elem(9)
+      |> elem(4)
+    rescue
+      _ -> %{}
+    end
+  end
 end


### PR DESCRIPTION
These tags include information like plausible.site.id and http.route.

The tags will be exposed in system.query_log table log_comment column and can be used for query performance analysis.

The tags are indirectly fetched from OpenTelemetry traces to avoid duplicating data. The fetching mechanism is clunky and the best I could figure out for now - help appreciated.

Example of using this data:
```
SELECT
    event_time,
    query,
    log_comment,
    JSONExtractString(log_comment, 'http.route')
FROM system.query_log
WHERE (type = 1) AND (query LIKE '%sessions_v2%') AND (query NOT LIKE '%query_log%')
ORDER BY event_time DESC
LIMIT 5

Query id: 8bd3b8dd-2898-4399-9f0d-5ff2eb5a2585

Row 1:
──────
event_time:                                   2024-01-17 12:21:14
query:                                        SELECT toDate(toTimeZone(s0.timestamp, _CAST('UTC', 'String'))), toUInt32(ifNotFinite(round(sum(duration * sign) / sum(sign)), 0)), toUInt32(sum(sign)) FROM sessions_v2 AS s0 SAMPLE 20000000 WHERE (s0.site_id = _CAST(1, 'Int64')) AND ((s0.start >= _CAST(1702771200, 'DateTime')) AND (s0.start < _CAST(1705449600, 'DateTime'))) GROUP BY toDate(toTimeZone(s0.timestamp, _CAST('UTC', 'String'))) ORDER BY toDate(toTimeZone(s0.timestamp, _CAST('UTC', 'String'))) ASC
log_comment:                                  {"http.client_ip":"127.0.0.1","http.flavor":"1.1","http.method":"GET","http.scheme":"http","http.target":"/api/stats/dummy.site/main-graph","http.user_agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","net.host.name":"localhost","net.host.port":8000,"net.peer.port":46892,"net.sock.host.addr":"127.0.0.1","net.sock.peer.addr":"127.0.0.1","net.transport":"IP.TCP","http.route":"/api/stats/:domain/main-graph","phoenix.action":"main_graph","phoenix.plug":"Elixir.PlausibleWeb.Api.StatsController","plausible.site.domain":"dummy.site","plausible.site.id":1,"plausible.user.id":1}
JSONExtractString(log_comment, 'http.route'): /api/stats/:domain/main-graph
```