### PR TITLE
remove Plausible Team footer from self-hosted emails

### DIFF
--- a/lib/plausible_web/templates/layout/base_email.html.eex
+++ b/lib/plausible_web/templates/layout/base_email.html.eex
@@ -4,12 +4,12 @@
 <%= @inner_content %>
 <br /><br />
 
-Regards,<br />
+<%= if full_build?() do %>Regards,<br />
 The Plausible Team 💌
-<br /><br />
+<br /><br /><% end %>
 
 --
 <br /><br />
 <%= link(plausible_url(), to: plausible_url()) %><br />
 
-{{{ pm:unsubscribe }}}
+<%= if full_build?() do %>{{{ pm:unsubscribe }}}<% end %>

--- a/lib/plausible_web/templates/layout/priority_email.html.eex
+++ b/lib/plausible_web/templates/layout/priority_email.html.eex
@@ -4,9 +4,9 @@
 <%= @inner_content %>
 <br /><br />
 
-Regards,<br />
+<%= if full_build?() do %>Regards,<br />
 The Plausible Team 💌
-<br /><br />
+<br /><br /><% end %>
 
 --
 <br /><br />

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -31,6 +31,7 @@ defmodule PlausibleWeb.EmailTest do
       assert email.html_body =~ plausible_link()
     end
 
+    @tag :full_build_only
     test "renders unsubscribe placeholder" do
       email =
         Email.base_email()


### PR DESCRIPTION
### Changes

This PR removes

> Regards
> The Plausible Team 💌

from self-hosted emails.

### Tests
- [ ] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
