### PR TITLE
Fix StatsAPI access for new accounts on business tier

### DIFF
--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -213,15 +213,22 @@ defmodule Plausible.Billing.Feature.StatsAPI do
   recommended.
   """
   def check_availability(%Plausible.Auth.User{} = user) do
+    user = Plausible.Users.with_subscription(user)
     unlimited_trial? = is_nil(user.trial_expiry_date)
+    subscription? = Plausible.Billing.Subscriptions.active?(user.subscription)
 
     pre_business_tier_account? =
       Timex.before?(user.inserted_at, Plausible.Billing.Plans.business_tier_launch())
 
     cond do
-      unlimited_trial? && pre_business_tier_account? -> :ok
-      unlimited_trial? && !pre_business_tier_account? -> {:error, :upgrade_required}
-      true -> super(user)
+      !subscription? && unlimited_trial? && pre_business_tier_account? ->
+        :ok
+
+      !subscription? && unlimited_trial? && !pre_business_tier_account? ->
+        {:error, :upgrade_required}
+
+      true ->
+        super(user)
     end
   end
 end

--- a/test/plausible/billing/feature_test.exs
+++ b/test/plausible/billing/feature_test.exs
@@ -73,6 +73,12 @@ defmodule Plausible.Billing.FeatureTest do
     assert :ok == Plausible.Billing.Feature.StatsAPI.check_availability(user)
   end
 
+  test "Plausible.Billing.Feature.StatsAPI.check_availability/2 returns :ok if user is subscribed and account was created after business tier launch" do
+    user = insert(:user, trial_expiry_date: nil, subscription: build(:business_subscription))
+
+    assert :ok == Plausible.Billing.Feature.StatsAPI.check_availability(user)
+  end
+
   test "Plausible.Billing.Feature.StatsAPI.check_availability/2 returns error when user trial hasn't started and was created after the business tier launch" do
     user = insert(:user, trial_expiry_date: nil)
 


### PR DESCRIPTION
Currently, business tier users created after business tier launch who never used the trial can't access Stats API due to faulty grandfathering logic. This change should fix that.