### PR TITLE
Fix division by zero in imported queries

### DIFF
--- a/lib/plausible/stats/compare.ex
+++ b/lib/plausible/stats/compare.ex
@@ -4,9 +4,7 @@ defmodule Plausible.Stats.Compare do
   end
 
   def calculate_change(:bounce_rate, old_count, new_count) do
-    if is_integer(old_count) && is_integer(new_count) && old_count > 0 do
-      new_count - old_count
-    end
+    if old_count > 0, do: new_count - old_count
   end
 
   def calculate_change(_metric, old_count, new_count) do

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -488,7 +488,15 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([s, i], %{
       views_per_visit:
         fragment(
-          "round((? + ? * coalesce(?, 0)) / (coalesce(?, 0) + coalesce(?, 0)), 2)",
+          """
+          if(
+            coalesce(?, 0) + coalesce(?, 0) > 0,
+            round((? + ? * coalesce(?, 0)) / (coalesce(?, 0) + coalesce(?, 0)), 2),
+            0
+          )
+          """,
+          s.__internal_visits,
+          i.__internal_visits,
           i.pageviews,
           s.views_per_visit,
           s.__internal_visits,
@@ -504,7 +512,15 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([s, i], %{
       bounce_rate:
         fragment(
-          "round(100 * (coalesce(?, 0) + coalesce((? * ? / 100), 0)) / (coalesce(?, 0) + coalesce(?, 0)))",
+          """
+          if(
+            coalesce(?, 0) + coalesce(?, 0) > 0,
+            round(100 * (coalesce(?, 0) + coalesce((? * ? / 100), 0)) / (coalesce(?, 0) + coalesce(?, 0))),
+            0
+          )
+          """,
+          s.__internal_visits,
+          i.__internal_visits,
           i.bounces,
           s.bounce_rate,
           s.__internal_visits,
@@ -520,7 +536,15 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([s, i], %{
       visit_duration:
         fragment(
-          "round((? + ? * ?) / (? + ?), 1)",
+          """
+          if(
+            ? + ? > 0,
+            round((? + ? * ?) / (? + ?), 1),
+            0
+          )
+          """,
+          s.__internal_visits,
+          i.__internal_visits,
           i.visit_duration,
           s.visit_duration,
           s.__internal_visits,

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -423,6 +423,23 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
   describe "GET /api/stats/top-stats - with imported data" do
     setup [:create_user, :log_in, :create_new_site, :add_imported_data]
 
+    test "returns divisible metrics as 0 when no stats exist", %{
+      site: site,
+      conn: conn
+    } do
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"name" => "Bounce rate", "value" => 0} in res["top_stats"]
+      assert %{"name" => "Views per visit", "value" => 0.0} in res["top_stats"]
+      assert %{"name" => "Visit duration", "value" => 0} in res["top_stats"]
+    end
+
     test "merges imported data into all top stat metrics", %{
       conn: conn,
       site: site


### PR DESCRIPTION
### Changes

This PR tackles the problem that surfaced with https://github.com/plausible/analytics/pull/3858. The PR stopped casting `nil` values into zeros in the aggregate API **after** having fetched those results from ClickHouse:

<img width="968" alt="image" src="https://github.com/plausible/analytics/assets/56999674/7d437e80-02ee-4222-b942-5397cd654895">


Consequently some Top Stats queries crashed due to the `calculate_change` function blowing up when getting `nil` as input when expecting a number. This was mitigated with https://github.com/plausible/analytics/pull/3886, but it did not tackle the root cause of the issue. Hence, this PR rolls that change back - we can still keep relying on `bounce_rate` being a number in the `calculate_change` function.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
