### PR TITLE
remove init-admin.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Removed the `prop_names` returned in the Stats API `event:goal` breakdown response
 - Removed the `prop-breakdown.csv` file from CSV export
 - Deprecated `CLICKHOUSE_MAX_BUFFER_SIZE`
+- Removed `/app/init-admin.sh` that was deprecated in v2.0.0 plausible/analytics#3903
 
 ### Changed
 - Limit the number of Goal Conversions shown on the dashboard and render a "Details" link when there are more entries to show

--- a/rel/overlays/init-admin.sh
+++ b/rel/overlays/init-admin.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# Create an admin user
-
-echo "init-admin is deprecated and is no-op now"
-echo "user registration on first launch happens via Web UI instead"


### PR DESCRIPTION
### Changes

This PR removes a self-hosted script that was deprecated in v2.0.0

Related:
- https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/5654487286
- https://github.com/plausible/analytics/pull/2357/files#diff-77b70fa380a802709c9ea8ed072df0c4194425604a61f0e13390d8717eaee37cR4-R5

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI