### PR TITLE
Improve Stats API upgrade required error message

### DIFF
--- a/lib/plausible_web/plugs/authorize_stats_api.ex
+++ b/lib/plausible_web/plugs/authorize_stats_api.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.AuthorizeStatsApiPlug do
       {:error, :upgrade_required} ->
         H.payment_required(
           conn,
-          "#{Plausible.Billing.Feature.StatsAPI.display_name()} is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
+          "The account that owns this API key does not have access to Stats API. Please make sure you're using the API key of a subscriber account and that the subscription plan includes Stats API"
         )
 
       {:error, :site_locked} ->

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
     |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain, "metrics" => "pageviews"})
     |> assert_error(
       402,
-      "Stats API is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
+      "The account that owns this API key does not have access to Stats API."
     )
   end
 


### PR DESCRIPTION
### Changes

We recently fixed a bug and took away Stats API (and other features) access from users without a trial or an active subscription. Before we made that change, users might have been using API keys of admin accounts that didn't have an active subscription. Now that we've finally blocked the access, those API keys do not have access anymore, and the current error message is pretty intimidating -

> Stats API is part of the Plausible Business plan. To get access to this feature, please upgrade your account.

Upgrading the owner account will not fix the issue if you keep using the admin key. This PR is a quick fix to improve the communication and tell users about the real problem.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
