### PR TITLE
Display upgrade tooltips for exceeded limits

### DIFF
--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -189,6 +189,14 @@ defmodule PlausibleWeb.Live.ChoosePlan do
      )}
   end
 
+  def handle_event("show-tooltip", %{"paddle-product-id" => product_id}, socket) do
+    {:noreply, assign(socket, display_tooltip_product_id: product_id)}
+  end
+
+  def handle_event("hide-tooltip", _, socket) do
+    {:noreply, assign(socket, display_tooltip_product_id: nil)}
+  end
+
   defp default_selected_volume(%Plan{monthly_pageview_limit: limit}, _, _), do: limit
 
   defp default_selected_volume(_, last_30_days_usage, available_volumes) do

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -19,6 +19,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   @slider_value "#slider-value"
 
   @growth_plan_box "#growth-plan-box"
+  @growth_plan_tooltip "#growth-plan-box .tooltip-wrapper span"
+  @growth_plan_tooltip_link ~s/#growth-plan-box .tooltip-wrapper a[phx-click="show-tooltip"]/
   @growth_price_tag_amount "#growth-price-tag-amount"
   @growth_price_tag_interval "#growth-price-tag-interval"
   @growth_highlight_pill "#{@growth_plan_box} #highlight-pill"
@@ -243,6 +245,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+      refute element_exists?(doc, @growth_plan_tooltip)
 
       generate_usage_for(site, 1)
 
@@ -251,6 +254,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Monthly pageview limit"
     end
 
     test "allows upgrade to a 10k plan with a pageview allowance margin of 0.3 when trial ended 10 days ago",
@@ -497,6 +503,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Team member limit"
     end
 
     test "checkout is disabled when sites usage exceeds rendered plan limit", %{
@@ -509,6 +518,55 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Site limit"
+    end
+
+    test "clicking the tooltip changes makes it sticky", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user))
+        ]
+      )
+
+      {:ok, lv, doc} = get_liveview(conn)
+
+      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0 group-hover:opacity-90"
+
+      doc = element(lv, @growth_plan_tooltip_link) |> render_click()
+
+      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-90"
+      refute class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0"
+    end
+
+    test "when more than one limit is exceeded, the tooltip enumerates them", %{
+      conn: conn,
+      user: user
+    } do
+      for _ <- 1..11, do: insert(:site, members: [user])
+
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user))
+        ]
+      )
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @growth_plan_tooltip) =~ "Team member limit"
+      assert text_of_element(doc, @growth_plan_tooltip) =~ "Site limit"
     end
 
     test "checkout is not disabled when pageview usage exceeded but next upgrade allowed by override",


### PR DESCRIPTION
### Changes

This PR adds tooltips about specific limits exceeded if the current usage doesn't allow plan change. The tooltips normally appear on hover, become sticky on click and disappear on click-away.

![image](https://github.com/plausible/analytics/assets/173738/0c2de4ef-f2ce-4d72-8408-84c307076d5f)


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
