### PR TITLE
Remove ARRAY JOINs

### DIFF
--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -1,6 +1,8 @@
 defmodule Plausible.Stats.Base do
   use Plausible.ClickhouseRepo
   use Plausible
+  use Plausible.Stats.Fragments
+
   alias Plausible.Stats.{Query, Filters}
   alias Plausible.Timezones
   import Ecto.Query
@@ -114,14 +116,12 @@ defmodule Plausible.Stats.Base do
           if value == "(none)" do
             from(
               e in q,
-              where: fragment("not has(?, ?)", field(e, :"meta.key"), ^prop_name)
+              where: not has_key(e, :meta, ^prop_name)
             )
           else
             from(
               e in q,
-              where:
-                fragment("has(meta.key, ? > 0", ^prop_name) and
-                  fragment("meta.value[indexOf(meta.key, ?)] = ?", ^prop_name, ^value)
+              where: has_key(e, :meta, ^prop_name) and get_by_key(e, :meta, ^prop_name) == ^value
             )
           end
 
@@ -129,15 +129,13 @@ defmodule Plausible.Stats.Base do
           if value == "(none)" do
             from(
               e in q,
-              where: fragment("has(?, ?)", field(e, :"meta.key"), ^prop_name)
+              where: has_key(e, :meta, ^prop_name)
             )
           else
             from(
               e in q,
               where:
-                (fragment("has(meta.key, ? > 0", ^prop_name) and
-                   fragment("meta.value[indexOf(meta.key, ?)] = ?", ^prop_name, ^value)) or
-                  fragment("not has(?, ?)", field(e, :"meta.key"), ^prop_name)
+                not has_key(e, :meta, ^prop_name) or get_by_key(e, :meta, ^prop_name) != ^value
             )
           end
 
@@ -147,8 +145,8 @@ defmodule Plausible.Stats.Base do
           from(
             e in q,
             where:
-              fragment("has(meta.key, ? > 0", ^prop_name) and
-                fragment("match(meta.value[indexOf(meta.key, ?)], ?)", ^prop_name, ^regex)
+              has_key(e, :meta, ^prop_name) and
+                fragment("match(?, ?)", get_by_key(e, :meta, ^prop_name), ^regex)
           )
 
         {"event:props:" <> prop_name, {:member, values}} ->
@@ -157,10 +155,8 @@ defmodule Plausible.Stats.Base do
           from(
             e in q,
             where:
-              (fragment("has(meta.key, ? > 0", ^prop_name) and
-                 fragment("meta.value[indexOf(meta.key, ?)]", ^prop_name) in ^values) or
-                (^none_value_included and
-                   fragment("not has(?, ?)", field(e, :"meta.key"), ^prop_name))
+              (has_key(e, :meta, ^prop_name) and get_by_key(e, :meta, ^prop_name) in ^values) or
+                (^none_value_included and not has_key(e, :meta, ^prop_name))
           )
 
         {"event:props:" <> prop_name, {:not_member, values}} ->
@@ -168,17 +164,13 @@ defmodule Plausible.Stats.Base do
 
           from(
             e in q,
-            # left_array_join: meta in "meta",
-            # as: :meta,
-            # (meta.key == ^prop_name and meta.value not in ^values) or
             where:
-              (fragment("has(meta.key, ? > 0", ^prop_name) and
-                 fragment("meta.value[indexOf(meta.key, ?)]", ^prop_name) not in ^values and
-                 (^none_value_included and
-                    fragment("has(?, ?)", field(e, :"meta.key"), ^prop_name) and
-                    fragment("meta.value[indexOf(meta.key, ?)]", ^prop_name) not in ^values)) or
-                (not (^none_value_included) and
-                   fragment("not has(?, ?)", field(e, :"meta.key"), ^prop_name))
+              (has_key(e, :meta, ^prop_name) and
+                 get_by_key(e, :meta, ^prop_name) not in ^values) or
+                (^none_value_included and
+                   has_key(e, :meta, ^prop_name) and
+                   get_by_key(e, :meta, ^prop_name) not in ^values) or
+                (not (^none_value_included) and not has_key(e, :meta, ^prop_name))
           )
 
         _ ->
@@ -241,34 +233,31 @@ defmodule Plausible.Stats.Base do
   def apply_entry_prop_filter(sessions_q, prop_name, {:is, "(none)"}) do
     from(
       s in sessions_q,
-      where: fragment("not has(?, ?)", field(s, :"entry_meta.key"), ^prop_name)
+      where: not has_key(s, :entry_meta, ^prop_name)
     )
   end
 
   def apply_entry_prop_filter(sessions_q, prop_name, {:is, value}) do
     from(
       s in sessions_q,
-      array_join: meta in "entry_meta",
-      as: :meta,
-      where: meta.key == ^prop_name and meta.value == ^value
+      where:
+        has_key(s, :entry_meta, ^prop_name) and get_by_key(s, :entry_meta, ^prop_name) == ^value
     )
   end
 
   def apply_entry_prop_filter(sessions_q, prop_name, {:is_not, "(none)"}) do
     from(
       s in sessions_q,
-      where: fragment("has(?, ?)", field(s, :"entry_meta.key"), ^prop_name)
+      where: has_key(s, :entry_meta, ^prop_name)
     )
   end
 
   def apply_entry_prop_filter(sessions_q, prop_name, {:is_not, value}) do
     from(
       s in sessions_q,
-      left_array_join: meta in "entry_meta",
-      as: :meta,
       where:
-        (meta.key == ^prop_name and meta.value != ^value) or
-          fragment("not has(?, ?)", field(s, :"entry_meta.key"), ^prop_name)
+        not has_key(s, :entry_meta, ^prop_name) or
+          get_by_key(s, :entry_meta, ^prop_name) != ^value
     )
   end
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -1,6 +1,8 @@
 defmodule Plausible.Stats.Breakdown do
   use Plausible.ClickhouseRepo
   use Plausible
+  use Plausible.Stats.Fragments
+
   import Plausible.Stats.{Base, Imported, Util}
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.Query
@@ -401,11 +403,10 @@ defmodule Plausible.Stats.Breakdown do
        ) do
     from(
       e in q,
-      where: fragment("has(`meta.key`, ?)", ^prop),
-      select_merge: %{^prop => fragment("`meta.value`[indexOf(`meta.key`, ?)]", ^prop)},
-      group_by: fragment("`meta.value`[indexOf(`meta.key`, ?)]", ^prop),
-      # :TODO: Correct ordering {:asc, `meta.value`}
-      order_by: {:asc, fragment("`meta.value`[indexOf(`meta.key`, ?)]", ^prop)}
+      where: has_key(e, :meta, ^prop),
+      select_merge: %{^prop => get_by_key(e, :meta, ^prop)},
+      group_by: get_by_key(e, :meta, ^prop),
+      order_by: {:asc, get_by_key(e, :meta, ^prop)}
     )
   end
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -538,16 +538,12 @@ defmodule Plausible.Stats.Clickhouse do
       if val == "(none)" do
         from(
           e in q,
-          where: fragment("not has(meta.key, ?)", ^key)
+          where: not has_key(e, :meta, ^key)
         )
       else
         from(
           e in q,
-          where:
-            fragment("indexOf(meta.key, ?) > 0", ^key) and
-              fragment("meta.value[indexOf(meta.key, ?)] = ?", ^key, ^val)
-          # array_join: meta in fragment("meta"),
-          # where: meta.key == ^key and meta.value == ^val
+          where: has_key(e, :meta, ^key) and get_by_key(e, :meta, ^key) == ^val
         )
       end
     else

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -543,8 +543,11 @@ defmodule Plausible.Stats.Clickhouse do
       else
         from(
           e in q,
-          array_join: meta in fragment("meta"),
-          where: meta.key == ^key and meta.value == ^val
+          where:
+            fragment("indexOf(meta.key, ?) > 0", ^key) and
+              fragment("meta.value[indexOf(meta.key, ?)] = ?", ^key, ^val)
+          # array_join: meta in fragment("meta"),
+          # where: meta.key == ^key and meta.value == ^val
         )
       end
     else

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -1,6 +1,7 @@
 defmodule Plausible.Stats.FilterSuggestions do
   use Plausible.Repo
   use Plausible.ClickhouseRepo
+  use Plausible.Stats.Fragments
   import Plausible.Stats.Base
   alias Plausible.Stats.Query
 
@@ -155,21 +156,21 @@ defmodule Plausible.Stats.FilterSuggestions do
     none_q =
       from(e in base_event_query(site, Query.remove_event_filters(query, [:props])),
         select: "(none)",
-        where: fragment("not has(?, ?)", field(e, :"meta.key"), ^key),
+        where: not has_key(e, :meta, ^key),
         limit: 1
       )
 
     search_q =
       from(e in base_event_query(site, query),
-        select: fragment("meta.value[indexOf(meta.key, ?)]", ^key),
+        select: get_by_key(e, :meta, ^key),
         where:
-          fragment("has(meta.key, ?)", ^key) and
+          has_key(e, :meta, ^key) and
             fragment(
               "? ilike ?",
-              fragment("meta.value[indexOf(meta.key, ?)]", ^key),
+              get_by_key(e, :meta, ^key),
               ^filter_query
             ),
-        group_by: fragment("meta.value[indexOf(meta.key, ?)]", ^key),
+        group_by: get_by_key(e, :meta, ^key),
         order_by: [desc: fragment("count(*)")],
         limit: 25
       )

--- a/lib/plausible/stats/fragments.ex
+++ b/lib/plausible/stats/fragments.ex
@@ -97,6 +97,46 @@ defmodule Plausible.Stats.Fragments do
     end
   end
 
+  @doc """
+  Returns whether a key (usually property) exists under `meta.key` array or similar.
+
+  This macro is used for operating on custom properties.
+
+  ## Examples
+
+  `has_key(e, :meta, "some_property_name")` expands to SQL `has(meta.key, "some_property_name")`
+  """
+  defmacro has_key(table, meta_column, key) do
+    quote do
+      fragment(
+        "has(?, ?)",
+        field(unquote(table), unquote(String.to_atom("#{meta_column}.key"))),
+        unquote(key)
+      )
+    end
+  end
+
+  @doc """
+  Returns value of a key (usually property) under `meta.value` array or similar.
+
+  This macro is used for operating on custom properties.
+  Callsites should also check whether key exists first in SQL via `has_key` macro.
+
+  ## Examples
+
+  `get_by_key(e, :meta, "some_property_name")` expands to SQL `meta.value[indexOf(meta.key, "some_property")]`
+  """
+  defmacro get_by_key(table, meta_column, key) do
+    quote do
+      fragment(
+        "?[indexOf(?, ?)]",
+        field(unquote(table), unquote(String.to_atom("#{meta_column}.value"))),
+        field(unquote(table), unquote(String.to_atom("#{meta_column}.key"))),
+        unquote(key)
+      )
+    end
+  end
+
   defmacro __using__(_) do
     quote do
       import Plausible.Stats.Fragments

--- a/lib/plausible/stats/fragments.ex
+++ b/lib/plausible/stats/fragments.ex
@@ -110,7 +110,7 @@ defmodule Plausible.Stats.Fragments do
     quote do
       fragment(
         "has(?, ?)",
-        field(unquote(table), unquote(String.to_atom("#{meta_column}.key"))),
+        field(unquote(table), unquote(meta_key_column(meta_column))),
         unquote(key)
       )
     end
@@ -130,12 +130,18 @@ defmodule Plausible.Stats.Fragments do
     quote do
       fragment(
         "?[indexOf(?, ?)]",
-        field(unquote(table), unquote(String.to_atom("#{meta_column}.value"))),
-        field(unquote(table), unquote(String.to_atom("#{meta_column}.key"))),
+        field(unquote(table), unquote(meta_value_column(meta_column))),
+        field(unquote(table), unquote(meta_key_column(meta_column))),
         unquote(key)
       )
     end
   end
+
+  defp meta_key_column(:meta), do: :"meta.key"
+  defp meta_key_column(:entry_meta), do: :"entry_meta.key"
+
+  defp meta_value_column(:meta), do: :"meta.value"
+  defp meta_value_column(:entry_meta), do: :"entry_meta.value"
 
   defmacro __using__(_) do
     quote do


### PR DESCRIPTION
### Changes

This PR refactors the backend code to use `meta.value[indexOf(meta.key, 'custom_property')]` over array joins. Doing so has a few benefits:

1. It allows us to more easily add support for multiple custom property filters.
2. Performance - tests showed ~20% performance benefit for some production queries (see [basecamp](https://3.basecamp.com/5308029/buckets/35611491/card_tables/cards/6946026076) for an example)

Note that ARRAY JOINs were retained in places where it still makes sense - e.g. `Plausible.Stats.CustomProps#fetch_prop_names`.

Based on top of https://github.com/plausible/analytics/pull/3687 as that introduced new LEFT JOINs.
