### PR TITLE
Query imported data for views_per_visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ### Added
+- Query the `views_per_visit` metric based on imported data as well if possible
 - Group `operating_system_versions` by `operating_system` in Stats API breakdown
 - Add `operating_system_versions.csv` into the CSV export
 - Display `Total visitors`, `Conversions`, and `CR` in the "Details" views of Countries, Regions and Cities (when filtering by a goal)

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -69,9 +69,6 @@ export default class TopStats extends React.Component {
     let statName = stat.name.toLowerCase()
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
-    const { topStatData, lastLoadTimestamp } = this.props
-    const showingImported = topStatData?.imported_source && topStatData?.with_imported
-
     return (
       <div>
         {query.comparison && <div className="whitespace-nowrap">
@@ -83,8 +80,7 @@ export default class TopStats extends React.Component {
           {this.topStatNumberLong(stat.name, stat.value)} {statName}
         </div>}
 
-        {stat.name === 'Current visitors' && <p className="font-normal text-xs">Last updated <SecondsSinceLastLoad lastLoadTimestamp={lastLoadTimestamp}/>s ago</p>}
-        {stat.name === 'Views per visit' && showingImported && <p className="font-normal text-xs whitespace-nowrap">Based only on native data</p>}
+        {stat.name === 'Current visitors' && <p className="font-normal text-xs">Last updated <SecondsSinceLastLoad lastLoadTimestamp={this.props.lastLoadTimestamp}/>s ago</p>}
       </div>
     )
   }

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -336,7 +336,8 @@ defmodule Plausible.Stats.Base do
     from(s in q,
       select_merge: %{
         views_per_visit:
-          fragment("ifNotFinite(round(sum(? * ?) / sum(?), 2), 0)", s.sign, s.pageviews, s.sign)
+          fragment("ifNotFinite(round(sum(? * ?) / sum(?), 2), 0)", s.sign, s.pageviews, s.sign),
+        __internal_visits: fragment("toUInt32(sum(sign))")
       }
     )
     |> select_session_metrics(rest, query)

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -9,8 +9,8 @@ defmodule Plausible.Stats.Util do
   Sometimes we need to manually add metrics in order to calculate the value for
   other metrics. E.g:
 
-  * `__internal_visits` is fetched when querying bounce rate and visit duration,
-    as it is needed to calculate these from imported data.
+  * `__internal_visits` is fetched when querying bounce rate, visit duration,
+    or views_per_visit, as it is needed to calculate these from imported data.
 
   * `visitors` metric might be added manually via `maybe_add_visitors_metric/1`,
     in order to be able to calculate conversion rate.

--- a/test/plausible/imported/imported_test.exs
+++ b/test/plausible/imported/imported_test.exs
@@ -1211,7 +1211,7 @@ defmodule Plausible.ImportedTest do
                    %{"name" => "Unique visitors", "value" => 1},
                    %{"name" => "Total visits", "value" => 1},
                    %{"name" => "Total pageviews", "value" => 1},
-                   %{"name" => "Views per visit", "value" => +0.0},
+                   %{"name" => "Views per visit", "value" => 1.0},
                    %{"name" => "Bounce rate", "value" => 0},
                    %{"name" => "Visit duration", "value" => 60}
                  ]

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -420,7 +420,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
                "visits" => %{"value" => 5, "change" => 150},
                "pageviews" => %{"value" => 9, "change" => -10},
                "bounce_rate" => %{"value" => 40, "change" => -10},
-               "views_per_visit" => %{"value" => 1.0, "change" => 100},
+               "views_per_visit" => %{"value" => 1.8, "change" => -64},
                "visit_duration" => %{"value" => 20, "change" => -80}
              }
     end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -387,7 +387,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
   describe "GET /api/stats/top-stats - with imported data" do
     setup [:create_user, :log_in, :create_new_site, :add_imported_data]
 
-    test "merges imported data into all top stat metrics except views_per_visit", %{
+    test "merges imported data into all top stat metrics", %{
       conn: conn,
       site: site
     } do
@@ -418,7 +418,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
                %{"name" => "Unique visitors", "value" => 3},
                %{"name" => "Total visits", "value" => 3},
                %{"name" => "Total pageviews", "value" => 4},
-               %{"name" => "Views per visit", "value" => 1.5},
+               %{"name" => "Views per visit", "value" => 1.33},
                %{"name" => "Bounce rate", "value" => 33},
                %{"name" => "Visit duration", "value" => 303}
              ]


### PR DESCRIPTION
### Changes

Currently, the `views_per_visit` metric is only queried from native stats. This limitation is arbitrary, since imported data has  both `visits` and `pageviews` needed to calculate the metric.

The motivation behind doing it now is that we could make `with_imported=true` by default in Stats API. Otherwise, we'd need to exclude imported data whenever this metric is queried, or worse, only exclude imported data for this metric without a notice.

On the dashboard we have a tooltip, which is not ideal either as on mobile you wouldn't see it:
<img width="154" alt="image" src="https://github.com/plausible/analytics/assets/56999674/86a3e870-6035-4182-8309-d8575581ffde">

This PR removes that arbitrary limitation and starts including imported data in the calculation of `views_per_visit`.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
