### PR TITLE
Fix escaping of source filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `total_conversions` and `conversion_rate` to `visitors.csv` in a goal-filtered CSV export
 - Ability to display total conversions (with a goal filter) on the main graph
-- Add `conversion_rate` to Stats API Timeseries and on the main graph 
+- Add `conversion_rate` to Stats API Timeseries and on the main graph
 - Add `time_on_page` metric into the Stats API
 - County Block List in Site Settings
 - Query the `views_per_visit` metric based on imported data as well if possible
@@ -76,6 +76,7 @@ All notable changes to this project will be documented in this file.
 - Fix automatic scrolling to the bottom on the dashboard if previously selected properties tab plausible/analytics#3872
 - Allow running the container with arbitrary UID plausible/analytics#2986
 - Fix `width=manual` in embedded dashboards plausible/analytics#3910
+- Fix URL escpaing when pipes are used in UTM tags plausible/analytics#3930
 
 ## v2.0.0 - 2023-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ All notable changes to this project will be documented in this file.
 - Fix automatic scrolling to the bottom on the dashboard if previously selected properties tab plausible/analytics#3872
 - Allow running the container with arbitrary UID plausible/analytics#2986
 - Fix `width=manual` in embedded dashboards plausible/analytics#3910
-- Fix URL escpaing when pipes are used in UTM tags plausible/analytics#3930
+- Fix URL escaping when pipes are used in UTM tags plausible/analytics#3930
 
 ## v2.0.0 - 2023-07-12
 

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -7,6 +7,7 @@ import ListReport from '../reports/list'
 import { VISITORS_METRIC, maybeWithCR } from '../reports/metrics';
 import { Menu, Transition } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
+import { escapeFilterValue } from '../../util/filters'
 import classNames from 'classnames'
 
 const UTM_TAGS = {
@@ -25,7 +26,7 @@ function AllSources(props) {
   }
 
   function getFilterFor(listItem) {
-    return { source: listItem['name'] }
+    return { source: escapeFilterValue(listItem['name']) }
   }
 
   function renderIcon(listItem) {
@@ -60,7 +61,7 @@ function UTMSources(props) {
   }
 
   function getFilterFor(listItem) {
-    return { [props.tab]: listItem['name'] }
+    return { [props.tab]: escapeFilterValue(listItem['name']) }
   }
 
   return (


### PR DESCRIPTION
### Changes

I tried making escaping more DRY in general but couldn't make it work with custom prop filters which are special.

Fixes #3893 

### Tests
- [x] We don't have JS tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
