### PR TITLE
add DATA_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 - Add Yesterday as an time range option in the dashboard
 - Add support for importing Google Analytics 4 data
 - Import custom events from Google Analytics 4
+- Add `DATA_DIR` env var for exports/imports plausible/analytics#4100
 
 ### Removed
 - Removed the nested custom event property breakdown UI when filtering by a goal in Goal Conversions

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -232,6 +232,9 @@ maxmind_edition = get_var_from_path_or_env(config_dir, "MAXMIND_EDITION", "GeoLi
 data_dir = get_var_from_path_or_env(config_dir, "DATA_DIR")
 persistent_cache_dir = get_var_from_path_or_env(config_dir, "PERSISTENT_CACHE_DIR")
 
+data_dir = data_dir || persistent_cache_dir
+persistent_cache_dir = persistent_cache_dir || data_dir
+
 enable_email_verification =
   config_dir
   |> get_var_from_path_or_env("ENABLE_EMAIL_VERIFICATION", "false")
@@ -298,7 +301,7 @@ config :plausible,
   custom_script_name: custom_script_name,
   log_failed_login_attempts: log_failed_login_attempts,
   license_key: license_key,
-  data_dir: data_dir || persistent_cache_dir
+  data_dir: data_dir
 
 config :plausible, :selfhost,
   enable_email_verification: enable_email_verification,
@@ -632,7 +635,7 @@ geo_opts =
       [
         license_key: maxmind_license_key,
         edition: maxmind_edition,
-        cache_dir: persistent_cache_dir || data_dir,
+        cache_dir: persistent_cache_dir,
         async: true
       ]
 
@@ -684,9 +687,7 @@ else
     traces_exporter: :none
 end
 
-config :tzdata,
-       :data_dir,
-       Path.join(persistent_cache_dir || data_dir || System.tmp_dir!(), "tzdata_data")
+config :tzdata, :data_dir, Path.join(persistent_cache_dir || System.tmp_dir!(), "tzdata_data")
 
 promex_disabled? =
   config_dir

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -229,6 +229,7 @@ ip_geolocation_db = get_var_from_path_or_env(config_dir, "IP_GEOLOCATION_DB", ge
 geonames_source_file = get_var_from_path_or_env(config_dir, "GEONAMES_SOURCE_FILE")
 maxmind_license_key = get_var_from_path_or_env(config_dir, "MAXMIND_LICENSE_KEY")
 maxmind_edition = get_var_from_path_or_env(config_dir, "MAXMIND_EDITION", "GeoLite2-City")
+data_dir = get_var_from_path_or_env(config_dir, "DATA_DIR")
 persistent_cache_dir = get_var_from_path_or_env(config_dir, "PERSISTENT_CACHE_DIR")
 
 enable_email_verification =
@@ -297,7 +298,7 @@ config :plausible,
   custom_script_name: custom_script_name,
   log_failed_login_attempts: log_failed_login_attempts,
   license_key: license_key,
-  persistent_cache_dir: persistent_cache_dir
+  data_dir: data_dir || persistent_cache_dir
 
 config :plausible, :selfhost,
   enable_email_verification: enable_email_verification,
@@ -631,7 +632,7 @@ geo_opts =
       [
         license_key: maxmind_license_key,
         edition: maxmind_edition,
-        cache_dir: persistent_cache_dir,
+        cache_dir: persistent_cache_dir || data_dir,
         async: true
       ]
 
@@ -683,7 +684,9 @@ else
     traces_exporter: :none
 end
 
-config :tzdata, :data_dir, Path.join(persistent_cache_dir || System.tmp_dir!(), "tzdata_data")
+config :tzdata,
+       :data_dir,
+       Path.join(persistent_cache_dir || data_dir || System.tmp_dir!(), "tzdata_data")
 
 promex_disabled? =
   config_dir

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -130,13 +130,8 @@ defmodule Plausible.Exports do
 
   @spec local_export_file(pos_integer) :: Path.t()
   defp local_export_file(site_id) do
-    persistent_cache_dir = Application.get_env(:plausible, :persistent_cache_dir)
-
-    Path.join([
-      persistent_cache_dir || System.tmp_dir!(),
-      "plausible-exports",
-      Integer.to_string(site_id)
-    ])
+    data_dir = Application.get_env(:plausible, :data_dir)
+    Path.join([data_dir || System.tmp_dir!(), "plausible-exports", Integer.to_string(site_id)])
   end
 
   @doc "Gets S3 export for a site"

--- a/lib/plausible/imported/csv_importer.ex
+++ b/lib/plausible/imported/csv_importer.ex
@@ -321,7 +321,7 @@ defmodule Plausible.Imported.CSVImporter do
   @doc """
   Returns local directory for CSV imports storage.
 
-  Builds upon `$PERSISTENT_CACHE_DIR` (if set) and falls back to /tmp
+  Builds upon `$DATA_DIR` or `$PERSISTENT_CACHE_DIR` (if set) and falls back to /tmp
 
   Examples:
 
@@ -331,12 +331,7 @@ defmodule Plausible.Imported.CSVImporter do
 
   """
   def local_dir(site_id) do
-    persistent_cache_dir = Application.get_env(:plausible, :persistent_cache_dir)
-
-    Path.join([
-      persistent_cache_dir || System.tmp_dir!(),
-      "plausible-imports",
-      Integer.to_string(site_id)
-    ])
+    data_dir = Application.get_env(:plausible, :data_dir)
+    Path.join([data_dir || System.tmp_dir!(), "plausible-imports", Integer.to_string(site_id)])
   end
 end

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -278,8 +278,55 @@ defmodule Plausible.ConfigTest do
     end
   end
 
-  describe "data_dir" do
-    test "todo"
+  describe "storage" do
+    test "with only DATA_DIR set" do
+      env = [
+        {"MAXMIND_LICENSE_KEY", "abc"},
+        {"DATA_DIR", "/data"}
+      ]
+
+      config = runtime_config(env)
+
+      # exports/imports
+      assert get_in(config, [:plausible, :data_dir]) == "/data"
+      # locus (mmdb cache)
+      assert get_in(config, [:plausible, Plausible.Geo, :cache_dir]) == "/data"
+      # tzdata (timezones cache)
+      assert get_in(config, [:tzdata, :data_dir]) == "/data/tzdata_data"
+    end
+
+    test "with only PERSISTENT_CACHE_DIR set" do
+      env = [
+        {"MAXMIND_LICENSE_KEY", "abc"},
+        {"PERSISTENT_CACHE_DIR", "/cache"}
+      ]
+
+      config = runtime_config(env)
+
+      # exports/imports
+      assert get_in(config, [:plausible, :data_dir]) == "/cache"
+      # locus (mmdb cache)
+      assert get_in(config, [:plausible, Plausible.Geo, :cache_dir]) == "/cache"
+      # tzdata (timezones cache)
+      assert get_in(config, [:tzdata, :data_dir]) == "/cache/tzdata_data"
+    end
+
+    test "with both DATA_DIR and PERSISTENT_CACHE_DIR set" do
+      env = [
+        {"MAXMIND_LICENSE_KEY", "abc"},
+        {"DATA_DIR", "/data"},
+        {"PERSISTENT_CACHE_DIR", "/cache"}
+      ]
+
+      config = runtime_config(env)
+
+      # exports/imports
+      assert get_in(config, [:plausible, :data_dir]) == "/data"
+      # locus (mmdb cache)
+      assert get_in(config, [:plausible, Plausible.Geo, :cache_dir]) == "/cache"
+      # tzdata (timezones cache)
+      assert get_in(config, [:tzdata, :data_dir]) == "/cache/tzdata_data"
+    end
   end
 
   describe "extra config" do

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -278,6 +278,10 @@ defmodule Plausible.ConfigTest do
     end
   end
 
+  describe "data_dir" do
+    test "todo"
+  end
+
   describe "extra config" do
     test "no-op when no extra path is set" do
       put_system_env_undo({"EXTRA_CONFIG_PATH", nil})

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -282,6 +282,7 @@ defmodule Plausible.ConfigTest do
     test "with only DATA_DIR set" do
       env = [
         {"MAXMIND_LICENSE_KEY", "abc"},
+        {"PERSISTENT_CACHE_DIR", nil},
         {"DATA_DIR", "/data"}
       ]
 
@@ -298,7 +299,8 @@ defmodule Plausible.ConfigTest do
     test "with only PERSISTENT_CACHE_DIR set" do
       env = [
         {"MAXMIND_LICENSE_KEY", "abc"},
-        {"PERSISTENT_CACHE_DIR", "/cache"}
+        {"PERSISTENT_CACHE_DIR", "/cache"},
+        {"DATA_DIR", nil}
       ]
 
       config = runtime_config(env)
@@ -314,8 +316,8 @@ defmodule Plausible.ConfigTest do
     test "with both DATA_DIR and PERSISTENT_CACHE_DIR set" do
       env = [
         {"MAXMIND_LICENSE_KEY", "abc"},
-        {"DATA_DIR", "/data"},
-        {"PERSISTENT_CACHE_DIR", "/cache"}
+        {"PERSISTENT_CACHE_DIR", "/cache"},
+        {"DATA_DIR", "/data"}
       ]
 
       config = runtime_config(env)


### PR DESCRIPTION
### Changes

This PR adds a new env var DATA_DIR which would configure where exports/imports/mmdb/tzdata go in self-hosted setups. If PERSISTENT_CACHE_DIR is also provided, it takes precedence when configuring where mmdb and tzdata go.

Relevant: https://3.basecamp.com/5308029/buckets/35871979/card_tables/cards/7377179488

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] Docs will be updated later: https://github.com/plausible/community-edition/issues/124

### Dark mode
- [x] This PR does not change the UI