### PR TITLE
Implement adjusting imported date range to actual and existing stats

### DIFF
--- a/fixture/ga4_end_date.json
+++ b/fixture/ga4_end_date.json
@@ -1,0 +1,38 @@
+{
+  "kind": "analyticsData#batchRunReports",
+  "reports": [
+    {
+      "dimensionHeaders": [
+        {
+          "name": "date"
+        }
+      ],
+      "kind": "analyticsData#runReport",
+      "metadata": {
+        "currencyCode": "USD",
+        "timeZone": "Europe/Warsaw"
+      },
+      "metricHeaders": [
+        {
+          "name": "screenPageViews",
+          "type": "TYPE_INTEGER"
+        }
+      ],
+      "rowCount": 3,
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "20240302"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "13"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixture/ga_end_date.json
+++ b/fixture/ga_end_date.json
@@ -1,0 +1,38 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": [
+          "ga:date"
+        ],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            {
+              "name": "ga:pageviews",
+              "type": "INTEGER"
+            }
+          ]
+        }
+      },
+      "data": {
+        "isDataGolden": true,
+        "rowCount": 849,
+        "rows": [
+          {
+            "dimensions": [
+              "20200421"
+            ],
+            "metrics": [
+              {
+                "values": [
+                  "37"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "nextPageToken": "1"
+    }
+  ]
+}

--- a/fixture/ga_start_date_later.json
+++ b/fixture/ga_start_date_later.json
@@ -1,0 +1,38 @@
+{
+  "reports": [
+    {
+      "columnHeader": {
+        "dimensions": [
+          "ga:date"
+        ],
+        "metricHeader": {
+          "metricHeaderEntries": [
+            {
+              "name": "ga:pageviews",
+              "type": "INTEGER"
+            }
+          ]
+        }
+      },
+      "data": {
+        "isDataGolden": true,
+        "rowCount": 849,
+        "rows": [
+          {
+            "dimensions": [
+              "20170118"
+            ],
+            "metrics": [
+              {
+                "values": [
+                  "37"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "nextPageToken": "1"
+    }
+  ]
+}

--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -55,6 +55,14 @@ defmodule Plausible.Google.API do
     end
   end
 
+  def get_analytics_end_date(access_token, property_or_view) do
+    if property?(property_or_view) do
+      Plausible.Google.GA4.API.get_analytics_end_date(access_token, property_or_view)
+    else
+      Plausible.Google.UA.API.get_analytics_end_date(access_token, property_or_view)
+    end
+  end
+
   def fetch_verified_properties(auth) do
     with {:ok, access_token} <- maybe_refresh_token(auth),
          {:ok, sites} <- Plausible.Google.HTTP.list_sites(access_token) do

--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -64,6 +64,10 @@ defmodule Plausible.Google.GA4.API do
     GA4.HTTP.get_analytics_start_date(access_token, property)
   end
 
+  def get_analytics_end_date(access_token, property) do
+    GA4.HTTP.get_analytics_end_date(access_token, property)
+  end
+
   def import_analytics(date_range, property, auth, persist_fn) do
     Logger.debug(
       "[#{inspect(__MODULE__)}:#{property}] Starting import from #{date_range.first} to #{date_range.last}"

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -217,6 +217,52 @@ defmodule Plausible.Google.GA4.HTTP do
     end
   end
 
+  def get_analytics_end_date(access_token, property) do
+    params = %{
+      requests: [
+        %{
+          property: "#{property}",
+          dateRanges: [
+            %{startDate: @earliest_valid_date, endDate: Date.to_iso8601(Timex.today())}
+          ],
+          dimensions: [%{name: "date"}],
+          metrics: [%{name: "screenPageViews"}],
+          orderBys: [
+            %{dimension: %{dimensionName: "date", orderType: "ALPHANUMERIC"}, desc: true}
+          ],
+          limit: 1
+        }
+      ]
+    }
+
+    url = "#{reporting_api_url()}/v1beta/#{property}:batchRunReports"
+    headers = [{"Authorization", "Bearer #{access_token}"}]
+
+    case HTTPClient.impl().post(url, headers, params) do
+      {:ok, %Finch.Response{body: body, status: 200}} ->
+        report = List.first(body["reports"])
+
+        date =
+          case report["rows"] do
+            [%{"dimensionValues" => [%{"value" => date_str}]}] ->
+              Timex.parse!(date_str, "%Y%m%d", :strftime) |> NaiveDateTime.to_date()
+
+            _ ->
+              nil
+          end
+
+        {:ok, date}
+
+      {:error, %{reason: %Finch.Response{body: body}}} ->
+        Sentry.capture_message("Error fetching GA4 start date", extra: %{body: inspect(body)})
+        {:error, body}
+
+      {:error, %{reason: reason} = e} ->
+        Sentry.capture_message("Error fetching GA4 start date", extra: %{error: inspect(e)})
+        {:error, reason}
+    end
+  end
+
   defp reporting_api_url, do: "https://analyticsdata.googleapis.com"
   defp admin_api_url, do: "https://analyticsadmin.googleapis.com"
 end

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -141,7 +141,7 @@ defmodule Plausible.Google.GA4.HTTP do
         {:error, :authentication_failed}
 
       {:error, %HTTPClient.Non200Error{} = error} ->
-        Sentry.capture_message("Error listing Google accounts for user", extra: %{error: error})
+        Sentry.capture_message("Error listing GA4 accounts for user", extra: %{error: error})
         {:error, :unknown}
     end
   end
@@ -162,7 +162,7 @@ defmodule Plausible.Google.GA4.HTTP do
         {:error, :not_found}
 
       {:error, %HTTPClient.Non200Error{} = error} ->
-        Sentry.capture_message("Error retrieving Google property #{property}",
+        Sentry.capture_message("Error retrieving GA4 property #{property}",
           extra: %{error: error}
         )
 
@@ -218,13 +218,15 @@ defmodule Plausible.Google.GA4.HTTP do
 
         {:ok, date}
 
-      {:error, %{reason: %Finch.Response{body: body}}} ->
-        Sentry.capture_message("Error fetching GA4 start date", extra: %{body: inspect(body)})
-        {:error, body}
+      {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
+        {:error, :authentication_failed}
 
-      {:error, %{reason: reason} = e} ->
-        Sentry.capture_message("Error fetching GA4 start date", extra: %{error: inspect(e)})
-        {:error, reason}
+      {:error, %HTTPClient.Non200Error{} = error} ->
+        Sentry.capture_message("Error retrieving GA4 #{edge} date",
+          extra: %{error: error}
+        )
+
+        {:error, :unknown}
     end
   end
 

--- a/lib/plausible/google/ua/api.ex
+++ b/lib/plausible/google/ua/api.ex
@@ -64,6 +64,10 @@ defmodule Plausible.Google.UA.API do
     UA.HTTP.get_analytics_start_date(access_token, view_id)
   end
 
+  def get_analytics_end_date(access_token, view_id) do
+    UA.HTTP.get_analytics_end_date(access_token, view_id)
+  end
+
   @spec import_analytics(Date.Range.t(), String.t(), import_auth(), (String.t(), [map()] -> :ok)) ::
           :ok | {:error, term()}
   @doc """

--- a/lib/plausible/google/ua/http.ex
+++ b/lib/plausible/google/ua/http.ex
@@ -109,7 +109,7 @@ defmodule Plausible.Google.UA.HTTP do
         {:error, :authentication_failed}
 
       {:error, %HTTPClient.Non200Error{} = error} ->
-        Sentry.capture_message("Error listing GA views for user", extra: %{error: error})
+        Sentry.capture_message("Error listing UA views for user", extra: %{error: error})
         {:error, :unknown}
     end
   end
@@ -167,13 +167,15 @@ defmodule Plausible.Google.UA.HTTP do
 
         {:ok, date}
 
-      {:error, %{reason: %Finch.Response{body: body}}} ->
-        Sentry.capture_message("Error fetching UA start date", extra: %{body: inspect(body)})
-        {:error, body}
+      {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
+        {:error, :authentication_failed}
 
-      {:error, %{reason: reason} = e} ->
-        Sentry.capture_message("Error fetching UA start date", extra: %{error: inspect(e)})
-        {:error, reason}
+      {:error, %HTTPClient.Non200Error{} = error} ->
+        Sentry.capture_message("Error retrieving UA #{edge} date",
+          extra: %{error: error}
+        )
+
+        {:error, :unknown}
     end
   end
 

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -1,6 +1,11 @@
 defmodule PlausibleWeb.GoogleAnalyticsController do
   use PlausibleWeb, :controller
 
+  alias Plausible.Google
+  alias Plausible.Imported
+
+  require Plausible.Imported.SiteImport
+
   plug(PlausibleWeb.RequireAccountPlug)
 
   plug(PlausibleWeb.AuthorizeSiteAccess, [:owner, :admin, :super_admin])
@@ -10,6 +15,8 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         "access_token" => access_token,
         "refresh_token" => refresh_token,
         "expires_at" => expires_at,
+        "start_date" => start_date,
+        "end_date" => end_date,
         "legacy" => legacy
       }) do
     site = conn.assigns.site
@@ -22,17 +29,22 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
       access_token: access_token,
       refresh_token: refresh_token,
       expires_at: expires_at,
+      start_date: start_date,
+      end_date: end_date,
       legacy: legacy,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )
   end
 
-  def property_or_view_form(conn, %{
-        "access_token" => access_token,
-        "refresh_token" => refresh_token,
-        "expires_at" => expires_at,
-        "legacy" => legacy
-      }) do
+  def property_or_view_form(
+        conn,
+        %{
+          "access_token" => access_token,
+          "refresh_token" => refresh_token,
+          "expires_at" => expires_at,
+          "legacy" => legacy
+        } = params
+      ) do
     site = conn.assigns.site
 
     redirect_route =
@@ -44,9 +56,21 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
 
     result =
       if legacy == "true" do
-        Plausible.Google.UA.API.list_views(access_token)
+        Google.UA.API.list_views(access_token)
       else
-        Plausible.Google.API.list_properties_and_views(access_token)
+        Google.API.list_properties_and_views(access_token)
+      end
+
+    error =
+      case params["error"] do
+        "no_data" ->
+          "No data found. Nothing to import."
+
+        "no_time_window" ->
+          "Imported data time range is completely overlapping with existing data. Nothing to import."
+
+        _ ->
+          nil
       end
 
     case result do
@@ -59,6 +83,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           expires_at: expires_at,
           site: conn.assigns.site,
           properties_and_views: properties_and_views,
+          selected_property_or_view_error: error,
           legacy: legacy,
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
@@ -82,58 +107,51 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
   end
 
   # see https://stackoverflow.com/a/57416769
-  @google_analytics_new_user_metric_date ~D[2016-08-24]
+  @universal_analytics_new_user_metric_date ~D[2016-08-24]
 
-  def property_or_view(conn, %{
-        "property_or_view" => property_or_view,
-        "access_token" => access_token,
-        "refresh_token" => refresh_token,
-        "expires_at" => expires_at,
-        "legacy" => legacy
-      }) do
+  def property_or_view(
+        conn,
+        %{
+          "property_or_view" => property_or_view,
+          "access_token" => access_token,
+          "refresh_token" => refresh_token,
+          "expires_at" => expires_at,
+          "legacy" => legacy
+        } = params
+      ) do
     site = conn.assigns.site
-    start_date = Plausible.Google.API.get_analytics_start_date(access_token, property_or_view)
 
-    case start_date do
-      {:ok, nil} ->
-        {:ok, properties_and_views} =
-          if legacy == "true" do
-            Plausible.Google.UA.API.list_views(access_token)
-          else
-            Plausible.Google.API.list_properties_and_views(access_token)
-          end
+    with {:ok, api_start_date} <-
+           Google.API.get_analytics_start_date(access_token, property_or_view),
+         {:ok, api_end_date} <- Google.API.get_analytics_end_date(access_token, property_or_view),
+         {:ok, start_date, end_date} <- Imported.check_dates(site, api_start_date, api_end_date) do
+      action =
+        if Timex.before?(api_start_date, @universal_analytics_new_user_metric_date) do
+          :user_metric_notice
+        else
+          :confirm
+        end
 
-        conn
-        |> assign(:skip_plausible_tracking, true)
-        |> render("property_or_view_form.html",
-          access_token: access_token,
-          refresh_token: refresh_token,
-          expires_at: expires_at,
-          site: site,
-          properties_and_views: properties_and_views,
-          selected_property_or_view_error: "No data found. Nothing to import",
-          legacy: legacy,
-          layout: {PlausibleWeb.LayoutView, "focus.html"}
-        )
+      redirect(conn,
+        external:
+          Routes.google_analytics_path(conn, action, site.domain,
+            property_or_view: property_or_view,
+            access_token: access_token,
+            refresh_token: refresh_token,
+            expires_at: expires_at,
+            start_date: Date.to_iso8601(start_date),
+            end_date: Date.to_iso8601(end_date),
+            legacy: legacy
+          )
+      )
+    else
+      {:error, error} when error in [:no_data, :no_time_window] ->
+        params =
+          params
+          |> Map.take(["access_token", "refresh_token", "expires_at", "legacy"])
+          |> Map.put("error", Atom.to_string(error))
 
-      {:ok, date} ->
-        action =
-          if Timex.before?(date, @google_analytics_new_user_metric_date) do
-            :user_metric_notice
-          else
-            :confirm
-          end
-
-        redirect(conn,
-          to:
-            Routes.google_analytics_path(conn, action, site.domain,
-              property_or_view: property_or_view,
-              access_token: access_token,
-              refresh_token: refresh_token,
-              expires_at: expires_at,
-              legacy: legacy
-            )
-        )
+        property_or_view_form(conn, params)
     end
   end
 
@@ -142,16 +160,17 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         "access_token" => access_token,
         "refresh_token" => refresh_token,
         "expires_at" => expires_at,
+        "start_date" => start_date,
+        "end_date" => end_date,
         "legacy" => legacy
       }) do
     site = conn.assigns.site
 
-    start_date = Plausible.Google.API.get_analytics_start_date(access_token, property_or_view)
-
-    end_date = Plausible.Sites.native_stats_start_date(site) || Timex.today(site.timezone)
+    start_date = Date.from_iso8601!(start_date)
+    end_date = Date.from_iso8601!(end_date)
 
     {:ok, %{name: property_or_view_name, id: property_or_view}} =
-      Plausible.Google.API.get_property_or_view(access_token, property_or_view)
+      Google.API.get_property_or_view(access_token, property_or_view)
 
     conn
     |> assign(:skip_plausible_tracking, true)
@@ -164,7 +183,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
       selected_property_or_view_name: property_or_view_name,
       start_date: start_date,
       end_date: end_date,
-      property?: Plausible.Google.API.property?(property_or_view),
+      property?: Google.API.property?(property_or_view),
       legacy: legacy,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )
@@ -182,6 +201,9 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
     site = conn.assigns.site
     current_user = conn.assigns.current_user
 
+    start_date = Date.from_iso8601!(start_date)
+    end_date = Date.from_iso8601!(end_date)
+
     redirect_route =
       if legacy == "true" do
         Routes.site_path(conn, :settings_integrations, site.domain)
@@ -189,36 +211,48 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         Routes.site_path(conn, :settings_imports_exports, site.domain)
       end
 
-    if Plausible.Google.API.property?(property_or_view) do
-      {:ok, _} =
-        Plausible.Imported.GoogleAnalytics4.new_import(
-          site,
-          current_user,
-          property: property_or_view,
-          label: property_or_view,
-          start_date: start_date,
-          end_date: end_date,
-          access_token: access_token,
-          refresh_token: refresh_token,
-          token_expires_at: expires_at
-        )
-    else
-      Plausible.Imported.UniversalAnalytics.new_import(
-        site,
-        current_user,
-        view_id: property_or_view,
-        label: property_or_view,
-        start_date: start_date,
-        end_date: end_date,
-        access_token: access_token,
-        refresh_token: refresh_token,
-        token_expires_at: expires_at,
-        legacy: legacy == "true"
-      )
-    end
+    case Imported.check_dates(site, start_date, end_date) do
+      {:ok, start_date, end_date} ->
+        if Google.API.property?(property_or_view) do
+          {:ok, _} =
+            Imported.GoogleAnalytics4.new_import(
+              site,
+              current_user,
+              property: property_or_view,
+              label: property_or_view,
+              start_date: start_date,
+              end_date: end_date,
+              access_token: access_token,
+              refresh_token: refresh_token,
+              token_expires_at: expires_at
+            )
+        else
+          {:ok, _} =
+            Imported.UniversalAnalytics.new_import(
+              site,
+              current_user,
+              view_id: property_or_view,
+              label: property_or_view,
+              start_date: start_date,
+              end_date: end_date,
+              access_token: access_token,
+              refresh_token: refresh_token,
+              token_expires_at: expires_at,
+              legacy: legacy == "true"
+            )
+        end
 
-    conn
-    |> put_flash(:success, "Import scheduled. An email will be sent when it completes.")
-    |> redirect(external: redirect_route)
+        conn
+        |> put_flash(:success, "Import scheduled. An email will be sent when it completes.")
+        |> redirect(external: redirect_route)
+
+      {:error, :no_time_window} ->
+        conn
+        |> put_flash(
+          :error,
+          "Import failed. No data can be imported because time range overlaps with existing data."
+        )
+        |> redirect(external: redirect_route)
+    end
   end
 end

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -64,7 +64,9 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
           <p class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
             <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
             <span :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal">
-              (<%= Map.get(@pageview_counts, entry.site_import.id, 0) %> page views)
+              (<%= PlausibleWeb.StatsView.large_number_format(
+                Map.get(@pageview_counts, entry.site_import.id, 0)
+              ) %> page views)
             </span>
             <Heroicons.clock
               :if={entry.live_status == SiteImport.pending()}

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -62,7 +62,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       <li :for={entry <- @site_imports} class="py-4 flex items-center justify-between space-x-4">
         <div class="flex flex-col">
           <p class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
-            Import from <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
+            <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
             <span :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal">
               (<%= Map.get(@pageview_counts, entry.site_import.id, 0) %> page views)
             </span>

--- a/lib/plausible_web/templates/google_analytics/confirm.html.heex
+++ b/lib/plausible_web/templates/google_analytics/confirm.html.heex
@@ -6,55 +6,47 @@
   <%= hidden_input(f, :expires_at, value: @expires_at) %>
   <%= hidden_input(f, :legacy, value: @legacy) %>
 
-  <%= case @start_date do %>
-    <% {:ok, start_date} -> %>
-      <div class="mt-6 text-sm text-gray-500 dark:text-gray-200">
-        Stats from this
-        <%= if @property? do %>
-          property
-        <% else %>
-          view
-        <% end %>
-        and time period will be imported from your Google Analytics account to your Plausible dashboard
-      </div>
+  <div class="mt-6 text-sm text-gray-500 dark:text-gray-200">
+    Stats from this
+    <%= if @property? do %>
+      property
+    <% else %>
+      view
+    <% end %>
+    and time period will be imported from your Google Analytics account to your Plausible dashboard
+  </div>
 
-      <div class="mt-6">
-        <%= styled_label(
-          f,
-          :property_or_view,
-          "Google Analytics #{if @property?, do: "property", else: "view"}"
-        ) %>
-        <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
-          <%= @selected_property_or_view_name %>
-        </span>
-        <%= hidden_input(f, :property_or_view,
-          readonly: "true",
-          value: @selected_property_or_view
-        ) %>
-      </div>
-      <div class="flex justify-between mt-3">
-        <div class="w-36">
-          <%= styled_label(f, :start_date, "From") %>
-          <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
-            <%= PlausibleWeb.EmailView.date_format(start_date) %>
-          </span>
-          <%= hidden_input(f, :start_date, value: start_date, readonly: "true") %>
-        </div>
-        <div class="align-middle pt-4 dark:text-gray-100">&rarr;</div>
-        <div class="w-36">
-          <%= styled_label(f, :end_date, "To") %>
-          <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
-            <%= PlausibleWeb.EmailView.date_format(@end_date) %>
-          </span>
-          <%= hidden_input(f, :end_date, value: @end_date, readonly: "true") %>
-        </div>
-      </div>
-    <% {:error, error} -> %>
-      <p class="text-gray-700 dark:text-gray-300 mt-6">
-        The following error occurred when fetching your Google Analytics data.
-      </p>
-      <p class="text-red-700 font-medium mt-3"><%= error %></p>
-  <% end %>
+  <div class="mt-6">
+    <%= styled_label(
+      f,
+      :property_or_view,
+      "Google Analytics #{if @property?, do: "property", else: "view"}"
+    ) %>
+    <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
+      <%= @selected_property_or_view_name %>
+    </span>
+    <%= hidden_input(f, :property_or_view,
+      readonly: "true",
+      value: @selected_property_or_view
+    ) %>
+  </div>
+  <div class="flex justify-between mt-3">
+    <div class="w-36">
+      <%= styled_label(f, :start_date, "From") %>
+      <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
+        <%= PlausibleWeb.EmailView.date_format(@start_date) %>
+      </span>
+      <%= hidden_input(f, :start_date, value: @start_date, readonly: "true") %>
+    </div>
+    <div class="align-middle pt-4 dark:text-gray-100">&rarr;</div>
+    <div class="w-36">
+      <%= styled_label(f, :end_date, "To") %>
+      <span class="block w-full text-base dark:text-gray-100 sm:text-sm dark:bg-gray-800">
+        <%= PlausibleWeb.EmailView.date_format(@end_date) %>
+      </span>
+      <%= hidden_input(f, :end_date, value: @end_date, readonly: "true") %>
+    </div>
+  </div>
 
   <%= submit("Confirm import", class: "button mt-6") %>
 <% end %>

--- a/lib/plausible_web/templates/google_analytics/user_metric_form.html.heex
+++ b/lib/plausible_web/templates/google_analytics/user_metric_form.html.heex
@@ -39,6 +39,8 @@
         access_token: @access_token,
         refresh_token: @refresh_token,
         expires_at: @expires_at,
+        start_date: @start_date,
+        end_date: @end_date,
         legacy: @legacy
       ),
     class: "button mt-6"

--- a/test/plausible/google/ga4/api_test.exs
+++ b/test/plausible/google/ga4/api_test.exs
@@ -55,4 +55,17 @@ defmodule Plausible.Google.GA4.APITest do
                GA4.API.get_analytics_start_date("some_access_token", "properties/153293282")
     end
   end
+
+  describe "get_analytics_end_date/2" do
+    test "returns stats end date for a given property" do
+      result = Jason.decode!(File.read!("fixture/ga4_end_date.json"))
+
+      expect(Plausible.HTTPClient.Mock, :post, fn _url, _headers, _body ->
+        {:ok, %Finch.Response{status: 200, body: result}}
+      end)
+
+      assert {:ok, ~D[2024-03-02]} =
+               GA4.API.get_analytics_end_date("some_access_token", "properties/153293282")
+    end
+  end
 end

--- a/test/plausible/imported_test.exs
+++ b/test/plausible/imported_test.exs
@@ -105,6 +105,77 @@ defmodule Plausible.ImportedTest do
                Imported.check_dates(site, ~D[2019-03-21], ~D[2024-01-12])
     end
 
+    test "does not alter the dates when there are no imports and no native stats" do
+      site = insert(:site)
+
+      assert {:ok, ~D[2021-05-12], ~D[2024-01-12]} =
+               Imported.check_dates(site, ~D[2021-05-12], ~D[2024-01-12])
+    end
+
+    test "ignores input date range difference smaller than 2 days" do
+      site = insert(:site)
+
+      assert {:error, :no_time_window} =
+               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-12])
+
+      assert {:error, :no_time_window} =
+               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-13])
+
+      assert {:ok, ~D[2024-01-12], ~D[2024-01-14]} =
+               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-14])
+    end
+
+    test "ignores imports with date range difference smaller than 2 days" do
+      site = insert(:site)
+
+      start_date = ~D[2024-01-12]
+      end_date = ~D[2024-01-13]
+
+      _existing_import =
+        insert(:site_import,
+          site: site,
+          start_date: start_date,
+          end_date: end_date,
+          status: :completed
+        )
+
+      assert {:ok, ~D[2021-04-22], ~D[2024-03-14]} =
+               Imported.check_dates(site, ~D[2021-04-22], ~D[2024-03-14])
+    end
+
+    test "returns no time window when input range starts after native stats start date" do
+      site = insert(:site)
+
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2023-10-25 15:58:00])
+      ])
+
+      assert {:error, :no_time_window} =
+               Imported.check_dates(site, ~D[2023-10-28], ~D[2024-01-13])
+    end
+
+    test "returns no time window when input range starts less than 2 days before native stats start date" do
+      site = insert(:site)
+
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2023-10-25 15:58:00])
+      ])
+
+      assert {:error, :no_time_window} =
+               Imported.check_dates(site, ~D[2023-10-24], ~D[2024-01-13])
+    end
+
+    test "crops time range at native stats start date when effective range is 2 days or longer" do
+      site = insert(:site)
+
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2023-10-25 15:58:00])
+      ])
+
+      assert {:ok, ~D[2023-10-23], ~D[2023-10-25]} =
+               Imported.check_dates(site, ~D[2023-10-23], ~D[2024-01-13])
+    end
+
     test "returns no data error when start date missing" do
       site = insert(:site)
 

--- a/test/plausible/imported_test.exs
+++ b/test/plausible/imported_test.exs
@@ -83,7 +83,7 @@ defmodule Plausible.ImportedTest do
                Imported.check_dates(site, ~D[2021-04-11], ~D[2024-01-12])
     end
 
-    test "picks longest conitnuous range when containing existing import" do
+    test "picks longest continuous range when containing existing import" do
       site = insert(:site)
 
       populate_stats(site, [


### PR DESCRIPTION
### Changes

The main change in this PR is introduction of logic setting import's date range. 

Currently import's end date is always set to either native stats start date or today if there are no native stats collected yet. After this change, the end date will be set to the date of the actual last imported stats entry. When doing import in presence of other imported data, the new import's date range will be additionally cropped so that it does not overlap with any existing import - in addition to being cropped by native stats start date.

Other improvements done by the way:

- improved error handling in import process
- pageview numbers in imports list made more legible and redundant prefix dropped

### Tests
- [x] Automated tests have been added

