### PR TITLE
remove no-op coalesce calls

### DIFF
--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -457,29 +457,19 @@ defmodule Plausible.Stats.Imported do
 
   defp select_joined_metrics(q, [:visits | rest]) do
     q
-    |> select_merge([s, i], %{
-      :visits => fragment("? + ?", s.visits, i.visits)
-    })
+    |> select_merge([s, i], %{visits: s.visits + i.visits})
     |> select_joined_metrics(rest)
   end
 
   defp select_joined_metrics(q, [:visitors | rest]) do
     q
-    |> select_merge([s, i], %{
-      :visitors =>
-        selected_as(
-          fragment("coalesce(?, 0) + coalesce(?, 0)", s.visitors, i.visitors),
-          :visitors
-        )
-    })
+    |> select_merge([s, i], %{visitors: selected_as(s.visitors + i.visitors, :visitors)})
     |> select_joined_metrics(rest)
   end
 
   defp select_joined_metrics(q, [:pageviews | rest]) do
     q
-    |> select_merge([s, i], %{
-      pageviews: fragment("coalesce(?, 0) + coalesce(?, 0)", s.pageviews, i.pageviews)
-    })
+    |> select_merge([s, i], %{pageviews: s.pageviews + i.pageviews})
     |> select_joined_metrics(rest)
   end
 
@@ -488,13 +478,7 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([s, i], %{
       views_per_visit:
         fragment(
-          """
-          if(
-            coalesce(?, 0) + coalesce(?, 0) > 0,
-            round((? + ? * coalesce(?, 0)) / (coalesce(?, 0) + coalesce(?, 0)), 2),
-            0
-          )
-          """,
+          "if(? + ? > 0, round((? + ? * ?) / (? + ?), 2), 0)",
           s.__internal_visits,
           i.__internal_visits,
           i.pageviews,
@@ -512,13 +496,7 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([s, i], %{
       bounce_rate:
         fragment(
-          """
-          if(
-            coalesce(?, 0) + coalesce(?, 0) > 0,
-            round(100 * (coalesce(?, 0) + coalesce((? * ? / 100), 0)) / (coalesce(?, 0) + coalesce(?, 0))),
-            0
-          )
-          """,
+          "if(? + ? > 0, round(100 * (? + (? * ? / 100)) / (? + ?)), 0)",
           s.__internal_visits,
           i.__internal_visits,
           i.bounces,
@@ -567,7 +545,7 @@ defmodule Plausible.Stats.Imported do
   end
 
   defp apply_order_by(q, [:visitors | rest]) do
-    order_by(q, [s, i], desc: fragment("coalesce(?, 0) + coalesce(?, 0)", s.visitors, i.visitors))
+    order_by(q, [s, i], desc: s.visitors + i.visitors)
     |> apply_order_by(rest)
   end
 


### PR DESCRIPTION
### Changes

This PR removes no-op coalesce calls from joined columns.

ClickHouse doesn't make columns Nullable after a full join, instead they become the default value for the type (some kind of zero usually): https://play.clickhouse.com/play?user=play#d2l0aCBhIGFzIChzZWxlY3QgKiBmcm9tIG51bWJlcnMoMTApKSwgYiBhcyAoc2VsZWN0IG51bWJlciArIDUgYXMgbnVtYmVyIGZyb20gbnVtYmVycygxMCkpIHNlbGVjdCBhLm51bWJlciwgYi5udW1iZXIgZnJvbSBhIGZ1bGwgam9pbiBiIG9uIGEubnVtYmVyID0gYi5udW1iZXI7

### Tests
- [ ] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI