### PR TITLE
remove Plausible Analytics metions from CE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ENV LANG=C.UTF-8
 ARG MIX_ENV=ce
 ENV MIX_ENV=$MIX_ENV
 
-RUN adduser -S -H -u 999 -G nogroup plausible -g 'Plausible Analytics'
+RUN adduser -S -H -u 999 -G nogroup plausible
 
 RUN apk upgrade --no-cache
 RUN apk add --no-cache openssl ncurses libstdc++ libgcc ca-certificates

--- a/lib/plausible.ex
+++ b/lib/plausible.ex
@@ -57,4 +57,14 @@ defmodule Plausible do
       end
     end
   end
+
+  if Mix.env() in @ce_builds do
+    def product_name do
+      "Plausible CE"
+    end
+  else
+    def product_name do
+      "Plausible Analytics"
+    end
+  end
 end

--- a/lib/plausible/auth/totp.ex
+++ b/lib/plausible/auth/totp.ex
@@ -88,7 +88,6 @@ defmodule Plausible.Auth.TOTP do
   alias Plausible.Repo
   alias PlausibleWeb.Email
 
-  @issuer_name "Plausible Analytics"
   @recovery_codes_count 10
 
   @spec enabled?(Auth.User.t()) :: boolean()
@@ -298,9 +297,8 @@ defmodule Plausible.Auth.TOTP do
   end
 
   defp totp_uri(user) do
-    NimbleTOTP.otpauth_uri("#{@issuer_name}:#{user.email}", user.totp_secret,
-      issuer: @issuer_name
-    )
+    issuer_name = Plausible.product_name()
+    NimbleTOTP.otpauth_uri("#{issuer_name}:#{user.email}", user.totp_secret, issuer: issuer_name)
   end
 
   defp readable_secret(user) do

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -224,7 +224,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(invitation.email)
     |> tag("new-user-invitation")
-    |> subject("[Plausible Analytics] You've been invited to #{invitation.site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to #{invitation.site.domain}")
     |> render("new_user_invitation.html",
       invitation: invitation
     )
@@ -234,7 +234,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(invitation.email)
     |> tag("existing-user-invitation")
-    |> subject("[Plausible Analytics] You've been invited to #{invitation.site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to #{invitation.site.domain}")
     |> render("existing_user_invitation.html",
       invitation: invitation
     )
@@ -244,7 +244,9 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(invitation.email)
     |> tag("ownership-transfer-request")
-    |> subject("[Plausible Analytics] Request to transfer ownership of #{invitation.site.domain}")
+    |> subject(
+      "[#{Plausible.product_name()}] Request to transfer ownership of #{invitation.site.domain}"
+    )
     |> render("ownership_transfer_request.html",
       invitation: invitation,
       new_owner_account: new_owner_account
@@ -256,7 +258,7 @@ defmodule PlausibleWeb.Email do
     |> to(invitation.inviter.email)
     |> tag("invitation-accepted")
     |> subject(
-      "[Plausible Analytics] #{invitation.email} accepted your invitation to #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{invitation.email} accepted your invitation to #{invitation.site.domain}"
     )
     |> render("invitation_accepted.html",
       user: invitation.inviter,
@@ -269,7 +271,7 @@ defmodule PlausibleWeb.Email do
     |> to(invitation.inviter.email)
     |> tag("invitation-rejected")
     |> subject(
-      "[Plausible Analytics] #{invitation.email} rejected your invitation to #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{invitation.email} rejected your invitation to #{invitation.site.domain}"
     )
     |> render("invitation_rejected.html",
       user: invitation.inviter,
@@ -282,7 +284,7 @@ defmodule PlausibleWeb.Email do
     |> to(invitation.inviter.email)
     |> tag("ownership-transfer-accepted")
     |> subject(
-      "[Plausible Analytics] #{invitation.email} accepted the ownership transfer of #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{invitation.email} accepted the ownership transfer of #{invitation.site.domain}"
     )
     |> render("ownership_transfer_accepted.html",
       user: invitation.inviter,
@@ -295,7 +297,7 @@ defmodule PlausibleWeb.Email do
     |> to(invitation.inviter.email)
     |> tag("ownership-transfer-rejected")
     |> subject(
-      "[Plausible Analytics] #{invitation.email} rejected the ownership transfer of #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{invitation.email} rejected the ownership transfer of #{invitation.site.domain}"
     )
     |> render("ownership_transfer_rejected.html",
       user: invitation.inviter,
@@ -307,7 +309,9 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(membership.user.email)
     |> tag("site-member-removed")
-    |> subject("[Plausible Analytics] Your access to #{membership.site.domain} has been revoked")
+    |> subject(
+      "[#{Plausible.product_name()}] Your access to #{membership.site.domain} has been revoked"
+    )
     |> render("site_member_removed.html",
       user: membership.user,
       membership: membership
@@ -348,13 +352,6 @@ defmodule PlausibleWeb.Email do
   end
 
   def export_success(user, site, expires_at) do
-    subject =
-      on_ee do
-        "Your Plausible Analytics export is now ready for download"
-      else
-        "Your export is now ready for download"
-      end
-
     expires_in =
       if expires_at do
         Timex.Format.DateTime.Formatters.Relative.format!(
@@ -373,7 +370,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(user)
     |> tag("export-success")
-    |> subject(subject)
+    |> subject("[#{Plausible.product_name()}] Your export is now ready for download")
     |> render("export_success.html",
       user: user,
       site: site,
@@ -383,16 +380,9 @@ defmodule PlausibleWeb.Email do
   end
 
   def export_failure(user, site) do
-    subject =
-      on_ee do
-        "Your Plausible Analytics export has failed"
-      else
-        "Your export has failed"
-      end
-
     priority_email()
     |> to(user)
-    |> subject(subject)
+    |> subject("[#{Plausible.product_name()}] Your export has failed")
     |> render("export_failure.html", user: user, site: site)
   end
 

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
   def render(%{invitation_expired: true} = assigns) do
     ~H"""
     <div class="mx-auto mt-6 text-center dark:text-gray-300">
-      <h1 class="text-3xl font-black">Plausible Analytics</h1>
+      <h1 class="text-3xl font-black"><%= Plausible.product_name() %></h1>
       <div class="text-xl font-medium">Lightweight and privacy-friendly web analytics</div>
     </div>
 
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
     <div class="mx-auto mt-6 text-center dark:text-gray-300">
       <h1 class="text-3xl font-black">
         <%= if ce?() or @live_action == :register_from_invitation_form do %>
-          Register your Plausible Analytics account
+          Register your <%= Plausible.product_name() %> account
         <% else %>
           Register your 30-day free trial
         <% end %>

--- a/lib/plausible_web/mjml/templates/stats_report.mjml.eex
+++ b/lib/plausible_web/mjml/templates/stats_report.mjml.eex
@@ -16,7 +16,7 @@
     <mj-section padding="25px 0 0 0">
       <mj-column>
         <mj-text mj-class="text-sm" height="40px">
-          Plausible Analytics
+          <%= Plausible.product_name() %>
         </mj-text>
         <mj-text mj-class="text-lg">
           <%= @site.domain %>

--- a/lib/plausible_web/templates/email/approaching_accept_traffic_until.html.heex
+++ b/lib/plausible_web/templates/email/approaching_accept_traffic_until.html.heex
@@ -1,4 +1,4 @@
-You used to have an active account with Plausible Analytics, a simple, lightweight, open source and privacy-first Google Analytics alternative.
+You used to have an active account with <%= Plausible.product_name() %>, a simple, lightweight, open source and privacy-first Google Analytics alternative.
 <br /><br />
 We've noticed that you're still sending us stats so we're writing to inform you that we'll stop accepting stats from your sites <%= @time %>. We're an independent, bootstrapped service and we don't sell your data, so this will reduce our server costs and help keep us sustainable.
 <br /><br /> If you'd like to continue counting your site stats in a privacy-friendly way, please

--- a/lib/plausible_web/templates/email/dashboard_locked.html.eex
+++ b/lib/plausible_web/templates/email/dashboard_locked.html.eex
@@ -1,4 +1,4 @@
-Last week we sent a reminder that your site traffic has exceeded the limits of your Plausible Analytics subscription tier for two consecutive months. Since we haven't received a response, we've had to temporarily lock access to your stats.
+Last week we sent a reminder that your site traffic has exceeded the limits of your <%= Plausible.product_name() %> subscription tier for two consecutive months. Since we haven't received a response, we've had to temporarily lock access to your stats.
 <br /><br />
 Your subscription is still active, we're still counting your stats and haven't deleted any of your data but as you have outgrown your subscription tier, we kindly ask you to upgrade to match your new traffic levels. Upon upgrading to a suitable tier, your dashboard access will be immediately restored.
 <br /><br />

--- a/lib/plausible_web/templates/email/existing_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/existing_user_invitation.html.eex
@@ -1,3 +1,3 @@
-<%= @invitation.inviter.email %> has invited you to the <%= @invitation.site.domain %> site on Plausible Analytics.
+<%= @invitation.inviter.email %> has invited you to the <%= @invitation.site.domain %> site on <%= Plausible.product_name() %>.
 <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent.

--- a/lib/plausible_web/templates/email/export_failure.html.eex
+++ b/lib/plausible_web/templates/email/export_failure.html.eex
@@ -1,4 +1,4 @@
-Your <%= if ee?() do %>Plausible Analytics <% end %>export for <%= @site.domain %> has encountered an error and was unsuccessful.
+Your <%= Plausible.product_name() %> export for <%= @site.domain %> has encountered an error and was unsuccessful.
 Sorry for the trouble this may have caused.
 <br/><br/>
 Please attempt to export your data again.

--- a/lib/plausible_web/templates/email/export_success.html.eex
+++ b/lib/plausible_web/templates/email/export_success.html.eex
@@ -1,3 +1,3 @@
-Your <%= if ee?() do %>Plausible Analytics <% end %>export for <%= @site.domain %> is now ready for download.
+Your <%= Plausible.product_name() %> export for <%= @site.domain %> is now ready for download.
 Please click <a href="<%= @download_url %>">here</a> to start the download process.
 <%= if @expires_in do %>Note that this link will expire <%= @expires_in %>.<% end %>

--- a/lib/plausible_web/templates/email/new_user_invitation.html.eex
+++ b/lib/plausible_web/templates/email/new_user_invitation.html.eex
@@ -1,4 +1,4 @@
-<%= @invitation.inviter.email %> has invited you to join the <%= @invitation.site.domain %> site on Plausible Analytics.
+<%= @invitation.inviter.email %> has invited you to join the <%= @invitation.site.domain %> site on <%= Plausible.product_name() %>.
 <%= link("Click here", to: Routes.auth_url(PlausibleWeb.Endpoint, :register_from_invitation_form, @invitation.invitation_id)) %> to create your account. The link is valid for 48 hours after this email is sent.
 <br /><br />
 Plausible is a lightweight and open-source website analytics tool. We hope you like our simple and ethical approach to tracking website visitors.

--- a/lib/plausible_web/templates/email/over_limit.html.eex
+++ b/lib/plausible_web/templates/email/over_limit.html.eex
@@ -1,4 +1,4 @@
-Thanks for being a Plausible Analytics subscriber!
+Thanks for being a <%= Plausible.product_name() %> subscriber!
 <br /><br />
 This is a friendly reminder that your traffic has exceeded your subscription tier for two consecutive months. Congrats on all that traffic!
 <br /><br />

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.eex
@@ -1,4 +1,4 @@
-<%= @invitation.inviter.email %> has requested to transfer the ownership of <%= @invitation.site.domain %> site on Plausible Analytics to you.
+<%= @invitation.inviter.email %> has requested to transfer the ownership of <%= @invitation.site.domain %> site on <%= Plausible.product_name() %> to you.
 <%= if @new_owner_account do %>
   <%= link("Click here", to: Routes.site_url(PlausibleWeb.Endpoint, :index)) %> to view and respond to the invitation.
 <% else %>

--- a/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_expiration_notification.html.eex
@@ -1,4 +1,4 @@
-Time flies! This is a reminder that your annual subscription for Plausible Analytics will expire on <%= @next_bill_date %>.
+Time flies! This is a reminder that your annual subscription for <%= Plausible.product_name() %> will expire on <%= @next_bill_date %>.
 <br /><br />
 You need to <%= link("renew your subscription", to: PlausibleWeb.Router.Helpers.billing_url(PlausibleWeb.Endpoint, :choose_plan)) %> if you want to continue using Plausible to count your website stats in a privacy-friendly way.
 <br /><br />

--- a/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
+++ b/lib/plausible_web/templates/email/yearly_renewal_notification.html.eex
@@ -1,4 +1,4 @@
-Time flies! This is a reminder that your annual subscription for Plausible Analytics is due to renew on <%= @date %>. We will automatically charge <%= PlausibleWeb.BillingView.present_currency(@currency) %><%= @next_bill_amount %> from your preferred billing method.
+Time flies! This is a reminder that your annual subscription for <%= Plausible.product_name() %> is due to renew on <%= @date %>. We will automatically charge <%= PlausibleWeb.BillingView.present_currency(@currency) %><%= @next_bill_amount %> from your preferred billing method.
 <br /><br />
 There's no action required if you're happy to continue using Plausible to count your website stats in a privacy-friendly way.
 <br /><br />

--- a/lib/plausible_web/templates/layout/focus.html.heex
+++ b/lib/plausible_web/templates/layout/focus.html.heex
@@ -47,9 +47,11 @@
     <% end %>
     <%= @inner_content %>
 
-    <p class="text-center text-gray-500 text-xs py-8">
-      © <%= DateTime.utc_now().year() %> Plausible Analytics. All rights reserved.
-    </p>
+    <%= if ee?() do %>
+      <p class="text-center text-gray-500 text-xs py-8">
+        © <%= DateTime.utc_now().year() %> Plausible Analytics. All rights reserved.
+      </p>
+    <% end %>
 
     <PlausibleWeb.Components.Layout.theme_script current_user={assigns[:current_user]} />
 

--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,9 +1,9 @@
 <div class="mt-12 w-full md:max-w-xl md:mx-auto bg-white dark:bg-gray-800 md:shadow-md md:rounded px-8 py-6">
   <p class="text-gray-900 text-xl font-black dark:text-gray-100">
-    Welcome to <%= Plausible.product_name() %>!
+    Welcome to Plausible!
   </p>
   <p class="mt-4 text-gray-600 dark:text-gray-200">
-  <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500"><%= Plausible.product_name() %></a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
+  <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">Plausible Analytics</a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
   </p>
   <ul class="mt-6 flex flex-wrap text-gray-700 dark:text-gray-300 space-y-1 md:space-y-0">
     <li class="w-full md:w-1/2 md:order-1">

--- a/lib/plausible_web/templates/page/index.html.eex
+++ b/lib/plausible_web/templates/page/index.html.eex
@@ -1,9 +1,9 @@
 <div class="mt-12 w-full md:max-w-xl md:mx-auto bg-white dark:bg-gray-800 md:shadow-md md:rounded px-8 py-6">
   <p class="text-gray-900 text-xl font-black dark:text-gray-100">
-    Welcome to Plausible Analytics!
+    Welcome to <%= Plausible.product_name() %>!
   </p>
   <p class="mt-4 text-gray-600 dark:text-gray-200">
-  <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">Plausible Analytics</a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
+  <a href="https://plausible.io/" class="border-b text-indigo-700 font-semibold dark:text-indigo-400 border-indigo-700 dark:border-indigo-500"><%= Plausible.product_name() %></a> is a simple, open source, lightweight (&lt; 1 KB) and privacy-friendly alternative to Google Analytics. We're completely independent and solely funded by our 10,000+ paying subscribers. Read more <a href="https://plausible.io/about" class="border-b font-semibold text-indigo-700 dark:text-indigo-400 border-indigo-700 dark:border-indigo-500">about us.</a>
   </p>
   <ul class="mt-6 flex flex-wrap text-gray-700 dark:text-gray-300 space-y-1 md:space-y-0">
     <li class="w-full md:w-1/2 md:order-1">

--- a/lib/plausible_web/templates/site/settings_search_console.html.heex
+++ b/lib/plausible_web/templates/site/settings_search_console.html.heex
@@ -116,7 +116,7 @@
         </path>
       </svg>
       <p class="text-gray-900 dark:text-gray-200">
-        An extra step is needed to set up your Plausible Analytics Self Hosted for the Google Search Console integration.
+        An extra step is needed to set up your <%= Plausible.product_name() %> for the Google Search Console integration.
         Find instructions <%= link("here",
           to: "https://plausible.io/docs/self-hosting-configuration#google-search-integration",
           class: "text-indigo-500"

--- a/test/plausible/plausible_test.exs
+++ b/test/plausible/plausible_test.exs
@@ -1,0 +1,15 @@
+defmodule PlausibleTest do
+  use ExUnit.Case, async: true
+
+  describe "product_name/0" do
+    @tag :ce_build_only
+    test "returns the correct name in CE" do
+      assert Plausible.product_name() == "Plausible CE"
+    end
+
+    @tag :ee_only
+    test "returns the correct name in EE" do
+      assert Plausible.product_name() == "Plausible Analytics"
+    end
+  end
+end

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -1,6 +1,9 @@
 defmodule Plausible.Site.AdminTest do
+  use Plausible
   use Plausible.DataCase, async: true
   use Bamboo.Test
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   setup do
     admin_user = insert(:user)
@@ -56,12 +59,12 @@ defmodule Plausible.Site.AdminTest do
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site1.domain}"
       )
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site2.domain}"
       )
     end
   end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -6,6 +6,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
   alias Plausible.Site.Memberships.AcceptInvitation
 
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
+
   describe "transfer_ownership/3" do
     test "transfers ownership successfully" do
       site = insert(:site, memberships: [])
@@ -210,8 +212,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: inviter.email],
-        subject:
-          "[Plausible Analytics] #{invitee.email} accepted your invitation to #{site.domain}"
+        subject: @subject_prefix <> "#{invitee.email} accepted your invitation to #{site.domain}"
       )
     end
 
@@ -311,7 +312,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert_email_delivered_with(
         to: [nil: existing_owner.email],
         subject:
-          "[Plausible Analytics] #{new_owner.email} accepted the ownership transfer of #{site.domain}"
+          @subject_prefix <>
+            "#{new_owner.email} accepted the ownership transfer of #{site.domain}"
       )
     end
 

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -1,7 +1,10 @@
 defmodule Plausible.Site.Memberships.CreateInvitationTest do
   alias Plausible.Site.Memberships.CreateInvitation
+  use Plausible
   use Plausible.DataCase
   use Bamboo.Test
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   describe "create_invitation/4" do
     test "creates an invitation" do
@@ -49,7 +52,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: invitee.email],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
     end
 
@@ -62,7 +65,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
     end
 
@@ -143,7 +146,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
       )
     end
 
@@ -261,7 +264,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site1.domain}"
       )
 
       assert Repo.exists?(
@@ -275,7 +278,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site2.domain}"
       )
 
       assert_invitation_exists(site2, new_owner.email, :owner)
@@ -299,7 +302,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site1.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site1.domain}"
       )
 
       assert Repo.exists?(
@@ -313,7 +316,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
 
       assert_email_delivered_with(
         to: [nil: new_owner.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site2.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site2.domain}"
       )
 
       assert_invitation_exists(site2, new_owner.email, :owner)

--- a/test/plausible/site/memberships/reject_invitation_test.exs
+++ b/test/plausible/site/memberships/reject_invitation_test.exs
@@ -1,6 +1,9 @@
 defmodule Plausible.Site.Memberships.RejectInvitationTest do
+  use Plausible
   use Plausible.DataCase, async: true
   use Bamboo.Test
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   alias Plausible.Site.Memberships.RejectInvitation
 
@@ -25,7 +28,7 @@ defmodule Plausible.Site.Memberships.RejectInvitationTest do
 
     assert_email_delivered_with(
       to: [nil: inviter.email],
-      subject: "[Plausible Analytics] #{invitee.email} rejected your invitation to #{site.domain}"
+      subject: @subject_prefix <> "#{invitee.email} rejected your invitation to #{site.domain}"
     )
   end
 

--- a/test/plausible_web/controllers/page_controller_test.exs
+++ b/test/plausible_web/controllers/page_controller_test.exs
@@ -4,9 +4,8 @@ defmodule PlausibleWeb.PageControllerTest do
   setup {PlausibleWeb.FirstLaunchPlug.Test, :skip}
 
   describe "GET /" do
-    @tag :ce_build_only
     test "shows landing page when user not authenticated", %{conn: conn} do
-      assert conn |> get("/") |> html_response(200) =~ "Welcome to Plausible CE!"
+      assert conn |> get("/") |> html_response(200) =~ "Welcome to Plausible!"
     end
 
     test "redirects to /sites if user is authenticated", %{conn: conn} do

--- a/test/plausible_web/controllers/page_controller_test.exs
+++ b/test/plausible_web/controllers/page_controller_test.exs
@@ -4,8 +4,9 @@ defmodule PlausibleWeb.PageControllerTest do
   setup {PlausibleWeb.FirstLaunchPlug.Test, :skip}
 
   describe "GET /" do
+    @tag :ce_build_only
     test "shows landing page when user not authenticated", %{conn: conn} do
-      assert conn |> get("/") |> html_response(200) =~ "Welcome to Plausible Analytics!"
+      assert conn |> get("/") |> html_response(200) =~ "Welcome to Plausible CE!"
     end
 
     test "redirects to /sites if user is authenticated", %{conn: conn} do

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -1,9 +1,12 @@
 defmodule PlausibleWeb.Site.MembershipControllerTest do
+  use Plausible
   use PlausibleWeb.ConnCase
   use Plausible.Repo
   use Bamboo.Test
 
   import Plausible.Test.Support.HTML
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   setup [:create_user, :log_in]
 
@@ -115,7 +118,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "john.doe@example.com"],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
     end
 
@@ -130,7 +133,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: existing_user.email],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
     end
 
@@ -168,7 +171,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "joe@example.com"],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
 
       req2 =
@@ -179,7 +182,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       refute_email_delivered_with(
         to: [nil: "joe@example.com"],
-        subject: "[Plausible Analytics] You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}"
       )
 
       assert people_settings = redirected_to(req2, 302)
@@ -226,7 +229,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "john.doe@example.com"],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
       )
     end
 
@@ -238,7 +241,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: existing_user.email],
-        subject: "[Plausible Analytics] Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
       )
     end
 
@@ -478,7 +481,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: admin.email],
-        subject: "[Plausible Analytics] Your access to #{site.domain} has been revoked"
+        subject: @subject_prefix <> "Your access to #{site.domain} has been revoked"
       )
     end
   end


### PR DESCRIPTION
### Changes

This PR removes some of Plausible Analytics mentions from CE builds. There are still places where this mention is kept:

- https://github.com/plausible/analytics/blob/23a6431adbd61553fed1b658485d469c025b492b/assets/js/app.js#L108 since the link leads to plausible.io and not the CE instance
- https://github.com/plausible/analytics/blob/23a6431adbd61553fed1b658485d469c025b492b/lib/plausible_web/controllers/stats_controller.ex#L381 since it's unlikely a CE user would add plausible.io site
- https://github.com/plausible/analytics/blob/23a6431adbd61553fed1b658485d469c025b492b/lib/plausible_web/templates/layout/_footer.html.heex#L23 since the link leads to plausible.io and not the CE instance

- https://github.com/plausible/analytics/blob/23a6431adbd61553fed1b658485d469c025b492b/lib/plausible_web/templates/page/index.html.eex#L6 since the link leads to plausible.io and the copy talks about Plausible Analytics (it mentions subscribers) and not just the CE version

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode