### PR TITLE
use newer postgres versions in the ci

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        postgres_version: [13, 14, 15]
+        postgres_version: [14, 15, 16]
 
     services:
       postgres:


### PR DESCRIPTION
### Changes

This PR updates the versions of PostgreSQL to newer ones in the CI. (So that I can update https://github.com/plausible/community-edition/blob/v2.0.0/docker-compose.yml#L8 😅)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
