### PR TITLE
don't log migrations in tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -150,7 +150,7 @@ defmodule Plausible.MixProject do
       setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test", "clean_clickhouse"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test", "clean_clickhouse"],
       sentry_recompile: ["compile", "deps.compile sentry --force"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": [


### PR DESCRIPTION
### Changes

When tests fail in GitHub actions, I need to scroll through the migrations output to see the failure reason. This PR tries to make seeing the failure reason easier.

I expect the data migration output to still be logged, so there is another approach with running migrations in a separate step: https://github.com/plausible/analytics/pull/3897

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI