### PR TITLE
Remove `maybe_drop_prop_filter`

### DIFF
--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -270,17 +270,17 @@ defmodule Plausible.Stats.Query do
   end
 
   defp maybe_drop_prop_filter(query, site) do
+    props_keys =
+      query.filters
+      |> Map.keys()
+      |> Enum.filter(&String.starts_with?(&1, "event:props"))
+
     props_unavailable? = fn ->
       site = Plausible.Repo.preload(site, :owner)
       Plausible.Billing.Feature.Props.check_availability(site.owner) != :ok
     end
 
-    if props_unavailable?.() do
-      props_keys =
-        query.filters
-        |> Map.keys()
-        |> Enum.filter(&String.starts_with?(&1, "event:props"))
-
+    if length(props_keys) > 0 and props_unavailable?.() do
       struct!(query, filters: Map.drop(query.filters, props_keys))
     else
       query

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -203,21 +203,5 @@ defmodule Plausible.Stats.QueryTest do
 
       assert q.filters["visit:source"] == {:is, "Twitter"}
     end
-
-    test "allows prop filters when site owner is on a business plan", %{site: site, user: user} do
-      insert(:business_subscription, user: user)
-      filters = Jason.encode!(%{"props" => %{"author" => "!John Doe"}})
-      query = Query.from(site, %{"period" => "6mo", "filters" => filters})
-
-      assert query.filters == %{"event:props:author" => {:is_not, "John Doe"}}
-    end
-
-    test "drops prop filter when site owner is on a growth plan", %{site: site, user: user} do
-      insert(:growth_subscription, user: user)
-      filters = Jason.encode!(%{"props" => %{"author" => "!John Doe"}})
-      query = Query.from(site, %{"period" => "6mo", "filters" => filters})
-
-      assert query.filters == %{}
-    end
   end
 end

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -209,7 +209,7 @@ defmodule Plausible.Stats.QueryTest do
       filters = Jason.encode!(%{"props" => %{"author" => "!John Doe"}})
       query = Query.from(site, %{"period" => "6mo", "filters" => filters})
 
-      assert Map.has_key?(query.filters, "event:props:author")
+      assert query.filters == %{"event:props:author" => {:is_not, "John Doe"}}
     end
 
     test "drops prop filter when site owner is on a growth plan", %{site: site, user: user} do
@@ -217,7 +217,7 @@ defmodule Plausible.Stats.QueryTest do
       filters = Jason.encode!(%{"props" => %{"author" => "!John Doe"}})
       query = Query.from(site, %{"period" => "6mo", "filters" => filters})
 
-      refute Map.has_key?(query.filters, "props")
+      assert query.filters == %{}
     end
   end
 end


### PR DESCRIPTION
Previous code wasn't properly omitting event property filters from queries.

Fixing the code causes issues with external_stats_controllers validations so I propose we just drop this.