### PR TITLE
Improve import procedure to ensure no time range overlaps

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -62,9 +62,9 @@ defmodule Plausible.Imported do
     }
   end
 
-  @spec get_import(non_neg_integer()) :: SiteImport.t() | nil
-  def get_import(import_id) do
-    Repo.get(SiteImport, import_id)
+  @spec get_import(Site.t(), non_neg_integer()) :: SiteImport.t() | nil
+  def get_import(site, import_id) do
+    Repo.get_by(SiteImport, id: import_id, site_id: site.id)
   end
 
   defdelegate listen(), to: Imported.Importer

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -83,6 +83,16 @@ defmodule Plausible.Imported do
     end
   end
 
+  @spec other_imports_in_progress?(SiteImport.t()) :: boolean()
+  def other_imports_in_progress?(site_import) do
+    Repo.exists?(
+      from(i in SiteImport,
+        where: i.site_id == ^site_import.site_id and i.id != ^site_import.id,
+        where: i.status in ^[SiteImport.pending(), SiteImport.importing()]
+      )
+    )
+  end
+
   defp maybe_filter_by_status(query, nil), do: query
 
   defp maybe_filter_by_status(query, status) do

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -301,22 +301,12 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
   end
 
   defp schedule_job(site, current_user, property_or_view, opts) do
-    property? = Google.API.property?(property_or_view)
-
-    importer_fun =
-      if property? do
-        &Imported.GoogleAnalytics4.new_import/3
-      else
-        &Imported.UniversalAnalytics.new_import/3
-      end
-
-    opts =
-      if property? do
-        Keyword.put(opts, :property, property_or_view)
-      else
-        Keyword.put(opts, :view_id, property_or_view)
-      end
-
-    importer_fun.(site, current_user, opts)
+    if Google.API.property?(property_or_view) do
+      opts = Keyword.put(opts, :property, property_or_view)
+      Imported.GoogleAnalytics4.new_import(site, current_user, opts)
+    else
+      opts = Keyword.put(opts, :view_id, property_or_view)
+      Imported.UniversalAnalytics.new_import(site, current_user, opts)
+    end
   end
 end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -652,7 +652,7 @@ defmodule PlausibleWeb.SiteController do
         |> Plausible.Site.remove_imported_data()
         |> Repo.update!()
 
-      site_import = Plausible.Imported.get_import(import_id) ->
+      site_import = Plausible.Imported.get_import(site, import_id) ->
         Oban.cancel_all_jobs(
           from(j in Oban.Job,
             where:

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -42,7 +42,39 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
   end
 
   def render(assigns) do
+    import_in_progress? =
+      Enum.any?(
+        assigns.site_imports,
+        &(&1.live_status in [SiteImport.pending(), SiteImport.importing()])
+      )
+
+    assigns = assign(assigns, :import_in_progress?, import_in_progress?)
+
     ~H"""
+    <div class="mt-5 flex gap-x-4">
+      <.button_link
+        class="w-36 h-20"
+        theme="bright"
+        disabled={@import_in_progress?}
+        href={Plausible.Google.API.import_authorize_url(@site.id, "import", legacy: false)}
+      >
+        <img src="/images/icon/google_analytics_logo.svg" alt="Google Analytics import" />
+      </.button_link>
+
+      <.button_link
+        class="w-36 h-20"
+        theme="bright"
+        disabled={@import_in_progress?}
+        href={"/#{URI.encode_www_form(@site.domain)}/settings/import"}
+      >
+        <img class="h-16" src="/images/icon/csv_logo.svg" alt="New CSV import" />
+      </.button_link>
+    </div>
+
+    <p :if={@import_in_progress?} class="mt-4 text-red-400 text-sm">
+      No new imports can be started until the import in progress is completed or cancelled.
+    </p>
+
     <header class="relative border-b border-gray-200 pb-4">
       <h3 class="mt-8 text-md leading-6 font-medium text-gray-900 dark:text-gray-100">
         Existing Imports

--- a/lib/plausible_web/templates/site/settings_imports_exports.html.heex
+++ b/lib/plausible_web/templates/site/settings_imports_exports.html.heex
@@ -10,24 +10,6 @@
     <PlausibleWeb.Components.Generic.docs_info slug="google-analytics-import" />
   </header>
 
-  <div class="mt-5 flex gap-x-4">
-    <PlausibleWeb.Components.Generic.button_link
-      class="w-36 h-20"
-      theme="bright"
-      href={Plausible.Google.API.import_authorize_url(@site.id, "import", legacy: false)}
-    >
-      <img src="/images/icon/google_analytics_logo.svg" alt="Google Analytics import" />
-    </PlausibleWeb.Components.Generic.button_link>
-
-    <PlausibleWeb.Components.Generic.button_link
-      class="w-36 h-20"
-      theme="bright"
-      href={"/#{URI.encode_www_form(@site.domain)}/settings/import"}
-    >
-      <img class="h-16" src="/images/icon/csv_logo.svg" alt="New CSV import" />
-    </PlausibleWeb.Components.Generic.button_link>
-  </div>
-
   <%= live_render(@conn, PlausibleWeb.Live.ImportsExportsSettings,
     session: %{"domain" => @site.domain}
   ) %>

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -43,7 +43,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
           token_expires_at: DateTime.to_iso8601(past)
         )
 
-      site_import = Plausible.Imported.get_import(job.args.import_id)
+      site_import = Plausible.Imported.get_import(site, job.args.import_id)
 
       assert site_import.label == "properties/123456"
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -680,6 +680,25 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert resp =~ "Google Analytics (123456)"
       assert resp =~ "(98 page views)"
     end
+
+    test "disables import buttons when there's import in progress", %{conn: conn, site: site} do
+      _site_import1 = insert(:site_import, site: site, status: SiteImport.completed())
+      _site_import2 = insert(:site_import, site: site, status: SiteImport.importing())
+
+      conn = get(conn, "/#{site.domain}/settings/imports-exports")
+      assert html_response(conn, 200) =~ "No new imports can be started"
+    end
+
+    test "enables import buttons when all imports are in completed or failed state", %{
+      conn: conn,
+      site: site
+    } do
+      _site_import1 = insert(:site_import, site: site, status: SiteImport.completed())
+      _site_import2 = insert(:site_import, site: site, status: SiteImport.failed())
+
+      conn = get(conn, "/#{site.domain}/settings/imports-exports")
+      refute html_response(conn, 200) =~ "No new imports can be started"
+    end
   end
 
   describe "GET /:website/settings/integrations for self-hosting" do


### PR DESCRIPTION
### Changes

<img width="1155" alt="image" src="https://github.com/plausible/analytics/assets/588351/fde3ba27-9635-40d7-a8bc-0caff3f5dee1">

This PR ensures that a new import can be started only if all the current ones are in completed state for a given site.

When check import's time range and altering it so that we avoid overlap, only complete imports are considered. If more than a single import is in progress at a time, there's a risk of ending up in inconsistent state where imports do overlap one another.

The check is enforced on UI level for Google imports as well as on Importer level to avoid a situation where multiple jobs get created for the same import due to, for instance, double form submission.

### Tests
- [x] Automated tests have been added

### Dark mode
- [x] The UI has been tested both in dark and light mode

