### PR TITLE
Speed up calculating monthly usage for users with many many sites

### DIFF
--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -51,9 +51,9 @@ defmodule Plausible.Stats.Clickhouse do
   end
 
   def usage_breakdown([sid | _] = site_ids, date_range) when is_integer(sid) do
-    Enum.chunk_every(site_ids, 300)
-    |> Enum.reduce({0, 0}, fn site_ids, {pageviews_total, custom_events_total} ->
-      {chunk_pageviews, chunk_custom_events} =
+    Enum.chunk_every(site_ids, 1000)
+    |> Enum.map(fn site_ids ->
+      fn ->
         ClickhouseRepo.one(
           from(e in "events_v2",
             where: e.site_id in ^site_ids,
@@ -65,8 +65,11 @@ defmodule Plausible.Stats.Clickhouse do
             }
           )
         )
-
-      {pageviews_total + chunk_pageviews, custom_events_total + chunk_custom_events}
+      end
+    end)
+    |> ClickhouseRepo.parallel_tasks(max_concurrency: 10)
+    |> Enum.reduce(fn {pageviews, custom_events}, {pageviews_total, custom_events_total} ->
+      {pageviews_total + pageviews, custom_events_total + custom_events}
     end)
   end
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -50,26 +50,6 @@ defmodule Plausible.Stats.Clickhouse do
     |> Map.new()
   end
 
-  def usage_breakdown([d | _] = domains, date_range) when is_binary(d) do
-    Enum.chunk_every(domains, 300)
-    |> Enum.reduce({0, 0}, fn domains, {pageviews_total, custom_events_total} ->
-      {chunk_pageviews, chunk_custom_events} =
-        ClickhouseRepo.one(
-          from(e in "events",
-            where: e.domain in ^domains,
-            where: fragment("toDate(?)", e.timestamp) >= ^date_range.first,
-            where: fragment("toDate(?)", e.timestamp) <= ^date_range.last,
-            select: {
-              fragment("countIf(? = 'pageview')", e.name),
-              fragment("countIf(? != 'pageview')", e.name)
-            }
-          )
-        )
-
-      {pageviews_total + chunk_pageviews, custom_events_total + chunk_custom_events}
-    end)
-  end
-
   def usage_breakdown([sid | _] = site_ids, date_range) when is_integer(sid) do
     Enum.chunk_every(site_ids, 300)
     |> Enum.reduce({0, 0}, fn site_ids, {pageviews_total, custom_events_total} ->


### PR DESCRIPTION
### Changes

Currently, the settings page time outs for a user with 14k sites.

This PR speeds things up by:
1. Doing the work in parallel (max 10 queries at once)
2. Increasing chunking size (300 -> 1000)

Note that the query is relatively lightweight on clickhouse - running
these queries manually takes ~70ms. If this becomes slow we can also
introduce a PROJECTION to speed up the calculation, but this wasn't a
bottleneck currently.

On chunking size:
ClickHouse can handle even 10k site_ids in a single query fast if run
via clickhouse-client , but running the same query via ecto_ch it becomes
really slow (60ms vs 1s).

Not sure if this is a driver, serialization or networking issue.

Some other alternative solutions were discarded:
- Making the query async: requires refactoring the settings page significantly
- Caching: Not needed, might cause issues due to validation
- Projections: did not speed up the query
- Postgres engine table to do join: Networking on both cloud and self-hosted is tricky