### PR TITLE
Improve UI for failed import entry case

### DIFF
--- a/lib/plausible/google/ua/http.ex
+++ b/lib/plausible/google/ua/http.ex
@@ -45,10 +45,18 @@ defmodule Plausible.Google.UA.HTTP do
       {:ok, {report, token}}
     else
       {:error, %{reason: %{status: status, body: body}}} ->
+        Logger.debug(
+          "[#{inspect(__MODULE__)}:#{report_request.view_id}] Request failed for #{report_request.dataset} with code #{status}: #{inspect(body)}"
+        )
+
         Sentry.Context.set_extra_context(%{ga_response: %{body: body, status: status}})
         {:error, :request_failed}
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        Logger.debug(
+          "[#{inspect(__MODULE__)}:#{report_request.view_id}] Request failed for #{report_request.dataset}: #{inspect(reason)}"
+        )
+
         {:error, :request_failed}
     end
   end

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -137,8 +137,8 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
               :if={entry.live_status == SiteImport.failed()}
               class="inline-block h-6 w-5 text-red-700 dark:text-red-700"
             />
-            <span :if={entry.live_status == SiteImport.failed()} class="text-xs font-normal">
-              (Import failed)
+            <span :if={entry.live_status == SiteImport.failed()}>
+              Import failed -
             </span>
             <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
             <span :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal">

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -135,8 +135,11 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
             />
             <Heroicons.exclamation_triangle
               :if={entry.live_status == SiteImport.failed()}
-              class="inline-block h-6 w-5 text-indigo-600 dark:text-green-600"
+              class="inline-block h-6 w-5 text-red-700 dark:text-red-700"
             />
+            <span :if={entry.live_status == SiteImport.failed()} class="text-xs font-normal">
+              (Import failed)
+            </span>
             <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
             <span :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal">
               (<%= PlausibleWeb.StatsView.large_number_format(
@@ -147,9 +150,13 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
           <p class="text-sm leading-5 text-gray-500 dark:text-gray-200">
             From <%= format_date(entry.site_import.start_date) %> to <%= format_date(
               entry.site_import.end_date
-            ) %> (created on <%= format_date(
-              entry.site_import.inserted_at || entry.site_import.start_date
-            ) %>)
+            ) %>
+            <%= if entry.live_status == SiteImport.completed() do %>
+              (imported
+            <% else %>
+              (started
+            <% end %>
+            on <%= format_date(entry.site_import.inserted_at) %>)
           </p>
         </div>
         <.button
@@ -160,8 +167,11 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
           class="sm:ml-3 sm:w-auto w-full"
           data-confirm="Are you sure you want to delete this import?"
         >
-          <span :if={entry.live_status in [SiteImport.completed(), SiteImport.failed()]}>
+          <span :if={entry.live_status == SiteImport.completed()}>
             Delete Import
+          </span>
+          <span :if={entry.live_status == SiteImport.failed()}>
+            Discard
           </span>
           <span :if={entry.live_status not in [SiteImport.completed(), SiteImport.failed()]}>
             Cancel Import


### PR DESCRIPTION
### Changes

This PR introduces slight visual improvements when rendering failed imports:

* the warning sigh preceding the label is red
* "(Import failed)" preceeds the label for added clarity
* Deletion button states "Discard" to avoid suggesting that it's a functional import
* All in progress and failed imports state "started on DD-MM-YYYY" and "imported on DD-MM-YYYY " is only shown by completed ones)

This should further reduce the chance of missing the fact that the entry is for a failed import which can only be discarded.

<img width="1227" alt="image" src="https://github.com/plausible/analytics/assets/588351/196b3303-e951-4373-b19a-7d8f0cb13f9e">

Additionally, failed request debug logging for UA was extended to be on par with GA4.
