### PR TITLE
Fix setting with_imported to false explicitly in the URL

### DIFF
--- a/assets/js/dashboard/stats/graph/with-imported-switch.js
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.js
@@ -24,7 +24,7 @@ export default function WithImportedSwitch({site, topStatData}) {
   if (isQueryingImportedPeriod || isComparingImportedPeriod) {
     const withImported = topStatData.with_imported;
     const toggleColor = withImported ? " dark:text-gray-300 text-gray-700" : " dark:text-gray-500 text-gray-400"
-    const target = url.setQuery('with_imported', !withImported)
+    const target = url.setQuery('with_imported', (!withImported).toString())
     const tip = withImported ? "" : "do not ";
 
     return (


### PR DESCRIPTION
### Changes

Currently, when clicking on the imported exclude/include icon on the dashboard (see `with-imported-switch.js`), it doesn't set the `with_imported` to false due to PlausibleSearchParams class dropping any keys with `false` boolean value. The default for the `with_imported` field is `true` so we need to explicitly set it to false sometimes. Otherwise we'd end up with a URL identical to the current location, and the button simply doesn't work.

What I've done here is set the value as a string instead. Not aware of any other cases of this causing problems but maybe it would be worth to double-check (cc @macobo ). Is it necessary to drop the keys with false values or is it only an optimization?