### PR TITLE
Plugins API: mark data_domain as nullable in capabilities schema

### DIFF
--- a/lib/plausible_web/plugins/api/schemas/capabilities.ex
+++ b/lib/plausible_web/plugins/api/schemas/capabilities.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Capabilities do
     required: [:authorized, :data_domain, :features],
     properties: %{
       authorized: %Schema{type: :boolean},
-      data_domain: %Schema{type: :string},
+      data_domain: %Schema{type: :string, nullable: true},
       features: %Schema{
         type: :object,
         required: @features,

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -14,9 +14,12 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
 
   describe "unauthorized" do
     test "no token", %{conn: conn} do
-      resp = get(conn, Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+      resp =
+        conn
+        |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+        |> json_response(200)
 
-      assert json_response(resp, 200) ==
+      assert resp ==
                %{
                  "authorized" => false,
                  "data_domain" => nil,
@@ -28,6 +31,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false
                  }
                }
+
+      assert_schema(resp, "Capabilities", spec())
     end
 
     test "bad token", %{conn: conn} do
@@ -36,8 +41,9 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
         |> put_req_header("content-type", "application/json")
         |> authenticate("foo", "bad token")
         |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+        |> json_response(200)
 
-      assert json_response(resp, 200) ==
+      assert resp ==
                %{
                  "authorized" => false,
                  "data_domain" => nil,
@@ -49,6 +55,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false
                  }
                }
+
+      assert_schema(resp, "Capabilities", spec())
     end
   end
 
@@ -59,8 +67,9 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
         |> put_req_header("content-type", "application/json")
         |> authenticate(site.domain, token)
         |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+        |> json_response(200)
 
-      assert json_response(resp, 200) ==
+      assert resp ==
                %{
                  "authorized" => true,
                  "data_domain" => site.domain,
@@ -72,6 +81,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true
                  }
                }
+
+      assert_schema(resp, "Capabilities", spec())
     end
 
     test "growth", %{conn: conn, site: site, token: token} do
@@ -83,8 +94,9 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
         |> put_req_header("content-type", "application/json")
         |> authenticate(site.domain, token)
         |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+        |> json_response(resp, 200)
 
-      assert json_response(resp, 200) ==
+      assert resp ==
                %{
                  "authorized" => true,
                  "data_domain" => site.domain,
@@ -96,6 +108,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false
                  }
                }
+
+      assert_schema(resp, "Capabilities", spec())
     end
   end
 end

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
         |> put_req_header("content-type", "application/json")
         |> authenticate(site.domain, token)
         |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
-        |> json_response(resp, 200)
+        |> json_response(200)
 
       assert resp ==
                %{


### PR DESCRIPTION
### Changes

When no/bad token is provided, `data_domain` is null. The schema must reflect that.