### PR TITLE
Unify percentage change for CR and bounce_rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file.
 - Replace `CLICKHOUSE_MAX_BUFFER_SIZE` with `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES`
 
 ### Fixed
+- Calculate `conversion_rate` percentage change in the same way like `bounce_rate` (subtraction instead of division)
+- Calculate `bounce_rate` percentage change in the Stats API in the same way as it's done in the dashboard
 - Stop returning custom events in goal breakdown with a pageview goal filter and vice versa
 - Only return `(none)` values in custom property breakdown for the first page (pagination) of results
 - Fixed weekly/monthly e-mail report [rendering issues](https://github.com/plausible/analytics/issues/284)

--- a/lib/plausible/stats/compare.ex
+++ b/lib/plausible/stats/compare.ex
@@ -1,4 +1,8 @@
 defmodule Plausible.Stats.Compare do
+  def calculate_change(:conversion_rate, old_value, new_value) do
+    Float.round(new_value - old_value, 1)
+  end
+
   def calculate_change(:bounce_rate, old_count, new_count) do
     if old_count > 0, do: new_count - old_count
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -322,7 +322,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       assert json_response(conn, 200)["results"] == %{
                "pageviews" => %{"value" => 4, "change" => 100},
                "visitors" => %{"value" => 3, "change" => 100},
-               "bounce_rate" => %{"value" => 100, "change" => 100},
+               "bounce_rate" => %{"value" => 100, "change" => nil},
                "visit_duration" => %{"value" => 0, "change" => 0}
              }
     end
@@ -419,7 +419,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
                "visitors" => %{"value" => 2, "change" => 100},
                "visits" => %{"value" => 5, "change" => 150},
                "pageviews" => %{"value" => 9, "change" => -10},
-               "bounce_rate" => %{"value" => 40, "change" => -20},
+               "bounce_rate" => %{"value" => 40, "change" => -10},
                "views_per_visit" => %{"value" => 1.0, "change" => 100},
                "visit_duration" => %{"value" => 20, "change" => -80}
              }

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -352,7 +352,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "conversion_rate" => %{"value" => 50.0, "change" => 50.0}
+               "conversion_rate" => %{"value" => 50.0, "change" => 16.7}
              }
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1081,7 +1081,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert %{
-               "change" => -50,
+               "change" => -33.4,
                "comparison_value" => 66.7,
                "name" => "Conversion rate",
                "value" => 33.3


### PR DESCRIPTION
### Changes

1. Calculate `conversion_rate` change by subtracting the percentages (similar to bounce rate), not taking percentages of percentages (involving Top Stats in the dashboard and the `conversion_rate` metric in Stats API aggregate with `compare=previous_period`)

    This is how the percentage change is reported on the dashboard currently:
    <img width="709" alt="Pasted Graphic" src="https://github.com/plausible/analytics/assets/56999674/76b07d65-5284-41e5-a7b4-a102a3275ee9">
    
    Since with CR we're talking about percentages from 0-100, that change should be -1.4% instead. That should be consistent with the percentage change of `bounce_rate`
    
    <img width="240" alt="48 vs  49 bounce rate" src="https://github.com/plausible/analytics/assets/56999674/f8dfc463-fb97-4345-98cb-5be6b2395db4">


2. Use the same percentage change between the dashboard API and Stats API
    
    * The Stats API percentage change for bounce rate is currently calculated by taking percentages of percentages. This PR makes it consistent with the dashboard.
    * Exactly the same for `conversion_rate` change - not live yet, but this PR intends to fix that before we publish the docs

### Tests
- [x] Automated tests have been modified

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
