### PR TITLE
Avoid changing Custom properties tab automatically every time filter changes

### DIFF
--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState } from "react"
 import ListReport from "../reports/list";
 import Combobox from '../../components/combobox'
 import * as api from '../../api'
@@ -14,10 +14,6 @@ export default function Properties(props) {
   const propKeyStorageNameForGoal = `${query.filters.goal}__prop_key__${site.domain}`
 
   const [propKey, setPropKey] = useState(choosePropKey())
-
-  useEffect(() => {
-    setPropKey(choosePropKey())
-  }, [query.filters.goal, query.filters.props])
 
   function singleGoalFilterApplied() {
     const goalFilter = query.filters.goal


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/3719

The previous behavior was predicated on:
- Allowing a single custom property filter
- Allowing breaking down only by the chosen custom property filter

Now these restrictions are removed the previous auto-switching just becomes annoying