### PR TITLE
Stop importing page referrer from GA4

### DIFF
--- a/fixture/ga4_report_imported_sources.json
+++ b/fixture/ga4_report_imported_sources.json
@@ -20,9 +20,6 @@
         },
         {
           "name": "sessionGoogleAdsKeyword"
-        },
-        {
-          "name": "pageReferrer"
         }
       ],
       "kind": "analyticsData#runReport",
@@ -52,7 +49,7 @@
           "type": "TYPE_SECONDS"
         }
       ],
-      "rowCount": 1090,
+      "rowCount": 210,
       "rows": [
         {
           "dimensionValues": [
@@ -73,26 +70,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "110"
+              "value": "125"
             },
             {
-              "value": "95"
+              "value": "102"
             },
             {
-              "value": "99"
+              "value": "106"
             },
             {
-              "value": "34"
+              "value": "36"
             },
             {
-              "value": "3718"
+              "value": "4066"
             }
           ]
         },
@@ -115,26 +109,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "33"
+              "value": "60"
             },
             {
-              "value": "16"
+              "value": "29"
             },
             {
-              "value": "17"
+              "value": "30"
             },
             {
-              "value": "7"
+              "value": "13"
             },
             {
-              "value": "322"
+              "value": "676"
             }
           ]
         },
@@ -144,81 +135,36 @@
               "value": "20240131"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": ""
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "23"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "13"
+              "value": "6"
             },
             {
               "value": "6"
             },
             {
-              "value": "293"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
+              "value": "6"
             },
             {
-              "value": "(direct)"
+              "value": "5"
             },
             {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
+              "value": "10"
             }
           ]
         },
@@ -241,9 +187,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -270,133 +213,7 @@
               "value": "20240131"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "185"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "pinterest.com"
+              "value": "lm.facebook.com"
             },
             {
               "value": "referral"
@@ -409,23 +226,20 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "1"
             },
             {
-              "value": "2"
+              "value": "1"
             },
             {
-              "value": "2"
+              "value": "1"
             },
             {
-              "value": "2"
+              "value": "1"
             },
             {
               "value": "0"
@@ -435,49 +249,46 @@
         {
           "dimensionValues": [
             {
-              "value": "20240131"
+              "value": "20240130"
             },
             {
-              "value": "pinterest.com"
+              "value": "google"
             },
             {
-              "value": "referral"
+              "value": "organic"
             },
             {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(organic)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "https://www.pinterest.com/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "111"
             },
             {
-              "value": "2"
+              "value": "80"
             },
             {
-              "value": "2"
+              "value": "80"
             },
             {
-              "value": "1"
+              "value": "27"
             },
             {
-              "value": "10"
+              "value": "2912"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240131"
+              "value": "20240130"
             },
             {
               "value": "(direct)"
@@ -493,369 +304,69 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "30"
             },
             {
-              "value": "1"
+              "value": "19"
             },
             {
-              "value": "1"
+              "value": "19"
             },
             {
-              "value": "0"
+              "value": "8"
             },
             {
-              "value": "25"
+              "value": "261"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240131"
+              "value": "20240130"
             },
             {
-              "value": "google"
+              "value": "pinterest.com"
             },
             {
-              "value": "organic"
+              "value": "referral"
             },
             {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "https://www.google.at/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "12"
             },
             {
-              "value": "1"
+              "value": "8"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "8"
             },
             {
               "value": "3"
+            },
+            {
+              "value": "161"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com.au/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/fini-detalji-za-cajanku/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/provola/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sezam-kolacici-bez-brasna-mlijeka-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "86"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/stabljike-celera-i-waldorf-salata-na-novi-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
+              "value": "20240130"
             },
             {
               "value": "lm.facebook.com"
@@ -871,310 +382,13 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
             }
           ],
           "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240131"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/pin/570479477807938277/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "91"
-            },
-            {
-              "value": "78"
-            },
-            {
-              "value": "78"
-            },
-            {
-              "value": "27"
-            },
-            {
-              "value": "2625"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "17"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "159"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "11"
-            },
             {
               "value": "9"
             },
             {
-              "value": "9"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "90"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "161"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
               "value": "1"
             },
             {
@@ -1184,7 +398,7 @@
               "value": "0"
             },
             {
-              "value": "28"
+              "value": "48"
             }
           ]
         },
@@ -1207,14 +421,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
+              "value": "5"
             },
             {
               "value": "3"
@@ -1226,301 +437,7 @@
               "value": "1"
             },
             {
-              "value": "43"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "101"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/rusticni-kruh-sa-zobenim-mekinjama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/varivo-sa-mahunama-i-krompirom-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/?fbclid=IwAR2s3lAlZgbVYxVw4i9yOWoxZLzLmth73H7bPG6aht2WZ3L8G1K_a4nNZXw"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
+              "value": "72"
             }
           ]
         },
@@ -1543,9 +460,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -1563,300 +477,6 @@
             },
             {
               "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sendvic-na-grilu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "29"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "83"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.nl/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/64/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
             }
           ]
         },
@@ -1879,9 +499,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://kuhinjica-mignone.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -1921,93 +538,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240130"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
@@ -2047,26 +577,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "88"
+              "value": "104"
             },
             {
-              "value": "73"
+              "value": "75"
             },
             {
-              "value": "76"
+              "value": "82"
             },
             {
-              "value": "33"
+              "value": "39"
             },
             {
-              "value": "2122"
+              "value": "2428"
             }
           ]
         },
@@ -2089,68 +616,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "17"
+              "value": "34"
             },
             {
-              "value": "10"
+              "value": "19"
             },
             {
-              "value": "10"
+              "value": "20"
             },
             {
-              "value": "5"
+              "value": "11"
             },
             {
-              "value": "239"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "16"
-            },
-            {
-              "value": "9"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "143"
+              "value": "394"
             }
           ]
         },
@@ -2173,68 +655,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
+            {
+              "value": "8"
+            },
             {
               "value": "6"
             },
             {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "47"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
+              "value": "6"
             },
             {
               "value": "2"
             },
             {
-              "value": "6"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "0"
+              "value": "47"
             }
           ]
         },
@@ -2257,9 +694,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -2286,48 +720,6 @@
               "value": "20240129"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
               "value": "m.facebook.com"
             },
             {
@@ -2341,9 +733,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -2367,7 +756,7 @@
         {
           "dimensionValues": [
             {
-              "value": "20240129"
+              "value": "20240128"
             },
             {
               "value": "google"
@@ -2383,33 +772,30 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-stvari-po-kojima-je-danska-poznata-u-svijetu/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "190"
             },
             {
-              "value": "2"
+              "value": "141"
             },
             {
-              "value": "2"
+              "value": "147"
             },
             {
-              "value": "0"
+              "value": "49"
             },
             {
-              "value": "276"
+              "value": "5776"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240129"
+              "value": "20240128"
             },
             {
               "value": "(direct)"
@@ -2425,120 +811,33 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cudotvorni-sok-od-stabljike-celera/?fbclid=IwAR0-hYTbNaNm5AZI0KBCKQQh5MXTYf24bzfUY5iM5y__ZEcQk3E3TjZYUX4_aem_AZZiDeDgvqsAPBw6YWT4USFfvPjYwlYS-A_jw46FYEETU24PGecmQ0dXW1LaOkeGt6Y"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "38"
             },
             {
-              "value": "1"
+              "value": "25"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
+              "value": "25"
             },
             {
               "value": "15"
+            },
+            {
+              "value": "459"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240129"
+              "value": "20240128"
             },
             {
-              "value": "google"
+              "value": "bing"
             },
             {
               "value": "organic"
@@ -2551,117 +850,30 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-u-kaputu/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peceni-krompir-sa-sezamom/?relatedposts_hit=1&relatedposts_origin=15352&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
+              "value": "18"
             },
             {
               "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-pohovani-tofu-stapici/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "5"
             },
             {
               "value": "0"
             },
             {
-              "value": "1"
+              "value": "559"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240129"
+              "value": "20240128"
             },
             {
               "value": "pinterest.com"
@@ -2677,219 +889,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240129"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/pin/779545016801493703/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "157"
-            },
-            {
-              "value": "139"
-            },
-            {
-              "value": "143"
-            },
-            {
-              "value": "46"
-            },
-            {
-              "value": "5445"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "23"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "215"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "16"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "113"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
@@ -2906,259 +905,7 @@
               "value": "8"
             },
             {
-              "value": "138"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "54"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "147"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "111"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
               "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
             }
           ]
         },
@@ -3181,9 +928,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -3195,762 +939,6 @@
             },
             {
               "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "77"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "168"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "167"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-pohovani-tofu-stapici/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/grace-and-frankie/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/karamelizirani-bademi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kassava-yuca-povrce-buducnosti/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "41"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kuhinjske-price-ikea-sitnice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrave-grickalice-suseni-dudovi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240128"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/pin/14847873763228358"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
             },
             {
               "value": "1"
@@ -3979,9 +967,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com.au/"
             }
           ],
           "metricValues": [
@@ -4021,26 +1006,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "125"
-            },
-            {
-              "value": "112"
+              "value": "137"
             },
             {
               "value": "115"
             },
             {
-              "value": "42"
+              "value": "118"
             },
             {
-              "value": "4523"
+              "value": "43"
+            },
+            {
+              "value": "4721"
             }
           ]
         },
@@ -4063,68 +1045,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "23"
+              "value": "54"
             },
             {
-              "value": "16"
+              "value": "30"
             },
             {
-              "value": "16"
+              "value": "30"
             },
             {
-              "value": "8"
+              "value": "17"
             },
             {
-              "value": "129"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "22"
-            },
-            {
-              "value": "14"
-            },
-            {
-              "value": "14"
-            },
-            {
-              "value": "9"
-            },
-            {
-              "value": "219"
+              "value": "447"
             }
           ]
         },
@@ -4147,68 +1084,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brzi-ustipci-sa-tikvicama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
+              "value": "6"
             },
             {
               "value": "6"
+            },
+            {
+              "value": "6"
+            },
+            {
+              "value": "5"
+            },
+            {
+              "value": "10"
             }
           ]
         },
@@ -4218,175 +1110,7 @@
               "value": "20240127"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/najbolje-i-najbrze-kiflice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peceni-krompir-sa-sezamom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/salata-od-slanutka-i-brokula/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "92"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "pinterest.com"
+              "value": "vikendkuvarica.blogspot.com"
             },
             {
               "value": "referral"
@@ -4399,56 +1123,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
               "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
             },
             {
               "value": "1"
@@ -4460,91 +1139,7 @@
               "value": "0"
             },
             {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-u-kaputu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "41"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/slatki-krompir-na-vise-nacina/?relatedposts_hit=1&relatedposts_origin=13794&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
+              "value": "40"
             }
           ]
         },
@@ -4567,9 +1162,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -4587,342 +1179,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/chia-dorucak/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dressing-za-salate/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-pripremiti-brunch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/novi-zacin-u-mojoj-kuhinji-makedonska-biena-sol/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
             }
           ]
         },
@@ -4945,9 +1201,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -4965,90 +1218,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "vikendkuvarica.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://vikendkuvarica.blogspot.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240127"
-            },
-            {
-              "value": "vikendkuvarica.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
             }
           ]
         },
@@ -5071,9 +1240,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://r.search.yahoo.com/_ylt=AwrighyCKLVlr2g.lDXw3olQ;_ylu=c2VjA3NyBHNsawNpbWcEb2lkAzcxYjViNWUwNTI2ODUzMTI3Njg4YjU4ZDk5YWRkYjU5BGdwb3MDMjgEaXQDYmluZw--/RV=2/RE=1706400003/RO=11/RU=http://www.kuhinjskeprice.com/kucica-u-cvijecu//RK=2/RS=3uEcfo4M.IO3c5b6GZHlNQ25OJU-"
             }
           ],
           "metricValues": [
@@ -5113,26 +1279,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "116"
+              "value": "133"
             },
             {
-              "value": "94"
+              "value": "100"
             },
             {
-              "value": "102"
+              "value": "110"
             },
             {
-              "value": "36"
+              "value": "40"
             },
             {
-              "value": "4011"
+              "value": "4709"
             }
           ]
         },
@@ -5155,26 +1318,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "22"
+              "value": "43"
             },
             {
-              "value": "10"
+              "value": "21"
             },
             {
-              "value": "10"
+              "value": "21"
             },
             {
-              "value": "2"
+              "value": "9"
             },
             {
-              "value": "164"
+              "value": "731"
             }
           ]
         },
@@ -5184,64 +1344,19 @@
               "value": "20240126"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "17"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "469"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pekara-kuhinjske-price/"
             }
           ],
           "metricValues": [
@@ -5249,16 +1364,16 @@
               "value": "5"
             },
             {
-              "value": "1"
+              "value": "4"
+            },
+            {
+              "value": "4"
+            },
+            {
+              "value": "3"
             },
             {
               "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "171"
             }
           ]
         },
@@ -5281,9 +1396,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -5310,13 +1422,10 @@
               "value": "20240126"
             },
             {
-              "value": "google"
+              "value": "(not set)"
             },
             {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
+              "value": "(not set)"
             },
             {
               "value": "(not set)"
@@ -5325,91 +1434,7 @@
               "value": "(not set)"
             },
             {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "306"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
               "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
             }
           ],
           "metricValues": [
@@ -5423,262 +1448,10 @@
               "value": "1"
             },
             {
-              "value": "0"
-            },
-            {
-              "value": "43"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "55"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/najbolje-i-najbrze-kiflice/"
-            }
-          ],
-          "metricValues": [
-            {
               "value": "1"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/4/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://l.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "4"
+              "value": "16"
             }
           ]
         },
@@ -5701,9 +1474,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.abaiak.com/"
             }
           ],
           "metricValues": [
@@ -5721,300 +1491,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/search?q=salata+sa+maslinkama+i+kaparima&rlz=1C1JZAP_srRS966RS966&oq=salata+sa+maslinkama+i+kapar&gs_lcrp=EgZjaHJvbWUqCQgBECEYChigATIGCAAQRRg5MgkIARAhGAoYoAEyCQgCECEYChigATIJCAMQIRgKGKABMgkIBBAhGAoYoAEyCQgFECEYChigAdIBCjIxMjYxajBqMTWoAgCwAgA&sourceid=chrome&ie=UTF-8"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "78"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/10-zanimljivosti-o-zivotu-u-danskoj/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/arapski-dorucak-manakish/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanski-topli-sendvic-mozzarella-in-carrozza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240126"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/spageti-sa-maslinama-i-kaparima-puttanesca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "65"
             }
           ]
         },
@@ -6037,9 +1513,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -6079,26 +1552,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "127"
+              "value": "149"
             },
             {
-              "value": "100"
+              "value": "105"
             },
             {
-              "value": "103"
+              "value": "108"
             },
             {
-              "value": "42"
+              "value": "45"
             },
             {
-              "value": "3805"
+              "value": "4206"
             }
           ]
         },
@@ -6121,68 +1591,62 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "26"
+              "value": "62"
             },
             {
-              "value": "16"
+              "value": "33"
             },
             {
-              "value": "16"
+              "value": "34"
+            },
+            {
+              "value": "20"
+            },
+            {
+              "value": "654"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240125"
+            },
+            {
+              "value": "pinterest.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "9"
             },
             {
               "value": "7"
             },
             {
-              "value": "239"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
+              "value": "7"
             },
             {
-              "value": "(direct)"
+              "value": "4"
             },
             {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "22"
-            },
-            {
-              "value": "16"
-            },
-            {
-              "value": "17"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "134"
+              "value": "108"
             }
           ]
         },
@@ -6205,9 +1669,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -6234,426 +1695,6 @@
               "value": "20240125"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "144"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=najbolje+i+najbrze+kiflice"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.co.uk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/novi-zacin-u-mojoj-kuhinji-makedonska-biena-sol/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "50"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/162/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "63"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/4/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
               "value": "pinterest.it"
             },
             {
@@ -6667,434 +1708,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.it/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dobrodosli-u-moju-kuhinju/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "50"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/5/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "38"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.it/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "52"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bakar-ponovo-u-modi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/danske-malina-snite/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
+              "value": "3"
             },
             {
               "value": "1"
@@ -7107,132 +1725,6 @@
             },
             {
               "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/indijski-curry-sa-slanutkom-patlidzanom-paprikama-i-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ljevusa-sa-toskanskim-keljom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/u-modi-je-kelj/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
             }
           ]
         },
@@ -7255,9 +1747,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://parfe-dunja.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -7275,132 +1764,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/pin/296182113000541261/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "93"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240125"
-            },
-            {
-              "value": "pinterest.it"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
             }
           ]
         },
@@ -7423,26 +1786,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "139"
+              "value": "174"
             },
             {
-              "value": "107"
+              "value": "112"
             },
             {
-              "value": "116"
+              "value": "122"
             },
             {
-              "value": "50"
+              "value": "53"
             },
             {
-              "value": "3181"
+              "value": "3668"
             }
           ]
         },
@@ -7465,236 +1825,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "19"
+              "value": "35"
             },
             {
-              "value": "11"
+              "value": "18"
             },
             {
-              "value": "11"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "178"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
+              "value": "18"
             },
             {
               "value": "7"
             },
             {
-              "value": "7"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "313"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "49"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "139"
+              "value": "654"
             }
           ]
         },
@@ -7717,14 +1864,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
             }
           ],
           "metricValues": [
             {
-              "value": "3"
+              "value": "5"
             },
             {
               "value": "1"
@@ -7736,7 +1880,7 @@
               "value": "0"
             },
             {
-              "value": "24"
+              "value": "114"
             }
           ]
         },
@@ -7746,39 +1890,36 @@
               "value": "20240124"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "https://www.kuhinjskeprice.com/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
+              "value": "3"
+            },
+            {
+              "value": "3"
+            },
+            {
+              "value": "3"
+            },
+            {
               "value": "2"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
               "value": "0"
-            },
-            {
-              "value": "14"
             }
           ]
         },
@@ -7801,9 +1942,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -7830,174 +1968,6 @@
               "value": "20240124"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-pripremiti-brunch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/provola/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/varivo-sa-mahunama-i-krompirom-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
               "value": "lm.facebook.com"
             },
             {
@@ -8011,9 +1981,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
             }
           ],
           "metricValues": [
@@ -8037,49 +2004,46 @@
         {
           "dimensionValues": [
             {
-              "value": "20240124"
+              "value": "20240123"
             },
             {
-              "value": "pinterest.com"
+              "value": "google"
             },
             {
-              "value": "referral"
+              "value": "organic"
             },
             {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(organic)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "http://www.pinterest.com/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "215"
             },
             {
-              "value": "2"
+              "value": "135"
             },
             {
-              "value": "2"
+              "value": "139"
             },
             {
-              "value": "1"
+              "value": "51"
             },
             {
-              "value": "0"
+              "value": "4160"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240124"
+              "value": "20240123"
             },
             {
               "value": "(direct)"
@@ -8095,992 +2059,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/trend-hrana-iz-teglica/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "26"
             },
             {
-              "value": "1"
+              "value": "15"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "132"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/trend-hrana-iz-teglica/?relatedposts_hit=1&relatedposts_origin=18416&relatedposts_position=0&relatedposts_hit=1&relatedposts_origin=18416&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.dk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-dobrih-savjeta-kako-sloziti-platu-sa-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cemu-sluze-kuhinjski-aparati/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
+              "value": "15"
             },
             {
               "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/crni-ugalj-za-bijele-zube/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cvrsti-sampon-novi-nacin-pranja-kose/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavna-pita-sa-prokeljom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavni-keksici-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kakao-napitak-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/liker-od-tresanja/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lisnato-tijesto-sa-feta-sirom-i-sezamom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pecena-muskatna-tikva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "108"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sta-nas-moze-nauciti-hobotnica-i-zasto-bi-svi-trebali-pogledati-dokumentarni-film-my-octopus-teacher/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "vikendkuvarica.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://vikendkuvarica.blogspot.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "67"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240124"
-            },
-            {
-              "value": "vikendkuvarica.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "167"
-            },
-            {
-              "value": "129"
-            },
-            {
-              "value": "133"
-            },
-            {
-              "value": "49"
-            },
-            {
-              "value": "3640"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "12"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "8"
-            },
-            {
-              "value": "8"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "104"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "1"
             },
             {
-              "value": "210"
+              "value": "366"
             }
           ]
         },
@@ -9103,14 +2098,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "8"
+              "value": "10"
             },
             {
               "value": "4"
@@ -9122,49 +2114,7 @@
               "value": "1"
             },
             {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "12"
+              "value": "62"
             }
           ]
         },
@@ -9187,23 +2137,20 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "5"
+              "value": "7"
+            },
+            {
+              "value": "6"
+            },
+            {
+              "value": "6"
             },
             {
               "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
             },
             {
               "value": "36"
@@ -9216,64 +2163,19 @@
               "value": "20240123"
             },
             {
-              "value": "google"
+              "value": "pinterest.se"
             },
             {
-              "value": "organic"
+              "value": "referral"
             },
             {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Lisnato+feta+sir"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
             }
           ],
           "metricValues": [
@@ -9290,217 +2192,7 @@
               "value": "0"
             },
             {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/amchoor-mango-u-prahu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "58"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lisnato-tijesto-sa-feta-sirom-i-sezamom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/caorle-biser-sjevera-italije-1-dio/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
+              "value": "147"
             }
           ]
         },
@@ -9523,9 +2215,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com.au/"
             }
           ],
           "metricValues": [
@@ -9565,9 +2254,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -9594,846 +2280,6 @@
               "value": "20240123"
             },
             {
-              "value": "pinterest.se"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.se/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "126"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://l.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "39"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com.au/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "100"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/6-ukusnih-poslastica-sa-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "29"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/aktivni-ugalj-prociscavac-vode/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dahl-brzo-i-ukusno-indijsko-jelo-sa-crvenom-lecom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/danske-malina-snite/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ljevusa-sa-toskanskim-keljom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/miris-kafe-u-parfumeriji/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/nutritivni-kvasac-kako-i-zasto/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-jela-od-krompira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/provola/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
               "value": "links.google.wdsystem.cn"
             },
             {
@@ -10447,9 +2293,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://links.google.wdsystem.cn/"
             }
           ],
           "metricValues": [
@@ -10489,9 +2332,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://nely-bluehortensia.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -10515,132 +2355,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240123"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240123"
-            },
-            {
-              "value": "pinterest.se"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240122"
             },
             {
@@ -10657,26 +2371,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "153"
+              "value": "173"
             },
             {
-              "value": "117"
+              "value": "122"
             },
             {
-              "value": "120"
+              "value": "126"
             },
             {
-              "value": "43"
+              "value": "46"
             },
             {
-              "value": "3758"
+              "value": "4127"
             }
           ]
         },
@@ -10699,488 +2410,62 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "29"
+              "value": "40"
             },
             {
-              "value": "22"
+              "value": "28"
             },
             {
-              "value": "22"
+              "value": "28"
             },
+            {
+              "value": "20"
+            },
+            {
+              "value": "423"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240122"
+            },
+            {
+              "value": "pinterest.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
             {
               "value": "16"
             },
             {
-              "value": "297"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
+              "value": "7"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "61"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "66"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
+              "value": "7"
             },
             {
               "value": "3"
             },
             {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "42"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "196"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
+              "value": "310"
             }
           ]
         },
@@ -11203,9 +2488,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -11223,510 +2505,6 @@
             },
             {
               "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.co.uk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/10-savjeta-kako-malu-kuhinju-napraviti-vecom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "136"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ezme-turski-pikantni-sos/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lisnato-tijesto-sa-feta-sirom-i-sezamom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/namaz-od-graha-sa-korijanderom-i-limetom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/neke-vrste-vrecica-ostavljaju-mikroplastiku-u-nasoj-solji-caja/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/provola/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/stari-tanjiri-u-novom-ruhu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -11749,9 +2527,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://links.google.wdsystem.cn/"
             }
           ],
           "metricValues": [
@@ -11791,51 +2566,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240122"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com"
             }
           ],
           "metricValues": [
@@ -11875,26 +2605,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "274"
+              "value": "330"
             },
             {
-              "value": "196"
+              "value": "203"
             },
             {
-              "value": "202"
+              "value": "214"
             },
             {
-              "value": "74"
+              "value": "82"
             },
             {
-              "value": "7369"
+              "value": "8230"
             }
           ]
         },
@@ -11917,9 +2644,45 @@
             },
             {
               "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "35"
             },
             {
-              "value": ""
+              "value": "26"
+            },
+            {
+              "value": "26"
+            },
+            {
+              "value": "14"
+            },
+            {
+              "value": "281"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240121"
+            },
+            {
+              "value": "pinterest.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
             }
           ],
           "metricValues": [
@@ -11927,223 +2690,13 @@
               "value": "16"
             },
             {
-              "value": "14"
+              "value": "13"
             },
             {
-              "value": "14"
+              "value": "13"
             },
-            {
-              "value": "8"
-            },
-            {
-              "value": "195"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "15"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
             {
               "value": "9"
-            },
-            {
-              "value": "8"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "187"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "8"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "114"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "3"
             },
             {
               "value": "108"
@@ -12156,636 +2709,6 @@
               "value": "20240121"
             },
             {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "m.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Digestiv+keks"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Paprika%C5%A1+bez+mesa"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/digestive-keks-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "67"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lisnato-tijesto-sa-feta-sirom-i-sezamom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/mozemo-li-biti-zdraviji-jeduci-u-prozoru-od-10-sati/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.fr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "47"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "51"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/u-posjeti-restoranu-el-pimpi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/plavi-razlicak-caj/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
               "value": "bing"
             },
             {
@@ -12799,656 +2722,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "10"
             },
             {
-              "value": "1"
+              "value": "8"
             },
             {
-              "value": "1"
+              "value": "10"
             },
             {
-              "value": "0"
+              "value": "6"
             },
             {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.se/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/5-recepata-i-najvaznije-o-avokadu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "98"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/5-recepata-i-najvaznije-o-avokadu/?relatedposts_hit=1&relatedposts_origin=1905&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "103"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "79"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ezme-turski-pikantni-sos/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kasa-od-prosa-sa-mljevenim-orasima-cimetom-i-svjezim-vocem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/meksicka-hrana-brz-i-zdrav-rucak/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pita-od-visanja/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
+              "value": "204"
             }
           ]
         },
@@ -13471,26 +2761,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/varivo-sa-mahunama-i-krompirom-bez-mesa/?fbclid=IwAR3u2fnDKFUXKAKqpfZLky9uvr6Q23MImh_gWyAr4C4tXhjbftA5I-vgTG4_aem_AUuGgEw3Mmjhz9-B83qQBCBW6s2nOwY8cbxOb4NdsW0kK_vQaHYP_dm5RDqcjg49UD4"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "5"
             },
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "0"
+              "value": "2"
             },
             {
-              "value": "17"
+              "value": "21"
             }
           ]
         },
@@ -13513,9 +2800,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://nl.pinterest.com/"
             }
           ],
           "metricValues": [
@@ -13533,174 +2817,6 @@
             },
             {
               "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/pin/616641373977729316/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240121"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/pin/452189618844487049"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -13723,26 +2839,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "235"
+              "value": "292"
             },
             {
-              "value": "172"
+              "value": "176"
             },
             {
-              "value": "177"
+              "value": "183"
             },
             {
-              "value": "77"
+              "value": "79"
             },
             {
-              "value": "4552"
+              "value": "5692"
             }
           ]
         },
@@ -13765,14 +2878,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "19"
+              "value": "44"
             },
             {
               "value": "1"
@@ -13784,7 +2894,7 @@
               "value": "0"
             },
             {
-              "value": "145"
+              "value": "571"
             }
           ]
         },
@@ -13807,26 +2917,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
+            {
+              "value": "33"
+            },
+            {
+              "value": "25"
+            },
+            {
+              "value": "27"
+            },
             {
               "value": "17"
             },
             {
-              "value": "14"
-            },
-            {
-              "value": "16"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "121"
+              "value": "490"
             }
           ]
         },
@@ -13836,963 +2943,36 @@
               "value": "20240120"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.pinterest/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
-            {
-              "value": "15"
-            },
             {
               "value": "10"
             },
             {
-              "value": "10"
+              "value": "8"
+            },
+            {
+              "value": "8"
             },
             {
               "value": "3"
             },
             {
-              "value": "368"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "11"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "51"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://m.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "458"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "62"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/skandinavci-obozavaju-jedan-mali-ormar-zasto-ga-ikea-ne-zeli-vise-prodavati/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "67"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "92"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ezme-turski-pikantni-sos/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolac-bez-secera-bez-brasna-bez-maslaca-bez/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "39"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/americki-kukuruzni-kruh/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "82"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?fbclid=IwAR1T6yaMZuxRGz6QQJn0IrhfbukcK90kZJudBmIBAxHypYXShhe1vXdpUyI"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Dal"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "126"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lucia-peciva-sa-safranom/?fbclid=IwAR1Oc7m6VuwOfAGzleF9bAiSL9lBEDqqEWuOcIqM0-p1WDffbNeD9l7oc1s"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-chili-sin-carne/?fbclid=IwAR3qbK_3XH2gBQQt3KvfsSwZVm4hHYgiOeMCL4AYXsqy7zj2P_L27ou9f7A"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "122"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/pin/827043919071016035/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "68"
             }
           ]
         },
@@ -14815,9 +2995,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -14835,552 +3012,6 @@
             },
             {
               "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "79"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/5-lijepih-vitrina/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "60"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/basta-zivota-dvorca-egeskov-danska/?relatedposts_hit=1&relatedposts_origin=3372&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/djumbir-limun-shot/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/miris-kafe-u-parfumeriji/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/novi-zacin-u-mojoj-kuhinji-makedonska-biena-sol/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "67"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "31"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-stvari-po-kojima-je-danska-poznata-u-svijetu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-ljetna-povrtna-supa/?relatedposts_hit=1&relatedposts_origin=25420&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/praznicni-kolac-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/tajlandska-supa-tom-yum-na-vegeterijanski-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://l.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
-              "value": "lm.facebook.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?fbclid=IwAR0F_mvU6Q6QcfBC7MYnlPFentp2Y8ZGuwJkA_GMXCdqsP7Czy2OQdhJLgM"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "75"
             }
           ]
         },
@@ -15403,9 +3034,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -15445,9 +3073,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.ca/"
             }
           ],
           "metricValues": [
@@ -15474,48 +3099,6 @@
               "value": "20240120"
             },
             {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240120"
-            },
-            {
               "value": "pinterest.de"
             },
             {
@@ -15529,9 +3112,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -15571,14 +3151,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://kuhinjskeprice.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "5046"
+              "value": "5220"
             },
             {
               "value": "165"
@@ -15590,7 +3167,7 @@
               "value": "0"
             },
             {
-              "value": "83469"
+              "value": "92166"
             }
           ]
         },
@@ -15613,68 +3190,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "207"
+              "value": "249"
             },
-            {
-              "value": "166"
-            },
-            {
-              "value": "172"
-            },
-            {
-              "value": "77"
-            },
-            {
-              "value": "4288"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://urlumbrella.com/site/kuhinjskeprice.com"
-            }
-          ],
-          "metricValues": [
             {
               "value": "174"
             },
             {
-              "value": "165"
+              "value": "182"
             },
             {
-              "value": "0"
+              "value": "82"
             },
             {
-              "value": "0"
-            },
-            {
-              "value": "8697"
+              "value": "4929"
             }
           ]
         },
@@ -15697,9 +3229,45 @@
             },
             {
               "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "60"
             },
             {
-              "value": ""
+              "value": "27"
+            },
+            {
+              "value": "30"
+            },
+            {
+              "value": "11"
+            },
+            {
+              "value": "852"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240119"
+            },
+            {
+              "value": "pinterest.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
             }
           ],
           "metricValues": [
@@ -15707,100 +3275,16 @@
               "value": "29"
             },
             {
-              "value": "16"
+              "value": "7"
             },
             {
-              "value": "18"
+              "value": "7"
             },
             {
-              "value": "9"
+              "value": "3"
             },
             {
-              "value": "275"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "15"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "429"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
+              "value": "323"
             }
           ]
         },
@@ -15823,9 +3307,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -15852,804 +3333,6 @@
               "value": "20240119"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "54"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brownies-sa-bijelom-cokoladom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "106"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/crisp-bread-domaci-hrskavi-kruh/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/najbolje-i-najbrze-kiflice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "79"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kruh-kamenog-doba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/pin/14847873763228358/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peciva-bez-brasna-kvasca-soli-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "48"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peciva-bez-brasna-kvasca-soli-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "45"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
               "value": "duckduckgo"
             },
             {
@@ -16663,9 +3346,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://duckduckgo.com/"
             }
           ],
           "metricValues": [
@@ -16683,678 +3363,6 @@
             },
             {
               "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "70"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Kljukusa+s+jogurtom+i+bijelim+lukom"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "65"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brzi-ustipci-sa-tikvicama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cannelloni-sa-spinatom-i-ricotta-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/danske-malina-snite/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/digestive-keks-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "81"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanski-durum-kruh-pan-pugliese/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-da-stari-kruh-pretvoris-u-ukusan-obrok/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "37"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/nutritivni-kvasac-kako-i-zasto/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/poslovi-vezani-za-bastu-koje-mozes-raditi-zimi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/provola/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sicilijanski-suvenir-pigna/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
             }
           ]
         },
@@ -17377,9 +3385,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.hitree.shop/"
             }
           ],
           "metricValues": [
@@ -17419,9 +3424,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -17439,48 +3441,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240119"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "40"
             }
           ]
         },
@@ -17503,9 +3463,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.se/"
             }
           ],
           "metricValues": [
@@ -17545,26 +3502,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "162"
+              "value": "218"
             },
             {
-              "value": "135"
+              "value": "137"
             },
             {
-              "value": "141"
+              "value": "145"
             },
             {
-              "value": "65"
+              "value": "68"
             },
             {
-              "value": "3716"
+              "value": "4590"
             }
           ]
         },
@@ -17587,194 +3541,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "20"
+              "value": "48"
             },
             {
-              "value": "12"
+              "value": "30"
             },
             {
-              "value": "12"
+              "value": "30"
             },
-            {
-              "value": "3"
-            },
-            {
-              "value": "139"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "14"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "118"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
             {
               "value": "13"
             },
             {
-              "value": "12"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "109"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "263"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "35"
+              "value": "756"
             }
           ]
         },
@@ -17797,14 +3580,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
+              "value": "5"
             },
             {
               "value": "4"
@@ -17816,49 +3596,7 @@
               "value": "1"
             },
             {
-              "value": "83"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/indijski-zacin-na-francuski-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
+              "value": "160"
             }
           ]
         },
@@ -17881,362 +3619,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "3"
+              "value": "5"
+            },
+            {
+              "value": "5"
+            },
+            {
+              "value": "5"
             },
             {
               "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
             },
             {
               "value": "41"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "72"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "28"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/162/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pau-bhai-indijski-pire-krompir/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "137"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
             }
           ]
         },
@@ -18259,9 +3658,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
             }
           ],
           "metricValues": [
@@ -18288,13 +3684,10 @@
               "value": "20240118"
             },
             {
-              "value": "(direct)"
+              "value": "(not set)"
             },
             {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
+              "value": "(not set)"
             },
             {
               "value": "(not set)"
@@ -18303,53 +3696,14 @@
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
             {
               "value": "0"
             },
             {
-              "value": "155"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
               "value": "1"
             },
             {
@@ -18357,261 +3711,6 @@
             },
             {
               "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrave-kuglice-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "77"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.co.uk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "40"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dahl-brzo-i-ukusno-indijsko-jelo-sa-crvenom-lecom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
             },
             {
               "value": "6"
@@ -18621,7 +3720,7 @@
         {
           "dimensionValues": [
             {
-              "value": "20240118"
+              "value": "20240117"
             },
             {
               "value": "google"
@@ -18637,663 +3736,69 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dobrodosli-u-moju-kuhinju/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "208"
             },
             {
-              "value": "1"
+              "value": "154"
             },
             {
-              "value": "1"
+              "value": "161"
             },
             {
-              "value": "0"
+              "value": "62"
             },
             {
-              "value": "17"
+              "value": "5575"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240118"
+              "value": "20240117"
             },
             {
-              "value": "google"
+              "value": "(direct)"
             },
             {
-              "value": "organic"
+              "value": "(none)"
             },
             {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(direct)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "https://www.kuhinjskeprice.com/italijanski-topli-sendvic-mozzarella-in-carrozza/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-kuhati-na-pari/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-lako-ocistiti-mrlje-od-caja-na-soljama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-lako-pripremiti-articoke/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/mercado-central-de-atarazanas-market-hrane-malaga/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pau-bhai-indijski-pire-krompir/?relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pau-bhai-indijski-pire-krompir/?relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pecena-zuta-repa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/shantaram/?relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=1&relatedposts_hit=1&relatedposts_origin=17781&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sicilijanski-suvenir-pigna/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/vitastiq-olovka-koja-mjeri-vitamine-u-tijelu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdraviji-nacin-bojenja-kose/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "219"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
+              "value": "47"
             },
             {
               "value": "35"
+            },
+            {
+              "value": "39"
+            },
+            {
+              "value": "25"
+            },
+            {
+              "value": "876"
             }
           ]
         },
         {
           "dimensionValues": [
             {
-              "value": "20240118"
+              "value": "20240117"
             },
             {
               "value": "pinterest.com"
@@ -19309,219 +3814,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240118"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "169"
-            },
-            {
-              "value": "145"
-            },
-            {
-              "value": "152"
-            },
-            {
-              "value": "60"
-            },
-            {
-              "value": "4585"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "32"
-            },
-            {
-              "value": "27"
-            },
-            {
-              "value": "31"
-            },
-            {
-              "value": "24"
-            },
-            {
-              "value": "312"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
             }
           ],
           "metricValues": [
@@ -19529,139 +3821,13 @@
               "value": "10"
             },
             {
-              "value": "1"
+              "value": "10"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "29"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
+              "value": "10"
             },
             {
               "value": "7"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "312"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "300"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "2"
             },
             {
               "value": "227"
@@ -19687,9 +3853,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -19716,888 +3879,6 @@
               "value": "20240117"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "102"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/digestive-keks-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pire-od-krompira-na-5-nacina/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "74"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "216"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/hrskavi-keksici-od-zobenih-pahuljica-bez-secera/?relatedposts_hit=1&relatedposts_origin=18921&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=18921&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "187"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-kuhati-na-pari/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kiflice-bez-secera/?relatedposts_hit=1&relatedposts_origin=18921&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kiflice-bez-secera/?relatedposts_hit=1&relatedposts_origin=18921&relatedposts_position=1&relatedposts_hit=1&relatedposts_origin=18921&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/da-li-su-susene-marelice-zdrave/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ezme-turski-pikantni-sos/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/idli-dorucak-na-indijski-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "49"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jelovnik-bez-mesa-za-7-dana/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "51"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolaci-i-peciva-bez-brasna-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-na-milion-nacina-rosti/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/namaz-od-suvih-smokava/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-jela-od-krompira/?relatedposts_hit=1&relatedposts_origin=2686&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "98"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
               "value": "l.facebook.com"
             },
             {
@@ -20611,51 +3892,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://l.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240117"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com"
             }
           ],
           "metricValues": [
@@ -20695,9 +3931,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.thursdaycooking.com.hr/"
             }
           ],
           "metricValues": [
@@ -20737,26 +3970,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "203"
+              "value": "238"
             },
             {
-              "value": "168"
+              "value": "174"
             },
             {
-              "value": "171"
+              "value": "177"
             },
             {
-              "value": "58"
+              "value": "61"
             },
             {
-              "value": "7542"
+              "value": "8231"
             }
           ]
         },
@@ -20779,194 +4009,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "13"
+              "value": "26"
             },
             {
-              "value": "9"
+              "value": "16"
             },
             {
-              "value": "9"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "604"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "8"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "7"
+              "value": "16"
             },
             {
               "value": "3"
             },
             {
-              "value": "134"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "142"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "241"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "126"
+              "value": "831"
             }
           ]
         },
@@ -20989,26 +4048,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "5"
+              "value": "7"
             },
             {
-              "value": "2"
+              "value": "4"
             },
             {
-              "value": "2"
+              "value": "4"
             },
             {
-              "value": "0"
+              "value": "1"
             },
             {
-              "value": "0"
+              "value": "54"
             }
           ]
         },
@@ -21018,49 +4074,7 @@
               "value": "20240116"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peceni-poriluk-prasa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
+              "value": "bing"
             },
             {
               "value": "organic"
@@ -21073,152 +4087,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "6"
             },
             {
-              "value": "2"
+              "value": "4"
             },
             {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavni-keksici-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "4"
             },
             {
               "value": "0"
             },
             {
-              "value": "83"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-pohovani-tofu-stapici/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "78"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-povrce-peceno-u-rerni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
+              "value": "246"
             }
           ]
         },
@@ -21241,9 +4126,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.at/"
             }
           ],
           "metricValues": [
@@ -21270,846 +4152,6 @@
               "value": "20240116"
             },
             {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "54"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "38"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Poriluk"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.fr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/5-detalja-ove-sedmice-2/?relatedposts_hit=1&relatedposts_origin=13891&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cronut-kolac-koji-je-zaludio-svijet/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanski-durum-kruh-pan-pugliese/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jelovnik-bez-mesa-za-7-dana/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolacici-peceni-u-tavi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-sa-timijanom/?relatedposts_hit=1&relatedposts_origin=31617&relatedposts_position=0&relatedposts_hit=1&relatedposts_origin=31617&relatedposts_position=0&relatedposts_hit=1&relatedposts_origin=31617&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "28"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-sa-vrhnjem-za-kuhanje/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "39"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/neke-vrste-vrecica-ostavljaju-mikroplastiku-u-nasoj-solji-caja/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240116"
-            },
-            {
               "value": "mojaslatkakuhinja.wordpress.com"
             },
             {
@@ -22123,9 +4165,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
             }
           ],
           "metricValues": [
@@ -22149,48 +4188,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240116"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-poslastica-grilovani-marshmallows/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240115"
             },
             {
@@ -22207,26 +4204,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "240"
+              "value": "274"
             },
             {
-              "value": "212"
+              "value": "223"
             },
             {
-              "value": "225"
+              "value": "235"
             },
             {
-              "value": "69"
+              "value": "72"
             },
             {
-              "value": "9180"
+              "value": "11002"
             }
           ]
         },
@@ -22249,152 +4243,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "18"
+              "value": "31"
             },
             {
-              "value": "15"
+              "value": "26"
             },
             {
-              "value": "17"
+              "value": "28"
             },
             {
-              "value": "11"
+              "value": "12"
             },
             {
-              "value": "414"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "11"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "590"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "129"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sedam-jela-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "130"
+              "value": "1126"
             }
           ]
         },
@@ -22417,9 +4282,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -22446,804 +4308,6 @@
               "value": "20240115"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "85"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "116"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "436"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "93"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "83"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.no/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-ideja-za-rucak-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-poslastica-grilovani-marshmallows/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/palacinke-na-slatki-i-slani-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-povrce-peceno-u-rerni/?relatedposts_hit=1&relatedposts_origin=31731&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sarena-pizza-od-polente/?relatedposts_hit=1&relatedposts_origin=17260&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=17260&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sedam-jela-bez-mesa/?relatedposts_hit=1&relatedposts_origin=31731&relatedposts_position=0&relatedposts_hit=1&relatedposts_origin=31731&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/torta-sa-vrucom-vodom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "687"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
               "value": "pinterest.com"
             },
             {
@@ -23257,107 +4321,20 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240115"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "2"
             },
             {
               "value": "0"
@@ -23383,26 +4360,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "199"
+              "value": "236"
             },
             {
-              "value": "181"
+              "value": "190"
             },
             {
-              "value": "191"
+              "value": "202"
             },
             {
-              "value": "57"
+              "value": "63"
             },
             {
-              "value": "6752"
+              "value": "7933"
             }
           ]
         },
@@ -23425,68 +4399,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "26"
+              "value": "47"
             },
             {
-              "value": "23"
+              "value": "37"
             },
             {
-              "value": "25"
+              "value": "39"
             },
             {
-              "value": "13"
+              "value": "15"
             },
             {
-              "value": "800"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "14"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1268"
+              "value": "2445"
             }
           ]
         },
@@ -23509,14 +4438,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "6"
+              "value": "9"
             },
             {
               "value": "6"
@@ -23528,91 +4454,7 @@
               "value": "1"
             },
             {
-              "value": "210"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "83"
+              "value": "545"
             }
           ]
         },
@@ -23635,488 +4477,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
+              "value": "7"
             },
             {
-              "value": "4"
+              "value": "7"
             },
             {
-              "value": "4"
+              "value": "7"
             },
             {
-              "value": "2"
+              "value": "5"
             },
             {
               "value": "70"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "69"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/rusticni-kruh-sa-zobenim-mekinjama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "314"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "63"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pire-od-krompira-na-5-nacina/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-ideja-za-rucak-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cevapi-bez-mesa/?relatedposts_hit=1&relatedposts_origin=10193&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "148"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanski-durum-kruh-pan-pugliese/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "172"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/limunova-trava/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "2"
             }
           ]
         },
@@ -24139,9 +4516,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -24159,132 +4533,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "136"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/projice-sa-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "175"
             }
           ]
         },
@@ -24307,9 +4555,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://duckduckgo.com/"
             }
           ],
           "metricValues": [
@@ -24327,804 +4572,6 @@
             },
             {
               "value": "71"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "55"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/chokoladeboller-danska-peciva-sa-cokoladom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/danski-razeni-kruh/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "69"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dorucak-sa-zobenim-mekinjama-i-vocem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kasa-od-prosa-sa-mljevenim-orasima-cimetom-i-svjezim-vocem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kuglice-sa-zobenim-mekinjama-i-kokosom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/mini-palacinke-od-zobenih-mekinja-sa-vocem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "47"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/najlaksi-nacin-da-zavolis-heljdu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peciva-sa-semolina-brasnom-i-zobenim-pahuljicama-zamijesis-uvece-peces-ujutro/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "72"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/proteinska-skyr-peciva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/rusticni-kruh-sa-zobenim-mekinjama/?relatedposts_hit=1&relatedposts_origin=16966&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "49"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sipak-u-prahu-baklava-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "50"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrave-kuglice-bez-secera/?relatedposts_hit=1&relatedposts_origin=18378&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "178"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240114"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -25147,9 +4594,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.it/"
             }
           ],
           "metricValues": [
@@ -25189,26 +4633,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "203"
+              "value": "241"
             },
             {
-              "value": "187"
+              "value": "196"
             },
             {
-              "value": "197"
+              "value": "209"
             },
             {
-              "value": "66"
+              "value": "71"
             },
             {
-              "value": "7420"
+              "value": "8947"
             }
           ]
         },
@@ -25231,152 +4672,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "13"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "226"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "443"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "10"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "130"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "3"
+              "value": "26"
             },
             {
               "value": "26"
+            },
+            {
+              "value": "26"
+            },
+            {
+              "value": "15"
+            },
+            {
+              "value": "1055"
             }
           ]
         },
@@ -25399,9 +4711,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -25419,132 +4728,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-stvari-po-kojima-je-danska-poznata-u-svijetu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "37"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/tjestenina-sa-ricotta-sirom-i-tikvicama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
             }
           ]
         },
@@ -25567,152 +4750,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
+              "value": "3"
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "321"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sicilijanski-suvenir-pigna/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "65"
             }
           ]
         },
@@ -25735,9 +4789,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://alohafind.com/search/?q=topli+sendvic&gl=RS"
             }
           ],
           "metricValues": [
@@ -25777,9 +4828,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -25806,720 +4854,6 @@
               "value": "20240113"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com.au/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/url?esrc=s&q=&rct=j&sa=U&url=https://www.kuhinjskeprice.com/kako-kuhati-na-pari/&ved=2ahUKEwiQrI2V59qDAxU5i_0HHV6dDhoQFnoECAQQAg&usg=AOvVaw0ChSFFr6aHHk1HyI1S7LZ-"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "37"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "110"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ie/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "38"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/6-ukusnih-poslastica-sa-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "65"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/caj-od-ruze/?relatedposts_hit=1&relatedposts_origin=28512&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "51"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/caj-vjecni-zivot/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dorucak-sa-proteinom-graska/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kukuruzna-ljevusa-sa-mascarpone-sirom/?relatedposts_hit=1&relatedposts_origin=19887&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=19887&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=19887&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "98"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pecenje-u-vrhnju-za-kuhanje-na-danski-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/plavi-razlicak-caj/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "71"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/polenta-tortice-sa-salsom-i-kozjim-sirem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/salata-od-slanutka-i-brokula/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "570"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240113"
-            },
-            {
               "value": "pinterest.de"
             },
             {
@@ -26533,9 +4867,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -26559,48 +4890,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240113"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jedemo-li-wasabi-ili-kopiju/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "112"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240112"
             },
             {
@@ -26617,26 +4906,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "178"
+              "value": "212"
             },
             {
-              "value": "163"
+              "value": "170"
             },
             {
-              "value": "171"
+              "value": "179"
             },
             {
-              "value": "50"
+              "value": "54"
             },
             {
-              "value": "7176"
+              "value": "8401"
             }
           ]
         },
@@ -26659,26 +4945,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "21"
+              "value": "38"
             },
             {
-              "value": "18"
+              "value": "31"
             },
             {
-              "value": "18"
+              "value": "31"
             },
             {
-              "value": "10"
+              "value": "12"
             },
             {
-              "value": "475"
+              "value": "1634"
             }
           ]
         },
@@ -26688,123 +4971,36 @@
               "value": "20240112"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.pinterest/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "13"
+              "value": "7"
             },
             {
-              "value": "13"
+              "value": "7"
             },
             {
-              "value": "13"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "989"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "5"
+              "value": "7"
             },
             {
               "value": "6"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "94"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "172"
+              "value": "36"
             }
           ]
         },
@@ -26827,320 +5023,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
+              "value": "5"
+            },
+            {
               "value": "4"
+            },
+            {
+              "value": "5"
             },
             {
               "value": "3"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
             },
             {
               "value": "42"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "63"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "51"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "75"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/6-ukusnih-poslastica-sa-sirom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "54"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/korpe-za-ves-sa-stilom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "254"
             }
           ]
         },
@@ -27163,9 +5062,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -27192,216 +5088,6 @@
               "value": "20240112"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/film-koji-svakako-treba-pogledati-the-lunchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavno-jelo-od-zelene-lece/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "102"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zanemarene-namirnice-leca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "68"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
               "value": "duckduckgo"
             },
             {
@@ -27415,9 +5101,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://duckduckgo.com/"
             }
           ],
           "metricValues": [
@@ -27441,468 +5124,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "87"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/3-poznata-recepta-u-vegeterijanskoj-verziji/?relatedposts_hit=1&relatedposts_origin=9422&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "124"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/korpe-za-ves-sa-stilom/?relatedposts_hit=1&relatedposts_origin=31739&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/liker-od-tresanja/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/orascici-za-pranje-rublja/?relatedposts_hit=1&relatedposts_origin=27319&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/prodavacica-sayaka-murata/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sarma-sa-orasima-2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sedam-jela-bez-mesa/?relatedposts_hit=1&relatedposts_origin=31731&relatedposts_position=0&relatedposts_hit=1&relatedposts_origin=31731&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240112"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/trznica-na-campo-dei-fiori-trgu-u-rimu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "82"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240111"
             },
             {
@@ -27919,26 +5140,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "153"
+              "value": "181"
             },
             {
-              "value": "140"
+              "value": "147"
             },
             {
-              "value": "145"
+              "value": "152"
             },
             {
-              "value": "46"
+              "value": "48"
             },
             {
-              "value": "5337"
+              "value": "6321"
             }
           ]
         },
@@ -27961,26 +5179,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "17"
+              "value": "37"
             },
             {
-              "value": "13"
+              "value": "25"
             },
             {
-              "value": "16"
+              "value": "28"
             },
             {
-              "value": "9"
+              "value": "10"
             },
             {
-              "value": "533"
+              "value": "1606"
             }
           ]
         },
@@ -27990,81 +5205,36 @@
               "value": "20240111"
             },
             {
-              "value": "(direct)"
+              "value": "mojaslatkakuhinja.wordpress.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.pinterest/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "12"
+              "value": "8"
             },
             {
-              "value": "11"
+              "value": "2"
             },
             {
-              "value": "11"
+              "value": "2"
             },
             {
-              "value": "0"
+              "value": "1"
             },
             {
-              "value": "525"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "393"
+              "value": "71"
             }
           ]
         },
@@ -28087,9 +5257,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -28107,300 +5274,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "77"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "39"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-couscous-sa-grilanim-tikvicama-i-susenim-paradajzom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "122"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "40"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "58"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
             }
           ]
         },
@@ -28423,278 +5296,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "2"
+              "value": "3"
             },
             {
-              "value": "0"
+              "value": "1"
             },
             {
               "value": "96"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kajgana-sa-sirom-i-bez-jaja-i-bez-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kako-napraviti-posirano-jaje/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/nutritivni-kvasac-kako-i-zasto/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "103"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pecena-zuta-repa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "85"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-couscous-sa-grilanim-tikvicama-i-susenim-paradajzom/?relatedposts_hit=1&relatedposts_origin=15507&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "232"
             }
           ]
         },
@@ -28717,9 +5335,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -28746,594 +5361,6 @@
               "value": "20240111"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "159"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/boje-u-kuhinji/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "62"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "48"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/plavi-zmijanjski-vez/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sedam-jela-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/o-meni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240111"
-            },
-            {
               "value": "pinterest.de"
             },
             {
@@ -29347,9 +5374,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -29389,9 +5413,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.thursdaycooking.com.hr/"
             }
           ],
           "metricValues": [
@@ -29431,26 +5452,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "146"
+              "value": "175"
             },
             {
-              "value": "133"
+              "value": "143"
             },
             {
-              "value": "140"
+              "value": "152"
             },
             {
-              "value": "36"
+              "value": "38"
             },
             {
-              "value": "4967"
+              "value": "6286"
             }
           ]
         },
@@ -29473,194 +5491,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "19"
+              "value": "41"
+            },
+            {
+              "value": "32"
+            },
+            {
+              "value": "35"
             },
             {
               "value": "16"
             },
             {
-              "value": "19"
-            },
-            {
-              "value": "13"
-            },
-            {
-              "value": "270"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "15"
-            },
-            {
-              "value": "15"
-            },
-            {
-              "value": "15"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "938"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "263"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "333"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "77"
+              "value": "1458"
             }
           ]
         },
@@ -29683,68 +5530,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
+              "value": "10"
+            },
+            {
+              "value": "7"
+            },
+            {
+              "value": "7"
             },
             {
               "value": "3"
             },
             {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "80"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jelovnik-bez-mesa-za-7-dana/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
+              "value": "103"
             }
           ]
         },
@@ -29767,26 +5569,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
             }
           ],
           "metricValues": [
             {
+              "value": "9"
+            },
+            {
               "value": "3"
             },
             {
-              "value": "1"
+              "value": "4"
             },
             {
-              "value": "1"
+              "value": "2"
             },
             {
-              "value": "0"
-            },
-            {
-              "value": "282"
+              "value": "473"
             }
           ]
         },
@@ -29809,14 +5608,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://de.search.yahoo.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "3"
+              "value": "5"
             },
             {
               "value": "1"
@@ -29828,217 +5624,7 @@
               "value": "0"
             },
             {
-              "value": "515"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "138"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "128"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrave-grickalice-suseni-dudovi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
+              "value": "663"
             }
           ]
         },
@@ -30061,9 +5647,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -30090,300 +5673,6 @@
               "value": "20240110"
             },
             {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-ideja-za-rucak-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "114"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "de.search.yahoo.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "76"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "de.search.yahoo.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "72"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
               "value": "gagasrce.blogspot.com"
             },
             {
@@ -30397,9 +5686,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://gagasrce.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -30417,342 +5703,6 @@
             },
             {
               "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "78"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.nl/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "89"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "142"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.se/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "111"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/karamelizirani-bademi/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "63"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-povrce-peceno-u-rerni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sirnica-sa-danskim-sirom-i-sampinjonima/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
             }
           ]
         },
@@ -30775,9 +5725,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.petalsearch.com/"
             }
           ],
           "metricValues": [
@@ -30795,90 +5742,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240110"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/pin/341007003047077892/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
             }
           ]
         },
@@ -30901,26 +5764,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "169"
+              "value": "209"
             },
             {
-              "value": "151"
+              "value": "156"
             },
             {
-              "value": "157"
+              "value": "163"
             },
             {
-              "value": "42"
+              "value": "45"
             },
             {
-              "value": "7197"
+              "value": "8820"
             }
           ]
         },
@@ -30943,68 +5803,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "18"
+              "value": "41"
             },
             {
-              "value": "17"
+              "value": "33"
             },
             {
-              "value": "19"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "895"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "16"
+              "value": "36"
             },
             {
               "value": "14"
             },
             {
-              "value": "15"
-            },
-            {
-              "value": "9"
-            },
-            {
-              "value": "292"
+              "value": "1354"
             }
           ]
         },
@@ -31014,39 +5829,36 @@
               "value": "20240109"
             },
             {
-              "value": "google"
+              "value": "kadjakuvam.blogspot.com"
             },
             {
-              "value": "organic"
+              "value": "referral"
             },
             {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "7"
+              "value": "26"
             },
             {
-              "value": "4"
+              "value": "1"
             },
             {
-              "value": "4"
+              "value": "3"
             },
             {
               "value": "0"
             },
             {
-              "value": "354"
+              "value": "861"
             }
           ]
         },
@@ -31056,7 +5868,7 @@
               "value": "20240109"
             },
             {
-              "value": "google"
+              "value": "bing"
             },
             {
               "value": "organic"
@@ -31069,9 +5881,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
             }
           ],
           "metricValues": [
@@ -31079,132 +5888,6 @@
               "value": "6"
             },
             {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "192"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jelovnik-bez-mesa-za-7-dana/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "229"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "152"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
               "value": "3"
             },
             {
@@ -31214,343 +5897,7 @@
               "value": "0"
             },
             {
-              "value": "228"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "60"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "73"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "219"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "92"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "233"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lupini-salata/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "48"
+              "value": "447"
             }
           ]
         },
@@ -31573,152 +5920,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "5"
             },
             {
-              "value": "2"
+              "value": "5"
             },
             {
-              "value": "2"
+              "value": "5"
             },
             {
-              "value": "1"
+              "value": "3"
             },
             {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/krompir-sa-vrhnjem-za-kuhanje/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
+              "value": "36"
             }
           ]
         },
@@ -31741,9 +5959,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -31761,1350 +5976,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-vocna-salata/?relatedposts_hit=1&relatedposts_origin=30103&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "37"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dorucak-sa-proteinom-graska/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "12"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavno-jelo-od-zelene-lece/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "87"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/koju-salatu-da-pravim-danas/?relatedposts_hit=1&relatedposts_origin=30103&relatedposts_position=1&relatedposts_hit=1&relatedposts_origin=30103&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "42"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lupini-salata/?relatedposts_hit=1&relatedposts_origin=889&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pau-bhai-indijski-pire-krompir/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "101"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-stvari-po-kojima-je-danska-poznata-u-svijetu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/salata-od-mrkve-marinirane-sokom-od-narandze/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/slane-kiflice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zanemarene-namirnice-leca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "74"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://kadjakuvam.blogspot.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/10/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "50"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/11/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/12/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/13/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/14/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/15/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/16/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/17/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/18/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/19/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "43"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "69"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/20/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/21/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/4/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "76"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/5/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/6/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/7/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/8/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "37"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/9/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "28"
             }
           ]
         },
@@ -33127,9 +5998,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
             }
           ],
           "metricValues": [
@@ -33169,9 +6037,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.ch/"
             }
           ],
           "metricValues": [
@@ -33195,132 +6060,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240109"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240109"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240108"
             },
             {
@@ -33337,26 +6076,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "160"
+              "value": "188"
             },
             {
-              "value": "143"
+              "value": "154"
             },
             {
-              "value": "151"
+              "value": "165"
             },
             {
-              "value": "44"
+              "value": "52"
             },
             {
-              "value": "5605"
+              "value": "6359"
             }
           ]
         },
@@ -33379,26 +6115,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "19"
+              "value": "32"
             },
             {
-              "value": "14"
+              "value": "26"
             },
             {
-              "value": "16"
+              "value": "28"
             },
             {
-              "value": "8"
+              "value": "11"
             },
             {
-              "value": "507"
+              "value": "1262"
             }
           ]
         },
@@ -33408,81 +6141,36 @@
               "value": "20240108"
             },
             {
-              "value": "(direct)"
+              "value": "pinterest.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.pinterest/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
             {
-              "value": "12"
+              "value": "5"
             },
             {
-              "value": "11"
+              "value": "5"
             },
             {
-              "value": "11"
+              "value": "5"
             },
             {
               "value": "3"
             },
             {
-              "value": "682"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
+              "value": "64"
             }
           ]
         },
@@ -33505,9 +6193,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -33534,90 +6219,6 @@
               "value": "20240108"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "100"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
               "value": "bing"
             },
             {
@@ -33631,9 +6232,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -33673,9 +6271,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.ecosia.org/"
             }
           ],
           "metricValues": [
@@ -33702,846 +6297,6 @@
               "value": "20240108"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jelovnik-bez-mesa-za-7-dana/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "72"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zasto-japanci-nose-maske-na-ustima/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "73"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "143"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "28"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.dk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/3-ideje-za-zdrav-dorucak/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/aleppo-sapun/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "93"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/caj-od-crne-soje/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pecena-muskatna-tikva/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-topla-quinoa-salata/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "40"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "11"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/quinoa-ideja-za-fantastican-dorucak/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/stabljike-celera-i-waldorf-salata-na-novi-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240108"
-            },
-            {
               "value": "kuhinjica-mignone.blogspot.com"
             },
             {
@@ -34555,9 +6310,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://kuhinjica-mignone.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -34597,9 +6349,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.ch/"
             }
           ],
           "metricValues": [
@@ -34639,9 +6388,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://tr.pinterest.com/"
             }
           ],
           "metricValues": [
@@ -34681,26 +6427,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "179"
+              "value": "220"
             },
             {
-              "value": "155"
+              "value": "164"
             },
             {
-              "value": "165"
+              "value": "175"
             },
             {
-              "value": "52"
+              "value": "58"
             },
             {
-              "value": "7293"
+              "value": "8334"
             }
           ]
         },
@@ -34723,110 +6466,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "18"
+              "value": "37"
             },
             {
-              "value": "16"
+              "value": "30"
             },
             {
-              "value": "18"
+              "value": "33"
             },
             {
-              "value": "12"
+              "value": "15"
             },
             {
-              "value": "322"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "14"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "938"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "68"
+              "value": "1327"
             }
           ]
         },
@@ -34849,401 +6505,20 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "4"
+              "value": "8"
             },
             {
-              "value": "4"
+              "value": "8"
             },
             {
-              "value": "4"
+              "value": "8"
             },
             {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozicni-shopping/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "83"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "61"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "89"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/digestive-keks-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kiflice-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "125"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/salata-sa-heljdom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "71"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
+              "value": "7"
             },
             {
               "value": "55"
@@ -35256,132 +6531,6 @@
               "value": "20240107"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
               "value": "bing"
             },
             {
@@ -35395,14 +6544,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "7"
             },
             {
               "value": "1"
@@ -35414,1183 +6560,7 @@
               "value": "0"
             },
             {
-              "value": "66"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvene-torte/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "63"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozicni-poklon-na-mom-radnom-mjestu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "45"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pakovanje-poklona/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/umjetnost-pakovanja-poklona/?relatedposts_hit=1&relatedposts_origin=8369&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "41"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "172"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/9-poslastica-sa-vocem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Kod+Jovane"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Pri%C4%8De+iz+kuhinje+"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brzi-kolac-bez-brasna-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "75"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/islandska-nordjur-so/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "10"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jovanina-plazma-torta/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/10/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/11/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/12/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/13/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/4/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/5/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/6/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/7/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/8/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/9/?s=Riba"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
+              "value": "271"
             }
           ]
         },
@@ -36613,93 +6583,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://lm.facebook.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240107"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/"
             }
           ],
           "metricValues": [
@@ -36739,9 +6622,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com.au/"
             }
           ],
           "metricValues": [
@@ -36765,48 +6645,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240107"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240106"
             },
             {
@@ -36823,26 +6661,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "224"
+              "value": "259"
             },
             {
-              "value": "199"
+              "value": "216"
             },
             {
-              "value": "219"
+              "value": "240"
             },
             {
-              "value": "87"
+              "value": "102"
             },
             {
-              "value": "5930"
+              "value": "6671"
             }
           ]
         },
@@ -36865,152 +6700,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "16"
+              "value": "34"
             },
             {
-              "value": "16"
+              "value": "31"
             },
             {
-              "value": "16"
+              "value": "32"
             },
             {
-              "value": "10"
+              "value": "12"
             },
             {
-              "value": "346"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "16"
-            },
-            {
-              "value": "15"
-            },
-            {
-              "value": "16"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1193"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "98"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "6"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "5"
+              "value": "1637"
             }
           ]
         },
@@ -37033,68 +6739,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "3"
+              "value": "5"
             },
             {
-              "value": "3"
+              "value": "5"
             },
             {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
+              "value": "5"
             },
             {
               "value": "4"
             },
             {
-              "value": "3"
-            },
-            {
-              "value": "31"
+              "value": "45"
             }
           ]
         },
@@ -37104,7 +6765,7 @@
               "value": "20240106"
             },
             {
-              "value": "google"
+              "value": "bing"
             },
             {
               "value": "organic"
@@ -37117,9 +6778,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
             }
           ],
           "metricValues": [
@@ -37136,91 +6794,7 @@
               "value": "0"
             },
             {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-jela-od-krompira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "247"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrava-hrana-u-srcu-banja-luke/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "25"
+              "value": "28"
             }
           ]
         },
@@ -37243,9 +6817,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.es/"
             }
           ],
           "metricValues": [
@@ -37263,678 +6834,6 @@
             },
             {
               "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ezme-turski-pikantni-sos/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "89"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lychee-vocka-za-novogodisnju-trpezu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "bing"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "20"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.at/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.me/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "38"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "76"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/energetske-kuglice-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "24"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/mali-medni-poklopci/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sicilijanski-suvenir-pigna/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/soja-kofta-u-paradajz-sosu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zapeceni-pire-krompir-pippe-middleton/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "62"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zapeceni-pire-krompir/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "98"
             }
           ]
         },
@@ -37957,9 +6856,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://l.facebook.com/"
             }
           ],
           "metricValues": [
@@ -37983,90 +6879,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240106"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240106"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "45"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240105"
             },
             {
@@ -38083,26 +6895,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "183"
+              "value": "209"
             },
             {
-              "value": "165"
+              "value": "172"
             },
             {
-              "value": "171"
+              "value": "181"
             },
             {
-              "value": "52"
+              "value": "61"
             },
             {
-              "value": "6570"
+              "value": "7231"
             }
           ]
         },
@@ -38125,110 +6934,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "19"
+              "value": "40"
             },
             {
-              "value": "19"
+              "value": "36"
             },
             {
-              "value": "19"
+              "value": "36"
             },
             {
-              "value": "4"
+              "value": "13"
             },
             {
-              "value": "902"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "17"
-            },
-            {
-              "value": "14"
-            },
-            {
-              "value": "14"
-            },
-            {
-              "value": "7"
-            },
-            {
-              "value": "314"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "7"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "268"
+              "value": "1530"
             }
           ]
         },
@@ -38251,68 +6973,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "6"
+              "value": "12"
             },
             {
-              "value": "6"
+              "value": "11"
             },
             {
-              "value": "7"
+              "value": "13"
             },
             {
-              "value": "4"
+              "value": "9"
             },
             {
               "value": "146"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -38335,9 +7012,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -38364,216 +7038,6 @@
               "value": "20240105"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "80"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.nl/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolaci-i-peciva-bez-brasna-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "100"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolacici-bez-brasna-jaja-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "125"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
               "value": "mojaslatkakuhinja.wordpress.com"
             },
             {
@@ -38587,14 +7051,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "2"
+              "value": "3"
             },
             {
               "value": "1"
@@ -38606,7 +7067,7 @@
               "value": "0"
             },
             {
-              "value": "19"
+              "value": "49"
             }
           ]
         },
@@ -38629,9 +7090,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -38658,594 +7116,6 @@
               "value": "20240105"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "187"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kljukusa-sa-jogurtom-i-bijelim-lukom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "59"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-ideja-za-rucak-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanski-durum-kruh-pan-pugliese/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/najljepsi-izlog-kopenhagena/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peciva-bez-brasna-kvasca-soli-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/rucak-sa-pogledom-u-restoranu-kazamat-u-banja-luci/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sipak-u-prahu-baklava-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240105"
-            },
-            {
               "value": "nely-bluehortensia.blogspot.com"
             },
             {
@@ -39259,9 +7129,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://nely-bluehortensia.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -39285,48 +7152,6 @@
         {
           "dimensionValues": [
             {
-              "value": "20240105"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
               "value": "20240104"
             },
             {
@@ -39343,26 +7168,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "178"
+              "value": "221"
             },
             {
-              "value": "164"
+              "value": "174"
             },
             {
-              "value": "172"
+              "value": "184"
             },
             {
-              "value": "51"
+              "value": "54"
             },
             {
-              "value": "7149"
+              "value": "9029"
             }
           ]
         },
@@ -39385,68 +7207,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "15"
+              "value": "34"
+            },
+            {
+              "value": "31"
+            },
+            {
+              "value": "34"
             },
             {
               "value": "15"
             },
             {
-              "value": "15"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1696"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "14"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "15"
-            },
-            {
-              "value": "12"
-            },
-            {
-              "value": "14"
+              "value": "2370"
             }
           ]
         },
@@ -39469,23 +7246,20 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "6"
+              "value": "11"
             },
             {
-              "value": "5"
+              "value": "10"
             },
             {
-              "value": "5"
+              "value": "10"
             },
             {
-              "value": "2"
+              "value": "7"
             },
             {
               "value": "556"
@@ -39511,9 +7285,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -39531,132 +7302,6 @@
             },
             {
               "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "409"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "121"
             }
           ]
         },
@@ -39679,9 +7324,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -39708,1266 +7350,6 @@
               "value": "20240104"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "161"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "94"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "52"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sedam-jela-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "112"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/search?q=krompir+paprika%C5%A1+bez+mesa+sa+testom&sca_esv=595645066&sxsrf=AM9HkKkjlg7Xf6tJ-ZMuKlKc4OT_2Gr4Tg%3A1704367564795&ei=zJWWZfqVMIi0i-gP7NSWwA0&oq=krompir+paprika%C5%A1+bez+mesa+sa+tes&gs_lp=Egxnd3Mtd2l6LXNlcnAiIWtyb21waXIgcGFwcmlrYcWhIGJleiBtZXNhIHNhIHRlcyoCCAAyBxAhGAoYoAEyBxAhGAoYoAEyBxAhGAoYoAFI2jhQiwxYkiVwAXgBkAEAmAGmBKABuQ-qAQswLjIuMy4xLjAuMbgBAcgBAPgBAcICChAAGEcY1gQYsAPCAgYQABgWGB"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "15"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/dorucak-sa-zobenim-pahuljicama-za-sedam-dana-u-sedmici/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.googlequicksearchbox/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "513"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/energetske-kuglice-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "157"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ch/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com.au/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "70"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-zimska-supa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "7"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-zimska-supa/?relatedposts_hit=1&relatedposts_origin=3616&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cvrsti-sampon-novi-nacin-pranja-kose/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/italijanska-caprese-salata-na-drugaciji-nacin/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jednostavni-keksici-bez-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "74"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jela-bez-mesa-krompir-paprikas/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "27"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/noletove-super-pahuljice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "42"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/novi-trendovi-pranje-kose-bez-sampona/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "29"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "176"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/peciva-sa-semolina-brasnom-i-zobenim-pahuljicama-zamijesis-uvece-peces-ujutro/?relatedposts_hit=1&relatedposts_origin=23896&relatedposts_position=2&relatedposts_hit=1&relatedposts_origin=23896&relatedposts_position=2"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-povrce-peceno-u-rerni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "60"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/quinoa-ideja-za-fantastican-dorucak/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "157"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/shortbread-keksici-sa-maslacem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "77"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/sicilijanski-suvenir-pigna/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "3"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/supa-od-graska-sa-sampanjcem-2/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdraviji-nacin-bojenja-kose/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240104"
-            },
-            {
               "value": "m.facebook.com"
             },
             {
@@ -40981,9 +7363,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://m.facebook.com/"
             }
           ],
           "metricValues": [
@@ -41007,7 +7386,85 @@
         {
           "dimensionValues": [
             {
-              "value": "20240104"
+              "value": "20240103"
+            },
+            {
+              "value": "google"
+            },
+            {
+              "value": "organic"
+            },
+            {
+              "value": "(organic)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "228"
+            },
+            {
+              "value": "182"
+            },
+            {
+              "value": "192"
+            },
+            {
+              "value": "54"
+            },
+            {
+              "value": "8590"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240103"
+            },
+            {
+              "value": "(direct)"
+            },
+            {
+              "value": "(none)"
+            },
+            {
+              "value": "(direct)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "39"
+            },
+            {
+              "value": "37"
+            },
+            {
+              "value": "39"
+            },
+            {
+              "value": "20"
+            },
+            {
+              "value": "1576"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240103"
             },
             {
               "value": "pinterest.com"
@@ -41023,236 +7480,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "8"
             },
             {
-              "value": "1"
+              "value": "7"
             },
             {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "184"
-            },
-            {
-              "value": "171"
-            },
-            {
-              "value": "180"
-            },
-            {
-              "value": "48"
-            },
-            {
-              "value": "7170"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "22"
-            },
-            {
-              "value": "20"
-            },
-            {
-              "value": "22"
-            },
-            {
-              "value": "18"
-            },
-            {
-              "value": "93"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "17"
-            },
-            {
-              "value": "17"
-            },
-            {
-              "value": "17"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1483"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/7-supa-bez-mesa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "9"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "624"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "6"
+              "value": "7"
             },
             {
               "value": "4"
             },
             {
-              "value": "4"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
+              "value": "140"
             }
           ]
         },
@@ -41275,9 +7519,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -41304,930 +7545,6 @@
               "value": "20240103"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com.au/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "88"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "140"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.it/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "62"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-zimska-supa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/noletove-super-pahuljice/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.google.android.gm/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "32"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.ca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "146"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/search?client=ms-opera-mini&sca_esv=595327113&q=Zuto+kukuruzno+brasno+recepti&sa=X&ved=2ahUKEwjr1Yimj8GDAxXb9wIHHWWzDJ8Q1QJ6BAgAEAg"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/url?q=https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/&sa=U&ved=2ahUKEwiwwZSU0cGDAxWagP0HHdc5D_kQFnoECAcQAQ&usg=AOvVaw2n_D13O0tt8DgQVdl6Y8H5"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "86"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "39"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/5-namirnica-koje-uvijek-imam-u-frizideru/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "80"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/energetske-kuglice-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "8"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lasagne-sa-povrcem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/novi-trendovi-pranje-kose-bez-sampona/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "120"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pire-od-krompira-na-5-nacina/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "23"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pita-krompirusa-sa-susenim-vlascem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/polenta-tortice-sa-salsom-i-kozjim-sirem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
               "value": "kadjakuvam.blogspot.com"
             },
             {
@@ -42241,14 +7558,11 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://kadjakuvam.blogspot.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "1"
+              "value": "2"
             },
             {
               "value": "1"
@@ -42260,49 +7574,7 @@
               "value": "0"
             },
             {
-              "value": "9"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "kadjakuvam.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
+              "value": "31"
             }
           ]
         },
@@ -42325,9 +7597,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://kuhinjica-mignone.blogspot.com/"
             }
           ],
           "metricValues": [
@@ -42345,174 +7614,6 @@
             },
             {
               "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240103"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -42535,26 +7636,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "152"
+              "value": "171"
             },
             {
-              "value": "139"
+              "value": "150"
             },
             {
-              "value": "142"
+              "value": "154"
             },
             {
-              "value": "28"
+              "value": "32"
             },
             {
-              "value": "7543"
+              "value": "8448"
             }
           ]
         },
@@ -42577,26 +7675,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": ""
             }
           ],
           "metricValues": [
             {
-              "value": "21"
+              "value": "44"
             },
             {
-              "value": "17"
+              "value": "36"
             },
             {
-              "value": "20"
+              "value": "40"
             },
             {
-              "value": "14"
+              "value": "18"
             },
             {
-              "value": "264"
+              "value": "1356"
             }
           ]
         },
@@ -42606,39 +7701,114 @@
               "value": "20240102"
             },
             {
-              "value": "(direct)"
+              "value": "kuhinjica-mignone.blogspot.com"
             },
             {
-              "value": "(none)"
+              "value": "referral"
             },
             {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
+              "value": "(referral)"
             },
             {
               "value": "(not set)"
             },
             {
-              "value": "android-app://com.pinterest/"
+              "value": "(not set)"
             }
           ],
           "metricValues": [
-            {
-              "value": "21"
-            },
             {
               "value": "19"
             },
             {
-              "value": "20"
+              "value": "1"
             },
             {
-              "value": "4"
+              "value": "1"
             },
             {
-              "value": "1029"
+              "value": "0"
+            },
+            {
+              "value": "553"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240102"
+            },
+            {
+              "value": "mojaslatkakuhinja.wordpress.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "19"
+            },
+            {
+              "value": "1"
+            },
+            {
+              "value": "1"
+            },
+            {
+              "value": "0"
+            },
+            {
+              "value": "727"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "20240102"
+            },
+            {
+              "value": "pinterest.com"
+            },
+            {
+              "value": "referral"
+            },
+            {
+              "value": "(referral)"
+            },
+            {
+              "value": "(not set)"
+            },
+            {
+              "value": "(not set)"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "9"
+            },
+            {
+              "value": "8"
+            },
+            {
+              "value": "8"
+            },
+            {
+              "value": "6"
+            },
+            {
+              "value": "1"
             }
           ]
         },
@@ -42661,9 +7831,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -42690,678 +7857,6 @@
               "value": "20240102"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "5"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "140"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "229"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/3/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "36"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/4/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "109"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/6/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "135"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "181"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.de/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "208"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "16"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.se/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-poslastice-sa-jabukama/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "129"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/5/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "66"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "44"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/bozanstvena-bomba-torta-i-cestitika/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "19"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
               "value": "emea.search.yahoo.com"
             },
             {
@@ -43375,9 +7870,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://emea.search.yahoo.com/"
             }
           ],
           "metricValues": [
@@ -43404,1224 +7896,6 @@
               "value": "20240102"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://www.google.ba/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "81"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.dk/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "14"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.si/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "6"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/8-korisnih-savjeta-za-cuvanje-sira/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "13"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pet-stvari-po-kojima-je-danska-poznata-u-svijetu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "189"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/ponedjeljak-bez-mesa-pohovani-tofu-stapici/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "57"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://kuhinjica-mignone.blogspot.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "46"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-poslastice-sa-jabukama/?relatedposts_hit=1&relatedposts_origin=25165&relatedposts_position=0"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "41"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/africki-crni-sapun/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/africki-crni-sapun/?relatedposts_hit=1&relatedposts_origin=7857&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-zimska-supa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "40"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jesen-u-gradu-poslastice-s-jabukama-francuski-sapun/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/jesen-u-gradu-poslastice-s-jabukama-francuski-sapun/?relatedposts_hit=1&relatedposts_origin=27542&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "26"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/paradajz-supa/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/supa-od-crvene-lece/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/supa-od-crvene-lece/?relatedposts_hit=1&relatedposts_origin=12680&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "33"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/tvrdi-ili-tecni-sapuni/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/tvrdi-ili-tecni-sapuni/?relatedposts_hit=1&relatedposts_origin=17469&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "22"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zanemarene-namirnice-leca/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zanemarene-namirnice-leca/?relatedposts_hit=1&relatedposts_origin=8801&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "58"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrava-hrana-crne-boje/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zdrava-hrana-crne-boje/?relatedposts_hit=1&relatedposts_origin=16737&relatedposts_position=1"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "53"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "kuhinjica-mignone.blogspot.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/zimska-kremasta-supa-od-mrkve/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "72"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/cvrsti-sampon-novi-nacin-pranja-kose/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "92"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "mojaslatkakuhinja.wordpress.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/7/?wref=bif"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "30"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/pin/616641373977729316/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/pin/827043919071016035/?source_app=android"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/americki-kukuruzni-kruh/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240102"
-            },
-            {
               "value": "pinterest.de"
             },
             {
@@ -44635,9 +7909,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.de/"
             }
           ],
           "metricValues": [
@@ -44677,9 +7948,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.startraffic.online/"
             }
           ],
           "metricValues": [
@@ -44719,26 +7987,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "137"
+              "value": "159"
             },
             {
-              "value": "120"
+              "value": "129"
             },
             {
-              "value": "125"
+              "value": "134"
             },
             {
-              "value": "39"
+              "value": "42"
             },
             {
-              "value": "5364"
+              "value": "6225"
             }
           ]
         },
@@ -44761,110 +8026,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "android-app://com.pinterest/"
             }
           ],
           "metricValues": [
             {
-              "value": "20"
+              "value": "50"
             },
             {
-              "value": "20"
+              "value": "47"
             },
             {
-              "value": "20"
+              "value": "48"
             },
-            {
-              "value": "5"
-            },
-            {
-              "value": "1009"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
             {
               "value": "18"
             },
             {
-              "value": "16"
-            },
-            {
-              "value": "17"
-            },
-            {
-              "value": "11"
-            },
-            {
-              "value": "203"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "11"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "10"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "368"
+              "value": "1580"
             }
           ]
         },
@@ -44887,320 +8065,23 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://www.pinterest.com/"
             }
           ],
           "metricValues": [
             {
-              "value": "5"
+              "value": "11"
             },
             {
-              "value": "5"
+              "value": "11"
             },
             {
-              "value": "5"
+              "value": "11"
             },
             {
-              "value": "5"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "4"
-            },
-            {
-              "value": "2"
+              "value": "9"
             },
             {
               "value": "236"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": ""
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.hr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "161"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kolaci-i-peciva-bez-brasna-i-secera/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "3"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "216"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/page/33/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "35"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "pinterest.com"
-            },
-            {
-              "value": "referral"
-            },
-            {
-              "value": "(referral)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "http://pinterest.com/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "2"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(none)"
-            },
-            {
-              "value": "(direct)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/kladdkaka-jednostavni-svedski-kolac/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
             }
           ]
         },
@@ -45223,9 +8104,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://baidu.com/"
             }
           ],
           "metricValues": [
@@ -45265,9 +8143,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://www.bing.com/"
             }
           ],
           "metricValues": [
@@ -45294,468 +8169,6 @@
               "value": "20240101"
             },
             {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.com"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "18"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.fr/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.it/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "144"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.nl/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "21"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.google.rs/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "4"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/4-laka-recepta-sa-kukuruznim-brasnom/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "48"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/brza-kukuruza/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "0"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/energetske-kuglice-sa-pistacijem/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "17"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/lychee-vocka-za-novogodisnju-trpezu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "64"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/pire-od-krompira-na-5-nacina/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "34"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
-              "value": "google"
-            },
-            {
-              "value": "organic"
-            },
-            {
-              "value": "(organic)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "(not set)"
-            },
-            {
-              "value": "https://www.kuhinjskeprice.com/serviraj-za-pobjedu/"
-            }
-          ],
-          "metricValues": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "1"
-            },
-            {
-              "value": "0"
-            },
-            {
-              "value": "81"
-            }
-          ]
-        },
-        {
-          "dimensionValues": [
-            {
-              "value": "20240101"
-            },
-            {
               "value": "mojaslatkakuhinja.wordpress.com"
             },
             {
@@ -45769,9 +8182,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "https://mojaslatkakuhinja.wordpress.com/"
             }
           ],
           "metricValues": [
@@ -45811,9 +8221,6 @@
             },
             {
               "value": "(not set)"
-            },
-            {
-              "value": "http://vrtaljica.blogspot.com/"
             }
           ],
           "metricValues": [

--- a/lib/plausible/google/ga4/report_request.ex
+++ b/lib/plausible/google/ga4/report_request.ex
@@ -46,8 +46,7 @@ defmodule Plausible.Google.GA4.ReportRequest do
           "sessionMedium",
           "sessionCampaignName",
           "sessionManualAdContent",
-          "sessionGoogleAdsKeyword",
-          "pageReferrer"
+          "sessionGoogleAdsKeyword"
         ],
         metrics: [
           "screenPageViews",

--- a/lib/plausible/imported/google_analytics4.ex
+++ b/lib/plausible/imported/google_analytics4.ex
@@ -96,19 +96,12 @@ defmodule Plausible.Imported.GoogleAnalytics4 do
   end
 
   defp new_from_report(site_id, import_id, "imported_sources", row) do
-    referrer_uri = row.dimensions |> Map.fetch!("pageReferrer") |> URI.parse()
-
-    referrer =
-      if PlausibleWeb.RefInspector.right_uri?(referrer_uri) do
-        PlausibleWeb.RefInspector.format_referrer(referrer_uri)
-      end
-
     %{
       site_id: site_id,
       import_id: import_id,
       date: get_date(row),
       source: row.dimensions |> Map.fetch!("sessionSource") |> parse_referrer(),
-      referrer: referrer,
+      referrer: nil,
       # Only `source` exists in GA4 API
       utm_source: nil,
       utm_medium: row.dimensions |> Map.fetch!("sessionMedium") |> default_if_missing(),

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -82,7 +82,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
       Enum.each(Plausible.Imported.tables(), fn table ->
         count =
           case table do
-            "imported_sources" -> 1090
+            "imported_sources" -> 210
             "imported_visitors" -> 31
             "imported_pages" -> 3340
             "imported_entry_pages" -> 2934


### PR DESCRIPTION
### Changes

This PR removes `pageReferrer` from GA4 import. As this is en event-scoped dimension, combining it with session-scoped dimensions results in overcounting due to explosion of combinations (which also means that the results contain significant overlap between sessions and can't be added for calculating aggregates). See also: https://github.com/plausible/analytics/pull/4014/commits/4cbd29789cfaef1f80a7ac42680b1c5eb535790d

### Tests
- [x] Automated tests have been updated
