### PR TITLE
Remove hostname filter from the external API

### DIFF
--- a/lib/plausible/stats/props.ex
+++ b/lib/plausible/stats/props.ex
@@ -1,5 +1,5 @@
 defmodule Plausible.Stats.Props do
-  @event_props ["event:page", "event:name", "event:goal", "event:hostname"]
+  @event_props ["event:page", "event:name", "event:goal"]
   @session_props [
     "visit:source",
     "visit:country",

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -963,50 +963,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
              }
     end
 
-    test "can filter by hostname", %{
-      conn: conn,
-      site: site
-    } do
-      populate_stats(site, [
-        build(:pageview,
-          user_id: @user_id,
-          hostname: "landing.example.com",
-          timestamp: ~N[2021-01-01 00:00:01]
-        ),
-        build(:pageview,
-          user_id: @user_id,
-          hostname: "example.com",
-          timestamp: ~N[2021-01-01 00:00:02]
-        ),
-        build(:pageview,
-          user_id: @user_id,
-          hostname: "example.com",
-          timestamp: ~N[2021-01-01 00:00:06]
-        )
-      ])
-
-      conn =
-        get(conn, "/api/v1/stats/timeseries", %{
-          "site_id" => site.domain,
-          "period" => "day",
-          "date" => "2021-01-01",
-          "filters" => "event:hostname==example.com",
-          "metrics" => "visitors,visits,pageviews,bounce_rate,visit_duration"
-        })
-
-      res =
-        json_response(conn, 200)["results"]
-
-      assert List.first(res) == %{
-               "bounce_rate" => 0,
-               "date" => "2021-01-01 00:00:00",
-               "pageviews" => 2,
-               "visit_duration" => 5,
-               "visitors" => 1,
-               "visits" => 1
-             }
-    end
-
     test "can filter by event:name", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:event,


### PR DESCRIPTION
This got in too early, while the hostname filter is still being worked on and its behaviour may be subject to change. 