### PR TITLE
copy changes to the CTA on the top of a new dashboard

### DIFF
--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -1,7 +1,7 @@
 <div class="<%= stats_container_class(@conn) %>" data-site-domain="<%= @site.domain %>">
   <%= if @offer_email_report do %>
     <div class="w-full px-4 text-sm font-bold text-center text-blue-900 bg-blue-200 rounded transition" style="top: 91px" role="alert">
-      <%= link("Team members, email reports and GA import. Explore more →", to: "/#{URI.encode_www_form(@site.domain)}/settings/people", class: "py-2 block") %>
+      <%= link("Team members, email reports and GA import. Explore more →", to: "/#{URI.encode_www_form(@site.domain)}/settings/email-reports", class: "py-2 block") %>
     </div>
   <% end %>
 

--- a/lib/plausible_web/templates/stats/stats.html.eex
+++ b/lib/plausible_web/templates/stats/stats.html.eex
@@ -1,7 +1,7 @@
 <div class="<%= stats_container_class(@conn) %>" data-site-domain="<%= @site.domain %>">
   <%= if @offer_email_report do %>
     <div class="w-full px-4 text-sm font-bold text-center text-blue-900 bg-blue-200 rounded transition" style="top: 91px" role="alert">
-      <%= link("Click here to enable weekly email reports →", to: "/#{URI.encode_www_form(@site.domain)}/settings/email-reports", class: "py-2 block") %>
+      <%= link("Team members, email reports and GA import. Explore more →", to: "/#{URI.encode_www_form(@site.domain)}/settings/people", class: "py-2 block") %>
     </div>
   <% end %>
 


### PR DESCRIPTION
we haven't changed this copy in 5 years. site settings area is way more powerful now than it used to be so wanted to highlight a couple more things you can do in there. I have tried to keep it short but don't have a way to check how the new copy looks like on the actual dashboard so please doublecheck that it looks good on the actual screen and on smaller devices too. and it should go away on its own after it's been clicked on like it does now