### PR TITLE
Work around add_percentages errors due to race condition

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1328,10 +1328,16 @@ defmodule PlausibleWeb.Api.StatsController do
        when not is_map_key(query.filters, "event:goal") do
     %{visitors: %{value: total_visitors}} = Stats.aggregate(site, query, [:visitors])
 
-    breakdown_result
-    |> Enum.map(fn stat ->
-      Map.put(stat, :percentage, Float.round(stat.visitors / total_visitors * 100, 1))
-    end)
+    # :HACK: With realtime graphs, total_visitors might report as 0 while there are stats
+    #   As division by 0 would result in errors, just don't include percentages
+    if total_visitors == 0 do
+      breakdown_result
+    else
+      breakdown_result
+      |> Enum.map(fn stat ->
+        Map.put(stat, :percentage, Float.round(stat.visitors / total_visitors * 100, 1))
+      end)
+    end
   end
 
   defp add_percentages(breakdown_result, _, _), do: breakdown_result


### PR DESCRIPTION
Basecamp issue: https://3.basecamp.com/5308029/buckets/35611491/card_tables/cards/6964655047

We occasionally seem to get divided-by-zero errors with add_percentages function. As this seems to mainly happen with low-traffic sites on realtime graphs, I believe it's caused by a race condition where `total_visitors` (which is calculated later) returns 0 but the previous calculations returned results.

Not fully confident in this.