### PR TITLE
Clear `sites.imported_data` after backfilling site imports in data migration script

### DIFF
--- a/lib/plausible/data_migration/site_imports.ex
+++ b/lib/plausible/data_migration/site_imports.ex
@@ -77,10 +77,6 @@ defmodule Plausible.DataMigration.SiteImports do
             "Site import #{site_import.id} (site ID #{site.id}) does not have any recorded stats. Removing it."
           )
 
-          if site_import.legacy do
-            clear_imported_data(site, dry_run?)
-          end
-
           delete!(site_import, dry_run?)
         else
           end_date =
@@ -104,7 +100,11 @@ defmodule Plausible.DataMigration.SiteImports do
         end
       end
 
-      IO.puts("Done processing site ID #{site.id}")
+      clear_imported_data(site, dry_run?)
+
+      IO.puts(
+        "Done processing site ID #{site.id} (site.imported_data: #{inspect(site.imported_data)})"
+      )
     end
 
     IO.puts("Finished")

--- a/test/plausible/data_migration/site_imports_test.exs
+++ b/test/plausible/data_migration/site_imports_test.exs
@@ -43,9 +43,11 @@ defmodule Plausible.DataMigration.SiteImportsTest do
 
       site = Repo.reload!(site)
 
+      assert site.imported_data == nil
+
       assert [%{id: id, legacy: true} = site_import] = Imported.list_all_imports(site)
       assert id > 0
-      assert site_import.start_date == site.imported_data.start_date
+      assert site_import.start_date == ~D[2021-01-02]
       assert site_import.end_date == ~D[2021-01-07]
       assert site_import.source == :universal_analytics
     end
@@ -84,9 +86,10 @@ defmodule Plausible.DataMigration.SiteImportsTest do
 
       site = Repo.reload!(site)
 
+      assert site.imported_data == nil
       assert [%{id: id, legacy: true} = site_import] = Imported.list_all_imports(site)
       assert id > 0
-      assert site_import.start_date == site.imported_data.start_date
+      assert site_import.start_date == ~D[2021-01-02]
       assert site_import.end_date == ~D[2021-01-08]
       assert site_import.source == :universal_analytics
     end
@@ -132,9 +135,10 @@ defmodule Plausible.DataMigration.SiteImportsTest do
 
       site = Repo.reload!(site)
 
+      assert site.imported_data == nil
       assert [%{id: id, legacy: true} = site_import] = Imported.list_all_imports(site)
       assert id == existing_import.id
-      assert site_import.start_date == site.imported_data.start_date
+      assert site_import.start_date == ~D[2021-01-02]
       assert site_import.end_date == ~D[2021-01-08]
       assert site_import.source == :universal_analytics
     end


### PR DESCRIPTION
### Changes

This is one final change that should ensure import processing remains consistent after running the data migration. Otherwise, the outdated `sites.imported_data` will interfere with date range calculation for further imports until they are finally cleared. Doing it right away minimizes chance of further inconsistencies popping up.

### Tests
- [x] Automated tests have been added

