### PR TITLE
Crop debug query headers if length > 8000

### DIFF
--- a/lib/plausible_web/plugs/inject_debug_headers.ex
+++ b/lib/plausible_web/plugs/inject_debug_headers.ex
@@ -4,6 +4,8 @@ defmodule PlausibleWeb.Plugs.InjectDebugHeaders do
   granted they were tracked via `Plausible.DebugReplayInfo`.
   """
 
+  @max_header_size 8000
+
   def init(opts), do: opts
 
   def call(conn, _opts \\ []) do
@@ -14,12 +16,21 @@ defmodule PlausibleWeb.Plugs.InjectDebugHeaders do
       |> Enum.reduce(conn, fn {q, index}, conn ->
         {[label], [value]} = Enum.unzip(q)
 
-        conn
-        |> Plug.Conn.put_resp_header(
-          "x-plausible-query-#{String.pad_leading("#{index}", 3, "0")}-#{label}",
-          String.replace(value, ["\n", "\r", "\x00"], "")
-        )
+        {label, value} = sanitize(label, value, index)
+
+        Plug.Conn.put_resp_header(conn, label, String.replace(value, ["\n", "\r", "\x00"], ""))
       end)
     end)
   end
+
+  defp sanitize(label, value, index) when byte_size(value) > @max_header_size do
+    {"#{annotate(label, index)}-cropped", String.slice(value, 0, @max_header_size)}
+  end
+
+  defp sanitize(label, value, index) do
+    {"#{annotate(label, index)}", value}
+  end
+
+  defp annotate(label, index),
+    do: "x-plausible-query-#{String.pad_leading("#{index}", 3, "0")}-#{label}"
 end

--- a/test/plausible_web/plugs/inject_debug_headers_test.exs
+++ b/test/plausible_web/plugs/inject_debug_headers_test.exs
@@ -36,4 +36,13 @@ defmodule PlausibleWeb.Plugs.InjectDebugHeadersTest do
                {"x-plausible-query-002-trap3", "baz"}
              ]
   end
+
+  test "crops lengthy header values" do
+    :ok = Plausible.DebugReplayInfo.track_query(:binary.copy("a", 10_000), "trap1")
+    conn = :get |> conn("/") |> InjectDebugHeaders.call() |> send_resp(200, "")
+
+    assert Plug.Conn.get_resp_header(conn, "x-plausible-query-000-trap1-cropped") == [
+             :binary.copy("a", 8000)
+           ]
+  end
 end


### PR DESCRIPTION
This is a temporary measure, until we figure out a better fix, such as chunking/compressing the queries and client-side assembly.

