### PR TITLE
Add table migrations for supporting multiple imports per site

### DIFF
--- a/priv/ingest_repo/migrations/20240123142959_add_import_id_to_imported_tables.exs
+++ b/priv/ingest_repo/migrations/20240123142959_add_import_id_to_imported_tables.exs
@@ -1,0 +1,23 @@
+defmodule Plausible.IngestRepo.Migrations.AddImportIdToImportedTables do
+  use Ecto.Migration
+
+  @imported_tables [
+    :imported_browsers,
+    :imported_devices,
+    :imported_entry_pages,
+    :imported_exit_pages,
+    :imported_locations,
+    :imported_operating_systems,
+    :imported_pages,
+    :imported_sources,
+    :imported_visitors
+  ]
+
+  def change do
+    for table <- @imported_tables do
+      alter table(table) do
+        add(:import_id, :UInt64)
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20240123095646_remove_google_analytics_imports_jobs.exs
+++ b/priv/repo/migrations/20240123095646_remove_google_analytics_imports_jobs.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.Repo.Migrations.RemoveGoogleAnalyticsImportsJobs do
+  use Ecto.Migration
+
+  def up do
+    execute "DELETE FROM oban_jobs WHERE queue = 'google_analytics_imports'"
+  end
+
+  def down do
+  end
+end

--- a/priv/repo/migrations/20240123144308_add_site_imports.exs
+++ b/priv/repo/migrations/20240123144308_add_site_imports.exs
@@ -1,0 +1,20 @@
+defmodule Plausible.Repo.Migrations.AddSiteImports do
+  use Ecto.Migration
+
+  def change do
+    create table(:site_imports) do
+      add :start_date, :date, null: false
+      add :end_date, :date, null: false
+      add :source, :string, null: false
+      add :status, :string, null: false
+
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+      add :imported_by_id, references(:users, on_delete: :nilify_all), null: true
+
+      timestamps()
+    end
+
+    create index(:site_imports, [:site_id])
+    create index(:site_imports, [:imported_by_id])
+  end
+end

--- a/priv/repo/migrations/20240123144308_add_site_imports.exs
+++ b/priv/repo/migrations/20240123144308_add_site_imports.exs
@@ -14,7 +14,7 @@ defmodule Plausible.Repo.Migrations.AddSiteImports do
       timestamps()
     end
 
-    create index(:site_imports, [:site_id])
+    create index(:site_imports, [:site_id, :start_date])
     create index(:site_imports, [:imported_by_id])
   end
 end


### PR DESCRIPTION
### Changes

Migrations extracted from https://github.com/plausible/analytics/pull/3724 that have to be applied before releasing the rest of the code changes. Also includes a migration cleaning up Oban queue entries for a now long defunct queue.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
