### PR TITLE
always enable ipv6 connections in CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Increase hourly request limit for API keys in CE from 600 to 1000000 (practically removing the limit) plausible/analytics#4200
+- Always enable IPv6 connections in CE
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Increase hourly request limit for API keys in CE from 600 to 1000000 (practically removing the limit) plausible/analytics#4200
-- Always enable IPv6 connections in CE
+- automatic IPv6 connections in CE plausible/analytics#4134
 
 ### Fixed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -494,6 +494,15 @@ case mailer_adapter do
         port: port
     end
 
+    default_mua_ipv6 = to_string(is_selfhost)
+
+    maybe_mua_ipv6 =
+      config_dir
+      |> get_var_from_path_or_env("MUA_IPV6", default_mua_ipv6)
+      |> String.to_existing_atom()
+
+    config :plausible, Plausible.Mailer, transport_opts: [inet6: maybe_mua_ipv6]
+
   "Bamboo.LocalAdapter" ->
     config :plausible, Plausible.Mailer, adapter: Bamboo.LocalAdapter
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -342,13 +342,15 @@ if is_nil(db_socket_dir) do
   if maybe_pg_ipv6 do
     %URI{host: host, port: port} = URI.parse(db_url)
 
-    default_endpoints = [{host, port}]
+    # default_endpoint is what Postgrex would've connected to by default, with :url option
+    default_endpoint = {host, port}
     ipv4_endpoints = :inet_res.lookup(to_charlist(host), :in, :a)
     ipv6_endpoints = :inet_res.lookup(to_charlist(host), :in, :aaaa)
+    fallback_endpoints = ConfigHelpers.join_intersperse(ipv6_endpoints, ipv4_endpoints)
 
     config :plausible, Plausible.Repo,
       port: port,
-      endpoints: default_endpoints ++ ipv4_endpoints ++ ipv6_endpoints
+      endpoints: [default_endpoint | fallback_endpoints]
   else
     config :plausible, Plausible.Repo, url: db_url
   end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -329,9 +329,11 @@ maybe_pg_ipv6 =
 db_cacertfile = get_var_from_path_or_env(config_dir, "DATABASE_CACERTFILE", CAStore.file_path())
 
 if is_nil(db_socket_dir) do
+  pg_socket_options = if maybe_pg_ipv6, do: [:inet6, :inet], else: []
+
   config :plausible, Plausible.Repo,
     url: db_url,
-    socket_options: if(maybe_pg_ipv6, do: [:inet6], else: []),
+    socket_options: pg_socket_options,
     ssl_opts: [
       cacertfile: db_cacertfile,
       verify: :verify_peer,

--- a/lib/plausible/helpers/config.ex
+++ b/lib/plausible/helpers/config.ex
@@ -23,4 +23,58 @@ defmodule Plausible.ConfigHelpers do
         end
     end
   end
+
+  @doc """
+  Similar to `Enum.zip/2` and `List.flatten/1` but doesn't truncate any of the lists.
+
+  Examples:
+
+      iex> join_intersperse([], [])
+      []
+
+      iex> join_intersperse([1], [])
+      [1]
+
+      iex> join_intersperse([], [2])
+      [2]
+
+      iex> join_intersperse([1], [2])
+      [1, 2]
+
+      iex> join_intersperse([1], [2, 3])
+      [1, 2, 3]
+
+      iex> join_intersperse([1, 3], [2])
+      [1, 2, 3]
+
+      iex> join_intersperse([1], [2, 3, 4])
+      [1, 2, 3, 4]
+
+      iex> join_intersperse([1, 3, 4], [2])
+      [1, 2, 3, 4]
+
+      iex> ipv4 = ["142.251.175.139", "142.251.175.100", "142.251.175.138", "142.251.175.113", "142.251.175.102", "142.251.175.101"]
+      iex> ipv6 = ["2404:6800:4003:c1c::66", "2404:6800:4003:c1c::8a", "2404:6800:4003:c1c::64", "2404:6800:4003:c1c::71"]
+      iex> join_intersperse(ipv6, ipv4)
+      [
+        "2404:6800:4003:c1c::66",
+        "142.251.175.139",
+        "2404:6800:4003:c1c::8a",
+        "142.251.175.100",
+        "2404:6800:4003:c1c::64",
+        "142.251.175.138",
+        "2404:6800:4003:c1c::71",
+        "142.251.175.113",
+        "142.251.175.102",
+        "142.251.175.101"
+      ]
+
+  """
+  def join_intersperse([], []), do: []
+  def join_intersperse([], [_ | _] = right), do: right
+  def join_intersperse([_ | _] = left, []), do: left
+
+  def join_intersperse([left | rest_left], [right | rest_right]) do
+    [left, right | join_intersperse(rest_left, rest_right)]
+  end
 end

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -1,5 +1,6 @@
 defmodule Plausible.ConfigTest do
   use ExUnit.Case
+  doctest Plausible.ConfigHelpers, import: true
 
   describe "mailer" do
     test "mailer email default" do
@@ -144,7 +145,9 @@ defmodule Plausible.ConfigTest do
       env = [{"MAILER_ADAPTER", "Bamboo.Mua"}]
 
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
-               {:adapter, Bamboo.Mua}
+               adapter: Bamboo.Mua,
+               tcp: [inet6: false],
+               ssl: [inet6: false]
              ]
     end
 
@@ -158,10 +161,12 @@ defmodule Plausible.ConfigTest do
       ]
 
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
-               {:adapter, Bamboo.Mua},
-               {:auth, [username: "neo", password: "one"]},
-               {:relay, "localhost"},
-               {:port, 2525}
+               adapter: Bamboo.Mua,
+               auth: [username: "neo", password: "one"],
+               relay: "localhost",
+               port: 2525,
+               tcp: [inet6: false],
+               ssl: [inet6: false]
              ]
     end
 


### PR DESCRIPTION
### Changes

This PR removes the need for custom IPv6 configuration (ECTO_IPV6, ECTO_CH_IPV6, FINCH_IPV6) in CE and makes Mint and Mua try IPv6 connection first with fallback to IPv4 and Postgrex try default (URL) and then interspersed IPv4 and  IPv6 addresses.

This PR is the first step to full IPv6 support. tzdata (hackney), locus (httpc without inet6fb4), ua_inspector (hackney) and some other libraries would still fail in IPv6-only setups.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI