### PR TITLE
Parse referrer filter value when passed separately

### DIFF
--- a/lib/plausible/stats/filters/dashboard_filter_parser.ex
+++ b/lib/plausible/stats/filters/dashboard_filter_parser.ex
@@ -26,13 +26,8 @@ defmodule Plausible.Stats.Filters.DashboardFilterParser do
     end)
   end
 
-  defp put_parsed_props(new_filters, name, val) do
-    Enum.reduce(val, new_filters, fn {prop_key, prop_val}, new_filters ->
-      Map.put(new_filters, "event:props:" <> prop_key, filter_value(name, prop_val))
-    end)
-  end
-
-  defp filter_value(key, val) do
+  @spec filter_value(String.t(), String.t()) :: {atom(), String.t() | [String.t()]}
+  def filter_value(key, val) do
     {is_negated, val} = parse_negated_prefix(val)
     {is_contains, val} = parse_contains_prefix(val)
     is_list = list_expression?(val)
@@ -55,6 +50,12 @@ defmodule Plausible.Stats.Filters.DashboardFilterParser do
       is_wildcard -> {:matches, val}
       true -> {:is, val}
     end
+  end
+
+  defp put_parsed_props(new_filters, name, val) do
+    Enum.reduce(val, new_filters, fn {prop_key, prop_val}, new_filters ->
+      Map.put(new_filters, "event:props:" <> prop_key, filter_value(name, prop_val))
+    end)
   end
 
   defp parse_negated_prefix("!" <> val), do: {true, val}

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -168,8 +168,15 @@ defmodule Plausible.Stats.Query do
   end
 
   def put_filter(query, key, val) do
+    parsed_val =
+      if is_binary(val) do
+        Filters.DashboardFilterParser.filter_value(key, val)
+      else
+        val
+      end
+
     struct!(query,
-      filters: Map.put(query.filters, key, val)
+      filters: Map.put(query.filters, key, parsed_val)
     )
   end
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -709,7 +709,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     query =
       Query.from(site, params)
-      |> Query.put_filter("visit:source", {:is, "Google"})
+      |> Query.put_filter("visit:source", "Google")
 
     search_terms =
       if site.google_auth && site.google_auth.property && !query.filters["goal"] do
@@ -744,7 +744,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     query =
       Query.from(site, params)
-      |> Query.put_filter("visit:source", {:is, referrer})
+      |> Query.put_filter("visit:source", referrer)
 
     pagination = parse_pagination(params)
 

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1460,11 +1460,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
     test "works when filter expression is provided for source", %{
       conn: conn,
-      user: user,
       site: site
     } do
-      insert(:google_auth, user: user, user: user, site: site, property: "sc-domain:example.com")
-
       populate_stats(site, [
         build(:pageview,
           referrer_source: "DuckDuckGo",

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1458,6 +1458,41 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
              }
     end
 
+    test "works when filter expression is provided for source", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      insert(:google_auth, user: user, user: user, site: site, property: "sc-domain:example.com")
+
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/!Google?period=day")
+
+      assert json_response(conn, 200) == [
+               %{"name" => "duckduckgo.com", "visitors" => 1}
+             ]
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google|DuckDuckGo?period=day")
+
+      assert [entry1, entry2] = json_response(conn, 200)
+      assert %{"name" => "google.com", "visitors" => 2} in [entry1, entry2]
+      assert %{"name" => "duckduckgo.com", "visitors" => 1} in [entry1, entry2]
+    end
+
     test "returns top referring urls for a custom goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,


### PR DESCRIPTION
### Changes

This PR fixes an issue where filter expression provided for source in referrer drilldown is not parsed and filtered by properly.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
