### PR TITLE
Discard sessions switching hostnames for UTM/referrer breakdowns

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -213,11 +213,18 @@ defmodule Plausible.Stats.Breakdown do
     end
   end
 
-  defp maybe_update_breakdown_filters("visit:source", query) do
-    update_hostname(query, "visit:entry_page_hostname")
-  end
-
-  defp maybe_update_breakdown_filters("visit:entry_page", query) do
+  defp maybe_update_breakdown_filters(visit_entry_prop, query)
+       when visit_entry_prop in [
+              "visit:source",
+              "visit:entry_page",
+              "visit:utm_medium",
+              "visit:utm_source",
+              "visit:utm_campaign",
+              "visit:utm_content",
+              "visit:utm_term",
+              "visit:entry_page",
+              "visit:referrer"
+            ] do
     update_hostname(query, "visit:entry_page_hostname")
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1560,7 +1560,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
 
       assert json_response(conn, 200) == [
-               %{"name" => "example.com/page1", "visitors"=> 1}
+               %{"name" => "example.com/page1", "visitors" => 1}
              ]
     end
 


### PR DESCRIPTION
### Changes

In reference to https://github.com/plausible/analytics/pull/3998#issuecomment-2046813239 - this PR adds hostname filtering support when the breakdowns are made by `visit:utm*` and `visit:referrer` properties.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
