### PR TITLE
Ensure all the react container attributes are strings

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -354,12 +354,11 @@ defmodule PlausibleWeb.StatsController do
 
   defp is_dbip() do
     on_full_build do
-      "false"
+      false
     else
       Plausible.Geo.database_type()
       |> to_string()
       |> String.starts_with?("DBIP")
-      |> to_string()
     end
   end
 

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -17,23 +17,25 @@
     style="overflow-anchor: none;"
     data-domain={@site.domain}
     data-offset={Plausible.Site.tz_offset(@site)}
-    data-has-goals={@has_goals}
-    data-conversions-opted-out={Plausible.Billing.Feature.Goals.opted_out?(@site)}
-    data-funnels-opted-out={Plausible.Billing.Feature.Funnels.opted_out?(@site)}
-    data-props-opted-out={Plausible.Billing.Feature.Props.opted_out?(@site)}
+    data-has-goals={to_string(@has_goals)}
+    data-conversions-opted-out={to_string(Plausible.Billing.Feature.Goals.opted_out?(@site))}
+    data-funnels-opted-out={to_string(Plausible.Billing.Feature.Funnels.opted_out?(@site))}
+    data-props-opted-out={to_string(Plausible.Billing.Feature.Props.opted_out?(@site))}
     data-funnels-available={
-      Plausible.Billing.Feature.Funnels.check_availability(@site.owner) == :ok
+      to_string(Plausible.Billing.Feature.Funnels.check_availability(@site.owner) == :ok)
     }
-    data-props-available={Plausible.Billing.Feature.Props.check_availability(@site.owner) == :ok}
+    data-props-available={
+      to_string(Plausible.Billing.Feature.Props.check_availability(@site.owner) == :ok)
+    }
     data-funnels={Jason.encode!(@funnels)}
-    data-has-props={@has_props}
-    data-logged-in={!!@conn.assigns[:current_user]}
+    data-has-props={to_string(@has_props)}
+    data-logged-in={to_string(!!@conn.assigns[:current_user])}
     data-stats-begin={@stats_start_date}
     data-native-stats-begin={@native_stats_start_date}
     data-shared-link-auth={assigns[:shared_link_auth]}
-    data-embedded={@conn.assigns[:embedded]}
+    data-embedded={to_string(@conn.assigns[:embedded])}
     data-background={@conn.assigns[:background]}
-    data-is-dbip={@is_dbip}
+    data-is-dbip={to_string(@is_dbip)}
     data-current-user-role={@conn.assigns[:current_user_role]}
     data-flags={Jason.encode!(@flags)}
     data-valid-intervals-by-period={

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -16,6 +16,18 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert text_of_attr(resp, @react_container, "data-domain") == site.domain
       assert text_of_attr(resp, @react_container, "data-is-dbip") == "false"
+      assert text_of_attr(resp, @react_container, "data-has-goals") == "false"
+      assert text_of_attr(resp, @react_container, "data-conversions-opted-out") == "false"
+      assert text_of_attr(resp, @react_container, "data-funnels-opted-out") == "false"
+      assert text_of_attr(resp, @react_container, "data-props-opted-out") == "false"
+      assert text_of_attr(resp, @react_container, "data-props-available") == "true"
+      assert text_of_attr(resp, @react_container, "data-funnels-available") == "true"
+      assert text_of_attr(resp, @react_container, "data-has-props") == "false"
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "false"
+      assert text_of_attr(resp, @react_container, "data-embedded") == ""
+
+      [{"div", attrs, _}] = find(resp, @react_container)
+      assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
 
       assert ["noindex, nofollow"] ==
                resp
@@ -61,7 +73,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "can view stats of a website I've created", %{conn: conn, site: site} do
       populate_stats(site, [build(:pageview)])
       conn = get(conn, "/" <> site.domain)
-      assert html_response(conn, 200) =~ "stats-react-container"
+      resp = html_response(conn, 200)
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
     test "shows locked page if page is locked", %{conn: conn, user: user} do
@@ -102,8 +115,11 @@ defmodule PlausibleWeb.StatsControllerTest do
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
-      assert html_response(conn, 200) =~ "stats-react-container"
-      assert html_response(conn, 200) =~ "This dashboard is actually locked"
+      resp = html_response(conn, 200)
+      assert resp =~ "This dashboard is actually locked"
+
+      [{"div", attrs, _}] = find(resp, @react_container)
+      assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
     end
 
     test "can view a private locked dashboard without stats", %{conn: conn} do
@@ -120,7 +136,10 @@ defmodule PlausibleWeb.StatsControllerTest do
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
-      assert html_response(conn, 200) =~ "stats-react-container"
+      resp = html_response(conn, 200)
+
+      [{"div", attrs, _}] = find(resp, @react_container)
+      assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
     end
   end
 
@@ -616,7 +635,24 @@ defmodule PlausibleWeb.StatsControllerTest do
       link = insert(:shared_link, site: site)
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
+      resp = html_response(conn, 200)
+      assert text_of_attr(resp, @react_container, "data-embedded") == "false"
       assert Plug.Conn.get_resp_header(conn, "x-frame-options") == []
+    end
+
+    test "returns page embedded page", %{
+      conn: conn
+    } do
+      site = insert(:site, domain: "test-site.com")
+      link = insert(:shared_link, site: site)
+
+      conn = get(conn, "/share/test-site.com/?auth=#{link.slug}&embed=true")
+      resp = html_response(conn, 200)
+      assert text_of_attr(resp, @react_container, "data-embedded") == "true"
+      assert Plug.Conn.get_resp_header(conn, "x-frame-options") == []
+
+      [{"div", attrs, _}] = find(resp, @react_container)
+      assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
     end
 
     test "shows locked page if page is locked", %{conn: conn} do


### PR DESCRIPTION
Ref #3762 

#3892 introduced a regression - during template conversion from `eex` to `heex` the booleans were rendered verbatim, whilst the react code is expecting string literals. This caused, for example, "set up your goals" prompts appear on customer dashboards, despite them having goals configured.