### PR TITLE
Display tooltips on plan change when limits exceeded

### DIFF
--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -174,7 +174,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
         change_plan_link_text == "Currently on this plan" && not subscription_deleted ->
           {true, nil}
 
-        assigns.available && usage_check != :ok ->
+        usage_check != :ok ->
           {true, "Your usage exceeds this plan"}
 
         billing_details_expired ->

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -318,6 +318,32 @@ defmodule PlausibleWeb.Components.Generic do
     """
   end
 
+  slot :inner_block, required: true
+  slot :tooltip_content, required: true
+
+  def tooltip(assigns) do
+    ~H"""
+    <div x-data="{sticky: false, hovered: false}" class="tooltip-wrapper relative">
+      <p
+        x-on:click="sticky = true; hovered = true"
+        x-on:click.outside="sticky = false; hovered = false"
+        x-on:mouseover="hovered = true"
+        x-on:mouseout="hovered = false"
+        class="cursor-pointer text-sm text-red-700 dark:text-red-500 mt-1 flex justify-center align-items-center"
+      >
+        <%= render_slot(@inner_block) %>
+        <Heroicons.information_circle class="w-5 h-5 ml-2" />
+      </p>
+      <span
+        x-show="hovered || sticky"
+        class="bg-gray-900 pointer-events-none absolute bottom-10 margin-x-auto left-10 right-10 transition-opacity p-4 rounded text-white"
+      >
+        <%= render_slot(List.first(@tooltip_content)) %>
+      </span>
+    </div>
+    """
+  end
+
   attr :rest, :global, include: ~w(fill stroke stroke-width)
   attr :name, :atom, required: true
   attr :outline, :boolean, default: true

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -189,14 +189,6 @@ defmodule PlausibleWeb.Live.ChoosePlan do
      )}
   end
 
-  def handle_event("show-tooltip", %{"paddle-product-id" => product_id}, socket) do
-    {:noreply, assign(socket, display_tooltip_product_id: product_id)}
-  end
-
-  def handle_event("hide-tooltip", _, socket) do
-    {:noreply, assign(socket, display_tooltip_product_id: nil)}
-  end
-
   defp default_selected_volume(%Plan{monthly_pageview_limit: limit}, _, _), do: limit
 
   defp default_selected_volume(_, last_30_days_usage, available_volumes) do

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -189,6 +189,14 @@ defmodule PlausibleWeb.Live.ChoosePlan do
      )}
   end
 
+  def handle_event("show-tooltip", %{"paddle-product-id" => product_id}, socket) do
+    {:noreply, assign(socket, display_tooltip_product_id: product_id)}
+  end
+
+  def handle_event("hide-tooltip", _, socket) do
+    {:noreply, assign(socket, display_tooltip_product_id: nil)}
+  end
+
   defp default_selected_volume(%Plan{monthly_pageview_limit: limit}, _, _), do: limit
 
   defp default_selected_volume(_, last_30_days_usage, available_volumes) do

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -523,30 +523,6 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                "Your usage exceeds the following limit(s): Site limit"
     end
 
-    test "clicking the tooltip changes makes it sticky", %{
-      conn: conn,
-      user: user
-    } do
-      insert(:site,
-        memberships: [
-          build(:site_membership, user: user, role: :owner),
-          build(:site_membership, user: build(:user)),
-          build(:site_membership, user: build(:user)),
-          build(:site_membership, user: build(:user)),
-          build(:site_membership, user: build(:user))
-        ]
-      )
-
-      {:ok, lv, doc} = get_liveview(conn)
-
-      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0 group-hover:opacity-90"
-
-      doc = element(lv, @growth_plan_tooltip_link) |> render_click()
-
-      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-90"
-      refute class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0"
-    end
-
     test "when more than one limit is exceeded, the tooltip enumerates them", %{
       conn: conn,
       user: user

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -20,7 +20,6 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
   @growth_plan_box "#growth-plan-box"
   @growth_plan_tooltip "#growth-plan-box .tooltip-wrapper span"
-  @growth_plan_tooltip_link ~s/#growth-plan-box .tooltip-wrapper a[phx-click="show-tooltip"]/
   @growth_price_tag_amount "#growth-price-tag-amount"
   @growth_price_tag_interval "#growth-price-tag-interval"
   @growth_highlight_pill "#{@growth_plan_box} #highlight-pill"

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -19,6 +19,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   @slider_value "#slider-value"
 
   @growth_plan_box "#growth-plan-box"
+  @growth_plan_tooltip "#growth-plan-box .tooltip-wrapper span"
+  @growth_plan_tooltip_link ~s/#growth-plan-box .tooltip-wrapper a[phx-click="show-tooltip"]/
   @growth_price_tag_amount "#growth-price-tag-amount"
   @growth_price_tag_interval "#growth-price-tag-interval"
   @growth_highlight_pill "#{@growth_plan_box} #highlight-pill"
@@ -243,6 +245,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+      refute element_exists?(doc, @growth_plan_tooltip)
 
       generate_usage_for(site, 1)
 
@@ -251,6 +254,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Monthly pageview limit"
     end
 
     test "allows upgrade to a 10k plan with a pageview allowance margin of 0.3 when trial ended 10 days ago",
@@ -497,6 +503,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Team member limit"
     end
 
     test "checkout is disabled when sites usage exceeds rendered plan limit", %{
@@ -509,6 +518,55 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @growth_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Site limit"
+    end
+
+    test "clicking the tooltip changes makes it sticky", %{
+      conn: conn,
+      user: user
+    } do
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user))
+        ]
+      )
+
+      {:ok, lv, doc} = get_liveview(conn)
+
+      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0 group-hover:opacity-90"
+
+      doc = element(lv, @growth_plan_tooltip_link) |> render_click()
+
+      assert class_of_element(doc, @growth_plan_tooltip) =~ "opacity-90"
+      refute class_of_element(doc, @growth_plan_tooltip) =~ "opacity-0"
+    end
+
+    test "when more than one limit is exceeded, the tooltip enumerates them", %{
+      conn: conn,
+      user: user
+    } do
+      for _ <- 1..11, do: insert(:site, members: [user])
+
+      insert(:site,
+        memberships: [
+          build(:site_membership, user: user, role: :owner),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user)),
+          build(:site_membership, user: build(:user))
+        ]
+      )
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @growth_plan_tooltip) =~ "Team member limit"
+      assert text_of_element(doc, @growth_plan_tooltip) =~ "Site limit"
     end
 
     test "checkout is not disabled when pageview usage exceeded but next upgrade allowed by override",


### PR DESCRIPTION
### Changes

Another iteration of #4032 - pairing with @RobertJoonas 


https://github.com/plausible/analytics/assets/173738/3e871ffd-4e08-40a4-8d84-4d7a38b13eac






### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
