### PR TITLE
Changing the copy of the locked screen

### DIFF
--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -28,11 +28,11 @@
               Please subscribe to the appropriate tier with the link below to access the stats again.
             </p>
             <p class="mt-6 text-sm text-gray-500">
-              You can check the
+              You can configure your
               <.styled_link href={Routes.site_path(@conn, :settings_general, @site.domain)}>
                 site settings
               </.styled_link>
-              and we're still counting the stats but your access to the dashboard is restricted.
+              but your access to the dashboard is restricted.
             </p>
           </div>
           <div class="mt-6 w-full text-center">


### PR DESCRIPTION
changing the copy here as I think that in some situations the "we're still counting stats" message is now shown even to those dashboards where we've stopped counting stats so best to avoid that
