### PR TITLE
Hide user name overlay on mobile

### DIFF
--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -40,7 +40,7 @@
               <li class="w-full sm:w-auto">
                 <.dropdown>
                   <:button class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
-                    <span class="font-medium truncate dark:text-gray-100">
+                    <span class="font-medium truncate dark:text-gray-100 hidden md:block">
                       <%= @conn.assigns[:current_user].name %>
                     </span>
                     <%= img_tag(Plausible.Auth.User.profile_img_url(@conn.assigns[:current_user]),


### PR DESCRIPTION
### Changes

Before:

![image](https://github.com/plausible/analytics/assets/173738/b9b2c5c4-a790-4068-9848-221b45a41ff2)


After:

![image](https://github.com/plausible/analytics/assets/173738/d6028c02-7e54-4963-8308-8f895c98e043)


### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
