### PR TITLE
reboot system after config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule Plausible.MixProject do
       releases: [
         plausible: [
           include_executables_for: [:unix],
+          reboot_system_after_config: true,
           config_providers: [
             {Config.Reader,
              path: {:system, "RELEASE_ROOT", "/import_extra_config.exs"}, imports: []}


### PR DESCRIPTION
### Changes

This solves code injection in [extra configs,](https://github.com/plausible/analytics/pull/3906) e.g:

<sub><kbd>my_extra_config.exs</kbd></sub>
```elixir
import Config

defmodule Plausible.Application do
  use Application

  def start(_type, _args) do
    raise "oops"
  end
end
```

TODOs:
- [ ] is there better way?
- [ ] does it affect any of the existing configuration?

### Tests
- [ ] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI