### PR TITLE
fix manual embed width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - Fix crash when using special characters in filter plausible/analytics#3634
 - Fix automatic scrolling to the bottom on the dashboard if previously selected properties tab plausible/analytics#3872
 - Allow running the container with arbitrary UID plausible/analytics#2986
+- Fix `width=manual` in embedded dashboards plausible/analytics#3910
 
 ## v2.0.0 - 2023-07-12
 

--- a/lib/plausible_web/views/stats_view.ex
+++ b/lib/plausible_web/views/stats_view.ex
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.StatsView do
 
   def stats_container_class(conn) do
     cond do
-      conn.assigns[:embedded] && conn.assigns[:width] == "manual" -> ""
+      conn.assigns[:embedded] && conn.params["width"] == "manual" -> "px-6"
       conn.assigns[:embedded] -> "max-w-screen-xl mx-auto px-6"
       !conn.assigns[:embedded] -> "container print:max-w-full"
     end


### PR DESCRIPTION
### Changes

This PR fixes https://github.com/plausible/docs/issues/470

Here's how it looks in `bg-red-200 mx-auto max-w-md` container
<img width="1582" alt="Screenshot 2024-03-18 at 07 50 30" src="https://github.com/plausible/analytics/assets/67764432/c0ef1a98-739e-41ca-b94c-4a22a6a092ad">

And here's how it looks in `bg-red-200` container

<img width="1582" alt="Screenshot 2024-03-18 at 07 52 35" src="https://github.com/plausible/analytics/assets/67764432/0ef72728-b74e-4bb4-a121-3e2b7294a464">

And here's how it looks on master (where `max-w-screen-xl` was applied regardless of `width=manual`)

<img width="1582" alt="Screenshot 2024-03-18 at 07 53 49" src="https://github.com/plausible/analytics/assets/67764432/9d0bba88-8407-404c-a036-63ebcb427bfc">

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode