### PR TITLE
Refactor: Exclude selected prop keys in API instead of in FE

### DIFF
--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -92,9 +92,7 @@ export default function PlausibleCombobox(props) {
   }
 
   function isOptionDisabled(option) {
-    const optionAlreadySelected = props.values.some((val) => val.value === option.value)
-    const optionDisabled = (props.disabledOptions || []).some((val) => val?.value === option.value)
-    return optionAlreadySelected || optionDisabled
+    return props.values.some((val) => val.value === option.value)
   }
 
   function fetchOptions(query) {

--- a/assets/js/dashboard/stats/modals/prop-filter-modal.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-modal.js
@@ -34,7 +34,7 @@ function PropFilterModal(props) {
   const query = parseQuery(props.location.search, props.site)
   const [formState, setFormState] = useState(getFormState(query))
 
-  const selectedPropKeys = useMemo(() => Object.values(formState.values).map((value) => value.propKey), [formState])
+  const selectedPropKeys = useMemo(() => Object.values(formState.values).map((value) => value.propKey).filter((value) => value), [formState])
 
   function onPropKeySelect(id, selectedOptions) {
     const newPropKey = selectedOptions.length === 0 ? null : selectedOptions[0]

--- a/assets/js/dashboard/stats/modals/prop-filter-row.js
+++ b/assets/js/dashboard/stats/modals/prop-filter-row.js
@@ -23,7 +23,8 @@ function PropFilterRow({
 }) {
   function fetchPropKeyOptions() {
     return (input) => {
-      return api.get(apiPath(site, "/suggestions/prop_key"), query, { q: input.trim() })
+      const exclude = selectedPropKeys.map((key) => key.value)
+      return api.get(apiPath(site, "/suggestions/prop_key"), query, { q: input.trim(), exclude: JSON.stringify(exclude) })
     }
   }
 
@@ -50,7 +51,6 @@ function PropFilterRow({
           values={propKey ? [propKey] : []}
           onSelect={(value) => onPropKeySelect(id, value)}
           placeholder={'Property'}
-          disabledOptions={selectedPropKeys}
         />
       </div>
       <div className="col-span-3 mx-2">

--- a/lib/plausible/stats.ex
+++ b/lib/plausible/stats.ex
@@ -38,8 +38,8 @@ defmodule Plausible.Stats do
     end
   end
 
-  def filter_suggestions(site, query, filter_name, filter_search) do
+  def filter_suggestions(site, query, filter_name, filter_search, exclude \\ %{}) do
     include_sentry_replay_info()
-    FilterSuggestions.filter_suggestions(site, query, filter_name, filter_search)
+    FilterSuggestions.filter_suggestions(site, query, filter_name, filter_search, exclude)
   end
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1273,10 +1273,11 @@ defmodule PlausibleWeb.Api.StatsController do
     site = conn.assigns[:site]
 
     query = Query.from(site, params)
+    exclude = Jason.decode!(params["exclude"] || "[]")
 
     json(
       conn,
-      Stats.filter_suggestions(site, query, params["filter_name"], params["q"])
+      Stats.filter_suggestions(site, query, params["filter_name"], params["q"], exclude)
     )
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -282,6 +282,51 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
              ]
     end
 
+    test "allowing excluding keys", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["Uku Taht"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["logged_in"],
+          "meta.value": ["false"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["logged_in"],
+          "meta.value": ["false"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["dark_mode"],
+          "meta.value": ["true"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&exclude=[\"author\",\"logged_in\"]"
+        )
+
+      assert json_response(conn, 200) == [
+               %{"label" => "dark_mode", "value" => "dark_mode"}
+             ]
+    end
+
     test "returns suggestions found in time frame", %{
       conn: conn,
       site: site


### PR DESCRIPTION
Solves feedback from original PR: https://github.com/plausible/analytics/pull/3719#discussion_r1466583893

The FE approach would run into problems if you have >25 custom props, so excluding in the BE allows avoiding problems