### PR TITLE
Refactor spike detection top sources query

### DIFF
--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -9,8 +9,6 @@ defmodule Plausible.Stats.Clickhouse do
   alias Plausible.Stats.Query
   alias Plausible.Timezones
 
-  @no_ref "Direct / None"
-
   @spec pageview_start_date_local(Plausible.Site.t()) :: Date.t() | nil
   def pageview_start_date_local(site) do
     datetime =

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -83,17 +83,21 @@ defmodule Plausible.Stats.Clickhouse do
 
   def usage_breakdown([], _date_range), do: {0, 0}
 
-  def top_sources(site, query, limit, page, show_noref \\ false, include_details) do
+  def top_sources_for_spike(site, query, limit, page, show_noref \\ false, include_details) do
     offset = (page - 1) * limit
 
+    {first_datetime, last_datetime} = utc_boundaries(query, site)
+
     referrers =
-      from(s in base_session_query(site, query),
+      from(s in "sessions_v2",
+        where: s.site_id == ^site.id,
+        # Note: This query intentionally uses session end timestamp to get currently active users
+        where: s.timestamp >= ^first_datetime and s.start < ^last_datetime,
         group_by: s.referrer_source,
         order_by: [desc: uniq(s.user_id), asc: s.referrer_source],
         limit: ^limit,
         offset: ^offset
       )
-      |> filter_converted_sessions(site, query)
 
     referrers =
       if show_noref do
@@ -103,6 +107,10 @@ defmodule Plausible.Stats.Clickhouse do
       end
 
     referrers = apply_page_as_entry_page(referrers, site, query)
+
+    on_full_build do
+      referrers = Plausible.Stats.Sampling.add_query_hint(referrers, 10_000_000)
+    end
 
     referrers =
       if include_details do
@@ -143,25 +151,6 @@ defmodule Plausible.Stats.Clickhouse do
     |> Enum.map(fn ref ->
       Map.update(ref, :url, nil, fn url -> url && URI.parse("http://" <> url).host end)
     end)
-  end
-
-  defp filter_converted_sessions(db_query, site, query) do
-    goal = query.filters["goal"]
-    page = query.filters[:page]
-
-    if is_binary(goal) || is_binary(page) do
-      converted_sessions =
-        from(e in base_query(site, query),
-          select: %{session_id: fragment("DISTINCT ?", e.session_id)}
-        )
-
-      from(s in db_query,
-        join: cs in subquery(converted_sessions),
-        on: s.session_id == cs.session_id
-      )
-    else
-      db_query
-    end
   end
 
   defp apply_page_as_entry_page(db_query, _site, query) do
@@ -296,128 +285,6 @@ defmodule Plausible.Stats.Clickhouse do
         interval: NaiveDateTime.add(first, offset, :hour),
         visitors: 0
       }
-    end
-  end
-
-  defp base_session_query(site, query) do
-    {first_datetime, last_datetime} = utc_boundaries(query, site)
-
-    q =
-      from(s in "sessions_v2",
-        where: s.site_id == ^site.id,
-        where: s.timestamp >= ^first_datetime and s.start < ^last_datetime
-      )
-
-    on_full_build do
-      q = Plausible.Stats.Sampling.add_query_hint(q, 10_000_000)
-    end
-
-    q =
-      if query.filters["source"] do
-        source = query.filters["source"]
-        source = if source == @no_ref, do: "", else: source
-        from(s in q, where: s.referrer_source == ^source)
-      else
-        q
-      end
-
-    q =
-      if query.filters["screen"] do
-        size = query.filters["screen"]
-        from(s in q, where: s.screen_size == ^size)
-      else
-        q
-      end
-
-    q =
-      if query.filters["browser"] do
-        browser = query.filters["browser"]
-        from(s in q, where: s.browser == ^browser)
-      else
-        q
-      end
-
-    q =
-      if query.filters["browser_version"] do
-        version = query.filters["browser_version"]
-        from(s in q, where: s.browser_version == ^version)
-      else
-        q
-      end
-
-    q =
-      if query.filters["os"] do
-        os = query.filters["os"]
-        from(s in q, where: s.operating_system == ^os)
-      else
-        q
-      end
-
-    q =
-      if query.filters["os_version"] do
-        version = query.filters["os_version"]
-        from(s in q, where: s.operating_system_version == ^version)
-      else
-        q
-      end
-
-    q =
-      if query.filters["country"] do
-        country = query.filters["country"]
-        from(s in q, where: s.country_code == ^country)
-      else
-        q
-      end
-
-    q =
-      if query.filters["utm_medium"] do
-        utm_medium = query.filters["utm_medium"]
-        from(s in q, where: s.utm_medium == ^utm_medium)
-      else
-        q
-      end
-
-    q =
-      if query.filters["utm_source"] do
-        utm_source = query.filters["utm_source"]
-        from(s in q, where: s.utm_source == ^utm_source)
-      else
-        q
-      end
-
-    q =
-      if query.filters["utm_campaign"] do
-        utm_campaign = query.filters["utm_campaign"]
-        from(s in q, where: s.utm_campaign == ^utm_campaign)
-      else
-        q
-      end
-
-    q =
-      if query.filters["utm_content"] do
-        utm_content = query.filters["utm_content"]
-        from(s in q, where: s.utm_content == ^utm_content)
-      else
-        q
-      end
-
-    q =
-      if query.filters["utm_term"] do
-        utm_term = query.filters["utm_term"]
-        from(s in q, where: s.utm_term == ^utm_term)
-      else
-        q
-      end
-
-    q = include_path_filter_entry(q, query.filters["entry_page"])
-
-    q = include_path_filter_exit(q, query.filters["exit_page"])
-
-    if query.filters["referrer"] do
-      ref = query.filters["referrer"]
-      from(s in q, where: s.referrer == ^ref)
-    else
-      q
     end
   end
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -91,17 +91,8 @@ defmodule Plausible.Stats.Clickhouse do
     referrers =
       from(s in "sessions_v2",
         select: %{
-          name:
-            fragment(
-              "if(empty(?), ?, ?) as name",
-              s.referrer_source,
-              @no_ref,
-              s.referrer_source
-            ),
-          url: fragment("any(?)", s.referrer),
-          count: uniq(s.user_id),
-          bounce_rate: bounce_rate(),
-          visit_duration: visit_duration()
+          name: s.referrer_source,
+          count: uniq(s.user_id)
         },
         where: s.site_id == ^site.id,
         # Note: This query intentionally uses session end timestamp to get currently active users
@@ -118,9 +109,6 @@ defmodule Plausible.Stats.Clickhouse do
     end
 
     ClickhouseRepo.all(referrers)
-    |> Enum.map(fn ref ->
-      Map.update(ref, :url, nil, fn url -> url && URI.parse("http://" <> url).host end)
-    end)
   end
 
   def current_visitors(site, query) do

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -89,7 +89,7 @@ defmodule Plausible.Stats.Clickhouse do
     referrers =
       from(s in base_session_query(site, query),
         group_by: s.referrer_source,
-        order_by: [desc: uniq(s.user_id), asc: fragment("min(start)")],
+        order_by: [desc: uniq(s.user_id), asc: s.referrer_source],
         limit: ^limit,
         offset: ^offset
       )

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Workers.SpikeNotifier do
       current_visitors = clickhouse.current_visitors(notification.site, query)
 
       if current_visitors >= notification.threshold do
-        sources = clickhouse.top_sources(notification.site, query, 3, 1, true)
+        sources = clickhouse.top_sources_for_spike(notification.site, query, 3, 1, true)
         notify(notification, current_visitors, sources)
       end
     end

--- a/lib/workers/spike_notifier.ex
+++ b/lib/workers/spike_notifier.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Workers.SpikeNotifier do
       current_visitors = clickhouse.current_visitors(notification.site, query)
 
       if current_visitors >= notification.threshold do
-        sources = clickhouse.top_sources_for_spike(notification.site, query, 3, 1, true)
+        sources = clickhouse.top_sources_for_spike(notification.site, query, 3, 1)
         notify(notification, current_visitors, sources)
       end
     end

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -15,7 +15,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 5 end)
-      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -33,7 +33,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -59,7 +59,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -72,7 +72,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -93,7 +93,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 

--- a/test/workers/spike_notifier_test.exs
+++ b/test/workers/spike_notifier_test.exs
@@ -15,7 +15,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 5 end)
-      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -33,7 +33,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -59,7 +59,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -72,7 +72,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 
@@ -93,7 +93,7 @@ defmodule Plausible.Workers.SpikeNotifierTest do
 
     clickhouse_stub =
       stub(Plausible.Stats.Clickhouse, :current_visitors, fn _site, _query -> 10 end)
-      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page, _show_noref -> [] end)
+      |> stub(:top_sources_for_spike, fn _site, _query, _limit, _page -> [] end)
 
     SpikeNotifier.perform(nil, clickhouse_stub)
 


### PR DESCRIPTION
### Changes

While planning to [improve sessions schema](https://3.basecamp.com/5308029/buckets/35611491/messages/7061875211), spike detection email code [stood out](https://3.basecamp.com/5308029/buckets/35611491/messages/7043364021) in that it queried and grouped sessions differently.

One thing led to another and I ended up removing some dead code as well as bringing what's left in-line with how we query sessions elsewhere.