### PR TITLE
safe(r) Oban telemetry

### DIFF
--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -1,9 +1,17 @@
 defmodule ObanErrorReporter do
+  require Logger
+
   def handle_event(name, measurements, metadata, _) do
-    # handling telemetry event in an unlinked process
+    # handling telemetry event in a try/catch block
     # to avoid handler detachment in the case of an error
     # see https://hexdocs.pm/telemetry/telemetry.html#attach/4
-    Task.start(fn -> handle_event(name, measurements, metadata) end)
+    try do
+      handle_event(name, measurements, metadata)
+    catch
+      kind, reason ->
+        message = Exception.format(kind, reason, __STACKTRACE__)
+        Logger.error(message)
+    end
   end
 
   defp handle_event([:oban, :job, :exception], measure, %{job: job} = meta) do

--- a/test/workers/oban_error_reporter_test.exs
+++ b/test/workers/oban_error_reporter_test.exs
@@ -15,7 +15,12 @@ defmodule ObanErrorReporterTest do
 
     @tag :capture_log
     test "doesn't detach on failure" do
-      :telemetry.execute([:oban, :job, :exception], %{}, %{job: %{}})
+      :ok =
+        :telemetry.execute(
+          [:oban, :job, :exception],
+          _bad_measurements = %{},
+          _bad_metadata = %{job: :bad_job}
+        )
 
       handlers = :telemetry.list_handlers([:oban, :job, :exception])
       assert Enum.any?(handlers, &(&1.id == "oban-errors-test"))
@@ -24,10 +29,15 @@ defmodule ObanErrorReporterTest do
     test "logs an error on failure" do
       log =
         ExUnit.CaptureLog.capture_log(fn ->
-          :telemetry.execute([:oban, :job, :exception], %{}, %{job: %{}})
+          :ok =
+            :telemetry.execute(
+              [:oban, :job, :exception],
+              _bad_measurements = %{},
+              _bad_metadata = %{job: :bad_job}
+            )
         end)
 
-      assert log =~ "[error] ** (KeyError) key :reason not found in: %{job: %{}}"
+      assert log =~ "[error] ** (BadMapError) expected a map, got: :bad_job"
     end
   end
 end

--- a/test/workers/oban_error_reporter_test.exs
+++ b/test/workers/oban_error_reporter_test.exs
@@ -1,0 +1,33 @@
+defmodule ObanErrorReporterTest do
+  use ExUnit.Case, async: true
+
+  describe "handle_event/4" do
+    setup do
+      :telemetry.attach_many(
+        "oban-errors-test",
+        [[:oban, :job, :exception], [:oban, :notifier, :exception], [:oban, :plugin, :exception]],
+        &ObanErrorReporter.handle_event/4,
+        %{}
+      )
+
+      on_exit(fn -> :ok = :telemetry.detach("oban-errors-test") end)
+    end
+
+    @tag :capture_log
+    test "doesn't detach on failure" do
+      :telemetry.execute([:oban, :job, :exception], %{}, %{job: %{}})
+
+      handlers = :telemetry.list_handlers([:oban, :job, :exception])
+      assert Enum.any?(handlers, &(&1.id == "oban-errors-test"))
+    end
+
+    test "logs an error on failure" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          :telemetry.execute([:oban, :job, :exception], %{}, %{job: %{}})
+        end)
+
+      assert log =~ "[error] ** (KeyError) key :reason not found in: %{job: %{}}"
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR makes ObanErrorReporter safer by processing the potentially fallible events in ~~an unlinked process.~~ a try/catch block.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
