### PR TITLE
More fixes to the verification process

### DIFF
--- a/lib/plausible/verification/checks/fetch_body.ex
+++ b/lib/plausible/verification/checks/fetch_body.ex
@@ -27,11 +27,11 @@ defmodule Plausible.Verification.Checks.FetchBody do
     {req, resp} = opts |> Req.new() |> Req.Request.run_request()
 
     case resp do
-      %Req.Response{status: status, body: body} = response
+      %Req.Response{status: status, body: body}
       when is_binary(body) and status in 200..299 ->
         state
         |> assign(final_domain: req.url.host)
-        |> extract_document(response)
+        |> extract_document(resp)
 
       _ ->
         state

--- a/lib/plausible/verification/checks/fetch_body.ex
+++ b/lib/plausible/verification/checks/fetch_body.ex
@@ -24,12 +24,14 @@ defmodule Plausible.Verification.Checks.FetchBody do
         fetch_body_opts
       )
 
-    req = Req.new(opts)
+    {req, resp} = opts |> Req.new() |> Req.Request.run_request()
 
-    case Req.get(req) do
-      {:ok, %Req.Response{status: status, body: body} = response}
+    case resp do
+      %Req.Response{status: status, body: body} = response
       when is_binary(body) and status in 200..299 ->
-        extract_document(state, response)
+        state
+        |> assign(final_domain: req.url.host)
+        |> extract_document(response)
 
       _ ->
         state

--- a/lib/plausible/verification/checks/snippet.ex
+++ b/lib/plausible/verification/checks/snippet.ex
@@ -40,7 +40,7 @@ defmodule Plausible.Verification.Checks.Snippet do
     "defer",
     "data-api",
     "data-exclude",
-    "data-include",
+    "data-include"
   ]
 
   defp unknown_attributes?(nodes) do

--- a/lib/plausible/verification/checks/snippet.ex
+++ b/lib/plausible/verification/checks/snippet.ex
@@ -59,8 +59,7 @@ defmodule Plausible.Verification.Checks.Snippet do
     |> Enum.any?(fn script_data_domain ->
       multiple = String.split(script_data_domain, ",")
 
-      script_data_domain not in [data_domain, final_data_domain] and data_domain not in multiple and
-        final_data_domain not in multiple
+      data_domain not in multiple and final_data_domain not in multiple
     end)
   end
 end

--- a/lib/plausible/verification/checks/snippet.ex
+++ b/lib/plausible/verification/checks/snippet.ex
@@ -21,7 +21,8 @@ defmodule Plausible.Verification.Checks.Snippet do
       snippets_found_in_body: Enum.count(in_body),
       proxy_likely?: proxy_likely?(all),
       snippet_unknown_attributes?: unknown_attributes?(all),
-      data_domain_mismatch?: data_domain_mismatch?(all, state.data_domain)
+      data_domain_mismatch?:
+        data_domain_mismatch?(all, state.data_domain, state.assigns[:final_domain])
     )
   end
 
@@ -33,20 +34,33 @@ defmodule Plausible.Verification.Checks.Snippet do
     |> Enum.any?(&(not String.starts_with?(&1, PlausibleWeb.Endpoint.url())))
   end
 
-  @known_attributes ["data-domain", "src", "defer", "data-api", "data-exclude", "data-include"]
-  @known_prefix "event-"
+  @known_attributes [
+    "data-domain",
+    "src",
+    "defer",
+    "data-api",
+    "data-exclude",
+    "data-include",
+  ]
 
   defp unknown_attributes?(nodes) do
     Enum.any?(nodes, fn {_, attrs, _} ->
-      Enum.any?(attrs, fn {key, _} ->
-        key not in @known_attributes and not String.starts_with?(key, @known_prefix)
+      Enum.any?(attrs, fn
+        {"type", "text/javascript"} -> false
+        {"event-" <> _, _} -> false
+        {key, _} -> key not in @known_attributes
       end)
     end)
   end
 
-  defp data_domain_mismatch?(nodes, data_domain) do
+  defp data_domain_mismatch?(nodes, data_domain, final_data_domain) do
     nodes
     |> Floki.attribute("data-domain")
-    |> Enum.any?(&(&1 != data_domain and data_domain not in String.split(&1, ",")))
+    |> Enum.any?(fn script_data_domain ->
+      multiple = String.split(script_data_domain, ",")
+
+      script_data_domain not in [data_domain, final_data_domain] and data_domain not in multiple and
+        final_data_domain not in multiple
+    end)
   end
 end

--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -354,10 +354,10 @@ defmodule Plausible.Verification.Diagnostics do
     }
   end
 
-  def interpret(%__MODULE__{data_domain_mismatch?: true}, url) do
+  def interpret(%__MODULE__{data_domain_mismatch?: true}, "https://" <> domain) do
     %Result{
       ok?: false,
-      errors: ["Your data-domain is different than #{url}"],
+      errors: ["Your data-domain is different than #{domain}"],
       recommendations: [
         {"Please ensure that the site in the data-domain attribute is an exact match to the site as you added it to your Plausible account",
          "https://plausible.io/docs/troubleshoot-integration"}

--- a/test/plausible/site/verification/checks/fetch_body_test.exs
+++ b/test/plausible/site/verification/checks/fetch_body_test.exs
@@ -45,7 +45,7 @@ defmodule Plausible.Verification.Checks.FetchBodyTest do
     stub(200, @normal_body, "text/plain")
     state = @check.perform(state)
 
-    assert map_size(state.assigns) == 0
+    assert state.assigns == %{final_domain: "example.com"}
 
     refute state.diagnostics.body_fetched?
   end

--- a/test/plausible/site/verification/checks/snippet_test.exs
+++ b/test/plausible/site/verification/checks/snippet_test.exs
@@ -109,7 +109,7 @@ defmodule Plausible.Verification.Checks.SnippetTest do
 
   @valid_attributes """
   <head>
-  <script defer data-api="some" data-include="some" data-exclude="some" data-domain="example.com" src="http://my-domain.example.com/js/script.js"></script>
+  <script defer type="text/javascript" data-api="some" data-include="some" data-exclude="some" data-domain="example.com" src="http://my-domain.example.com/js/script.js"></script>
   </head>
   """
 


### PR DESCRIPTION
 - extend the list of known attributes
 - follow redirect chain host to verify data-domain difference
 - display the actual data-domain in error message, not URL
