### PR TITLE
Remove ORDER BY min(session.start)

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -200,7 +200,7 @@ defmodule Plausible.Stats.Breakdown do
 
   defp breakdown_sessions(site, query, property, metrics, pagination) do
     from(s in query_sessions(site, query),
-      order_by: [desc: fragment("uniq(?)", s.user_id), asc: fragment("min(?)", s.start)],
+      order_by: [desc: fragment("uniq(?)", s.user_id)],
       select: %{}
     )
     |> filter_converted_sessions(site, query)

--- a/test/plausible_web/controllers/CSVs/30d/browser_versions.csv
+++ b/test/plausible_web/controllers/CSVs/30d/browser_versions.csv
@@ -1,3 +1,3 @@
 name,version,visitors
-Firefox,120,2
 (not set),(not set),2
+Firefox,120,2

--- a/test/plausible_web/controllers/CSVs/30d/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/30d/browsers.csv
@@ -1,3 +1,3 @@
 name,visitors
-Firefox,2
 (not set),2
+Firefox,2

--- a/test/plausible_web/controllers/CSVs/6m/browser_versions.csv
+++ b/test/plausible_web/controllers/CSVs/6m/browser_versions.csv
@@ -1,4 +1,4 @@
 name,version,visitors
-Firefox,120,2
 (not set),(not set),2
+Firefox,120,2
 FirefoxNoVersion,(not set),1

--- a/test/plausible_web/controllers/CSVs/6m/browsers.csv
+++ b/test/plausible_web/controllers/CSVs/6m/browsers.csv
@@ -1,4 +1,4 @@
 name,visitors
-Firefox,2
 (not set),2
+Firefox,2
 FirefoxNoVersion,1


### PR DESCRIPTION
This can add a needless performance overhead. Note that all queries already sort by the _name_ of the breakdown value besides the session start.

Related: https://3.basecamp.com/5308029/buckets/35611491/messages/7061875211