### PR TITLE
Store referrers from android apps

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -381,9 +381,7 @@ defmodule Plausible.Ingestion.Event do
     uri = URI.parse(ref.referer)
 
     if PlausibleWeb.RefInspector.right_uri?(uri) do
-      host = String.replace_prefix(uri.host, "www.", "")
-      path = uri.path || ""
-      host <> String.trim_trailing(path, "/")
+      PlausibleWeb.RefInspector.format_referrer(uri)
     end
   end
 

--- a/lib/plausible_web/refinspector.ex
+++ b/lib/plausible_web/refinspector.ex
@@ -7,12 +7,17 @@ defmodule PlausibleWeb.RefInspector do
         uri = URI.parse(String.trim(ref.referer))
 
         if right_uri?(uri) do
-          String.replace_leading(uri.host, "www.", "")
+          format_referrer_host(uri)
         end
 
       source ->
         source
     end
+  end
+
+  def format_referrer(uri) do
+    path = String.trim_trailing(uri.path || "", "/")
+    format_referrer_host(uri) <> path
   end
 
   def right_uri?(%URI{host: nil}), do: false
@@ -22,4 +27,11 @@ defmodule PlausibleWeb.RefInspector do
       do: true
 
   def right_uri?(_), do: false
+
+  defp format_referrer_host(uri) do
+    protocol = if uri.scheme == "android-app", do: "android-app://", else: ""
+    host = String.replace_prefix(uri.host, "www.", "")
+
+    protocol <> host
+  end
 end

--- a/lib/plausible_web/refinspector.ex
+++ b/lib/plausible_web/refinspector.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.RefInspector do
   def right_uri?(%URI{host: nil}), do: false
 
   def right_uri?(%URI{host: host, scheme: scheme})
-      when scheme in ["http", "https"] and byte_size(host) > 0,
+      when scheme in ["http", "https", "android-app"] and byte_size(host) > 0,
       do: true
 
   def right_uri?(_), do: false

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -444,6 +444,26 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert session.referrer_source == "indiehackers.com"
     end
 
+    test "if the referrer is not http, https, or android it is ignored", %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://example.com/",
+        referrer: "ftp://wat",
+        domain: site.domain
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      pageview = get_event(site)
+
+      assert response(conn, 202) == "ok"
+      assert pageview.referrer_source == ""
+      assert pageview.referrer == ""
+    end
+
     test "stores referrer from android app", %{conn: conn, site: site} do
       params = %{
         name: "pageview",

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -480,7 +480,8 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.referrer_source == "some.android.app"
+      assert session.referrer == "android-app://some.android.app"
+      assert session.referrer_source == "android-app://some.android.app"
     end
 
     test "screen size is calculated from user agent", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -444,11 +444,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert session.referrer_source == "indiehackers.com"
     end
 
-    test "if the referrer is not http or https, it is ignored", %{conn: conn, site: site} do
+    test "stores referrer from android app", %{conn: conn, site: site} do
       params = %{
         name: "pageview",
         url: "http://example.com/",
-        referrer: "android-app://random",
+        referrer: "android-app://some.android.app",
         domain: site.domain
       }
 
@@ -460,7 +460,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.referrer_source == ""
+      assert session.referrer_source == "some.android.app"
     end
 
     test "screen size is calculated from user agent", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Overall task is figuring out if we can separate the Google Discover referral source from Google (the search engine). Some sources say that the referrer `android-app://com.google.android.googlequicksearchbox` is Google Discover but other sources say different things. I want to check our actual data to see which bloggers are most correct.

We currently only store referral sources with `http` and `https` protocol in the URI. With this change we'll also be storing referrers with `android-app://` protocol. This will allow me to correlate this referrer data with proprietary numbers from Google Search Console to see if the number of visitors is similar.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
