### PR TITLE
redirect to s3 url when downloading exports

### DIFF
--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -98,7 +98,6 @@ defmodule Plausible.Exports do
           path: Path.t(),
           name: String.t(),
           expires_at: DateTime.t() | nil,
-          download_link: String.t(),
           size: pos_integer
         }
 
@@ -113,14 +112,7 @@ defmodule Plausible.Exports do
       created_on_in_site_tz = Plausible.Timezones.to_date_in_timezone(created_at, timezone)
       name = archive_filename(domain, created_on_in_site_tz)
 
-      download_link =
-        PlausibleWeb.Router.Helpers.site_path(
-          PlausibleWeb.Endpoint,
-          :download_local_export,
-          domain
-        )
-
-      %{path: path, name: name, expires_at: nil, download_link: download_link, size: size}
+      %{path: path, name: name, expires_at: nil, size: size}
     end
   end
 
@@ -175,7 +167,6 @@ defmodule Plausible.Exports do
           path: path,
           name: name,
           expires_at: expires_at,
-          download_link: Plausible.S3.download_url(bucket, path),
           size: String.to_integer(size)
         }
     end

--- a/lib/plausible/s3.ex
+++ b/lib/plausible/s3.ex
@@ -93,7 +93,7 @@ defmodule Plausible.S3 do
 
   @doc """
   Returns a presigned URL to download the exported Zip archive from S3.
-  The URL expires in 24 hours.
+  The URL expires in 300 seconds, which should be enough for a redirect.
 
   In the current implementation the bucket always goes into the path component.
   """
@@ -101,11 +101,8 @@ defmodule Plausible.S3 do
   def download_url(s3_bucket, s3_path) do
     config = ExAws.Config.new(:s3)
 
-    # ex_aws_s3 doesn't allow expires_in longer than one week
-    one_week = 60 * 60 * 24 * 7
-
     {:ok, download_url} =
-      ExAws.S3.presigned_url(config, :get, s3_bucket, s3_path, expires_in: one_week)
+      ExAws.S3.presigned_url(config, :get, s3_bucket, s3_path, expires_in: 300)
 
     download_url
   end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -679,7 +679,7 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
-  on_full_build do
+  on_ee do
     def download_export(conn, _params) do
       %{id: site_id, domain: domain} = conn.assigns.site
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -679,20 +679,30 @@ defmodule PlausibleWeb.SiteController do
     |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
-  on_ee do
-    # exported archives are downloaded from object storage
-  else
-    alias Plausible.Exports
+  on_full_build do
+    def download_export(conn, _params) do
+      %{id: site_id, domain: domain} = conn.assigns.site
 
-    def download_local_export(conn, _params) do
+      if s3_export = Plausible.Exports.get_s3_export(site_id) do
+        s3_bucket = Plausible.S3.exports_bucket()
+        download_url = Plausible.S3.download_url(s3_bucket, s3_export.path)
+        redirect(conn, external: download_url)
+      else
+        conn
+        |> put_flash(:error, "Export not found")
+        |> redirect(external: Routes.site_path(conn, :settings_imports_exports, domain))
+      end
+    end
+  else
+    def download_export(conn, _params) do
       %{id: site_id, domain: domain, timezone: timezone} = conn.assigns.site
 
-      if local_export = Exports.get_local_export(site_id, domain, timezone) do
+      if local_export = Plausible.Exports.get_local_export(site_id, domain, timezone) do
         %{path: export_path, name: name} = local_export
 
         conn
         |> put_resp_content_type("application/zip")
-        |> put_resp_header("content-disposition", Exports.content_disposition(name))
+        |> put_resp_header("content-disposition", Plausible.Exports.content_disposition(name))
         |> send_file(200, export_path)
       else
         conn

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -347,7 +347,7 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  def export_success(user, site, download_url, expires_at) do
+  def export_success(user, site, expires_at) do
     subject =
       on_ee do
         "Your Plausible Analytics export is now ready for download"
@@ -362,6 +362,13 @@ defmodule PlausibleWeb.Email do
           "{relative}"
         )
       end
+
+    download_url =
+      PlausibleWeb.Router.Helpers.site_url(
+        PlausibleWeb.Endpoint,
+        :download_export,
+        site.domain
+      )
 
     priority_email()
     |> to(user)

--- a/lib/plausible_web/live/csv_export.ex
+++ b/lib/plausible_web/live/csv_export.ex
@@ -101,7 +101,11 @@ defmodule PlausibleWeb.Live.CSVExport do
       <% "failed" -> %>
         <.failed />
       <% "ready" -> %>
-        <.download storage={@storage} export={@export} />
+        <.download
+          storage={@storage}
+          export={@export}
+          href={Routes.site_path(@socket, :download_export, @site.domain)}
+        />
     <% end %>
     """
   end
@@ -151,7 +155,7 @@ defmodule PlausibleWeb.Live.CSVExport do
   defp download(assigns) do
     ~H"""
     <div class="flex items-center justify-between space-x-2">
-      <a href={@export.download_link} class="inline-flex items-center">
+      <a href={@href} class="inline-flex items-center">
         <Heroicons.document_text class="w-4 h-4" />
         <span class="ml-1 text-indigo-500"><%= @export.name %></span>
       </a>

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -391,12 +391,7 @@ defmodule PlausibleWeb.Router do
     delete "/:website/settings/forget-imported", SiteController, :forget_imported
     delete "/:website/settings/forget-import/:import_id", SiteController, :forget_import
 
-    on_ee do
-      # exported archives are downloaded from object storage
-    else
-      get "/:website/exported-archive", SiteController, :download_local_export
-    end
-
+    get "/:website/download/export", SiteController, :download_export
     get "/:website/settings/import", SiteController, :csv_import
 
     get "/:domain/export", StatsController, :csv_export

--- a/lib/workers/notify_exported_analytics.ex
+++ b/lib/workers/notify_exported_analytics.ex
@@ -22,20 +22,11 @@ defmodule Plausible.Workers.NotifyExportedAnalytics do
         "success" ->
           case storage do
             "s3" ->
-              %{"s3_bucket" => s3_bucket, "s3_path" => s3_path} = args
-              download_url = Plausible.S3.download_url(s3_bucket, s3_path)
               %{expires_at: expires_at} = Plausible.Exports.get_s3_export(site_id)
-              PlausibleWeb.Email.export_success(user, site, download_url, expires_at)
+              PlausibleWeb.Email.export_success(user, site, expires_at)
 
             "local" ->
-              download_url =
-                PlausibleWeb.Router.Helpers.site_path(
-                  PlausibleWeb.Endpoint,
-                  :download_local_export,
-                  site.domain
-                )
-
-              PlausibleWeb.Email.export_success(user, site, download_url, _expires_at = nil)
+              PlausibleWeb.Email.export_success(user, site, _expires_at = nil)
           end
 
         "failure" ->

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -494,7 +494,7 @@ defmodule Plausible.Imported.CSVImporterTest do
                Oban.drain_queue(queue: :notify_exported_analytics, with_safety: false)
 
       # check mailbox
-      assert_receive {:delivered_email, email}, _within = :timer.seconds(55)
+      assert_receive {:delivered_email, email}, _within = :timer.seconds(5)
       assert email.to == [{user.name, user.email}]
 
       assert email.html_body =~

--- a/test/workers/notify_exported_analytics_test.exs
+++ b/test/workers/notify_exported_analytics_test.exs
@@ -15,7 +15,7 @@ defmodule Plausible.Workers.NotifyExportedAnalyticsTest do
       job =
         Plausible.Workers.NotifyExportedAnalytics.new(%{
           "status" => "failure",
-          "storage" => on_full_build(do: "s3", else: "local"),
+          "storage" => on_ee(do: "s3", else: "local"),
           "email_to" => user.email,
           "site_id" => site.id
         })

--- a/test/workers/notify_exported_analytics_test.exs
+++ b/test/workers/notify_exported_analytics_test.exs
@@ -1,0 +1,32 @@
+defmodule Plausible.Workers.NotifyExportedAnalyticsTest do
+  use Plausible
+  use Plausible.DataCase
+  use Bamboo.Test
+
+  describe "perform/1" do
+    setup do
+      user = insert(:user)
+      site = insert(:site, members: [user])
+      {:ok, user: user, site: site}
+    end
+
+    # for 'success' case please see Plausible.Imported.CSVImporterTest
+    test "delivers 'failure' email", %{user: user, site: site} do
+      job =
+        Plausible.Workers.NotifyExportedAnalytics.new(%{
+          "status" => "failure",
+          "storage" => on_full_build(do: "s3", else: "local"),
+          "email_to" => user.email,
+          "site_id" => site.id
+        })
+
+      Oban.insert!(job)
+
+      assert %{success: 1} =
+               Oban.drain_queue(queue: :notify_exported_analytics, with_safety: false)
+
+      assert_receive {:delivered_email, email}
+      assert email.html_body =~ "was unsuccessful."
+    end
+  end
+end


### PR DESCRIPTION
### Changes

https://3.basecamp.com/5308029/buckets/35871979/card_tables/cards/6945042601#__recording_7282802614

### Tests
- [x] try it out, including "save as..."
- [x] add some tests (email template)