### PR TITLE
remove DISABLE_AUTH deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Removed the `prop-breakdown.csv` file from CSV export
 - Deprecated `CLICKHOUSE_MAX_BUFFER_SIZE`
 - Removed `/app/init-admin.sh` that was deprecated in v2.0.0 plausible/analytics#3903
+- Remove `DISABLE_AUTH` deprecation warning plausible/analytics#3904
 
 ### Changed
 - Limit the number of Goal Conversions shown on the dashboard and render a "Details" link when there are more entries to show

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -231,10 +231,6 @@ maxmind_license_key = get_var_from_path_or_env(config_dir, "MAXMIND_LICENSE_KEY"
 maxmind_edition = get_var_from_path_or_env(config_dir, "MAXMIND_EDITION", "GeoLite2-City")
 persistent_cache_dir = get_var_from_path_or_env(config_dir, "PERSISTENT_CACHE_DIR")
 
-if System.get_env("DISABLE_AUTH") do
-  Logger.warning("DISABLE_AUTH env var is no longer supported")
-end
-
 enable_email_verification =
   config_dir
   |> get_var_from_path_or_env("ENABLE_EMAIL_VERIFICATION", "false")


### PR DESCRIPTION
### Changes

This PR removes deprecation warning for DISABLE_AUTH

Related:
- https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/5654485136
- DISABLE_AUTH  was deprecated in v2.0.0 https://github.com/plausible/analytics/pull/2357/files#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092R134-R137

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI