### PR TITLE
Implement resumable GA4 imports to work around rate limiting

### DIFF
--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -48,7 +48,7 @@ defmodule ObanErrorReporter do
     site_import = Plausible.Repo.get(Plausible.Imported.SiteImport, import_id)
 
     if site_import do
-      Plausible.Workers.ImportAnalytics.import_fail(site_import)
+      Plausible.Workers.ImportAnalytics.import_fail(site_import, [])
     end
   end
 

--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -71,23 +71,56 @@ defmodule Plausible.Google.GA4.API do
     GA4.HTTP.get_analytics_end_date(access_token, property)
   end
 
-  def import_analytics(date_range, property, auth, persist_fn) do
+  def import_analytics(date_range, property, auth, opts) do
+    persist_fn = Keyword.fetch!(opts, :persist_fn)
+    resume_opts = Keyword.get(opts, :resume_opts, [])
+
     Logger.debug(
       "[#{inspect(__MODULE__)}:#{property}] Starting import from #{date_range.first} to #{date_range.last}"
     )
 
     with {:ok, access_token} <- Google.API.maybe_refresh_token(auth) do
-      do_import_analytics(date_range, property, access_token, persist_fn)
+      do_import_analytics(date_range, property, access_token, persist_fn, resume_opts)
     end
   end
 
-  defp do_import_analytics(date_range, property, access_token, persist_fn) do
+  defp do_import_analytics(date_range, property, access_token, persist_fn, [] = _resume_opts) do
     Enum.reduce_while(GA4.ReportRequest.full_report(), :ok, fn report_request, :ok ->
       Logger.debug(
         "[#{inspect(__MODULE__)}:#{property}] Starting to import #{report_request.dataset}"
       )
 
       report_request = prepare_request(report_request, date_range, property, access_token)
+
+      case fetch_and_persist(report_request, persist_fn: persist_fn) do
+        :ok -> {:cont, :ok}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp do_import_analytics(date_range, property, access_token, persist_fn, resume_opts) do
+    dataset = Keyword.fetch!(resume_opts, :dataset)
+    offset = Keyword.fetch!(resume_opts, :offset)
+
+    GA4.ReportRequest.full_report()
+    |> Enum.drop_while(&(&1.dataset != dataset))
+    |> Enum.reduce_while(:ok, fn report_request, :ok ->
+      Logger.debug(
+        "[#{inspect(__MODULE__)}:#{property}] Starting to import #{report_request.dataset}"
+      )
+
+      request_offset =
+        if report_request.dataset == dataset do
+          offset
+        else
+          0
+        end
+
+      report_request =
+        report_request
+        |> prepare_request(date_range, property, access_token)
+        |> Map.put(:offset, request_offset)
 
       case fetch_and_persist(report_request, persist_fn: persist_fn) do
         :ok -> {:cont, :ok}
@@ -123,6 +156,9 @@ defmodule Plausible.Google.GA4.API do
         else
           :ok
         end
+
+      {:error, {:rate_limit_exceeded, details}} ->
+        {:error, {:rate_limit_exceeded, details}}
 
       {:error, cause} ->
         if attempt >= @max_attempts do

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -147,6 +147,9 @@ defmodule Plausible.Google.GA4.HTTP do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, body}
 
+      {:error, %HTTPClient.Non200Error{reason: %{status: 429}}} ->
+        {:error, :rate_limit_exceeded}
+
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
 
@@ -167,6 +170,9 @@ defmodule Plausible.Google.GA4.HTTP do
     case HTTPClient.impl().get(url, headers) do
       {:ok, %Finch.Response{body: body, status: 200}} ->
         {:ok, body}
+
+      {:error, %HTTPClient.Non200Error{reason: %{status: 429}}} ->
+        {:error, :rate_limit_exceeded}
 
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}
@@ -233,6 +239,9 @@ defmodule Plausible.Google.GA4.HTTP do
           end
 
         {:ok, date}
+
+      {:error, %HTTPClient.Non200Error{reason: %{status: 429}}} ->
+        {:error, :rate_limit_exceeded}
 
       {:error, %HTTPClient.Non200Error{} = error} when error.reason.status in [401, 403] ->
         {:error, :authentication_failed}

--- a/lib/plausible/imported/google_analytics4.ex
+++ b/lib/plausible/imported/google_analytics4.ex
@@ -112,7 +112,7 @@ defmodule Plausible.Imported.GoogleAnalytics4 do
             resume_from_import_id: site_import.id,
             resume_from_dataset: dataset,
             resume_from_offset: offset,
-            job_opts: [schedule_in: {60, :minutes}, unique: nil]
+            job_opts: [schedule_in: {65, :minutes}, unique: nil]
           ]
 
           new_import(

--- a/lib/plausible/imported/noop_importer.ex
+++ b/lib/plausible/imported/noop_importer.ex
@@ -24,10 +24,10 @@ defmodule Plausible.Imported.NoopImporter do
   def import_data(_site_import, _opts), do: :ok
 
   @impl true
-  def before_start(site_import) do
+  def before_start(site_import, _opts) do
     send(self(), {:before_start, site_import.id})
 
-    :ok
+    {:ok, site_import}
   end
 
   @impl true

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -217,7 +217,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       class="h-0 text-center text-sm text-red-700 dark:text-red-500 disabled-message"
     >
       <%= if @exceeded_plan_limits != [] do %>
-        <PlausibleWeb.Components.Generic.tooltip>
+        <PlausibleWeb.Components.Generic.tooltip class="text-sm text-red-700 dark:text-red-500 mt-1 justify-center">
           <%= @disabled_message %>
           <:tooltip_content>
             Your usage exceeds the following limit(s):<br /><br />

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -318,25 +318,27 @@ defmodule PlausibleWeb.Components.Generic do
     """
   end
 
+  attr :wrapper_class, :any, default: ""
+  attr :class, :any, default: ""
   slot :inner_block, required: true
   slot :tooltip_content, required: true
 
   def tooltip(assigns) do
     ~H"""
-    <div x-data="{sticky: false, hovered: false}" class="tooltip-wrapper relative">
+    <div x-data="{sticky: false, hovered: false}" class={["tooltip-wrapper relative", @wrapper_class]}>
       <p
         x-on:click="sticky = true; hovered = true"
         x-on:click.outside="sticky = false; hovered = false"
         x-on:mouseover="hovered = true"
         x-on:mouseout="hovered = false"
-        class="cursor-pointer text-sm text-red-700 dark:text-red-500 mt-1 flex justify-center align-items-center"
+        class={["cursor-pointer flex align-items-center", @class]}
       >
         <%= render_slot(@inner_block) %>
         <Heroicons.information_circle class="w-5 h-5 ml-2" />
       </p>
       <span
         x-show="hovered || sticky"
-        class="bg-gray-900 pointer-events-none absolute bottom-10 margin-x-auto left-10 right-10 transition-opacity p-4 rounded text-white"
+        class="bg-gray-900 pointer-events-none absolute bottom-10 margin-x-auto left-10 right-10 transition-opacity p-4 rounded text-sm text-white"
       >
         <%= render_slot(List.first(@tooltip_content)) %>
       </span>

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -79,6 +79,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
 
+      {:error, :rate_limit_exceeded} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics rate limit has been exceeded. Please try again later."
+        )
+        |> redirect(external: redirect_route)
+
       {:error, :authentication_failed} ->
         conn
         |> put_flash(
@@ -153,6 +161,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
 
         property_or_view_form(conn, params)
 
+      {:error, :rate_limit_exceeded} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics rate limit has been exceeded. Please try again later."
+        )
+        |> redirect(external: redirect_route)
+
       {:error, :authentication_failed} ->
         conn
         |> put_flash(
@@ -210,6 +226,14 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           property?: Google.API.property?(property_or_view),
           layout: {PlausibleWeb.LayoutView, "focus.html"}
         )
+
+      {:error, :rate_limit_exceeded} ->
+        conn
+        |> put_flash(
+          :error,
+          "Google Analytics rate limit has been exceeded. Please try again later."
+        )
+        |> redirect(external: redirect_route)
 
       {:error, :authentication_failed} ->
         conn

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -122,42 +122,42 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
     <ul :if={not Enum.empty?(@site_imports)}>
       <li :for={entry <- @site_imports} class="py-4 flex items-center justify-between space-x-4">
         <div class="flex flex-col">
-          <p class="text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
+          <div class="flex items-center text-sm leading-5 font-medium text-gray-900 dark:text-gray-100">
             <Heroicons.clock
               :if={entry.live_status == SiteImport.pending()}
-              class="inline-block h-6 w-5 text-indigo-600 dark:text-green-600"
+              class="block h-6 w-5 text-indigo-600 dark:text-green-600"
             />
             <.spinner
               :if={entry.live_status == SiteImport.importing()}
-              class="inline-block h-6 w-5 text-indigo-600 dark:text-green-600"
+              class="block h-6 w-5 text-indigo-600 dark:text-green-600"
             />
             <Heroicons.check
               :if={entry.live_status == SiteImport.completed()}
-              class="inline-block h-6 w-5 text-indigo-600 dark:text-green-600"
+              class="block h-6 w-5 text-indigo-600 dark:text-green-600"
             />
             <Heroicons.exclamation_triangle
               :if={entry.live_status == SiteImport.failed()}
-              class="inline-block h-6 w-5 text-red-700 dark:text-red-700"
+              class="block h-6 w-5 text-red-700 dark:text-red-700"
             />
-            <span :if={entry.live_status == SiteImport.failed()}>
+            <div :if={entry.live_status == SiteImport.failed()}>
               Import failed -
-            </span>
-            <.tooltip :if={entry.tooltip}>
+            </div>
+            <.tooltip :if={entry.tooltip} wrapper_class="ml-2 grow" class="justify-left">
               <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
               <:tooltip_content>
                 <.notice_message message_label={entry.tooltip} />
               </:tooltip_content>
             </.tooltip>
-            <span :if={!entry.tooltip}>
+            <div :if={!entry.tooltip} class="ml-2">
               <%= Plausible.Imported.SiteImport.label(entry.site_import) %>
-            </span>
-            <span :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal">
+            </div>
+            <div :if={entry.live_status == SiteImport.completed()} class="text-xs font-normal ml-1">
               (<%= PlausibleWeb.StatsView.large_number_format(
                 pageview_count(entry.site_import, @pageview_counts)
               ) %> page views)
-            </span>
-          </p>
-          <p class="text-sm leading-5 text-gray-500 dark:text-gray-200">
+            </div>
+          </div>
+          <div class="text-sm leading-5 text-gray-500 dark:text-gray-200">
             From <%= format_date(entry.site_import.start_date) %> to <%= format_date(
               entry.site_import.end_date
             ) %>
@@ -167,7 +167,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
               (started
             <% end %>
             on <%= format_date(entry.site_import.inserted_at) %>)
-          </p>
+          </div>
         </div>
         <.button
           data-to={"/#{URI.encode_www_form(@site.domain)}/settings/forget-import/#{entry.site_import.id}"}
@@ -246,7 +246,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
 
   defp notice_message(%{message_label: :slow_import} = assigns) do
     ~H"""
-    The import process might be taking longer due to the amount of data<br />
+    The import process might be taking longer due to the amount of data
     and rate limiting enforced by Google Analytics.
     """
   end

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -176,12 +176,12 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
       assert {:error, :rate_limit_exceeded, skip_purge?: true, skip_mark_failed?: true} =
                GoogleAnalytics4.import_data(site_import, opts)
 
-      in_an_hour = DateTime.add(DateTime.utc_now(), 3600, :second)
+      in_65_minutes = DateTime.add(DateTime.utc_now(), 3900, :second)
 
       assert_enqueued(
         worker: Plausible.Workers.ImportAnalytics,
         args: %{resume_from_import_id: site_import.id},
-        scheduled_at: {in_an_hour, delta: 10}
+        scheduled_at: {in_65_minutes, delta: 10}
       )
 
       [%{args: resume_args}, _] = all_enqueued()


### PR DESCRIPTION
### Changes

![image](https://github.com/plausible/analytics/assets/588351/9a499d6c-c05d-4c8e-bdc9-5e71b7a04a78)

This PR implements graceful handling of rate limiting error (HTTP code 429) returned by Google Data API (GA4). When it occurs, instead of retrying the request immediately or discarding the import entirely, another import job is scheduled for the same exact site import, resuming the import process at the exact dataset and offset position where it failed. The job is scheduled 65 minutes in the future - the hourly rate limit on the property should be reset by then. All the existing data fetched for that import so far are left intact.

In addition, all other HTTP calls to the GA Data API are returning explicit error message on hitting rate limit error so that the user is aware that it should work again when they try later.

The imports list displays a notice tooltip by in-progress import when it's taking longer than 5 minutes hinting that the import might take longer due to the amount of the data and rate limiting enforced by the Google API.

### Tests
- [x] Automated tests have been added

### Dark mode
- [x] The UI has been tested both in dark and light mode

