### PR TITLE
Move hostname filter appending to Breakdown module

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -458,13 +458,6 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site, params)
     pagination = parse_pagination(params)
 
-    query =
-      if query.filters["event:hostname"] do
-        Query.put_filter(query, "visit:entry_page_hostname", query.filters["event:hostname"])
-      else
-        query
-      end
-
     extra_metrics =
       if params["detailed"], do: [:bounce_rate, :visit_duration], else: []
 
@@ -770,13 +763,6 @@ defmodule PlausibleWeb.Api.StatsController do
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:visits, :visit_duration])
 
-    query =
-      if query.filters["event:hostname"] do
-        Query.put_filter(query, "visit:entry_page_hostname", query.filters["event:hostname"])
-      else
-        query
-      end
-
     entry_pages =
       Stats.breakdown(site, query, "visit:entry_page", metrics, pagination)
       |> transform_keys(%{entry_page: :name})
@@ -806,13 +792,6 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site, params)
     {limit, page} = parse_pagination(params)
     metrics = breakdown_metrics(query, [:visits])
-
-    query =
-      if query.filters["event:hostname"] do
-        Query.put_filter(query, "visit:exit_page_hostname", query.filters["event:hostname"])
-      else
-        query
-      end
 
     exit_pages =
       Stats.breakdown(site, query, "visit:exit_page", metrics, {limit, page})


### PR DESCRIPTION
We currently update the query filtered by hostname to its respective visit props in some cases.
This patch moves it down, from controllers, to the Breakdown module, so any changes in logic will be also reflected in the Stats API.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
