### PR TITLE
Return 400 when using invalid filters for stats api

### DIFF
--- a/lib/plausible/stats/props.ex
+++ b/lib/plausible/stats/props.ex
@@ -1,5 +1,5 @@
 defmodule Plausible.Stats.Props do
-  @event_props ["event:page", "event:name", "event:goal"]
+  @event_props ["event:page", "event:name", "event:goal", "event:hostname"]
   @session_props [
     "visit:source",
     "visit:country",
@@ -19,8 +19,6 @@ defmodule Plausible.Stats.Props do
     "visit:browser",
     "visit:browser_version"
   ]
-
-  def event_props(), do: @event_props
 
   def valid_prop?(prop) when prop in @event_props, do: true
   def valid_prop?(prop) when prop in @session_props, do: true

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -597,6 +597,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       assert msg =~ "The goal `Register` is not configured for this site. Find out how"
     end
 
+    test "validates that filters are valid", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "filters" => "badproperty==bar"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Invalid filter property 'badproperty'. Please provide a valid filter property: https://plausible.io/docs/stats-api#properties"
+             }
+    end
+
     test "can filter by source", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -1338,6 +1338,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert msg =~ "The goal `Register` is not configured for this site. Find out how"
     end
 
+    test "validates that filters are valid", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "filters" => "badproperty==bar"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Invalid filter property 'badproperty'. Please provide a valid filter property: https://plausible.io/docs/stats-api#properties"
+             }
+    end
+
     test "event:page filter for breakdown by session props", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -468,8 +468,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
   describe "filters" do
     test "event:goal filter returns 400 when goal not configured", %{conn: conn, site: site} do
       conn =
-        get(conn, "/api/v1/stats/aggregate", %{
+        get(conn, "/api/v1/stats/timeseries", %{
           "site_id" => site.domain,
+          "period" => "month",
+          "date" => "2021-01-01",
+          "metrics" => "visitors,events",
           "filters" => "event:goal==Visit /register**"
         })
 
@@ -477,6 +480,22 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
       assert msg =~
                "The pageview goal for the pathname `/register**` is not configured for this site"
+    end
+
+    test "validates that filters are valid", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "period" => "month",
+          "date" => "2021-01-01",
+          "metrics" => "visitors,events",
+          "filters" => "badproperty==bar"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Invalid filter property 'badproperty'. Please provide a valid filter property: https://plausible.io/docs/stats-api#properties"
+             }
     end
 
     test "can filter by a custom event goal", %{conn: conn, site: site} do


### PR DESCRIPTION
Currently a 500 is returned instead and logged to sentry.

Long-term it would be great to unify how filters work and unify parsing and validation.