### PR TITLE
Remove `imports_exports` and `csv_imports_exports` feature flags

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -43,13 +43,9 @@ defmodule Plausible.Imported do
   @spec tables() :: [String.t()]
   def tables, do: @table_names
 
-  @spec max_complete_imports(Site.t()) :: non_neg_integer()
-  def max_complete_imports(site) do
-    if FunWithFlags.enabled?(:imports_exports, for: site) do
-      @max_complete_imports
-    else
-      1
-    end
+  @spec max_complete_imports() :: non_neg_integer()
+  def max_complete_imports() do
+    @max_complete_imports
   end
 
   @spec load_import_data(Site.t()) :: Site.t()

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -46,12 +46,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
 
     redirect_route = Routes.site_path(conn, :settings_imports_exports, site.domain)
 
-    result =
-      if FunWithFlags.enabled?(:imports_exports, for: site) do
-        Google.API.list_properties_and_views(access_token)
-      else
-        Google.UA.API.list_views(access_token)
-      end
+    result = Google.API.list_properties_and_views(access_token)
 
     error =
       case params["error"] do

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -37,13 +37,10 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       |> assign_new(:current_user, fn ->
         Plausible.Repo.get(Plausible.Auth.User, user_id)
       end)
-      |> assign_new(:max_imports, fn %{site: site} ->
-        Imported.max_complete_imports(site)
-      end)
 
     :ok = Imported.listen()
 
-    {:ok, socket}
+    {:ok, assign(socket, max_imports: Imported.max_complete_imports())}
   end
 
   def render(assigns) do
@@ -54,8 +51,6 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       )
 
     at_maximum? = length(assigns.site_imports) >= assigns.max_imports
-
-    csv_imports_exports_enabled? = FunWithFlags.enabled?(:csv_imports_exports, for: assigns.site)
 
     import_warning =
       cond do
@@ -74,8 +69,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       assign(assigns,
         import_in_progress?: import_in_progress?,
         at_maximum?: at_maximum?,
-        import_warning: import_warning,
-        csv_imports_exports_enabled?: csv_imports_exports_enabled?
+        import_warning: import_warning
       )
 
     ~H"""
@@ -90,7 +84,6 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       </.button_link>
 
       <.button_link
-        :if={@csv_imports_exports_enabled?}
         class="w-36 h-20"
         theme="bright"
         disabled={@import_in_progress? or @at_maximum?}

--- a/lib/plausible_web/templates/site/settings_imports_exports.html.heex
+++ b/lib/plausible_web/templates/site/settings_imports_exports.html.heex
@@ -5,11 +5,7 @@
     </h2>
     <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
       Import existing data from external sources.
-      <%= if FunWithFlags.enabled?(:csv_imports_exports, for: @site) do %>
-        Pick one of the options below to start a new import.
-      <% else %>
-        Click below to start a new import.
-      <% end %>
+      Pick one of the options below to start a new import.
     </p>
 
     <PlausibleWeb.Components.Generic.docs_info slug="google-analytics-import" />
@@ -20,23 +16,21 @@
   ) %>
 </div>
 
-<%= if FunWithFlags.enabled?(:csv_imports_exports, for: @site) or Plausible.Auth.is_super_admin?(@current_user) do %>
-  <div class="shadow bg-white dark:bg-gray-800 dark:text-gray-200 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
-    <header class="relative border-b border-gray-200 pb-4 mb-5">
-      <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
-        Export Data
-      </h2>
-      <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
-        Export all your data into CSV format.
-      </p>
-    </header>
+<div class="shadow bg-white dark:bg-gray-800 dark:text-gray-200 sm:rounded-md sm:overflow-hidden py-6 px-4 sm:p-6">
+  <header class="relative border-b border-gray-200 pb-4 mb-5">
+    <h2 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
+      Export Data
+    </h2>
+    <p class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-200">
+      Export all your data into CSV format.
+    </p>
+  </header>
 
-    <%= live_render(@conn, PlausibleWeb.Live.CSVExport,
-      session: %{
-        "site_id" => @site.id,
-        "email_to" => @current_user.email,
-        "storage" => on_ee(do: "s3", else: "local")
-      }
-    ) %>
-  </div>
-<% end %>
+  <%= live_render(@conn, PlausibleWeb.Live.CSVExport,
+    session: %{
+      "site_id" => @site.id,
+      "email_to" => @current_user.email,
+      "storage" => on_ee(do: "s3", else: "local")
+    }
+  ) %>
+</div>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -49,13 +49,6 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def settings_tabs(conn) do
-    imports_exports_key =
-      if FunWithFlags.enabled?(:csv_imports_exports, for: conn.assigns.site) do
-        "Imports & Exports"
-      else
-        "Imports"
-      end
-
     [
       %{key: "General", value: "general", icon: :rocket_launch},
       %{key: "People", value: "people", icon: :users},
@@ -66,7 +59,7 @@ defmodule PlausibleWeb.LayoutView do
       end,
       %{key: "Custom Properties", value: "properties", icon: :document_text},
       %{key: "Integrations", value: "integrations", icon: :arrow_path_rounded_square},
-      %{key: imports_exports_key, value: "imports-exports", icon: :arrows_up_down},
+      %{key: "Imports & Exports", value: "imports-exports", icon: :arrows_up_down},
       %{
         key: "Shields",
         icon: :shield_exclamation,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,9 +10,6 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-FunWithFlags.enable(:imports_exports)
-FunWithFlags.enable(:csv_imports_exports)
-
 user = Plausible.Factory.insert(:user, email: "user@plausible.test", password: "plausible")
 
 native_stats_range =

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -679,7 +679,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "disables import buttons when imports are at maximum", %{conn: conn, site: site} do
-      insert_list(Plausible.Imported.max_complete_imports(site), :site_import,
+      insert_list(Plausible.Imported.max_complete_imports(), :site_import,
         site: site,
         status: SiteImport.completed()
       )
@@ -687,7 +687,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn = get(conn, "/#{site.domain}/settings/imports-exports")
 
       assert html_response(conn, 200) =~
-               "Maximum of #{Plausible.Imported.max_complete_imports(site)} imports is reached."
+               "Maximum of #{Plausible.Imported.max_complete_imports()} imports is reached."
     end
 
     test "considers older legacy imports when showing pageview count", %{conn: conn, site: site} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,8 +5,6 @@ end
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 Application.ensure_all_started(:double)
-FunWithFlags.enable(:imports_exports)
-FunWithFlags.enable(:csv_imports_exports)
 
 # Temporary flag to test `experimental_reduced_joins` flag on all tests.
 if System.get_env("TEST_EXPERIMENTAL_REDUCED_JOINS") == "1" do


### PR DESCRIPTION
### Changes

This PR removes both, `imports_exports` and `csv_imports_exports` flags from the code as they are fully enabled in production now.
