### PR TITLE
Always sort occupied date ranges in `Imported.clamp_dates/3`

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -187,6 +187,7 @@ defmodule Plausible.Imported do
     |> Imported.list_all_imports(Imported.SiteImport.completed())
     |> Enum.reject(&(Date.diff(&1.end_date, &1.start_date) < 2))
     |> Enum.map(&Date.range(&1.start_date, &1.end_date))
+    |> Enum.sort_by(& &1.first, Date)
   end
 
   @spec get_cutoff_date(Site.t()) :: Date.t()

--- a/test/plausible/imported_test.exs
+++ b/test/plausible/imported_test.exs
@@ -164,6 +164,29 @@ defmodule Plausible.ImportedTest do
                Imported.clamp_dates(site, ~D[2019-03-21], ~D[2024-01-12])
     end
 
+    test "does not depend on the order of insertion of site imports (regression fix)" do
+      site = insert(:site)
+
+      _existing_import1 =
+        insert(:site_import,
+          site: site,
+          start_date: ~D[2020-10-14],
+          end_date: ~D[2024-04-01],
+          status: :completed
+        )
+
+      _existing_import2 =
+        insert(:site_import,
+          site: site,
+          start_date: ~D[2012-01-18],
+          end_date: ~D[2018-03-09],
+          status: :completed
+        )
+
+      assert {:ok, ~D[2018-03-09], ~D[2020-10-14]} =
+               Imported.clamp_dates(site, ~D[2012-01-18], ~D[2018-03-09])
+    end
+
     test "does not alter the dates when there are no imports and no native stats" do
       site = insert(:site)
 


### PR DESCRIPTION
### Changes

This PR addresses a bug where when imports done in non-chronological order of their date ranges could cause unwanted overlap.

### Tests
- [x] Automated tests have been added

