### PR TITLE
Fix opening a filter modal

### DIFF
--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -16,7 +16,7 @@ function partitionFilters(modalType, filters) {
 
   filters.forEach((filter, index) => {
     const filterGroup = getFilterGroup(filter)
-    if (FILTER_GROUP_TO_MODAL_TYPE[modalType].includes(filterGroup)) {
+    if (FILTER_GROUP_TO_MODAL_TYPE[filterGroup] === modalType) {
       const key = filterState[filterGroup] ? `${filterGroup}:${index}` : filterGroup
       filterState[key] = filter
       hasRelevantFilters = true


### PR DESCRIPTION
Follow-up to #4117

Opening a utm modal crashed if there was an existing page filter. Bug struck in during a last-minute renaming. :facepalm: 