### PR TITLE
Validate the same metric isnt queried multiple times in external stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Require custom properties to be explicitly added from Site Settings > Custom Properties in order for them to show up on the dashboard
 - GA/SC sections moved to new settings: Integrations
 - Replace `CLICKHOUSE_MAX_BUFFER_SIZE` with `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES`
+- Validate metric isn't queried multiple times
 
 ### Fixed
 - Using `VersionedCollapsingMergeTree` to store visit data to avoid rare race conditions that led to wrong visit data being shown

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -150,12 +150,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   defp validate_all_metrics(metrics, property, query) do
-    Enum.reduce_while(metrics, [], fn metric, acc ->
-      case validate_metric(metric, property, query) do
-        {:ok, metric} -> {:cont, acc ++ [metric]}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
+    if length(metrics) == length(Enum.uniq(metrics)) do
+      Enum.reduce_while(metrics, [], fn metric, acc ->
+        case validate_metric(metric, property, query) do
+          {:ok, metric} -> {:cont, acc ++ [metric]}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+    else
+      {:error, "Metrics cannot be queried multiple times."}
+    end
   end
 
   defp validate_metric("conversion_rate" = metric, property, query) do

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -189,6 +189,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
                  "Session metric `views_per_visit` cannot be queried when using a filter on `event:name`."
              }
     end
+
+    test "validates a metric isn't asked multiple times", %{
+      conn: conn,
+      site: site
+    } do
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "metrics" => "visitors,visitors"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" => "Metrics cannot be queried multiple times."
+             }
+    end
   end
 
   test "aggregates a single metric", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Requesting same metric multiple times could blow up in the stats API. so instead, let's validate and raise an error!

[Sentry](https://sentry.plausible.io/organizations/sentry/issues/5535/?query=is%3Aunresolved&statsPeriod=30d), [Basecamp](https://3.basecamp.com/5308029/buckets/35611491/card_tables/cards/7161347855)

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change
