### PR TITLE
Include query string when logging the request

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -100,6 +100,7 @@ defmodule Plausible.Application do
 
     opts = [strategy: :one_for_one, name: Plausible.Supervisor]
 
+    setup_request_logging()
     setup_sentry()
     setup_opentelemetry()
 
@@ -173,6 +174,15 @@ defmodule Plausible.Application do
       true ->
         pool_config
     end
+  end
+
+  def setup_request_logging() do
+    :telemetry.attach(
+      "plausible-request-logging",
+      [:phoenix, :router_dispatch, :stop],
+      &Plausible.RequestLogger.log_request/4,
+      %{}
+    )
   end
 
   def setup_sentry() do

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -179,7 +179,7 @@ defmodule Plausible.Application do
   def setup_request_logging() do
     :telemetry.attach(
       "plausible-request-logging",
-      [:phoenix, :router_dispatch, :stop],
+      [:phoenix, :endpoint, :stop],
       &Plausible.RequestLogger.log_request/4,
       %{}
     )

--- a/lib/plausible/request_logger.ex
+++ b/lib/plausible/request_logger.ex
@@ -1,0 +1,19 @@
+defmodule Plausible.RequestLogger do
+  @moduledoc """
+  Custom request logger which:
+  - Includes query parameters on the same line
+  - Includes request duration on the same line
+  """
+
+  require Logger
+
+  def log_request(_, %{duration: duration}, %{conn: conn}, _) do
+    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+    path = path_with_params(conn.request_path, conn.query_string)
+
+    Logger.info("(#{conn.status}) #{conn.method} #{path} took #{duration_ms}ms")
+  end
+
+  defp path_with_params(request_path, ""), do: request_path
+  defp path_with_params(request_path, query_string), do: request_path <> "?" <> query_string
+end

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -69,7 +69,6 @@ defmodule PlausibleWeb.Endpoint do
 
   plug(Plug.RequestId)
   plug(PromEx.Plug, prom_ex_module: Plausible.PromEx)
-  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
 
   plug(Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -69,6 +69,7 @@ defmodule PlausibleWeb.Endpoint do
 
   plug(Plug.RequestId)
   plug(PromEx.Plug, prom_ex_module: Plausible.PromEx)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint], log: false)
 
   plug(Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],


### PR DESCRIPTION
Ultimate goal is to be able to compare results with and without a flag against each other. To do this we need logging which displays the full request url with parameters.

Example logs:
```
14:46:09.042 request_id=F8MRLSsaKB7BeIkAAAHk [info] (200) GET /api/sites took 17ms
14:46:09.175 request_id=F8MRLTKYV3G-GqEAAAZB [info] (200) GET /api/stats/dummy.site/current-visitors took 24ms
14:46:09.396 request_id=F8MRLUDfav28LIkAAAIE [info] (202) POST /api/event took 5ms
14:46:09.501 request_id=F8MRLUDS_YhftUkAAAAD [info] (200) GET /api/stats/dummy.site/sources?period=30d&date=2024-04-04&filters=%7B%7D&with_imported=true&limit=9 took 111ms
14:46:09.508 request_id=F8MRLUDhHbK8WKUAAAah [info] (200) GET /api/stats/dummy.site/main-graph?period=30d&date=2024-04-04&filters=%7B%7D&with_imported=true&metric=visitors took 117ms
14:46:09.511 request_id=F8MRLUDS1CYntK4AAAaB [info] (200) GET /api/stats/dummy.site/entry-pages?period=30d&date=2024-04-04&filters=%7B%7D&with_imported=true&limit=9 took 121ms
14:46:09.541 request_id=F8MRLTk5sIPYSn4AABoC [info] (200) GET /api/stats/dummy.site/top-stats?period=30d&date=2024-04-04&filters=%7B%7D&with_imported=true&comparison=previous_period&compare_from=undefined&compare_to=undefined&match_day_of_week=true took 278ms
```