### PR TITLE
Refactor filter suggestions with a more DRY approach

### DIFF
--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -192,7 +192,24 @@ defmodule Plausible.Stats.FilterSuggestions do
     filter_name =
       case filter_name do
         "page" -> :pathname
-        filter_name -> String.to_existing_atom(filter_name)
+        "entry_page" -> :entry_page
+        "source" -> :referrer_source
+        "os" -> :operating_system
+        "os_version" -> :operating_system_version
+        "screen" -> :screen_size
+        "exit_page" -> :exit_page
+        "utm_source" -> :utm_source
+        "utm_medium" -> :utm_medium
+        "utm_campaign" -> :utm_campaign
+        "utm_content" -> :utm_content
+        "utm_term" -> :utm_term
+        "referrer" -> :referrer
+        "browser" -> :browser
+        "browser_version" -> :browser_version
+        "operating_system" -> :operating_system
+        "operating_system_version" -> :operating_system_version
+        "screen_size" -> :screen_size
+        "hostname" -> :hostname
       end
 
     base_q =

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -192,149 +192,42 @@ defmodule Plausible.Stats.FilterSuggestions do
     filter_name =
       case filter_name do
         "page" -> :pathname
-        "entry_page" -> :entry_page
-        "source" -> :referrer_source
-        "os" -> :operating_system
-        "os_version" -> :operating_system_version
-        "screen" -> :screen_size
-        "exit_page" -> :exit_page
-        "utm_source" -> :utm_source
-        "utm_medium" -> :utm_medium
-        "utm_campaign" -> :utm_campaign
-        "utm_content" -> :utm_content
-        "utm_term" -> :utm_term
-        "referrer" -> :referrer
-        "browser" -> :browser
-        "browser_version" -> :browser_version
-        "operating_system" -> :operating_system
-        "operating_system_version" -> :operating_system_version
-        "screen_size" -> :screen_size
-        "hostname" -> :hostname
-        _ -> :unknown
+        filter_name -> String.to_existing_atom(filter_name)
       end
 
-    q =
-      if(filter_name == :pathname or filter_name == :hostname,
-        do: base_event_query(site, query),
-        else: query_sessions(site, query)
-      )
-      |> from(
-        group_by: ^filter_name,
-        order_by: [desc: fragment("count(*)")],
-        limit: 25
-      )
-
-    q =
-      case filter_name do
-        :pathname ->
-          from(e in q,
-            select: e.pathname,
-            where: fragment("? ilike ?", e.pathname, ^filter_query)
-          )
-
-        :hostname ->
-          q =
-            from(e in q,
-              select: e.hostname,
-              where: fragment("? ilike ?", e.hostname, ^filter_query)
-            )
-
-          case Plausible.Shields.allowed_hostname_patterns(site.domain) do
-            :all ->
-              q
-
-            limited_to when is_list(limited_to) ->
-              from(e in q,
-                where: fragment("multiMatchAny(?, ?)", e.hostname, ^limited_to)
-              )
-          end
-
-        :entry_page ->
-          from(e in q,
-            select: e.entry_page,
-            where: fragment("? ilike ?", e.entry_page, ^filter_query)
-          )
-
-        :exit_page ->
-          from(e in q,
-            select: e.exit_page,
-            where: fragment("? ilike ?", e.exit_page, ^filter_query)
-          )
-
-        :referrer_source ->
-          from(e in q,
-            select: e.referrer_source,
-            where: fragment("? ilike ?", e.referrer_source, ^filter_query)
-          )
-
-        :utm_medium ->
-          from(e in q,
-            select: e.utm_medium,
-            where: fragment("? ilike ?", e.utm_medium, ^filter_query)
-          )
-
-        :utm_source ->
-          from(e in q,
-            select: e.utm_source,
-            where: fragment("? ilike ?", e.utm_source, ^filter_query)
-          )
-
-        :utm_campaign ->
-          from(e in q,
-            select: e.utm_campaign,
-            where: fragment("? ilike ?", e.utm_campaign, ^filter_query)
-          )
-
-        :utm_content ->
-          from(e in q,
-            select: e.utm_content,
-            where: fragment("? ilike ?", e.utm_content, ^filter_query)
-          )
-
-        :utm_term ->
-          from(e in q,
-            select: e.utm_term,
-            where: fragment("? ilike ?", e.utm_term, ^filter_query)
-          )
-
-        :referrer ->
-          from(e in q,
-            select: e.referrer,
-            where: fragment("? ilike ?", e.referrer, ^filter_query)
-          )
-
-        :browser ->
-          from(e in q, select: e.browser, where: fragment("? ilike ?", e.browser, ^filter_query))
-
-        :browser_version ->
-          from(e in q,
-            select: e.browser_version,
-            where: fragment("? ilike ?", e.browser_version, ^filter_query)
-          )
-
-        :operating_system ->
-          from(e in q,
-            select: e.operating_system,
-            where: fragment("? ilike ?", e.operating_system, ^filter_query)
-          )
-
-        :operating_system_version ->
-          from(e in q,
-            select: e.operating_system_version,
-            where: fragment("? ilike ?", e.operating_system_version, ^filter_query)
-          )
-
-        :screen_size ->
-          from(e in q,
-            select: e.screen_size,
-            where: fragment("? ilike ?", e.screen_size, ^filter_query)
-          )
+    base_q =
+      if filter_name in [:pathname, :hostname] do
+        base_event_query(site, query)
+      else
+        query_sessions(site, query)
       end
 
-    ClickhouseRepo.all(q)
+    from(e in base_q,
+      where: fragment("? ilike ?", field(e, ^filter_name), ^filter_query),
+      select: field(e, ^filter_name),
+      group_by: ^filter_name,
+      order_by: [desc: fragment("count(*)")],
+      limit: 25
+    )
+    |> apply_additional_filters(filter_name, site)
+    |> ClickhouseRepo.all()
     |> Enum.filter(fn suggestion -> suggestion != "" end)
     |> wrap_suggestions()
   end
+
+  defp apply_additional_filters(q, :hostname, site) do
+    case Plausible.Shields.allowed_hostname_patterns(site.domain) do
+      :all ->
+        q
+
+      limited_to when is_list(limited_to) ->
+        from(e in q,
+          where: fragment("multiMatchAny(?, ?)", e.hostname, ^limited_to)
+        )
+    end
+  end
+
+  defp apply_additional_filters(q, _, _), do: q
 
   defp wrap_suggestions(list) do
     Enum.map(list, fn val -> %{value: val, label: val} end)


### PR DESCRIPTION
### Changes

I was starting to use filter_suggestions API for custom event names suggestions and this was the preliminary refactoring. Later on I changed my mind but this can still go in.