### PR TITLE
Rename Plugins API Token(s) to Plugin Token(s)

### DIFF
--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -54,7 +54,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
       <div class="border-t border-gray-200 pt-4 grid">
         <div class="mt-4 sm:ml-4 sm:mt-0 justify-self-end">
           <PlausibleWeb.Components.Generic.button phx-click="add-token">
-            + Add Token
+            + Add Plugin Token
           </PlausibleWeb.Components.Generic.button>
         </div>
       </div>
@@ -140,7 +140,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
   def handle_info({:token_added, token}, socket) do
     displayed_tokens = [token | socket.assigns.displayed_tokens]
 
-    socket = put_live_flash(socket, :success, "Plugins API Token created successfully")
+    socket = put_live_flash(socket, :success, "Plugins Token created successfully")
 
     {:noreply,
      assign(socket,

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -57,7 +57,9 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
           phx-submit="save-token"
           phx-click-away="cancel-add-token"
         >
-          <h2 class="text-xl font-black dark:text-gray-100 mb-8">Add Token for <%= @domain %></h2>
+          <h2 class="text-xl font-black dark:text-gray-100 mb-8">
+            Add Plugin Token for <%= @domain %>
+          </h2>
 
           <.input
             autofocus
@@ -72,22 +74,22 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
           <.input_with_clipboard
             id="token-clipboard"
             name="token_clipboard"
-            label="API Token"
+            label="Plugin Token"
             value={@token.raw}
             onfocus="this.value = this.value;"
             class="focus:ring-indigo-500 focus:border-indigo-500 bg-gray-50 dark:bg-gray-850 dark:text-gray-300 block w-7/12 rounded-md sm:text-sm border-gray-300 dark:border-gray-500 w-full p-2 mt-2"
           />
 
           <p class="text-sm mt-2 text-gray-500 dark:text-gray-200">
-            Once created, we will not be able to show the Token again.
-            Please copy the Token now and store it in a secure place.
+            Once created, we will not be able to show the Plugin Token again.
+            Please copy the Plugin Token now and store it in a secure place.
             <span :if={@token_description == "WordPress"}>
               You'll need to paste it in the settings area of the Plausible WordPress plugin.
             </span>
           </p>
           <div class="py-4 mt-8">
             <PlausibleWeb.Components.Generic.button type="submit" class="w-full">
-              Add Token →
+              Add Plugin Token →
             </PlausibleWeb.Components.Generic.button>
           </div>
         </.form>

--- a/lib/plausible_web/plugins/api/spec.ex
+++ b/lib/plausible_web/plugins/api/spec.ex
@@ -29,7 +29,7 @@ defmodule PlausibleWeb.Plugins.API.Spec do
             scheme: "basic",
             description: """
             HTTP basic access authentication using your Site Domain as the
-            username and the Plugins API Token contents as the password.
+            username and the Plugin Token contents as the password.
             Note that Site Domain is optional, a password alone suffices.
 
             For more information see

--- a/lib/plausible_web/templates/site/settings_integrations.html.heex
+++ b/lib/plausible_web/templates/site/settings_integrations.html.heex
@@ -10,10 +10,10 @@
   <div class="py-6 px-4 sm:p-6">
     <header class="relative">
       <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
-        Plugins API Tokens
+        Plugin Tokens
       </h2>
       <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
-        Control Plugins API Access
+        Control Plugin Access
       </p>
     </header>
 

--- a/test/plausible_web/live/plugins_api_tokens_test.exs
+++ b/test/plausible_web/live/plugins_api_tokens_test.exs
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       conn = get(conn, "/#{site.domain}/integrations")
       resp = html_response(conn, 200)
 
-      refute resp =~ "Plugins API Tokens"
+      refute resp =~ "Plugin Tokens"
     end
 
     test "does display the Plugins API section on ?new_token=....", %{
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       conn = get(conn, "/#{site.domain}/settings/integrations?new_token=test")
       resp = html_response(conn, 200)
 
-      assert resp =~ "Plugins API Tokens"
+      assert resp =~ "Plugin Tokens"
     end
 
     test "does display the Plugins API section when there are tokens already created", %{
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       conn = get(conn, "/#{site.domain}/settings/integrations")
       resp = html_response(conn, 200)
 
-      assert resp =~ "Plugins API Tokens"
+      assert resp =~ "Plugin Tokens"
     end
 
     test "lists tokens with revoke actions", %{conn: conn, site: site} do
@@ -83,7 +83,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       assert element_exists?(html, "#token-form")
       assert text_of_element(html, "label[for=token_description]") == "Description"
       assert element_exists?(html, "input[value=WordPress]#token_description")
-      assert text_of_element(html, "label[for=token-clipboard]") == "API Token"
+      assert text_of_element(html, "label[for=token-clipboard]") == "Plugin Token"
       assert element_exists?(html, "input#token-clipboard")
 
       assert element_exists?(


### PR DESCRIPTION
Deployment needs to be coordinated with WordPress plugin update. Reasoning: there's too much confusion coming from the use of the "API" terminology, leading to wrong keys being generated by users.
