### PR TITLE
Improve CSV importer tests and visit duration query for imported data

### DIFF
--- a/lib/plausible/stats/imported.ex
+++ b/lib/plausible/stats/imported.ex
@@ -608,7 +608,7 @@ defmodule Plausible.Stats.Imported do
           """
           if(
             ? + ? > 0,
-            round((? + ? * ?) / (? + ?), 1),
+            round((? + ? * ?) / (? + ?), 0),
             0
           )
           """,

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -646,30 +646,12 @@ defmodule Plausible.Imported.CSVImporterTest do
       pairwise(exported_pages, imported_pages, fn exported, imported ->
         assert exported["page"] == imported["page"]
         assert exported["pageviews"] == imported["pageviews"]
+        assert exported["visit_duration"] == imported["visit_duration"]
         assert exported["bounce_rate"] == imported["bounce_rate"]
 
         # time on page is not being exported/imported right now
         assert imported["time_on_page"] == 0
       end)
-
-      # NOTE: page breakdown's visit duration difference is up to almost 43%
-      assert summary(field(exported_pages, "visit_duration")) == [0, 0.0, 13.0, 46.5, 264]
-      assert summary(field(imported_pages, "visit_duration")) == [0.0, 0.0, 13.3, 46.6, 264.5]
-
-      assert summary(
-               pairwise(exported_pages, imported_pages, fn exported, imported ->
-                 e = exported["visit_duration"]
-                 i = imported["visit_duration"]
-
-                 if is_number(e) and is_number(i) and i > 0 do
-                   abs(1 - e / i)
-                 else
-                   # both nil or both zero
-                   assert e == i
-                   _no_diff = 0
-                 end
-               end)
-             ) == [0.0, 0.0, 0.0, 0.008812019016100597, 0.4285714285714286]
 
       # NOTE: page breakdown's visitors difference is up to 28%
       assert summary(field(exported_pages, "visitors")) == [1, 1.0, 5.5, 17.75, 495]
@@ -776,12 +758,9 @@ defmodule Plausible.Imported.CSVImporterTest do
                end)
              ) == [0.0, 0.0, 0.0, 0.0, 0.03614457831325302]
 
-      # NOTE: city breakdown's visit duration difference can reach 100% in some cases,
-      # though these extreme cases seem to come from the fact that duration in native query
-      # is half-up rounded to full integer, while imported visit duration is rounded
-      # to first decimal place.
+      # NOTE: city breakdown's visit duration difference is up to 14%
       assert summary(field(exported_cities, "visit_duration")) == [0, 0.0, 0.0, 1.0, 1718]
-      assert summary(field(imported_cities, "visit_duration")) == [0.0, 0.0, 0.0, 0.9, 1718.0]
+      assert summary(field(imported_cities, "visit_duration")) == [0.0, 0.0, 0.0, 1.0, 1718.0]
 
       assert summary(
                pairwise(exported_cities, imported_cities, fn exported, imported ->
@@ -796,21 +775,7 @@ defmodule Plausible.Imported.CSVImporterTest do
                    _no_diff = 0
                  end
                end)
-             ) == [0, 0, 0, 0, 1.0]
-
-      assert Enum.reject(
-               pairwise(exported_cities, imported_cities, fn exported, imported ->
-                 e = exported["visit_duration"]
-                 i = imported["visit_duration"]
-
-                 if i > 0 and e == 0 do
-                   {e, i}
-                 else
-                   nil
-                 end
-               end),
-               &is_nil/1
-             ) == [{0, 0.3}, {0, 0.4}, {0, 0.4}]
+             ) == [0, 0.0, 0.0, 0.0, 0.1428571428571429]
 
       # NOTE: city breakdown's visitors relative difference is up to 27%
       assert summary(field(exported_cities, "visitors")) == [1, 1.0, 1.0, 2.0, 22]

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -652,7 +652,7 @@ defmodule Plausible.Imported.CSVImporterTest do
         assert imported["time_on_page"] == 0
       end)
 
-      # NOTE: page breakdown's visitors difference is up to almost 43%
+      # NOTE: page breakdown's visit duration difference is up to almost 43%
       assert summary(field(exported_pages, "visit_duration")) == [0, 0.0, 13.0, 46.5, 264]
       assert summary(field(imported_pages, "visit_duration")) == [0.0, 0.0, 13.3, 46.6, 264.5]
 

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -503,7 +503,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
                "bounce_rate" => 58.0,
                "pageviews" => 491,
                "utm_medium" => "referral",
-               "visit_duration" => 27.5,
+               "visit_duration" => 27.0,
                "visitors" => 294,
                "visits" => 298
              }
@@ -521,7 +521,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.first(results) == %{
              "bounce_rate" => 35.0,
              "pageviews" => 838,
-             "visit_duration" => 43.1,
+             "visit_duration" => 43.0,
              "visitors" => 675,
              "visits" => 712,
              "entry_page" => "/brza-kukuruza"
@@ -549,7 +549,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
              "bounce_rate" => 35.0,
              "city" => 792_680,
              "pageviews" => 1650,
-             "visit_duration" => 38.9,
+             "visit_duration" => 39.0,
              "visitors" => 1233,
              "visits" => 1273
            }
@@ -575,7 +575,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.first(results) == %{
              "bounce_rate" => 38.0,
              "pageviews" => 7041,
-             "visit_duration" => 36.6,
+             "visit_duration" => 37.0,
              "visitors" => 5277,
              "visits" => 5532,
              "device" => "Mobile"
@@ -584,7 +584,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.last(results) == %{
              "bounce_rate" => 37.0,
              "pageviews" => 143,
-             "visit_duration" => 59.8,
+             "visit_duration" => 60.0,
              "visitors" => 97,
              "visits" => 100,
              "device" => "Tablet"
@@ -602,7 +602,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.first(results) == %{
              "bounce_rate" => 33.0,
              "pageviews" => 8143,
-             "visit_duration" => 50.2,
+             "visit_duration" => 50.0,
              "visitors" => 4625,
              "visits" => 4655,
              "browser" => "Chrome"
@@ -629,7 +629,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     assert List.first(results) == %{
              "bounce_rate" => 34.0,
              "pageviews" => 5827,
-             "visit_duration" => 40.6,
+             "visit_duration" => 41.0,
              "visitors" => 4319,
              "visits" => 4495,
              "os" => "Android"
@@ -658,7 +658,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
              "os" => "Android",
              "os_version" => "13.0.0",
              "pageviews" => 1673,
-             "visit_duration" => 42.4,
+             "visit_duration" => 42.0,
              "visitors" => 1247,
              "visits" => 1295
            }

--- a/test/plausible_web/controllers/api/stats_controller/imported_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/imported_test.exs
@@ -514,7 +514,7 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
                    "name" => "Sweden",
                    "visitors" => 3,
                    "bounce_rate" => 67.0,
-                   "visit_duration" => 33.3
+                   "visit_duration" => 33.0
                  },
                  %{
                    "name" => "oat milk",
@@ -1158,7 +1158,7 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
 
         visit_duration = Enum.find(top_stats, fn stat -> stat["name"] == "Visit duration" end)
 
-        assert visit_duration["value"] == 3_479_033
+        assert visit_duration["value"] == 3_479_032
       end
 
       test "skips empty dates from import", %{conn: conn, site: site, import_id: import_id} do


### PR DESCRIPTION
### Changes

This PR applies post-merge feedback from https://github.com/plausible/analytics/pull/4096#pullrequestreview-2063866535 (h/t @ruslandoga) and changes visit duration computation in imported data query to be in line with native one, always rounding to full integers instead of first decimal place.

### Tests
- [x] Automated tests have been added

