### PR TITLE
Migration to improve compression options of sessions_v2 and events_v2 tables

### DIFF
--- a/priv/ingest_repo/migrations/20240220123656_create_sessions_events_compression_options.exs
+++ b/priv/ingest_repo/migrations/20240220123656_create_sessions_events_compression_options.exs
@@ -1,0 +1,45 @@
+defmodule Plausible.IngestRepo.Migrations.CreateSessionsEventsCompressionOptions do
+  @moduledoc """
+  Improves compression options for events_v2 and sessions_v2 tables.
+
+  It's suggested to run OPTIMIZE both tables after this to get full compression wins afterwards
+  """
+
+  use Ecto.Migration
+
+  @sessions_codecs %{
+    timestamp: "Codec(Delta(4), LZ4)",
+    start: "Codec(Delta(4), LZ4)",
+    entry_page: "Codec(ZSTD(3))",
+    exit_page: "Codec(ZSTD(3))",
+    hostname: "Codec(ZSTD(3))",
+    referrer: "Codec(ZSTD(3))",
+    referrer_source: "Codec(ZSTD(3))",
+    utm_medium: "Codec(ZSTD(3))",
+    utm_source: "Codec(ZSTD(3))",
+    utm_campaign: "Codec(ZSTD(3))",
+    utm_content: "Codec(ZSTD(3))",
+    utm_term: "Codec(ZSTD(3))",
+    "entry_meta.key": "Codec(ZSTD(3))",
+    "entry_meta.value": "Codec(ZSTD(3))"
+  }
+
+  @events_codecs %{
+    hostname: "Codec(ZSTD(3))",
+    "meta.key": "Codec(ZSTD(3))",
+    "meta.value": "Codec(ZSTD(3))"
+  }
+
+  def up do
+    for {column, codec} <- @sessions_codecs do
+      execute "ALTER TABLE sessions_v2 MODIFY COLUMN #{column} #{codec}"
+    end
+
+    for {column, codec} <- @events_codecs do
+      execute "ALTER TABLE events_v2 MODIFY COLUMN #{column} #{codec}"
+    end
+  end
+
+  # No need to explicitly revert
+  def down, do: nil
+end


### PR DESCRIPTION
Part of https://3.basecamp.com/5308029/buckets/35611491/messages/7061875211 

Based on work in https://3.basecamp.com/5308029/buckets/35611491/messages/6949640880#__recording_7015576045

Note that the improved compression options only apply for new incoming data - to get the full benefits, running an `OPTIMIZE TABLE` afterwards is needed (but expensive computationally)

After merging this, planning to:
1. Do a before-and-after of compression ratios
2. Run OPTIMIZE TABLE for both tables during a quiet period