### PR TITLE
run migrations in a separate step

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -73,6 +73,8 @@ jobs:
         run: npm run deploy --prefix ./tracker
       - name: Check Credo Warnings
         run: mix credo diff --from-git-merge-base origin/master
+      - name: Run migrations
+        run: mix do ecto.create, ecto.migrate
       - name: Run tests
         run: mix test --include slow --include minio --max-failures 1 --warnings-as-errors
       - name: Run tests (small build)


### PR DESCRIPTION
### Changes

When tests fail in GitHub actions, I need to scroll through the migrations output to see the failure reason. This PR tries to make seeing the failure reason easier.

Alternative to https://github.com/plausible/analytics/pull/3896

This change is included in https://github.com/plausible/analytics/pull/3898 so if https://github.com/plausible/analytics/pull/3898 is merged, this PR can be closed.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI