### PR TITLE
Improve print dashboard css

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -9,6 +9,13 @@
 
 [x-cloak] { display: none; }
 
+@media print {
+  canvas {
+    width: 100% !important;
+    height: auto !important;
+  }
+}
+
 .button {
   @apply inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md leading-5 transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500;
 }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -349,7 +349,7 @@ class LineGraph extends React.Component {
             <IntervalPicker site={site} query={query} graphData={graphData} metric={metric} updateInterval={updateInterval} />
           </div>
           <FadeIn show={graphData}>
-            <div className="relative h-96 w-full z-0">
+            <div className="relative h-96 print:h-auto print:pb-8 w-full z-0">
               <canvas id="main-graph-canvas" className={canvasClass}></canvas>
             </div>
           </FadeIn>

--- a/lib/plausible_web/templates/layout/_footer.html.heex
+++ b/lib/plausible_web/templates/layout/_footer.html.heex
@@ -39,7 +39,7 @@
         <% end %>
       </div>
       <div class="grid grid-cols-2 gap-8 xl:col-span-2">
-        <div class="md:grid md:grid-cols-2 md:gap-8">
+        <div class="md:grid md:grid-cols-2 md:gap-8 print:hidden">
           <div>
             <h4 class="text-sm font-semibold tracking-wider text-gray-400 uppercase leading-5">
               Why Plausible?
@@ -154,7 +154,7 @@
             </ul>
           </div>
         </div>
-        <div class="md:grid md:grid-cols-2 md:gap-8">
+        <div class="md:grid md:grid-cols-2 md:gap-8 print:hidden">
           <div>
             <h4 class="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
               Community

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -1,5 +1,5 @@
 <nav class="relative z-20 py-8">
-  <div class="container">
+  <div class="container print:max-w-full">
     <nav class="relative flex items-center justify-between sm:h-10 md:justify-center">
       <div class="flex items-center flex-1 md:absolute md:inset-y-0 md:left-0">
         <a href={home_dest(@conn)}>

--- a/lib/plausible_web/views/stats_view.ex
+++ b/lib/plausible_web/views/stats_view.ex
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.StatsView do
     cond do
       conn.assigns[:embedded] && conn.assigns[:width] == "manual" -> ""
       conn.assigns[:embedded] -> "max-w-screen-xl mx-auto px-6"
-      !conn.assigns[:embedded] -> "container"
+      !conn.assigns[:embedded] -> "container print:max-w-full"
     end
   end
 


### PR DESCRIPTION
### Changes

This PR improves print layout at least in chromium-based browsers. Firefox for me will refuse to print anything but the first page :shrug: 

Before:

![image](https://github.com/plausible/analytics/assets/173738/1534467a-3392-47d0-856a-eda0b79bf090)


After:

![image](https://github.com/plausible/analytics/assets/173738/524ae065-9434-46e8-9534-f2c2d7338366)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
