### PR TITLE
remove warning in migration

### DIFF
--- a/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs
+++ b/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs
@@ -53,7 +53,7 @@ defmodule Plausible.IngestRepo.Migrations.AliasApiPropNames do
   def down do
     on_cluster = Plausible.MigrationUtils.on_cluster_statement("sessions_v2")
 
-    for {alias_name, column_name} <- @sessions_prop_names do
+    for {alias_name, _column_name} <- @sessions_prop_names do
       execute """
       ALTER TABLE sessions_v2
       #{on_cluster}
@@ -61,7 +61,7 @@ defmodule Plausible.IngestRepo.Migrations.AliasApiPropNames do
       """
     end
 
-    for {alias_name, column_name} <- @events_prop_names do
+    for {alias_name, _column_name} <- @events_prop_names do
       execute """
       ALTER TABLE events_v2
       #{on_cluster}


### PR DESCRIPTION
### Changes

This PR removes some warnings that show up on new CE installations:

```
plausible-1            | Loading plausible..
plausible-1            | Starting dependencies..
plausible-1            | Starting repos..
plausible-1            | Running migrations for Elixir.Plausible.Repo
plausible-1            | Running migrations for Elixir.Plausible.IngestRepo
plausible-1            | warning: code block contains unused literal "Migration adds a ALIAS columns needed to keep DB schema and api\nproperty naming in sync to reduce overhead in code.\n" (remove the literal or assign it to _ to avoid warnings)
plausible-1            | └─ lib/plausible-0.0.1/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs: Plausible.IngestRepo.Migrations.AliasApiPropNames (module)
plausible-1            |
plausible-1            |     warning: variable "column_name" is unused (if the variable is not meant to be used, prefix it with an underscore)
plausible-1            |     │
plausible-1            |  56 │     for {alias_name, column_name} <- @sessions_prop_names do
plausible-1            |     │                      ~
plausible-1            |     │
plausible-1            |     └─ lib/plausible-0.0.1/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs:56:22: Plausible.IngestRepo.Migrations.AliasApiPropNames.down/0
plausible-1            |
plausible-1            |     warning: variable "column_name" is unused (if the variable is not meant to be used, prefix it with an underscore)
plausible-1            |     │
plausible-1            |  64 │     for {alias_name, column_name} <- @events_prop_names do
plausible-1            |     │                      ~
plausible-1            |     │
plausible-1            |     └─ lib/plausible-0.0.1/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs:64:22: Plausible.IngestRepo.Migrations.AliasApiPropNames.down/0
plausible-1            |
plausible-1            |     list-partitions Done!
plausible-1            |
plausible-1            | ------------------------------------------------------------------------------
plausible-1            |     get-sessions-table-settings Done!
plausible-1            |
plausible-1            | ------------------------------------------------------------------------------
plausible-1            |     drop-sessions-tmp-table Done!
plausible-1            |
plausible-1            | ------------------------------------------------------------------------------
plausible-1            |     create-sessions-tmp-table Done!
plausible-1            |
plausible-1            | ------------------------------------------------------------------------------
plausible-1            |     exchange-sessions-tables Done!
plausible-1            |
plausible-1            | ------------------------------------------------------------------------------
plausible-1            | Migration done!
plausible-1            | Migrations successful!
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI