### PR TITLE
Handle Google API timeouts gracefully during imports

### DIFF
--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -140,7 +140,10 @@ defmodule Plausible.Google.GA4.HTTP do
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
 
-      {:error, %HTTPClient.Non200Error{} = error} ->
+      {:error, %{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, error} ->
         Sentry.capture_message("Error listing GA4 accounts for user", extra: %{error: error})
         {:error, :unknown}
     end
@@ -161,7 +164,10 @@ defmodule Plausible.Google.GA4.HTTP do
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [404] ->
         {:error, :not_found}
 
-      {:error, %HTTPClient.Non200Error{} = error} ->
+      {:error, %{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, error} ->
         Sentry.capture_message("Error retrieving GA4 property #{property}",
           extra: %{error: error}
         )
@@ -221,7 +227,10 @@ defmodule Plausible.Google.GA4.HTTP do
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
 
-      {:error, %HTTPClient.Non200Error{} = error} ->
+      {:error, %{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, error} ->
         Sentry.capture_message("Error retrieving GA4 #{edge} date",
           extra: %{error: error}
         )

--- a/lib/plausible/google/ua/http.ex
+++ b/lib/plausible/google/ua/http.ex
@@ -108,7 +108,10 @@ defmodule Plausible.Google.UA.HTTP do
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
 
-      {:error, %HTTPClient.Non200Error{} = error} ->
+      {:error, %{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, error} ->
         Sentry.capture_message("Error listing UA views for user", extra: %{error: error})
         {:error, :unknown}
     end
@@ -170,7 +173,10 @@ defmodule Plausible.Google.UA.HTTP do
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
 
-      {:error, %HTTPClient.Non200Error{} = error} ->
+      {:error, %{reason: :timeout}} ->
+        {:error, :timeout}
+
+      {:error, error} ->
         Sentry.capture_message("Error retrieving UA #{edge} date",
           extra: %{error: error}
         )

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -96,6 +96,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         )
         |> redirect(external: redirect_route)
 
+      {:error, :timeout} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics API has timed out. Please try again."
+        )
+        |> redirect(external: redirect_route)
+
       {:error, _any} ->
         conn
         |> put_flash(
@@ -168,6 +176,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         )
         |> redirect(external: redirect_route)
 
+      {:error, :timeout} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics API has timed out. Please try again."
+        )
+        |> redirect(external: redirect_route)
+
       {:error, _any} ->
         conn
         |> put_flash(
@@ -222,6 +238,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         |> put_flash(
           :error,
           "Google Analytics authentication seems to have expired. Please try again."
+        )
+        |> redirect(external: redirect_route)
+
+      {:error, :timeout} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics API has timed out. Please try again."
         )
         |> redirect(external: redirect_route)
 

--- a/test/plausible_web/controllers/google_analytics_controller_test.exs
+++ b/test/plausible_web/controllers/google_analytics_controller_test.exs
@@ -139,6 +139,38 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
                  "We were unable to authenticate your Google Analytics account"
       end
 
+      test "redirects to #{view} on timeout error with flash error (legacy: #{legacy})", %{
+        conn: conn,
+        site: site
+      } do
+        expect(
+          Plausible.HTTPClient.Mock,
+          :get,
+          fn _url, _opts ->
+            {:error, %Mint.TransportError{reason: :timeout}}
+          end
+        )
+
+        conn =
+          conn
+          |> get("/#{site.domain}/import/google-analytics/property-or-view", %{
+            "access_token" => "token",
+            "refresh_token" => "foo",
+            "expires_at" => "2022-09-22T20:01:37.112777",
+            "legacy" => unquote(legacy)
+          })
+
+        assert redirected_to(conn, 302) ==
+                 PlausibleWeb.Router.Helpers.site_path(
+                   conn,
+                   unquote(view),
+                   site.domain
+                 )
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+                 "Google Analytics API has timed out."
+      end
+
       test "redirects to #{view} on list retrival failure with flash error (legacy: #{legacy})",
            %{
              conn: conn,
@@ -460,6 +492,40 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
         assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                  "Google Analytics authentication seems to have expired."
       end
+
+      test "redirects to #{view} on timeout with flash error (legacy: #{legacy})",
+           %{
+             conn: conn,
+             site: site
+           } do
+        expect(
+          Plausible.HTTPClient.Mock,
+          :post,
+          fn _url, _opts, _params ->
+            {:error, %Mint.TransportError{reason: :timeout}}
+          end
+        )
+
+        conn =
+          conn
+          |> post("/#{site.domain}/import/google-analytics/property-or-view", %{
+            "property_or_view" => "properties/428685906",
+            "access_token" => "token",
+            "refresh_token" => "foo",
+            "expires_at" => "2022-09-22T20:01:37.112777",
+            "legacy" => unquote(legacy)
+          })
+
+        assert redirected_to(conn, 302) ==
+                 PlausibleWeb.Router.Helpers.site_path(
+                   conn,
+                   unquote(view),
+                   site.domain
+                 )
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+                 "Google Analytics API has timed out."
+      end
     end
   end
 
@@ -623,6 +689,42 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                  "Google Analytics authentication seems to have expired."
+      end
+
+      test "redirects to #{view} on timeout with flash error (legacy: #{legacy})",
+           %{
+             conn: conn,
+             site: site
+           } do
+        expect(
+          Plausible.HTTPClient.Mock,
+          :get,
+          fn _url, _params ->
+            {:error, %Mint.TransportError{reason: :timeout}}
+          end
+        )
+
+        conn =
+          conn
+          |> get("/#{site.domain}/import/google-analytics/confirm", %{
+            "property_or_view" => "properties/428685906",
+            "access_token" => "token",
+            "refresh_token" => "foo",
+            "expires_at" => "2022-09-22T20:01:37.112777",
+            "start_date" => "2024-02-22",
+            "end_date" => "2024-02-26",
+            "legacy" => unquote(legacy)
+          })
+
+        assert redirected_to(conn, 302) ==
+                 PlausibleWeb.Router.Helpers.site_path(
+                   conn,
+                   unquote(view),
+                   site.domain
+                 )
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+                 "Google Analytics API has timed out."
       end
     end
   end


### PR DESCRIPTION
### Changes

This PR improves feedback on Google API timeout errors when doing stats imports.

### Tests
- [x] Automated tests have been added
