### PR TITLE
CH Migration: exit page hostname on sessions_v2

### DIFF
--- a/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
+++ b/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
@@ -5,7 +5,7 @@ defmodule Plausible.ClickhouseRepo.Migrations.HostnamesInSessions do
     execute """
     ALTER TABLE sessions_v2
     #{Plausible.MigrationUtils.on_cluster_statement("sessions_v2")}
-    ADD COLUMN exit_page_hostname String
+    ADD COLUMN exit_page_hostname String CODEC(ZSTD(3))
     """
   end
 

--- a/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
+++ b/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.ClickhouseRepo.Migrations.HostnamesInSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sessions_v2) do
+      add(:entry_page_hostname, :string)
+      add(:exit_page_hostname, :string)
+    end
+  end
+end

--- a/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
+++ b/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
@@ -3,7 +3,6 @@ defmodule Plausible.ClickhouseRepo.Migrations.HostnamesInSessions do
 
   def change do
     alter table(:sessions_v2) do
-      add(:entry_page_hostname, :string)
       add(:exit_page_hostname, :string)
     end
   end

--- a/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
+++ b/priv/ingest_repo/migrations/20240327085855_hostnames_in_sessions.exs
@@ -1,9 +1,19 @@
 defmodule Plausible.ClickhouseRepo.Migrations.HostnamesInSessions do
   use Ecto.Migration
 
-  def change do
-    alter table(:sessions_v2) do
-      add(:exit_page_hostname, :string)
-    end
+  def up do
+    execute """
+    ALTER TABLE sessions_v2
+    #{Plausible.MigrationUtils.on_cluster_statement("sessions_v2")}
+    ADD COLUMN exit_page_hostname String
+    """
+  end
+
+  def down do
+    execute """
+    ALTER TABLE sessions_v2
+    #{Plausible.MigrationUtils.on_cluster_statement("sessions_v2")}
+    DROP COLUMN exit_page_hostname
+    """
   end
 end


### PR DESCRIPTION
### Changes

This PR adds `exit_page_hostname` to `sessions_v2` table, so that we can filter by hostnames avoiding joining `events_v2` where possible.

https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/6925576254

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
