### PR TITLE
add space after logo on the index page

### DIFF
--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,4 +1,4 @@
-<div class="w-full md:max-w-xl md:mx-auto bg-white dark:bg-gray-800 md:shadow-md md:rounded px-8 py-6">
+<div class="mt-12 w-full md:max-w-xl md:mx-auto bg-white dark:bg-gray-800 md:shadow-md md:rounded px-8 py-6">
   <p class="text-gray-900 text-xl font-black dark:text-gray-100">
     Welcome to Plausible Analytics!
   </p>


### PR DESCRIPTION
### Changes

This PR adds some space after the logo on the index page.

Before (can be seen on https://who.copycat.fun):

<img width="1582" alt="Screenshot 2024-02-25 at 18 34 35" src="https://github.com/plausible/analytics/assets/67764432/e5415a5d-2ffb-4630-8d77-e391bddbe483">

After

<img width="1582" alt="Screenshot 2024-02-25 at 18 36 37" src="https://github.com/plausible/analytics/assets/67764432/f2ef4148-d211-4f02-b928-748e84ea47d5">

<img width="1582" alt="Screenshot 2024-02-25 at 18 37 33" src="https://github.com/plausible/analytics/assets/67764432/11a210d4-0927-44d1-832b-49b6aeb36e2b">

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
