### PR TITLE
Drop events_v2 columns with session properties

### DIFF
--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -15,25 +15,6 @@ defmodule Plausible.ClickhouseEventV2 do
     field :session_id, Ch, type: "UInt64"
     field :timestamp, :naive_datetime
 
-    field :referrer, :string
-    field :referrer_source, :string
-    field :utm_medium, :string
-    field :utm_source, :string
-    field :utm_campaign, :string
-    field :utm_content, :string
-    field :utm_term, :string
-
-    field :country_code, Ch, type: "FixedString(2)"
-    field :subdivision1_code, Ch, type: "LowCardinality(String)"
-    field :subdivision2_code, Ch, type: "LowCardinality(String)"
-    field :city_geoname_id, Ch, type: "UInt32"
-
-    field :screen_size, Ch, type: "LowCardinality(String)"
-    field :operating_system, Ch, type: "LowCardinality(String)"
-    field :operating_system_version, Ch, type: "LowCardinality(String)"
-    field :browser, Ch, type: "LowCardinality(String)"
-    field :browser_version, Ch, type: "LowCardinality(String)"
-
     field :"meta.key", {:array, :string}
     field :"meta.value", {:array, :string}
 
@@ -42,7 +23,26 @@ defmodule Plausible.ClickhouseEventV2 do
     field :revenue_reporting_amount, Ch, type: "Nullable(Decimal64(3))"
     field :revenue_reporting_currency, Ch, type: "FixedString(3)"
 
-    field :transferred_from, :string
+    # Fields which are in the schema but not managed by us anymore.
+    # field :referrer, :string
+    # field :referrer_source, :string
+    # field :utm_medium, :string
+    # field :utm_source, :string
+    # field :utm_campaign, :string
+    # field :utm_content, :string
+    # field :utm_term, :string
+
+    # field :country_code, Ch, type: "FixedString(2)"
+    # field :subdivision1_code, Ch, type: "LowCardinality(String)"
+    # field :subdivision2_code, Ch, type: "LowCardinality(String)"
+    # field :city_geoname_id, Ch, type: "UInt32"
+
+    # field :screen_size, Ch, type: "LowCardinality(String)"
+    # field :operating_system, Ch, type: "LowCardinality(String)"
+    # field :operating_system_version, Ch, type: "LowCardinality(String)"
+    # field :browser, Ch, type: "LowCardinality(String)"
+    # field :browser_version, Ch, type: "LowCardinality(String)"
+    # field :transferred_from, :string
   end
 
   def new(attrs) do
@@ -56,22 +56,6 @@ defmodule Plausible.ClickhouseEventV2 do
         :pathname,
         :user_id,
         :timestamp,
-        :operating_system,
-        :operating_system_version,
-        :browser,
-        :browser_version,
-        :referrer,
-        :referrer_source,
-        :utm_medium,
-        :utm_source,
-        :utm_campaign,
-        :utm_content,
-        :utm_term,
-        :country_code,
-        :subdivision1_code,
-        :subdivision2_code,
-        :city_geoname_id,
-        :screen_size,
         :"meta.key",
         :"meta.value",
         :revenue_source_amount,

--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -22,27 +22,6 @@ defmodule Plausible.ClickhouseEventV2 do
     field :revenue_source_currency, Ch, type: "FixedString(3)"
     field :revenue_reporting_amount, Ch, type: "Nullable(Decimal64(3))"
     field :revenue_reporting_currency, Ch, type: "FixedString(3)"
-
-    # Fields which are in the schema but not managed by us anymore.
-    # field :referrer, :string
-    # field :referrer_source, :string
-    # field :utm_medium, :string
-    # field :utm_source, :string
-    # field :utm_campaign, :string
-    # field :utm_content, :string
-    # field :utm_term, :string
-
-    # field :country_code, Ch, type: "FixedString(2)"
-    # field :subdivision1_code, Ch, type: "LowCardinality(String)"
-    # field :subdivision2_code, Ch, type: "LowCardinality(String)"
-    # field :city_geoname_id, Ch, type: "UInt32"
-
-    # field :screen_size, Ch, type: "LowCardinality(String)"
-    # field :operating_system, Ch, type: "LowCardinality(String)"
-    # field :operating_system_version, Ch, type: "LowCardinality(String)"
-    # field :browser, Ch, type: "LowCardinality(String)"
-    # field :browser_version, Ch, type: "LowCardinality(String)"
-    # field :transferred_from, :string
   end
 
   def new(attrs) do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -13,6 +13,7 @@ defmodule Plausible.Ingestion.Event do
   defstruct domain: nil,
             site: nil,
             clickhouse_event_attrs: %{},
+            clickhouse_session_attrs: %{},
             clickhouse_event: nil,
             dropped?: false,
             drop_reason: nil,
@@ -32,6 +33,7 @@ defmodule Plausible.Ingestion.Event do
           domain: String.t() | nil,
           site: %Plausible.Site{} | nil,
           clickhouse_event_attrs: map(),
+          clickhouse_session_attrs: %{},
           clickhouse_event: %ClickhouseEventV2{} | nil,
           dropped?: boolean(),
           drop_reason: drop_reason(),
@@ -139,8 +141,12 @@ defmodule Plausible.Ingestion.Event do
     struct!(event, fields)
   end
 
-  defp update_attrs(%__MODULE__{} = event, %{} = attrs) do
+  defp update_event_attrs(%__MODULE__{} = event, %{} = attrs) do
     struct!(event, clickhouse_event_attrs: Map.merge(event.clickhouse_event_attrs, attrs))
+  end
+
+  defp update_session_attrs(%__MODULE__{} = event, %{} = attrs) do
+    struct!(event, clickhouse_session_attrs: Map.merge(event.clickhouse_session_attrs, attrs))
   end
 
   defp drop_datacenter_ip(%__MODULE__{} = event) do
@@ -175,7 +181,7 @@ defmodule Plausible.Ingestion.Event do
         drop(event, :bot)
 
       %UAInspector.Result{} = user_agent ->
-        update_attrs(event, %{
+        update_session_attrs(event, %{
           operating_system: os_name(user_agent),
           operating_system_version: os_version(user_agent),
           browser: browser_name(user_agent),
@@ -189,7 +195,7 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp put_basic_info(%__MODULE__{} = event) do
-    update_attrs(event, %{
+    update_event_attrs(event, %{
       domain: event.domain,
       site_id: event.site.id,
       timestamp: event.request.timestamp,
@@ -202,7 +208,7 @@ defmodule Plausible.Ingestion.Event do
   defp put_referrer(%__MODULE__{} = event) do
     ref = parse_referrer(event.request.uri, event.request.referrer)
 
-    update_attrs(event, %{
+    update_session_attrs(event, %{
       referrer_source: get_referrer_source(event.request, ref),
       referrer: clean_referrer(ref)
     })
@@ -211,7 +217,7 @@ defmodule Plausible.Ingestion.Event do
   defp put_utm_tags(%__MODULE__{} = event) do
     query_params = event.request.query_params
 
-    update_attrs(event, %{
+    update_session_attrs(event, %{
       utm_medium: query_params["utm_medium"],
       utm_source: query_params["utm_source"],
       utm_campaign: query_params["utm_campaign"],
@@ -223,14 +229,14 @@ defmodule Plausible.Ingestion.Event do
   defp put_geolocation(%__MODULE__{} = event) do
     result = Plausible.Ingestion.Geolocation.lookup(event.request.remote_ip) || %{}
 
-    update_attrs(event, result)
+    update_session_attrs(event, result)
   end
 
   defp put_props(%__MODULE__{request: %{props: %{} = props}} = event) do
     # defensive: ensuring the keys/values are always in the same order
     {keys, values} = Enum.unzip(props)
 
-    update_attrs(event, %{
+    update_event_attrs(event, %{
       "meta.key": keys,
       "meta.value": values
     })
@@ -241,7 +247,7 @@ defmodule Plausible.Ingestion.Event do
   defp put_revenue(event) do
     on_full_build do
       attrs = Plausible.Ingestion.Event.Revenue.get_revenue_attrs(event)
-      update_attrs(event, attrs)
+      update_event_attrs(event, attrs)
     else
       event
     end
@@ -252,7 +258,7 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp put_user_id(%__MODULE__{} = event) do
-    update_attrs(event, %{
+    update_event_attrs(event, %{
       user_id:
         generate_user_id(
           event.request,
@@ -287,7 +293,12 @@ defmodule Plausible.Ingestion.Event do
         event.salts.previous
       )
 
-    session_id = Plausible.Session.CacheStore.on_event(event.clickhouse_event, previous_user_id)
+    session_id =
+      Plausible.Session.CacheStore.on_event(
+        event.clickhouse_event,
+        event.clickhouse_session_attrs,
+        previous_user_id
+      )
 
     clickhouse_event = Map.put(event.clickhouse_event, :session_id, session_id)
     %{event | clickhouse_event: clickhouse_event}

--- a/lib/plausible/ingestion/write_buffer.ex
+++ b/lib/plausible/ingestion/write_buffer.ex
@@ -130,7 +130,8 @@ defmodule Plausible.Ingestion.WriteBuffer do
       |> Ch.RowBinary.encode_names_and_types(types)
       |> IO.iodata_to_binary()
 
-    insert_sql = "INSERT INTO #{schema.__schema__(:source)} FORMAT RowBinaryWithNamesAndTypes"
+    insert_sql =
+      "INSERT INTO #{schema.__schema__(:source)} (#{Enum.join(fields, ", ")}) FORMAT RowBinaryWithNamesAndTypes"
 
     %{
       fields: fields,

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -2,7 +2,7 @@ defmodule Plausible.Session.CacheStore do
   require Logger
   alias Plausible.Session.WriteBuffer
 
-  def on_event(event, prev_user_id, buffer \\ WriteBuffer) do
+  def on_event(event, session_attributes, prev_user_id, buffer \\ WriteBuffer) do
     found_session = find_session(event, event.user_id) || find_session(event, prev_user_id)
 
     session =
@@ -11,7 +11,7 @@ defmodule Plausible.Session.CacheStore do
         buffer.insert([%{found_session | sign: -1}, %{updated_session | sign: 1}])
         persist_session(updated_session)
       else
-        new_session = new_session_from_event(event)
+        new_session = new_session_from_event(event, session_attributes)
         buffer.insert([new_session])
         persist_session(new_session)
       end
@@ -59,7 +59,7 @@ defmodule Plausible.Session.CacheStore do
     }
   end
 
-  defp new_session_from_event(event) do
+  defp new_session_from_event(event, session_attributes) do
     %Plausible.ClickhouseSessionV2{
       sign: 1,
       session_id: Plausible.ClickhouseSessionV2.random_uint64(),
@@ -72,22 +72,22 @@ defmodule Plausible.Session.CacheStore do
       duration: 0,
       pageviews: if(event.name == "pageview", do: 1, else: 0),
       events: 1,
-      referrer: event.referrer,
-      referrer_source: event.referrer_source,
-      utm_medium: event.utm_medium,
-      utm_source: event.utm_source,
-      utm_campaign: event.utm_campaign,
-      utm_content: event.utm_content,
-      utm_term: event.utm_term,
-      country_code: event.country_code,
-      subdivision1_code: event.subdivision1_code,
-      subdivision2_code: event.subdivision2_code,
-      city_geoname_id: event.city_geoname_id,
-      screen_size: event.screen_size,
-      operating_system: event.operating_system,
-      operating_system_version: event.operating_system_version,
-      browser: event.browser,
-      browser_version: event.browser_version,
+      referrer: Map.get(session_attributes, :referrer),
+      referrer_source: Map.get(session_attributes, :referrer_source),
+      utm_medium: Map.get(session_attributes, :utm_medium),
+      utm_source: Map.get(session_attributes, :utm_source),
+      utm_campaign: Map.get(session_attributes, :utm_campaign),
+      utm_content: Map.get(session_attributes, :utm_content),
+      utm_term: Map.get(session_attributes, :utm_term),
+      country_code: Map.get(session_attributes, :country_code),
+      subdivision1_code: Map.get(session_attributes, :subdivision1_code),
+      subdivision2_code: Map.get(session_attributes, :subdivision2_code),
+      city_geoname_id: Map.get(session_attributes, :city_geoname_id),
+      screen_size: Map.get(session_attributes, :screen_size),
+      operating_system: Map.get(session_attributes, :operating_system),
+      operating_system_version: Map.get(session_attributes, :operating_system_version),
+      browser: Map.get(session_attributes, :browser),
+      browser_version: Map.get(session_attributes, :browser_version),
       timestamp: event.timestamp,
       start: event.timestamp,
       "entry_meta.key": Map.get(event, :"meta.key"),

--- a/priv/ingest_repo/migrations/20240220081207_drop_event_session_columns.exs
+++ b/priv/ingest_repo/migrations/20240220081207_drop_event_session_columns.exs
@@ -1,0 +1,31 @@
+defmodule Plausible.IngestRepo.Migrations.DropEventSessionColumns do
+  use Ecto.Migration
+
+  @dropped_columns [
+    :referrer,
+    :referrer_source,
+    :utm_medium,
+    :utm_source,
+    :utm_campaign,
+    :utm_content,
+    :utm_term,
+    :country_code,
+    :subdivision1_code,
+    :subdivision2_code,
+    :city_geoname_id,
+    :screen_size,
+    :operating_system,
+    :operating_system_version,
+    :browser,
+    :browser_version,
+    :transferred_from
+  ]
+
+  def change do
+    alter table(:events_v2) do
+      for column <- @dropped_columns do
+        remove(column)
+      end
+    end
+  end
+end

--- a/test/plausible/stats/clickhouse_test.exs
+++ b/test/plausible/stats/clickhouse_test.exs
@@ -228,22 +228,22 @@ defmodule Plausible.Stats.ClickhouseTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/",
-          referrer_source: "Twitter"
+          session: %{referrer_source: "Twitter"}
         ),
         build(:pageview,
           pathname: "/plausible.io"
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          referrer_source: "Google"
+          session: %{referrer_source: "Google"}
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          referrer_source: "Google"
+          session: %{referrer_source: "Google"}
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          referrer_source: "Bing"
+          session: %{referrer_source: "Bing"}
         )
       ])
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -223,13 +223,13 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.operating_system == "Mac"
-      assert pageview.operating_system_version == "10.13"
-      assert pageview.browser == "Chrome"
-      assert pageview.browser_version == "70.0"
+      assert session.operating_system == "Mac"
+      assert session.operating_system_version == "10.13"
+      assert session.browser == "Chrome"
+      assert session.browser_version == "70.0"
     end
 
     test "parses referrer", %{conn: conn, site: site} do
@@ -245,10 +245,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == "Facebook"
+      assert session.referrer_source == "Facebook"
     end
 
     test "strips trailing slash from referrer", %{conn: conn, site: site} do
@@ -264,11 +264,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer == "facebook.com/page"
-      assert pageview.referrer_source == "Facebook"
+      assert session.referrer == "facebook.com/page"
+      assert session.referrer_source == "Facebook"
     end
 
     test "ignores event when referrer is a spammer", %{conn: conn, site: site} do
@@ -321,10 +321,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == ""
+      assert session.referrer_source == ""
     end
 
     test "ignores localhost referrer", %{conn: conn, site: site} do
@@ -340,10 +340,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == ""
+      assert session.referrer_source == ""
     end
 
     test "parses subdomain referrer", %{conn: conn, site: site} do
@@ -359,10 +359,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == "blog.example.com"
+      assert session.referrer_source == "blog.example.com"
     end
 
     test "referrer is cleaned", %{conn: conn, site: site} do
@@ -376,9 +376,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       conn
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.referrer == "indiehackers.com/page"
+      assert session.referrer == "indiehackers.com/page"
     end
 
     test "utm_source overrides referrer source", %{conn: conn, site: site} do
@@ -392,9 +392,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       conn
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.referrer_source == "betalist"
+      assert session.referrer_source == "betalist"
     end
 
     test "utm tags are stored", %{conn: conn, site: site} do
@@ -408,11 +408,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       conn
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.utm_medium == "ads"
-      assert pageview.utm_source == "instagram"
-      assert pageview.utm_campaign == "video_story"
+      assert session.utm_medium == "ads"
+      assert session.utm_source == "instagram"
+      assert session.utm_campaign == "video_story"
     end
 
     test "if it's an :unknown referrer, just the domain is used", %{conn: conn, site: site} do
@@ -428,10 +428,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == "indiehackers.com"
+      assert session.referrer_source == "indiehackers.com"
     end
 
     test "if the referrer is not http or https, it is ignored", %{conn: conn, site: site} do
@@ -447,10 +447,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.referrer_source == ""
+      assert session.referrer_source == ""
     end
 
     test "screen size is calculated from user agent", %{conn: conn, site: site} do
@@ -465,10 +465,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent_mobile)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.screen_size == "Mobile"
+      assert session.screen_size == "Mobile"
     end
 
     test "screen size is nil if user agent is unknown", %{conn: conn, site: site} do
@@ -483,10 +483,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", "unknown UA")
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.screen_size == ""
+      assert session.screen_size == ""
     end
 
     test "screen size is calculated from user_agent when is tablet", %{conn: conn, site: site} do
@@ -501,10 +501,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent_tablet)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.screen_size == "Tablet"
+      assert session.screen_size == "Tablet"
     end
 
     test "screen size is calculated from user_agent when is desktop", %{
@@ -522,10 +522,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert pageview.screen_size == "Desktop"
+      assert session.screen_size == "Desktop"
     end
 
     test "can trigger a custom event", %{conn: conn, site: site} do
@@ -792,10 +792,10 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         |> put_req_header("user-agent", @user_agent)
         |> post("/api/event", params)
 
-      event = get_event(site)
+      session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert event.referrer == ""
+      assert session.referrer == ""
     end
 
     # Fake geo is loaded from test/priv/GeoLite2-City-Test.mmdb
@@ -810,12 +810,12 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "2.125.160.216")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "GB"
-      assert pageview.subdivision1_code == "GB-ENG"
-      assert pageview.subdivision2_code == "GB-WBK"
-      assert pageview.city_geoname_id == 2_655_045
+      assert session.country_code == "GB"
+      assert session.subdivision1_code == "GB-ENG"
+      assert session.subdivision2_code == "GB-WBK"
+      assert session.city_geoname_id == 2_655_045
     end
 
     test "ignores unknown country code ZZ", %{conn: conn, site: site} do
@@ -829,12 +829,12 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "0.0.0.0")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == <<0, 0>>
-      assert pageview.subdivision1_code == ""
-      assert pageview.subdivision2_code == ""
-      assert pageview.city_geoname_id == 0
+      assert session.country_code == <<0, 0>>
+      assert session.subdivision1_code == ""
+      assert session.subdivision2_code == ""
+      assert session.city_geoname_id == 0
     end
 
     test "ignores disputed territory code XX", %{conn: conn, site: site} do
@@ -848,12 +848,12 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "0.0.0.1")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == <<0, 0>>
-      assert pageview.subdivision1_code == ""
-      assert pageview.subdivision2_code == ""
-      assert pageview.city_geoname_id == 0
+      assert session.country_code == <<0, 0>>
+      assert session.subdivision1_code == ""
+      assert session.subdivision2_code == ""
+      assert session.city_geoname_id == 0
     end
 
     test "ignores TOR exit node country code T1", %{conn: conn, site: site} do
@@ -867,12 +867,12 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "0.0.0.2")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == <<0, 0>>
-      assert pageview.subdivision1_code == ""
-      assert pageview.subdivision2_code == ""
-      assert pageview.city_geoname_id == 0
+      assert session.country_code == <<0, 0>>
+      assert session.subdivision1_code == ""
+      assert session.subdivision2_code == ""
+      assert session.city_geoname_id == 0
     end
 
     test "scrubs port from x-forwarded-for", %{conn: conn, site: site} do
@@ -886,9 +886,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "216.160.83.56:123")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "US"
+      assert session.country_code == "US"
     end
 
     test "works with ipv6 without port in x-forwarded-for", %{conn: conn, site: site} do
@@ -902,9 +902,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "2001:218:1:1:1:1:1:1")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "JP"
+      assert session.country_code == "JP"
     end
 
     test "works with ipv6 with a port number in x-forwarded-for", %{conn: conn, site: site} do
@@ -918,9 +918,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-forwarded-for", "[2001:218:1:1:1:1:1:1]:123")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "JP"
+      assert session.country_code == "JP"
     end
 
     test "uses cloudflare's special header for client IP address if present", %{
@@ -938,9 +938,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("cf-connecting-ip", "216.160.83.56")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "US"
+      assert session.country_code == "US"
     end
 
     test "uses BunnyCDN's custom header for client IP address if present", %{
@@ -958,9 +958,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("b-forwarded-for", "216.160.83.56,9.9.9.9")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "US"
+      assert session.country_code == "US"
     end
 
     test "prioritizes x-plausible-ip header over everything else", %{
@@ -981,9 +981,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("x-plausible-ip", "216.160.83.56")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "US"
+      assert session.country_code == "US"
     end
 
     test "Uses the Forwarded header when cf-connecting-ip and x-forwarded-for are missing", %{
@@ -999,9 +999,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> put_req_header("forwarded", "by=0.0.0.0;for=216.160.83.56;host=somehost.com;proto=https")
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "US"
+      assert session.country_code == "US"
     end
 
     test "Forwarded header can parse ipv6", %{site: site} do
@@ -1018,9 +1018,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       )
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.country_code == "JP"
+      assert session.country_code == "JP"
     end
 
     test "URL is decoded", %{conn: conn, site: site} do
@@ -1051,10 +1051,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> post("/api/event", params)
 
       pageview = get_event(site)
+      session = get_created_session(site)
 
       assert pageview.pathname == "/opportunity"
-      assert pageview.referrer_source == "Facebook"
-      assert pageview.referrer == "facebook.com/page"
+      assert session.referrer_source == "Facebook"
+      assert session.referrer == "facebook.com/page"
     end
 
     test "records hash when in hash mode", %{conn: conn, site: site} do
@@ -1102,10 +1103,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       |> post("/api/event", params)
 
       pageview = get_event(site)
+      session = get_created_session(site)
 
       assert pageview.hostname == "test.com"
       assert pageview.pathname == "/ﺝﻭﺎﺋﺯ-ﻮﻤﺳﺎﺒﻗﺎﺗ"
-      assert pageview.utm_source == "%balle%"
+      assert session.utm_source == "%balle%"
     end
 
     test "can use double quotes in query params", %{conn: conn, site: site} do
@@ -1121,9 +1123,9 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       conn
       |> post("/api/event", params)
 
-      pageview = get_event(site)
+      session = get_created_session(site)
 
-      assert pageview.utm_source == "Something \"quoted\""
+      assert session.utm_source == "Something \"quoted\""
     end
 
     test "responds 400 when required fields are missing", %{conn: conn, site: site} do
@@ -1373,6 +1375,17 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       from(e in Plausible.ClickhouseEventV2,
         where: e.site_id == ^site.id,
         order_by: [desc: e.timestamp]
+      )
+    )
+  end
+
+  defp get_created_session(site) do
+    Plausible.Session.WriteBuffer.flush()
+
+    ClickhouseRepo.one(
+      from(s in Plausible.ClickhouseSessionV2,
+        where: s.site_id == ^site.id and s.sign == 1,
+        order_by: [desc: s.timestamp]
       )
     )
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -1207,19 +1207,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         %{
           site_id: site.id,
           session_id: 1000,
-          country_code: "EE",
           name: "pageview"
         },
         %{
           site_id: site.id,
           session_id: 1000,
-          country_code: "EE",
           name: "pageview"
         },
         %{
           site_id: site.id,
           session_id: 1000,
-          country_code: "EE",
           name: "pageview"
         }
       ])

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -367,7 +367,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       populate_stats(site, [
         build(:imported_visitors, date: ~D[2023-01-01]),
         build(:imported_sources, date: ~D[2023-01-01]),
-        build(:pageview, referrer_source: "Google", timestamp: ~N[2023-01-02 00:10:00])
+        build(:pageview,
+          session: %{referrer_source: "Google"},
+          timestamp: ~N[2023-01-02 00:10:00]
+        )
       ])
 
       conn =
@@ -420,7 +423,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -459,7 +462,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -484,7 +487,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by referrer", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer: "https://facebook.com",
+          session: %{referrer: "https://facebook.com"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -514,9 +517,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
 
     test "wildcard referrer filter with special regex characters", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, referrer: "https://a.com"),
-        build(:pageview, referrer: "https://a.com"),
-        build(:pageview, referrer: "https://ab.com")
+        build(:pageview, session: %{referrer: "https://a.com"}),
+        build(:pageview, session: %{referrer: "https://a.com"}),
+        build(:pageview, session: %{referrer: "https://ab.com"})
       ])
 
       conn =
@@ -532,7 +535,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_medium", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -563,7 +566,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_source: "Twitter",
+          session: %{utm_source: "Twitter"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -594,7 +597,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_campaign", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -625,7 +628,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by device type", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          screen_size: "Desktop",
+          session: %{screen_size: "Desktop"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -656,7 +659,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by browser", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -687,8 +690,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by browser version", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
-          browser_version: "56",
+          session: %{browser: "Chrome", browser_version: "56"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -719,7 +721,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by operating system", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          operating_system: "Mac",
+          session: %{operating_system: "Mac"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -750,7 +752,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by operating system version", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          operating_system_version: "10.5",
+          session: %{operating_system_version: "10.5"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -781,7 +783,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by country", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1073,7 +1075,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/blogpost",
-          country_code: "EE",
+          session: %{country_code: "EE"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -210,15 +210,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:source", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        referrer_source: "Google",
+        session: %{referrer_source: "Google"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        referrer_source: "Google",
+        session: %{referrer_source: "Google"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        referrer_source: "",
+        session: %{referrer_source: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -241,9 +241,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
   test "breakdown by visit:country", %{conn: conn, site: site} do
     populate_stats(site, [
-      build(:pageview, country_code: "EE", timestamp: ~N[2021-01-01 00:00:00]),
-      build(:pageview, country_code: "EE", timestamp: ~N[2021-01-01 00:25:00]),
-      build(:pageview, country_code: "US", timestamp: ~N[2021-01-01 00:00:00])
+      build(:pageview, session: %{country_code: "EE"}, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, session: %{country_code: "EE"}, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, session: %{country_code: "US"}, timestamp: ~N[2021-01-01 00:00:00])
     ])
 
     conn =
@@ -265,15 +265,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:referrer", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        referrer: "https://ref.com",
+        session: %{referrer: "https://ref.com"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        referrer: "https://ref.com",
+        session: %{referrer: "https://ref.com"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        referrer: "",
+        session: %{referrer: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -297,15 +297,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_medium", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        utm_medium: "Search",
+        session: %{utm_medium: "Search"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        utm_medium: "Search",
+        session: %{utm_medium: "Search"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_medium: "",
+        session: %{utm_medium: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -328,15 +328,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_source", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        utm_source: "Google",
+        session: %{utm_source: "Google"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        utm_source: "Google",
+        session: %{utm_source: "Google"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_source: "",
+        session: %{utm_source: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -359,15 +359,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_campaign", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        utm_campaign: "ads",
+        session: %{utm_campaign: "ads"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        utm_campaign: "ads",
+        session: %{utm_campaign: "ads"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_campaign: "",
+        session: %{utm_campaign: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -390,15 +390,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_content", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        utm_content: "Content1",
+        session: %{utm_content: "Content1"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        utm_content: "Content1",
+        session: %{utm_content: "Content1"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_content: "",
+        session: %{utm_content: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -421,15 +421,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_term", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        utm_term: "Term1",
+        session: %{utm_term: "Term1"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        utm_term: "Term1",
+        session: %{utm_term: "Term1"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        utm_term: "",
+        session: %{utm_term: ""},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -452,15 +452,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:device", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        screen_size: "Desktop",
+        session: %{screen_size: "Desktop"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        screen_size: "Desktop",
+        session: %{screen_size: "Desktop"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        screen_size: "Mobile",
+        session: %{screen_size: "Mobile"},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -484,15 +484,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:os", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        operating_system: "Mac",
+        session: %{operating_system: "Mac"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        operating_system: "Mac",
+        session: %{operating_system: "Mac"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        operating_system: "Windows",
+        session: %{operating_system: "Windows"},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -516,15 +516,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:os_version", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        operating_system_version: "10.5",
+        session: %{operating_system_version: "10.5"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        operating_system_version: "10.5",
+        session: %{operating_system_version: "10.5"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        operating_system_version: "10.6",
+        session: %{operating_system_version: "10.6"},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -547,9 +547,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
   test "breakdown by visit:browser", %{conn: conn, site: site} do
     populate_stats(site, [
-      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
-      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:25:00]),
-      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00])
+      build(:pageview, session: %{browser: "Firefox"}, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, session: %{browser: "Firefox"}, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, session: %{browser: "Safari"}, timestamp: ~N[2021-01-01 00:00:00])
     ])
 
     conn =
@@ -571,15 +571,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:browser_version", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        browser_version: "56",
+        session: %{browser_version: "56"},
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        browser_version: "56",
+        session: %{browser_version: "56"},
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        browser_version: "57",
+        session: %{browser_version: "57"},
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -789,30 +789,30 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageB",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/pageA",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -840,7 +840,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -850,7 +850,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Twitter",
+          session: %{referrer_source: "Twitter"},
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -888,7 +888,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         ),
         build(:pageview,
           pathname: "/pageB",
-          referrer_source: "Twitter",
+          session: %{referrer_source: "Twitter"},
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -1271,21 +1271,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/ignore",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          browser: "Safari",
+          session: %{browser: "Safari"},
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:00:00]
         )
@@ -1315,10 +1315,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/",
-          referrer_source: "Twitter",
-          utm_medium: "Twitter",
-          utm_source: "Twitter",
-          utm_campaign: "Twitter",
+          session: %{
+            referrer_source: "Twitter",
+            utm_medium: "Twitter",
+            utm_source: "Twitter",
+            utm_campaign: "Twitter"
+          },
           user_id: @user_id
         ),
         build(:pageview,
@@ -1327,17 +1329,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          referrer_source: "Google",
-          utm_medium: "Google",
-          utm_source: "Google",
-          utm_campaign: "Google"
+          session: %{
+            referrer_source: "Google",
+            utm_medium: "Google",
+            utm_source: "Google",
+            utm_campaign: "Google"
+          }
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          referrer_source: "Google",
-          utm_medium: "Google",
-          utm_source: "Google",
-          utm_campaign: "Google"
+          session: %{
+            referrer_source: "Google",
+            utm_medium: "Google",
+            utm_source: "Google",
+            utm_campaign: "Google"
+          }
         )
       ])
 
@@ -1365,31 +1371,31 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           user_id: @user_id,
           pathname: "/ignore",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           user_id: @user_id,
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           user_id: 456,
           pathname: "/important-page",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           user_id: 456,
           pathname: "/",
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:01:00]
         )
@@ -1421,11 +1427,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Bing",
+          session: %{referrer_source: "Bing"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1457,11 +1463,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Bing",
+          session: %{referrer_source: "Bing"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1518,10 +1524,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     test "mixed multi-goal filter for breakdown by visit:country", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, country_code: "EE", pathname: "/en/register"),
-        build(:event, country_code: "EE", name: "Signup", pathname: "/en/register"),
-        build(:pageview, country_code: "US", pathname: "/123/it/register"),
-        build(:pageview, country_code: "US", pathname: "/different")
+        build(:pageview, session: %{country_code: "EE"}, pathname: "/en/register"),
+        build(:event, session: %{country_code: "EE"}, name: "Signup", pathname: "/en/register"),
+        build(:pageview, session: %{country_code: "US"}, pathname: "/123/it/register"),
+        build(:pageview, session: %{country_code: "US"}, pathname: "/different")
       ])
 
       insert(:goal, %{site: site, page_path: "/**register"})
@@ -1619,22 +1625,22 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/ignore",
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/important-page",
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1734,25 +1740,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "IN filter for event:props:*", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Safari",
+          session: %{browser: "Safari"},
           "meta.key": ["browser"],
           "meta.value": ["Safari"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           "meta.key": ["browser"],
           "meta.value": ["Firefox"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1779,25 +1785,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "Multiple event:props:* filters", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser", "prop"],
           "meta.value": ["Chrome", "xyz"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Safari",
+          session: %{browser: "Safari"},
           "meta.key": ["browser", "prop"],
           "meta.value": ["Safari", "target_value"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           "meta.key": ["browser", "prop"],
           "meta.value": ["Firefox", "target_value"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1823,23 +1829,23 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "IN filter for event:props:* including (none) value", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           "meta.key": ["browser"],
           "meta.value": ["Firefox"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1865,10 +1871,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     test "can use a is_not filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "Chrome"),
-        build(:pageview, browser: "Safari"),
-        build(:pageview, browser: "Safari"),
-        build(:pageview, browser: "Edge")
+        build(:pageview, session: %{browser: "Chrome"}),
+        build(:pageview, session: %{browser: "Safari"}),
+        build(:pageview, session: %{browser: "Safari"}),
+        build(:pageview, session: %{browser: "Edge"})
       ])
 
       conn =
@@ -2005,26 +2011,26 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 1,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "signup",
           user_id: 1,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:05:00]
         ),
         build(:pageview,
           user_id: 1,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:10:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          referrer_source: "Twitter",
+          session: %{referrer_source: "Twitter"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -2077,7 +2083,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         build(:pageview,
           user_id: 2,
           pathname: "/entry-page-2",
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:05:00]
         )
       ])
@@ -2111,28 +2117,28 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          browser: "Safari",
+          session: %{browser: "Safari"},
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["personal"],
-          browser: "IE",
+          session: %{browser: "IE"},
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -661,7 +661,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -683,7 +683,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -703,7 +703,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by referrer", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer: "https://facebook.com",
+          session: %{referrer: "https://facebook.com"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -724,7 +724,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_medium", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -745,7 +745,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_source: "Twitter",
+          session: %{utm_source: "Twitter"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -766,7 +766,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_campaign", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -787,7 +787,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by device type", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          screen_size: "Desktop",
+          session: %{screen_size: "Desktop"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -808,13 +808,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by browser", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          browser: "Chrome",
-          browser_version: "56.1",
+          session: %{
+            browser: "Chrome",
+            browser_version: "56.1"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          browser: "Chrome",
-          browser_version: "55",
+          session: %{
+            browser: "Chrome",
+            browser_version: "55"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -835,18 +839,24 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by operating system", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          operating_system: "Mac",
-          operating_system_version: "10.5",
+          session: %{
+            operating_system: "Mac",
+            operating_system_version: "10.5"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          operating_system: "Something else",
-          operating_system_version: "10.5",
+          session: %{
+            operating_system: "Something else",
+            operating_system_version: "10.5"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          operating_system: "Mac",
-          operating_system_version: "10.4",
+          session: %{
+            operating_system: "Mac",
+            operating_system_version: "10.4"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -868,14 +878,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: @user_id,
-          country_code: "EE",
-          operating_system_version: "10.5",
+          session: %{country_code: "EE"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          country_code: "EE",
-          operating_system_version: "10.5",
+          session: %{country_code: "EE"},
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browsers by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "Chrome"),
-        build(:pageview, browser: "Chrome"),
-        build(:pageview, browser: "Firefox")
+        build(:pageview, session: %{browser: "Chrome"}),
+        build(:pageview, session: %{browser: "Chrome"}),
+        build(:pageview, session: %{browser: "Firefox"})
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
@@ -26,21 +26,21 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          browser: "Chrome"
+          session: %{browser: "Chrome"}
         ),
         build(:pageview,
           user_id: 123,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          browser: "Safari"
+          session: %{browser: "Safari"}
         )
       ])
 
@@ -59,23 +59,23 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          browser: "Chrome",
+          session: %{browser: "Chrome"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          browser: "Firefox",
+          session: %{browser: "Firefox"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          browser: "Safari"
+          session: %{browser: "Safari"}
         )
       ])
 
@@ -90,8 +90,8 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, browser: "Chrome"),
-        build(:pageview, user_id: 2, browser: "Chrome"),
+        build(:pageview, user_id: 1, session: %{browser: "Chrome"}),
+        build(:pageview, user_id: 2, session: %{browser: "Chrome"}),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -111,7 +111,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browsers including imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "Chrome"),
+        build(:pageview, session: %{browser: "Chrome"}),
         build(:imported_browsers, browser: "Chrome"),
         build(:imported_browsers, browser: "Firefox"),
         build(:imported_visitors, visitors: 2)
@@ -156,7 +156,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          browser: ""
+          session: %{browser: ""}
         )
       ])
 
@@ -173,10 +173,10 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browser versions by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "Chrome", browser_version: "78.0"),
-        build(:pageview, browser: "Chrome", browser_version: "78.0"),
-        build(:pageview, browser: "Chrome", browser_version: "77.0"),
-        build(:pageview, browser: "Firefox", browser_version: "88.0")
+        build(:pageview, session: %{browser: "Chrome", browser_version: "78.0"}),
+        build(:pageview, session: %{browser: "Chrome", browser_version: "78.0"}),
+        build(:pageview, session: %{browser: "Chrome", browser_version: "77.0"}),
+        build(:pageview, session: %{browser: "Firefox", browser_version: "88.0"})
       ])
 
       filters = Jason.encode!(%{browser: "Chrome"})
@@ -195,7 +195,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns results for (not set)", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "", browser_version: "")
+        build(:pageview, session: %{browser: "", browser_version: ""})
       ])
 
       filters = Jason.encode!(%{browser: "(not set)"})

--- a/test/plausible_web/controllers/api/stats_controller/cities_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/cities_test.exs
@@ -4,11 +4,21 @@ defmodule PlausibleWeb.Api.StatsController.CitiesTest do
   describe "GET /api/stats/:domain/cities" do
     defp seed(%{site: site}) do
       populate_stats(site, [
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632)
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632}
+        )
       ])
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "returns top countries by new visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, country_code: "EE"),
-        build(:pageview, country_code: "EE"),
-        build(:pageview, country_code: "GB"),
+        build(:pageview, session: %{country_code: "EE"}),
+        build(:pageview, session: %{country_code: "EE"}),
+        build(:pageview, session: %{country_code: "GB"}),
         build(:imported_locations, country: "EE"),
         build(:imported_locations, country: "GB"),
         build(:imported_visitors, visitors: 2)
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "ignores unknown country code ZZ", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, country_code: "ZZ"),
+        build(:pageview, session: %{country_code: "ZZ"}),
         build(:imported_locations, country: "ZZ")
       ])
 
@@ -72,16 +72,16 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 1,
-          country_code: "EE"
+          session: %{country_code: "EE"}
         ),
         build(:event, user_id: 1, name: "Signup"),
         build(:pageview,
           user_id: 2,
-          country_code: "EE"
+          session: %{country_code: "EE"}
         ),
         build(:pageview,
           user_id: 3,
-          country_code: "GB"
+          session: %{country_code: "GB"}
         ),
         build(:event, user_id: 3, name: "Signup")
       ])
@@ -119,21 +119,21 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          country_code: "EE"
+          session: %{country_code: "EE"}
         ),
         build(:pageview,
           user_id: 123,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          country_code: "GB",
+          session: %{country_code: "GB"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          country_code: "US"
+          session: %{country_code: "US"}
         )
       ])
 
@@ -159,23 +159,23 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          country_code: "GB",
+          session: %{country_code: "GB"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          country_code: "GB"
+          session: %{country_code: "GB"}
         )
       ])
 
@@ -200,17 +200,17 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          country_code: "GB",
+          session: %{country_code: "GB"},
           "meta.key": ["logged_in"],
           "meta.value": ["true"]
         ),
         build(:pageview,
-          country_code: "GB"
+          session: %{country_code: "GB"}
         )
       ])
 
@@ -235,22 +235,22 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          country_code: "EE",
+          session: %{country_code: "EE"},
           "meta.key": ["author"],
           "meta.value": [""]
         ),
         build(:pageview,
-          country_code: "GB",
+          session: %{country_code: "GB"},
           "meta.key": ["logged_in"],
           "meta.value": ["true"]
         ),
         build(:pageview,
-          country_code: "GB"
+          session: %{country_code: "GB"}
         )
       ])
 
@@ -271,9 +271,9 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "when list is filtered by country returns one country only", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, country_code: "EE"),
-        build(:pageview, country_code: "EE"),
-        build(:pageview, country_code: "GB")
+        build(:pageview, session: %{country_code: "EE"}),
+        build(:pageview, session: %{country_code: "EE"}),
+        build(:pageview, session: %{country_code: "GB"})
       ])
 
       filters = Jason.encode!(%{country: "GB"})

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -688,14 +688,14 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
 
     test "Property breakdown with prop and goal filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, utm_campaign: "campaignA"),
+        build(:pageview, user_id: 1, session: %{utm_campaign: "campaignA"}),
         build(:event,
           user_id: 1,
           name: "ButtonClick",
           "meta.key": ["variant"],
           "meta.value": ["A"]
         ),
-        build(:pageview, user_id: 2, utm_campaign: "campaignA"),
+        build(:pageview, user_id: 2, session: %{utm_campaign: "campaignA"}),
         build(:event,
           user_id: 2,
           name: "ButtonClick",
@@ -710,7 +710,9 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
         Jason.encode!(%{
           goal: "ButtonClick",
           props: %{variant: "A"},
-          utm_campaign: "campaignA"
+          session: %{
+            utm_campaign: "campaignA"
+          }
         })
 
       prop_key = "variant"
@@ -733,15 +735,15 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
 
     test "Property breakdown with goal and source filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, referrer_source: "Google"),
+        build(:pageview, user_id: 1, session: %{referrer_source: "Google"}),
         build(:event,
           user_id: 1,
           name: "ButtonClick",
           "meta.key": ["variant"],
           "meta.value": ["A"]
         ),
-        build(:pageview, user_id: 2, referrer_source: "Google"),
-        build(:pageview, user_id: 3, referrer_source: "ignore"),
+        build(:pageview, user_id: 2, session: %{referrer_source: "Google"}),
+        build(:pageview, user_id: 3, session: %{referrer_source: "ignore"}),
         build(:event,
           user_id: 3,
           name: "ButtonClick",
@@ -962,7 +964,11 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
 
       populate_stats(site, [
         build(:pageview, "meta.key": [prop_key], "meta.value": ["K2sna Kalle"]),
-        build(:pageview, browser: "Chrome", "meta.key": [prop_key], "meta.value": ["Sipsik"])
+        build(:pageview,
+          session: %{browser: "Chrome"},
+          "meta.key": [prop_key],
+          "meta.value": ["Sipsik"]
+        )
       ])
 
       filters = Jason.encode!(%{browser: "Chrome"})

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -106,15 +106,15 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
           build(:pageview,
             pathname: "/blog/announcement",
             user_id: @other_user_id,
-            utm_medium: "social",
-            timestamp: ~N[2021-01-01 12:00:00]
+            timestamp: ~N[2021-01-01 12:00:00],
+            session: %{utm_medium: "social"}
           ),
           build(:event, name: "Signup", user_id: @user_id),
           build(:event,
             name: "Signup",
             user_id: @other_user_id,
-            utm_medium: "social",
-            timestamp: ~N[2021-01-01 12:01:00]
+            timestamp: ~N[2021-01-01 12:01:00],
+            session: %{utm_medium: "social"}
           ),
           build(:pageview, pathname: "/cart/add/product", user_id: @user_id),
           build(:event, name: "Purchase", user_id: @user_id)

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "returns operating systems by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Android")
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Android"})
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
@@ -22,10 +22,10 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          operating_system: ""
+          session: %{operating_system: ""}
         ),
         build(:pageview,
-          operating_system: "Linux"
+          session: %{operating_system: "Linux"}
         )
       ])
 
@@ -48,8 +48,8 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, operating_system: "Mac"),
-        build(:pageview, user_id: 2, operating_system: "Mac"),
+        build(:pageview, user_id: 1, session: %{operating_system: "Mac"}),
+        build(:pageview, user_id: 2, session: %{operating_system: "Mac"}),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -75,21 +75,21 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          operating_system: "Mac"
+          session: %{operating_system: "Mac"}
         ),
         build(:pageview,
           user_id: 123,
-          operating_system: "Mac",
+          session: %{operating_system: "Mac"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          operating_system: "Windows",
+          session: %{operating_system: "Windows"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          operating_system: "Android"
+          session: %{operating_system: "Android"}
         )
       ])
 
@@ -110,23 +110,23 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          operating_system: "Windows",
+          session: %{operating_system: "Windows"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          operating_system: "Windows",
+          session: %{operating_system: "Windows"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          operating_system: "Mac",
+          session: %{operating_system: "Mac"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          operating_system: "Android"
+          session: %{operating_system: "Android"}
         )
       ])
 
@@ -146,9 +146,9 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       site: site
     } do
       populate_stats(site, [
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Android"),
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Android"}),
         build(:imported_operating_systems, operating_system: "Mac"),
         build(:imported_operating_systems, operating_system: "Android"),
         build(:imported_visitors, visitors: 2)
@@ -172,8 +172,8 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "imported data is ignored when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, operating_system: "Mac"),
-        build(:pageview, user_id: 2, operating_system: "Mac"),
+        build(:pageview, user_id: 1, session: %{operating_system: "Mac"}),
+        build(:pageview, user_id: 2, session: %{operating_system: "Mac"}),
         build(:imported_operating_systems, operating_system: "Mac"),
         build(:event, user_id: 1, name: "Signup")
       ])
@@ -199,10 +199,10 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "returns top OS versions by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, operating_system: "Mac", operating_system_version: "10.15"),
-        build(:pageview, operating_system: "Mac", operating_system_version: "10.16"),
-        build(:pageview, operating_system: "Mac", operating_system_version: "10.16"),
-        build(:pageview, operating_system: "Android", operating_system_version: "4")
+        build(:pageview, session: %{operating_system: "Mac", operating_system_version: "10.15"}),
+        build(:pageview, session: %{operating_system: "Mac", operating_system_version: "10.16"}),
+        build(:pageview, session: %{operating_system: "Mac", operating_system_version: "10.16"}),
+        build(:pageview, session: %{operating_system: "Android", operating_system_version: "4"})
       ])
 
       filters = Jason.encode!(%{os: "Mac"})

--- a/test/plausible_web/controllers/api/stats_controller/regions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_test.exs
@@ -4,11 +4,21 @@ defmodule PlausibleWeb.Api.StatsController.RegionsTest do
   describe "GET /api/stats/:domain/regions" do
     defp seed(%{site: site}) do
       populate_stats(site, [
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632)
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632}
+        )
       ])
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes by new visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Laptop")
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Laptop"})
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/screen-sizes?period=day")
@@ -22,10 +22,10 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          screen_size: ""
+          session: %{screen_size: ""}
         ),
         build(:pageview,
-          screen_size: "Desktop"
+          session: %{screen_size: "Desktop"}
         )
       ])
 
@@ -53,21 +53,21 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          screen_size: "Desktop"
+          session: %{screen_size: "Desktop"}
         ),
         build(:pageview,
           user_id: 123,
-          screen_size: "Desktop",
+          session: %{screen_size: "Desktop"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          screen_size: "Mobile",
+          session: %{screen_size: "Mobile"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          screen_size: "Tablet"
+          session: %{screen_size: "Tablet"}
         )
       ])
 
@@ -86,23 +86,23 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          screen_size: "Desktop",
+          session: %{screen_size: "Desktop"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          screen_size: "Desktop",
+          session: %{screen_size: "Desktop"},
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          screen_size: "Mobile",
+          session: %{screen_size: "Mobile"},
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          screen_size: "Tablet"
+          session: %{screen_size: "Tablet"}
         )
       ])
 
@@ -117,9 +117,9 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes by new visitors with imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Laptop")
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Laptop"})
       ])
 
       populate_stats(site, [
@@ -146,8 +146,8 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, screen_size: "Desktop"),
-        build(:pageview, user_id: 2, screen_size: "Desktop"),
+        build(:pageview, user_id: 1, session: %{screen_size: "Desktop"}),
+        build(:pageview, user_id: 2, session: %{screen_size: "Desktop"}),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -167,11 +167,11 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes with not_member filter type", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, referrer_source: "Google", screen_size: "Desktop"),
-        build(:pageview, referrer_source: "Bad source", screen_size: "Desktop"),
-        build(:pageview, referrer_source: "Google", screen_size: "Desktop"),
-        build(:pageview, referrer_source: "Twitter", screen_size: "Mobile"),
-        build(:pageview, referrer_source: "Second bad source", screen_size: "Mobile")
+        build(:pageview, session: %{referrer_source: "Google", screen_size: "Desktop"}),
+        build(:pageview, session: %{referrer_source: "Bad source", screen_size: "Desktop"}),
+        build(:pageview, session: %{referrer_source: "Google", screen_size: "Desktop"}),
+        build(:pageview, session: %{referrer_source: "Twitter", screen_size: "Mobile"}),
+        build(:pageview, session: %{referrer_source: "Second bad source", screen_size: "Mobile"})
       ])
 
       filters = Jason.encode!(%{"source" => "!Bad source|Second bad source"})

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -9,24 +9,34 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com"
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com"
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          }
         ),
         build(:pageview)
       ])
@@ -43,8 +53,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources with :is filter on custom pageview props", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -55,22 +67,28 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -95,8 +113,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           user_id: 123,
@@ -109,20 +129,26 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -149,8 +175,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           user_id: 123,
@@ -161,20 +189,26 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -199,8 +233,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           "meta.key": ["logged_in"],
           "meta.value": ["true"],
           user_id: 123,
@@ -213,22 +249,28 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["author"],
           "meta.value": ["another"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -249,9 +291,9 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
     test "returns top sources with imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, referrer_source: "Google", referrer: "google.com"),
-        build(:pageview, referrer_source: "Google", referrer: "google.com"),
-        build(:pageview, referrer_source: "DuckDuckGo", referrer: "duckduckgo.com")
+        build(:pageview, session: %{referrer_source: "Google", referrer: "google.com"}),
+        build(:pageview, session: %{referrer_source: "Google", referrer: "google.com"}),
+        build(:pageview, session: %{referrer_source: "DuckDuckGo", referrer: "duckduckgo.com"})
       ])
 
       populate_stats(site, [
@@ -283,20 +325,26 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "calculates bounce rate and visit duration for sources", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -329,20 +377,26 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -412,18 +466,24 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources in realtime report", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           timestamp: relative_time(minutes: -3)
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           timestamp: relative_time(minutes: -2)
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           timestamp: relative_time(minutes: -1)
         )
       ])
@@ -439,16 +499,22 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "can paginate the results", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com"
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          }
         ),
         build(:imported_sources,
           source: "DuckDuckGo"
@@ -470,10 +536,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
     test "shows sources for a page", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, pathname: "/page1", referrer_source: "Google"),
-        build(:pageview, pathname: "/page1", referrer_source: "Google"),
-        build(:pageview, user_id: 1, pathname: "/page2", referrer_source: "DuckDuckGo"),
-        build(:pageview, user_id: 1, pathname: "/page1", referrer_source: "DuckDuckGo")
+        build(:pageview, pathname: "/page1", session: %{referrer_source: "Google"}),
+        build(:pageview, pathname: "/page1", session: %{referrer_source: "Google"}),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page2",
+          session: %{referrer_source: "DuckDuckGo"}
+        ),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page1",
+          session: %{referrer_source: "DuckDuckGo"}
+        )
       ])
 
       filters = Jason.encode!(%{"page" => "/page1"})
@@ -492,17 +566,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_mediums by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_medium: "email",
+          session: %{utm_medium: "email"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -572,17 +646,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_medium present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_medium: "social",
+          session: %{utm_medium: "social"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_medium: "",
+          session: %{utm_medium: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -644,21 +718,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_campaigns by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_campaign: "august",
+          session: %{utm_campaign: "august"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_campaign: "august",
+          session: %{utm_campaign: "august"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -728,21 +802,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_campaign present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_campaign: "profile",
+          session: %{utm_campaign: "profile"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_campaign: "",
+          session: %{utm_campaign: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_campaign: "",
+          session: %{utm_campaign: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -804,21 +878,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_sources by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_source: "Twitter",
+          session: %{utm_source: "Twitter"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_source: "Twitter",
+          session: %{utm_source: "Twitter"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_source: "newsletter",
+          session: %{utm_source: "newsletter"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_source: "newsletter",
+          session: %{utm_source: "newsletter"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -852,21 +926,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_terms by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_term: "oat milk",
+          session: %{utm_term: "oat milk"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_term: "oat milk",
+          session: %{utm_term: "oat milk"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_term: "Sweden",
+          session: %{utm_term: "Sweden"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_term: "Sweden",
+          session: %{utm_term: "Sweden"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -936,21 +1010,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_term present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_term: "oat milk",
+          session: %{utm_term: "oat milk"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_term: "oat milk",
+          session: %{utm_term: "oat milk"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_term: "",
+          session: %{utm_term: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_term: "",
+          session: %{utm_term: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1012,21 +1086,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_contents by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_content: "ad",
+          session: %{utm_content: "ad"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_content: "ad",
+          session: %{utm_content: "ad"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_content: "blog",
+          session: %{utm_content: "blog"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_content: "blog",
+          session: %{utm_content: "blog"},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1096,21 +1170,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_content present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          utm_content: "ad",
+          session: %{utm_content: "ad"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_content: "ad",
+          session: %{utm_content: "ad"},
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          utm_content: "",
+          session: %{utm_content: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          utm_content: "",
+          session: %{utm_content: ""},
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1175,7 +1249,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Twitter",
+          session: %{referrer_source: "Twitter"},
           user_id: @user_id
         ),
         build(:event,
@@ -1183,7 +1257,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           user_id: @user_id
         ),
         build(:pageview,
-          referrer_source: "Twitter"
+          session: %{referrer_source: "Twitter"}
         )
       ])
 
@@ -1213,8 +1287,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers with goal filter + :is prop filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1226,15 +1302,19 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           "meta.key": ["logged_in"],
           "meta.value": ["true"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
-          referrer_source: "Facebook",
-          referrer: "facebook.com",
+          session: %{
+            referrer_source: "Facebook",
+            referrer: "facebook.com"
+          },
           name: "Download",
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "false"],
@@ -1263,8 +1343,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers with goal filter + prop :is_not filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com",
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          },
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1277,16 +1359,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         ),
         build(:event,
           name: "Download",
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "true"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Download",
-          referrer_source: "Google",
-          referrer: "google.com",
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          },
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "false"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1323,7 +1409,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Twitter",
+          session: %{referrer_source: "Twitter"},
           user_id: @user_id
         ),
         build(:pageview,
@@ -1331,7 +1417,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           user_id: @user_id
         ),
         build(:pageview,
-          referrer_source: "Twitter"
+          session: %{referrer_source: "Twitter"}
         )
       ])
 
@@ -1360,20 +1446,28 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers for a particular source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com"
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com"
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com/page1"
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com/page1"
+          }
         ),
         build(:pageview,
-          referrer_source: "ignored",
-          referrer: "ignored"
+          session: %{
+            referrer_source: "ignored",
+            referrer: "ignored"
+          }
         )
       ])
 
@@ -1392,25 +1486,33 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "calculates bounce rate and visit duration for referrer urls", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com",
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com",
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          },
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com",
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          },
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          referrer_source: "ignored",
-          referrer: "ignored",
+          session: %{
+            referrer_source: "ignored",
+            referrer: "ignored"
+          },
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1436,16 +1538,22 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com"
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         )
       ])
 
@@ -1464,16 +1572,22 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "DuckDuckGo",
-          referrer: "duckduckgo.com"
+          session: %{
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "Google",
-          referrer: "google.com"
+          session: %{
+            referrer_source: "Google",
+            referrer: "google.com"
+          }
         )
       ])
 
@@ -1493,12 +1607,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referring urls for a custom goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com"
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com",
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          },
           user_id: @user_id
         ),
         build(:event,
@@ -1531,12 +1649,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referring urls for a pageview goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com"
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          }
         ),
         build(:pageview,
-          referrer_source: "10words",
-          referrer: "10words.com",
+          session: %{
+            referrer_source: "10words",
+            referrer: "10words.com"
+          },
           user_id: @user_id
         ),
         build(:pageview,

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -57,9 +57,12 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for sources", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "10words")
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], session: %{referrer_source: "Bing"}),
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], session: %{referrer_source: "Bing"}),
+        build(:pageview,
+          timestamp: ~N[2019-01-01 23:00:00],
+          session: %{referrer_source: "10words"}
+        )
       ])
 
       conn =
@@ -73,7 +76,11 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for countries", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:01], pathname: "/", country_code: "US")
+        build(:pageview,
+          timestamp: ~N[2019-01-01 23:00:01],
+          pathname: "/",
+          session: %{country_code: "US"}
+        )
       ])
 
       conn =
@@ -89,8 +96,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       {:ok, [site: site]} = create_new_site(%{user: user})
 
       populate_stats(site, [
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37"),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39")
+        build(:pageview, session: %{country_code: "EE", subdivision1_code: "EE-37"}),
+        build(:pageview, session: %{country_code: "EE", subdivision1_code: "EE-39"})
       ])
 
       conn =
@@ -106,8 +113,12 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       {:ok, [site: site]} = create_new_site(%{user: user})
 
       populate_stats(site, [
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409),
-        build(:pageview, country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632)
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-37", city_geoname_id: 588_409}
+        ),
+        build(:pageview,
+          session: %{country_code: "EE", subdivision1_code: "EE-39", city_geoname_id: 591_632}
+        )
       ])
 
       conn =
@@ -134,7 +145,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
           pathname: "/",
-          screen_size: "Desktop"
+          session: %{screen_size: "Desktop"}
         )
       ])
 
@@ -146,7 +157,11 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for browsers", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], pathname: "/", browser: "Chrome")
+        build(:pageview,
+          timestamp: ~N[2019-01-01 23:00:00],
+          pathname: "/",
+          session: %{browser: "Chrome"}
+        )
       ])
 
       conn =
@@ -161,8 +176,10 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       populate_stats(site, [
         build(:pageview,
           timestamp: ~N[2019-01-01 00:00:00],
-          browser: "Chrome",
-          browser_version: "78.0"
+          session: %{
+            browser: "Chrome",
+            browser_version: "78.0"
+          }
         )
       ])
 
@@ -177,7 +194,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for OS", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 00:00:00], operating_system: "Mac")
+        build(:pageview, timestamp: ~N[2019-01-01 00:00:00], session: %{operating_system: "Mac"})
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/suggestions/os?period=month&date=2019-01-01")
@@ -191,8 +208,10 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       populate_stats(site, [
         build(:pageview,
           timestamp: ~N[2019-01-01 00:00:00],
-          operating_system: "Mac",
-          operating_system_version: "10.15"
+          session: %{
+            operating_system: "Mac",
+            operating_system_version: "10.15"
+          }
         )
       ])
 
@@ -222,7 +241,9 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
           pathname: "/",
-          referrer: "10words.com/page1"
+          session: %{
+            referrer: "10words.com/page1"
+          }
         )
       ])
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -511,9 +511,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors from a country based on alpha2 code", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, country_code: "US"),
-        build(:pageview, country_code: "US"),
-        build(:pageview, country_code: "EE")
+        build(:pageview, session: %{country_code: "US"}),
+        build(:pageview, session: %{country_code: "US"}),
+        build(:pageview, session: %{country_code: "EE"})
       ])
 
       filters = Jason.encode!(%{country: "US"})
@@ -571,9 +571,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Desktop"),
-        build(:pageview, screen_size: "Mobile")
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Desktop"}),
+        build(:pageview, session: %{screen_size: "Mobile"})
       ])
 
       filters = Jason.encode!(%{screen: "Desktop"})
@@ -591,9 +591,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific browser", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, browser: "Chrome"),
-        build(:pageview, browser: "Chrome"),
-        build(:pageview, browser: "Safari")
+        build(:pageview, session: %{browser: "Chrome"}),
+        build(:pageview, session: %{browser: "Chrome"}),
+        build(:pageview, session: %{browser: "Safari"})
       ])
 
       filters = Jason.encode!(%{browser: "Chrome"})
@@ -611,9 +611,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific operating system", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Mac"),
-        build(:pageview, operating_system: "Windows")
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Mac"}),
+        build(:pageview, session: %{operating_system: "Windows"})
       ])
 
       filters = Jason.encode!(%{os: "Mac"})
@@ -633,17 +633,17 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: @user_id,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 00:05:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          referrer_source: "Google",
+          session: %{referrer_source: "Google"},
           timestamp: ~N[2021-01-01 05:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:10:00])

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -383,51 +383,61 @@ defmodule PlausibleWeb.StatsControllerTest do
   defp populate_exported_stats(site) do
     populate_stats(site, [
       build(:pageview,
-        country_code: "EE",
-        subdivision1_code: "EE-37",
-        city_geoname_id: 588_409,
+        user_id: 123,
         pathname: "/",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], minutes: -1) |> NaiveDateTime.truncate(:second),
-        referrer_source: "Google",
-        user_id: 123
+        session: %{
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409,
+          referrer_source: "Google"
+        }
       ),
       build(:pageview,
-        country_code: "EE",
-        subdivision1_code: "EE-37",
-        city_geoname_id: 588_409,
+        user_id: 123,
         pathname: "/some-other-page",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], minutes: -2) |> NaiveDateTime.truncate(:second),
-        referrer_source: "Google",
-        user_id: 123
+        session: %{
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409,
+          referrer_source: "Google"
+        }
       ),
       build(:pageview,
         pathname: "/",
-        utm_medium: "search",
-        utm_campaign: "ads",
-        utm_source: "google",
-        utm_content: "content",
-        utm_term: "term",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], days: -1) |> NaiveDateTime.truncate(:second),
-        browser: "Firefox",
-        browser_version: "120"
+        session: %{
+          utm_medium: "search",
+          utm_campaign: "ads",
+          utm_source: "google",
+          utm_content: "content",
+          utm_term: "term",
+          browser: "Firefox",
+          browser_version: "120"
+        }
       ),
       build(:pageview,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -1) |> NaiveDateTime.truncate(:second),
-        country_code: "EE",
-        browser: "Firefox",
-        browser_version: "120"
+        session: %{
+          country_code: "EE",
+          browser: "Firefox",
+          browser_version: "120"
+        }
       ),
       build(:pageview,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -5) |> NaiveDateTime.truncate(:second),
-        utm_campaign: "ads",
-        country_code: "EE",
-        referrer_source: "Google",
-        browser: "FirefoxNoVersion"
+        session: %{
+          utm_campaign: "ads",
+          country_code: "EE",
+          referrer_source: "Google",
+          browser: "FirefoxNoVersion"
+        }
       ),
       build(:event,
         timestamp:

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -69,24 +69,20 @@ defmodule Plausible.Factory do
   end
 
   def pageview_factory do
-    struct!(
-      event_factory(),
-      %{
-        name: "pageview"
-      }
-    )
+    Map.put(event_factory(), :name, "pageview")
   end
 
   def event_factory do
     hostname = sequence(:domain, &"example-#{&1}.com")
 
-    %Plausible.ClickhouseEventV2{
+    %{
       hostname: hostname,
       site_id: Enum.random(1000..10_000),
       pathname: "/",
       timestamp: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
       user_id: SipHash.hash!(hash_key(), Ecto.UUID.generate()),
-      session_id: SipHash.hash!(hash_key(), Ecto.UUID.generate())
+      session_id: SipHash.hash!(hash_key(), Ecto.UUID.generate()),
+      _factory_event: true
     }
   end
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -196,7 +196,8 @@ defmodule Plausible.TestUtils do
   defp populate_native_stats(events) do
     sessions =
       Enum.reduce(events, %{}, fn event, sessions ->
-        session_id = Plausible.Session.CacheStore.on_event(event, nil)
+        # :TODO: Handle session parameters separately
+        session_id = Plausible.Session.CacheStore.on_event(event, event, nil)
         Map.put(sessions, {event.site_id, event.user_id}, session_id)
       end)
 

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -79,9 +79,9 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
       populate_stats(site, [
         build(:pageview,
-          referrer_source: "Google",
           user_id: 123,
-          timestamp: Timex.shift(now, days: -7)
+          timestamp: Timex.shift(now, days: -7),
+          session: %{referrer_source: "Google"}
         ),
         build(:pageview, user_id: 123, timestamp: Timex.shift(now, days: -7)),
         build(:pageview, timestamp: Timex.shift(now, days: -7))


### PR DESCRIPTION
Depends on https://github.com/plausible/analytics/pull/3800, part of [the project to improve sessions and events table schemas](https://3.basecamp.com/5308029/buckets/35611491/messages/7061875211).