### PR TITLE
Redact search params and fragment from referrer

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -74,7 +74,7 @@
     payload.u = location.href
     {{/if}}
     payload.d = scriptEl.getAttribute('data-domain')
-    payload.r = document.referrer || null
+    payload.r = document.referrer?.split("?")[0].split("#")[0] || null
     if (options && options.meta) {
       payload.m = JSON.stringify(options.meta)
     }


### PR DESCRIPTION
### Changes

#### Redact search params and fragment from referrer

In the referrer URL, the search parameters (following the `?`) and the fragment (following the `#`) might contain personal/sensitive information.

They are already dropped by Plausible server, but I think we could even make them never leave the user's device.

It could be quite frightening for a user observing network requests in their browser's dev tools, to see that sensitive information is sent to Plausible, a third party service they might have never heard of.

Observing that the search params and fragment are not being sent would be reassuring.

> Note: apologises for dropping a PR here before asking in an issue — the change is so trivial that I preferred to make it directly. Feel free to simply reject it.

### Tests

- [x] This PR does not require tests

### Changelog

- [x] This PR does not make a user-facing change

### Documentation

- [x] This change does not need a documentation update

### Dark mode

- [x] This PR does not change the UI
