### PR TITLE
Use parallel_hash for joins in clickhouse

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -390,7 +390,8 @@ config :plausible, Plausible.ClickhouseRepo,
   url: ch_db_url,
   transport_opts: ch_transport_opts,
   settings: [
-    readonly: 1
+    readonly: 1,
+    join_algorithm: "direct,parallel_hash"
   ]
 
 config :plausible, Plausible.IngestRepo,


### PR DESCRIPTION
### Changes

JOINs are frequently the slowest part of any clickhouse query. We make a lot of them.

I've benchmarked [`join_algorithm` query setting](https://clickhouse.com/docs/en/operations/settings/settings#join_algorithm) and results showed a consistent 50%-200% improvement in slow (>1s) queries. Some fast queries (e.g. <400s) became around 20% slower, which is acceptable and might be statistical noise.

More context under https://3.basecamp.com/5308029/buckets/35611491/messages/7009643334

Question to reviewers: Should this go to changelog?

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
