### PR TITLE
Temporarily disable tzdata auto-updating

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -693,6 +693,9 @@ config :tzdata,
        :data_dir,
        get_var_from_path_or_env(config_dir, "STORAGE_DIR", Application.app_dir(:tzdata, "priv"))
 
+# Temporarily disable tzdata auto-updating
+config :tzdata, :autoupdate, :disabled
+
 promex_disabled? =
   config_dir
   |> get_var_from_path_or_env("PROMEX_DISABLED", "true")


### PR DESCRIPTION
This can cause issues as 1 day after a deploy the tzdata list is updated from 2021 to 2024. Selecting a timezone thats not supported in 2021 can then break dashboards temporarily following a deploy.

This can be reverted after https://github.com/plausible/analytics/pull/3811