### PR TITLE
CombBox bugfix: stale spinner on creatable options selection

### DIFF
--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -243,7 +243,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
     >
       <a
         x-ref={"dropdown-#{@ref}-option-#{@idx}"}
-        x-on:click="selectionInProgress = true"
+        x-on:click={not @creatable && "selectionInProgress = true"}
         phx-click={select_option(@ref, @submit_value, @display_value)}
         phx-value-submit-value={@submit_value}
         phx-value-display-value={@display_value}

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -274,6 +274,20 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
                "input[type=hidden][name=some_submit_name][value=\"my new option\"]"
              )
     end
+
+    test "selectionInProgress doesn't apply when no server roundtrip is needed", %{conn: conn} do
+      {:ok, lv, html} = live_isolated(conn, CreatableView, session: %{})
+      regular_option = find(html, "li#dropdown-test-creatable-component-option-1 a")
+
+      assert Floki.attribute(regular_option, "x-on:click") == ["selectionInProgress = true"]
+
+      creatable_option =
+        lv
+        |> type_into_combo("test-creatable-component", "my new option")
+        |> find("input[type=hidden][name=some_submit_name][value=\"my new option\"]")
+
+      assert Floki.attribute(creatable_option, "x-on:click") == []
+    end
   end
 
   describe "async suggestions" do


### PR DESCRIPTION
### Changes

This PR fixes a bug where a `creatable` option selection makes the spinner stuck in the combobox input. Instead, in such cases no spinner should be shown, since there is no server roundtrip the user has to wait for.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
