### PR TITLE
Add migration for minmax indexes on session timestamps

### DIFF
--- a/lib/plausible/migration_utils.ex
+++ b/lib/plausible/migration_utils.ex
@@ -1,0 +1,12 @@
+defmodule Plausible.MigrationUtils do
+  @moduledoc """
+  Base module for to use in Clickhouse migrations
+  """
+
+  def on_cluster_statement(table) do
+    case Plausible.IngestRepo.query("SELECT 1 FROM system.replicas WHERE table = '#{table}'") do
+      {:ok, %{rows: []}} -> ""
+      {:ok, _} -> "ON CLUSTER '{cluster}'"
+    end
+  end
+end

--- a/priv/ingest_repo/migrations/20240209085338_minmax_index_session_timestamp.exs
+++ b/priv/ingest_repo/migrations/20240209085338_minmax_index_session_timestamp.exs
@@ -1,0 +1,25 @@
+defmodule Plausible.IngestRepo.Migrations.MinmaxIndexSessionTimestamp do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      ALTER TABLE sessions_v2
+      #{Plausible.MigrationUtils.on_cluster_statement("sessions_v2")}
+      ADD INDEX IF NOT EXISTS minmax_timestamp timestamp
+      TYPE minmax GRANULARITY 1
+    """
+
+    execute """
+      ALTER TABLE sessions_v2
+      MATERIALIZE INDEX minmax_timestamp
+    """
+  end
+
+  def down do
+    execute """
+      ALTER TABLE sessions_v2
+      #{Plausible.MigrationUtils.on_cluster_statement("sessions_v2")}
+      DROP INDEX IF EXISTS minmax_timestamp
+    """
+  end
+end


### PR DESCRIPTION
### Changes

Related: https://github.com/plausible/analytics/pull/3770

This PR adds a minmax index for sessions_v2.timestamp column. This will make it cheaper to calculate queries like `SELECT * FROM sessions_v2 WHERE start >= ? and timestamp < ?` as clickhouse will know what parts of the data it can skip.

Operationally not sure how we can run these migrations - dear reviewer if you do know, ping me and let's run/document together!