### PR TITLE
Migration only - add new metric columns to imported tables

### DIFF
--- a/priv/ingest_repo/migrations/20240326134840_add_metrics_to_imported_tables.exs
+++ b/priv/ingest_repo/migrations/20240326134840_add_metrics_to_imported_tables.exs
@@ -1,0 +1,30 @@
+defmodule Plausible.IngestRepo.Migrations.AddMetricsToImportedTables do
+  use Ecto.Migration
+
+  @add_pageviews_for [
+    :imported_browsers,
+    :imported_devices,
+    :imported_entry_pages,
+    :imported_locations,
+    :imported_operating_systems,
+    :imported_sources
+  ]
+
+  def change do
+    for table <- @add_pageviews_for do
+      alter table(table) do
+        add(:pageviews, :UInt64)
+      end
+    end
+
+    alter table(:imported_pages) do
+      add(:visits, :UInt64)
+    end
+
+    alter table(:imported_exit_pages) do
+      add(:pageviews, :UInt64)
+      add(:bounces, :UInt32)
+      add(:visit_duration, :UInt64)
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Since we want to be able to support very basic filtering with imported data at some point, we need to start fetching some additional metrics. This PR contains only the migration adding those fields.