### PR TITLE
use custom email template for csv imports

### DIFF
--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -12,9 +12,8 @@ defmodule Plausible.Imported.CSVImporter do
   @impl true
   def label(), do: "CSV"
 
-  # NOTE: change it once CSV import is implemented
   @impl true
-  def email_template(), do: "google_analytics_import.html"
+  def email_template(), do: "csv_import.html"
 
   @impl true
   def parse_args(%{"uploads" => uploads, "storage" => storage}) do

--- a/lib/plausible_web/templates/email/csv_import.html.heex
+++ b/lib/plausible_web/templates/email/csv_import.html.heex
@@ -1,0 +1,14 @@
+<%= if @success do %>
+  Your CSV import has completed successfully. The Plausible dashboard for <%= @site_import.site.domain %> now contains historical imported data from <%= date_format(
+    @site_import.start_date
+  ) %> to <%= date_format(@site_import.end_date) %>
+  <br /><br />
+  <%= link("Click here", to: @link) %> to view your dashboard.
+<% else %>
+  Unfortunately, your CSV import for <%= @site_import.site.domain %> did not complete successfully. Sorry about that!
+  <br /><br /> Please try to do the import once again.
+  <%= if full_build?() do %>
+    <br /> <br />
+    Please reply to this email to let us know if you're still experiencing issues with the import.
+  <% end %>
+<% end %>


### PR DESCRIPTION
### Changes

This PR adds a new email template for CSV imports and starts using it in CSVImporter instead of the GA one.