### PR TITLE
drop local_start_date/1

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -196,35 +196,6 @@ defmodule Plausible.Sites do
     |> Plausible.Repo.update!()
   end
 
-  @doc """
-  Returns the date of the first recorded stat in the timezone configured by the user.
-  This function does 2 transformations:
-    UTC %NaiveDateTime{} -> Local %DateTime{} -> Local %Date
-
-  ## Examples
-
-    iex> Plausible.Site.local_start_date(%Plausible.Site{stats_start_date: nil})
-    nil
-
-    iex> utc_start = ~N[2022-09-28 00:00:00]
-    iex> tz = "Europe/Helsinki"
-    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
-    iex> Plausible.Site.local_start_date(site)
-    ~D[2022-09-28]
-
-    iex> utc_start = ~N[2022-09-28 00:00:00]
-    iex> tz = "America/Los_Angeles"
-    iex> site = %Plausible.Site{stats_start_date: utc_start, timezone: tz}
-    iex> Plausible.Site.local_start_date(site)
-    ~D[2022-09-27]
-  """
-  @spec local_start_date(Site.t()) :: Date.t() | nil
-  def local_start_date(site) do
-    if stats_start_date = stats_start_date(site) do
-      Plausible.Timezones.to_date_in_timezone(stats_start_date, site.timezone)
-    end
-  end
-
   @spec stats_start_date(Site.t()) :: Date.t() | nil
   @doc """
   Returns the date of the first event of the given site, or `nil` if the site

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -150,7 +150,7 @@ defmodule Plausible.Stats.Query do
 
   defp put_period(query, site, %{"period" => "all"}) do
     now = today(site.timezone)
-    start_date = Plausible.Sites.local_start_date(site) || now
+    start_date = Plausible.Sites.stats_start_date(site) || now
 
     struct!(query,
       period: "all",

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -105,7 +105,7 @@ defmodule Plausible.Stats.QueryTest do
     site = Map.put(site, :timezone, "America/Cancun")
     q = Query.from(site, %{"period" => "all"})
 
-    assert q.date_range.first == ~D[2019-12-31]
+    assert q.date_range.first == ~D[2020-01-01]
     assert q.date_range.last == Timex.today("America/Cancun")
   end
 


### PR DESCRIPTION
### Changes

More info: https://3.basecamp.com/5308029/buckets/35871979/card_tables/cards/7202028179#__recording_7227349424

### Tests
- [x] Automated tests have been updated

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI