### PR TITLE
Ecto migration to move sessions_v2 to VersionedCollapsingMergeTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Replace `CLICKHOUSE_MAX_BUFFER_SIZE` with `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES`
 
 ### Fixed
+- Using `VersionedCollapsingMergeTree` to store visit data to avoid rare race conditions that led to wrong visit data being shown
 - Fix `conversion_rate` metric in a `browser_versions` breakdown
 - Calculate `conversion_rate` percentage change in the same way like `bounce_rate` (subtraction instead of division)
 - Calculate `bounce_rate` percentage change in the Stats API in the same way as it's done in the dashboard

--- a/priv/ingest_repo/migrations/20240222082911_sessions_v2_versioned_collapsing_merge_tree.exs
+++ b/priv/ingest_repo/migrations/20240222082911_sessions_v2_versioned_collapsing_merge_tree.exs
@@ -1,0 +1,13 @@
+defmodule Plausible.IngestRepo.Migrations.SessionsV2VersionedCollapsingMergeTree do
+  use Ecto.Migration
+
+  def up do
+    Plausible.DataMigration.VersionedSessions.run(run_exchange?: true)
+
+    # After this migration a `sessions_v2_tmp_versioned` backup table is left behind, to be cleaned up manually
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end


### PR DESCRIPTION
This migration will noop in staging/production as it already has been run. It also leaves behind a backup table that initially takes no extra space but will need to be cleaned up manually.

@ruslandoga Mind if I hand off handling the self-hosted side of this to you from here?