### PR TITLE
Trace aggregate and timeseries queries too

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -24,6 +24,8 @@ defmodule Plausible.Stats.Aggregate do
         {nil, metrics}
       end
 
+    Query.trace(query, metrics)
+
     event_metrics = Enum.filter(metrics, &(&1 in @event_metrics))
     event_task = fn -> aggregate_events(site, query, event_metrics) end
     session_metrics = Enum.filter(metrics, &(&1 in @session_metrics))

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -684,13 +684,10 @@ defmodule Plausible.Stats.Breakdown do
   end
 
   defp trace(query, property, metrics) do
-    Query.trace(query)
-
-    metrics = Enum.sort(metrics) |> Enum.join(";")
+    Query.trace(query, metrics)
 
     Tracer.set_attributes([
-      {"plausible.query.breakdown_property", property},
-      {"plausible.query.breakdown_metrics", metrics}
+      {"plausible.query.breakdown_property", property}
     ])
   end
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -250,15 +250,17 @@ defmodule Plausible.Stats.Query do
     end
   end
 
-  @spec trace(%__MODULE__{}) :: %__MODULE__{}
-  def trace(%__MODULE__{} = query) do
+  @spec trace(%__MODULE__{}, [atom()]) :: %__MODULE__{}
+  def trace(%__MODULE__{} = query, metrics) do
     filter_keys = Map.keys(query.filters) |> Enum.sort() |> Enum.join(";")
+    metrics = metrics |> Enum.sort() |> Enum.join(";")
 
     Tracer.set_attributes([
       {"plausible.query.interval", query.interval},
       {"plausible.query.period", query.period},
       {"plausible.query.include_imported", query.include_imported},
-      {"plausible.query.filter_keys", filter_keys}
+      {"plausible.query.filter_keys", filter_keys},
+      {"plausible.query.metrics", metrics}
     ])
 
     query

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -33,6 +33,8 @@ defmodule Plausible.Stats.Timeseries do
         {nil, event_metrics}
       end
 
+    Query.trace(query, metrics)
+
     [event_result, session_result] =
       Plausible.ClickhouseRepo.parallel_tasks([
         fn -> events_timeseries(site, query, event_metrics) end,


### PR DESCRIPTION
### Changes

This is a continuation of [query tracing improvements](https://github.com/plausible/analytics/pull/3704) which might as well have been included in the last PR 🤡.

We'll also want to track how the filters are used in `aggregate` and `timeseries` functions - not only `breakdown`. This PR implements that, and not only filters but the entire query.

Also, we're currently tracing the `breakdown_metrics` field. This PR changes the name of that field to just `metrics`. It doesn't make sense to have a separation between `breakdown_metrics` and every other metric - we already know by `http.route` whether the endpoint returns a breakdown or not. And the same `metrics` field will also be tracked in `aggregate` and `timeseries`.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
