### PR TITLE
Bump GA4 import page limit to max 250k

### DIFF
--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -37,6 +37,9 @@ defmodule Plausible.Google.GA4.API do
 
         {:ok, accounts}
 
+      {:ok, _} ->
+        {:ok, []}
+
       {:error, cause} ->
         {:error, cause}
     end

--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Google.GA4.API do
           expires_at :: String.t()
         }
 
-  @per_page 50_000
+  @per_page 250_000
   @backoff_factor :timer.seconds(10)
   @max_attempts 5
 

--- a/test/plausible/google/ga4/api_test.exs
+++ b/test/plausible/google/ga4/api_test.exs
@@ -27,6 +27,14 @@ defmodule Plausible.Google.GA4.APITest do
                 ]}
              ] = accounts
     end
+
+    test "handles empty response properly" do
+      expect(Plausible.HTTPClient.Mock, :get, fn _url, _opts ->
+        {:ok, %Finch.Response{status: 200, body: %{}}}
+      end)
+
+      assert {:ok, []} = GA4.API.list_properties("some_access_token")
+    end
   end
 
   describe "get_property/2" do


### PR DESCRIPTION
### Changes

Bumps page size to the maximum allowed by GA4.

Also, handles completely empty GA4 properties list response gracefully.

### Tests
- [x] Automated tests have been added
