### PR TITLE
Update clickhouse docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ server: ## Start the web server
 CH_FLAGS ?= --detach -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --name plausible_clickhouse
 
 clickhouse: ## Start a container with a recent version of clickhouse
-	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:22.9-alpine
+	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:latest-alpine
 
 clickhouse-prod: ## Start a container with the same version of clickhouse as the one in prod
 	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol_prod:/var/lib/clickhouse clickhouse/clickhouse-server:23.3.7.5-alpine


### PR DESCRIPTION
### Changes

Updated clickhouse docker image to `clickhouse/clickhouse-server:latest-alpine`. This fixes issue: https://github.com/plausible/analytics/issues/3694

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
