### PR TITLE
Allow using verified routes

### DIFF
--- a/lib/plausible_web.ex
+++ b/lib/plausible_web.ex
@@ -10,6 +10,7 @@ defmodule PlausibleWeb do
       end
 
       alias PlausibleWeb.Router.Helpers, as: Routes
+      unquote(verified_routes())
       alias Phoenix.LiveView.JS
     end
   end
@@ -21,6 +22,7 @@ defmodule PlausibleWeb do
       import Plug.Conn
       import PlausibleWeb.ControllerHelpers
       alias PlausibleWeb.Router.Helpers, as: Routes
+      unquote(verified_routes())
     end
   end
 
@@ -41,6 +43,7 @@ defmodule PlausibleWeb do
       import PlausibleWeb.FormHelpers
       import PlausibleWeb.Components.Generic
       alias PlausibleWeb.Router.Helpers, as: Routes
+      unquote(verified_routes())
     end
   end
 
@@ -91,6 +94,17 @@ defmodule PlausibleWeb do
       require OpenApiSpex
       alias OpenApiSpex.Schema
       alias PlausibleWeb.Plugins.API.Schemas
+    end
+  end
+
+  def static_paths, do: ~w(css js images favicon.ico robots.txt)
+
+  def verified_routes do
+    quote do
+      use Phoenix.VerifiedRoutes,
+        endpoint: PlausibleWeb.Endpoint,
+        router: PlausibleWeb.Router,
+        statics: PlausibleWeb.static_paths()
     end
   end
 

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.Endpoint do
     at: "/",
     from: :plausible,
     gzip: false,
-    only: ~w(css js images favicon.ico robots.txt)
+    only: PlausibleWeb.static_paths()
   )
 
   on_full_build do

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -73,7 +73,7 @@ defmodule PlausibleWeb.Live.Sites do
           You don't have any sites yet.
         </p>
         <div class="mt-4 flex sm:ml-4 sm:mt-0">
-          <a href="/sites/new" class="button">
+          <a href={~p"/sites/new"} class="button">
             + Add Website
           </a>
         </div>
@@ -217,7 +217,7 @@ defmodule PlausibleWeb.Live.Sites do
       }
       phx-mounted={JS.show()}
     >
-      <.unstyled_link href={"/#{URI.encode_www_form(@site.domain)}"}>
+      <.unstyled_link href={~p"/#{URI.encode_www_form(@site.domain)}"}>
         <div class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">
           <div class="w-full flex items-center justify-between space-x-4">
             <.favicon domain={@site.domain} />
@@ -249,7 +249,7 @@ defmodule PlausibleWeb.Live.Sites do
         <div class="py-1 text-sm" role="none">
           <.dropdown_link
             :if={List.first(@site.memberships).role != :viewer}
-            href={"/#{URI.encode_www_form(@site.domain)}/settings/general"}
+            href={~p"/#{URI.encode_www_form(@site.domain)}/settings/general"}
           >
             <Heroicons.cog_6_tooth class="mr-3 h-5 w-5" />
             <span>Settings</span>

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -32,7 +32,7 @@
                 class="hidden mr-6 sm:block"
               >
                 <%= link(trial_notificaton(@conn.assigns[:current_user]),
-                  to: "/settings",
+                  to: ~p"/settings",
                   class:
                     "text-sm text-yellow-900 dark:text-yellow-900 rounded px-3 py-2 rounded-md bg-yellow-100 dark:bg-yellow-100"
                 ) %>
@@ -57,7 +57,7 @@
                       </p>
                     </div>
                     <div class="py-1.5" role="none">
-                      <.dropdown_link href="/settings">Account Settings</.dropdown_link>
+                      <.dropdown_link href={~p"/settings"}>Account Settings</.dropdown_link>
                       <.dropdown_link new_tab href="https://plausible.io/docs">
                         Help Center
                       </.dropdown_link>
@@ -75,7 +75,7 @@
                       <% end %>
                     </div>
                     <div class="py-1.5" role="none">
-                      <.dropdown_link href="/logout">Log Out</.dropdown_link>
+                      <.dropdown_link href={~p"/logout"}>Log Out</.dropdown_link>
                     </div>
                   </:panel>
                 </.dropdown>
@@ -89,7 +89,7 @@
               <li>
                 <div class="inline-flex">
                   <a
-                    href="/login"
+                    href={~p"/login"}
                     class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out"
                   >
                     Login
@@ -102,7 +102,7 @@
               <li>
                 <div class="inline-flex">
                   <a
-                    href="/login"
+                    href={~p"/login"}
                     class="font-medium text-gray-500 dark:text-gray-200 hover:text-gray-900 focus:outline-none focus:text-gray-900 transition duration-150 ease-in-out"
                   >
                     Login
@@ -110,7 +110,7 @@
                 </div>
                 <div class="inline-flex ml-6 rounded shadow">
                   <a
-                    href="/register"
+                    href={~p"/register"}
                     class="inline-flex items-center justify-center px-5 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring transition duration-150 ease-in-out"
                   >
                     Sign up

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -20,7 +20,7 @@
       <%= assigns[:title] ||
         "Plausible · Simple, privacy-friendly alternative to Google Analytics" %>
     </title>
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")} />
+    <link rel="stylesheet" href={~p"/css/app.css"} />
     <PlausibleWeb.Components.Layout.theme_script {Map.take(assigns, [:current_user, :theme])} />
     <%= render("_tracking.html", assigns) %>
   </head>
@@ -44,15 +44,15 @@
 
     <%= if assigns[:embedded] do %>
       <div data-iframe-height></div>
-      <script type="text/javascript" src={Routes.static_path(@conn, "/js/embed.content.js")}>
+      <script type="text/javascript" src={~p"/js/embed.content.js"}>
       </script>
     <% else %>
       <%= render("_footer.html", assigns) %>
     <% end %>
-    <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>
+    <script type="text/javascript" src={~p"/js/app.js"}>
     </script>
     <%= if assigns[:load_dashboard_js] do %>
-      <script type="text/javascript" src={Routes.static_path(@conn, "/js/dashboard.js")}>
+      <script type="text/javascript" src={~p"/js/dashboard.js"}>
       </script>
     <% end %>
   </body>

--- a/lib/plausible_web/templates/layout/base_error.html.heex
+++ b/lib/plausible_web/templates/layout/base_error.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <PlausibleWeb.Components.Layout.favicon conn={@conn} />
     <title>Plausible · Web analytics</title>
-    <link rel="stylesheet" href={Routes.static_path(PlausibleWeb.Endpoint, "/css/app.css")} />
+    <link rel="stylesheet" href={~p"/css/app.css"} />
   </head>
   <body class="flex flex-col h-full bg-gray-100 dark:bg-gray-900">
     <div class="w-full my-8 text-center">
@@ -34,7 +34,7 @@
 
     <%= @inner_content %>
 
-    <script type="text/javascript" src={Routes.static_path(PlausibleWeb.Endpoint, "/js/app.js")}>
+    <script type="text/javascript" src={~p"/js/app.js"}>
     </script>
   </body>
 </html>

--- a/lib/plausible_web/templates/layout/focus.html.heex
+++ b/lib/plausible_web/templates/layout/focus.html.heex
@@ -15,7 +15,7 @@
     <% end %>
     <PlausibleWeb.Components.Layout.favicon conn={@conn} />
     <title><%= assigns[:title] || "Plausible · Web analytics" %></title>
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")} />
+    <link rel="stylesheet" href={~p"/css/app.css"} />
     <%= render("_tracking.html", assigns) %>
   </head>
   <body class="flex flex-col h-full bg-gray-100 dark:bg-gray-900">
@@ -53,7 +53,7 @@
 
     <PlausibleWeb.Components.Layout.theme_script current_user={assigns[:current_user]} />
 
-    <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>
+    <script type="text/javascript" src={~p"/js/app.js"}>
     </script>
   </body>
 </html>

--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
@@ -29,7 +29,7 @@
       <div class="block pulsating-circle top-1/2 left-1/2"></div>
       <p class="text-gray-600 dark:text-gray-400 text-xs absolute left-0 bottom-0 mb-6 w-full text-center leading-normal">
         Need to see the snippet again?
-        <.styled_link href={"/#{URI.encode_www_form(@site.domain)}/snippet"}>
+        <.styled_link href={~p"/#{URI.encode_www_form(@site.domain)}/snippet"}>
           Click here
         </.styled_link>
 


### PR DESCRIPTION
### Changes

This PR allows using [verified routes](https://hexdocs.pm/phoenix/routing.html#verified-routes) in liveviews, controllers, and views.

The reason for this PR is that I'd like to use verified routes in https://github.com/plausible/analytics/pull/3845 but it feels wrong to include these changes there.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI