### PR TITLE
Allow importing extra config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 - Add 'browser_versions.csv' to CSV export
 - Add `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES` env var which defaults to `100000` (100KB)
 - Add alternative SMTP adapter plausible/analytics#3654
-- Add `EXTRA_CONFIG_PATH` env var to specify extra Elixir config
+- Add `EXTRA_CONFIG_PATH` env var to specify extra Elixir config plausible/analytics#3906
 
 ### Removed
 - Removed the nested custom event property breakdown UI when filtering by a goal in Goal Conversions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Add 'browser_versions.csv' to CSV export
 - Add `CLICKHOUSE_MAX_BUFFER_SIZE_BYTES` env var which defaults to `100000` (100KB)
 - Add alternative SMTP adapter plausible/analytics#3654
+- Add `EXTRA_CONFIG_PATH` env var to specify extra Elixir config
 
 ### Removed
 - Removed the nested custom event property breakdown UI when filtering by a goal in Goal Conversions

--- a/mix.exs
+++ b/mix.exs
@@ -19,8 +19,10 @@ defmodule Plausible.MixProject do
       releases: [
         plausible: [
           include_executables_for: [:unix],
-          applications: [plausible: :permanent],
-          steps: [:assemble, :tar]
+          config_providers: [
+            {Config.Reader,
+             path: {:system, "RELEASE_ROOT", "/import_extra_config.exs"}, imports: []}
+          ]
         ]
       ],
       dialyzer: [

--- a/rel/overlays/import_extra_config.exs
+++ b/rel/overlays/import_extra_config.exs
@@ -1,0 +1,8 @@
+import Config
+import Plausible.ConfigHelpers
+
+config_dir = System.get_env("CONFIG_DIR", "/run/secrets")
+
+if extra_config_path = get_var_from_path_or_env(config_dir, "EXTRA_CONIFG_PATH") do
+  import_config extra_config_path
+end

--- a/rel/overlays/import_extra_config.exs
+++ b/rel/overlays/import_extra_config.exs
@@ -3,6 +3,6 @@ import Plausible.ConfigHelpers
 
 config_dir = System.get_env("CONFIG_DIR", "/run/secrets")
 
-if extra_config_path = get_var_from_path_or_env(config_dir, "EXTRA_CONIFG_PATH") do
+if extra_config_path = get_var_from_path_or_env(config_dir, "EXTRA_CONFIG_PATH") do
   import_config extra_config_path
 end

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -264,6 +264,44 @@ defmodule Plausible.ConfigTest do
     end
   end
 
+  describe "extra config" do
+    test "no-op when no extra path is set" do
+      put_system_env_undo({"EXTRA_CONFIG_PATH", nil})
+
+      assert Config.Reader.read!("rel/overlays/import_extra_config.exs") == []
+    end
+
+    test "raises if path is invalid" do
+      put_system_env_undo({"EXTRA_CONFIG_PATH", "no-such-file"})
+
+      assert_raise File.Error, ~r/could not read file/, fn ->
+        Config.Reader.read!("rel/overlays/import_extra_config.exs")
+      end
+    end
+
+    @tag :tmp_dir
+    test "reads extra config", %{tmp_dir: tmp_dir} do
+      extra_config_path = Path.join(tmp_dir, "config.exs")
+
+      File.write!(extra_config_path, """
+      import Config
+
+      config :plausible, Plausible.Repo,
+        after_connect: {Postgrex, :query!, ["SET search_path TO global_prefix", []]}
+      """)
+
+      put_system_env_undo({"EXTRA_CONFIG_PATH", extra_config_path})
+
+      assert Config.Reader.read!("rel/overlays/import_extra_config.exs") == [
+               {:plausible,
+                [
+                  {Plausible.Repo,
+                   [after_connect: {Postgrex, :query!, ["SET search_path TO global_prefix", []]}]}
+                ]}
+             ]
+    end
+  end
+
   defp runtime_config(env) do
     put_system_env_undo(env)
     Config.Reader.read!("config/runtime.exs", env: :prod)


### PR DESCRIPTION
### Changes

This PR allows importing extra config as suggested in https://github.com/plausible/analytics/pull/3705#issuecomment-2002363143

It can serve as an easy escape hatch for specifying configurations not covered by env vars. Like https://github.com/plausible/analytics/pull/3823

Example:

<sub><kbd>my_config.exs</kbd></sub>
```elixir
import Config

config :plausible, Plausible.Repo,
  after_connect: {Postgrex, :query!, ["SET search_path TO global_prefix", []]}
```

<sub><kbd>[docker-compose.yml](https://github.com/plausible/community-edition/blob/v2.1.0/docker-compose.yml)</kbd></sub>
```diff
plausible:
  image: ghcr.io/plausible/community-edition:v2.1.0
+ volumes:
+   - ./my_config.exs:/app/my_config.exs
```

<sub><kbd>[plausible-conf.env](https://github.com/plausible/community-edition/blob/v2.1.0/plausible-conf.env)</kbd></sub>
```diff
+ EXTRA_CONFIG_PATH=/app/my_config.exs
```

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] https://github.com/plausible/community-edition/issues/107

### Dark mode
- [x] This PR does not change the UI