### PR TITLE
Tests: session properties without the prefixes

### DIFF
--- a/test/plausible/stats/clickhouse_test.exs
+++ b/test/plausible/stats/clickhouse_test.exs
@@ -228,22 +228,22 @@ defmodule Plausible.Stats.ClickhouseTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/",
-          session_referrer_source: "Twitter"
+          referrer_source: "Twitter"
         ),
         build(:pageview,
           pathname: "/plausible.io"
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_referrer_source: "Google"
+          referrer_source: "Google"
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_referrer_source: "Google"
+          referrer_source: "Google"
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_referrer_source: "Bing"
+          referrer_source: "Bing"
         )
       ])
 

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -430,7 +430,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         build(:imported_visitors, date: ~D[2023-01-01]),
         build(:imported_sources, date: ~D[2023-01-01]),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2023-01-02 00:10:00]
         )
       ])
@@ -485,7 +485,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -524,7 +524,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -549,7 +549,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by referrer", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer: "https://facebook.com",
+          referrer: "https://facebook.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -579,9 +579,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
 
     test "wildcard referrer filter with special regex characters", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_referrer: "https://a.com"),
-        build(:pageview, session_referrer: "https://a.com"),
-        build(:pageview, session_referrer: "https://ab.com")
+        build(:pageview, referrer: "https://a.com"),
+        build(:pageview, referrer: "https://a.com"),
+        build(:pageview, referrer: "https://ab.com")
       ])
 
       conn =
@@ -597,7 +597,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_medium", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -628,7 +628,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_source: "Twitter",
+          utm_source: "Twitter",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -659,7 +659,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by utm_campaign", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -690,7 +690,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by device type", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_screen_size: "Desktop",
+          screen_size: "Desktop",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -721,7 +721,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by browser", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -752,8 +752,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by browser version", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
-          session_browser_version: "56",
+          browser: "Chrome",
+          browser_version: "56",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -784,7 +784,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by operating system", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_operating_system: "Mac",
+          operating_system: "Mac",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -815,7 +815,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by operating system version", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_operating_system_version: "10.5",
+          operating_system_version: "10.5",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -846,7 +846,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can filter by country", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
+          country_code: "EE",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1138,7 +1138,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/blogpost",
-          session_country_code: "EE",
+          country_code: "EE",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1349,10 +1349,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     } do
       populate_stats(site, [
         build(:event, name: "Signup"),
-        build(:event, name: "Signup", session_browser: "Chrome"),
-        build(:event, name: "Signup", session_browser: "Firefox", user_id: 123),
-        build(:event, name: "Signup", session_browser: "Firefox", user_id: 123),
-        build(:pageview, session_browser: "Firefox"),
+        build(:event, name: "Signup", browser: "Chrome"),
+        build(:event, name: "Signup", browser: "Firefox", user_id: 123),
+        build(:event, name: "Signup", browser: "Firefox", user_id: 123),
+        build(:pageview, browser: "Firefox"),
         build(:pageview)
       ])
 

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -227,15 +227,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:source", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_referrer_source: "Google",
+        referrer_source: "Google",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_referrer_source: "Google",
+        referrer_source: "Google",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_referrer_source: "",
+        referrer_source: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -258,9 +258,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
   test "breakdown by visit:country", %{conn: conn, site: site} do
     populate_stats(site, [
-      build(:pageview, session_country_code: "EE", timestamp: ~N[2021-01-01 00:00:00]),
-      build(:pageview, session_country_code: "EE", timestamp: ~N[2021-01-01 00:25:00]),
-      build(:pageview, session_country_code: "US", timestamp: ~N[2021-01-01 00:00:00])
+      build(:pageview, country_code: "EE", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, country_code: "EE", timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, country_code: "US", timestamp: ~N[2021-01-01 00:00:00])
     ])
 
     conn =
@@ -282,15 +282,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:referrer", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_referrer: "https://ref.com",
+        referrer: "https://ref.com",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_referrer: "https://ref.com",
+        referrer: "https://ref.com",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_referrer: "",
+        referrer: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -314,15 +314,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_medium", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_utm_medium: "Search",
+        utm_medium: "Search",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_utm_medium: "Search",
+        utm_medium: "Search",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_utm_medium: "",
+        utm_medium: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -345,15 +345,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_source", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_utm_source: "Google",
+        utm_source: "Google",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_utm_source: "Google",
+        utm_source: "Google",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_utm_source: "",
+        utm_source: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -376,15 +376,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_campaign", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_utm_campaign: "ads",
+        utm_campaign: "ads",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_utm_campaign: "ads",
+        utm_campaign: "ads",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_utm_campaign: "",
+        utm_campaign: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -407,15 +407,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_content", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_utm_content: "Content1",
+        utm_content: "Content1",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_utm_content: "Content1",
+        utm_content: "Content1",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_utm_content: "",
+        utm_content: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -438,15 +438,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:utm_term", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_utm_term: "Term1",
+        utm_term: "Term1",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_utm_term: "Term1",
+        utm_term: "Term1",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_utm_term: "",
+        utm_term: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -469,15 +469,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:device", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_screen_size: "Desktop",
+        screen_size: "Desktop",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_screen_size: "Desktop",
+        screen_size: "Desktop",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_screen_size: "Mobile",
+        screen_size: "Mobile",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -501,15 +501,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:os", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_operating_system: "Mac",
+        operating_system: "Mac",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_operating_system: "Mac",
+        operating_system: "Mac",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_operating_system: "Windows",
+        operating_system: "Windows",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -532,17 +532,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
   test "breakdown by visit:os_version", %{conn: conn, site: site} do
     populate_stats(site, [
-      build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
-      build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
-      build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
-      build(:pageview, session_operating_system_version: "14"),
+      build(:pageview, operating_system: "Mac", operating_system_version: "14"),
+      build(:pageview, operating_system: "Mac", operating_system_version: "14"),
+      build(:pageview, operating_system: "Mac", operating_system_version: "14"),
+      build(:pageview, operating_system_version: "14"),
       build(:pageview,
-        session_operating_system: "Windows",
-        session_operating_system_version: "11"
+        operating_system: "Windows",
+        operating_system_version: "11"
       ),
       build(:pageview,
-        session_operating_system: "Windows",
-        session_operating_system_version: "11"
+        operating_system: "Windows",
+        operating_system_version: "11"
       )
     ])
 
@@ -564,9 +564,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
   test "breakdown by visit:browser", %{conn: conn, site: site} do
     populate_stats(site, [
-      build(:pageview, session_browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
-      build(:pageview, session_browser: "Firefox", timestamp: ~N[2021-01-01 00:25:00]),
-      build(:pageview, session_browser: "Safari", timestamp: ~N[2021-01-01 00:00:00])
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00])
     ])
 
     conn =
@@ -588,15 +588,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:browser_version", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        session_browser_version: "56",
+        browser_version: "56",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        session_browser_version: "56",
+        browser_version: "56",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        session_browser_version: "57",
+        browser_version: "57",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])
@@ -806,30 +806,30 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageA",
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Signup",
           pathname: "/pageB",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/pageA",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -857,7 +857,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -867,7 +867,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Twitter",
+          referrer_source: "Twitter",
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -905,7 +905,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         ),
         build(:pageview,
           pathname: "/pageB",
-          session_referrer_source: "Twitter",
+          referrer_source: "Twitter",
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])
@@ -1288,21 +1288,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/ignore",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          session_browser: "Safari",
+          browser: "Safari",
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:00:00]
         )
@@ -1332,10 +1332,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/",
-          session_referrer_source: "Twitter",
-          session_utm_medium: "Twitter",
-          session_utm_source: "Twitter",
-          session_utm_campaign: "Twitter",
+          referrer_source: "Twitter",
+          utm_medium: "Twitter",
+          utm_source: "Twitter",
+          utm_campaign: "Twitter",
           user_id: @user_id
         ),
         build(:pageview,
@@ -1344,17 +1344,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_referrer_source: "Google",
-          session_utm_medium: "Google",
-          session_utm_source: "Google",
-          session_utm_campaign: "Google"
+          referrer_source: "Google",
+          utm_medium: "Google",
+          utm_source: "Google",
+          utm_campaign: "Google"
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_referrer_source: "Google",
-          session_utm_medium: "Google",
-          session_utm_source: "Google",
-          session_utm_campaign: "Google"
+          referrer_source: "Google",
+          utm_medium: "Google",
+          utm_source: "Google",
+          utm_campaign: "Google"
         )
       ])
 
@@ -1382,31 +1382,31 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           user_id: @user_id,
           pathname: "/ignore",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           user_id: @user_id,
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           user_id: 456,
           pathname: "/important-page",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           user_id: 456,
           pathname: "/",
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           pathname: "/plausible.io",
           timestamp: ~N[2021-01-01 00:01:00]
         )
@@ -1438,11 +1438,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Bing",
+          referrer_source: "Bing",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1474,11 +1474,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Bing",
+          referrer_source: "Bing",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1535,10 +1535,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     test "mixed multi-goal filter for breakdown by visit:country", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_country_code: "EE", pathname: "/en/register"),
-        build(:event, session_country_code: "EE", name: "Signup", pathname: "/en/register"),
-        build(:pageview, session_country_code: "US", pathname: "/123/it/register"),
-        build(:pageview, session_country_code: "US", pathname: "/different")
+        build(:pageview, country_code: "EE", pathname: "/en/register"),
+        build(:event, country_code: "EE", name: "Signup", pathname: "/en/register"),
+        build(:pageview, country_code: "US", pathname: "/123/it/register"),
+        build(:pageview, country_code: "US", pathname: "/different")
       ])
 
       insert(:goal, %{site: site, page_path: "/**register"})
@@ -1636,22 +1636,22 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/ignore",
-          session_browser: "Firefox",
+          browser: "Firefox",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/plausible.io",
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           pathname: "/important-page",
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1751,25 +1751,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "IN filter for event:props:*", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Safari",
+          browser: "Safari",
           "meta.key": ["browser"],
           "meta.value": ["Safari"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Firefox",
+          browser: "Firefox",
           "meta.key": ["browser"],
           "meta.value": ["Firefox"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1796,25 +1796,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "Multiple event:props:* filters", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser", "prop"],
           "meta.value": ["Chrome", "xyz"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Safari",
+          browser: "Safari",
           "meta.key": ["browser", "prop"],
           "meta.value": ["Safari", "target_value"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Firefox",
+          browser: "Firefox",
           "meta.key": ["browser", "prop"],
           "meta.value": ["Firefox", "target_value"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1840,23 +1840,23 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
     test "IN filter for event:props:* including (none) value", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["browser"],
           "meta.value": ["Chrome"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Firefox",
+          browser: "Firefox",
           "meta.key": ["browser"],
           "meta.value": ["Firefox"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1882,10 +1882,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
 
     test "can use a is_not filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "Chrome"),
-        build(:pageview, session_browser: "Safari"),
-        build(:pageview, session_browser: "Safari"),
-        build(:pageview, session_browser: "Edge")
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Safari"),
+        build(:pageview, browser: "Safari"),
+        build(:pageview, browser: "Edge")
       ])
 
       conn =
@@ -2250,12 +2250,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       site: site
     } do
       populate_stats(site, [
-        build(:event, session_screen_size: "Mobile", name: "pageview"),
-        build(:event, session_screen_size: "Mobile", name: "AddToCart"),
-        build(:event, session_screen_size: "Mobile", name: "AddToCart"),
-        build(:event, session_screen_size: "Desktop", name: "AddToCart", user_id: 1),
-        build(:event, session_screen_size: "Desktop", name: "Purchase", user_id: 1),
-        build(:event, session_screen_size: "Desktop", name: "pageview")
+        build(:event, screen_size: "Mobile", name: "pageview"),
+        build(:event, screen_size: "Mobile", name: "AddToCart"),
+        build(:event, screen_size: "Mobile", name: "AddToCart"),
+        build(:event, screen_size: "Desktop", name: "AddToCart", user_id: 1),
+        build(:event, screen_size: "Desktop", name: "Purchase", user_id: 1),
+        build(:event, screen_size: "Desktop", name: "pageview")
       ])
 
       # Make sure that revenue goals are treated the same
@@ -2295,8 +2295,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       site: site
     } do
       populate_stats(site, [
-        build(:event, session_screen_size: "Mobile", name: "pageview"),
-        build(:event, session_screen_size: "Mobile", name: "AddToCart")
+        build(:event, screen_size: "Mobile", name: "pageview"),
+        build(:event, screen_size: "Mobile", name: "AddToCart")
       ])
 
       insert(:goal, %{site: site, event_name: "AddToCart"})
@@ -2325,13 +2325,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       conn: conn
     } do
       populate_stats(site, [
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "110"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "110"),
-        build(:pageview, session_browser: "Avast Secure Browser", session_browser_version: "110"),
-        build(:pageview, session_browser: "Avast Secure Browser", session_browser_version: "110"),
-        build(:event, name: "Signup", session_browser: "Edge", session_browser_version: "110")
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Chrome", browser_version: "110"),
+        build(:pageview, browser: "Chrome", browser_version: "110"),
+        build(:pageview, browser: "Avast Secure Browser", browser_version: "110"),
+        build(:pageview, browser: "Avast Secure Browser", browser_version: "110"),
+        build(:event, name: "Signup", browser: "Edge", browser_version: "110")
       ])
 
       insert(:goal, site: site, event_name: "Signup")
@@ -2363,26 +2363,26 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 1,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "signup",
           user_id: 1,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:05:00]
         ),
         build(:pageview,
           user_id: 1,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:10:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:pageview,
-          session_referrer_source: "Twitter",
+          referrer_source: "Twitter",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -2435,7 +2435,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
         build(:pageview,
           user_id: 2,
           pathname: "/entry-page-2",
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:05:00]
         )
       ])
@@ -2469,28 +2469,28 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          session_browser: "Chrome",
+          browser: "Chrome",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["business"],
-          session_browser: "Safari",
+          browser: "Safari",
           timestamp: ~N[2021-01-01 00:25:00]
         ),
         build(:event,
           name: "Purchase",
           "meta.key": ["package"],
           "meta.value": ["personal"],
-          session_browser: "IE",
+          browser: "IE",
           timestamp: ~N[2021-01-01 00:25:00]
         )
       ])

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -661,7 +661,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -683,7 +683,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -703,7 +703,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by referrer", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer: "https://facebook.com",
+          referrer: "https://facebook.com",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -724,7 +724,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_medium", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -745,7 +745,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_source: "Twitter",
+          utm_source: "Twitter",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -766,7 +766,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by utm_campaign", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -787,7 +787,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by device type", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_screen_size: "Desktop",
+          screen_size: "Desktop",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -808,13 +808,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by browser", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_browser: "Chrome",
-          session_browser_version: "56.1",
+          browser: "Chrome",
+          browser_version: "56.1",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_browser: "Chrome",
-          session_browser_version: "55",
+          browser: "Chrome",
+          browser_version: "55",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -835,18 +835,18 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by operating system", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.5",
+          operating_system: "Mac",
+          operating_system_version: "10.5",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_operating_system: "Something else",
-          session_operating_system_version: "10.5",
+          operating_system: "Something else",
+          operating_system_version: "10.5",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.4",
+          operating_system: "Mac",
+          operating_system_version: "10.4",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
@@ -868,12 +868,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: @user_id,
-          session_country_code: "EE",
+          country_code: "EE",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          session_country_code: "EE",
+          country_code: "EE",
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browsers by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "Chrome"),
-        build(:pageview, session_browser: "Chrome"),
-        build(:pageview, session_browser: "Firefox")
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Firefox")
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
@@ -26,21 +26,21 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_browser: "Chrome"
+          browser: "Chrome"
         ),
         build(:pageview,
           user_id: 123,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_browser: "Firefox",
+          browser: "Firefox",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_browser: "Safari"
+          browser: "Safari"
         )
       ])
 
@@ -59,23 +59,23 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_browser: "Firefox",
+          browser: "Firefox",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_browser: "Safari"
+          browser: "Safari"
         )
       ])
 
@@ -90,8 +90,8 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_browser: "Chrome"),
-        build(:pageview, user_id: 2, session_browser: "Chrome"),
+        build(:pageview, user_id: 1, browser: "Chrome"),
+        build(:pageview, user_id: 2, browser: "Chrome"),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -111,7 +111,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browsers including imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "Chrome"),
+        build(:pageview, browser: "Chrome"),
         build(:imported_browsers, browser: "Chrome"),
         build(:imported_browsers, browser: "Firefox"),
         build(:imported_visitors, visitors: 2)
@@ -156,7 +156,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_browser: ""
+          browser: ""
         )
       ])
 
@@ -176,16 +176,16 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       site: site
     } do
       populate_stats(site, [
-        build(:event, session_browser: "Chrome", session_browser_version: "110", name: "Signup"),
-        build(:event, session_browser: "Chrome", session_browser_version: "110", name: "Signup"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "110"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "121"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "121"),
-        build(:event, session_browser: "Firefox", session_browser_version: "121", name: "Signup"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "110")
+        build(:event, browser: "Chrome", browser_version: "110", name: "Signup"),
+        build(:event, browser: "Chrome", browser_version: "110", name: "Signup"),
+        build(:pageview, browser: "Chrome", browser_version: "110"),
+        build(:pageview, browser: "Chrome", browser_version: "121"),
+        build(:pageview, browser: "Chrome", browser_version: "121"),
+        build(:event, browser: "Firefox", browser_version: "121", name: "Signup"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110")
       ])
 
       insert(:goal, site: site, event_name: "Signup")
@@ -217,10 +217,10 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns top browser versions by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "Chrome", session_browser_version: "78.0"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "78.0"),
-        build(:pageview, session_browser: "Chrome", session_browser_version: "77.0"),
-        build(:pageview, session_browser: "Firefox", session_browser_version: "88.0")
+        build(:pageview, browser: "Chrome", browser_version: "78.0"),
+        build(:pageview, browser: "Chrome", browser_version: "78.0"),
+        build(:pageview, browser: "Chrome", browser_version: "77.0"),
+        build(:pageview, browser: "Firefox", browser_version: "88.0")
       ])
 
       filters = Jason.encode!(%{browser: "Chrome"})
@@ -239,7 +239,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
     test "returns results for (not set)", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "", session_browser_version: "")
+        build(:pageview, browser: "", browser_version: "")
       ])
 
       filters = Jason.encode!(%{browser: "(not set)"})

--- a/test/plausible_web/controllers/api/stats_controller/cities_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/cities_test.exs
@@ -5,29 +5,29 @@ defmodule PlausibleWeb.Api.StatsController.CitiesTest do
     defp seed(%{site: site}) do
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-39",
-          session_city_geoname_id: 591_632
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-39",
-          session_city_geoname_id: 591_632
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
         )
       ])
     end

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "returns top countries by new visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_country_code: "EE"),
-        build(:pageview, session_country_code: "EE"),
-        build(:pageview, session_country_code: "GB"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB"),
         build(:imported_locations, country: "EE"),
         build(:imported_locations, country: "GB"),
         build(:imported_visitors, visitors: 2)
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "ignores unknown country code ZZ", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_country_code: "ZZ"),
+        build(:pageview, country_code: "ZZ"),
         build(:imported_locations, country: "ZZ")
       ])
 
@@ -72,16 +72,16 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 1,
-          session_country_code: "EE"
+          country_code: "EE"
         ),
         build(:event, user_id: 1, name: "Signup"),
         build(:pageview,
           user_id: 2,
-          session_country_code: "EE"
+          country_code: "EE"
         ),
         build(:pageview,
           user_id: 3,
-          session_country_code: "GB"
+          country_code: "GB"
         ),
         build(:event, user_id: 3, name: "Signup")
       ])
@@ -119,21 +119,21 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_country_code: "EE"
+          country_code: "EE"
         ),
         build(:pageview,
           user_id: 123,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_country_code: "GB",
+          country_code: "GB",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_country_code: "US"
+          country_code: "US"
         )
       ])
 
@@ -159,23 +159,23 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_country_code: "GB",
+          country_code: "GB",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_country_code: "GB"
+          country_code: "GB"
         )
       ])
 
@@ -200,17 +200,17 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_country_code: "GB",
+          country_code: "GB",
           "meta.key": ["logged_in"],
           "meta.value": ["true"]
         ),
         build(:pageview,
-          session_country_code: "GB"
+          country_code: "GB"
         )
       ])
 
@@ -235,22 +235,22 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_country_code: "EE",
+          country_code: "EE",
           "meta.key": ["author"],
           "meta.value": [""]
         ),
         build(:pageview,
-          session_country_code: "GB",
+          country_code: "GB",
           "meta.key": ["logged_in"],
           "meta.value": ["true"]
         ),
         build(:pageview,
-          session_country_code: "GB"
+          country_code: "GB"
         )
       ])
 
@@ -271,9 +271,9 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
     test "when list is filtered by country returns one country only", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_country_code: "EE"),
-        build(:pageview, session_country_code: "EE"),
-        build(:pageview, session_country_code: "GB")
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB")
       ])
 
       filters = Jason.encode!(%{country: "GB"})

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -688,14 +688,14 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
 
     test "Property breakdown with prop and goal filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_utm_campaign: "campaignA"),
+        build(:pageview, user_id: 1, utm_campaign: "campaignA"),
         build(:event,
           user_id: 1,
           name: "ButtonClick",
           "meta.key": ["variant"],
           "meta.value": ["A"]
         ),
-        build(:pageview, user_id: 2, session_utm_campaign: "campaignA"),
+        build(:pageview, user_id: 2, utm_campaign: "campaignA"),
         build(:event,
           user_id: 2,
           name: "ButtonClick",
@@ -710,7 +710,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
         Jason.encode!(%{
           goal: "ButtonClick",
           props: %{variant: "A"},
-          session_utm_campaign: "campaignA"
+          utm_campaign: "campaignA"
         })
 
       prop_key = "variant"
@@ -733,15 +733,15 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
 
     test "Property breakdown with goal and source filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_referrer_source: "Google"),
+        build(:pageview, user_id: 1, referrer_source: "Google"),
         build(:event,
           user_id: 1,
           name: "ButtonClick",
           "meta.key": ["variant"],
           "meta.value": ["A"]
         ),
-        build(:pageview, user_id: 2, session_referrer_source: "Google"),
-        build(:pageview, user_id: 3, session_referrer_source: "ignore"),
+        build(:pageview, user_id: 2, referrer_source: "Google"),
+        build(:pageview, user_id: 3, referrer_source: "ignore"),
         build(:event,
           user_id: 3,
           name: "ButtonClick",
@@ -963,7 +963,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
       populate_stats(site, [
         build(:pageview, "meta.key": [prop_key], "meta.value": ["K2sna Kalle"]),
         build(:pageview,
-          session_browser: "Chrome",
+          browser: "Chrome",
           "meta.key": [prop_key],
           "meta.value": ["Sipsik"]
         )

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -107,14 +107,14 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
             pathname: "/blog/announcement",
             user_id: @other_user_id,
             timestamp: ~N[2021-01-01 12:00:00],
-            session_utm_medium: "social"
+            utm_medium: "social"
           ),
           build(:event, name: "Signup", user_id: @user_id),
           build(:event,
             name: "Signup",
             user_id: @other_user_id,
             timestamp: ~N[2021-01-01 12:01:00],
-            session_utm_medium: "social"
+            utm_medium: "social"
           ),
           build(:pageview, pathname: "/cart/add/product", user_id: @user_id),
           build(:event, name: "Purchase", user_id: @user_id)

--- a/test/plausible_web/controllers/api/stats_controller/imported_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/imported_test.exs
@@ -154,18 +154,18 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
       test "Sources are imported", %{conn: conn, site: site, import_id: import_id} do
         populate_stats(site, [
           build(:pageview,
-            session_referrer_source: "Google",
-            session_referrer: "google.com",
+            referrer_source: "Google",
+            referrer: "google.com",
             timestamp: ~N[2021-01-01 00:00:00]
           ),
           build(:pageview,
-            session_referrer_source: "Google",
-            session_referrer: "google.com",
+            referrer_source: "Google",
+            referrer: "google.com",
             timestamp: ~N[2021-01-01 00:00:00]
           ),
           build(:pageview,
-            session_referrer_source: "DuckDuckGo",
-            session_referrer: "duckduckgo.com",
+            referrer_source: "DuckDuckGo",
+            referrer: "duckduckgo.com",
             timestamp: ~N[2021-01-01 00:00:00]
           )
         ])
@@ -296,11 +296,11 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
       } do
         populate_stats(site, [
           build(:pageview,
-            session_utm_medium: "social",
+            utm_medium: "social",
             timestamp: ~N[2021-01-01 00:00:00]
           ),
           build(:pageview,
-            session_utm_medium: "social",
+            utm_medium: "social",
             timestamp: ~N[2021-01-01 12:00:00]
           )
         ])
@@ -367,8 +367,8 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, [
-          build(:pageview, session_utm_campaign: "profile", timestamp: ~N[2021-01-01 00:00:00]),
-          build(:pageview, session_utm_campaign: "august", timestamp: ~N[2021-01-01 00:00:00])
+          build(:pageview, utm_campaign: "profile", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_campaign: "august", timestamp: ~N[2021-01-01 00:00:00])
         ])
 
         import_data(
@@ -455,9 +455,9 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, [
-          build(:pageview, session_utm_term: "oat milk", timestamp: ~N[2021-01-01 00:00:00]),
-          build(:pageview, session_utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00]),
-          build(:pageview, session_utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00])
+          build(:pageview, utm_term: "oat milk", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_term: "Sweden", timestamp: ~N[2021-01-01 00:00:00])
         ])
 
         import_data(
@@ -544,8 +544,8 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, [
-          build(:pageview, session_utm_content: "ad", timestamp: ~N[2021-01-01 00:00:00]),
-          build(:pageview, session_utm_content: "blog", timestamp: ~N[2021-01-01 00:00:00])
+          build(:pageview, utm_content: "ad", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, utm_content: "blog", timestamp: ~N[2021-01-01 00:00:00])
         ])
 
         import_data(
@@ -817,15 +817,15 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
       } do
         populate_stats(site, [
           build(:pageview,
-            session_country_code: "EE",
+            country_code: "EE",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:pageview,
-            session_country_code: "EE",
+            country_code: "EE",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:pageview,
-            session_country_code: "GB",
+            country_code: "GB",
             timestamp: ~N[2021-01-01 00:15:00]
           )
         ])
@@ -890,15 +890,15 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
       } do
         populate_stats(site, import_id, [
           build(:pageview,
-            session_country_code: "EE",
+            country_code: "EE",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:pageview,
-            session_country_code: "EE",
+            country_code: "EE",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:pageview,
-            session_country_code: "GB",
+            country_code: "GB",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
@@ -972,9 +972,9 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, import_id, [
-          build(:pageview, session_screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
-          build(:pageview, session_screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
-          build(:pageview, session_screen_size: "Laptop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, screen_size: "Desktop", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, screen_size: "Laptop", timestamp: ~N[2021-01-01 00:15:00]),
           build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)
         ])
 
@@ -1023,8 +1023,8 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, import_id, [
-          build(:pageview, session_browser: "Chrome", timestamp: ~N[2021-01-01 00:15:00]),
-          build(:pageview, session_browser: "Firefox", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:15:00]),
           build(:imported_visitors, visitors: 2, date: ~D[2021-01-01])
         ])
 
@@ -1076,10 +1076,10 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         import_id: import_id
       } do
         populate_stats(site, import_id, [
-          build(:pageview, session_operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
-          build(:pageview, session_operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
+          build(:pageview, operating_system: "Mac", timestamp: ~N[2021-01-01 00:15:00]),
           build(:pageview,
-            session_operating_system: "GNU/Linux",
+            operating_system: "GNU/Linux",
             timestamp: ~N[2021-01-01 00:15:00]
           ),
           build(:imported_visitors, date: ~D[2021-01-01], visitors: 2)

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "returns operating systems by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Android")
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Android")
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
@@ -22,10 +22,10 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_operating_system: ""
+          operating_system: ""
         ),
         build(:pageview,
-          session_operating_system: "Linux"
+          operating_system: "Linux"
         )
       ])
 
@@ -48,8 +48,8 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_operating_system: "Mac"),
-        build(:pageview, user_id: 2, session_operating_system: "Mac"),
+        build(:pageview, user_id: 1, operating_system: "Mac"),
+        build(:pageview, user_id: 2, operating_system: "Mac"),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -75,21 +75,21 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_operating_system: "Mac"
+          operating_system: "Mac"
         ),
         build(:pageview,
           user_id: 123,
-          session_operating_system: "Mac",
+          operating_system: "Mac",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_operating_system: "Windows",
+          operating_system: "Windows",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_operating_system: "Android"
+          operating_system: "Android"
         )
       ])
 
@@ -110,23 +110,23 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_operating_system: "Windows",
+          operating_system: "Windows",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          session_operating_system: "Windows",
+          operating_system: "Windows",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_operating_system: "Mac",
+          operating_system: "Mac",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_operating_system: "Android"
+          operating_system: "Android"
         )
       ])
 
@@ -146,9 +146,9 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       site: site
     } do
       populate_stats(site, [
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Android"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Android"),
         build(:imported_operating_systems, operating_system: "Mac"),
         build(:imported_operating_systems, operating_system: "Android"),
         build(:imported_visitors, visitors: 2)
@@ -172,8 +172,8 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
     test "imported data is ignored when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_operating_system: "Mac"),
-        build(:pageview, user_id: 2, session_operating_system: "Mac"),
+        build(:pageview, user_id: 1, operating_system: "Mac"),
+        build(:pageview, user_id: 2, operating_system: "Mac"),
         build(:imported_operating_systems, operating_system: "Mac"),
         build(:event, user_id: 1, name: "Signup")
       ])
@@ -200,20 +200,20 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
     test "returns top OS versions by unique visitors", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.15"
+          operating_system: "Mac",
+          operating_system_version: "10.15"
         ),
         build(:pageview,
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.16"
+          operating_system: "Mac",
+          operating_system_version: "10.16"
         ),
         build(:pageview,
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.16"
+          operating_system: "Mac",
+          operating_system_version: "10.16"
         ),
         build(:pageview,
-          session_operating_system: "Android",
-          session_operating_system_version: "4"
+          operating_system: "Android",
+          operating_system_version: "4"
         )
       ])
 

--- a/test/plausible_web/controllers/api/stats_controller/regions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_test.exs
@@ -5,29 +5,29 @@ defmodule PlausibleWeb.Api.StatsController.RegionsTest do
     defp seed(%{site: site}) do
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-39",
-          session_city_geoname_id: 591_632
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-39",
-          session_city_geoname_id: 591_632
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
         )
       ])
     end

--- a/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
@@ -6,9 +6,9 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes by new visitors", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Laptop")
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Laptop")
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/screen-sizes?period=day")
@@ -22,10 +22,10 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_screen_size: ""
+          screen_size: ""
         ),
         build(:pageview,
-          session_screen_size: "Desktop"
+          screen_size: "Desktop"
         )
       ])
 
@@ -53,21 +53,21 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_screen_size: "Desktop"
+          screen_size: "Desktop"
         ),
         build(:pageview,
           user_id: 123,
-          session_screen_size: "Desktop",
+          screen_size: "Desktop",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_screen_size: "Mobile",
+          screen_size: "Mobile",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_screen_size: "Tablet"
+          screen_size: "Tablet"
         )
       ])
 
@@ -86,23 +86,23 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          session_screen_size: "Desktop",
+          screen_size: "Desktop",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
           user_id: 123,
-          session_screen_size: "Desktop",
+          screen_size: "Desktop",
           "meta.key": ["author"],
           "meta.value": ["John Doe"]
         ),
         build(:pageview,
-          session_screen_size: "Mobile",
+          screen_size: "Mobile",
           "meta.key": ["author"],
           "meta.value": ["other"]
         ),
         build(:pageview,
-          session_screen_size: "Tablet"
+          screen_size: "Tablet"
         )
       ])
 
@@ -117,9 +117,9 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes by new visitors with imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Laptop")
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Laptop")
       ])
 
       populate_stats(site, [
@@ -146,8 +146,8 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, user_id: 1, session_screen_size: "Desktop"),
-        build(:pageview, user_id: 2, session_screen_size: "Desktop"),
+        build(:pageview, user_id: 1, screen_size: "Desktop"),
+        build(:pageview, user_id: 2, screen_size: "Desktop"),
         build(:event, user_id: 1, name: "Signup")
       ])
 
@@ -167,13 +167,13 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
 
     test "returns screen sizes with not_member filter type", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_referrer_source: "Google", session_screen_size: "Desktop"),
-        build(:pageview, session_referrer_source: "Bad source", session_screen_size: "Desktop"),
-        build(:pageview, session_referrer_source: "Google", session_screen_size: "Desktop"),
-        build(:pageview, session_referrer_source: "Twitter", session_screen_size: "Mobile"),
+        build(:pageview, referrer_source: "Google", screen_size: "Desktop"),
+        build(:pageview, referrer_source: "Bad source", screen_size: "Desktop"),
+        build(:pageview, referrer_source: "Google", screen_size: "Desktop"),
+        build(:pageview, referrer_source: "Twitter", screen_size: "Mobile"),
         build(:pageview,
-          session_referrer_source: "Second bad source",
-          session_screen_size: "Mobile"
+          referrer_source: "Second bad source",
+          screen_size: "Mobile"
         )
       ])
 

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -9,24 +9,24 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         ),
         build(:pageview)
       ])
@@ -43,8 +43,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources with :is filter on custom pageview props", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -55,22 +55,22 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -95,8 +95,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           user_id: 123,
@@ -109,20 +109,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -149,8 +149,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           user_id: 123,
@@ -161,20 +161,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -199,8 +199,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           "meta.key": ["logged_in"],
           "meta.value": ["true"],
           user_id: 123,
@@ -213,22 +213,22 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["author"],
           "meta.value": ["another"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -249,11 +249,11 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
     test "returns top sources with imported data", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_referrer_source: "Google", session_referrer: "google.com"),
-        build(:pageview, session_referrer_source: "Google", session_referrer: "google.com"),
+        build(:pageview, referrer_source: "Google", referrer: "google.com"),
+        build(:pageview, referrer_source: "Google", referrer: "google.com"),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         )
       ])
 
@@ -286,20 +286,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "calculates bounce rate and visit duration for sources", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -332,20 +332,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -415,18 +415,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top sources in realtime report", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           timestamp: relative_time(minutes: -3)
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           timestamp: relative_time(minutes: -2)
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           timestamp: relative_time(minutes: -1)
         )
       ])
@@ -442,16 +442,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "can paginate the results", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         ),
         build(:imported_sources,
           source: "DuckDuckGo"
@@ -473,17 +473,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
     test "shows sources for a page", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, pathname: "/page1", session_referrer_source: "Google"),
-        build(:pageview, pathname: "/page1", session_referrer_source: "Google"),
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
         build(:pageview,
           user_id: 1,
           pathname: "/page2",
-          session_referrer_source: "DuckDuckGo"
+          referrer_source: "DuckDuckGo"
         ),
         build(:pageview,
           user_id: 1,
           pathname: "/page1",
-          session_referrer_source: "DuckDuckGo"
+          referrer_source: "DuckDuckGo"
         )
       ])
 
@@ -503,17 +503,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_mediums by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_medium: "email",
+          utm_medium: "email",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -583,17 +583,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_medium present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_medium: "social",
+          utm_medium: "social",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_medium: "",
+          utm_medium: "",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -655,21 +655,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_campaigns by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_campaign: "august",
+          utm_campaign: "august",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_campaign: "august",
+          utm_campaign: "august",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -739,21 +739,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_campaign present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_campaign: "profile",
+          utm_campaign: "profile",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_campaign: "",
+          utm_campaign: "",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_campaign: "",
+          utm_campaign: "",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -815,21 +815,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_sources by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_source: "Twitter",
+          utm_source: "Twitter",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_source: "Twitter",
+          utm_source: "Twitter",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_source: "newsletter",
+          utm_source: "newsletter",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_source: "newsletter",
+          utm_source: "newsletter",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -863,21 +863,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_terms by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_term: "oat milk",
+          utm_term: "oat milk",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_term: "oat milk",
+          utm_term: "oat milk",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_term: "Sweden",
+          utm_term: "Sweden",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_term: "Sweden",
+          utm_term: "Sweden",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -947,21 +947,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_term present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_term: "oat milk",
+          utm_term: "oat milk",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_term: "oat milk",
+          utm_term: "oat milk",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_term: "",
+          utm_term: "",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_term: "",
+          utm_term: "",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1023,21 +1023,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top utm_contents by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_content: "ad",
+          utm_content: "ad",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_content: "ad",
+          utm_content: "ad",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_content: "blog",
+          utm_content: "blog",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_content: "blog",
+          utm_content: "blog",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1107,21 +1107,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "filters out entries without utm_content present", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_utm_content: "ad",
+          utm_content: "ad",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_content: "ad",
+          utm_content: "ad",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_utm_content: "",
+          utm_content: "",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_utm_content: "",
+          utm_content: "",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1186,7 +1186,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Twitter",
+          referrer_source: "Twitter",
           user_id: @user_id
         ),
         build(:event,
@@ -1194,7 +1194,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           user_id: @user_id
         ),
         build(:pageview,
-          session_referrer_source: "Twitter"
+          referrer_source: "Twitter"
         )
       ])
 
@@ -1224,8 +1224,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers with goal filter + :is prop filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1237,15 +1237,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           timestamp: ~N[2021-01-01 00:01:00]
         ),
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           "meta.key": ["logged_in"],
           "meta.value": ["true"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
-          session_referrer_source: "Facebook",
-          session_referrer: "facebook.com",
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
           name: "Download",
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "false"],
@@ -1274,8 +1274,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers with goal filter + prop :is_not filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com",
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1288,16 +1288,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         ),
         build(:event,
           name: "Download",
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "true"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:event,
           name: "Download",
-          session_referrer_source: "Google",
-          session_referrer: "google.com",
+          referrer_source: "Google",
+          referrer: "google.com",
           "meta.key": ["method", "logged_in"],
           "meta.value": ["HTTP", "false"],
           timestamp: ~N[2021-01-01 00:00:00]
@@ -1334,7 +1334,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "Twitter",
+          referrer_source: "Twitter",
           user_id: @user_id
         ),
         build(:pageview,
@@ -1342,7 +1342,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           user_id: @user_id
         ),
         build(:pageview,
-          session_referrer_source: "Twitter"
+          referrer_source: "Twitter"
         )
       ])
 
@@ -1371,20 +1371,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referrers for a particular source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com"
+          referrer_source: "10words",
+          referrer: "10words.com"
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com"
+          referrer_source: "10words",
+          referrer: "10words.com"
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com/page1"
+          referrer_source: "10words",
+          referrer: "10words.com/page1"
         ),
         build(:pageview,
-          session_referrer_source: "ignored",
-          session_referrer: "ignored"
+          referrer_source: "ignored",
+          referrer: "ignored"
         )
       ])
 
@@ -1403,25 +1403,25 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "calculates bounce rate and visit duration for referrer urls", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com",
+          referrer_source: "10words",
+          referrer: "10words.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com",
+          referrer_source: "10words",
+          referrer: "10words.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com",
+          referrer_source: "10words",
+          referrer: "10words.com",
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          session_referrer_source: "ignored",
-          session_referrer: "ignored",
+          referrer_source: "ignored",
+          referrer: "ignored",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])
@@ -1447,16 +1447,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         )
       ])
 
@@ -1475,16 +1475,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     } do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "DuckDuckGo",
-          session_referrer: "duckduckgo.com"
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         ),
         build(:pageview,
-          session_referrer_source: "Google",
-          session_referrer: "google.com"
+          referrer_source: "Google",
+          referrer: "google.com"
         )
       ])
 
@@ -1504,12 +1504,12 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referring urls for a custom goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com"
+          referrer_source: "10words",
+          referrer: "10words.com"
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com",
+          referrer_source: "10words",
+          referrer: "10words.com",
           user_id: @user_id
         ),
         build(:event,
@@ -1542,12 +1542,12 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top referring urls for a pageview goal", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com"
+          referrer_source: "10words",
+          referrer: "10words.com"
         ),
         build(:pageview,
-          session_referrer_source: "10words",
-          session_referrer: "10words.com",
+          referrer_source: "10words",
+          referrer: "10words.com",
           user_id: @user_id
         ),
         build(:pageview,

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -57,11 +57,11 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for sources", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], session_referrer_source: "Bing"),
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], session_referrer_source: "Bing"),
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
-          session_referrer_source: "10words"
+          referrer_source: "10words"
         )
       ])
 
@@ -79,7 +79,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:01],
           pathname: "/",
-          session_country_code: "US"
+          country_code: "US"
         )
       ])
 
@@ -96,8 +96,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       {:ok, [site: site]} = create_new_site(%{user: user})
 
       populate_stats(site, [
-        build(:pageview, session_country_code: "EE", session_subdivision1_code: "EE-37"),
-        build(:pageview, session_country_code: "EE", session_subdivision1_code: "EE-39")
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-37"),
+        build(:pageview, country_code: "EE", subdivision1_code: "EE-39")
       ])
 
       conn =
@@ -114,14 +114,14 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
       populate_stats(site, [
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-37",
-          session_city_geoname_id: 588_409
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
         ),
         build(:pageview,
-          session_country_code: "EE",
-          session_subdivision1_code: "EE-39",
-          session_city_geoname_id: 591_632
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
         )
       ])
 
@@ -149,7 +149,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
           pathname: "/",
-          session_screen_size: "Desktop"
+          screen_size: "Desktop"
         )
       ])
 
@@ -164,7 +164,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
           pathname: "/",
-          session_browser: "Chrome"
+          browser: "Chrome"
         )
       ])
 
@@ -180,8 +180,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       populate_stats(site, [
         build(:pageview,
           timestamp: ~N[2019-01-01 00:00:00],
-          session_browser: "Chrome",
-          session_browser_version: "78.0"
+          browser: "Chrome",
+          browser_version: "78.0"
         )
       ])
 
@@ -196,7 +196,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for OS", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 00:00:00], session_operating_system: "Mac")
+        build(:pageview, timestamp: ~N[2019-01-01 00:00:00], operating_system: "Mac")
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/suggestions/os?period=month&date=2019-01-01")
@@ -210,8 +210,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       populate_stats(site, [
         build(:pageview,
           timestamp: ~N[2019-01-01 00:00:00],
-          session_operating_system: "Mac",
-          session_operating_system_version: "10.15"
+          operating_system: "Mac",
+          operating_system_version: "10.15"
         )
       ])
 
@@ -241,7 +241,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
           pathname: "/",
-          session_referrer: "10words.com/page1"
+          referrer: "10words.com/page1"
         )
       ])
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -511,9 +511,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors from a country based on alpha2 code", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_country_code: "US"),
-        build(:pageview, session_country_code: "US"),
-        build(:pageview, session_country_code: "EE")
+        build(:pageview, country_code: "US"),
+        build(:pageview, country_code: "US"),
+        build(:pageview, country_code: "EE")
       ])
 
       filters = Jason.encode!(%{country: "US"})
@@ -571,9 +571,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific screen size", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Desktop"),
-        build(:pageview, session_screen_size: "Mobile")
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Desktop"),
+        build(:pageview, screen_size: "Mobile")
       ])
 
       filters = Jason.encode!(%{screen: "Desktop"})
@@ -591,9 +591,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific browser", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_browser: "Chrome"),
-        build(:pageview, session_browser: "Chrome"),
-        build(:pageview, session_browser: "Safari")
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Safari")
       ])
 
       filters = Jason.encode!(%{browser: "Chrome"})
@@ -611,9 +611,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     test "returns only visitors with specific operating system", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Mac"),
-        build(:pageview, session_operating_system: "Windows")
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Windows")
       ])
 
       filters = Jason.encode!(%{os: "Mac"})
@@ -633,17 +633,17 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       populate_stats(site, [
         build(:pageview,
           user_id: @user_id,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 00:05:00]
         ),
         build(:pageview,
           user_id: @user_id,
-          session_referrer_source: "Google",
+          referrer_source: "Google",
           timestamp: ~N[2021-01-01 05:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:10:00])

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -292,18 +292,18 @@ defmodule PlausibleWeb.StatsControllerTest do
 
     test "exports operating system versions", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
-        build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
-        build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
+        build(:pageview, operating_system: "Mac", operating_system_version: "14"),
+        build(:pageview, operating_system: "Mac", operating_system_version: "14"),
+        build(:pageview, operating_system: "Mac", operating_system_version: "14"),
         build(:pageview,
-          session_operating_system: "Ubuntu",
-          session_operating_system_version: "20.04"
+          operating_system: "Ubuntu",
+          operating_system_version: "20.04"
         ),
         build(:pageview,
-          session_operating_system: "Ubuntu",
-          session_operating_system_version: "20.04"
+          operating_system: "Ubuntu",
+          operating_system_version: "20.04"
         ),
-        build(:pageview, session_operating_system: "Mac", session_operating_system_version: "13")
+        build(:pageview, operating_system: "Mac", operating_system_version: "13")
       ])
 
       conn = get(conn, "/#{site.domain}/export")
@@ -422,52 +422,52 @@ defmodule PlausibleWeb.StatsControllerTest do
         pathname: "/",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], minutes: -1) |> NaiveDateTime.truncate(:second),
-        session_country_code: "EE",
-        session_subdivision1_code: "EE-37",
-        session_city_geoname_id: 588_409,
-        session_referrer_source: "Google"
+        country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
+        referrer_source: "Google"
       ),
       build(:pageview,
         user_id: 123,
         pathname: "/some-other-page",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], minutes: -2) |> NaiveDateTime.truncate(:second),
-        session_country_code: "EE",
-        session_subdivision1_code: "EE-37",
-        session_city_geoname_id: 588_409,
-        session_referrer_source: "Google"
+        country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
+        referrer_source: "Google"
       ),
       build(:pageview,
         pathname: "/",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], days: -1) |> NaiveDateTime.truncate(:second),
-        session_utm_medium: "search",
-        session_utm_campaign: "ads",
-        session_utm_source: "google",
-        session_utm_content: "content",
-        session_utm_term: "term",
-        session_browser: "Firefox",
-        session_browser_version: "120",
-        session_operating_system: "Mac",
-        session_operating_system_version: "14"
+        utm_medium: "search",
+        utm_campaign: "ads",
+        utm_source: "google",
+        utm_content: "content",
+        utm_term: "term",
+        browser: "Firefox",
+        browser_version: "120",
+        operating_system: "Mac",
+        operating_system_version: "14"
       ),
       build(:pageview,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -1) |> NaiveDateTime.truncate(:second),
-        session_country_code: "EE",
-        session_browser: "Firefox",
-        session_browser_version: "120",
-        session_operating_system: "Mac",
-        session_operating_system_version: "14"
+        country_code: "EE",
+        browser: "Firefox",
+        browser_version: "120",
+        operating_system: "Mac",
+        operating_system_version: "14"
       ),
       build(:pageview,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -5) |> NaiveDateTime.truncate(:second),
-        session_utm_campaign: "ads",
-        session_country_code: "EE",
-        session_referrer_source: "Google",
-        session_browser: "FirefoxNoVersion",
-        session_operating_system: "MacNoVersion"
+        utm_campaign: "ads",
+        country_code: "EE",
+        referrer_source: "Google",
+        browser: "FirefoxNoVersion",
+        operating_system: "MacNoVersion"
       ),
       build(:event,
         timestamp:
@@ -525,36 +525,36 @@ defmodule PlausibleWeb.StatsControllerTest do
       site: site
     } do
       populate_stats(site, [
-        build(:pageview, session_operating_system: "Mac", session_operating_system_version: "14"),
+        build(:pageview, operating_system: "Mac", operating_system_version: "14"),
         build(:event,
           name: "Signup",
-          session_operating_system: "Mac",
-          session_operating_system_version: "14"
+          operating_system: "Mac",
+          operating_system_version: "14"
         ),
         build(:event,
           name: "Signup",
-          session_operating_system: "Mac",
-          session_operating_system_version: "14"
+          operating_system: "Mac",
+          operating_system_version: "14"
         ),
         build(:event,
           name: "Signup",
-          session_operating_system: "Mac",
-          session_operating_system_version: "14"
+          operating_system: "Mac",
+          operating_system_version: "14"
         ),
         build(:event,
           name: "Signup",
-          session_operating_system: "Ubuntu",
-          session_operating_system_version: "20.04"
+          operating_system: "Ubuntu",
+          operating_system_version: "20.04"
         ),
         build(:event,
           name: "Signup",
-          session_operating_system: "Ubuntu",
-          session_operating_system_version: "20.04"
+          operating_system: "Ubuntu",
+          operating_system_version: "20.04"
         ),
         build(:event,
           name: "Signup",
-          session_operating_system: "Lubuntu",
-          session_operating_system_version: "20.04"
+          operating_system: "Lubuntu",
+          operating_system_version: "20.04"
         )
       ])
 

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -194,7 +194,7 @@ defmodule Plausible.TestUtils do
   defp populate_native_stats(events) do
     sessions =
       Enum.reduce(events, %{}, fn event, sessions ->
-        session_id = Plausible.Session.CacheStore.on_event(event, session_params(event), nil)
+        session_id = Plausible.Session.CacheStore.on_event(event, event, nil)
         Map.put(sessions, {event.site_id, event.user_id}, session_id)
       end)
 
@@ -214,24 +214,6 @@ defmodule Plausible.TestUtils do
   defp populate_imported_stats(events) do
     Enum.group_by(events, &Map.fetch!(&1, :table), &Map.delete(&1, :table))
     |> Enum.map(fn {table, events} -> Plausible.Imported.Buffer.insert_all(table, events) end)
-  end
-
-  defp session_params(event) do
-    event
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      str_key = Atom.to_string(key)
-
-      if String.starts_with?(str_key, "session_") and key != :session_id do
-        session_key =
-          str_key
-          |> String.trim("session_")
-          |> String.to_existing_atom()
-
-        Map.put(acc, session_key, value)
-      else
-        acc
-      end
-    end)
   end
 
   def relative_time(shifts) do

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -81,7 +81,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
         build(:pageview,
           user_id: 123,
           timestamp: Timex.shift(now, days: -7),
-          session_referrer_source: "Google"
+          referrer_source: "Google"
         ),
         build(:pageview, user_id: 123, timestamp: Timex.shift(now, days: -7)),
         build(:pageview, timestamp: Timex.shift(now, days: -7))


### PR DESCRIPTION
### Changes

This affects only tests. As part of https://github.com/plausible/analytics/pull/3800, we started writing session properties via `session_`. After working on queries a while I realized this will complicate working with ecto significantly. This PR undoes that change.