### PR TITLE
Avoid crashing on empty GA4 HTTP report response

### DIFF
--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -137,6 +137,13 @@ defmodule Plausible.Google.GA4.API do
     sleep_time = Keyword.get(opts, :sleep_time, @backoff_factor)
 
     case GA4.HTTP.get_report(report_request) do
+      {:ok, {_, 0}} ->
+        Logger.debug(
+          "[#{inspect(__MODULE__)}:#{report_request.property}] Fetched empty response for #{report_request.dataset}"
+        )
+
+        :ok
+
       {:ok, {rows, row_count}} ->
         Logger.debug(
           "[#{inspect(__MODULE__)}:#{report_request.property}] Fetched #{length(rows)} rows of total #{row_count} with offset #{report_request.offset} for #{report_request.dataset}"

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -51,7 +51,7 @@ defmodule Plausible.Google.GA4.HTTP do
 
     with {:ok, %{body: body}} <- response,
          {:ok, report} <- parse_report_from_response(body),
-         row_count <- Map.fetch!(report, "rowCount"),
+         row_count <- Map.get(report, "rowCount", 0),
          {:ok, report} <- convert_to_maps(report) do
       {:ok, {report, row_count}}
     else
@@ -128,6 +128,10 @@ defmodule Plausible.Google.GA4.HTTP do
       end)
 
     {:ok, report}
+  end
+
+  defp convert_to_maps(%{"dimensionHeaders" => _, "metricHeaders" => _}) do
+    {:ok, []}
   end
 
   defp convert_to_maps(response) do


### PR DESCRIPTION
### Changes

It turns out that google Data API (GA4 import) payload for dataset without any results is missing `rows` and `rowCount` fields. This change makes import procedure handle such cases gracefully.

### Tests
- [x] Automated tests have been added

