### PR TITLE
Fix experimental_reduced_joins

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -213,7 +213,7 @@ defmodule Plausible.Stats.Breakdown do
   end
 
   # Backwards compatibility
-  # defp breakdown_table(%Query{experimental_reduced_joins?: false}, _, _), do: :session
+  defp breakdown_table(%Query{experimental_reduced_joins?: false}, _, _), do: :session
 
   defp breakdown_table(_query, _metrics, "visit:entry_page"), do: :session
   defp breakdown_table(_query, _metrics, "visit:entry_page_hostname"), do: :session


### PR DESCRIPTION
The [original diff](https://github.com/plausible/analytics/pull/3966) had an important code branch commented out, causing events table to be queried for breakdowns with the flag off. :facepalm: 