### PR TITLE
Include breakdown property in the Query struct

### DIFF
--- a/lib/plausible/stats.ex
+++ b/lib/plausible/stats.ex
@@ -11,9 +11,9 @@ defmodule Plausible.Stats do
 
   use Plausible.DebugReplayInfo
 
-  def breakdown(site, query, prop, metrics, pagination) do
+  def breakdown(site, query, metrics, pagination) do
     include_sentry_replay_info()
-    Breakdown.breakdown(site, query, prop, metrics, pagination)
+    Breakdown.breakdown(site, query, metrics, pagination)
   end
 
   def aggregate(site, query, metrics) do

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Stats.Aggregate do
 
   defp aggregate_events(site, query, metrics) do
     from(e in base_event_query(site, query), select: ^select_event_metrics(metrics))
-    |> merge_imported(site, query, :aggregate, metrics)
+    |> merge_imported(site, query, metrics)
     |> maybe_add_conversion_rate(site, query, metrics, include_imported: query.include_imported)
     |> ClickhouseRepo.one(label: :aggregate_events)
   end
@@ -54,7 +54,7 @@ defmodule Plausible.Stats.Aggregate do
   defp aggregate_sessions(site, query, metrics) do
     from(e in query_sessions(site, query), select: ^select_session_metrics(metrics, query))
     |> filter_converted_sessions(site, query)
-    |> merge_imported(site, query, :aggregate, metrics)
+    |> merge_imported(site, query, metrics)
     |> ClickhouseRepo.one(label: :aggregate_sessions)
     |> Util.keep_requested_metrics(metrics)
   end

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -40,13 +40,18 @@ defmodule Plausible.Stats.EmailReport do
   end
 
   defp put_top_5_pages(stats, site, query) do
-    pages = Stats.breakdown(site, query, "event:page", [:visitors], {5, 1})
+    query = struct!(query, property: "event:page")
+    pages = Stats.breakdown(site, query, [:visitors], {5, 1})
     Map.put(stats, :pages, pages)
   end
 
   defp put_top_5_sources(stats, site, query) do
-    query = Query.put_filter(query, "visit:source", {:is_not, "Direct / None"})
-    sources = Stats.breakdown(site, query, "visit:source", [:visitors], {5, 1})
+    query =
+      query
+      |> Query.put_filter("visit:source", {:is_not, "Direct / None"})
+      |> struct!(property: "visit:source")
+
+    sources = Stats.breakdown(site, query, [:visitors], {5, 1})
 
     Map.put(stats, :sources, sources)
   end

--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -78,10 +78,10 @@ defmodule Plausible.Stats.Imported do
     |> select_merge([i], %{date: i.date})
   end
 
-  def merge_imported(q, _, %Query{include_imported: false}, _, _), do: q
-  def merge_imported(q, _, _, _, [:events | _]), do: q
+  def merge_imported(q, _, %Query{include_imported: false}, _), do: q
+  def merge_imported(q, _, _, [:events | _]), do: q
 
-  def merge_imported(q, site, query, property, metrics)
+  def merge_imported(q, site, %Query{property: property} = query, metrics)
       when property in @imported_properties do
     table = Map.fetch!(@property_to_table_mappings, property)
     dim = Plausible.Stats.Filters.without_prefix(property)
@@ -122,7 +122,7 @@ defmodule Plausible.Stats.Imported do
     |> apply_order_by(metrics)
   end
 
-  def merge_imported(q, site, query, :aggregate, metrics) do
+  def merge_imported(q, site, %Query{property: nil} = query, metrics) do
     imported_q =
       imported_visitors(site, query)
       |> select_imported_metrics(metrics)
@@ -135,7 +135,7 @@ defmodule Plausible.Stats.Imported do
     |> select_joined_metrics(metrics)
   end
 
-  def merge_imported(q, _, _, _, _), do: q
+  def merge_imported(q, _, _, _), do: q
 
   def total_imported_visitors(site, query) do
     imported_visitors(site, query)

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -4,6 +4,7 @@ defmodule Plausible.Stats.Query do
   defstruct date_range: nil,
             interval: nil,
             period: nil,
+            property: nil,
             filters: %{},
             sample_threshold: 20_000_000,
             imported_data_requested: false,
@@ -26,6 +27,7 @@ defmodule Plausible.Stats.Query do
       |> put_experimental_session_count(site, params)
       |> put_experimental_reduced_joins(site, params)
       |> put_period(site, params)
+      |> put_breakdown_property(params)
       |> put_interval(params)
       |> put_parsed_filters(params)
       |> put_imported_opts(site, params)
@@ -181,6 +183,10 @@ defmodule Plausible.Stats.Query do
     put_period(query, site, Map.merge(params, %{"period" => "30d"}))
   end
 
+  defp put_breakdown_property(query, params) do
+    struct!(query, property: params["property"])
+  end
+
   defp put_interval(%{:period => "all"} = query, params) do
     interval = Map.get(params, "interval", Interval.default_for_date_range(query.date_range))
     struct!(query, interval: interval)
@@ -295,6 +301,7 @@ defmodule Plausible.Stats.Query do
     Tracer.set_attributes([
       {"plausible.query.interval", query.interval},
       {"plausible.query.period", query.period},
+      {"plausible.query.breakdown_property", query.property},
       {"plausible.query.include_imported", query.include_imported},
       {"plausible.query.filter_keys", filter_keys},
       {"plausible.query.metrics", metrics}

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_date(params),
          query <- Query.from(site, params),
          :ok <- validate_filters(site, query.filters),
-         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query),
+         {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do
       results =
         if params["compare"] == "previous_period" do
@@ -51,14 +51,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
-         {:ok, property} <- validate_property(params),
+         :ok <- validate_property(params),
          query <- Query.from(site, params),
          :ok <- validate_filters(site, query.filters),
-         {:ok, metrics} <- parse_and_validate_metrics(params, property, query),
+         {:ok, metrics} <- parse_and_validate_metrics(params, query),
          {:ok, limit} <- validate_or_default_limit(params),
-         :ok <- ensure_custom_props_access(site, query, property) do
+         :ok <- ensure_custom_props_access(site, query) do
       page = String.to_integer(Map.get(params, "page", "1"))
-      results = Plausible.Stats.breakdown(site, query, property, metrics, {limit, page})
+      results = Plausible.Stats.breakdown(site, query, metrics, {limit, page})
 
       json(conn, %{results: results})
     else
@@ -68,7 +68,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   defp validate_property(%{"property" => property}) do
     if Plausible.Stats.Props.valid_prop?(property) do
-      {:ok, property}
+      :ok
     else
       {:error,
        "Invalid property '#{property}'. Please provide a valid property for the breakdown endpoint: https://plausible.io/docs/stats-api#properties"}
@@ -93,12 +93,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   @default_breakdown_limit 100
   defp validate_or_default_limit(_), do: {:ok, @default_breakdown_limit}
 
-  defp parse_and_validate_metrics(params, property, query) do
+  defp parse_and_validate_metrics(params, query) do
     metrics =
       Map.get(params, "metrics", "visitors")
       |> String.split(",")
 
-    case validate_metrics(metrics, property, query) do
+    case validate_metrics(metrics, query) do
       {:error, reason} ->
         {:error, reason}
 
@@ -107,14 +107,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
-  @spec ensure_custom_props_access(Plausible.Site.t(), Query.t(), String.t() | nil) ::
+  @spec ensure_custom_props_access(Plausible.Site.t(), Query.t()) ::
           :ok | {:error, {402, String.t()}}
-  defp ensure_custom_props_access(site, query, property \\ nil) do
+  defp ensure_custom_props_access(site, query) do
     allowed_props = Plausible.Props.allowed_for(site, bypass_setup?: true)
     prop_filter = Query.get_filter_by_prefix(query, "event:props:")
 
     query_allowed? =
-      case {prop_filter, property, allowed_props} do
+      case {prop_filter, query.property, allowed_props} do
         {_, _, :all} ->
           true
 
@@ -136,24 +136,24 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
-  defp validate_metrics(metrics, property, query) do
+  defp validate_metrics(metrics, query) do
     if length(metrics) == length(Enum.uniq(metrics)) do
-      validate_each_metric(metrics, property, query)
+      validate_each_metric(metrics, query)
     else
       {:error, "Metrics cannot be queried multiple times."}
     end
   end
 
-  defp validate_each_metric(metrics, property, query) do
+  defp validate_each_metric(metrics, query) do
     Enum.reduce_while(metrics, [], fn metric, acc ->
-      case validate_metric(metric, property, query) do
+      case validate_metric(metric, query) do
         {:ok, metric} -> {:cont, acc ++ [metric]}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
   end
 
-  defp validate_metric("time_on_page" = metric, property, query) do
+  defp validate_metric("time_on_page" = metric, query) do
     cond do
       query.filters["event:goal"] ->
         {:error, "Metric `#{metric}` cannot be queried when filtering by `event:goal`"}
@@ -161,10 +161,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
       query.filters["event:name"] ->
         {:error, "Metric `#{metric}` cannot be queried when filtering by `event:name`"}
 
-      property == "event:page" ->
+      query.property == "event:page" ->
         {:ok, metric}
 
-      not is_nil(property) ->
+      not is_nil(query.property) ->
         {:error,
          "Metric `#{metric}` is not supported in breakdown queries (except `event:page` breakdown)"}
 
@@ -177,9 +177,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
-  defp validate_metric("conversion_rate" = metric, property, query) do
+  defp validate_metric("conversion_rate" = metric, query) do
     cond do
-      property == "event:goal" ->
+      query.property == "event:goal" ->
         {:ok, metric}
 
       query.filters["event:goal"] ->
@@ -191,7 +191,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
-  defp validate_metric("events" = metric, _, query) do
+  defp validate_metric("events" = metric, query) do
     if query.include_imported do
       {:error, "Metric `#{metric}` cannot be queried with imported data"}
     else
@@ -199,37 +199,37 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     end
   end
 
-  defp validate_metric(metric, _, _) when metric in ["visitors", "pageviews"] do
+  defp validate_metric(metric, _) when metric in ["visitors", "pageviews"] do
     {:ok, metric}
   end
 
-  defp validate_metric("views_per_visit" = metric, property, query) do
+  defp validate_metric("views_per_visit" = metric, query) do
     cond do
       query.filters["event:page"] ->
         {:error, "Metric `#{metric}` cannot be queried with a filter on `event:page`."}
 
-      property != nil ->
+      query.property != nil ->
         {:error, "Metric `#{metric}` is not supported in breakdown queries."}
 
       true ->
-        validate_session_metric(metric, property, query)
+        validate_session_metric(metric, query)
     end
   end
 
-  defp validate_metric(metric, property, query)
+  defp validate_metric(metric, query)
        when metric in ["visits", "bounce_rate", "visit_duration"] do
-    validate_session_metric(metric, property, query)
+    validate_session_metric(metric, query)
   end
 
-  defp validate_metric(metric, _, _) do
+  defp validate_metric(metric, _) do
     {:error,
      "The metric `#{metric}` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"}
   end
 
-  defp validate_session_metric(metric, property, query) do
+  defp validate_session_metric(metric, query) do
     cond do
-      event_only_property?(property) ->
-        {:error, "Session metric `#{metric}` cannot be queried for breakdown by `#{property}`."}
+      event_only_property?(query.property) ->
+        {:error, "Session metric `#{metric}` cannot be queried for breakdown by `#{query.property}`."}
 
       event_only_filter = find_event_only_filter(query) ->
         {:error,
@@ -257,7 +257,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_interval(params),
          query <- Query.from(site, params),
          :ok <- validate_filters(site, query.filters),
-         {:ok, metrics} <- parse_and_validate_metrics(params, nil, query),
+         {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do
       graph = Plausible.Stats.timeseries(site, query, metrics)
 

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -13,6 +13,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   def aggregate(conn, params) do
     site = Repo.preload(conn.assigns.site, :owner)
 
+    params = Map.put(params, "property", nil)
+
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          query <- Query.from(site, params),
@@ -229,7 +231,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   defp validate_session_metric(metric, query) do
     cond do
       event_only_property?(query.property) ->
-        {:error, "Session metric `#{metric}` cannot be queried for breakdown by `#{query.property}`."}
+        {:error,
+         "Session metric `#{metric}` cannot be queried for breakdown by `#{query.property}`."}
 
       event_only_filter = find_event_only_filter(query) ->
         {:error,
@@ -251,6 +254,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   def timeseries(conn, params) do
     site = Repo.preload(conn.assigns.site, :owner)
+
+    params = Map.put(params, "property", nil)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -456,6 +456,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def sources(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:source")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
 
@@ -465,7 +466,7 @@ defmodule PlausibleWeb.Api.StatsController do
     metrics = breakdown_metrics(query, extra_metrics)
 
     res =
-      Stats.breakdown(site, query, "visit:source", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{source: :name})
 
     if params["csv"] do
@@ -537,12 +538,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def utm_mediums(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:utm_medium")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:utm_medium", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{utm_medium: :name})
 
     if params["csv"] do
@@ -560,12 +562,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def utm_campaigns(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:utm_campaign")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:utm_campaign", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{utm_campaign: :name})
 
     if params["csv"] do
@@ -583,12 +586,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def utm_contents(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:utm_content")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:utm_content", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{utm_content: :name})
 
     if params["csv"] do
@@ -606,12 +610,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def utm_terms(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:utm_term")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:utm_term", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{utm_term: :name})
 
     if params["csv"] do
@@ -629,12 +634,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def utm_sources(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:utm_source")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:utm_source", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{utm_source: :name})
 
     if params["csv"] do
@@ -652,12 +658,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def referrers(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:referrer")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:bounce_rate, :visit_duration])
 
     res =
-      Stats.breakdown(site, query, "visit:referrer", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{referrer: :name})
 
     if params["csv"] do
@@ -710,6 +717,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def referrer_drilldown(conn, %{"referrer" => referrer} = params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:referrer")
 
     query =
       Query.from(site, params)
@@ -723,7 +731,7 @@ defmodule PlausibleWeb.Api.StatsController do
     metrics = breakdown_metrics(query, extra_metrics)
 
     referrers =
-      Stats.breakdown(site, query, "visit:referrer", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{referrer: :name})
 
     json(conn, referrers)
@@ -731,6 +739,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def pages(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "event:page")
     query = Query.from(site, params)
 
     extra_metrics =
@@ -742,7 +751,7 @@ defmodule PlausibleWeb.Api.StatsController do
     pagination = parse_pagination(params)
 
     pages =
-      Stats.breakdown(site, query, "event:page", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{page: :name})
 
     if params["csv"] do
@@ -760,12 +769,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def entry_pages(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:entry_page")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:visits, :visit_duration])
 
     entry_pages =
-      Stats.breakdown(site, query, "visit:entry_page", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{entry_page: :name})
 
     if params["csv"] do
@@ -790,12 +800,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def exit_pages(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:exit_page")
     query = Query.from(site, params)
     {limit, page} = parse_pagination(params)
     metrics = breakdown_metrics(query, [:visits])
 
     exit_pages =
-      Stats.breakdown(site, query, "visit:exit_page", metrics, {limit, page})
+      Stats.breakdown(site, query, metrics, {limit, page})
       |> add_exit_rate(site, query, limit)
       |> transform_keys(%{exit_page: :name})
 
@@ -828,9 +839,10 @@ defmodule PlausibleWeb.Api.StatsController do
       total_visits_query =
         Query.put_filter(query, "event:page", {:member, pages})
         |> Query.put_filter("event:name", {:is, "pageview"})
+        |> struct!(property: "event:page")
 
       total_pageviews =
-        Stats.breakdown(site, total_visits_query, "event:page", [:pageviews], {limit, 1})
+        Stats.breakdown(site, total_visits_query, [:pageviews], {limit, 1})
 
       Enum.map(breakdown_results, fn result ->
         exit_rate =
@@ -849,12 +861,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def countries(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:country")
     query = site |> Query.from(params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     countries =
-      Stats.breakdown(site, query, "visit:country", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{country: :code})
 
     if params["csv"] do
@@ -900,12 +913,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def regions(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:region")
     query = site |> Query.from(params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query)
 
     regions =
-      Stats.breakdown(site, query, "visit:region", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{region: :code})
       |> Enum.map(fn region ->
         region_entry = Location.get_subdivision(region[:code])
@@ -934,12 +948,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def cities(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:city")
     query = site |> Query.from(params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query)
 
     cities =
-      Stats.breakdown(site, query, "visit:city", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{city: :code})
       |> Enum.map(fn city ->
         city_info = Location.get_city(city[:code])
@@ -973,12 +988,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def browsers(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:browser")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     browsers =
-      Stats.breakdown(site, query, "visit:browser", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{browser: :name})
 
     if params["csv"] do
@@ -996,12 +1012,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def browser_versions(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:browser_version")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     versions =
-      Stats.breakdown(site, query, "visit:browser_version", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{browser_version: :name})
 
     if params["csv"] do
@@ -1025,12 +1042,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def operating_systems(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:os")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     systems =
-      Stats.breakdown(site, query, "visit:os", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{os: :name})
 
     if params["csv"] do
@@ -1048,12 +1066,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def operating_system_versions(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:os_version")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     versions =
-      Stats.breakdown(site, query, "visit:os_version", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{os_version: :name})
 
     if params["csv"] do
@@ -1073,12 +1092,13 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def screen_sizes(conn, params) do
     site = conn.assigns[:site]
+    params = Map.put(params, "property", "visit:device")
     query = Query.from(site, params)
     pagination = parse_pagination(params)
     metrics = breakdown_metrics(query, [:percentage])
 
     sizes =
-      Stats.breakdown(site, query, "visit:device", metrics, pagination)
+      Stats.breakdown(site, query, metrics, pagination)
       |> transform_keys(%{device: :name})
 
     if params["csv"] do
@@ -1097,6 +1117,7 @@ defmodule PlausibleWeb.Api.StatsController do
   def conversions(conn, params) do
     pagination = parse_pagination(params)
     site = Plausible.Repo.preload(conn.assigns.site, :goals)
+    params = Map.put(params, "property", "event:goal")
     query = Query.from(site, params)
 
     query =
@@ -1110,7 +1131,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     conversions =
       site
-      |> Stats.breakdown(query, "event:goal", metrics, pagination)
+      |> Stats.breakdown(query, metrics, pagination)
       |> transform_keys(%{goal: :name})
       |> Enum.map(fn goal ->
         goal
@@ -1182,6 +1203,8 @@ defmodule PlausibleWeb.Api.StatsController do
     pagination = parse_pagination(params)
     prefixed_prop = "event:props:" <> prop_key
 
+    params = Map.put(params, "property", prefixed_prop)
+
     query =
       Query.from(site, params)
       |> Map.put(:include_imported, false)
@@ -1193,7 +1216,7 @@ defmodule PlausibleWeb.Api.StatsController do
         [:visitors, :events, :percentage] ++ @revenue_metrics
       end
 
-    Stats.breakdown(site, query, prefixed_prop, metrics, pagination)
+    Stats.breakdown(site, query, metrics, pagination)
     |> transform_keys(%{prop_key => :name})
     |> Enum.map(fn entry ->
       Enum.map(entry, &format_revenue_metric/1)

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -59,6 +59,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
              }
     end
 
+    test "ignores a given property parameter", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "property" => "event:props:author",
+          "metrics" => "visit_duration"
+        })
+
+      assert json_response(conn, 200)
+    end
+
     test "validates that period can be parsed", %{conn: conn, site: site} do
       conn =
         get(conn, "/api/v1/stats/aggregate", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -60,6 +60,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
              }
     end
 
+    test "ignores a given property parameter", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/timeseries", %{
+          "site_id" => site.domain,
+          "property" => "event:props:author",
+          "metrics" => "visit_duration"
+        })
+
+      assert json_response(conn, 200)
+    end
+
     test "validates that period can be parsed", %{conn: conn, site: site} do
       conn =
         get(conn, "/api/v1/stats/timeseries", %{


### PR DESCRIPTION
### Changes

This PR adds a `property` field into the `Stats.Query` struct, and uses it around the codebase instead of passing it as a separate argument to `Stats.Breakdown`.

There are no behavioural changes introduced here, except a tiny modification to tracing the `event:page` property in the `event:page` breakdown query (which I think is the desired behaviour). Instead of `visit:entry_page` which is the actual requested breakdown prop.

**Motivation for this change**

With the upcoming changes related to imported custom events and filtering by imported data, evaluating the `include_imported` field in the Query struct depends on the breakdown property.

Simply passing the `property` into the `Query.from` function and **not** persisting it in the struct is not enough. That's because we need to be able to construct a comparison Query struct based on the given source Query struct.



### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
