### PR TITLE
Make React frontend capable of reading API results under a results key

### DIFF
--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -11,9 +11,7 @@ import { getFiltersByKeyPrefix } from '../../util/filters';
 
 function Countries({query, site, onClick}) {
   function fetchData() {
-    return api.get(apiPath(site, '/countries'), query, {limit: 9}).then((res) => {
-      return res.map(row => Object.assign({}, row, {percentage: undefined}))
-    })
+    return api.get(apiPath(site, '/countries'), query, { limit: 9 })
   }
 
   function renderIcon(country) {

--- a/assets/js/dashboard/stats/locations/map.js
+++ b/assets/js/dashboard/stats/locations/map.js
@@ -75,7 +75,10 @@ class Countries extends React.Component {
 
   fetchCountries() {
     return api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/countries`, this.props.query, {limit: 300})
-      .then((res) => this.setState({loading: false, countries: res}))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState({loading: false, countries: results})
+      })
   }
 
   resizeMap() {

--- a/assets/js/dashboard/stats/locations/map.js
+++ b/assets/js/dashboard/stats/locations/map.js
@@ -76,7 +76,7 @@ class Countries extends React.Component {
   fetchCountries() {
     return api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/countries`, this.props.query, {limit: 300})
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState({loading: false, countries: results})
       })
   }

--- a/assets/js/dashboard/stats/modals/conversions.js
+++ b/assets/js/dashboard/stats/modals/conversions.js
@@ -37,7 +37,7 @@ function ConversionsModal(props) {
   function fetchData() {
     api.get(url.apiPath(site, `/conversions`), query, { limit: 100, page })
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         setLoading(false)
         setList(list.concat(results))
         setPage(page + 1)

--- a/assets/js/dashboard/stats/modals/conversions.js
+++ b/assets/js/dashboard/stats/modals/conversions.js
@@ -36,11 +36,12 @@ function ConversionsModal(props) {
 
   function fetchData() {
     api.get(url.apiPath(site, `/conversions`), query, { limit: 100, page })
-      .then((res) => {
+      .then((response) => {
+        const results = !!response.results ? response.results : response
         setLoading(false)
-        setList(list.concat(res))
+        setList(list.concat(results))
         setPage(page + 1)
-        setMoreResultsAvailable(res.length >= 100)
+        setMoreResultsAvailable(results.length >= 100)
       })
   }
 

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -33,13 +33,15 @@ class EntryPagesModal extends React.Component {
       query,
       { limit: 100, page }
     )
-      .then(
-        (res) => this.setState((state) => ({
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        
+        this.setState((state) => ({
           loading: false,
-          pages: state.pages.concat(res),
-          moreResultsAvailable: res.length === 100
+          pages: state.pages.concat(results),
+          moreResultsAvailable: results.length === 100
         }))
-      )
+      })
   }
 
   loadMore() {

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -34,7 +34,7 @@ class EntryPagesModal extends React.Component {
       { limit: 100, page }
     )
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         
         this.setState((state) => ({
           loading: false,

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -29,7 +29,7 @@ class ExitPagesModal extends React.Component {
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/exit-pages`, query, { limit: 100, page })
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState((state) => ({ loading: false, pages: state.pages.concat(results), moreResultsAvailable: results.length === 100 }))
       })
   }

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -28,7 +28,10 @@ class ExitPagesModal extends React.Component {
     const { query, page } = this.state;
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/exit-pages`, query, { limit: 100, page })
-      .then((res) => this.setState((state) => ({ loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100 })))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState((state) => ({ loading: false, pages: state.pages.concat(results), moreResultsAvailable: results.length === 100 }))
+      })
   }
 
   loadMore() {

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -30,7 +30,10 @@ class PagesModal extends React.Component {
     const { query, page } = this.state;
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, { limit: 100, page, detailed })
-      .then((res) => this.setState((state) => ({ loading: false, pages: state.pages.concat(res), moreResultsAvailable: res.length === 100 })))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState((state) => ({ loading: false, pages: state.pages.concat(results), moreResultsAvailable: results.length === 100 }))
+      })
   }
 
   loadMore() {

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -31,7 +31,7 @@ class PagesModal extends React.Component {
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/pages`, query, { limit: 100, page, detailed })
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState((state) => ({ loading: false, pages: state.pages.concat(results), moreResultsAvailable: results.length === 100 }))
       })
   }

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -38,11 +38,13 @@ function PropsModal(props) {
 
   function fetchData() {
     api.get(url.apiPath(site, `/custom-prop-values/${propKey}`), query, { limit: 100, page })
-      .then((res) => {
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+
         setLoading(false)
-        setList(list.concat(res))
+        setList(list.concat(results))
         setPage(page + 1)
-        setMoreResultsAvailable(res.length >= 100)
+        setMoreResultsAvailable(results >= 100)
       })
   }
 

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -39,7 +39,7 @@ function PropsModal(props) {
   function fetchData() {
     api.get(url.apiPath(site, `/custom-prop-values/${propKey}`), query, { limit: 100, page })
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
 
         setLoading(false)
         setList(list.concat(results))

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -44,7 +44,7 @@ function PropsModal(props) {
         setLoading(false)
         setList(list.concat(results))
         setPage(page + 1)
-        setMoreResultsAvailable(results >= 100)
+        setMoreResultsAvailable(results.length >= 100)
       })
   }
 

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -21,7 +21,10 @@ class ReferrerDrilldownModal extends React.Component {
     const detailed = this.showExtra()
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/referrers/${this.props.match.params.referrer}`, this.state.query, {limit: 100, detailed})
-      .then((referrers) => this.setState({loading: false, referrers: referrers}))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState({loading: false, referrers: results})
+      })
   }
 
   showExtra() {

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -22,7 +22,7 @@ class ReferrerDrilldownModal extends React.Component {
 
     api.get(`/api/stats/${encodeURIComponent(this.props.site.domain)}/referrers/${this.props.match.params.referrer}`, this.state.query, {limit: 100, detailed})
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState({loading: false, referrers: results})
       })
   }

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -36,7 +36,7 @@ class SourcesModal extends React.Component {
     const detailed = this.showExtra()
     api.get(`/api/stats/${encodeURIComponent(site.domain)}/${this.currentView()}`, query, { limit: 100, page, detailed })
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState({ loading: false, sources: sources.concat(results), moreResultsAvailable: results.length === 100 })
       })
   }

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -35,7 +35,10 @@ class SourcesModal extends React.Component {
 
     const detailed = this.showExtra()
     api.get(`/api/stats/${encodeURIComponent(site.domain)}/${this.currentView()}`, query, { limit: 100, page, detailed })
-      .then((res) => this.setState({ loading: false, sources: sources.concat(res), moreResultsAvailable: res.length === 100 }))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState({ loading: false, sources: sources.concat(results), moreResultsAvailable: results.length === 100 })
+      })
   }
 
   componentDidMount() {

--- a/assets/js/dashboard/stats/modals/table.js
+++ b/assets/js/dashboard/stats/modals/table.js
@@ -19,7 +19,10 @@ class ModalTable extends React.Component {
 
   componentDidMount() {
     api.get(this.props.endpoint, this.state.query, {limit: 100})
-      .then((res) => this.setState({loading: false, list: res}))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        this.setState({loading: false, list: results})
+      })
   }
 
   showConversionRate() {

--- a/assets/js/dashboard/stats/modals/table.js
+++ b/assets/js/dashboard/stats/modals/table.js
@@ -20,7 +20,7 @@ class ModalTable extends React.Component {
   componentDidMount() {
     api.get(this.props.endpoint, this.state.query, {limit: 100})
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         this.setState({loading: false, list: results})
       })
   }

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -58,10 +58,11 @@ function ExternalLink({ item, externalLinkDest }) {
 // The main function component for rendering list reports and making them react to what
 // is happening on the dashboard.
 
-// A `fetchData` function must be passed through props. This function defines the format
-// of the data, which is expected to be a list of objects. Think of these objects as rows
-// with keys being columns. The number of columns is dynamic and should be configured
-// via the `metrics` input list. For example:
+// A `fetchData` function must be passed through props. This function defines the data
+// to be rendered, and should return a list of objects under a `results` key. Think of
+// these objects as rows. The number of columns that are **actually rendered** is also
+// configurable through the `metrics` prop, which also defines the keys under which
+// column values are read. For example:
 
 // | keyLabel           |            METRIC_1.label |            METRIC_2.label | ...
 // |--------------------|---------------------------|---------------------------|-----
@@ -76,8 +77,8 @@ function ExternalLink({ item, externalLinkDest }) {
 
 //   * `query` - The query object representing the current state of the dashboard.
 
-//   * `fetchData` - a function that returns an `api.get` promise that will resolve to the
-//     list of data.
+//   * `fetchData` - a function that returns an `api.get` promise that will resolve to an
+//     object containing a `results` key.
 
 //   * `metrics` - a list of `metric` objects. Each `metric` object is required to have at
 //     least the `name` and the `label` keys. If the metric should have a different label
@@ -123,7 +124,10 @@ export default function ListReport(props) {
       setState({ loading: true, list: null })
     }
     props.fetchData()
-      .then((res) => setState({ loading: false, list: res }))
+      .then((response) => {
+        const results = !!response.results ? response.results : response
+        setState({ loading: false, list: results })
+      })
   }, [props.keyLabel, props.query])
 
   const onVisible = () => { setVisible(true) }

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -125,7 +125,7 @@ export default function ListReport(props) {
     }
     props.fetchData()
       .then((response) => {
-        const results = !!response.results ? response.results : response
+        const results = response.results ? response.results : response
         setState({ loading: false, list: results })
       })
   }, [props.keyLabel, props.query])


### PR DESCRIPTION
### Changes

With the new imported data filtering feature, we'll start returning warnings in the dashboard API results, which means we'll need to move the actual list of results under a separate `results` key.

This PR is a preparation in order to not break the frontend when suddenly receiving API results under a `results` key. For some time, we'll need to be able to handle both a straight-up list response, or a map, containing the `results` key.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
