### PR TITLE
Migration: add imported custom events

### DIFF
--- a/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
+++ b/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
@@ -28,6 +28,7 @@ defmodule Plausible.IngestRepo.Migrations.AddImportedCustomEvents do
                 `date` Date,
                 `name` String CODEC(ZSTD(3)),
                 `link_url` String CODEC(ZSTD(3)),
+                `path` String CODEC(ZSTD(3)),
                 `visitors` UInt64,
                 `events` UInt64
             )

--- a/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
+++ b/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
@@ -1,0 +1,40 @@
+defmodule Plausible.IngestRepo.Migrations.AddImportedCustomEvents do
+  use Ecto.Migration
+
+  def change do
+    # NOTE: Using another table for determining cluster presence
+    on_cluster = Plausible.MigrationUtils.on_cluster_statement("imported_pages")
+
+    settings =
+      if Plausible.MigrationUtils.clustered_table?("imported_pages") do
+        """
+        ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/imported_custom_events', '{replica}')
+        ORDER BY (site_id, import_id, date, name)
+        SETTINGS index_granularity = 8192, replicated_deduplication_window = 0, storage_policy = 'tiered'
+        """
+      else
+        """
+        ENGINE = MergeTree()
+        ORDER BY (site_id, import_id, date, name)
+        SETTINGS index_granularity = 8192, replicated_deduplication_window = 0
+        """
+      end
+
+    execute """
+            CREATE TABLE IF NOT EXISTS imported_custom_events #{on_cluster}
+                (
+                `site_id` UInt64,
+                `import_id` UInt64,
+                `date` Date,
+                `name` String CODEC(ZSTD(3)),
+                `link_url` String CODEC(ZSTD(3)),
+                `visitors` UInt64,
+                `events` UInt64
+            )
+            #{settings}
+            """,
+            """
+            DROP TABLE IF EXISTS imported_custom_events #{on_cluster} SYNC
+            """
+  end
+end

--- a/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
+++ b/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
@@ -10,13 +10,13 @@ defmodule Plausible.IngestRepo.Migrations.AddImportedCustomEvents do
         """
         ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/imported_custom_events', '{replica}')
         ORDER BY (site_id, import_id, date, name)
-        SETTINGS index_granularity = 8192, replicated_deduplication_window = 0, storage_policy = 'tiered'
+        SETTINGS replicated_deduplication_window = 0, storage_policy = 'tiered'
         """
       else
         """
         ENGINE = MergeTree()
         ORDER BY (site_id, import_id, date, name)
-        SETTINGS index_granularity = 8192, replicated_deduplication_window = 0
+        SETTINGS replicated_deduplication_window = 0
         """
       end
 


### PR DESCRIPTION
### Changes

Extracted migration from #4033. Also added `path` column which will be needed later on when exporting 404 goals into CSV.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
