### PR TITLE
Fix flashing on reapplying theme

### DIFF
--- a/lib/plausible_web/components/layout.ex
+++ b/lib/plausible_web/components/layout.ex
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Components.Layout do
 
   def theme_script(assigns) do
     ~H"""
-    <script>
+    <script blocking="rendering">
       (function(){
         var themePref = '<%= theme_preference(assigns) %>';
         function reapplyTheme() {

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -25,6 +25,7 @@
         "Plausible · Simple, privacy-friendly alternative to Google Analytics" %>
     </title>
     <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")} />
+    <PlausibleWeb.Components.Layout.theme_script {Map.take(assigns, [:current_user, :theme])} />
     <%= render("_tracking.html", assigns) %>
   </head>
   <body
@@ -44,8 +45,6 @@
     <main class="flex-1">
       <%= Map.get(assigns, :inner_layout) || @inner_content %>
     </main>
-
-    <PlausibleWeb.Components.Layout.theme_script {Map.take(assigns, [:current_user, :theme])} />
 
     <%= if assigns[:embedded] do %>
       <div data-iframe-height></div>


### PR DESCRIPTION
This seem to be making a difference on staging

ref https://github.com/plausible/analytics/pull/3639/
ref https://github.com/plausible/analytics/pull/3625/

Repro on prod: set dark mode, go to /sites, wait for full load, click plausible logo in the left corner