### PR TITLE
Add Yesterday as an time range option in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Hostname Allow List in Site Settings
 - Pages Block List in Site Settings
-- Add `conversion_rate` to Stats API Timeseries and on the main graph 
+- Add `conversion_rate` to Stats API Timeseries and on the main graph
 - Add `total_conversions` and `conversion_rate` to `visitors.csv` in a goal-filtered CSV export
 - Ability to display total conversions (with a goal filter) on the main graph
 - Add `conversion_rate` to Stats API Timeseries and on the main graph
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Add alternative SMTP adapter plausible/analytics#3654
 - Add `EXTRA_CONFIG_PATH` env var to specify extra Elixir config plausible/analytics#3906
 - Add restrictive `robots.txt` for self-hosted plausible/analytics#3905
+- Add Yesterday as an time range option in the dashboard
 
 ### Removed
 - Removed the nested custom event property breakdown UI when filtering by a goal in Goal Conversions

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -20,7 +20,9 @@ import {
   parseNaiveDate,
   isBefore,
   isAfter,
-  formatDateRange
+  formatDateRange,
+  yesterday,
+  isSameDate
 } from "./util/date";
 import { navigateToQuery, QueryLink, QueryButton } from "./query";
 import { shouldIgnoreKeypress } from "./keybinding.js"
@@ -282,7 +284,7 @@ function DatePicker({ query, site, history }) {
   function renderLink(period, text, opts = {}) {
     let boldClass;
     if (query.period === "day" && period === "day") {
-      boldClass = isToday(site, query.date) ? "font-bold" : "";
+      boldClass = isSameDate(opts.date, query.date) ? "font-bold" : "";
     } else if (query.period === "month" && period === "month") {
       const linkDate = opts.date || nowForSite(site);
       boldClass = isSameMonth(linkDate, query.date) ? "font-bold" : "";
@@ -319,7 +321,8 @@ function DatePicker({ query, site, history }) {
             font-medium text-gray-800 dark:text-gray-200 date-options"
           >
             <div className="py-1 border-b border-gray-200 dark:border-gray-500 date-option-group">
-              {renderLink("day", "Today", { keybindHint: 'D' })}
+              {renderLink("day", "Today", { keybindHint: 'D', date: nowForSite(site) })}
+              {renderLink("day", "Yesterday", { keybindHint: 'E', date: yesterday(site) })}
               {renderLink("realtime", "Realtime", { keybindHint: 'R' })}
             </div>
             <div className="py-1 border-b border-gray-200 dark:border-gray-500 date-option-group">

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -71,8 +71,16 @@ export function nowForSite(site) {
   return dayjs.utc().utcOffset(site.offset / 60)
 }
 
+export function yesterday(site) {
+  return nowForSite(site).subtract(1, 'day')
+}
+
 export function lastMonth(site) {
   return shiftMonths(nowForSite(site), -1)
+}
+
+export function isSameDate(date1, date2) {
+  return formatISO(date1) === formatISO(date2)
 }
 
 export function isSameMonth(date1, date2) {
@@ -80,7 +88,7 @@ export function isSameMonth(date1, date2) {
 }
 
 export function isToday(site, date) {
-  return formatISO(date) === formatISO(nowForSite(site))
+  return isSameDate(date, nowForSite(site))
 }
 
 export function isThisMonth(site, date) {


### PR DESCRIPTION
### Changes

Adds Yesterday option to dashboard time range picker. The keyboard shortcut has worked for the past few years already.

Motivation: https://feedback.plausible.io/264, warmup after vacation on a flight

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
