### PR TITLE
Populate site_imports from sites.imported_data in CE

### DIFF
--- a/lib/plausible/data_migration/site_imports.ex
+++ b/lib/plausible/data_migration/site_imports.ex
@@ -1,9 +1,10 @@
 defmodule Plausible.DataMigration.SiteImports do
   @moduledoc """
+  !!!WARNING!!!: This script is used in migrations. Please take special care
+  when altering it.
+
   Site imports migration backfilling SiteImport entries for old imports
   and alters import end dates to match actual end date of respective import stats.
-
-
   """
 
   import Ecto.Query

--- a/lib/plausible/data_migration/versioned_sessions.ex
+++ b/lib/plausible/data_migration/versioned_sessions.ex
@@ -1,6 +1,11 @@
 defmodule Plausible.DataMigration.VersionedSessions do
   @moduledoc """
-  Sessions CollapsingMergeTree -> VersionedCollapsingMergeTree migration, SQL files available at:
+  !!!WARNING!!!: This script is used in migrations. Please take special care
+  when altering it.
+
+  Sessions CollapsingMergeTree -> VersionedCollapsingMergeTree migration,
+  SQL files available at:
+
   priv/data_migrations/VersionedSessions/sql
   """
   use Plausible.DataMigration, dir: "VersionedSessions", repo: Plausible.IngestRepo

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -4,10 +4,7 @@ defmodule Plausible.Repo.Migrations.MigrateSiteImports do
 
   def up do
     if ce?() do
-      {:ok, _, _} =
-        Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
-          Plausible.DataMigration.SiteImports.run(dry_run?: false)
-        end)
+      Plausible.DataMigration.SiteImports.run(dry_run?: false)
     end
   end
 end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -4,7 +4,7 @@ defmodule Plausible.Repo.Migrations.MigrateSiteImports do
 
   def up do
     if ce?() do
-      Plausible.DataMigration.SiteImports.run()
+      Plausible.DataMigration.SiteImports.run(dry_run?: false)
     end
   end
 end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -7,4 +7,8 @@ defmodule Plausible.Repo.Migrations.MigrateSiteImports do
       Plausible.DataMigration.SiteImports.run(dry_run?: false)
     end
   end
+
+  def down do
+    raise "Irreversible"
+  end
 end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.Repo.Migrations.MigrateSiteImports do
+  use Plausible
+  use Ecto.Migration
+
+  def up do
+    if ce?() do
+      Plausible.DataMigration.SiteImports.run()
+    end
+  end
+end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -4,7 +4,10 @@ defmodule Plausible.Repo.Migrations.MigrateSiteImports do
 
   def up do
     if ce?() do
-      Plausible.DataMigration.SiteImports.run(dry_run?: false)
+      {:ok, _, _} =
+        Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
+          Plausible.DataMigration.SiteImports.run(dry_run?: false)
+        end)
     end
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -79,12 +79,14 @@ seeded_token = Plausible.Plugins.API.Token.generate("seed-token")
 {:ok, _goal5} = Plausible.Goals.create(site, %{"page_path" => Enum.random(long_random_paths)})
 {:ok, outbound} = Plausible.Goals.create(site, %{"event_name" => "Outbound Link: Click"})
 
-{:ok, _funnel} =
-  Plausible.Funnels.create(site, "From homepage to login", [
-    %{"goal_id" => goal1.id},
-    %{"goal_id" => goal2.id},
-    %{"goal_id" => goal3.id}
-  ])
+if Plausible.ee?() do
+  {:ok, _funnel} =
+    Plausible.Funnels.create(site, "From homepage to login", [
+      %{"goal_id" => goal1.id},
+      %{"goal_id" => goal2.id},
+      %{"goal_id" => goal3.id}
+    ])
+end
 
 put_random_time = fn
   date, 0 ->


### PR DESCRIPTION
### Changes

This PR makes site_imports be automatically populated from sites.imported_data on startup for CE builds. Right now the self-hosters need to do it manually. See https://github.com/plausible/analytics/discussions/4125#discussioncomment-9580118

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI