### PR TITLE
Turn Revenue Goals into Custom Events if the plan doesn't support them

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1144,7 +1144,8 @@ defmodule PlausibleWeb.Api.StatsController do
 
     metrics =
       on_full_build do
-        if Enum.any?(site.goals, &Plausible.Goal.Revenue.revenue?/1) do
+        if Enum.any?(site.goals, &Plausible.Goal.Revenue.revenue?/1) and
+             Plausible.Billing.Feature.RevenueGoals.enabled?(site) do
           [:visitors, :events] ++ @revenue_metrics
         else
           [:visitors, :events]

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -61,6 +61,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
         goals={@displayed_goals}
         domain={@domain}
         filter_text={@filter_text}
+        site={@site}
       />
     </div>
     """

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -25,6 +25,23 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
       assert resp =~ "Revenue Goal"
     end
 
+    test "lists Revenue Goals with feature availability annotation if the plan does not cover them",
+         %{conn: conn, user: user, site: site} do
+      {:ok, [_, _, g3]} = setup_goals(site)
+
+      user
+      |> Plausible.Auth.User.end_trial()
+      |> Plausible.Repo.update!()
+
+      conn = get(conn, "/#{site.domain}/settings/goals")
+
+      resp = html_response(conn, 200)
+
+      assert g3.currency
+      assert resp =~ to_string(g3)
+      assert resp =~ "Unlock Revenue Goals by upgrading to a business plan"
+    end
+
     test "lists goals with delete actions", %{conn: conn, site: site} do
       {:ok, goals} = setup_goals(site)
       conn = get(conn, "/#{site.domain}/settings/goals")

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -25,6 +25,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
       assert resp =~ "Revenue Goal"
     end
 
+    @tag :full_build_only
     test "lists Revenue Goals with feature availability annotation if the plan does not cover them",
          %{conn: conn, user: user, site: site} do
       {:ok, [_, _, g3]} = setup_goals(site)


### PR DESCRIPTION
### Changes

This PR hides the revenue-related metrics for users who have created Revenue Goals but their plan currently does not support them.

![image](https://github.com/plausible/analytics/assets/173738/43012044-536e-4e47-9f95-b861d612011c)

Visual indication of such case is also included in the goals list:

![image](https://github.com/plausible/analytics/assets/173738/94f867c5-2355-4422-8f51-381a408d955e)



### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
