### PR TITLE
Fix dry run mode in `DataMigration.SiteImports`

### DIFF
--- a/lib/plausible/data_migration/site_imports.ex
+++ b/lib/plausible/data_migration/site_imports.ex
@@ -141,7 +141,9 @@ defmodule Plausible.DataMigration.SiteImports do
 
   defp insert!(changeset, true = _dry_run?) do
     if changeset.valid? do
-      Ecto.Changeset.apply_changes(changeset)
+      changeset
+      |> Ecto.Changeset.change(id: 0)
+      |> Ecto.Changeset.apply_changes()
     else
       raise "Invalid insert: #{inspect(changeset)}"
     end


### PR DESCRIPTION
### Changes

Follow-up to #3954 fixing an issue where backfill of legacy entry in dry run mode failed because of passing `nil` for import ID to CH query extracting max date across import tables.

### Tests
- [x] Automated tests have been added
