### PR TITLE
Add multiple imports per site

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -524,8 +524,6 @@ base_queues = [
   check_stats_emails: 1,
   site_setup_emails: 1,
   clean_invitations: 1,
-  # NOTE: to be removed once #3700 is released
-  google_analytics_imports: 1,
   analytics_imports: 1,
   domain_change_transition: 1,
   check_accept_traffic_until: 1

--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -22,17 +22,14 @@ defmodule ObanErrorReporter do
     Sentry.capture_exception(meta.reason, stacktrace: meta.stacktrace, extra: extra)
   end
 
-  # NOTE: To be cleaned up once #3700 is released
-  @analytics_queues ["analytics_imports", "google_analytics_imports"]
-
   defp on_job_exception(%Oban.Job{
-         queue: queue,
+         queue: "analytics_imports",
          args: %{"site_id" => site_id, "source" => source},
          state: "executing",
          attempt: attempt,
          max_attempts: max_attempts
        })
-       when queue in @analytics_queues and attempt >= max_attempts do
+       when attempt >= max_attempts do
     site = Plausible.Repo.get(Plausible.Site, site_id)
 
     if site do
@@ -41,11 +38,10 @@ defmodule ObanErrorReporter do
   end
 
   defp on_job_exception(%Oban.Job{
-         queue: queue,
+         queue: "analytics_imports",
          args: %{"site_id" => site_id},
          state: "executing"
-       })
-       when queue in @analytics_queues do
+       }) do
     site = Plausible.Repo.get(Plausible.Site, site_id)
     Plausible.Purge.delete_imported_stats!(site)
   end

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -17,7 +17,7 @@ defmodule Plausible.Imported do
   @spec tables() :: [String.t()]
   def tables, do: @tables
 
- def list_all_imports(site) do
+  def list_all_imports(site) do
     SiteImport
     |> where(site_id: ^site.id)
     |> Repo.all()

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Imported do
 
   * `Plausible.Imported.UniversalAnalytics` - existing mechanism, for legacy Google
     analytics formerly known as "Google Analytics"
-  * `Plausible.Imported.NoopImporter` - importer stub, used mainly for testing pruposes
+  * `Plausible.Imported.NoopImporter` - importer stub, used mainly for testing purposes
   * `Plausible.Imported.CSVImporter` - a placeholder stub for CSV importer that will
     be added soon
 

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -1,6 +1,16 @@
 defmodule Plausible.Imported do
   @moduledoc """
   Context for managing site statistics imports.
+
+  Currently following importers are implemented:
+
+  * `Plausible.Imported.UniversalAnalytics` - existing mechanism, for legacy Google
+    analytics formerly known as "Google Analytics"
+  * `Plausible.Imported.NoopImporter` - importer stub, used mainly for testing pruposes
+  * `Plausible.Imported.CSVImporter` - a placeholder stub for CSV importer that will
+    be added soon
+
+  For more information on implementing importers, see `Plausible.Imported.Importer`.
   """
 
   import Ecto.Query

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -70,17 +70,9 @@ defmodule Plausible.Imported do
       )
       |> Repo.one()
 
-    # fall back to imported_data for legacy support
-    cond do
-      first_import ->
-        first_import
-
-      site.imported_data && site.imported_data.status == "ok" ->
-        site.imported_data
-
-      true ->
-        nil
-    end
+    [site.imported_data, first_import]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.min_by(& &1.start_date, Date, fn -> nil end)
   end
 
   @spec delete_imports_for_site(Site.t()) :: :ok

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -28,4 +28,8 @@ defmodule Plausible.Imported do
     |> where(site_id: ^site.id, status: :completed)
     |> Repo.all()
   end
+
+  def delete_imports_for_site(site) do
+    Repo.delete_all(from i in SiteImport, where: i.site_id == ^site.id)
+  end
 end

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -5,23 +5,35 @@ defmodule Plausible.Imported do
 
   import Ecto.Query
 
+  alias Plausible.Imported
   alias Plausible.Imported.SiteImport
   alias Plausible.Repo
+  alias Plausible.Site
 
-  @tables ~w(
-    imported_visitors imported_sources imported_pages imported_entry_pages
-    imported_exit_pages imported_locations imported_devices imported_browsers
-    imported_operating_systems
-  )
+  @tables [
+    Imported.Visitor,
+    Imported.Source,
+    Imported.Page,
+    Imported.EntryPage,
+    Imported.ExitPage,
+    Imported.Location,
+    Imported.Device,
+    Imported.Browser,
+    Imported.OperatingSystem
+  ]
+
+  @table_names Enum.map(@tables, & &1.__schema__(:source))
 
   @spec tables() :: [String.t()]
-  def tables, do: @tables
+  def tables, do: @table_names
 
+  @spec list_all_imports(Site.t()) :: [SiteImport.t()]
   def list_all_imports(site) do
     from(i in SiteImport, where: i.site_id == ^site.id)
     |> Repo.all()
   end
 
+  @spec list_complete_import_ids(Site.t()) :: [non_neg_integer()]
   def list_complete_import_ids(site) do
     ids =
       from(i in SiteImport,
@@ -38,6 +50,7 @@ defmodule Plausible.Imported do
     end
   end
 
+  @spec get_earliest_import(Site.t()) :: SiteImport.t() | nil
   def get_earliest_import(site) do
     first_import =
       from(i in SiteImport,
@@ -60,7 +73,10 @@ defmodule Plausible.Imported do
     end
   end
 
+  @spec delete_imports_for_site(Site.t()) :: :ok
   def delete_imports_for_site(site) do
     Repo.delete_all(from i in SiteImport, where: i.site_id == ^site.id)
+
+    :ok
   end
 end

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -22,11 +22,6 @@ defmodule Plausible.Imported do
     |> Repo.all()
   end
 
-  def list_complete_imports(site) do
-    from(i in SiteImport, where: i.site_id == ^site.id and i.status == ^:completed)
-    |> Repo.all()
-  end
-
   def list_complete_import_ids(site) do
     ids =
       from(i in SiteImport,

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -1,9 +1,14 @@
 defmodule Plausible.Imported do
+  @moduledoc """
+  Context for managing site statistics imports.
+  """
+
   @tables ~w(
     imported_visitors imported_sources imported_pages imported_entry_pages
     imported_exit_pages imported_locations imported_devices imported_browsers
     imported_operating_systems
   )
+
   @spec tables() :: [String.t()]
   def tables, do: @tables
 

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -3,6 +3,11 @@ defmodule Plausible.Imported do
   Context for managing site statistics imports.
   """
 
+  import Ecto.Query
+
+  alias Plausible.Imported.SiteImport
+  alias Plausible.Repo
+
   @tables ~w(
     imported_visitors imported_sources imported_pages imported_entry_pages
     imported_exit_pages imported_locations imported_devices imported_browsers
@@ -12,7 +17,15 @@ defmodule Plausible.Imported do
   @spec tables() :: [String.t()]
   def tables, do: @tables
 
-  def forget(site) do
-    Plausible.Purge.delete_imported_stats!(site)
+ def list_all_imports(site) do
+    SiteImport
+    |> where(site_id: ^site.id)
+    |> Repo.all()
+  end
+
+  def list_imports(site) do
+    SiteImport
+    |> where(site_id: ^site.id, status: :completed)
+    |> Repo.all()
   end
 end

--- a/lib/plausible/imported/browser.ex
+++ b/lib/plausible/imported/browser.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Browser do
   @primary_key false
   schema "imported_browsers" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :browser, :string
     field :visitors, Ch, type: "UInt64"

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -11,6 +11,10 @@ defmodule Plausible.Imported.CSVImporter do
   @impl true
   def label(), do: "CSV"
 
+  # NOTE: change it once CSV import is implemented
+  @impl true
+  def email_template(), do: "google_analytics_import.html"
+
   @impl true
   def parse_args(%{"s3_path" => s3_path}), do: [s3_path: s3_path]
 

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -1,0 +1,24 @@
+defmodule Plausible.Imported.CSVImporter do
+  @moduledoc """
+  CSV importer stub.
+  """
+  @name "CSV"
+
+  def name(), do: @name
+
+  def create_job(site, opts) do
+    s3_path = Keyword.fetch!(opts, :s3_path)
+
+    Plausible.Workers.ImportAnalytics.new(%{
+      "source" => @name,
+      "site_id" => site.id,
+      "s3_path" => s3_path
+    })
+  end
+
+  def parse_args(%{"s3_path" => s3_path}), do: [s3_path: s3_path]
+
+  def import(_site, _opts) do
+    :ok
+  end
+end

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -2,23 +2,19 @@ defmodule Plausible.Imported.CSVImporter do
   @moduledoc """
   CSV importer stub.
   """
+
+  use Plausible.Imported.Importer
+
   @name "CSV"
 
+  @impl true
   def name(), do: @name
 
-  def create_job(site, opts) do
-    s3_path = Keyword.fetch!(opts, :s3_path)
-
-    Plausible.Workers.ImportAnalytics.new(%{
-      "source" => @name,
-      "site_id" => site.id,
-      "s3_path" => s3_path
-    })
-  end
-
+  @impl true
   def parse_args(%{"s3_path" => s3_path}), do: [s3_path: s3_path]
 
-  def import(_site, _opts) do
+  @impl true
+  def import_data(_site, _opts) do
     :ok
   end
 end

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Imported.CSVImporter do
   def parse_args(%{"s3_path" => s3_path}), do: [s3_path: s3_path]
 
   @impl true
-  def import_data(_site, _opts) do
+  def import_data(_site_import, _opts) do
     :ok
   end
 end

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -5,10 +5,11 @@ defmodule Plausible.Imported.CSVImporter do
 
   use Plausible.Imported.Importer
 
-  @name "CSV"
+  @impl true
+  def name(), do: :csv
 
   @impl true
-  def name(), do: @name
+  def label(), do: "CSV"
 
   @impl true
   def parse_args(%{"s3_path" => s3_path}), do: [s3_path: s3_path]

--- a/lib/plausible/imported/device.ex
+++ b/lib/plausible/imported/device.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Device do
   @primary_key false
   schema "imported_devices" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :device, :string
     field :visitors, Ch, type: "UInt64"

--- a/lib/plausible/imported/entry_page.ex
+++ b/lib/plausible/imported/entry_page.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.EntryPage do
   @primary_key false
   schema "imported_entry_pages" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :entry_page, :string
     field :visitors, Ch, type: "UInt64"

--- a/lib/plausible/imported/exit_page.ex
+++ b/lib/plausible/imported/exit_page.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.ExitPage do
   @primary_key false
   schema "imported_exit_pages" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :exit_page, :string
     field :visitors, Ch, type: "UInt64"

--- a/lib/plausible/imported/import_sources.ex
+++ b/lib/plausible/imported/import_sources.ex
@@ -13,8 +13,10 @@ defmodule Plausible.Imported.ImportSources do
 
   @source_names Enum.map(@sources, & &1.name())
 
+  @spec names() :: [atom()]
   def names(), do: @source_names
 
+  @spec by_name(atom()) :: module()
   def by_name(name) do
     Map.fetch!(@sources_map, name)
   end

--- a/lib/plausible/imported/import_sources.ex
+++ b/lib/plausible/imported/import_sources.ex
@@ -5,7 +5,8 @@ defmodule Plausible.Imported.ImportSources do
 
   @sources [
     Plausible.Imported.UniversalAnalytics,
-    Plausible.Imported.NoopImporter
+    Plausible.Imported.NoopImporter,
+    Plausible.Imported.CSVImporter
   ]
 
   @sources_map Map.new(@sources, &{&1.name(), &1})

--- a/lib/plausible/imported/import_sources.ex
+++ b/lib/plausible/imported/import_sources.ex
@@ -11,6 +11,10 @@ defmodule Plausible.Imported.ImportSources do
 
   @sources_map Map.new(@sources, &{&1.name(), &1})
 
+  @source_names Enum.map(@sources, & &1.name())
+
+  def names(), do: @source_names
+
   def by_name(name) do
     Map.fetch!(@sources_map, name)
   end

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -71,7 +71,7 @@ defmodule Plausible.Imported.Importer do
 
   receive do
     {:notification, :analytics_imports_jobs, %{"complete" => ^import_id}} ->
-      IO.puts("Job compelete")
+      IO.puts("Job completed")
 
     {:notification, :analytics_imports_jobs, %{"transient_fail" => ^import_id}} ->
       IO.puts("Job failed transiently")

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -25,6 +25,9 @@ defmodule Plausible.Imported.Importer do
     by synchronous. The callback is expected to return either `:ok` or `{:ok, %{...}}`
     on successful import or `{:error, ...}` on failure. The map in success tuple is
     used for updating site import struct and is passed to `on_success/2` callback.
+    Please note that error tuple should be only returned on errors that can't be
+    recovered from. For transient errors, the import should throw an exception or
+    simply crash.
   * `before_start/1` - Optional callback run right before scheduling import job. It's
     expected to either return `:ok` for the import to proceed or `{:error, ...}` tuple,
     which will be returned from `new_import/3` call.

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -111,7 +111,7 @@ defmodule Plausible.Imported.Importer do
 
     import_opts = parse_args_fun.(args)
 
-    case import_fun.(site_import.site, import_opts) do
+    case import_fun.(site_import, import_opts) do
       :ok ->
         {:ok, mark_complete(site_import, %{}, on_success_fun)}
 

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -10,6 +10,9 @@ defmodule Plausible.Imported.Importer do
   * `name/0` - Returns import source name as an atom. Example: `:universal_analytics`.
   * `label/0` - Descriptive, display friendly name of the source.
     Example: "Google Analytics".
+  * `email_template/0` - Name of the email template to use for notifications in
+    `PlausibleWeb.Email` (`import_success` and `import_failure`). The template
+    should have content customized for a particular source.
   * `parse_args/1` - Receives Oban job arguments coming from `new_import/3`. Whatever
     options were passed to `new_import/3` will be present in the input map with string
     keys and values serialized to primitives. If, for instance `start_date: ~D[2024-01-03]`
@@ -52,6 +55,7 @@ defmodule Plausible.Imported.Importer do
 
   @callback name() :: atom()
   @callback label() :: String.t()
+  @callback email_template() :: String.t()
   @callback parse_args(map()) :: Keyword.t()
   @callback import_data(Plausible.Imported.SiteImport.t(), Keyword.t()) :: :ok | {:error, any()}
   @callback before_start(SiteImport.t()) :: :ok | {:ok, map()} | {:error, any()}

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -111,7 +111,7 @@ defmodule Plausible.Imported.Importer do
       end
 
       @doc false
-      @spec run_import(SiteImport.t(), Keyword.t()) :: :ok | {:error, :any}
+      @spec run_import(SiteImport.t(), map()) :: :ok | {:error, :any}
       def run_import(site_import, args) do
         Plausible.Imported.Importer.run_import(
           site_import,

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -11,6 +11,9 @@ defmodule Plausible.Imported.Importer do
   @callback name() :: String.t()
   @callback parse_args(map()) :: Keyword.t()
   @callback import_data(Plausible.Site.t(), Keyword.t()) :: :ok | {:error, any()}
+  @callback before_start(SiteImport.t()) :: :ok | {:error, any()}
+  @callback on_success(SiteImport.t()) :: :ok
+  @callback on_failure(SiteImport.t()) :: :ok
 
   defmacro __using__(_opts) do
     quote do
@@ -19,16 +22,46 @@ defmodule Plausible.Imported.Importer do
       @spec new_import(Plausible.Site.t(), Plausible.Auth.User.t(), Keyword.t()) ::
               {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
       def new_import(site, user, opts) do
-        Plausible.Imported.Importer.new_import(name(), site, user, opts)
+        Plausible.Imported.Importer.new_import(name(), site, user, opts, &before_start/1)
       end
 
-      def run_import(import_id, args) do
-        Plausible.Imported.Importer.run_import(import_id, args, &parse_args/1, &import_data/2)
+      @spec run_import(SiteImport.t(), Keyword.t()) :: :ok | {:error, :any}
+      def run_import(site_import, args) do
+        Plausible.Imported.Importer.run_import(
+          site_import,
+          args,
+          &parse_args/1,
+          &import_data/2,
+          &on_success/1
+        )
       end
+
+      @spec mark_failed(SiteImport.t()) :: SiteImport.t()
+      def mark_failed(site_import) do
+        site_import =
+          site_import
+          |> SiteImport.fail_changeset()
+          |> Repo.update!()
+
+        :ok = on_failure(site_import)
+
+        site_import
+      end
+
+      @impl true
+      def before_start(_site_import), do: :ok
+
+      @impl true
+      def on_success(_site_import), do: :ok
+
+      @impl true
+      def on_failure(_site_import), do: :ok
+
+      defoverridable before_start: 1, on_success: 1, on_failure: 1
     end
   end
 
-  def new_import(source, site, user, opts) do
+  def new_import(source, site, user, opts, before_start_fun) do
     import_params =
       opts
       |> Keyword.take([:start_date, :end_date])
@@ -43,6 +76,11 @@ defmodule Plausible.Imported.Importer do
 
       case result do
         {:ok, site_import} ->
+          case before_start_fun.(site_import) do
+            :ok -> :ok
+            {:error, error} -> Repo.rollback(error)
+          end
+
           job_params =
             opts
             |> Keyword.put(:import_id, site_import.id)
@@ -64,7 +102,7 @@ defmodule Plausible.Imported.Importer do
     end)
   end
 
-  def run_import(site_import, args, parse_args_fun, import_fun) do
+  def run_import(site_import, args, parse_args_fun, import_fun, on_success_fun) do
     site_import =
       site_import
       |> SiteImport.start_changeset()
@@ -75,23 +113,24 @@ defmodule Plausible.Imported.Importer do
 
     case import_fun.(site_import.site, import_opts) do
       :ok ->
-        site_import =
-          site_import
-          |> SiteImport.complete_changeset()
-          |> Repo.update!()
-
-        {:ok, site_import}
+        {:ok, mark_complete(site_import, %{}, on_success_fun)}
 
       {:ok, extra_data} ->
-        site_import =
-          site_import
-          |> SiteImport.complete_changeset(extra_data)
-          |> Repo.update!()
-
-        {:ok, site_import}
+        {:ok, mark_complete(site_import, extra_data, on_success_fun)}
 
       {:error, error} ->
         {:error, error}
     end
+  end
+
+  defp mark_complete(site_import, extra_data, on_success_fun) do
+    site_import =
+      site_import
+      |> SiteImport.complete_changeset(extra_data)
+      |> Repo.update!()
+
+    :ok = on_success_fun.(site_import)
+
+    site_import
   end
 end

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -1,8 +1,50 @@
 defmodule Plausible.Imported.Importer do
   @moduledoc """
-  Behaviour that should be implemented for each new import source.
+  Behaviour that should be implemented for each import source.
 
-  The new source should also be added to the list in `Plausible.Imported.ImportSources`.
+  All imports are executed as background jobs run via `Plausible.Workers.ImportAnalytics`
+  Oban worker. Each import source must define a module conforming `Importer` behaviour.
+
+  The callbacks that need to be implemented:
+
+  * `name/0` - Returns import source name as an atom. Example: `:universal_analytics`.
+  * `label/0` - Descriptive, display friendly name of the source.
+    Example: "Google Analytics".
+  * `parse_args/1` - Receives Oban job arguments coming from `new_import/3`. Whatever
+    options were passed to `new_import/3` will be present in the input map with string
+    keys and values serialized to primitives. If, for instance `start_date: ~D[2024-01-03]`
+    is passed as an option, `parse_args/1` receives `%{..., "start_date" => "2024-01-03"}`.
+    The expectation is parsing the map values producing a keyword list of options to
+    pass to `import_data/2`.
+  * `import_data/2` - Receives site import struct and options produced by `parse_args/1`.
+    This is where all the import processing is done. The way the import is implemented
+    is entirely arbitrary except the requirement that the process as a whole must
+    by synchronous. The callback is expected to return either `:ok` or `{:ok, %{...}}`
+    on successful import or `{:error, ...}` on failure. The map in success tuple is
+    used for updating site import struct and is passed to `on_success/2` callback.
+  * `before_start/1` - Optional callback run right before scheduling import job. It's
+    expected to either return `:ok` for the import to proceed or `{:error, ...}` tuple,
+    which will be returned from `new_import/3` call.
+  * `on_success/2` - Optional callback run once site import is completed. Receives map
+    returned from `import_data/2`. Expected to always return `:ok`.
+  * `on_failure/1` - Optional callback run when import job fails permanently.
+
+  All sources must be added to the list in `Plausible.Imported.ImportSources`.
+
+  In order to schedule a new import job using a given source, respective importer's
+  `new_import/3` function must be called. It accepts site, user who is doing the import
+  and any options necessary to carry out the import.
+
+  There's an expectation that `start_date` and `end_date` are provided either as options
+  passed to `new_import/3` or data in map returned from `import_data/2`. If these parameters
+  are not provided, the import will eventually crash. These parameters define time range
+  of imported data which is in turn used for efficient querying.
+
+  Logic running inside `import_data/2` is expected to populated all `imported_*` tables
+  in ClickHouse with `import_id` column set to site import's ID.
+
+  Managing any configuration or authentication prior to running import is outside of
+  scope of importer logic and is expected to be implemented separately.
   """
 
   alias Plausible.Imported.SiteImport
@@ -11,9 +53,9 @@ defmodule Plausible.Imported.Importer do
   @callback name() :: atom()
   @callback label() :: String.t()
   @callback parse_args(map()) :: Keyword.t()
-  @callback import_data(Plausible.Site.t(), Keyword.t()) :: :ok | {:error, any()}
-  @callback before_start(SiteImport.t()) :: :ok | {:error, any()}
-  @callback on_success(SiteImport.t()) :: :ok
+  @callback import_data(Plausible.Imported.SiteImport.t(), Keyword.t()) :: :ok | {:error, any()}
+  @callback before_start(SiteImport.t()) :: :ok | {:ok, map()} | {:error, any()}
+  @callback on_success(SiteImport.t(), map()) :: :ok
   @callback on_failure(SiteImport.t()) :: :ok
 
   defmacro __using__(_opts) do
@@ -33,7 +75,7 @@ defmodule Plausible.Imported.Importer do
           args,
           &parse_args/1,
           &import_data/2,
-          &on_success/1
+          &on_success/2
         )
       end
 
@@ -53,12 +95,12 @@ defmodule Plausible.Imported.Importer do
       def before_start(_site_import), do: :ok
 
       @impl true
-      def on_success(_site_import), do: :ok
+      def on_success(_site_import, _extra_data), do: :ok
 
       @impl true
       def on_failure(_site_import), do: :ok
 
-      defoverridable before_start: 1, on_success: 1, on_failure: 1
+      defoverridable before_start: 1, on_success: 2, on_failure: 1
     end
   end
 
@@ -121,7 +163,7 @@ defmodule Plausible.Imported.Importer do
       |> SiteImport.complete_changeset(extra_data)
       |> Repo.update!()
 
-    :ok = on_success_fun.(site_import)
+    :ok = on_success_fun.(site_import, extra_data)
 
     site_import
   end

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -1,0 +1,97 @@
+defmodule Plausible.Imported.Importer do
+  @moduledoc """
+  Behaviour that should be implemented for each new import source.
+
+  The new source should also be added to the list in `Plausible.Imported.ImportSources`.
+  """
+
+  alias Plausible.Imported.SiteImport
+  alias Plausible.Repo
+
+  @callback name() :: String.t()
+  @callback parse_args(map()) :: Keyword.t()
+  @callback import_data(Plausible.Site.t(), Keyword.t()) :: :ok | {:error, any()}
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Plausible.Imported.Importer
+
+      @spec new_import(Plausible.Site.t(), Plausible.Auth.User.t(), Keyword.t()) ::
+              {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
+      def new_import(site, user, opts) do
+        Plausible.Imported.Importer.new_import(name(), site, user, opts)
+      end
+
+      def run_import(import_id, args) do
+        Plausible.Imported.Importer.run_import(import_id, args, &parse_args/1, &import_data/2)
+      end
+    end
+  end
+
+  def new_import(source, site, user, opts) do
+    import_params =
+      opts
+      |> Keyword.take([:start_date, :end_date])
+      |> Keyword.put(:source, source)
+      |> Map.new()
+
+    Repo.transaction(fn ->
+      result =
+        site
+        |> SiteImport.create_changeset(user, import_params)
+        |> Repo.insert()
+
+      case result do
+        {:ok, site_import} ->
+          job_params =
+            opts
+            |> Keyword.put(:import_id, site_import.id)
+            |> Map.new()
+
+          job_changeset = Plausible.Workers.ImportAnalytics.new(job_params)
+
+          case Oban.insert(job_changeset) do
+            {:ok, job} ->
+              job
+
+            {:error, changeset} ->
+              Repo.rollback(changeset)
+          end
+
+        {:error, changeset} ->
+          Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  def run_import(site_import, args, parse_args_fun, import_fun) do
+    site_import =
+      site_import
+      |> SiteImport.start_changeset()
+      |> Repo.update!()
+      |> Repo.preload(:site)
+
+    import_opts = parse_args_fun.(args)
+
+    case import_fun.(site_import.site, import_opts) do
+      :ok ->
+        site_import =
+          site_import
+          |> SiteImport.complete_changeset()
+          |> Repo.update!()
+
+        {:ok, site_import}
+
+      {:ok, extra_data} ->
+        site_import =
+          site_import
+          |> SiteImport.complete_changeset(extra_data)
+          |> Repo.update!()
+
+        {:ok, site_import}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lib/plausible/imported/importer.ex
+++ b/lib/plausible/imported/importer.ex
@@ -8,7 +8,8 @@ defmodule Plausible.Imported.Importer do
   alias Plausible.Imported.SiteImport
   alias Plausible.Repo
 
-  @callback name() :: String.t()
+  @callback name() :: atom()
+  @callback label() :: String.t()
   @callback parse_args(map()) :: Keyword.t()
   @callback import_data(Plausible.Site.t(), Keyword.t()) :: :ok | {:error, any()}
   @callback before_start(SiteImport.t()) :: :ok | {:error, any()}

--- a/lib/plausible/imported/location.ex
+++ b/lib/plausible/imported/location.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Location do
   @primary_key false
   schema "imported_locations" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :country, :string
     field :region, :string

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -16,4 +16,25 @@ defmodule Plausible.Imported.NoopImporter do
   @impl true
   def import_data(_site, %{"error" => true}), do: {:error, "Something went wrong"}
   def import_data(_site, _opts), do: :ok
+
+  @impl true
+  def before_start(site_import) do
+    send(self(), {:before_start, site_import.id})
+
+    :ok
+  end
+
+  @impl true
+  def on_success(site_import) do
+    send(self(), {:on_success, site_import.id})
+
+    :ok
+  end
+
+  @impl true
+  def on_failure(site_import) do
+    send(self(), {:on_failure, site_import.id})
+
+    :ok
+  end
 end

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -5,10 +5,11 @@ defmodule Plausible.Imported.NoopImporter do
 
   use Plausible.Imported.Importer
 
-  @name "Noop"
+  @impl true
+  def name(), do: :noop
 
   @impl true
-  def name(), do: @name
+  def label(), do: "Noop"
 
   @impl true
   def parse_args(opts), do: opts

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -20,6 +20,7 @@ defmodule Plausible.Imported.NoopImporter do
 
   @impl true
   def import_data(_site_import, %{"error" => true}), do: {:error, "Something went wrong"}
+  def import_data(_site_import, %{"crash" => true}), do: raise("boom")
   def import_data(_site_import, _opts), do: :ok
 
   @impl true

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -14,8 +14,8 @@ defmodule Plausible.Imported.NoopImporter do
   def parse_args(opts), do: opts
 
   @impl true
-  def import_data(_site, %{"error" => true}), do: {:error, "Something went wrong"}
-  def import_data(_site, _opts), do: :ok
+  def import_data(_site_import, %{"error" => true}), do: {:error, "Something went wrong"}
+  def import_data(_site_import, _opts), do: :ok
 
   @impl true
   def before_start(site_import) do

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -11,6 +11,10 @@ defmodule Plausible.Imported.NoopImporter do
   @impl true
   def label(), do: "Noop"
 
+  # reusing existing template from another source
+  @impl true
+  def email_template(), do: "google_analytics_import.html"
+
   @impl true
   def parse_args(opts), do: opts
 

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Imported.NoopImporter do
   end
 
   @impl true
-  def on_success(site_import) do
+  def on_success(site_import, _extra_data) do
     send(self(), {:on_success, site_import.id})
 
     :ok

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -3,20 +3,17 @@ defmodule Plausible.Imported.NoopImporter do
   Stub import implementation.
   """
 
+  use Plausible.Imported.Importer
+
   @name "Noop"
 
+  @impl true
   def name(), do: @name
 
-  def create_job(site, opts) do
-    Plausible.Workers.ImportAnalytics.new(%{
-      "source" => @name,
-      "site_id" => site.id,
-      "error" => opts[:error]
-    })
-  end
-
+  @impl true
   def parse_args(opts), do: opts
 
-  def import(_site, %{"error" => true}), do: {:error, "Something went wrong"}
-  def import(_site, _opts), do: :ok
+  @impl true
+  def import_data(_site, %{"error" => true}), do: {:error, "Something went wrong"}
+  def import_data(_site, _opts), do: :ok
 end

--- a/lib/plausible/imported/operating_system.ex
+++ b/lib/plausible/imported/operating_system.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.OperatingSystem do
   @primary_key false
   schema "imported_operating_systems" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :operating_system, :string
     field :visitors, Ch, type: "UInt64"

--- a/lib/plausible/imported/page.ex
+++ b/lib/plausible/imported/page.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Page do
   @primary_key false
   schema "imported_pages" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :hostname, :string
     field :page, :string

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -1,0 +1,21 @@
+defmodule Plausible.Imported.SiteImport do
+  @moduledoc """
+  Site import schema.
+  """
+
+  use Ecto.Schema
+
+  @type t() :: %__MODULE__{}
+
+  schema "site_imports" do
+    field :start_date, :date
+    field :end_date, :date
+    field :source, :string
+    field :status, :string
+
+    belongs_to :site, Plausible.Site
+    belongs_to :imported_by, Plausible.Auth.User
+
+    timestamps()
+  end
+end

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Imported.SiteImport do
   schema "site_imports" do
     field :start_date, :date
     field :end_date, :date
-    field :source, :string
+    field :source, Ecto.Enum, values: ImportSources.names()
     field :status, Ecto.Enum, values: [:pending, :importing, :completed, :failed]
 
     belongs_to :site, Plausible.Site
@@ -23,11 +23,15 @@ defmodule Plausible.Imported.SiteImport do
     timestamps()
   end
 
+  # NOTE: this is necessary for backwards compatbility
+  # with legacy imports
+  def label(%__MODULE__{source: source}), do: ImportSources.by_name(source).label()
+  def label(%Plausible.Site.ImportedData{source: source}), do: source
+
   def create_changeset(site, user, params) do
     %__MODULE__{}
     |> cast(params, [:source, :start_date, :end_date])
     |> validate_required([:source])
-    |> validate_inclusion(:source, ImportSources.names())
     |> put_assoc(:site, site)
     |> put_assoc(:imported_by, user)
     |> put_change(:status, :pending)

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -11,18 +11,24 @@ defmodule Plausible.Imported.SiteImport do
   alias Plausible.Imported.ImportSources
   alias Plausible.Site
 
+  @statuses [:pending, :importing, :completed, :failed]
+
   @type t() :: %__MODULE__{}
 
   schema "site_imports" do
     field :start_date, :date
     field :end_date, :date
     field :source, Ecto.Enum, values: ImportSources.names()
-    field :status, Ecto.Enum, values: [:pending, :importing, :completed, :failed]
+    field :status, Ecto.Enum, values: @statuses
 
     belongs_to :site, Site
     belongs_to :imported_by, User
 
     timestamps()
+  end
+
+  for status <- @statuses do
+    defmacro unquote(status)(), do: unquote(status)
   end
 
   # NOTE: this is necessary for backwards compatibility
@@ -38,25 +44,25 @@ defmodule Plausible.Imported.SiteImport do
     |> validate_required([:source])
     |> put_assoc(:site, site)
     |> put_assoc(:imported_by, user)
-    |> put_change(:status, :pending)
+    |> put_change(:status, pending())
   end
 
   @spec start_changeset(t()) :: Ecto.Changeset.t()
   def start_changeset(site_import) do
     site_import
-    |> change(status: :importing)
+    |> change(status: importing())
   end
 
   @spec complete_changeset(t(), map()) :: Ecto.Changeset.t()
   def complete_changeset(site_import, params \\ %{}) do
     site_import
     |> cast(params, [:start_date, :end_date])
-    |> put_change(:status, :completed)
+    |> put_change(:status, completed())
     |> validate_required([:start_date, :end_date])
   end
 
   @spec fail_changeset(t()) :: Ecto.Changeset.t()
   def fail_changeset(site_import) do
-    change(site_import, status: :failed)
+    change(site_import, status: failed())
   end
 end

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -25,7 +25,7 @@ defmodule Plausible.Imported.SiteImport do
     timestamps()
   end
 
-  # NOTE: this is necessary for backwards compatbility
+  # NOTE: this is necessary for backwards compatibility
   # with legacy imports
   @spec label(t() | Site.ImportedData.t()) :: String.t()
   def label(%__MODULE__{source: source}), do: ImportSources.by_name(source).label()

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -5,17 +5,47 @@ defmodule Plausible.Imported.SiteImport do
 
   use Ecto.Schema
 
+  import Ecto.Changeset
+
+  alias Plausible.Imported.ImportSources
+
   @type t() :: %__MODULE__{}
 
   schema "site_imports" do
     field :start_date, :date
     field :end_date, :date
     field :source, :string
-    field :status, :string
+    field :status, Ecto.Enum, values: [:pending, :importing, :completed, :failed]
 
     belongs_to :site, Plausible.Site
     belongs_to :imported_by, Plausible.Auth.User
 
     timestamps()
+  end
+
+  def create_changeset(site, user, params) do
+    %__MODULE__{}
+    |> cast(params, [:source, :start_date, :end_date])
+    |> validate_required([:source])
+    |> validate_inclusion(:source, ImportSources.names())
+    |> put_assoc(:site, site)
+    |> put_assoc(:imported_by, user)
+    |> put_change(:status, :pending)
+  end
+
+  def start_changeset(site_import) do
+    site_import
+    |> change(status: :importing)
+  end
+
+  def complete_changeset(site_import, params \\ %{}) do
+    site_import
+    |> cast(params, [:start_date, :end_date])
+    |> put_change(:status, :completed)
+    |> validate_required([:start_date, :end_date])
+  end
+
+  def fail_changeset(site_import) do
+    change(site_import, status: :failed)
   end
 end

--- a/lib/plausible/imported/source.ex
+++ b/lib/plausible/imported/source.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Source do
   @primary_key false
   schema "imported_sources" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :source, :string
     field :utm_medium, :string

--- a/lib/plausible/imported/universal_analytics.ex
+++ b/lib/plausible/imported/universal_analytics.ex
@@ -32,7 +32,7 @@ defmodule Plausible.Imported.UniversalAnalytics do
   end
 
   @impl true
-  def on_success(site_import) do
+  def on_success(site_import, _extra_data) do
     site = Repo.preload(site_import, :site).site
 
     site

--- a/lib/plausible/imported/universal_analytics.ex
+++ b/lib/plausible/imported/universal_analytics.ex
@@ -5,6 +5,8 @@ defmodule Plausible.Imported.UniversalAnalytics do
 
   use Plausible.Imported.Importer
 
+  alias Plausible.Repo
+
   @missing_values ["(none)", "(not set)", "(not provided)", "(other)"]
 
   # NOTE: we have to use old name for now
@@ -12,6 +14,43 @@ defmodule Plausible.Imported.UniversalAnalytics do
 
   @impl true
   def name(), do: @name
+
+  @impl true
+  def before_start(site_import) do
+    site = Repo.preload(site_import, :site).site
+
+    site
+    |> Plausible.Site.start_import(
+      site_import.start_date,
+      site_import.end_date,
+      site_import.source
+    )
+    |> Repo.update!()
+
+    :ok
+  end
+
+  @impl true
+  def on_success(site_import) do
+    site = Repo.preload(site_import, :site).site
+
+    site
+    |> Plausible.Site.import_success()
+    |> Repo.update!()
+
+    :ok
+  end
+
+  @impl true
+  def on_failure(site_import) do
+    site = Repo.preload(site_import, :site).site
+
+    site
+    |> Plausible.Site.import_failure()
+    |> Repo.update!()
+
+    :ok
+  end
 
   @impl true
   def parse_args(

--- a/lib/plausible/imported/universal_analytics.ex
+++ b/lib/plausible/imported/universal_analytics.ex
@@ -9,11 +9,12 @@ defmodule Plausible.Imported.UniversalAnalytics do
 
   @missing_values ["(none)", "(not set)", "(not provided)", "(other)"]
 
-  # NOTE: we have to use old name for now
-  @name "Google Analytics"
-
   @impl true
-  def name(), do: @name
+  def name(), do: :universal_analytics
+
+  # NOTE: we have to use old name for now
+  @impl true
+  def label(), do: "Google Analytics"
 
   @impl true
   def before_start(site_import) do
@@ -23,7 +24,7 @@ defmodule Plausible.Imported.UniversalAnalytics do
     |> Plausible.Site.start_import(
       site_import.start_date,
       site_import.end_date,
-      site_import.source
+      label()
     )
     |> Repo.update!()
 

--- a/lib/plausible/imported/universal_analytics.ex
+++ b/lib/plausible/imported/universal_analytics.ex
@@ -12,9 +12,11 @@ defmodule Plausible.Imported.UniversalAnalytics do
   @impl true
   def name(), do: :universal_analytics
 
-  # NOTE: we have to use old name for now
   @impl true
   def label(), do: "Google Analytics"
+
+  @impl true
+  def email_template(), do: "google_analytics_import.html"
 
   @impl true
   def before_start(site_import) do

--- a/lib/plausible/imported/visitor.ex
+++ b/lib/plausible/imported/visitor.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Imported.Visitor do
   @primary_key false
   schema "imported_visitors" do
     field :site_id, Ch, type: "UInt64"
+    field :import_id, Ch, type: "UInt64"
     field :date, :date
     field :visitors, Ch, type: "UInt64"
     field :pageviews, Ch, type: "UInt64"

--- a/lib/plausible/purge.ex
+++ b/lib/plausible/purge.ex
@@ -37,10 +37,14 @@ defmodule Plausible.Purge do
 
   @spec delete_imported_stats!(Plausible.Site.t() | Plausible.Imported.SiteImport.t()) :: :ok
   @doc """
-  Deletes imported stats from Google Analytics, and clears the
-  `stats_start_date` field.
+  Deletes imported stats from and clears the `stats_start_date` field.
+
+  The `stats_start_date` is expected to get repopulated the next time
+  `Plausible.Sites.stats_start_date/1` is called.
+
+  If the input argument is a site, all imported stats are deleted. If it's a site import,
+  only imported stats for that import are deleted.
   """
-  # NOTE: consider getting rid of that clause
   def delete_imported_stats!(%Plausible.Site{} = site) do
     Enum.each(Plausible.Imported.tables(), fn table ->
       sql = "ALTER TABLE #{table} DELETE WHERE site_id = {$0:UInt64}"

--- a/lib/plausible/purge.ex
+++ b/lib/plausible/purge.ex
@@ -51,7 +51,7 @@ defmodule Plausible.Purge do
       Ecto.Adapters.SQL.query!(Plausible.ImportDeletionRepo, sql, [site.id])
     end)
 
-    clear_stats_start_date!(site)
+    Plausible.Sites.clear_stats_start_date!(site)
 
     :ok
   end
@@ -68,7 +68,7 @@ defmodule Plausible.Purge do
       ])
     end)
 
-    clear_stats_start_date!(site_import.site)
+    Plausible.Sites.clear_stats_start_date!(site_import.site)
 
     :ok
   end
@@ -89,12 +89,6 @@ defmodule Plausible.Purge do
       native_stats_start_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
       stats_start_date: nil
     )
-    |> Plausible.Repo.update!()
-  end
-
-  defp clear_stats_start_date!(site) do
-    site
-    |> Ecto.Changeset.change(stats_start_date: nil)
     |> Plausible.Repo.update!()
   end
 end

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -159,22 +159,12 @@ defmodule Plausible.Site do
 
   def import_success(site) do
     change(site,
-      stats_start_date: site.imported_data.start_date,
       imported_data: %{status: "ok"}
     )
   end
 
   def import_failure(site) do
     change(site, imported_data: %{status: "error"})
-  end
-
-  def set_imported_source(site, imported_source) do
-    change(site,
-      imported_data: %Plausible.Site.ImportedData{
-        end_date: Timex.today(),
-        source: imported_source
-      }
-    )
   end
 
   def remove_imported_data(site) do

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -6,7 +6,6 @@ defmodule Plausible.Site do
   import Ecto.Changeset
   alias Plausible.Auth.User
   alias Plausible.Site.GoogleAuth
-  alias Plausible.Timezones
 
   @type t() :: %__MODULE__{}
 
@@ -177,37 +176,6 @@ defmodule Plausible.Site do
 
   def remove_imported_data(site) do
     change(site, imported_data: nil)
-  end
-
-  @doc """
-  Returns the date of the first recorded stat in the timezone configured by the user.
-  This function does 2 transformations:
-    UTC %NaiveDateTime{} -> Local %DateTime{} -> Local %Date
-
-  ## Examples
-
-    iex> Plausible.Site.local_start_date(%Plausible.Site{stats_start_date: nil})
-    nil
-
-    iex> utc_start = ~N[2022-09-28 00:00:00]
-    iex> tz = "Europe/Helsinki"
-    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
-    iex> Plausible.Site.local_start_date(site)
-    ~D[2022-09-28]
-
-    iex> utc_start = ~N[2022-09-28 00:00:00]
-    iex> tz = "America/Los_Angeles"
-    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
-    iex> Plausible.Site.local_start_date(site)
-    ~D[2022-09-27]
-  """
-  def local_start_date(%__MODULE__{stats_start_date: nil}) do
-    nil
-  end
-
-  def local_start_date(site) do
-    site.stats_start_date
-    |> Timezones.to_date_in_timezone(site.timezone)
   end
 
   defp clean_domain(changeset) do

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -55,6 +55,14 @@ defmodule Plausible.Site do
     field :entry_type, :string, virtual: true
     field :pinned_at, :naive_datetime, virtual: true
 
+    # Used for caching imports data for the duration of the whole request
+    # to avoid multiple identical fetches. Populated by plugs putting
+    # `site` in `assigns`.
+    field :import_data_loaded, :boolean, default: false, virtual: true
+    field :earliest_import_start_date, :date, virtual: true
+    field :earliest_import_end_date, :date, virtual: true
+    field :complete_import_ids, {:array, :integer}, default: [], virtual: true
+
     timestamps()
   end
 

--- a/lib/plausible/site/imported_data.ex
+++ b/lib/plausible/site/imported_data.ex
@@ -4,6 +4,8 @@ defmodule Plausible.Site.ImportedData do
   """
   use Ecto.Schema
 
+  @type t() :: %__MODULE__{}
+
   embedded_schema do
     field :start_date, :date
     field :end_date, :date

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -204,10 +204,16 @@ defmodule Plausible.Sites do
   end
 
   def stats_start_date(%Site{} = site) do
-    start_dates =
+    earliest_import =
       site
-      |> Plausible.Imported.list_complete_imports()
-      |> Enum.map(& &1.start_date)
+      |> Plausible.Imported.get_earliest_import()
+
+    start_dates =
+      if earliest_import do
+        [earliest_import.start_date]
+      else
+        []
+      end
 
     start_dates =
       if native_start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -196,6 +196,35 @@ defmodule Plausible.Sites do
     |> Plausible.Repo.update!()
   end
 
+  @doc """
+  Returns the date of the first recorded stat in the timezone configured by the user.
+  This function does 2 transformations:
+    UTC %NaiveDateTime{} -> Local %DateTime{} -> Local %Date
+
+  ## Examples
+
+    iex> Plausible.Site.local_start_date(%Plausible.Site{stats_start_date: nil})
+    nil
+
+    iex> utc_start = ~N[2022-09-28 00:00:00]
+    iex> tz = "Europe/Helsinki"
+    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
+    iex> Plausible.Site.local_start_date(site)
+    ~D[2022-09-28]
+
+    iex> utc_start = ~N[2022-09-28 00:00:00]
+    iex> tz = "America/Los_Angeles"
+    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
+    iex> Plausible.Site.local_start_date(site)
+    ~D[2022-09-27]
+  """
+  @spec local_start_date(Site.t()) :: Date.t() | nil
+  def local_start_date(site) do
+    if stats_start_date = stats_start_date(site) do
+      Plausible.Timezones.to_date_in_timezone(stats_start_date, site.timezone)
+    end
+  end
+
   @spec stats_start_date(Site.t()) :: Date.t() | nil
   @doc """
   Returns the date of the first event of the given site, or `nil` if the site
@@ -212,6 +241,8 @@ defmodule Plausible.Sites do
   end
 
   def stats_start_date(%Site{} = site) do
+    site = Plausible.Imported.load_import_data(site)
+
     start_date =
       [
         site.earliest_import_start_date,

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -206,7 +206,7 @@ defmodule Plausible.Sites do
   def stats_start_date(%Site{} = site) do
     start_dates =
       site
-      |> Plausible.Imported.list_imports()
+      |> Plausible.Imported.list_complete_imports()
       |> Enum.map(& &1.start_date)
 
     start_dates =

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -212,13 +212,11 @@ defmodule Plausible.Sites do
   end
 
   def stats_start_date(%Site{} = site) do
-    import_start_date =
-      if earliest_import = Plausible.Imported.get_earliest_import(site) do
-        earliest_import.start_date
-      end
-
     start_date =
-      [import_start_date, Plausible.Stats.Clickhouse.pageview_start_date_local(site)]
+      [
+        site.earliest_import_start_date,
+        Plausible.Stats.Clickhouse.pageview_start_date_local(site)
+      ]
       |> Enum.reject(&is_nil/1)
       |> Enum.min(Date, fn -> nil end)
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -189,6 +189,13 @@ defmodule Plausible.Sites do
     end
   end
 
+  @spec clear_stats_start_date!(Site.t()) :: Site.t()
+  def clear_stats_start_date!(site) do
+    site
+    |> Ecto.Changeset.change(stats_start_date: nil)
+    |> Plausible.Repo.update!()
+  end
+
   @spec stats_start_date(Site.t()) :: Date.t() | nil
   @doc """
   Returns the date of the first event of the given site, or `nil` if the site

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -195,7 +195,8 @@ defmodule Plausible.Sites do
   does not have stats yet.
 
   If this is the first time the function is called for the site, it queries
-  Clickhouse and saves the date in the sites table.
+  imported stats and Clickhouse, choosing the earliest start date and saves
+  it in the sites table.
   """
   def stats_start_date(site)
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -204,7 +204,21 @@ defmodule Plausible.Sites do
   end
 
   def stats_start_date(%Site{} = site) do
-    if start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site) do
+    start_dates =
+      site
+      |> Plausible.Imported.list_imports()
+      |> Enum.map(& &1.start_date)
+
+    start_dates =
+      if native_start_date = Plausible.Stats.Clickhouse.pageview_start_date_local(site) do
+        [native_start_date | start_dates]
+      else
+        start_dates
+      end
+
+    start_date = Enum.min(start_dates, Date, fn -> nil end)
+
+    if start_date do
       updated_site =
         site
         |> Site.set_stats_start_date(start_date)

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -16,9 +16,12 @@ defmodule Plausible.Stats.Imported do
         query,
         metrics
       ) do
+    import_ids = Plausible.Imported.list_complete_import_ids(site)
+
     imported_q =
       from(v in "imported_visitors",
         where: v.site_id == ^site.id,
+        where: v.import_id in ^import_ids,
         where: v.date >= ^query.date_range.first and v.date <= ^query.date_range.last,
         select: %{}
       )
@@ -107,11 +110,14 @@ defmodule Plausible.Stats.Imported do
           {"imported_#{dim}s", String.to_existing_atom(dim)}
       end
 
+    import_ids = Plausible.Imported.list_complete_import_ids(site)
+
     imported_q =
       from(
         i in table,
         group_by: field(i, ^dim),
         where: i.site_id == ^site.id,
+        where: i.import_id in ^import_ids,
         where: i.date >= ^query.date_range.first and i.date <= ^query.date_range.last,
         where: i.visitors > 0,
         select: %{}
@@ -315,10 +321,13 @@ defmodule Plausible.Stats.Imported do
   end
 
   def merge_imported(q, site, query, :aggregate, metrics) do
+    import_ids = Plausible.Imported.list_complete_import_ids(site)
+
     imported_q =
       from(
         i in "imported_visitors",
         where: i.site_id == ^site.id,
+        where: i.import_id in ^import_ids,
         where: i.date >= ^query.date_range.first and i.date <= ^query.date_range.last,
         select: %{}
       )

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Stats.Imported do
         query,
         metrics
       ) do
-    import_ids = Plausible.Imported.list_complete_import_ids(site)
+    import_ids = site.complete_import_ids
 
     imported_q =
       from(v in "imported_visitors",
@@ -110,7 +110,7 @@ defmodule Plausible.Stats.Imported do
           {"imported_#{dim}s", String.to_existing_atom(dim)}
       end
 
-    import_ids = Plausible.Imported.list_complete_import_ids(site)
+    import_ids = site.complete_import_ids
 
     imported_q =
       from(
@@ -321,7 +321,7 @@ defmodule Plausible.Stats.Imported do
   end
 
   def merge_imported(q, site, query, :aggregate, metrics) do
-    import_ids = Plausible.Imported.list_complete_import_ids(site)
+    import_ids = site.complete_import_ids
 
     imported_q =
       from(

--- a/lib/plausible/stats/interval.ex
+++ b/lib/plausible/stats/interval.ex
@@ -78,7 +78,7 @@ defmodule Plausible.Stats.Interval do
           @valid_by_period
       end
 
-    with %Date{} = stats_start <- site.stats_start_date,
+    with %Date{} = stats_start <- Plausible.Sites.stats_start_date(site),
          true <- abs(Timex.diff(Date.utc_today(), stats_start, :months)) > 12 do
       Map.replace(table, "all", ["week", "month"])
     else

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -250,11 +250,9 @@ defmodule Plausible.Stats.Query do
 
   @spec include_imported?(t(), Plausible.Site.t(), boolean()) :: boolean()
   def include_imported?(query, site, requested?) do
-    site_import = Plausible.Imported.get_earliest_import(site)
-
     cond do
-      is_nil(site_import) -> false
-      Date.after?(query.date_range.first, site_import.end_date) -> false
+      is_nil(site.earliest_import_end_date) -> false
+      Date.after?(query.date_range.first, site.earliest_import_end_date) -> false
       Enum.any?(query.filters) -> false
       query.period == "realtime" -> false
       true -> requested?

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -254,7 +254,7 @@ defmodule Plausible.Stats.Query do
 
     cond do
       is_nil(site_import) -> false
-      Timex.after?(query.date_range.first, site_import.end_date) -> false
+      Date.after?(query.date_range.first, site_import.end_date) -> false
       Enum.any?(query.filters) -> false
       query.period == "realtime" -> false
       true -> requested?

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -121,7 +121,7 @@ defmodule Plausible.Stats.Query do
 
   defp put_period(query, site, %{"period" => "all"}) do
     now = today(site.timezone)
-    start_date = Plausible.Site.local_start_date(site) || now
+    start_date = Plausible.Sites.local_start_date(site) || now
 
     struct!(query,
       period: "all",

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -250,10 +250,11 @@ defmodule Plausible.Stats.Query do
 
   @spec include_imported?(t(), Plausible.Site.t(), boolean()) :: boolean()
   def include_imported?(query, site, requested?) do
+    site_import = Plausible.Imported.get_earliest_import(site)
+
     cond do
-      is_nil(site.imported_data) -> false
-      site.imported_data.status != "ok" -> false
-      Timex.after?(query.date_range.first, site.imported_data.end_date) -> false
+      is_nil(site_import) -> false
+      Timex.after?(query.date_range.first, site_import.end_date) -> false
       Enum.any?(query.filters) -> false
       query.period == "realtime" -> false
       true -> requested?

--- a/lib/plausible/timezones.ex
+++ b/lib/plausible/timezones.ex
@@ -22,7 +22,14 @@ defmodule Plausible.Timezones do
 
   @spec to_date_in_timezone(Date.t() | NaiveDateTime.t() | DateTime.t(), String.t()) :: Date.t()
   def to_date_in_timezone(dt, timezone) do
-    utc_dt = Timex.Timezone.convert(dt, "UTC")
+    utc_dt =
+      case dt do
+        %Date{} ->
+          Timex.to_datetime(dt, "UTC")
+
+        dt ->
+          Timex.Timezone.convert(dt, "UTC")
+      end
 
     case Timex.Timezone.convert(utc_dt, timezone) do
       %DateTime{} = tz_dt ->

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -3,6 +3,8 @@ defmodule PlausibleWeb.Api.StatsController do
   use PlausibleWeb, :controller
   use Plausible.Repo
   use PlausibleWeb.Plugs.ErrorHandler
+
+  alias Plausible.Imported.SiteImport
   alias Plausible.Stats
   alias Plausible.Stats.{Query, Comparisons}
   alias PlausibleWeb.Api.Helpers, as: H
@@ -142,7 +144,7 @@ defmodule PlausibleWeb.Api.StatsController do
         present_index: present_index,
         interval: query.interval,
         with_imported: with_imported?(query, comparison_query),
-        imported_source: site_import && site_import.source,
+        imported_source: site_import && SiteImport.label(site_import),
         full_intervals: full_intervals
       })
     else
@@ -218,12 +220,14 @@ defmodule PlausibleWeb.Api.StatsController do
 
       {top_stats, sample_percent} = fetch_top_stats(site, query, comparison_query)
 
+      site_import = Plausible.Imported.get_earliest_import(site)
+
       json(conn, %{
         top_stats: top_stats,
         interval: query.interval,
         sample_percent: sample_percent,
         with_imported: with_imported?(query, comparison_query),
-        imported_source: site.imported_data && site.imported_data.source,
+        imported_source: site_import && SiteImport.label(site_import),
         comparing_from: comparison_query && comparison_query.date_range.first,
         comparing_to: comparison_query && comparison_query.date_range.last,
         from: query.date_range.first,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -132,6 +132,8 @@ defmodule PlausibleWeb.Api.StatsController do
       present_index = present_index_for(site, query, labels)
       full_intervals = build_full_intervals(query, labels)
 
+      site_import = Plausible.Imported.get_earliest_import(site)
+
       json(conn, %{
         plot: plot_timeseries(timeseries_result, selected_metric),
         labels: labels,
@@ -140,7 +142,7 @@ defmodule PlausibleWeb.Api.StatsController do
         present_index: present_index,
         interval: query.interval,
         with_imported: with_imported?(query, comparison_query),
-        imported_source: site.imported_data && site.imported_data.source,
+        imported_source: site_import && site_import.source,
         full_intervals: full_intervals
       })
     else

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -791,6 +791,13 @@ defmodule PlausibleWeb.SiteController do
       |> Plausible.Imported.list_all_imports()
       |> Enum.map(& &1.id)
 
+    import_ids =
+      if site.imported_data do
+        [0 | import_ids]
+      else
+        import_ids
+      end
+
     if import_ids != [] do
       Oban.cancel_all_jobs(
         from j in Oban.Job,

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -801,6 +801,8 @@ defmodule PlausibleWeb.SiteController do
 
       Plausible.Purge.delete_imported_stats!(site)
 
+      Plausible.Imported.delete_imports_for_site(site)
+
       site
       |> Plausible.Site.remove_imported_data()
       |> Repo.update!()

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -813,15 +813,11 @@ defmodule PlausibleWeb.SiteController do
       site
       |> Plausible.Site.remove_imported_data()
       |> Repo.update!()
-
-      conn
-      |> put_flash(:success, "Imported data has been cleared")
-      |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
-    else
-      conn
-      |> put_flash(:error, "No data has been imported")
-      |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
     end
+
+    conn
+    |> put_flash(:success, "Imported data has been cleared")
+    |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
   def change_domain(conn, _params) do

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -790,9 +790,6 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
-  # NOTE: To be cleaned up once #3700 is released
-  @analytics_queues ["analytics_imports", "google_analytics_imports"]
-
   def forget_imported(conn, _params) do
     site = conn.assigns[:site]
 
@@ -801,7 +798,7 @@ defmodule PlausibleWeb.SiteController do
         Oban.cancel_all_jobs(
           from j in Oban.Job,
             where:
-              j.queue in @analytics_queues and
+              j.queue == "analytics_imports" and
                 fragment("(? ->> 'site_id')::int", j.args) == ^site.id
         )
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -309,6 +309,7 @@ defmodule PlausibleWeb.StatsController do
     cond do
       !shared_link.site.locked ->
         shared_link = Plausible.Repo.preload(shared_link, site: :owner)
+        stats_start_date = Plausible.Sites.stats_start_date(shared_link.site)
 
         conn
         |> put_resp_header("x-robots-tag", "noindex, nofollow")
@@ -318,7 +319,7 @@ defmodule PlausibleWeb.StatsController do
           has_goals: Sites.has_goals?(shared_link.site),
           funnels: list_funnels(shared_link.site),
           has_props: Plausible.Props.configured?(shared_link.site),
-          stats_start_date: shared_link.site.stats_start_date,
+          stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
           title: title(conn, shared_link.site),
           offer_email_report: false,

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -313,15 +313,15 @@ defmodule PlausibleWeb.Email do
     )
   end
 
-  # NOTE: make email different depending on import source
   def import_success(site_import, user) do
-    label = Plausible.Imported.SiteImport.label(site_import)
+    import_api = Plausible.Imported.ImportSources.by_name(site_import.source)
+    label = import_api.label()
 
     priority_email()
     |> to(user)
     |> tag("import-success-email")
     |> subject("#{label} data imported for #{site_import.site.domain}")
-    |> render("google_analytics_import.html", %{
+    |> render(import_api.email_template(), %{
       site_import: site_import,
       label: label,
       link: PlausibleWeb.Endpoint.url() <> "/" <> URI.encode_www_form(site_import.site.domain),
@@ -330,15 +330,15 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  # NOTE: make email different depending on import source
   def import_failure(site_import, user) do
-    label = Plausible.Imported.SiteImport.label(site_import)
+    import_api = Plausible.Imported.ImportSources.by_name(site_import.source)
+    label = import_api.label()
 
     priority_email()
     |> to(user)
     |> tag("import-failure-email")
     |> subject("#{label} import failed for #{site_import.site.domain}")
-    |> render("google_analytics_import.html", %{
+    |> render(import_api.email_template(), %{
       site_import: site_import,
       label: label,
       user: user,

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -315,12 +315,15 @@ defmodule PlausibleWeb.Email do
 
   # NOTE: make email different depending on import source
   def import_success(site_import, user) do
+    label = Plausible.Imported.SiteImport.label(site_import)
+
     priority_email()
     |> to(user)
     |> tag("import-success-email")
-    |> subject("#{site_import.source} data imported for #{site_import.site.domain}")
+    |> subject("#{label} data imported for #{site_import.site.domain}")
     |> render("google_analytics_import.html", %{
       site_import: site_import,
+      label: label,
       link: PlausibleWeb.Endpoint.url() <> "/" <> URI.encode_www_form(site_import.site.domain),
       user: user,
       success: true
@@ -329,13 +332,16 @@ defmodule PlausibleWeb.Email do
 
   # NOTE: make email different depending on import source
   def import_failure(site_import, user) do
+    label = Plausible.Imported.SiteImport.label(site_import)
+
     priority_email()
     |> to(user)
     |> tag("import-failure-email")
-    |> subject("#{site_import.source} import failed for #{site_import.site.domain}")
+    |> subject("#{label} import failed for #{site_import.site.domain}")
     |> render("google_analytics_import.html", %{
-      user: user,
       site_import: site_import,
+      label: label,
+      user: user,
       success: false
     })
   end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -314,28 +314,28 @@ defmodule PlausibleWeb.Email do
   end
 
   # NOTE: make email different depending on import source
-  def import_success(source, user, site) do
+  def import_success(site_import, user) do
     priority_email()
     |> to(user)
     |> tag("import-success-email")
-    |> subject("#{source} data imported for #{site.domain}")
+    |> subject("#{site_import.source} data imported for #{site_import.site.domain}")
     |> render("google_analytics_import.html", %{
-      site: site,
-      link: PlausibleWeb.Endpoint.url() <> "/" <> URI.encode_www_form(site.domain),
+      site_import: site_import,
+      link: PlausibleWeb.Endpoint.url() <> "/" <> URI.encode_www_form(site_import.site.domain),
       user: user,
       success: true
     })
   end
 
   # NOTE: make email different depending on import source
-  def import_failure(source, user, site) do
+  def import_failure(site_import, user) do
     priority_email()
     |> to(user)
     |> tag("import-failure-email")
-    |> subject("#{source} import failed for #{site.domain}")
+    |> subject("#{site_import.source} import failed for #{site_import.site.domain}")
     |> render("google_analytics_import.html", %{
       user: user,
-      site: site,
+      site_import: site_import,
       success: false
     })
   end

--- a/lib/plausible_web/plugs/authorize_plugins_api.ex
+++ b/lib/plausible_web/plugs/authorize_plugins_api.ex
@@ -21,8 +21,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPI do
     case Tokens.find(token_value) do
       {:ok, token} ->
         {:ok, token} = Tokens.update_last_seen(token)
-        site = Plausible.Imported.load_import_data(token.site)
-        {:ok, Plug.Conn.assign(conn, :authorized_site, site)}
+        {:ok, Plug.Conn.assign(conn, :authorized_site, token.site)}
 
       {:error, :not_found} ->
         Errors.unauthorized(conn)

--- a/lib/plausible_web/plugs/authorize_plugins_api.ex
+++ b/lib/plausible_web/plugs/authorize_plugins_api.ex
@@ -21,7 +21,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePluginsAPI do
     case Tokens.find(token_value) do
       {:ok, token} ->
         {:ok, token} = Tokens.update_last_seen(token)
-        {:ok, Plug.Conn.assign(conn, :authorized_site, token.site)}
+        site = Plausible.Imported.load_import_data(token.site)
+        {:ok, Plug.Conn.assign(conn, :authorized_site, site)}
 
       {:error, :not_found} ->
         Errors.unauthorized(conn)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -47,6 +47,8 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
         Sentry.Context.set_extra_context(%{site_id: site.id, domain: site.domain})
         Plausible.OpenTelemetry.add_site_attributes(site)
 
+        site = Plausible.Imported.load_import_data(site)
+
         merge_assigns(conn, site: site, current_user_role: role)
       else
         PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt

--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -16,6 +16,7 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
          :ok <- check_api_key_rate_limit(api_key),
          {:ok, site} <- verify_access(api_key, conn.params["site_id"]) do
       Plausible.OpenTelemetry.add_site_attributes(site)
+      site = Plausible.Imported.load_import_data(site)
       assign(conn, :site, site)
     else
       {:error, :missing_api_key} ->

--- a/lib/plausible_web/templates/email/google_analytics_import.html.heex
+++ b/lib/plausible_web/templates/email/google_analytics_import.html.heex
@@ -1,11 +1,11 @@
 <%= if @success do %>
-  Your Google Analytics import has completed successfully. The Plausible dashboard for <%= @site.domain %> now contains historical imported data from <%= date_format(
-    @site.imported_data.start_date
-  ) %> to <%= date_format(@site.imported_data.end_date) %>
+  Your Google Analytics import has completed successfully. The Plausible dashboard for <%= @site_import.site.domain %> now contains historical imported data from <%= date_format(
+    @site_import.start_date
+  ) %> to <%= date_format(@site_import.end_date) %>
   <br /><br />
   <%= link("Click here", to: @link) %> to view your dashboard.
 <% else %>
-  Unfortunately, your Google Analytics import for <%= @site.domain %> did not complete successfully. Sorry about that!
+  Unfortunately, your Google Analytics import for <%= @site_import.site.domain %> did not complete successfully. Sorry about that!
   <br /> <br />
   This may be due to the user metric setting in your Google Analytics account. We found that changing the user metric setting is necessary to get the correct data out of the Google API.
   <br /> <br />

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -71,10 +71,11 @@ defmodule Plausible.Workers.ImportAnalytics do
   end
 
   def import_fail(site_import) do
+    import_api = ImportSources.by_name(site_import.source)
+
     site_import =
       site_import
-      |> SiteImport.fail_changeset()
-      |> Repo.update!()
+      |> import_api.mark_failed()
       |> Repo.preload(site: [memberships: :user])
 
     Plausible.Purge.delete_imported_stats!(site_import)

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -63,6 +63,8 @@ defmodule Plausible.Workers.ImportAnalytics do
       end
     end)
 
+    Plausible.Sites.clear_stats_start_date!(site_import.site)
+
     Importer.notify(site_import, :complete)
 
     :ok

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -25,9 +25,8 @@ defmodule Plausible.Workers.ImportAnalytics do
       |> Repo.preload(:site)
 
     import_api = ImportSources.by_name(site_import.source)
-    import_opts = import_api.parse_args(args)
 
-    case import_api.run_import(site_import, import_opts) do
+    case import_api.run_import(site_import, args) do
       {:ok, site_import} ->
         import_complete(site_import)
 

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -9,7 +9,7 @@ defmodule Plausible.Workers.ImportAnalytics do
   use Oban.Worker,
     queue: :analytics_imports,
     max_attempts: 3,
-    unique: [fields: [:args], period: 60]
+    unique: [fields: [:args], keys: [:import_id], period: 60]
 
   alias Plausible.Imported.ImportSources
   alias Plausible.Imported.Importer

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Workers.ImportAnalytics do
 
         import_fail(site_import)
 
-        {:error, error}
+        {:discard, error}
     end
   end
 

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -71,12 +71,14 @@ defmodule Plausible.Workers.ImportAnalytics do
   end
 
   def import_fail_transient(site_import) do
-    Importer.notify(site_import, :transient_fail)
-
     Plausible.Purge.delete_imported_stats!(site_import)
+
+    Importer.notify(site_import, :transient_fail)
   end
 
   def import_fail(site_import) do
+    Plausible.Purge.delete_imported_stats!(site_import)
+
     import_api = ImportSources.by_name(site_import.source)
 
     site_import =
@@ -85,8 +87,6 @@ defmodule Plausible.Workers.ImportAnalytics do
       |> Repo.preload(site: [memberships: :user])
 
     Importer.notify(site_import, :fail)
-
-    Plausible.Purge.delete_imported_stats!(site_import)
 
     Enum.each(site_import.site.memberships, fn membership ->
       if membership.role in [:owner, :admin] do

--- a/lib/workers/import_analytics.ex
+++ b/lib/workers/import_analytics.ex
@@ -67,6 +67,8 @@ defmodule Plausible.Workers.ImportAnalytics do
   end
 
   def import_fail_transient(site_import) do
+    Oban.Notifier.notify(Oban, :analytics_imports_jobs, %{transient_fail: site_import.id})
+
     Plausible.Purge.delete_imported_stats!(site_import)
   end
 
@@ -77,6 +79,8 @@ defmodule Plausible.Workers.ImportAnalytics do
       site_import
       |> import_api.mark_failed()
       |> Repo.preload(site: [memberships: :user])
+
+    Oban.Notifier.notify(Oban, :analytics_imports_jobs, %{fail: site_import.id})
 
     Plausible.Purge.delete_imported_stats!(site_import)
 

--- a/test/plausible/google/api_test.exs
+++ b/test/plausible/google/api_test.exs
@@ -40,7 +40,7 @@ defmodule Plausible.Google.ApiTest do
     {:ok, buffer} = Plausible.Imported.Buffer.start_link()
 
     persist_fn = fn table, rows ->
-      records = UniversalAnalytics.from_report(rows, site.id, table)
+      records = UniversalAnalytics.from_report(rows, site.id, _import_id = 123, table)
       Plausible.Imported.Buffer.insert_many(buffer, table, records)
     end
 
@@ -82,7 +82,7 @@ defmodule Plausible.Google.ApiTest do
     {:ok, buffer} = Plausible.Imported.Buffer.start_link()
 
     persist_fn = fn table, rows ->
-      records = UniversalAnalytics.from_report(rows, site.id, table)
+      records = UniversalAnalytics.from_report(rows, site.id, _import_id = 123, table)
       Plausible.Imported.Buffer.insert_many(buffer, table, records)
     end
 

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -6,7 +6,7 @@ defmodule Plausible.ImportedTest do
 
   defp import_data(ga_data, site_id, table_name) do
     ga_data
-    |> Plausible.Imported.UniversalAnalytics.from_report(site_id, table_name)
+    |> Plausible.Imported.UniversalAnalytics.from_report(site_id, _import_id = nil, table_name)
     |> then(&Plausible.Imported.Buffer.insert_all(table_name, &1))
   end
 

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -4,1109 +4,1217 @@ defmodule Plausible.ImportedTest do
 
   @user_id 123
 
-  defp import_data(ga_data, site_id, table_name) do
+  defp import_data(ga_data, site_id, import_id, table_name) do
     ga_data
-    |> Plausible.Imported.UniversalAnalytics.from_report(site_id, _import_id = nil, table_name)
+    |> Plausible.Imported.UniversalAnalytics.from_report(site_id, import_id, table_name)
     |> then(&Plausible.Imported.Buffer.insert_all(table_name, &1))
   end
 
-  describe "Parse and import third party data fetched from Google Analytics" do
-    setup [:create_user, :log_in, :create_new_site, :add_imported_data]
+  for import_type <- [:legacy, :new_and_legacy, :new] do
+    describe "Parse and import third party data fetched from Google Analytics as #{import_type} import" do
+      if import_type == :new do
+        setup [:create_user, :log_in, :create_new_site]
+      else
+        setup [:create_user, :log_in, :create_new_site, :add_imported_data]
+      end
 
-    test "Visitors data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
-      ])
+      setup %{user: user, site: site} do
+        if unquote(import_type) in [:new, :new_and_legacy] do
+          import_params =
+            if unquote(import_type) == :new_and_legacy do
+              Map.from_struct(site.imported_data)
+            else
+              %{
+                source: "Google Analytics",
+                start_date: ~D[2005-01-01],
+                end_date: Timex.today()
+              }
+            end
 
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
+          site_import =
+            site
+            |> Plausible.Imported.SiteImport.create_changeset(
+              user,
+              import_params
+            )
+            |> Plausible.Repo.insert!()
+            |> Plausible.Imported.SiteImport.complete_changeset()
+            |> Plausible.Repo.update!()
+
+          {:ok, %{import_id: site_import.id}}
+        else
+          {:ok, %{import_id: 0}}
+        end
+      end
+
+      test "Visitors data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "20210131"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
             }
-          },
-          %{
-            dimensions: %{"ga:date" => "20210131"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
-            }
-          }
-        ],
-        site.id,
-        "imported_visitors"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
+          ],
+          site.id,
+          import_id,
+          "imported_visitors"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics"} = json_response(conn, 200)
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true"
+          )
 
-      assert Enum.count(plot) == 31
-      assert List.first(plot) == 2
-      assert List.last(plot) == 2
-      assert Enum.sum(plot) == 4
-    end
+        assert %{"plot" => plot, "imported_source" => "Google Analytics"} =
+                 json_response(conn, 200)
 
-    test "returns data grouped by week", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
-      ])
+        assert Enum.count(plot) == 31
+        assert List.first(plot) == 2
+        assert List.last(plot) == 2
+        assert Enum.sum(plot) == 4
+      end
 
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
+      test "returns data grouped by week", %{conn: conn, site: site, import_id: import_id} do
+        populate_stats(site, [
+          build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "20210131"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
             }
-          },
-          %{
-            dimensions: %{"ga:date" => "20210131"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
-            }
-          }
-        ],
-        site.id,
-        "imported_visitors"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true&interval=week"
+          ],
+          site.id,
+          import_id,
+          "imported_visitors"
         )
 
-      assert %{"plot" => plot, "imported_source" => "Google Analytics"} = json_response(conn, 200)
-      assert Enum.count(plot) == 5
-      assert List.first(plot) == 2
-      assert List.last(plot) == 2
-      assert Enum.sum(plot) == 4
-    end
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&with_imported=true&interval=week"
+          )
 
-    test "Sources are imported", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
-          timestamp: ~N[2021-01-01 00:00:00]
-        )
-      ])
+        assert %{"plot" => plot, "imported_source" => "Google Analytics"} =
+                 json_response(conn, 200)
 
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "organic",
-              "ga:source" => "duckduckgo.com"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210131",
-              "ga:keyword" => "",
-              "ga:medium" => "organic",
-              "ga:source" => "google.com"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "paid",
-              "ga:source" => "google.com"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "social",
-              "ga:source" => "Twitter"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "newsletter",
-              "ga:date" => "20210131",
-              "ga:keyword" => "",
-              "ga:medium" => "email",
-              "ga:source" => "A Nice Newsletter"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "(none)",
-              "ga:source" => "(direct)"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_sources"
-      )
+        assert Enum.count(plot) == 5
+        assert List.first(plot) == 2
+        assert List.last(plot) == 2
+        assert Enum.sum(plot) == 4
+      end
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=month&date=2021-01-01&with_imported=true"
-        )
+      test "Sources are imported", %{conn: conn, site: site, import_id: import_id} do
+        populate_stats(site, [
+          build(:pageview,
+            referrer_source: "Google",
+            referrer: "google.com",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            referrer_source: "Google",
+            referrer: "google.com",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com",
+            timestamp: ~N[2021-01-01 00:00:00]
+          )
+        ])
 
-      assert conn |> json_response(200) |> Enum.sort() == [
-               %{"name" => "A Nice Newsletter", "visitors" => 1},
-               %{"name" => "Direct / None", "visitors" => 1},
-               %{"name" => "DuckDuckGo", "visitors" => 2},
-               %{"name" => "Google", "visitors" => 4},
-               %{"name" => "Twitter", "visitors" => 1}
-             ]
-    end
-
-    test "UTM mediums data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          utm_medium: "social",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          utm_medium: "social",
-          timestamp: ~N[2021-01-01 12:00:00]
-        )
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "social",
-              "ga:source" => "Twitter"
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "organic",
+                "ga:source" => "duckduckgo.com"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
             },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "(none)",
-              "ga:source" => "(direct)"
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210131",
+                "ga:keyword" => "",
+                "ga:medium" => "organic",
+                "ga:source" => "google.com"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
             },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "paid",
+                "ga:source" => "google.com"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "social",
+                "ga:source" => "Twitter"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "newsletter",
+                "ga:date" => "20210131",
+                "ga:keyword" => "",
+                "ga:medium" => "email",
+                "ga:source" => "A Nice Newsletter"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "(none)",
+                "ga:source" => "(direct)"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
             }
-          }
-        ],
-        site.id,
-        "imported_sources"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+          ],
+          site.id,
+          import_id,
+          "imported_sources"
         )
 
-      assert json_response(conn, 200) == [
-               %{
-                 "bounce_rate" => 100.0,
-                 "name" => "social",
-                 "visit_duration" => 20,
-                 "visitors" => 3
-               }
-             ]
-    end
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/sources?period=month&date=2021-01-01&with_imported=true"
+          )
 
-    test "UTM campaigns data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, utm_campaign: "profile", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, utm_campaign: "august", timestamp: ~N[2021-01-01 00:00:00])
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "profile",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "social",
-              "ga:source" => "Twitter"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "august",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "email",
-              "ga:source" => "Gmail"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "(not set)",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "email",
-              "ga:source" => "Gmail"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_sources"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "august",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 50.0
-               },
-               %{
-                 "name" => "profile",
-                 "visitors" => 2,
-                 "bounce_rate" => 100.0,
-                 "visit_duration" => 50.0
-               }
-             ]
-    end
-
-    test "UTM terms data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, utm_term: "oat milk", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00])
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "oat milk",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "Sweden",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "(not set)",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_sources"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "Sweden",
-                 "visitors" => 3,
-                 "bounce_rate" => 67.0,
-                 "visit_duration" => 33.3
-               },
-               %{
-                 "name" => "oat milk",
-                 "visitors" => 2,
-                 "bounce_rate" => 100.0,
-                 "visit_duration" => 50.0
-               }
-             ]
-    end
-
-    test "UTM contents data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, utm_content: "ad", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, utm_content: "blog", timestamp: ~N[2021-01-01 00:00:00])
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:adContent" => "ad",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "blog",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:adContent" => "(not set)",
-              "ga:campaign" => "",
-              "ga:date" => "20210101",
-              "ga:keyword" => "",
-              "ga:medium" => "paid",
-              "ga:source" => "Google"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "100",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_sources"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "blog",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 50.0
-               },
-               %{
-                 "name" => "ad",
-                 "visitors" => 2,
-                 "bounce_rate" => 100.0,
-                 "visit_duration" => 50.0
-               }
-             ]
-    end
-
-    test "Page event data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          pathname: "/",
-          hostname: "host-a.com",
-          user_id: @user_id,
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          pathname: "/some-other-page",
-          hostname: "host-a.com",
-          user_id: @user_id,
-          timestamp: ~N[2021-01-01 00:15:00]
-        )
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:date" => "20210101",
-              "ga:hostname" => "host-a.com",
-              "ga:pagePath" => "/"
-            },
-            metrics: %{
-              "ga:exits" => "0",
-              "ga:pageviews" => "1",
-              "ga:timeOnPage" => "700",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:date" => "20210101",
-              "ga:hostname" => "host-b.com",
-              "ga:pagePath" => "/some-other-page"
-            },
-            metrics: %{
-              "ga:exits" => "1",
-              "ga:pageviews" => "2",
-              "ga:timeOnPage" => "60",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:date" => "20210101",
-              "ga:hostname" => "host-b.com",
-              "ga:pagePath" => "/some-other-page?wat=wot"
-            },
-            metrics: %{
-              "ga:exits" => "0",
-              "ga:pageviews" => "1",
-              "ga:timeOnPage" => "60",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_pages"
-      )
-
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:landingPagePath" => "/"},
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:entrances" => "3",
-              "ga:sessionDuration" => "10",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_entry_pages"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&detailed=true&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "bounce_rate" => nil,
-                 "time_on_page" => 60,
-                 "visitors" => 3,
-                 "pageviews" => 4,
-                 "name" => "/some-other-page"
-               },
-               %{
-                 "bounce_rate" => 25.0,
-                 "time_on_page" => 800.0,
-                 "visitors" => 2,
-                 "pageviews" => 2,
-                 "name" => "/"
-               }
-             ]
-    end
-
-    test "Exit page event data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          pathname: "/page1",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          pathname: "/page1",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          pathname: "/page1",
-          user_id: @user_id,
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          pathname: "/page2",
-          user_id: @user_id,
-          timestamp: ~N[2021-01-01 00:15:00]
-        )
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:date" => "20210101",
-              "ga:hostname" => "host-a.com",
-              "ga:pagePath" => "/page2"
-            },
-            metrics: %{
-              "ga:exits" => "0",
-              "ga:pageviews" => "4",
-              "ga:timeOnPage" => "10",
-              "ga:users" => "2"
-            }
-          }
-        ],
-        site.id,
-        "imported_pages"
-      )
-
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:exitPagePath" => "/page2"},
-            metrics: %{"ga:exits" => "3", "ga:users" => "2"}
-          }
-        ],
-        site.id,
-        "imported_exit_pages"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/exit-pages?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "name" => "/page2",
-                 "visitors" => 3,
-                 "visits" => 4,
-                 "exit_rate" => 80.0
-               },
-               %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66}
-             ]
-    end
-
-    test "imports city data from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          country_code: "EE",
-          timestamp: ~N[2021-01-01 00:15:00]
-        ),
-        build(:pageview,
-          country_code: "EE",
-          timestamp: ~N[2021-01-01 00:15:00]
-        ),
-        build(:pageview,
-          country_code: "GB",
-          timestamp: ~N[2021-01-01 00:15:00]
-        )
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:countryIsoCode" => "EE",
-              "ga:city" => "Tartu",
-              "ga:date" => "20210101",
-              "ga:regionIsoCode" => "Tartumaa"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:countryIsoCode" => "GB",
-              "ga:city" => "Edinburgh",
-              "ga:date" => "20210101",
-              "ga:regionIsoCode" => "Midlothian"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_locations"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/cities?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{"code" => 588_335, "name" => "Tartu", "visitors" => 1, "country_flag" => "🇪🇪"},
-               %{
-                 "code" => 2_650_225,
-                 "name" => "Edinburgh",
-                 "visitors" => 1,
-                 "country_flag" => "🇬🇧"
-               }
-             ]
-    end
-
-    test "imports country data from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          country_code: "EE",
-          timestamp: ~N[2021-01-01 00:15:00]
-        ),
-        build(:pageview,
-          country_code: "EE",
-          timestamp: ~N[2021-01-01 00:15:00]
-        ),
-        build(:pageview,
-          country_code: "GB",
-          timestamp: ~N[2021-01-01 00:15:00]
-        ),
-        build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:countryIsoCode" => "EE",
-              "ga:city" => "Tartu",
-              "ga:date" => "20210101",
-              "ga:regionIsoCode" => "Tartumaa"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{
-              "ga:countryIsoCode" => "GB",
-              "ga:city" => "Edinburgh",
-              "ga:date" => "20210101",
-              "ga:regionIsoCode" => "Midlothian"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_locations"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/countries?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "visitors" => 3,
-                 "percentage" => 60
-               },
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 2,
-                 "percentage" => 40
-               }
-             ]
-    end
-
-    test "Devices data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:pageview, screen_size: "Laptop", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:deviceCategory" => "mobile"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:deviceCategory" => "Laptop"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_devices"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/screen-sizes?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{"name" => "Desktop", "visitors" => 2, "percentage" => 40},
-               %{"name" => "Laptop", "visitors" => 2, "percentage" => 40},
-               %{"name" => "Mobile", "visitors" => 1, "percentage" => 20}
-             ]
-    end
-
-    test "Browsers data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:imported_visitors, visitors: 2, date: ~D[2021-01-01])
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{
-              "ga:browser" => "User-Agent: Mozilla",
-              "ga:date" => "20210101"
-            },
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{"ga:browser" => "Android Browser", "ga:date" => "20210101"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_browsers"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browsers?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert stats = json_response(conn, 200)
-      assert length(stats) == 3
-      assert %{"name" => "Firefox", "visitors" => 2, "percentage" => 50.0} in stats
-      assert %{"name" => "Mobile App", "visitors" => 1, "percentage" => 25.0} in stats
-      assert %{"name" => "Chrome", "visitors" => 1, "percentage" => 25.0} in stats
-    end
-
-    test "OS data imported from Google Analytics", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:pageview, operating_system: "GNU/Linux", timestamp: ~N[2021-01-01 00:15:00]),
-        build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:operatingSystem" => "Macintosh"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{"ga:date" => "20210101", "ga:operatingSystem" => "Linux"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:sessionDuration" => "10",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_operating_systems"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/operating-systems?period=day&date=2021-01-01&with_imported=true"
-        )
-
-      assert json_response(conn, 200) == [
-               %{"name" => "Mac", "visitors" => 3, "percentage" => 60},
-               %{"name" => "GNU/Linux", "visitors" => 2, "percentage" => 40}
-             ]
-    end
-
-    test "Can import visit duration with scientific notation", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
-      ])
-
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101"},
-            metrics: %{
-              "ga:bounces" => "0",
-              "ga:pageviews" => "1",
-              "ga:sessionDuration" => "1.391607E7",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          },
-          %{
-            dimensions: %{"ga:date" => "20210131"},
-            metrics: %{
-              "ga:bounces" => "1",
-              "ga:pageviews" => "1",
-              "ga:sessionDuration" => "60",
-              "ga:sessions" => "1",
-              "ga:users" => "1"
-            }
-          }
-        ],
-        site.id,
-        "imported_visitors"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true"
-        )
-
-      assert %{"top_stats" => top_stats} = json_response(conn, 200)
-
-      visit_duration = Enum.find(top_stats, fn stat -> stat["name"] == "Visit duration" end)
-
-      assert visit_duration["value"] == 3_479_033
-    end
-
-    test "skips empty dates from import", %{conn: conn, site: site} do
-      import_data(
-        [
-          %{
-            dimensions: %{"ga:date" => "20210101"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
-            }
-          },
-          %{
-            dimensions: %{"ga:date" => "(other)"},
-            metrics: %{
-              "ga:users" => "1",
-              "ga:pageviews" => "1",
-              "ga:bounces" => "0",
-              "ga:sessions" => "1",
-              "ga:sessionDuration" => "60"
-            }
-          }
-        ],
-        site.id,
-        "imported_visitors"
-      )
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true"
-        )
-
-      assert %{
-               "top_stats" => [
-                 %{"name" => "Unique visitors", "value" => 1},
-                 %{"name" => "Total visits", "value" => 1},
-                 %{"name" => "Total pageviews", "value" => 1},
-                 %{"name" => "Views per visit", "value" => +0.0},
-                 %{"name" => "Bounce rate", "value" => 0},
-                 %{"name" => "Visit duration", "value" => 60}
+        assert conn |> json_response(200) |> Enum.sort() == [
+                 %{"name" => "A Nice Newsletter", "visitors" => 1},
+                 %{"name" => "Direct / None", "visitors" => 1},
+                 %{"name" => "DuckDuckGo", "visitors" => 2},
+                 %{"name" => "Google", "visitors" => 4},
+                 %{"name" => "Twitter", "visitors" => 1}
                ]
-             } = json_response(conn, 200)
+      end
+
+      test "UTM mediums data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview,
+            utm_medium: "social",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            utm_medium: "social",
+            timestamp: ~N[2021-01-01 12:00:00]
+          )
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "social",
+                "ga:source" => "Twitter"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "(none)",
+                "ga:source" => "(direct)"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_sources"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "bounce_rate" => 100.0,
+                   "name" => "social",
+                   "visit_duration" => 20,
+                   "visitors" => 3
+                 }
+               ]
+      end
+
+      test "UTM campaigns data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview, utm_campaign: "profile", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_campaign: "august", timestamp: ~N[2021-01-01 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "profile",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "social",
+                "ga:source" => "Twitter"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "august",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "email",
+                "ga:source" => "Gmail"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "(not set)",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "email",
+                "ga:source" => "Gmail"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_sources"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "name" => "august",
+                   "visitors" => 2,
+                   "bounce_rate" => 50.0,
+                   "visit_duration" => 50.0
+                 },
+                 %{
+                   "name" => "profile",
+                   "visitors" => 2,
+                   "bounce_rate" => 100.0,
+                   "visit_duration" => 50.0
+                 }
+               ]
+      end
+
+      test "UTM terms data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview, utm_term: "oat milk", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "oat milk",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "Sweden",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "(not set)",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_sources"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "name" => "Sweden",
+                   "visitors" => 3,
+                   "bounce_rate" => 67.0,
+                   "visit_duration" => 33.3
+                 },
+                 %{
+                   "name" => "oat milk",
+                   "visitors" => 2,
+                   "bounce_rate" => 100.0,
+                   "visit_duration" => 50.0
+                 }
+               ]
+      end
+
+      test "UTM contents data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview, utm_content: "ad", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_content: "blog", timestamp: ~N[2021-01-01 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:adContent" => "ad",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "blog",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:adContent" => "(not set)",
+                "ga:campaign" => "",
+                "ga:date" => "20210101",
+                "ga:keyword" => "",
+                "ga:medium" => "paid",
+                "ga:source" => "Google"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "100",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_sources"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "name" => "blog",
+                   "visitors" => 2,
+                   "bounce_rate" => 50.0,
+                   "visit_duration" => 50.0
+                 },
+                 %{
+                   "name" => "ad",
+                   "visitors" => 2,
+                   "bounce_rate" => 100.0,
+                   "visit_duration" => 50.0
+                 }
+               ]
+      end
+
+      test "Page event data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview,
+            pathname: "/",
+            hostname: "host-a.com",
+            user_id: @user_id,
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            pathname: "/some-other-page",
+            hostname: "host-a.com",
+            user_id: @user_id,
+            timestamp: ~N[2021-01-01 00:15:00]
+          )
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:date" => "20210101",
+                "ga:hostname" => "host-a.com",
+                "ga:pagePath" => "/"
+              },
+              metrics: %{
+                "ga:exits" => "0",
+                "ga:pageviews" => "1",
+                "ga:timeOnPage" => "700",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:date" => "20210101",
+                "ga:hostname" => "host-b.com",
+                "ga:pagePath" => "/some-other-page"
+              },
+              metrics: %{
+                "ga:exits" => "1",
+                "ga:pageviews" => "2",
+                "ga:timeOnPage" => "60",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:date" => "20210101",
+                "ga:hostname" => "host-b.com",
+                "ga:pagePath" => "/some-other-page?wat=wot"
+              },
+              metrics: %{
+                "ga:exits" => "0",
+                "ga:pageviews" => "1",
+                "ga:timeOnPage" => "60",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_pages"
+        )
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:landingPagePath" => "/"},
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:entrances" => "3",
+                "ga:sessionDuration" => "10",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_entry_pages"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&detailed=true&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "bounce_rate" => nil,
+                   "time_on_page" => 60,
+                   "visitors" => 3,
+                   "pageviews" => 4,
+                   "name" => "/some-other-page"
+                 },
+                 %{
+                   "bounce_rate" => 25.0,
+                   "time_on_page" => 800.0,
+                   "visitors" => 2,
+                   "pageviews" => 2,
+                   "name" => "/"
+                 }
+               ]
+      end
+
+      test "Exit page event data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview,
+            pathname: "/page1",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            pathname: "/page1",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            pathname: "/page1",
+            user_id: @user_id,
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:pageview,
+            pathname: "/page2",
+            user_id: @user_id,
+            timestamp: ~N[2021-01-01 00:15:00]
+          )
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:date" => "20210101",
+                "ga:hostname" => "host-a.com",
+                "ga:pagePath" => "/page2"
+              },
+              metrics: %{
+                "ga:exits" => "0",
+                "ga:pageviews" => "4",
+                "ga:timeOnPage" => "10",
+                "ga:users" => "2"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_pages"
+        )
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:exitPagePath" => "/page2"},
+              metrics: %{"ga:exits" => "3", "ga:users" => "2"}
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_exit_pages"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/exit-pages?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "name" => "/page2",
+                   "visitors" => 3,
+                   "visits" => 4,
+                   "exit_rate" => 80.0
+                 },
+                 %{"name" => "/page1", "visitors" => 2, "visits" => 2, "exit_rate" => 66}
+               ]
+      end
+
+      test "imports city data from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview,
+            country_code: "EE",
+            timestamp: ~N[2021-01-01 00:15:00]
+          ),
+          build(:pageview,
+            country_code: "EE",
+            timestamp: ~N[2021-01-01 00:15:00]
+          ),
+          build(:pageview,
+            country_code: "GB",
+            timestamp: ~N[2021-01-01 00:15:00]
+          )
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:countryIsoCode" => "EE",
+                "ga:city" => "Tartu",
+                "ga:date" => "20210101",
+                "ga:regionIsoCode" => "Tartumaa"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:countryIsoCode" => "GB",
+                "ga:city" => "Edinburgh",
+                "ga:date" => "20210101",
+                "ga:regionIsoCode" => "Midlothian"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_locations"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/cities?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{"code" => 588_335, "name" => "Tartu", "visitors" => 1, "country_flag" => "🇪🇪"},
+                 %{
+                   "code" => 2_650_225,
+                   "name" => "Edinburgh",
+                   "visitors" => 1,
+                   "country_flag" => "🇬🇧"
+                 }
+               ]
+      end
+
+      test "imports country data from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, import_id, [
+          build(:pageview,
+            country_code: "EE",
+            timestamp: ~N[2021-01-01 00:15:00]
+          ),
+          build(:pageview,
+            country_code: "EE",
+            timestamp: ~N[2021-01-01 00:15:00]
+          ),
+          build(:pageview,
+            country_code: "GB",
+            timestamp: ~N[2021-01-01 00:15:00]
+          ),
+          build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:countryIsoCode" => "EE",
+                "ga:city" => "Tartu",
+                "ga:date" => "20210101",
+                "ga:regionIsoCode" => "Tartumaa"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{
+                "ga:countryIsoCode" => "GB",
+                "ga:city" => "Edinburgh",
+                "ga:date" => "20210101",
+                "ga:regionIsoCode" => "Midlothian"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_locations"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/countries?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{
+                   "code" => "EE",
+                   "alpha_3" => "EST",
+                   "name" => "Estonia",
+                   "flag" => "🇪🇪",
+                   "visitors" => 3,
+                   "percentage" => 60
+                 },
+                 %{
+                   "code" => "GB",
+                   "alpha_3" => "GBR",
+                   "name" => "United Kingdom",
+                   "flag" => "🇬🇧",
+                   "visitors" => 2,
+                   "percentage" => 40
+                 }
+               ]
+      end
+
+      test "Devices data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, import_id, [
+          build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, screen_size: "Laptop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:deviceCategory" => "mobile"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:deviceCategory" => "Laptop"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_devices"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/screen-sizes?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{"name" => "Desktop", "visitors" => 2, "percentage" => 40},
+                 %{"name" => "Laptop", "visitors" => 2, "percentage" => 40},
+                 %{"name" => "Mobile", "visitors" => 1, "percentage" => 20}
+               ]
+      end
+
+      test "Browsers data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, import_id, [
+          build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:imported_visitors, visitors: 2, date: ~D[2021-01-01])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{
+                "ga:browser" => "User-Agent: Mozilla",
+                "ga:date" => "20210101"
+              },
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{"ga:browser" => "Android Browser", "ga:date" => "20210101"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_browsers"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/browsers?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert stats = json_response(conn, 200)
+        assert length(stats) == 3
+        assert %{"name" => "Firefox", "visitors" => 2, "percentage" => 50.0} in stats
+        assert %{"name" => "Mobile App", "visitors" => 1, "percentage" => 25.0} in stats
+        assert %{"name" => "Chrome", "visitors" => 1, "percentage" => 25.0} in stats
+      end
+
+      test "OS data imported from Google Analytics", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, import_id, [
+          build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, operating_system: "GNU/Linux", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:operatingSystem" => "Macintosh"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "20210101", "ga:operatingSystem" => "Linux"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:sessionDuration" => "10",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_operating_systems"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/operating-systems?period=day&date=2021-01-01&with_imported=true"
+          )
+
+        assert json_response(conn, 200) == [
+                 %{"name" => "Mac", "visitors" => 3, "percentage" => 60},
+                 %{"name" => "GNU/Linux", "visitors" => 2, "percentage" => 40}
+               ]
+      end
+
+      test "Can import visit duration with scientific notation", %{
+        conn: conn,
+        site: site,
+        import_id: import_id
+      } do
+        populate_stats(site, [
+          build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, timestamp: ~N[2021-01-31 00:00:00])
+        ])
+
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101"},
+              metrics: %{
+                "ga:bounces" => "0",
+                "ga:pageviews" => "1",
+                "ga:sessionDuration" => "1.391607E7",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "20210131"},
+              metrics: %{
+                "ga:bounces" => "1",
+                "ga:pageviews" => "1",
+                "ga:sessionDuration" => "60",
+                "ga:sessions" => "1",
+                "ga:users" => "1"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_visitors"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true"
+          )
+
+        assert %{"top_stats" => top_stats} = json_response(conn, 200)
+
+        visit_duration = Enum.find(top_stats, fn stat -> stat["name"] == "Visit duration" end)
+
+        assert visit_duration["value"] == 3_479_033
+      end
+
+      test "skips empty dates from import", %{conn: conn, site: site, import_id: import_id} do
+        import_data(
+          [
+            %{
+              dimensions: %{"ga:date" => "20210101"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
+            },
+            %{
+              dimensions: %{"ga:date" => "(other)"},
+              metrics: %{
+                "ga:users" => "1",
+                "ga:pageviews" => "1",
+                "ga:bounces" => "0",
+                "ga:sessions" => "1",
+                "ga:sessionDuration" => "60"
+              }
+            }
+          ],
+          site.id,
+          import_id,
+          "imported_visitors"
+        )
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/top-stats?period=month&date=2021-01-01&with_imported=true"
+          )
+
+        assert %{
+                 "top_stats" => [
+                   %{"name" => "Unique visitors", "value" => 1},
+                   %{"name" => "Total visits", "value" => 1},
+                   %{"name" => "Total pageviews", "value" => 1},
+                   %{"name" => "Views per visit", "value" => +0.0},
+                   %{"name" => "Bounce rate", "value" => 0},
+                   %{"name" => "Visit duration", "value" => 60}
+                 ]
+               } = json_response(conn, 200)
+      end
     end
   end
 end

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -22,10 +22,12 @@ defmodule Plausible.ImportedTest do
         if unquote(import_type) in [:new, :new_and_legacy] do
           import_params =
             if unquote(import_type) == :new_and_legacy do
-              Map.from_struct(site.imported_data)
+              site.imported_data
+              |> Map.from_struct()
+              |> Map.put(:source, :universal_analytics)
             else
               %{
-                source: "Google Analytics",
+                source: :universal_analytics,
                 start_date: ~D[2005-01-01],
                 end_date: Timex.today()
               }

--- a/test/plausible/imported/universal_analytics_test.exs
+++ b/test/plausible/imported/universal_analytics_test.exs
@@ -62,7 +62,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
 
   describe "import_data/2" do
     @tag :slow
-    test "imports page views from Google Analytics", %{site: site} do
+    test "imports page views from Google Analytics", %{user: user, site: site} do
       mock_http_with("google_analytics_import#1.json")
 
       view_id = "54297898"
@@ -71,8 +71,16 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
       future = DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
       auth = {"***", "refresh_token", future}
 
+      site_import =
+        site
+        |> Plausible.Imported.SiteImport.create_changeset(
+          user,
+          %{source: "Google Analytics", start_date: date_range.first, end_date: date_range.last}
+        )
+        |> Plausible.Repo.insert!()
+
       assert :ok ==
-               UniversalAnalytics.import_data(site,
+               UniversalAnalytics.import_data(site_import,
                  date_range: date_range,
                  view_id: view_id,
                  auth: auth

--- a/test/plausible/imported/universal_analytics_test.exs
+++ b/test/plausible/imported/universal_analytics_test.exs
@@ -36,7 +36,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
       assert [
                %{
                  id: ^import_id,
-                 source: "Google Analytics",
+                 source: :universal_analytics,
                  start_date: ~D[2023-10-01],
                  end_date: ~D[2024-01-02],
                  status: :pending
@@ -75,7 +75,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
         site
         |> Plausible.Imported.SiteImport.create_changeset(
           user,
-          %{source: "Google Analytics", start_date: date_range.first, end_date: date_range.last}
+          %{source: :universal_analytics, start_date: date_range.first, end_date: date_range.last}
         )
         |> Plausible.Repo.insert!()
 

--- a/test/plausible/imported/universal_analytics_test.exs
+++ b/test/plausible/imported/universal_analytics_test.exs
@@ -6,14 +6,12 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
 
   setup [:create_user, :create_new_site]
 
-  describe "create_job/2 and parse_args/1" do
-    test "parses job args properly" do
-      site = insert(:site)
-      site_id = site.id
+  describe "parse_args/1" do
+    test "parses job args properly", %{user: user, site: site} do
       expires_at = NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
 
-      job =
-        UniversalAnalytics.create_job(site,
+      assert {:ok, job} =
+        UniversalAnalytics.new_import(site, user,
           view_id: 123,
           start_date: "2023-10-01",
           end_date: "2024-01-02",
@@ -22,21 +20,26 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
           token_expires_at: expires_at
         )
 
-      assert %Ecto.Changeset{
-               data: %Oban.Job{},
-               changes: %{
-                 args:
-                   %{
-                     "site_id" => ^site_id,
-                     "view_id" => 123,
-                     "start_date" => "2023-10-01",
-                     "end_date" => "2024-01-02",
-                     "access_token" => "access123",
-                     "refresh_token" => "refresh123",
-                     "token_expires_at" => ^expires_at
-                   } = args
+      assert %Oban.Job{
+               args:
+                 %{
+                   "import_id" => import_id,
+                   "view_id" => 123,
+                   "start_date" => "2023-10-01",
+                   "end_date" => "2024-01-02",
+                   "access_token" => "access123",
+                   "refresh_token" => "refresh123",
+                   "token_expires_at" => ^expires_at
+                 } = args
+             } = Repo.reload!(job)
+
+      assert [
+               %{
+                 id: ^import_id,
+                 start_date: ~D[2023-10-01],
+                 end_date: ~D[2024-01-02]
                }
-             } = job
+             ] = Plausible.Imported.list_all_imports(site)
 
       assert opts = [_ | _] = UniversalAnalytics.parse_args(args)
 
@@ -46,7 +49,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
     end
   end
 
-  describe "import/2" do
+  describe "import_data/2" do
     @tag :slow
     test "imports page views from Google Analytics", %{site: site} do
       mock_http_with("google_analytics_import#1.json")
@@ -58,7 +61,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
       auth = {"***", "refresh_token", future}
 
       assert :ok ==
-               UniversalAnalytics.import(site,
+               UniversalAnalytics.import_data(site,
                  date_range: date_range,
                  view_id: view_id,
                  auth: auth

--- a/test/plausible/imported/universal_analytics_test.exs
+++ b/test/plausible/imported/universal_analytics_test.exs
@@ -2,7 +2,10 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
   use Plausible.DataCase, async: true
   use Plausible.Test.Support.HTTPMocker
 
+  alias Plausible.Imported.SiteImport
   alias Plausible.Imported.UniversalAnalytics
+
+  require Plausible.Imported.SiteImport
 
   setup [:create_user, :create_new_site]
 
@@ -39,7 +42,7 @@ defmodule Plausible.Imported.UniversalAnalyticsTest do
                  source: :universal_analytics,
                  start_date: ~D[2023-10-01],
                  end_date: ~D[2024-01-02],
-                 status: :pending
+                 status: SiteImport.pending()
                }
              ] = Plausible.Imported.list_all_imports(site)
 

--- a/test/plausible/stats/interval_test.exs
+++ b/test/plausible/stats/interval_test.exs
@@ -72,7 +72,7 @@ defmodule Plausible.Stats.IntervalTest do
 
   describe "valid_for_period/3" do
     test "common" do
-      site = build(:site)
+      site = insert(:site)
       assert valid_for_period?("month", "date", site: site)
       refute valid_for_period?("30d", "month", site: site)
       refute valid_for_period?("realtime", "week", site: site)

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -120,7 +120,7 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   test "all time shows hourly if site is completely new", %{site: site} do
-    site = Map.put(site, :stats_start_date, Timex.now())
+    site = Map.put(site, :stats_start_date, Timex.now() |> Timex.to_date())
     q = Query.from(site, %{"period" => "all"})
 
     assert q.date_range.first == Timex.today()
@@ -130,7 +130,9 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   test "all time shows daily if site is more than a day old", %{site: site} do
-    site = Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(days: -1))
+    site =
+      Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(days: -1) |> Timex.to_date())
+
     q = Query.from(site, %{"period" => "all"})
 
     assert q.date_range.first == Timex.today() |> Timex.shift(days: -1)
@@ -140,7 +142,9 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   test "all time shows monthly if site is more than a month old", %{site: site} do
-    site = Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(months: -1))
+    site =
+      Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(months: -1) |> Timex.to_date())
+
     q = Query.from(site, %{"period" => "all"})
 
     assert q.date_range.first == Timex.today() |> Timex.shift(months: -1)
@@ -150,7 +154,9 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   test "all time uses passed interval different from the default interval", %{site: site} do
-    site = Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(months: -1))
+    site =
+      Map.put(site, :stats_start_date, Timex.now() |> Timex.shift(months: -1) |> Timex.to_date())
+
     q = Query.from(site, %{"period" => "all", "interval" => "week"})
 
     assert q.date_range.first == Timex.today() |> Timex.shift(months: -1)

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -8,6 +8,10 @@ defmodule PlausibleWeb.SiteControllerTest do
   import Mox
   import Plausible.Test.Support.HTML
 
+  alias Plausible.Imported.SiteImport
+
+  require Plausible.Imported.SiteImport
+
   @v4_business_plan_id "857105"
 
   setup :verify_on_exit!
@@ -1274,7 +1278,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       assert site_import.source == :universal_analytics
       assert site_import.end_date == ~D[2022-03-01]
-      assert site_import.status == :pending
+      assert site_import.status == SiteImport.pending()
     end
 
     test "schedules an import job in Oban", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1272,7 +1272,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       [site_import] = Plausible.Imported.list_all_imports(site)
 
-      assert site_import.source == "Google Analytics"
+      assert site_import.source == :universal_analytics
       assert site_import.end_date == ~D[2022-03-01]
       assert site_import.status == :pending
     end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1260,7 +1260,7 @@ defmodule PlausibleWeb.SiteControllerTest do
   describe "POST /:website/settings/google-import" do
     setup [:create_user, :log_in, :create_new_site]
 
-    test "adds in-progress imported tag to site", %{conn: conn, site: site} do
+    test "creates site import instance", %{conn: conn, site: site} do
       post(conn, "/#{site.domain}/settings/google-import", %{
         "view_id" => "123",
         "start_date" => "2018-03-01",
@@ -1270,12 +1270,11 @@ defmodule PlausibleWeb.SiteControllerTest do
         "expires_at" => "2022-09-22T20:01:37.112777"
       })
 
-      imported_data = Repo.reload(site).imported_data
+      [site_import] = Plausible.Imported.list_all_imports(site)
 
-      assert imported_data
-      assert imported_data.source == "Google Analytics"
-      assert imported_data.end_date == ~D[2022-03-01]
-      assert imported_data.status == "importing"
+      assert site_import.source == "Google Analytics"
+      assert site_import.end_date == ~D[2022-03-01]
+      assert site_import.status == :pending
     end
 
     test "schedules an import job in Oban", %{conn: conn, site: site} do
@@ -1288,11 +1287,12 @@ defmodule PlausibleWeb.SiteControllerTest do
         "expires_at" => "2022-09-22T20:01:37.112777"
       })
 
+      assert [%{id: import_id}] = Plausible.Imported.list_all_imports(site)
+
       assert_enqueued(
         worker: Plausible.Workers.ImportAnalytics,
         args: %{
-          "source" => "Google Analytics",
-          "site_id" => site.id,
+          "import_id" => import_id,
           "view_id" => "123",
           "start_date" => "2018-03-01",
           "end_date" => "2022-03-01",
@@ -1313,9 +1313,13 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert Repo.reload(site).imported_data == nil
     end
 
-    test "removes actual imported data from Clickhouse", %{conn: conn, site: site} do
-      Plausible.Site.start_import(site, ~D[2022-01-01], Timex.today(), "Google Analytics")
-      |> Repo.update!()
+    test "removes actual imported data from Clickhouse", %{conn: conn, user: user, site: site} do
+      Plausible.Imported.NoopImporter.new_import(
+        site,
+        user,
+        start_date: ~D[2022-01-01],
+        end_date: Timex.today()
+      )
 
       populate_stats(site, [
         build(:imported_visitors, pageviews: 10)
@@ -1329,20 +1333,14 @@ defmodule PlausibleWeb.SiteControllerTest do
              end)
     end
 
-    test "cancels Oban job if it exists", %{conn: conn, site: site} do
+    test "cancels Oban job if it exists", %{conn: conn, user: user, site: site} do
       {:ok, job} =
-        Plausible.Workers.ImportAnalytics.new(%{
-          "source" => "Google Analytics",
-          "site_id" => site.id,
-          "view_id" => "123",
-          "start_date" => "2022-01-01",
-          "end_date" => "2023-01-01",
-          "access_token" => "token"
-        })
-        |> Oban.insert()
-
-      Plausible.Site.start_import(site, ~D[2022-01-01], Timex.today(), "Google Analytics")
-      |> Repo.update!()
+        Plausible.Imported.NoopImporter.new_import(
+          site,
+          user,
+          start_date: ~D[2022-01-01],
+          end_date: Timex.today()
+        )
 
       populate_stats(site, [
         build(:imported_visitors, pageviews: 10)

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -145,6 +145,21 @@ defmodule Plausible.TestUtils do
     :ok
   end
 
+  def populate_stats(site, import_id, events) do
+    Enum.map(events, fn event ->
+      event = Map.put(event, :site_id, site.id)
+
+      case event do
+        %Plausible.ClickhouseEventV2{} ->
+          event
+
+        imported_event ->
+          Map.put(imported_event, :import_id, import_id)
+      end
+    end)
+    |> populate_stats
+  end
+
   def populate_stats(site, events) do
     Enum.map(events, fn event ->
       Map.put(event, :site_id, site.id)

--- a/test/workers/import_analytics_test.exs
+++ b/test/workers/import_analytics_test.exs
@@ -2,7 +2,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
   use Plausible.DataCase
   use Bamboo.Test
 
+  alias Plausible.Imported.SiteImport
   alias Plausible.Workers.ImportAnalytics
+
+  require Plausible.Imported.SiteImport
 
   @moduletag capture_log: true
 
@@ -24,7 +27,7 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       {:ok, job} = Plausible.Imported.NoopImporter.new_import(site, user, import_opts)
 
-      assert [%{status: :pending}] = Plausible.Imported.list_all_imports(site)
+      assert [%{status: SiteImport.pending()}] = Plausible.Imported.list_all_imports(site)
 
       # before_start callback triggered
       assert_received {:before_start, import_id}
@@ -34,7 +37,8 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
                |> Repo.reload!()
                |> ImportAnalytics.perform()
 
-      assert [%{id: ^import_id, status: :completed}] = Plausible.Imported.list_all_imports(site)
+      assert [%{id: ^import_id, status: SiteImport.completed()}] =
+               Plausible.Imported.list_all_imports(site)
 
       # on_success callback triggered
       assert_received {:on_success, ^import_id}
@@ -88,7 +92,7 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
                |> Repo.reload!()
                |> ImportAnalytics.perform()
 
-      assert [%{status: :failed}] = Plausible.Imported.list_all_imports(site)
+      assert [%{status: SiteImport.failed()}] = Plausible.Imported.list_all_imports(site)
     end
 
     test "clears any orphaned data during import", %{import_opts: import_opts} do

--- a/test/workers/import_analytics_test.exs
+++ b/test/workers/import_analytics_test.exs
@@ -53,6 +53,7 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       site = Repo.reload!(site)
       assert site.stats_start_date == nil
+      site = Plausible.Imported.load_import_data(site)
       assert Plausible.Sites.stats_start_date(site) == import_opts[:start_date]
       assert Repo.reload!(site).stats_start_date == import_opts[:start_date]
     end

--- a/test/workers/import_analytics_test.exs
+++ b/test/workers/import_analytics_test.exs
@@ -29,9 +29,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
       # before_start callback triggered
       assert_received {:before_start, import_id}
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert :ok =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       assert [%{id: ^import_id, status: :completed}] = Plausible.Imported.list_all_imports(site)
 
@@ -47,9 +48,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       {:ok, job} = Plausible.Imported.NoopImporter.new_import(site, user, import_opts)
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert :ok =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       site = Repo.reload!(site)
       assert site.stats_start_date == nil
@@ -63,9 +65,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       {:ok, job} = Plausible.Imported.NoopImporter.new_import(site, user, import_opts)
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert :ok =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       assert_email_delivered_with(
         to: [user],
@@ -80,9 +83,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       {:ok, job} = Plausible.Imported.NoopImporter.new_import(site, user, import_opts)
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert {:discard, "Something went wrong"} =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       assert [%{status: :failed}] = Plausible.Imported.list_all_imports(site)
     end
@@ -98,9 +102,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
         build(:imported_visitors, import_id: job.args.import_id, pageviews: 10)
       ])
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert {:discard, _} =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       assert eventually(fn ->
                count = Plausible.Stats.Clickhouse.imported_pageview_count(site)
@@ -118,9 +123,10 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       {:ok, job} = Plausible.Imported.NoopImporter.new_import(site, user, import_opts)
 
-      job
-      |> Repo.reload!()
-      |> ImportAnalytics.perform()
+      assert {:discard, _} =
+               job
+               |> Repo.reload!()
+               |> ImportAnalytics.perform()
 
       assert_email_delivered_with(
         to: [user],

--- a/test/workers/import_analytics_test.exs
+++ b/test/workers/import_analytics_test.exs
@@ -53,7 +53,6 @@ defmodule Plausible.Workers.ImportAnalyticsTest do
 
       site = Repo.reload!(site)
       assert site.stats_start_date == nil
-      site = Plausible.Imported.load_import_data(site)
       assert Plausible.Sites.stats_start_date(site) == import_opts[:start_date]
       assert Repo.reload!(site).stats_start_date == import_opts[:start_date]
     end


### PR DESCRIPTION
### Changes

This PR will be eventually have migrations extracted from it and merged first in order to safely deploy the rest of the code.

This is a significant refactor of imported stats logic to open up the possibility of a) having more than one import per site b) having imports from more than one source (beyond our current Google Analytics integration).

The most important addition is `Plausible.Imported.Importer` behaviour that defines a common interface for running all imports in the system. As all import jobs run through it, they are globally serialized to keep a better control over system load.

The `Importer` behaviour will be implemented for any future import sources.

All `imported_*` CH tables are now extended with an additional column, `import_id`, which is used for scoping imported statistics queries only to imports that are complete (not in progress or failed).

There's `Plausible.Imported.SiteImport` PG schema now, which holds information about each import with a reference to the site. Its ID is what is put in CH tables' `import_id` column.

In order to support soon-to-be legacy import, we still support transparently fetching data from `site.imported_data`, with the assumption that legacy imports have import ID of `0` (default column value in CH after migration).

The `Plausible.Imported.UniversalAnalytics` importer implementation in its current shape maintains `site.imported_data` contents to ensure import UI in its current shape is supported. Some of that logic will go away once we implemented proper import UI, replacing the existing one tightly bound with Google integration in "Integrations" site section (there's a stub built on top of this branch for this purpose in https://github.com/plausible/analytics/pull/3727).

Module docs of `Plausible.Imported` and `Plausible.Imported.Importer` might be a good starting point for review.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
