### PR TITLE
Add ReleaseRuntimeProvider for exs config at runtime

### DIFF
--- a/lib/plausible/config/release_runtime_provider.ex
+++ b/lib/plausible/config/release_runtime_provider.ex
@@ -1,0 +1,40 @@
+defmodule Plausible.Config.ReleaseRuntimeProvider do
+  @moduledoc false
+  @behaviour Config.Provider
+
+  @impl Config.Provider
+  def init(opts), do: opts
+
+  @impl Config.Provider
+  def load(config, opts) do
+    config_path =
+      opts[:config_path] || System.get_env("PLAUSIBLE_CONFIG_PATH") ||
+        "/etc/plausible/config.exs"
+
+    with_runtime_config =
+      if File.exists?(config_path) do
+        runtime_config = Config.Reader.read!(config_path)
+
+        config
+        |> Config.Reader.merge(
+          plausible: [
+            config_path: config_path
+          ]
+        )
+        |> Config.Reader.merge(runtime_config)
+      else
+        # enable to warn should the runtime.exs environment config should get deprecated
+        # warning = [
+        #   IO.ANSI.red(),
+        #   IO.ANSI.bright(),
+        #   "!!! Config path is not declared! Please ensure it exists and that PLAUSIBLE_CONFIG_PATH is unset or points to an existing file",
+        #   IO.ANSI.reset()
+        # ]
+
+        # IO.puts(warning)
+        config
+      end
+
+    with_runtime_config
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Plausible.MixProject do
         plausible: [
           include_executables_for: [:unix],
           applications: [plausible: :permanent],
+          config_providers: [{Plausible.Config.ReleaseRuntimeProvider, []}],
           steps: [:assemble, :tar]
         ]
       ],


### PR DESCRIPTION
### Changes

This lets the user define elixir code as config.

I plane to use this in my approach for OIDC as with this the config can easily define functions to apply roles base on claims in the token.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change
At this time the config is just an extra way to configure, so the user does not yet have to be aware of it.

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
