### PR TITLE
Include domain and dates in zip archive filename

### DIFF
--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -7,6 +7,22 @@ defmodule Plausible.Exports do
   import Ecto.Query
 
   @doc """
+  Renders filename for the Zip archive containing the exported CSV files.
+
+  Examples:
+
+      iex> archive_filename("plausible.io", ~D[2021-01-01], ~D[2024-12-31])
+      "plausible.io_20210101_20241231.zip"
+
+      iex> archive_filename("Bücher.example", ~D[2021-01-01], ~D[2024-12-31])
+      "B%C3%BCcher.example_20210101_20241231.zip"
+
+  """
+  def archive_filename(domain, min_date, max_date) do
+    "#{URI.encode_www_form(domain)}_#{Calendar.strftime(min_date, "%Y%m%d")}_#{Calendar.strftime(max_date, "%Y%m%d")}.zip"
+  end
+
+  @doc """
   Builds Ecto queries to export data from `events_v2` and `sessions_v2`
   tables  into the format of `imported_*` tables for a website.
   """

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -15,11 +15,11 @@ defmodule Plausible.Exports do
       "plausible.io_20210101_20241231.zip"
 
       iex> archive_filename("Bücher.example", ~D[2021-01-01], ~D[2024-12-31])
-      "B%C3%BCcher.example_20210101_20241231.zip"
+      "Bücher.example_20210101_20241231.zip"
 
   """
   def archive_filename(domain, min_date, max_date) do
-    "#{URI.encode_www_form(domain)}_#{Calendar.strftime(min_date, "%Y%m%d")}_#{Calendar.strftime(max_date, "%Y%m%d")}.zip"
+    "#{domain}_#{Calendar.strftime(min_date, "%Y%m%d")}_#{Calendar.strftime(max_date, "%Y%m%d")}.zip"
   end
 
   @doc """

--- a/lib/plausible/s3.ex
+++ b/lib/plausible/s3.ex
@@ -88,12 +88,21 @@ defmodule Plausible.S3 do
           :uri_string.uri_string()
   def export_upload_multipart(stream, s3_bucket, s3_path, filename, config_overrides \\ []) do
     config = ExAws.Config.new(:s3)
-    filename = String.replace(filename, "\"", "\\\"")
+
+    encoded_filename = URI.encode(filename)
+    disposition = ~s[attachment; filename="#{encoded_filename}"]
+
+    disposition =
+      if encoded_filename != filename do
+        disposition <> "; filename*=utf-8''#{encoded_filename}"
+      else
+        disposition
+      end
 
     # 5 MiB is the smallest chunk size AWS S3 supports
     chunk_into_parts(stream, 5 * 1024 * 1024)
     |> ExAws.S3.upload(s3_bucket, s3_path,
-      content_disposition: ~s|attachment; filename="#{filename}"|,
+      content_disposition: disposition,
       content_type: "application/zip"
     )
     |> ExAws.request!(config_overrides)

--- a/lib/plausible/s3.ex
+++ b/lib/plausible/s3.ex
@@ -84,15 +84,16 @@ defmodule Plausible.S3 do
 
   In the current implementation the bucket always goes into the path component.
   """
-  @spec export_upload_multipart(Enumerable.t(), String.t(), Path.t(), keyword) ::
+  @spec export_upload_multipart(Enumerable.t(), String.t(), Path.t(), String.t(), keyword) ::
           :uri_string.uri_string()
-  def export_upload_multipart(stream, s3_bucket, s3_path, config_overrides \\ []) do
+  def export_upload_multipart(stream, s3_bucket, s3_path, filename, config_overrides \\ []) do
     config = ExAws.Config.new(:s3)
+    filename = String.replace(filename, "\"", "\\\"")
 
     # 5 MiB is the smallest chunk size AWS S3 supports
     chunk_into_parts(stream, 5 * 1024 * 1024)
     |> ExAws.S3.upload(s3_bucket, s3_path,
-      content_disposition: ~s|attachment; filename="Plausible.zip"|,
+      content_disposition: ~s|attachment; filename="#{filename}"|,
       content_type: "application/zip"
     )
     |> ExAws.request!(config_overrides)

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -23,6 +23,14 @@ defmodule Plausible.Sites do
     Repo.get_by!(Site, domain: domain)
   end
 
+  def get_domain!(site_id) do
+    Plausible.Repo.one!(
+      from s in Plausible.Site,
+        where: [id: ^site_id],
+        select: s.domain
+    )
+  end
+
   @spec toggle_pin(Auth.User.t(), Site.t()) ::
           {:ok, Site.UserPreference.t()} | {:error, :too_many_pins}
   def toggle_pin(user, site) do

--- a/lib/workers/export_csv.ex
+++ b/lib/workers/export_csv.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Workers.ExportCSV do
         )
       )
     else
-      domain = fetch_site_domain(site_id)
+      domain = Plausible.Sites.get_domain!(site_id)
       export_archive_filename = Plausible.Exports.archive_filename(domain, min_date, max_date)
       s3_config_overrides = s3_config_overrides(args)
 
@@ -86,16 +86,6 @@ defmodule Plausible.Workers.ExportCSV do
     end
 
     :ok
-  end
-
-  defp fetch_site_domain(site_id) do
-    import Ecto.Query, only: [from: 2]
-
-    Plausible.Repo.one!(
-      from s in Plausible.Site,
-        where: [id: ^site_id],
-        select: s.domain
-    )
   end
 
   # right now custom config is used in tests only (to access the minio container)

--- a/test/plausible/exports_test.exs
+++ b/test/plausible/exports_test.exs
@@ -1,6 +1,8 @@
 defmodule Plausible.ExportsTest do
   use Plausible.DataCase, async: true
 
+  doctest Plausible.Exports, import: true
+
   # for e2e export->import tests please see Plausible.Imported.CSVImporterTest
 
   describe "export_queries/2" do


### PR DESCRIPTION
### Changes

This PR changes how the exported Zip archive is named, from `Plausible.zip` to `#{domain}_#{start_date}_#{end_date}.zip`

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI