### PR TITLE
Add link to settings on the "Waiting for first pageview" screen

### DIFF
--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
@@ -44,10 +44,10 @@
         <br />
         <span :if={full_build?()}>
           Check the
-              <.styled_link href={Routes.site_path(@conn, :settings_general, @site.domain)}>
-                site settings
-              </.styled_link>
-              to invite team members, import historical stats and more.
+          <.styled_link href={Routes.site_path(@conn, :settings_general, @site.domain)}>
+            site settings
+          </.styled_link>
+          to invite team members, <br /> import historical stats and more.
         </span>
         <span :if={small_build?()}>
           Still not working? Ask on our

--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
@@ -43,9 +43,11 @@
 
         <br />
         <span :if={full_build?()}>
-          Still not working?
-          <.styled_link new_tab href="https://plausible.io/contact">Contact us</.styled_link>
-          and we will help you with your setup
+          Check the
+              <.styled_link href={Routes.site_path(@conn, :settings_general, @site.domain)}>
+                site settings
+              </.styled_link>
+              to invite team members, import historical stats and more.
         </span>
         <span :if={small_build?()}>
           Still not working? Ask on our


### PR DESCRIPTION
we've had people ask how to start by importing their data first before integrating Plausible into their site (and some also want just to import and store their GA stats in Plausible rather than use Plausible to collect new stats) so the idea here is to give people access to the site settings area directly from the "Waiting for first pageview" screen