### PR TITLE
Include metrics for Plugins API router

### DIFF
--- a/lib/plausible/prom_ex.ex
+++ b/lib/plausible/prom_ex.ex
@@ -10,6 +10,7 @@ defmodule Plausible.PromEx do
       Plugins.Beam,
       Plugins.PhoenixLiveView,
       {Plugins.Phoenix, router: PlausibleWeb.Router, endpoint: PlausibleWeb.Endpoint},
+      {Plugins.Phoenix, router: PlausibleWeb.Plugins.API.Router, endpoint: PlausibleWeb.Endpoint},
       {Plugins.Ecto,
        repos: [
          Plausible.Repo,


### PR DESCRIPTION
It's a separate one, so PromEx must know about it.
