### PR TITLE
Timeseries for conversion rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ### Added
+- Add `conversion_rate` to Stats API Timeseries and on the main graph 
 - Add `time_on_page` metric into the Stats API
 - County Block List in Site Settings
 - Query the `views_per_visit` metric based on imported data as well if possible

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -10,6 +10,7 @@ export const METRIC_MAPPING = {
   'Total visits': 'visits',
   'Bounce rate': 'bounce_rate',
   'Unique conversions': 'conversions',
+  'Conversion rate': 'conversion_rate',
   'Average revenue': 'average_revenue',
   'Total revenue': 'total_revenue',
 }
@@ -22,6 +23,7 @@ export const METRIC_LABELS = {
   'bounce_rate': 'Bounce Rate',
   'visit_duration': 'Visit Duration',
   'conversions': 'Converted Visitors',
+  'conversion_rate': 'Conversion Rate',
   'average_revenue': 'Average Revenue',
   'total_revenue': 'Total Revenue',
 }
@@ -34,6 +36,7 @@ export const METRIC_FORMATTER = {
   'bounce_rate': (number) => (`${number}%`),
   'visit_duration': durationFormatter,
   'conversions': numberFormatter,
+  'conversion_rate': (number) => (`${number}%`),
   'total_revenue': numberFormatter,
   'average_revenue': numberFormatter,
 }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -436,7 +436,7 @@ export default class VisitorGraph extends React.Component {
     const selectableMetrics = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
     const canSelectSavedMetric = selectableMetrics && selectableMetrics.includes(savedMetric)
 
-    if (query.filters.goal) {
+    if (query.filters.goal && savedMetric === 'visitors') {
       this.setState({ metric: 'conversions' })
     } else if (canSelectSavedMetric) {
       this.setState({ metric: savedMetric })

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -436,7 +436,7 @@ export default class VisitorGraph extends React.Component {
     const selectableMetrics = topStatData && topStatData.top_stats.map(({ name }) => METRIC_MAPPING[name]).filter(name => name)
     const canSelectSavedMetric = selectableMetrics && selectableMetrics.includes(savedMetric)
 
-    if (query.filters.goal && savedMetric === 'visitors') {
+    if (query.filters.goal && savedMetric !== 'conversion_rate') {
       this.setState({ metric: 'conversions' })
     } else if (canSelectSavedMetric) {
       this.setState({ metric: savedMetric })

--- a/lib/plausible/stats/metrics.ex
+++ b/lib/plausible/stats/metrics.ex
@@ -1,23 +1,25 @@
 defmodule Plausible.Stats.Metrics do
   @moduledoc """
-  A module keeping the context of all available metrics in Plausible.
+  A module listing all available metrics in Plausible.
 
   Useful for an explicit string to atom conversion.
   """
 
-  @metrics [
-    :visitors,
-    :visits,
-    :pageviews,
-    :views_per_visit,
-    :bounce_rate,
-    :visit_duration,
-    :events,
-    :conversion_rate,
-    :time_on_page
-  ]
+  use Plausible
 
-  @metric_mappings Enum.into(@metrics, %{}, fn metric -> {to_string(metric), metric} end)
+  @all_metrics [
+                 :visitors,
+                 :visits,
+                 :pageviews,
+                 :views_per_visit,
+                 :bounce_rate,
+                 :visit_duration,
+                 :events,
+                 :conversion_rate,
+                 :time_on_page
+               ] ++ on_full_build(do: Plausible.Stats.Goal.Revenue.revenue_metrics(), else: [])
+
+  @metric_mappings Enum.into(@all_metrics, %{}, fn metric -> {to_string(metric), metric} end)
 
   def from_string!(str) do
     Map.fetch!(@metric_mappings, str)

--- a/lib/plausible/stats/metrics.ex
+++ b/lib/plausible/stats/metrics.ex
@@ -1,0 +1,25 @@
+defmodule Plausible.Stats.Metrics do
+  @moduledoc """
+  A module keeping the context of all available metrics in Plausible.
+
+  Useful for an explicit string to atom conversion.
+  """
+
+  @metrics [
+    :visitors,
+    :visits,
+    :pageviews,
+    :views_per_visit,
+    :bounce_rate,
+    :visit_duration,
+    :events,
+    :conversion_rate,
+    :time_on_page
+  ]
+
+  @metric_mappings Enum.into(@metrics, %{}, fn metric -> {to_string(metric), metric} end)
+
+  def from_string!(str) do
+    Map.fetch!(@metric_mappings, str)
+  end
+end

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -3,6 +3,7 @@ defmodule Plausible.Stats.Timeseries do
   use Plausible
   alias Plausible.Stats.{Query, Util}
   import Plausible.Stats.{Base}
+  import Ecto.Query
   use Plausible.Stats.Fragments
 
   @typep metric ::
@@ -18,7 +19,7 @@ defmodule Plausible.Stats.Timeseries do
 
   @revenue_metrics on_full_build(do: Plausible.Stats.Goal.Revenue.revenue_metrics(), else: [])
 
-  @event_metrics [:visitors, :pageviews, :events] ++ @revenue_metrics
+  @event_metrics [:visitors, :pageviews, :events, :conversion_rate] ++ @revenue_metrics
   @session_metrics [:visits, :bounce_rate, :visit_duration, :views_per_visit]
   def timeseries(site, query, metrics) do
     steps = buckets(query)
@@ -48,6 +49,7 @@ defmodule Plausible.Stats.Timeseries do
       |> Map.update!(:date, &date_format/1)
       |> cast_revenue_metrics_to_money(currency)
     end)
+    |> Util.keep_requested_metrics(metrics)
   end
 
   defp events_timeseries(_, _, []), do: []
@@ -55,6 +57,7 @@ defmodule Plausible.Stats.Timeseries do
   defp events_timeseries(site, query, metrics) do
     from(e in base_event_query(site, query), select: ^select_event_metrics(metrics))
     |> select_bucket(site, query)
+    |> maybe_add_timeseries_conversion_rate(site, query, metrics)
     |> Plausible.Stats.Imported.merge_imported_timeseries(site, query, metrics)
     |> ClickhouseRepo.all()
   end
@@ -234,6 +237,7 @@ defmodule Plausible.Stats.Timeseries do
         :visitors -> Map.merge(row, %{visitors: 0})
         :visits -> Map.merge(row, %{visits: 0})
         :views_per_visit -> Map.merge(row, %{views_per_visit: 0.0})
+        :conversion_rate -> Map.merge(row, %{conversion_rate: 0.0})
         :bounce_rate -> Map.merge(row, %{bounce_rate: nil})
         :visit_duration -> Map.merge(row, %{visit_duration: nil})
         :average_revenue -> Map.merge(row, %{average_revenue: nil})
@@ -248,5 +252,32 @@ defmodule Plausible.Stats.Timeseries do
     end
   else
     defp cast_revenue_metrics_to_money(results, _revenue_goals), do: results
+  end
+
+  defp maybe_add_timeseries_conversion_rate(q, site, query, metrics) do
+    if :conversion_rate in metrics do
+      totals_query = query |> Query.remove_event_filters([:goal, :props])
+
+      totals_timeseries_q =
+        from(e in base_event_query(site, totals_query), select: ^select_event_metrics([:visitors]))
+        |> select_bucket(site, query)
+
+      from(e in subquery(q),
+        left_join: c in subquery(totals_timeseries_q),
+        on: e.date == c.date,
+        select_merge: %{
+          total_visitors: c.visitors,
+          conversion_rate:
+            fragment(
+              "if(? > 0, round(? / ? * 100, 1), 0)",
+              c.visitors,
+              e.visitors,
+              c.visitors
+            )
+        }
+      )
+    else
+      q
+    end
   end
 end

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -261,7 +261,9 @@ defmodule Plausible.Stats.Timeseries do
       totals_query = query |> Query.remove_event_filters([:goal, :props])
 
       totals_timeseries_q =
-        from(e in base_event_query(site, totals_query), select: ^select_event_metrics([:visitors]))
+        from(e in base_event_query(site, totals_query),
+          select: ^select_event_metrics([:visitors])
+        )
         |> select_bucket(site, query)
 
       from(e in subquery(q),

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -55,6 +55,8 @@ defmodule Plausible.Stats.Timeseries do
   defp events_timeseries(_, _, []), do: []
 
   defp events_timeseries(site, query, metrics) do
+    metrics = Util.maybe_add_visitors_metric(metrics)
+
     from(e in base_event_query(site, query), select: ^select_event_metrics(metrics))
     |> select_bucket(site, query)
     |> maybe_add_timeseries_conversion_rate(site, query, metrics)

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -2,21 +2,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   use PlausibleWeb, :controller
   use Plausible.Repo
   use PlausibleWeb.Plugs.ErrorHandler
-  alias Plausible.Stats.{Query, Compare, Comparisons}
-
-  @metrics [
-    :visitors,
-    :visits,
-    :pageviews,
-    :views_per_visit,
-    :bounce_rate,
-    :visit_duration,
-    :events,
-    :conversion_rate,
-    :time_on_page
-  ]
-
-  @metric_mappings Enum.into(@metrics, %{}, fn metric -> {to_string(metric), metric} end)
+  alias Plausible.Stats.{Query, Compare, Comparisons, Metrics}
 
   def realtime_visitors(conn, _params) do
     site = conn.assigns.site
@@ -117,7 +103,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
         {:error, reason}
 
       metrics ->
-        {:ok, Enum.map(metrics, &Map.fetch!(@metric_mappings, &1))}
+        {:ok, Enum.map(metrics, &Metrics.from_string!/1)}
     end
   end
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1305,7 +1305,7 @@ defmodule PlausibleWeb.Api.StatsController do
     end
   end
 
-  def parse_and_validate_graph_metric(params, query) do
+  defp parse_and_validate_graph_metric(params, query) do
     metric =
       case params["metric"] do
         nil -> :visitors

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -1107,7 +1107,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       conn =
         get(conn, "/api/v1/stats/timeseries", %{
           "site_id" => site.domain,
-          "metrics" => "visitors,conversion_rate",
+          "metrics" => "conversion_rate",
           "filters" => "event:goal==Signup",
           "period" => "7d",
           "date" => "2021-01-10"
@@ -1118,12 +1118,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       assert [first, second] == [
                %{
                  "date" => "2021-01-04",
-                 "visitors" => 2,
                  "conversion_rate" => 66.7
                },
                %{
                  "date" => "2021-01-05",
-                 "visitors" => 1,
                  "conversion_rate" => 100.0
                }
              ]

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -1091,6 +1091,26 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
   end
 
   describe "metrics" do
+    test "returns conversion rate as 0 when no stats exist", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Signup")
+
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "metrics" => "conversion_rate",
+          "filters" => "event:goal==Signup",
+          "period" => "7d",
+          "date" => "2021-01-10"
+        })
+
+      Enum.each(json_response(conn, 200)["results"], fn bucket ->
+        bucket["conversion_rate"] == 0.0
+      end)
+    end
+
     test "returns conversion rate when goal filter is applied", %{
       conn: conn,
       site: site

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -433,6 +433,24 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
     end
   end
 
+  describe "GET /api/stats/main-graph - conversion_rate plot" do
+    setup [:create_user, :log_in, :create_new_site]
+
+    test "returns 400 when conversion rate is queried without a goal filter", %{
+      conn: conn,
+      site: site
+    } do
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=conversion_rate"
+        )
+
+      assert %{"error" => error} = json_response(conn, 400)
+      assert error =~ "can only be queried with a goal filter"
+    end
+  end
+
   describe "GET /api/stats/main-graph - bounce_rate plot" do
     setup [:create_user, :log_in, :create_new_site, :add_imported_data]
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -449,6 +449,33 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"error" => error} = json_response(conn, 400)
       assert error =~ "can only be queried with a goal filter"
     end
+
+    test "displays conversion_rate for a month", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Signup", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, timestamp: ~N[2021-01-31 00:00:00]),
+        build(:event, name: "Signup", timestamp: ~N[2021-01-31 00:00:00])
+      ])
+
+      filters = Jason.encode!(%{goal: "Signup"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=conversion_rate&filters=#{filters}"
+        )
+
+      assert %{"plot" => plot} = json_response(conn, 200)
+      assert Enum.count(plot) == 31
+
+      assert List.first(plot) == 33.3
+      assert Enum.at(plot, 10) == 0.0
+      assert List.last(plot) == 50.0
+    end
   end
 
   describe "GET /api/stats/main-graph - bounce_rate plot" do
@@ -986,6 +1013,36 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       assert 4 == Enum.sum(plot)
       assert 0 == Enum.sum(comparison_plot)
+    end
+
+    test "plots conversion rate previous period comparison", %{site: site, conn: conn} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event, name: "Signup", timestamp: ~N[2021-01-01 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:01:00]),
+        build(:event, name: "Signup", timestamp: ~N[2021-01-08 00:01:00]),
+        build(:pageview, timestamp: ~N[2021-01-08 00:01:00])
+      ])
+
+      filters = Jason.encode!(%{goal: "Signup"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=7d&date=2021-01-14&comparison=previous_period&metric=conversion_rate&filters=#{filters}"
+        )
+
+      assert %{
+               "plot" => this_week_plot,
+               "comparison_plot" => last_week_plot,
+               "imported_source" => "Google Analytics",
+               "with_imported" => false
+             } = json_response(conn, 200)
+
+      assert this_week_plot == [50.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      assert last_week_plot == [33.3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     end
   end
 


### PR DESCRIPTION
### Changes

This PR adds the `conversion_rate` metric into the Stats API timeseries, and also makes it possible to display it on the main graph.

Keeping this as a draft for now, since it builds upon https://github.com/plausible/analytics/pull/3887

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
