### PR TITLE
"on-the-fly" CSV export

### DIFF
--- a/assets/js/liveview/live_socket.js
+++ b/assets/js/liveview/live_socket.js
@@ -19,12 +19,30 @@ if (csrfToken && websocketUrl) {
       })
     }
   }
+  let Uploaders = {}
+  Uploaders.S3 = function (entries, onViewError) {
+    entries.forEach(entry => {
+      let xhr = new XMLHttpRequest()
+      onViewError(() => xhr.abort())
+      xhr.onload = () => xhr.status === 200 ? entry.progress(100) : entry.error()
+      xhr.onerror = () => entry.error()
+      xhr.upload.addEventListener("progress", (event) => {
+        if (event.lengthComputable) {
+          let percent = Math.round((event.loaded / event.total) * 100)
+          if (percent < 100) { entry.progress(percent) }
+        }
+      })
+      let url = entry.meta.url
+      xhr.open("PUT", url, true)
+      xhr.send(entry.file)
+    })
+  }
   let token = csrfToken.getAttribute("content")
   let url = websocketUrl.getAttribute("content")
   let liveUrl = (url === "") ? "/live" : new URL("/live", url).href;
   let liveSocket = new LiveSocket(liveUrl, Socket, {
     heartbeatIntervalMs: 10000,
-    params: { _csrf_token: token }, hooks: Hooks, dom: {
+    params: { _csrf_token: token }, hooks: Hooks, uploaders: Uploaders, dom: {
       // for alpinejs integration
       onBeforeElUpdated(from, to) {
         if (from._x_dataStack) {

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -12,14 +12,24 @@ defmodule Plausible.Exports do
   Examples:
 
       iex> archive_filename("plausible.io", ~D[2021-01-01], ~D[2024-12-31])
-      "plausible.io_20210101_20241231.zip"
+      "plausible_io_20210101_20241231.zip"
 
       iex> archive_filename("Bücher.example", ~D[2021-01-01], ~D[2024-12-31])
-      "Bücher.example_20210101_20241231.zip"
+      "Bücher_example_20210101_20241231.zip"
 
   """
   def archive_filename(domain, min_date, max_date) do
-    "#{domain}_#{Calendar.strftime(min_date, "%Y%m%d")}_#{Calendar.strftime(max_date, "%Y%m%d")}.zip"
+    name =
+      Enum.join(
+        [
+          String.replace(domain, ".", "_"),
+          Calendar.strftime(min_date, "%Y%m%d"),
+          Calendar.strftime(max_date, "%Y%m%d")
+        ],
+        "_"
+      )
+
+    name <> ".zip"
   end
 
   @doc """

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -32,6 +32,32 @@ defmodule Plausible.Exports do
     name <> ".zip"
   end
 
+  @doc ~S"""
+  Safely renders content disposition for an arbitrary filename.
+
+  Examples:
+
+      iex> content_disposition("Plausible.zip")
+      "attachment; filename=\"Plausible.zip\""
+
+      iex> content_disposition(archive_filename("plausible.io", ~D[2021-01-01], ~D[2024-12-31]))
+      "attachment; filename=\"plausible_io_20210101_20241231.zip\""
+
+      iex> content_disposition("ウェブサイトのエクスポート_それから現在まで.zip")
+      "attachment; filename=\"%E3%82%A6%E3%82%A7%E3%83%96%E3%82%B5%E3%82%A4%E3%83%88%E3%81%AE%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%9D%E3%83%BC%E3%83%88_%E3%81%9D%E3%82%8C%E3%81%8B%E3%82%89%E7%8F%BE%E5%9C%A8%E3%81%BE%E3%81%A7.zip\"; filename*=utf-8''%E3%82%A6%E3%82%A7%E3%83%96%E3%82%B5%E3%82%A4%E3%83%88%E3%81%AE%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%9D%E3%83%BC%E3%83%88_%E3%81%9D%E3%82%8C%E3%81%8B%E3%82%89%E7%8F%BE%E5%9C%A8%E3%81%BE%E3%81%A7.zip"
+
+  """
+  def content_disposition(filename) do
+    encoded_filename = URI.encode(filename)
+    disposition = ~s[attachment; filename="#{encoded_filename}"]
+
+    if encoded_filename != filename do
+      disposition <> "; filename*=utf-8''#{encoded_filename}"
+    else
+      disposition
+    end
+  end
+
   @doc """
   Builds Ecto queries to export data from `events_v2` and `sessions_v2`
   tables  into the format of `imported_*` tables for a website.

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -105,12 +105,12 @@ defmodule Plausible.Imported.CSVImporter do
       Date.range(~D[2019-01-01], ~D[2022-01-01])
 
       iex> date_range([])
-      ** (ArgumentError) empty uploads
+      nil
 
   """
-  @spec date_range([String.t() | %{String.t() => String.t()}, ...]) :: Date.Range.t()
+  @spec date_range([String.t() | %{String.t() => String.t()}, ...]) :: Date.Range.t() | nil
   def date_range([_ | _] = uploads), do: date_range(uploads, _start_date = nil, _end_date = nil)
-  def date_range([]), do: raise(ArgumentError, "empty uploads")
+  def date_range([]), do: nil
 
   defp date_range([upload | uploads], prev_start_date, prev_end_date) do
     filename =
@@ -173,5 +173,48 @@ defmodule Plausible.Imported.CSVImporter do
 
   def parse_filename!(_filename) do
     raise ArgumentError, "invalid filename"
+  end
+
+  @doc """
+  Checks if the provided filename conforms to the expected format.
+
+  Examples:
+
+      iex> valid_filename?("my_data.csv")
+      false
+
+      iex> valid_filename?("imported_devices_00010101_20250101.csv")
+      true
+
+  """
+  @spec valid_filename?(String.t()) :: boolean
+  def valid_filename?(filename) do
+    try do
+      parse_filename!(filename)
+    else
+      _ -> true
+    rescue
+      _ -> false
+    end
+  end
+
+  @doc """
+  Extracts the table name from the provided filename.
+
+  Raises if the filename doesn't conform to the expected format.
+
+  Examples:
+
+      iex> extract_table("my_data.csv")
+      ** (ArgumentError) invalid filename
+
+      iex> extract_table("imported_devices_00010101_20250101.csv")
+      "imported_devices"
+
+  """
+  @spec extract_table(String.t()) :: String.t()
+  def extract_table(filename) do
+    {table, _start_date, _end_date} = parse_filename!(filename)
+    table
   end
 end

--- a/lib/plausible/s3.ex
+++ b/lib/plausible/s3.ex
@@ -89,20 +89,10 @@ defmodule Plausible.S3 do
   def export_upload_multipart(stream, s3_bucket, s3_path, filename, config_overrides \\ []) do
     config = ExAws.Config.new(:s3)
 
-    encoded_filename = URI.encode(filename)
-    disposition = ~s[attachment; filename="#{encoded_filename}"]
-
-    disposition =
-      if encoded_filename != filename do
-        disposition <> "; filename*=utf-8''#{encoded_filename}"
-      else
-        disposition
-      end
-
     # 5 MiB is the smallest chunk size AWS S3 supports
     chunk_into_parts(stream, 5 * 1024 * 1024)
     |> ExAws.S3.upload(s3_bucket, s3_path,
-      content_disposition: disposition,
+      content_disposition: Plausible.Exports.content_disposition(filename),
       content_type: "application/zip"
     )
     |> ExAws.request!(config_overrides)

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -708,7 +708,7 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
-  def export(conn, _params) do
+  def csv_export(conn, _params) do
     %{site: site, current_user: user} = conn.assigns
 
     Oban.insert!(
@@ -723,6 +723,16 @@ defmodule PlausibleWeb.SiteController do
     conn
     |> put_flash(:success, "SCHEDULED. WAIT FOR MAIL")
     |> redirect(to: Routes.site_path(conn, :settings_imports_exports, site.domain))
+  end
+
+  # TODO can it be just a liveview? what to do about layout
+  def csv_import(conn, _params) do
+    conn
+    |> assign(:skip_plausible_tracking, true)
+    |> render("csv_import.html",
+      layout: {PlausibleWeb.LayoutView, "focus.html"},
+      connect_live_socket: true
+    )
   end
 
   def change_domain(conn, _params) do

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -725,7 +725,6 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(to: Routes.site_path(conn, :settings_imports_exports, site.domain))
   end
 
-  # TODO can it be just a liveview? what to do about layout
   def csv_import(conn, _params) do
     conn
     |> assign(:skip_plausible_tracking, true)

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -708,7 +708,7 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
-  def csv_export(conn, _params) do
+  def csv_export_s3(conn, _params) do
     %{site: site, current_user: user} = conn.assigns
 
     Oban.insert!(
@@ -723,6 +723,58 @@ defmodule PlausibleWeb.SiteController do
     conn
     |> put_flash(:success, "SCHEDULED. WAIT FOR MAIL")
     |> redirect(to: Routes.site_path(conn, :settings_imports_exports, site.domain))
+  end
+
+  def csv_export_direct(conn, _params) do
+    alias Plausible.Exports
+
+    site = conn.assigns.site
+
+    {:ok, ch} =
+      Plausible.ClickhouseRepo.config()
+      |> Keyword.replace!(:pool_size, 1)
+      |> Ch.start_link()
+
+    %Ch.Result{rows: [[%Date{} = min_date, %Date{} = max_date]]} =
+      Ch.query!(
+        ch,
+        "SELECT toDate(min(timestamp)), toDate(max(timestamp)) FROM events_v2 WHERE site_id={site_id:UInt64}",
+        %{"site_id" => site.id}
+      )
+
+    if max_date == ~D[1970-01-01] do
+      conn
+      |> put_flash(:error, "There is no data to export")
+      |> redirect(external: Routes.site_path(conn, :settings_imports_exports, site.domain))
+    else
+      export_archive_filename = Exports.archive_filename(site.domain, min_date, max_date)
+      export_content_disposition = Exports.content_disposition(export_archive_filename)
+
+      export_queries =
+        Exports.export_queries(site.id,
+          date_range: Date.range(min_date, max_date),
+          extname: ".csv"
+        )
+
+      conn =
+        conn
+        |> put_resp_content_type("application/zip")
+        |> put_resp_header("content-disposition", export_content_disposition)
+        |> send_chunked(200)
+
+      DBConnection.run(
+        ch,
+        fn ch ->
+          Exports.stream_archive(ch, export_queries, format: "CSVWithNames")
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          |> Stream.each(fn data -> {:ok, _conn} = chunk(conn, data) end)
+          |> Stream.run()
+        end,
+        timeout: :infinity
+      )
+
+      conn
+    end
   end
 
   def csv_import(conn, _params) do

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -153,10 +153,10 @@ defmodule PlausibleWeb.Live.CSVImport do
         uploads: uploads
       )
 
-    {:noreply,
-     redirect(socket,
-       to: Routes.site_path(socket, :settings_imports_exports, URI.encode_www_form(site.domain))
-     )}
+    redirect_to =
+      Routes.site_path(socket, :settings_imports_exports, URI.encode_www_form(site.domain))
+
+    {:noreply, redirect(socket, external: redirect_to)}
   end
 
   defp error_to_string(:too_large), do: "is too large (max size is 1 gigabyte)"

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -46,26 +46,26 @@ defmodule PlausibleWeb.Live.CSVImport do
     ~H"""
     <label
       phx-drop-target={@upload.ref}
-      class="block border-2 dark:border-gray-600 rounded p-4 hover:border-indigo-300 dark:hover:border-indigo-600 transition cursor-pointer"
+      class="block border-2 dark:border-gray-600 rounded p-4 group hover:border-indigo-500 dark:hover:border-indigo-600 transition cursor-pointer"
     >
       <div class="flex items-center">
-        <div class="bg-indigo-200 dark:bg-indigo-700 rounded p-1 hover:bg-indigo-300 dark:hover:bg-indigo-600 transition cursor-pointer">
-          <Heroicons.plus class="w-4 h-4" />
+        <div class="bg-gray-200 dark:bg-gray-600 rounded p-1 group-hover:bg-indigo-500 dark:group-hover:bg-indigo-600 transition">
+          <Heroicons.folder_plus class="w-5 h-5 group-hover:text-white transition" />
         </div>
         <span class="ml-2 text-sm text-gray-600 dark:text-gray-500">
-          (or drag-and-drop here)
+          (or drag-and-drop your folder here)
         </span>
         <.live_file_input upload={@upload} class="hidden" webkitdirectory />
       </div>
 
-      <div id="imported-tables" class="mt-5 mb-1 space-y-1">
+      <ul id="imported-tables" class="mt-3.5 mb-0.5 space-y-1.5">
         <.imported_table
           :for={{table, upload} <- @imported_tables}
           table={table}
           upload={upload}
           errors={if(upload, do: upload_errors(@upload, upload), else: [])}
         />
-      </div>
+      </ul>
     </label>
     """
   end
@@ -101,7 +101,7 @@ defmodule PlausibleWeb.Live.CSVImport do
     assigns = assign(assigns, status: status)
 
     ~H"""
-    <div id={@table} class="ml-1">
+    <li id={@table} class="ml-1.5">
       <div class="flex items-center space-x-2">
         <Heroicons.document_check :if={@status == :success} class="w-4 h-4 text-indigo-600" />
         <PlausibleWeb.Components.Generic.spinner
@@ -127,7 +127,7 @@ defmodule PlausibleWeb.Live.CSVImport do
       <p :for={error <- @errors} class="ml-6 text-sm text-red-600 dark:text-red-700">
         <%= error_to_string(error) %>
       </p>
-    </div>
+    </li>
     """
   end
 

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -53,7 +53,7 @@ defmodule PlausibleWeb.Live.CSVImport do
           <Heroicons.document_plus class="w-5 h-5 group-hover:text-white transition" />
         </div>
         <span class="ml-2 text-sm text-gray-600 dark:text-gray-500">
-          (or drag-and-drop your CSVs here)
+          (or drag-and-drop your unzipped CSVs here)
         </span>
         <.live_file_input upload={@upload} class="hidden" />
       </div>

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -1,0 +1,224 @@
+defmodule PlausibleWeb.Live.CSVImport do
+  use PlausibleWeb, :live_view
+  alias Plausible.Imported.CSVImporter
+
+  @impl true
+  def mount(_params, session, socket) do
+    %{"site_id" => site_id, "user_id" => user_id} = session
+
+    socket =
+      socket
+      |> assign(site_id: site_id, user_id: user_id)
+      |> allow_upload(:import,
+        accept: ~w[.csv],
+        auto_upload: true,
+        max_entries: length(Plausible.Imported.tables()),
+        max_file_size: _1GB = 1_000_000_000,
+        external: &presign_upload/2,
+        progress: &handle_progress/3
+      )
+      |> process_imported_tables()
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <form action="#" method="post" phx-change="validate-upload-form" phx-submit="submit-upload-form">
+        <.csv_picker upload={@uploads.import} imported_tables={@imported_tables} />
+        <.confirm_button date_range={@date_range} can_confirm?={@can_confirm?} />
+
+        <p :for={error <- upload_errors(@uploads.import)} class="text-red-400">
+          <%= error_to_string(error) %>
+        </p>
+      </form>
+    </div>
+    """
+  end
+
+  defp csv_picker(assigns) do
+    ~H"""
+    <label
+      phx-drop-target={@upload.ref}
+      class="block border-2 dark:border-gray-600 rounded p-4 hover:border-indigo-300 dark:hover:border-indigo-600 transition cursor-pointer"
+    >
+      <div class="flex items-center">
+        <div class="bg-indigo-200 dark:bg-indigo-700 rounded p-1 hover:bg-indigo-300 dark:hover:bg-indigo-600 transition cursor-pointer">
+          <Heroicons.plus class="w-4 h-4" />
+        </div>
+        <span class="ml-2 text-sm text-gray-600 dark:text-gray-500">
+          (or drag-and-drop here)
+        </span>
+        <.live_file_input upload={@upload} class="hidden" />
+      </div>
+
+      <div id="imported-tables" class="mt-5 mb-1 space-y-1">
+        <.imported_table
+          :for={{table, upload} <- @imported_tables}
+          table={table}
+          upload={upload}
+          errors={if(upload, do: upload_errors(@upload, upload), else: [])}
+        />
+      </div>
+    </label>
+    """
+  end
+
+  defp confirm_button(assigns) do
+    ~H"""
+    <button
+      type="submit"
+      disabled={not @can_confirm?}
+      class={[
+        "rounded-md w-full bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-400 dark:disabled:text-gray-400 dark:disabled:bg-gray-700 mt-4",
+        unless(@can_confirm?, do: "cursor-not-allowed")
+      ]}
+    >
+      <%= if @date_range do %>
+        Confirm import from <%= @date_range.first %> to <%= @date_range.last %>
+      <% else %>
+        Confirm import
+      <% end %>
+    </button>
+    """
+  end
+
+  defp imported_table(assigns) do
+    status =
+      cond do
+        assigns.upload && assigns.upload.progress == 100 -> :success
+        assigns.upload && assigns.upload.progress > 0 -> :in_progress
+        not Enum.empty?(assigns.errors) -> :error
+        true -> :empty
+      end
+
+    assigns = assign(assigns, status: status)
+
+    ~H"""
+    <div id={@table} class="ml-1">
+      <div class="flex items-center space-x-2">
+        <Heroicons.document_check :if={@status == :success} class="w-4 h-4 text-indigo-600" />
+        <PlausibleWeb.Components.Generic.spinner
+          :if={@status == :in_progress}
+          class="w-4 h-4 text-indigo-600"
+        />
+        <Heroicons.document :if={@status == :empty} class="w-4 h-4 text-gray-400 dark:text-gray-500" />
+        <Heroicons.document :if={@status == :error} class="w-4 h-4 text-red-600 dark:text-red-700" />
+
+        <span class={[
+          "text-sm",
+          if(@upload, do: "dark:text-gray-400", else: "text-gray-400 dark:text-gray-500"),
+          if(@status == :error, do: "text-red-600 dark:text-red-700")
+        ]}>
+          <%= if @upload do %>
+            <%= @upload.client_name %>
+          <% else %>
+            <%= @table %>_YYYYMMDD_YYYYMMDD.csv
+          <% end %>
+        </span>
+      </div>
+
+      <p :for={error <- @errors} class="ml-6 text-sm text-red-600 dark:text-red-700">
+        <%= error_to_string(error) %>
+      </p>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("validate-upload-form", _params, socket) do
+    {:noreply, process_imported_tables(socket)}
+  end
+
+  def handle_event("submit-upload-form", _params, socket) do
+    %{site_id: site_id, user_id: user_id, date_range: date_range} = socket.assigns
+    site = Plausible.Repo.get!(Plausible.Site, site_id)
+    user = Plausible.Repo.get!(Plausible.Auth.User, user_id)
+
+    uploads =
+      consume_uploaded_entries(socket, :import, fn meta, entry ->
+        {:ok, %{"s3_url" => meta.s3_url, "filename" => entry.client_name}}
+      end)
+
+    {:ok, _job} =
+      CSVImporter.new_import(site, user,
+        start_date: date_range.first,
+        end_date: date_range.last,
+        uploads: uploads
+      )
+
+    {:noreply,
+     redirect(socket,
+       to: Routes.site_path(socket, :settings_imports_exports, URI.encode_www_form(site.domain))
+     )}
+  end
+
+  defp error_to_string(:too_large), do: "is too large (max size is 1 gigabyte)"
+  defp error_to_string(:too_many_files), do: "too many files"
+  defp error_to_string(:not_accepted), do: "unacceptable file types"
+  defp error_to_string(:external_client_failure), do: "browser upload failed"
+
+  defp presign_upload(entry, socket) do
+    %{s3_url: s3_url, presigned_url: upload_url} =
+      Plausible.S3.import_presign_upload(socket.assigns.site_id, entry.client_name)
+
+    {:ok, %{uploader: "S3", s3_url: s3_url, url: upload_url}, socket}
+  end
+
+  defp handle_progress(:import, entry, socket) do
+    if entry.done? do
+      {:noreply, process_imported_tables(socket)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp process_imported_tables(socket) do
+    tables = Plausible.Imported.tables()
+    {completed, in_progress} = uploaded_entries(socket, :import)
+
+    {valid_uploads, invalid_uploads} =
+      Enum.split_with(completed ++ in_progress, &CSVImporter.valid_filename?(&1.client_name))
+
+    imported_tables_all_uploads =
+      Enum.map(tables, fn table ->
+        uploads =
+          Enum.filter(valid_uploads, fn upload ->
+            CSVImporter.extract_table(upload.client_name) == table
+          end)
+
+        {upload, replaced_uploads} = List.pop_at(uploads, -1)
+        {table, upload, replaced_uploads}
+      end)
+
+    imported_tables =
+      Enum.map(imported_tables_all_uploads, fn {table, upload, _replaced_uploads} ->
+        {table, upload}
+      end)
+
+    replaced_uploads =
+      Enum.flat_map(imported_tables_all_uploads, fn {_table, _upload, replaced_uploads} ->
+        replaced_uploads
+      end)
+
+    date_range = CSVImporter.date_range(Enum.map(valid_uploads, & &1.client_name))
+    all_uploaded? = completed != [] and in_progress == []
+
+    socket
+    |> cancel_uploads(invalid_uploads)
+    |> cancel_uploads(replaced_uploads)
+    |> assign(
+      imported_tables: imported_tables,
+      can_confirm?: all_uploaded?,
+      date_range: date_range
+    )
+  end
+
+  defp cancel_uploads(socket, uploads) do
+    Enum.reduce(uploads, socket, fn upload, socket ->
+      cancel_upload(socket, :import, upload.ref)
+    end)
+  end
+end

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Live.CSVImport do
         <span class="ml-2 text-sm text-gray-600 dark:text-gray-500">
           (or drag-and-drop here)
         </span>
-        <.live_file_input upload={@upload} class="hidden" />
+        <.live_file_input upload={@upload} class="hidden" webkitdirectory />
       </div>
 
       <div id="imported-tables" class="mt-5 mb-1 space-y-1">

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -1,4 +1,7 @@
 defmodule PlausibleWeb.Live.CSVImport do
+  @moduledoc """
+  LiveView allowing uploading CSVs for imported tables to S3
+  """
   use PlausibleWeb, :live_view
   alias Plausible.Imported.CSVImporter
 
@@ -13,7 +16,8 @@ defmodule PlausibleWeb.Live.CSVImport do
         accept: ~w[.csv],
         auto_upload: true,
         max_entries: length(Plausible.Imported.tables()),
-        max_file_size: _1GB = 1_000_000_000,
+        # 1GB
+        max_file_size: 1_000_000_000,
         external: &presign_upload/2,
         progress: &handle_progress/3
       )

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Live.CSVImport do
       socket
       |> assign(site_id: site_id, user_id: user_id)
       |> allow_upload(:import,
-        accept: ~w[.csv],
+        accept: [".csv", "text/csv"],
         auto_upload: true,
         max_entries: length(Plausible.Imported.tables()),
         # 1GB
@@ -50,12 +50,12 @@ defmodule PlausibleWeb.Live.CSVImport do
     >
       <div class="flex items-center">
         <div class="bg-gray-200 dark:bg-gray-600 rounded p-1 group-hover:bg-indigo-500 dark:group-hover:bg-indigo-600 transition">
-          <Heroicons.folder_plus class="w-5 h-5 group-hover:text-white transition" />
+          <Heroicons.document_plus class="w-5 h-5 group-hover:text-white transition" />
         </div>
         <span class="ml-2 text-sm text-gray-600 dark:text-gray-500">
-          (or drag-and-drop your folder here)
+          (or drag-and-drop your CSVs here)
         </span>
-        <.live_file_input upload={@upload} class="hidden" webkitdirectory />
+        <.live_file_input upload={@upload} class="hidden" />
       </div>
 
       <ul id="imported-tables" class="mt-3.5 mb-0.5 space-y-1.5">

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -390,7 +390,13 @@ defmodule PlausibleWeb.Router do
 
     delete "/:website/settings/forget-imported", SiteController, :forget_imported
     delete "/:website/settings/forget-import/:import_id", SiteController, :forget_import
-    post "/:website/settings/export", SiteController, :csv_export
+
+    on_full_build do
+      post "/:website/settings/export", SiteController, :csv_export_s3
+    else
+      get "/:website/settings/export", SiteController, :csv_export_direct
+    end
+
     get "/:website/settings/import", SiteController, :csv_import
 
     get "/:domain/export", StatsController, :csv_export

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -390,7 +390,8 @@ defmodule PlausibleWeb.Router do
 
     delete "/:website/settings/forget-imported", SiteController, :forget_imported
     delete "/:website/settings/forget-import/:import_id", SiteController, :forget_import
-    post "/:website/settings/export", SiteController, :export
+    post "/:website/settings/export", SiteController, :csv_export
+    get "/:website/settings/import", SiteController, :csv_import
 
     get "/:domain/export", StatsController, :csv_export
     get "/:domain/*path", StatsController, :stats

--- a/lib/plausible_web/templates/site/csv_import.html.heex
+++ b/lib/plausible_web/templates/site/csv_import.html.heex
@@ -1,0 +1,20 @@
+<div class="max-w-lg w-full mx-auto bg-white dark:bg-gray-800 shadow-md rounded p-6  mb-4 mt-8">
+  <h2 class="text-xl font-black dark:text-gray-100">Import from CSV files</h2>
+
+  <div class="my-3 space-y-1.5 text-sm text-gray-400">
+    <p>
+      Please ensure each file follows
+      <.styled_link href="https://plausible.io/docs/csv-import">
+        our CSV format guidelines.
+      </.styled_link>
+    </p>
+
+    <p>
+      You can upload multiple files simultaneously by either selecting them in the file dialog or dragging and dropping them into the designated area.
+    </p>
+  </div>
+
+  <%= live_render(@conn, PlausibleWeb.Live.CSVImport,
+    session: %{"site_id" => @site.id, "user_id" => @current_user.id}
+  ) %>
+</div>

--- a/lib/plausible_web/templates/site/settings_imports_exports.html.heex
+++ b/lib/plausible_web/templates/site/settings_imports_exports.html.heex
@@ -20,9 +20,9 @@
     </PlausibleWeb.Components.Generic.button_link>
 
     <PlausibleWeb.Components.Generic.button_link
-      class="w-36 h-20 opacity-40 cursor-not-allowed"
+      class="w-36 h-20"
       theme="bright"
-      href=""
+      href={"/#{URI.encode_www_form(@site.domain)}/settings/import"}
     >
       <img class="h-16" src="/images/icon/csv_logo.svg" alt="New CSV import" />
     </PlausibleWeb.Components.Generic.button_link>

--- a/lib/plausible_web/templates/site/settings_imports_exports.html.heex
+++ b/lib/plausible_web/templates/site/settings_imports_exports.html.heex
@@ -42,12 +42,18 @@
   </header>
 
   <div class="mt-4">
-    <PlausibleWeb.Components.Generic.button
-      data-method="post"
-      data-to={"/#{URI.encode_www_form(@site.domain)}/settings/export"}
-      data-csrf={Plug.CSRFProtection.get_csrf_token()}
-    >
-      Export to CSV
-    </PlausibleWeb.Components.Generic.button>
+    <%= on_full_build do %>
+      <PlausibleWeb.Components.Generic.button
+        data-method="post"
+        data-to={"/#{URI.encode_www_form(@site.domain)}/settings/export"}
+        data-csrf={Plug.CSRFProtection.get_csrf_token()}
+      >
+        Export to CSV
+      </PlausibleWeb.Components.Generic.button>
+    <% else %>
+      <PlausibleWeb.Components.Generic.button_link href={"/#{URI.encode_www_form(@site.domain)}/settings/export"}>
+        Export to CSV
+      </PlausibleWeb.Components.Generic.button_link>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Changes

This PR adds support for "on-the-fly" (streaming Zip archive chunks to Plug.Conn) CSV exports for community-edition builds. The benefit of this approach is that it doesn't rely on file system and provides a "natural" and immediate progress indicator. The downside is that errors cannot be shown since due to chunked response, the connection is simply closed in case of an error and the user is left with an invalid (incomplete) Zip archive. And https://github.com/ninenines/cowboy/issues/1278 (the connection might be closed while we are still streaming, unlikely but something to keep in mind)

Despite the downsides, I'd first try this approach and change to something else only after/if someone complains :)

Alternative method: https://github.com/plausible/analytics/pull/3938 (writing the chunks to tmp and then send_file)
Alternative method: https://github.com/plausible/analytics/pull/3944 (writing the chunks to tmp in Oban and then email a download link)

Depends on #3845

### Tests
- [ ] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [ ] The UI has been tested both in dark and light mode