### PR TITLE
Change the CTA to upgrade now rather than contact us

### DIFF
--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -16,9 +16,12 @@ defmodule PlausibleWeb.Components.Billing.Notice do
           title="You have outgrown your Plausible subscription tier"
           class="shadow-md dark:shadow-none"
         >
-          In order to keep your stats running, we require you to upgrade your account to accommodate your new usage levels. Please contact us to discuss a new custom plan.
-          <.link href="mailto:enterprise@plausible.io" class="whitespace-nowrap font-semibold">
-            Contact us <span aria-hidden="true"> &rarr;</span>
+          In order to keep your stats running, we require you to upgrade your account to accommodate your new usage levels.
+          <.link
+            href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
+            class="whitespace-nowrap font-semibold"
+          >
+            Upgrade now <span aria-hidden="true"> &rarr;</span>
           </.link>
         </.notice>
       </aside>


### PR DESCRIPTION
we've had couple of situations recently where people contact us about this notice that we display in their accounts. 

they don't actually need to contact us as we have already created a new custom plan for them at that stage (we get notified ourselves when they go over their limits) so they can just upgrade directly in their account instead

and in the case that we didn't create a new plan already, the upgrade page will tell them to contact us