### PR TITLE
Update join_algorithm

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -386,7 +386,7 @@ config :plausible, Plausible.ClickhouseRepo,
   transport_opts: ch_transport_opts,
   settings: [
     readonly: 1,
-    join_algorithm: "direct,parallel_hash"
+    join_algorithm: "direct,parallel_hash,hash"
   ]
 
 config :plausible, Plausible.IngestRepo,


### PR DESCRIPTION
Staging is currently (temporary) running a newer version of Clickhouse which needs this change.
It's safe to use it with the older Clickhouse version on prod.