### PR TITLE
Clean up deleted sites from clickhouse cron

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -524,7 +524,9 @@ cloud_cron = [
   # Every midnight
   {"0 0 * * *", Plausible.Workers.LockSites},
   # Daily at 8
-  {"0 8 * * *", Plausible.Workers.AcceptTrafficUntil}
+  {"0 8 * * *", Plausible.Workers.AcceptTrafficUntil},
+  # First sunday of the month, 4:00 UTC
+  {"0 4 1-7 * SUN", Plausible.Workers.ClickhouseCleanSites}
 ]
 
 crontab = if(is_selfhost, do: base_cron, else: base_cron ++ cloud_cron)


### PR DESCRIPTION
### Changes

The job has ran nicely 2x on cloud, daring to make this a once-per-month cron now.