### PR TITLE
Refactor `Imported.check_dates` (->`clamp_dates`) for better felxibility

### DIFF
--- a/test/plausible/imported_test.exs
+++ b/test/plausible/imported_test.exs
@@ -119,7 +119,7 @@ defmodule Plausible.ImportedTest do
     end
   end
 
-  describe "check_dates/3" do
+  describe "clamp_dates/3" do
     test "crops dates from both ends when overlapping with existing import and native stats" do
       site = insert(:site)
 
@@ -139,7 +139,7 @@ defmodule Plausible.ImportedTest do
         )
 
       assert {:ok, ~D[2021-05-12], ~D[2023-10-25]} =
-               Imported.check_dates(site, ~D[2021-04-11], ~D[2024-01-12])
+               Imported.clamp_dates(site, ~D[2021-04-11], ~D[2024-01-12])
     end
 
     test "picks longest continuous range when containing existing import" do
@@ -161,27 +161,27 @@ defmodule Plausible.ImportedTest do
         )
 
       assert {:ok, ~D[2021-05-12], ~D[2023-10-25]} =
-               Imported.check_dates(site, ~D[2019-03-21], ~D[2024-01-12])
+               Imported.clamp_dates(site, ~D[2019-03-21], ~D[2024-01-12])
     end
 
     test "does not alter the dates when there are no imports and no native stats" do
       site = insert(:site)
 
       assert {:ok, ~D[2021-05-12], ~D[2024-01-12]} =
-               Imported.check_dates(site, ~D[2021-05-12], ~D[2024-01-12])
+               Imported.clamp_dates(site, ~D[2021-05-12], ~D[2024-01-12])
     end
 
     test "ignores input date range difference smaller than 2 days" do
       site = insert(:site)
 
       assert {:error, :no_time_window} =
-               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-12])
+               Imported.clamp_dates(site, ~D[2024-01-12], ~D[2024-01-12])
 
       assert {:error, :no_time_window} =
-               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-13])
+               Imported.clamp_dates(site, ~D[2024-01-12], ~D[2024-01-13])
 
       assert {:ok, ~D[2024-01-12], ~D[2024-01-14]} =
-               Imported.check_dates(site, ~D[2024-01-12], ~D[2024-01-14])
+               Imported.clamp_dates(site, ~D[2024-01-12], ~D[2024-01-14])
     end
 
     test "ignores imports with date range difference smaller than 2 days" do
@@ -199,7 +199,7 @@ defmodule Plausible.ImportedTest do
         )
 
       assert {:ok, ~D[2021-04-22], ~D[2024-03-14]} =
-               Imported.check_dates(site, ~D[2021-04-22], ~D[2024-03-14])
+               Imported.clamp_dates(site, ~D[2021-04-22], ~D[2024-03-14])
     end
 
     test "returns no time window when input range starts after native stats start date" do
@@ -210,7 +210,7 @@ defmodule Plausible.ImportedTest do
       ])
 
       assert {:error, :no_time_window} =
-               Imported.check_dates(site, ~D[2023-10-28], ~D[2024-01-13])
+               Imported.clamp_dates(site, ~D[2023-10-28], ~D[2024-01-13])
     end
 
     test "returns no time window when input range starts less than 2 days before native stats start date" do
@@ -221,7 +221,7 @@ defmodule Plausible.ImportedTest do
       ])
 
       assert {:error, :no_time_window} =
-               Imported.check_dates(site, ~D[2023-10-24], ~D[2024-01-13])
+               Imported.clamp_dates(site, ~D[2023-10-24], ~D[2024-01-13])
     end
 
     test "crops time range at native stats start date when effective range is 2 days or longer" do
@@ -232,13 +232,7 @@ defmodule Plausible.ImportedTest do
       ])
 
       assert {:ok, ~D[2023-10-23], ~D[2023-10-25]} =
-               Imported.check_dates(site, ~D[2023-10-23], ~D[2024-01-13])
-    end
-
-    test "returns no data error when start date missing" do
-      site = insert(:site)
-
-      assert {:error, :no_data} = Imported.check_dates(site, nil, nil)
+               Imported.clamp_dates(site, ~D[2023-10-23], ~D[2024-01-13])
     end
 
     test "returns no time window error when date range overlaps with existing import and stats completely" do
@@ -260,7 +254,7 @@ defmodule Plausible.ImportedTest do
         )
 
       assert {:error, :no_time_window} =
-               Imported.check_dates(site, ~D[2021-04-11], ~D[2024-01-12])
+               Imported.clamp_dates(site, ~D[2021-04-11], ~D[2024-01-12])
     end
   end
 end


### PR DESCRIPTION
### Changes

Refactor `Imported.check_dates` (renamed to `clamp_dates` in the process) to make it more suitable for use outside Google Analytics import flow.

### Tests
- [x] Automated tests have been added
