### PR TITLE
Autoconfigure event goals

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -24,6 +24,10 @@ defmodule Plausible.Goal do
 
   @fields [:id, :site_id, :event_name, :page_path] ++ on_ee(do: [:currency], else: [])
 
+  @max_event_name_length 120
+
+  def max_event_name_length(), do: @max_event_name_length
+
   def changeset(goal, attrs \\ %{}) do
     goal
     |> cast(attrs, @fields)
@@ -35,7 +39,7 @@ defmodule Plausible.Goal do
     |> update_change(:page_path, &String.trim/1)
     |> unique_constraint(:event_name, name: :goals_event_name_unique)
     |> unique_constraint(:page_path, name: :goals_page_path_unique)
-    |> validate_length(:event_name, max: 120)
+    |> validate_length(:event_name, max: @max_event_name_length)
     |> check_constraint(:event_name,
       name: :check_event_name_or_page_path,
       message: "cannot co-exist with page_path"

--- a/lib/plausible/goals.ex
+++ b/lib/plausible/goals.ex
@@ -114,6 +114,15 @@ defmodule Plausible.Goals do
     end
   end
 
+  def batch_create_event_goals(names, site) do
+    Enum.reduce(names, [], fn name, acc ->
+      case insert_goal(site, %{event_name: name}, true) do
+        {:ok, _, goal} -> acc ++ [goal]
+        _ -> acc
+      end
+    end)
+  end
+
   @doc """
   If a goal belongs to funnel(s), we need to inspect their number of steps.
 

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -1,0 +1,68 @@
+defmodule Plausible.Stats.GoalSuggestions do
+  alias Plausible.{Repo, ClickhouseRepo}
+  alias Plausible.Stats.Query
+  import Plausible.Stats.Base
+  import Ecto.Query
+
+  defmacrop visitors(e) do
+    quote do
+      selected_as(
+        fragment("toUInt64(round(uniq(?)*any(_sample_factor)))", unquote(e).user_id),
+        :visitors
+      )
+    end
+  end
+
+  def suggest_event_names(site, search_input, opts \\ []) do
+    matches = "%#{search_input}%"
+
+    site =
+      site
+      |> Repo.preload(:goals)
+      |> Plausible.Imported.load_import_data()
+
+    excluded = Keyword.get(opts, :exclude, [])
+
+    params = %{"with_imported" => "true", "period" => "6mo"}
+    query = Query.from(site, params)
+
+    native_q =
+      from(e in base_event_query(site, query),
+        where: fragment("? ilike ?", e.name, ^matches),
+        where: e.name != "pageview",
+        where: e.name not in ^excluded,
+        select: %{
+          name: e.name,
+          visitors: visitors(e)
+        },
+        group_by: e.name,
+        limit: 25
+      )
+
+    imported_q =
+      from(i in "imported_custom_events",
+        where: i.site_id == ^site.id,
+        where: i.import_id in ^site.complete_import_ids,
+        where: i.date >= ^query.date_range.first and i.date <= ^query.date_range.last,
+        where: i.visitors > 0,
+        where: fragment("? ilike ?", i.name, ^matches),
+        where: i.name not in ^excluded,
+        select: %{
+          name: i.name,
+          visitors: selected_as(sum(i.visitors), :visitors)
+        },
+        group_by: i.name,
+        limit: 25
+      )
+
+    from(e in Ecto.Query.subquery(native_q),
+      full_join: i in subquery(imported_q),
+      on: e.name == i.name,
+      select: selected_as(fragment("if(empty(?), ?, ?)", e.name, i.name, e.name), :name),
+      order_by: [desc: e.visitors + i.visitors],
+      limit: 25
+    )
+    |> ClickhouseRepo.all()
+    |> Enum.map(&{&1, &1})
+  end
+end

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -1,4 +1,6 @@
 defmodule Plausible.Stats.GoalSuggestions do
+  @moduledoc false
+
   alias Plausible.{Repo, ClickhouseRepo}
   alias Plausible.Stats.Query
   import Plausible.Stats.Base

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -37,6 +37,7 @@ defmodule Plausible.Stats.GoalSuggestions do
           name: e.name,
           visitors: visitors(e)
         },
+        order_by: selected_as(:visitors),
         group_by: e.name,
         limit: 25
       )
@@ -53,6 +54,7 @@ defmodule Plausible.Stats.GoalSuggestions do
           name: i.name,
           visitors: selected_as(sum(i.visitors), :visitors)
         },
+        order_by: selected_as(:visitors),
         group_by: i.name,
         limit: 25
       )

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -67,6 +67,6 @@ defmodule Plausible.Stats.GoalSuggestions do
       limit: 25
     )
     |> ClickhouseRepo.all()
-    |> Enum.map(&{&1, &1})
+    |> Enum.reject(&(String.length(&1) > Plausible.Goal.max_event_name_length()))
   end
 end

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -85,7 +85,6 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
         <button
           :if={@selected_tab == "custom_events" && @event_name_options_count > 0}
-          title="Use this to add any existing properties from your past events into your settings. This allows you to set up properties without having to manually enter each item."
           class="mt-2 text-sm hover:underline text-indigo-600 dark:text-indigo-400 text-left"
           phx-click="autoconfigure"
           phx-target={@myself}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -28,12 +28,14 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       |> assign(
         id: assigns.id,
         form: form,
+        event_name_options_count: length(assigns.event_name_options),
         current_user: assigns.current_user,
         domain: assigns.domain,
         selected_tab: "custom_events",
         site: site,
         has_access_to_revenue_goals?: has_access_to_revenue_goals?,
-        on_save_goal: assigns.on_save_goal
+        on_save_goal: assigns.on_save_goal,
+        on_autoconfigure: assigns.on_autoconfigure
       )
 
     {:ok, socket}
@@ -80,6 +82,21 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
             Add Goal →
           </PlausibleWeb.Components.Generic.button>
         </div>
+
+        <button
+          :if={@selected_tab == "custom_events" && @event_name_options_count > 0}
+          title="Use this to add any existing properties from your past events into your settings. This allows you to set up properties without having to manually enter each item."
+          class="mt-2 text-sm hover:underline text-indigo-600 dark:text-indigo-400 text-left"
+          phx-click="autoconfigure"
+          phx-target={@myself}
+        >
+          <span :if={@event_name_options_count > 1}>
+            Already sending custom events? We've found <%= @event_name_options_count %> custom events from the last 6 months that are not yet configured as goals. Click here to add them.
+          </span>
+          <span :if={@event_name_options_count == 1}>
+            Already sending custom events? We've found 1 custom event from the last 6 months that is not yet configured as a goal. Click here to add it.
+          </span>
+        </button>
       </.form>
     </div>
     """
@@ -296,6 +313,10 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
     end
+  end
+
+  def handle_event("autoconfigure", _params, socket) do
+    {:noreply, socket.assigns.on_autoconfigure.(socket)}
   end
 
   def suggest_page_paths(input, _options, site) do

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -267,7 +267,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         !@selected? && "dark:text-gray-100 text-gray-800"
       ]}
       id="event-tab"
-      x-on:click="tabSelectionInProgress = true"
+      x-on:click={!@selected? && "tabSelectionInProgress = true"}
       phx-click="switch-tab"
       phx-value-tab="custom_events"
       phx-target={@myself}
@@ -286,7 +286,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         !@selected? && "dark:text-gray-100 text-gray-800"
       ]}
       id="pageview-tab"
-      x-on:click="tabSelectionInProgress = true"
+      x-on:click={!@selected? && "tabSelectionInProgress = true"}
       phx-click="switch-tab"
       phx-value-tab="pageviews"
       phx-target={@myself}

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -86,6 +86,7 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
                 id={"delete-goal-#{goal.id}"}
                 phx-click="delete-goal"
                 phx-value-goal-id={goal.id}
+                phx-value-goal-name={goal.event_name}
                 class="text-sm text-red-600"
                 data-confirm={delete_confirmation_text(goal)}
               >

--- a/test/plausible/stats/goal_suggestions_test.exs
+++ b/test/plausible/stats/goal_suggestions_test.exs
@@ -1,0 +1,76 @@
+defmodule Plausible.Stats.GoalSuggestionsTest do
+  use Plausible.DataCase, async: true
+  alias Plausible.Stats.GoalSuggestions
+
+  describe "suggest_event_names/3" do
+    setup [:create_user, :create_site]
+
+    test "returns custom event goal suggestions including imported data, ordered by visitor count",
+         %{site: site} do
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(
+        site,
+        site_import.id,
+        [
+          build(:event, name: "Signup"),
+          build(:event, name: "Signup"),
+          build(:event, name: "Signup"),
+          build(:event, name: "Signup"),
+          build(:event, name: "Signup Newsletter"),
+          build(:event, name: "Signup Newsletter"),
+          build(:imported_custom_events, name: "Signup Newsletter", visitors: 3),
+          build(:imported_custom_events, name: "Outbound Link: Click", visitors: 50)
+        ] ++ build_list(10, :event, name: "Purchase", user_id: 123)
+      )
+
+      assert GoalSuggestions.suggest_event_names(site, "") == [
+               {"Outbound Link: Click", "Outbound Link: Click"},
+               {"Signup Newsletter", "Signup Newsletter"},
+               {"Signup", "Signup"},
+               {"Purchase", "Purchase"}
+             ]
+    end
+
+    test "returns custom event goal suggestions with search input, including imported data",
+         %{site: site} do
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:event, name: "Some Signup"),
+        build(:event, name: "Some Signup"),
+        build(:event, name: "Some Signup"),
+        build(:event, name: "sign"),
+        build(:event, name: "A Sign"),
+        build(:event, name: "A Sign"),
+        build(:event, name: "Not Matching"),
+        build(:imported_custom_events, name: "GA Signup", visitors: 4),
+        build(:imported_custom_events, name: "Not Matching", visitors: 3)
+      ])
+
+      assert GoalSuggestions.suggest_event_names(site, "Sign") == [
+               {"GA Signup", "GA Signup"},
+               {"Some Signup", "Some Signup"},
+               {"A Sign", "A Sign"},
+               {"sign", "sign"}
+             ]
+    end
+
+    test "ignores the 'pageview' event name", %{site: site} do
+      populate_stats(site, [
+        build(:event, name: "Signup"),
+        build(:pageview)
+      ])
+
+      assert GoalSuggestions.suggest_event_names(site, "") == [
+               {"Signup", "Signup"}
+             ]
+    end
+
+    test "can exclude goals from being suggested", %{site: site} do
+      populate_stats(site, [build(:event, name: "Signup")])
+
+      assert GoalSuggestions.suggest_event_names(site, "", exclude: ["Signup"]) == []
+    end
+  end
+end

--- a/test/plausible/stats/goal_suggestions_test.exs
+++ b/test/plausible/stats/goal_suggestions_test.exs
@@ -25,10 +25,10 @@ defmodule Plausible.Stats.GoalSuggestionsTest do
       )
 
       assert GoalSuggestions.suggest_event_names(site, "") == [
-               {"Outbound Link: Click", "Outbound Link: Click"},
-               {"Signup Newsletter", "Signup Newsletter"},
-               {"Signup", "Signup"},
-               {"Purchase", "Purchase"}
+               "Outbound Link: Click",
+               "Signup Newsletter",
+               "Signup",
+               "Purchase"
              ]
     end
 
@@ -49,10 +49,10 @@ defmodule Plausible.Stats.GoalSuggestionsTest do
       ])
 
       assert GoalSuggestions.suggest_event_names(site, "Sign") == [
-               {"GA Signup", "GA Signup"},
-               {"Some Signup", "Some Signup"},
-               {"A Sign", "A Sign"},
-               {"sign", "sign"}
+               "GA Signup",
+               "Some Signup",
+               "A Sign",
+               "sign"
              ]
     end
 
@@ -62,15 +62,19 @@ defmodule Plausible.Stats.GoalSuggestionsTest do
         build(:pageview)
       ])
 
-      assert GoalSuggestions.suggest_event_names(site, "") == [
-               {"Signup", "Signup"}
-             ]
+      assert GoalSuggestions.suggest_event_names(site, "") == ["Signup"]
     end
 
     test "can exclude goals from being suggested", %{site: site} do
       populate_stats(site, [build(:event, name: "Signup")])
 
       assert GoalSuggestions.suggest_event_names(site, "", exclude: ["Signup"]) == []
+    end
+
+    test "does not suggest event names longer than schema allows", %{site: site} do
+      populate_stats(site, [build(:event, name: String.duplicate("A", 121))])
+
+      assert GoalSuggestions.suggest_event_names(site, "") == []
     end
   end
 end


### PR DESCRIPTION
### Changes

Instead of providing event name suggestions when adding a goal, we've decided for the time being to add an option to "autoconfigure" all event names that we've received as custom event goals. The UX is very similar to how custom properties are added, based on the data from the last 6 months.

<img width="845" alt="image" src="https://github.com/plausible/analytics/assets/56999674/de053dd2-ff80-451b-b5d0-0831bea9fbd4">


### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] https://github.com/plausible/docs/pull/496 is waiting to be merged

### Dark mode
- [x] The UI has been tested both in dark and light mode
