### PR TITLE
Fix bounce_rate change bug

### DIFF
--- a/lib/plausible/stats/compare.ex
+++ b/lib/plausible/stats/compare.ex
@@ -4,7 +4,9 @@ defmodule Plausible.Stats.Compare do
   end
 
   def calculate_change(:bounce_rate, old_count, new_count) do
-    if old_count > 0, do: new_count - old_count
+    if is_integer(old_count) && is_integer(new_count) && old_count > 0 do
+      new_count - old_count
+    end
   end
 
   def calculate_change(_metric, old_count, new_count) do


### PR DESCRIPTION
### Changes

Fixes a bug where Top Stats report crashes because of an ArithmeticError on calculating bounce rate. Introduced in https://github.com/plausible/analytics/pull/3858, more precisely https://github.com/plausible/analytics/pull/3858/commits/dab76296f6300abc630b97bce510a812da008628

Let's get that in quick to fix it. I'll add a test in a follow-up PR