### PR TITLE
Add github action to validate whether migrations and app change at the same time

### DIFF
--- a/.github/workflows/migrations-validation.yml
+++ b/.github/workflows/migrations-validation.yml
@@ -1,0 +1,28 @@
+name: Validate migrations
+
+on:
+  pull_request:
+    paths:
+      - 'priv/repo/migrations/**'
+      - 'priv/ingest_repo/migrations/**'
+
+jobs:
+  validate:
+    name: App code does not change at the same time
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        list-files: json
+        filters: |
+          lib:
+            - 'lib/**'
+            - 'extra/**'
+            - 'config/**'
+
+    - if: steps.changes.outputs.lib == 'true'
+      run: |
+        echo "::error file=${{ fromJSON(steps.changes.outputs.lib_files)[0] }}::Code and migrations shouldn't be changed at the same time"
+        exit 1


### PR DESCRIPTION
We discussed that it would be good to catch cases where we try to deploy migrations and app changes at the same time. This PR adds a minimal github action for that.

Example success:
![image](https://github.com/plausible/analytics/assets/148820/8df571fb-4841-4bf5-9083-f7e91b43e9a5)

Example failure:

![image](https://github.com/plausible/analytics/assets/148820/1c27ed07-0267-489b-b068-dfc55b09ce27)

![image](https://github.com/plausible/analytics/assets/148820/14a8af21-6c26-41f5-8229-d014f30dbc7c)


![image](https://github.com/plausible/analytics/assets/148820/234439e5-5bc2-4cd3-a68b-25514dfa7c9a)

