### PR TITLE
Fix special goal conversions

### DIFF
--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -20,7 +20,7 @@ function getSpecialGoal(query) {
   }
   const [_operation, _filterKey, clauses] = goalFilter
   if (clauses.length == 1) {
-    return SPECIAL_GOALS[clauses[0]]?.title || null
+    return SPECIAL_GOALS[clauses[0]] || null
   }
   return null
 


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/4117

Special goals (e.g. 404, Outbound link click) always reported (none) as results due to a function returning the wrong value.