### PR TITLE
Multiple filters on the frontend

### DIFF
--- a/assets/js/dashboard/stats/modals/filter-modal-group.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-group.js
@@ -17,7 +17,6 @@ export default function FilterModalGroup({
     () => Object.entries(filterState).filter(([_, filter]) => getFilterGroup(filter) == filterGroup).map(([id, filter]) => ({ id, filter })),
     [filterGroup, filterState]
   )
-
   const disabledOptions = useMemo(
     () => (filterGroup == 'props') ? rows.map(({ filter }) => ({ value: getPropertyKeyFromFilterKey(filter[1]) })) : null,
     [filterGroup, rows]
@@ -28,7 +27,7 @@ export default function FilterModalGroup({
 
   return (
     <>
-      <div className="mt-4">
+      <div className="mt-6">
         {showTitle && (<div className="text-sm font-medium text-gray-700 dark:text-gray-300">{formattedFilters[filterGroup]}</div>)}
         {rows.map(({ id, filter }) =>
           filterGroup === 'props' ? (
@@ -55,7 +54,7 @@ export default function FilterModalGroup({
         )}
       </div>
       {showAddRow && (
-        <div className="mt-6">
+        <div className="mt-2">
           <a className="underline text-indigo-500 text-sm cursor-pointer" onClick={() => onAddRow(filterGroup)}>
             + Add another
           </a>

--- a/assets/js/dashboard/stats/modals/filter-modal-group.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-group.js
@@ -23,7 +23,7 @@ export default function FilterModalGroup({
     [filterGroup, rows]
   )
 
-  const showAddRow = filterGroup == 'props'
+  const showAddRow = site.flags.multiple_filters ? filterGroup != 'goal' : filterGroup == 'props'
   const showTitle = filterGroup != 'props'
 
   return (

--- a/assets/js/dashboard/stats/modals/filter-modal-group.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-group.js
@@ -22,7 +22,7 @@ export default function FilterModalGroup({
     [filterGroup, rows]
   )
 
-  const showAddRow = site.flags.multiple_filters ? filterGroup != 'goal' : filterGroup == 'props'
+  const showAddRow = site.flags.multiple_filters ? !['goal', 'hostname'].includes(filterGroup) : filterGroup == 'props'
   const showTitle = filterGroup != 'props'
 
   return (

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -35,9 +35,9 @@ export const OPERATION_PREFIX = {
 };
 
 export const BACKEND_OPERATION = {
-  [FILTER_OPERATIONS.is]: 'member',
-  [FILTER_OPERATIONS.isNot]: 'not_member',
-  [FILTER_OPERATIONS.contains]: 'matches_member'
+  [FILTER_OPERATIONS.is]: 'is',
+  [FILTER_OPERATIONS.isNot]: 'is_not',
+  [FILTER_OPERATIONS.contains]: 'matches'
 }
 
 export function supportsIsNot(filterName) {

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -145,7 +145,7 @@ export function serializeApiFilters(filters) {
       apiFilterKey = `event:${filterKey}`
     }
     if (operation == FILTER_OPERATIONS.contains) {
-      clauses = clauses.map((value) => `**${value}**`)
+      clauses = clauses.map((value) => value.includes('*') ? value : `**${value}**`)
     }
     return [BACKEND_OPERATION[operation], apiFilterKey, clauses]
   })

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -34,6 +34,12 @@ export const OPERATION_PREFIX = {
   [FILTER_OPERATIONS.is]: ''
 };
 
+export const BACKEND_OPERATION = {
+  [FILTER_OPERATIONS.is]: 'member',
+  [FILTER_OPERATIONS.isNot]: 'not_member',
+  [FILTER_OPERATIONS.contains]: 'matches_member'
+}
+
 export function supportsIsNot(filterName) {
   return !['goal', 'prop_key'].includes(filterName)
 }
@@ -52,17 +58,6 @@ try {
 }
 
 const ESCAPED_PIPE = '\\|'
-
-function escapeFilterValue(value) {
-  return value.replaceAll(NON_ESCAPED_PIPE_REGEX, ESCAPED_PIPE)
-}
-
-function toFilterQuery(type, clauses) {
-  const prefix = OPERATION_PREFIX[type];
-  const result = clauses.map(clause => escapeFilterValue(clause.toString().trim())).join('|')
-  return prefix + result;
-}
-
 
 export function getLabel(labels, filterKey, value) {
   if (['country', 'region', 'city'].includes(filterKey)) {
@@ -141,19 +136,21 @@ export function cleanLabels(filters, labels, mergedFilterKey, mergedLabels) {
   return result
 }
 
+const EVENT_FILTER_KEYS = new Set(["name", "page", "goal", "hostname"])
 
-// :TODO: New schema for filters in the BE
 export function serializeApiFilters(filters) {
-  const cleaned = {}
-  filters.forEach(([operation, filterKey, clauses]) => {
-    if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
-      cleaned.props ||= {}
-      cleaned.props[getPropertyKeyFromFilterKey(filterKey)] = toFilterQuery(operation, clauses)
-    } else {
-      cleaned[filterKey] = toFilterQuery(operation, clauses)
+  const apiFilters = filters.map(([operation, filterKey, clauses]) => {
+    let apiFilterKey = `visit:${filterKey}`
+    if (filterKey.startsWith(EVENT_PROPS_PREFIX) || EVENT_FILTER_KEYS.has(filterKey)) {
+      apiFilterKey = `event:${filterKey}`
     }
+    if (operation == FILTER_OPERATIONS.contains) {
+      clauses = clauses.map((value) => `**${value}**`)
+    }
+    return [BACKEND_OPERATION[operation], apiFilterKey, clauses]
   })
-  return JSON.stringify(cleaned)
+
+  return JSON.stringify(apiFilters)
 }
 
 export function fetchSuggestions(apiPath, query, input, additionalFilter) {

--- a/extra/lib/plausible/stats/goal/revenue.ex
+++ b/extra/lib/plausible/stats/goal/revenue.ex
@@ -40,8 +40,7 @@ defmodule Plausible.Stats.Goal.Revenue do
   def get_revenue_tracking_currency(site, query, metrics) do
     goal_filters =
       case Query.get_filter(query, "event:goal") do
-        [:is, "event:goal", {_, goal_name}] -> [goal_name]
-        [:member, "event:goal", list] -> Enum.map(list, fn {_, goal_name} -> goal_name end)
+        [:is, "event:goal", list] -> Enum.map(list, fn {_, goal_name} -> goal_name end)
         _ -> []
       end
 

--- a/lib/plausible/google/search_console/filters.ex
+++ b/lib/plausible/google/search_console/filters.ex
@@ -39,7 +39,7 @@ defmodule Plausible.Google.SearchConsole.Filters do
   end
 
   defp transform_filter(_property, [:is, "visit:screen", devices]) when is_list(devices) do
-    expression = devices |> Enum.map(&search_console_device/1) |> Enum.join("|")
+    expression = Enum.map_join(devices, "|", &search_console_device/1)
     %{dimension: "device", operator: "includingRegex", expression: expression}
   end
 

--- a/lib/plausible/google/search_console/filters.ex
+++ b/lib/plausible/google/search_console/filters.ex
@@ -23,23 +23,14 @@ defmodule Plausible.Google.SearchConsole.Filters do
     transform_filter(property, [op, "visit:entry_page" | rest])
   end
 
-  defp transform_filter(property, [:is, "visit:entry_page", page]) when is_binary(page) do
-    %{dimension: "page", expression: property_url(property, page)}
-  end
-
-  defp transform_filter(property, [:member, "visit:entry_page", pages]) when is_list(pages) do
+  defp transform_filter(property, [:is, "visit:entry_page", pages]) when is_list(pages) do
     expression =
       Enum.map_join(pages, "|", fn page -> property_url(property, Regex.escape(page)) end)
 
     %{dimension: "page", operator: "includingRegex", expression: expression}
   end
 
-  defp transform_filter(property, [:matches, "visit:entry_page", page]) when is_binary(page) do
-    page = page_regex(property_url(property, page))
-    %{dimension: "page", operator: "includingRegex", expression: page}
-  end
-
-  defp transform_filter(property, [:matches_member, "visit:entry_page", pages])
+  defp transform_filter(property, [:matches, "visit:entry_page", pages])
        when is_list(pages) do
     expression =
       Enum.map_join(pages, "|", fn page -> page_regex(property_url(property, page)) end)
@@ -47,20 +38,12 @@ defmodule Plausible.Google.SearchConsole.Filters do
     %{dimension: "page", operator: "includingRegex", expression: expression}
   end
 
-  defp transform_filter(_property, [:is, "visit:screen", device]) when is_binary(device) do
-    %{dimension: "device", expression: search_console_device(device)}
-  end
-
-  defp transform_filter(_property, [:member, "visit:screen", devices]) when is_list(devices) do
-    expression = devices |> Enum.join("|")
+  defp transform_filter(_property, [:is, "visit:screen", devices]) when is_list(devices) do
+    expression = devices |> Enum.map(&search_console_device/1) |> Enum.join("|")
     %{dimension: "device", operator: "includingRegex", expression: expression}
   end
 
-  defp transform_filter(_property, [:is, "visit:country", country]) when is_binary(country) do
-    %{dimension: "country", expression: search_console_country(country)}
-  end
-
-  defp transform_filter(_property, [:member, "visit:country", countries])
+  defp transform_filter(_property, [:is, "visit:country", countries])
        when is_list(countries) do
     expression = Enum.map_join(countries, "|", &search_console_country/1)
     %{dimension: "country", operator: "includingRegex", expression: expression}

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -320,7 +320,7 @@ defmodule Plausible.Stats.Base do
 
   def add_percentage_metric(q, site, query, metrics) do
     if :percentage in metrics do
-      total_query = Query.set_property(query, nil)
+      total_query = Query.set_dimensions(query, [])
 
       q
       |> select_merge(
@@ -348,7 +348,7 @@ defmodule Plausible.Stats.Base do
       total_query =
         query
         |> Query.remove_filters(["event:goal", "event:props"])
-        |> Query.set_property(nil)
+        |> Query.set_dimensions([])
 
       # :TRICKY: Subquery is used due to event:goal breakdown above doing an UNION ALL
       subquery(q)

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -39,7 +39,7 @@ defmodule Plausible.Stats.Breakdown do
 
     event_query =
       query
-      |> Query.put_filter([:member, "event:name", events])
+      |> Query.put_filter([:is, "event:name", events])
       |> Query.set_dimensions(["event:name"])
 
     if !Keyword.get(opts, :skip_tracing), do: Query.trace(query, metrics)
@@ -182,7 +182,7 @@ defmodule Plausible.Stats.Breakdown do
         pages ->
           query
           |> Query.remove_filters(["event:page"])
-          |> Query.put_filter([:member, "visit:entry_page", Enum.map(pages, & &1[:page])])
+          |> Query.put_filter([:is, "visit:entry_page", Enum.map(pages, & &1[:page])])
           |> Query.set_dimensions(["visit:entry_page"])
       end
 

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -48,7 +48,7 @@ defmodule Plausible.Stats.EmailReport do
   defp put_top_5_sources(stats, site, query) do
     query =
       query
-      |> Query.put_filter([:is_not, "visit:source", "Direct / None"])
+      |> Query.put_filter([:is_not, "visit:source", ["Direct / None"]])
       |> Query.set_dimensions(["visit:source"])
 
     sources = Stats.breakdown(site, query, [:visitors], {5, 1})

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -40,7 +40,7 @@ defmodule Plausible.Stats.EmailReport do
   end
 
   defp put_top_5_pages(stats, site, query) do
-    query = Query.set_property(query, "event:page")
+    query = Query.set_dimensions(query, ["event:page"])
     pages = Stats.breakdown(site, query, [:visitors], {5, 1})
     Map.put(stats, :pages, pages)
   end
@@ -49,7 +49,7 @@ defmodule Plausible.Stats.EmailReport do
     query =
       query
       |> Query.put_filter([:is_not, "visit:source", "Direct / None"])
-      |> Query.set_property("visit:source")
+      |> Query.set_dimensions(["visit:source"])
 
     sources = Stats.breakdown(site, query, [:visitors], {5, 1})
 

--- a/lib/plausible/stats/filters/dashboard_filter_parser.ex
+++ b/lib/plausible/stats/filters/dashboard_filter_parser.ex
@@ -36,40 +36,40 @@ defmodule Plausible.Stats.Filters.DashboardFilterParser do
 
     cond do
       is_negated && is_wildcard && is_list ->
-        [:not_matches_member, key, val]
-
-      is_negated && is_contains && is_list ->
-        [:not_matches_member, key, Enum.map(val, &"**#{&1}**")]
-
-      is_wildcard && is_list ->
-        [:matches_member, key, val]
-
-      is_negated && is_wildcard ->
         [:does_not_match, key, val]
 
-      is_negated && is_list ->
-        [:not_member, key, val]
+      is_negated && is_contains && is_list ->
+        [:does_not_match, key, Enum.map(val, &"**#{&1}**")]
 
-      is_negated && is_contains ->
-        [:does_not_match, key, "**" <> val <> "**"]
-
-      is_contains && is_list ->
-        [:matches_member, key, Enum.map(val, &"**#{&1}**")]
-
-      is_negated ->
-        [:is_not, key, val]
-
-      is_list ->
-        [:member, key, val]
-
-      is_contains ->
-        [:matches, key, "**" <> val <> "**"]
-
-      is_wildcard ->
+      is_wildcard && is_list ->
         [:matches, key, val]
 
-      true ->
+      is_negated && is_wildcard ->
+        [:does_not_match, key, [val]]
+
+      is_negated && is_list ->
+        [:is_not, key, val]
+
+      is_negated && is_contains ->
+        [:does_not_match, key, ["**" <> val <> "**"]]
+
+      is_contains && is_list ->
+        [:matches, key, Enum.map(val, &"**#{&1}**")]
+
+      is_negated ->
+        [:is_not, key, [val]]
+
+      is_list ->
         [:is, key, val]
+
+      is_contains ->
+        [:matches, key, ["**" <> val <> "**"]]
+
+      is_wildcard ->
+        [:matches, key, [val]]
+
+      true ->
+        [:is, key, [val]]
     end
   end
 

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -3,6 +3,7 @@ defmodule Plausible.Stats.Filters do
   A module for parsing filters used in stat queries.
   """
 
+  alias Plausible.Stats.Filters.QueryParser
   alias Plausible.Stats.Filters.{DashboardFilterParser, StatsAPIFilterParser}
 
   @visit_props [
@@ -47,11 +48,11 @@ defmodule Plausible.Stats.Filters do
 
   Depending on the format and type of the `filters` argument, returns:
 
-    * a decoded map, when `filters` is encoded JSON
-    * a parsed filter map, when `filters` is a filter expression string
-    * the same map, when `filters` is a map
+    * a decoded list, when `filters` is encoded JSON
+    * a parsed filter list, when `filters` is a filter expression string
+    * the same list, when `filters` is a map
 
-  Returns an empty map when argument type is unexpected (e.g. `nil`).
+  Returns an empty list when argument type is unexpected (e.g. `nil`).
 
   ### Examples:
 
@@ -66,13 +67,19 @@ defmodule Plausible.Stats.Filters do
   """
   def parse(filters) when is_binary(filters) do
     case Jason.decode(filters) do
-      {:ok, filters} when is_map(filters) -> DashboardFilterParser.parse_and_prefix(filters)
+      {:ok, filters} when is_map(filters) or is_list(filters) -> parse(filters)
       {:ok, _} -> []
       {:error, err} -> StatsAPIFilterParser.parse_filter_expression(err.data)
     end
   end
 
   def parse(filters) when is_map(filters), do: DashboardFilterParser.parse_and_prefix(filters)
+
+  def parse(filters) when is_list(filters) do
+    {:ok, parsed_filters} = QueryParser.parse_filters(filters)
+    parsed_filters
+  end
+
   def parse(_), do: []
 
   def without_prefix(property) do

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Stats.Filters do
   """
 
   alias Plausible.Stats.Filters.QueryParser
-  alias Plausible.Stats.Filters.{DashboardFilterParser, StatsAPIFilterParser}
+  alias Plausible.Stats.Filters.{LegacyDashboardFilterParser, StatsAPIFilterParser}
 
   @visit_props [
     :source,
@@ -73,7 +73,8 @@ defmodule Plausible.Stats.Filters do
     end
   end
 
-  def parse(filters) when is_map(filters), do: DashboardFilterParser.parse_and_prefix(filters)
+  def parse(filters) when is_map(filters),
+    do: LegacyDashboardFilterParser.parse_and_prefix(filters)
 
   def parse(filters) when is_list(filters) do
     {:ok, parsed_filters} = QueryParser.parse_filters(filters)

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -57,10 +57,10 @@ defmodule Plausible.Stats.Filters do
   ### Examples:
 
       iex> Filters.parse("{\\"page\\":\\"/blog/**\\"}")
-      [[:matches, "event:page", "/blog/**"]]
+      [[:matches, "event:page", ["/blog/**"]]]
 
       iex> Filters.parse("visit:browser!=Chrome")
-      [[:is_not, "visit:browser", "Chrome"]]
+      [[:is_not, "visit:browser", ["Chrome"]]]
 
       iex> Filters.parse(nil)
       []

--- a/lib/plausible/stats/filters/legacy_dashboard_filter_parser.ex
+++ b/lib/plausible/stats/filters/legacy_dashboard_filter_parser.ex
@@ -1,4 +1,4 @@
-defmodule Plausible.Stats.Filters.DashboardFilterParser do
+defmodule Plausible.Stats.Filters.LegacyDashboardFilterParser do
   @moduledoc false
 
   import Plausible.Stats.Filters.Utils

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -59,10 +59,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_operator(["is_not" | _rest]), do: {:ok, :is_not}
   defp parse_operator(["matches" | _rest]), do: {:ok, :matches}
   defp parse_operator(["does_not_match" | _rest]), do: {:ok, :does_not_match}
-  defp parse_operator(["matches_member" | _rest]), do: {:ok, :matches_member}
-  defp parse_operator(["not_matches_member" | _rest]), do: {:ok, :not_matches_member}
-  defp parse_operator(["member" | _rest]), do: {:ok, :member}
-  defp parse_operator(["not_member" | _rest]), do: {:ok, :not_member}
   defp parse_operator(filter), do: {:error, "Unknown operator for filter '#{inspect(filter)}'"}
 
   defp parse_filter_key([_operator, filter_key | _rest] = filter) do
@@ -71,17 +67,10 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp parse_filter_key(filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
 
-  defp parse_filter_rest(:is, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
-  defp parse_filter_rest(:is_not, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
-  defp parse_filter_rest(:matches, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
-
-  defp parse_filter_rest(:does_not_match, [_, _, value]) when is_bitstring(value),
-    do: {:ok, [value]}
-
-  defp parse_filter_rest(:matches_member, filter), do: parse_clauses_list(filter)
-  defp parse_filter_rest(:not_matches_member, filter), do: parse_clauses_list(filter)
-  defp parse_filter_rest(:member, filter), do: parse_clauses_list(filter)
-  defp parse_filter_rest(:not_member, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:is, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:is_not, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:matches, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:does_not_match, filter), do: parse_clauses_list(filter)
 
   defp parse_filter_rest(_operator, filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -1,4 +1,6 @@
 defmodule Plausible.Stats.Filters.QueryParser do
+  @moduledoc false
+
   alias Plausible.Stats.Filters
 
   def parse(params) when is_map(params) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -72,11 +72,13 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_filter_rest(:matches, filter), do: parse_clauses_list(filter)
   defp parse_filter_rest(:does_not_match, filter), do: parse_clauses_list(filter)
 
-  defp parse_clauses_list([_, _, list] = filter) when is_list(list) do
-    if Enum.all?(list, &is_bitstring/1) do
-      {:ok, [list]}
-    else
-      {:error, "Invalid filter '#{inspect(filter)}'"}
+  defp parse_clauses_list([_operation, filter_key, list] = filter) when is_list(list) do
+    all_strings? = Enum.all?(list, &is_bitstring/1)
+
+    cond do
+      filter_key == "event:goal" && all_strings? -> {:ok, [Filters.Utils.wrap_goal_value(list)]}
+      filter_key != "event:goal" && all_strings? -> {:ok, [list]}
+      true -> {:error, "Invalid filter '#{inspect(filter)}'"}
     end
   end
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -1,0 +1,212 @@
+defmodule Plausible.Stats.Filters.QueryParser do
+  alias Plausible.Stats.Filters
+
+  def parse(params) when is_map(params) do
+    with {:ok, metrics} <- parse_metrics(Map.get(params, "metrics", [])),
+         {:ok, filters} <- parse_filters(Map.get(params, "filters", [])),
+         {:ok, date_range} <- parse_date_range(Map.get(params, "date_range")),
+         {:ok, dimensions} <- parse_dimensions(Map.get(params, "dimensions", [])),
+         {:ok, order_by} <- parse_order_by(Map.get(params, "order_by")),
+         query = %{
+           metrics: metrics,
+           filters: filters,
+           date_range: date_range,
+           dimensions: dimensions,
+           order_by: order_by
+         },
+         :ok <- validate_order_by(query) do
+      {:ok, query}
+    end
+  end
+
+  defp parse_metrics([]), do: {:error, "No valid metrics passed"}
+
+  defp parse_metrics(metrics) when is_list(metrics) do
+    if length(metrics) == length(Enum.uniq(metrics)) do
+      parse_list(metrics, &parse_metric/1)
+    else
+      {:error, "Metrics cannot be queried multiple times"}
+    end
+  end
+
+  defp parse_metrics(_invalid_metrics), do: {:error, "Invalid metrics passed"}
+
+  defp parse_metric("time_on_page"), do: {:ok, :time_on_page}
+  defp parse_metric("conversion_rate"), do: {:ok, :conversion_rate}
+  defp parse_metric("visitors"), do: {:ok, :visitors}
+  defp parse_metric("pageviews"), do: {:ok, :pageviews}
+  defp parse_metric("events"), do: {:ok, :events}
+  defp parse_metric("visits"), do: {:ok, :visits}
+  defp parse_metric("bounce_rate"), do: {:ok, :bounce_rate}
+  defp parse_metric("visit_duration"), do: {:ok, :visit_duration}
+  defp parse_metric(unknown_metric), do: {:error, "Unknown metric '#{inspect(unknown_metric)}'"}
+
+  def parse_filters(filters) when is_list(filters) do
+    parse_list(filters, &parse_filter/1)
+  end
+
+  def parse_filters(_invalid_metrics), do: {:error, "Invalid filters passed"}
+
+  defp parse_filter(filter) do
+    with {:ok, operator} <- parse_operator(filter),
+         {:ok, filter_key} <- parse_filter_key(filter),
+         {:ok, rest} <- parse_filter_rest(operator, filter) do
+      {:ok, [operator, filter_key | rest]}
+    end
+  end
+
+  defp parse_operator(["is" | _rest]), do: {:ok, :is}
+  defp parse_operator(["is_not" | _rest]), do: {:ok, :is_not}
+  defp parse_operator(["matches" | _rest]), do: {:ok, :matches}
+  defp parse_operator(["does_not_match" | _rest]), do: {:ok, :does_not_match}
+  defp parse_operator(["matches_member" | _rest]), do: {:ok, :matches_member}
+  defp parse_operator(["not_matches_member" | _rest]), do: {:ok, :not_matches_member}
+  defp parse_operator(["member" | _rest]), do: {:ok, :member}
+  defp parse_operator(["not_member" | _rest]), do: {:ok, :not_member}
+  defp parse_operator(filter), do: {:error, "Unknown operator for filter '#{inspect(filter)}'"}
+
+  defp parse_filter_key([_operator, filter_key | _rest] = filter) do
+    parse_filter_key_string(filter_key, "Invalid filter '#{inspect(filter)}")
+  end
+
+  defp parse_filter_key(filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
+
+  defp parse_filter_rest(:is, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
+  defp parse_filter_rest(:is_not, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
+  defp parse_filter_rest(:matches, [_, _, value]) when is_bitstring(value), do: {:ok, [value]}
+
+  defp parse_filter_rest(:does_not_match, [_, _, value]) when is_bitstring(value),
+    do: {:ok, [value]}
+
+  defp parse_filter_rest(:matches_member, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:not_matches_member, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:member, filter), do: parse_clauses_list(filter)
+  defp parse_filter_rest(:not_member, filter), do: parse_clauses_list(filter)
+
+  defp parse_filter_rest(_operator, filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
+
+  defp parse_clauses_list([_, _, list] = filter) when is_list(list) do
+    if Enum.all?(list, &is_bitstring/1) do
+      {:ok, [list]}
+    else
+      {:error, "Invalid filter '#{inspect(filter)}'"}
+    end
+  end
+
+  defp parse_clauses_list(filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
+
+  defp parse_date_range("day"), do: {:ok, "day"}
+  defp parse_date_range("7d"), do: {:ok, "7d"}
+  defp parse_date_range("30d"), do: {:ok, "30d"}
+  defp parse_date_range("month"), do: {:ok, "month"}
+  defp parse_date_range("6mo"), do: {:ok, "6mo"}
+  defp parse_date_range("12mo"), do: {:ok, "6mo"}
+  defp parse_date_range("year"), do: {:ok, "year"}
+  defp parse_date_range("all"), do: {:ok, "all"}
+
+  defp parse_date_range([from_date_string, to_date_string])
+       when is_bitstring(from_date_string) and is_bitstring(to_date_string) do
+    with {:ok, from_date} <- Date.from_iso8601(from_date_string),
+         {:ok, to_date} <- Date.from_iso8601(to_date_string) do
+      {:ok, Date.range(from_date, to_date)}
+    else
+      _ -> {:error, "Invalid date_range '#{inspect([from_date_string, to_date_string])}'"}
+    end
+  end
+
+  defp parse_date_range(unknown), do: {:error, "Invalid date range '#{inspect(unknown)}'"}
+
+  defp parse_dimensions(dimensions) when is_list(dimensions) do
+    if length(dimensions) == length(Enum.uniq(dimensions)) do
+      parse_list(
+        dimensions,
+        &parse_filter_key_string(&1, "Invalid dimensions '#{inspect(dimensions)}'")
+      )
+    else
+      {:error, "Some dimensions are listed multiple times"}
+    end
+  end
+
+  defp parse_dimensions(dimensions), do: {:error, "Invalid dimensions '#{inspect(dimensions)}'"}
+
+  def parse_order_by(order_by) when is_list(order_by) do
+    parse_list(order_by, &parse_order_by_entry/1)
+  end
+
+  def parse_order_by(nil), do: {:ok, nil}
+  def parse_order_by(order_by), do: {:error, "Invalid order_by '#{inspect(order_by)}'"}
+
+  def parse_order_by_entry(entry) do
+    with {:ok, metric_or_dimension} <- parse_metric_or_dimension(entry),
+         {:ok, order_direction} <- parse_order_direction(entry) do
+      {:ok, {metric_or_dimension, order_direction}}
+    end
+  end
+
+  def parse_metric_or_dimension([metric_or_dimension, _] = entry) do
+    case {parse_metric(metric_or_dimension), parse_filter_key_string(metric_or_dimension)} do
+      {{:ok, metric}, _} -> {:ok, metric}
+      {_, {:ok, dimension}} -> {:ok, dimension}
+      _ -> {:error, "Invalid order_by entry '#{inspect(entry)}'"}
+    end
+  end
+
+  def parse_order_direction([_, "asc"]), do: {:ok, :asc}
+  def parse_order_direction([_, "desc"]), do: {:ok, :desc}
+  def parse_order_direction(entry), do: {:error, "Invalid order_by entry '#{inspect(entry)}'"}
+
+  defp parse_filter_key_string(filter_key, error_message \\ "") do
+    case filter_key do
+      "event:props:" <> _property_name ->
+        {:ok, filter_key}
+
+      "event:" <> key ->
+        if key in Filters.event_props() do
+          {:ok, filter_key}
+        else
+          {:error, error_message}
+        end
+
+      "visit:" <> key ->
+        if key in Filters.visit_props() do
+          {:ok, filter_key}
+        else
+          {:error, error_message}
+        end
+
+      _ ->
+        {:error, error_message}
+    end
+  end
+
+  def validate_order_by(query) do
+    if query.order_by do
+      valid_values = query.metrics ++ query.dimensions
+
+      invalid_entry =
+        Enum.find(query.order_by, fn {value, _direction} ->
+          not Enum.member?(valid_values, value)
+        end)
+
+      case invalid_entry do
+        nil ->
+          :ok
+
+        _ ->
+          {:error,
+           "Invalid order_by entry '#{inspect(invalid_entry)}'. Entry is not a queried metric or dimension"}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp parse_list(list, parser_function) do
+    Enum.reduce_while(list, {:ok, []}, fn value, {:ok, results} ->
+      case parser_function.(value) do
+        {:ok, result} -> {:cont, {:ok, results ++ [result]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -72,8 +72,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_filter_rest(:matches, filter), do: parse_clauses_list(filter)
   defp parse_filter_rest(:does_not_match, filter), do: parse_clauses_list(filter)
 
-  defp parse_filter_rest(_operator, filter), do: {:error, "Invalid filter '#{inspect(filter)}'"}
-
   defp parse_clauses_list([_, _, list] = filter) when is_list(list) do
     if Enum.all?(list, &is_bitstring/1) do
       {:ok, [list]}

--- a/lib/plausible/stats/filters/stats_api_filter_parser.ex
+++ b/lib/plausible/stats/filters/stats_api_filter_parser.ex
@@ -27,11 +27,11 @@ defmodule Plausible.Stats.Filters.StatsAPIFilterParser do
         final_value = remove_escape_chars(raw_value)
 
         cond do
-          is_wildcard? && is_negated? -> [:does_not_match, key, raw_value]
-          is_wildcard? -> [:matches, key, raw_value]
-          is_list? -> [:member, key, parse_member_list(raw_value)]
-          is_negated? -> [:is_not, key, final_value]
-          true -> [:is, key, final_value]
+          is_wildcard? && is_negated? -> [:does_not_match, key, [raw_value]]
+          is_wildcard? -> [:matches, key, [raw_value]]
+          is_list? -> [:is, key, parse_member_list(raw_value)]
+          is_negated? -> [:is_not, key, [final_value]]
+          true -> [:is, key, [final_value]]
         end
         |> reject_invalid_country_codes()
 
@@ -71,10 +71,10 @@ defmodule Plausible.Stats.Filters.StatsAPIFilterParser do
       |> wrap_goal_value()
 
     cond do
-      is_list? && is_wildcard? -> [:matches_member, key, value]
-      is_list? -> [:member, key, value]
-      is_wildcard? -> [:matches, key, value]
-      true -> [:is, key, value]
+      is_list? && is_wildcard? -> [:matches, key, value]
+      is_list? -> [:is, key, value]
+      is_wildcard? -> [:matches, key, [value]]
+      true -> [:is, key, [value]]
     end
   end
 end

--- a/lib/plausible/stats/filters/utils.ex
+++ b/lib/plausible/stats/filters/utils.ex
@@ -1,6 +1,6 @@
 defmodule Plausible.Stats.Filters.Utils do
   @moduledoc """
-  Contains utility functions shared between `DashboardFilterParser`
+  Contains utility functions shared between `LegacyDashboardFilterParser`
   and `StatsAPIFilterParser`.
   """
 

--- a/lib/plausible/stats/filters/where_builder.ex
+++ b/lib/plausible/stats/filters/where_builder.ex
@@ -68,35 +68,17 @@ defmodule Plausible.Stats.Filters.WhereBuilder do
     )
   end
 
-  defp add_filter(:events, _query, [:is, "event:name", name]) do
-    dynamic([e], e.name == ^name)
-  end
-
-  defp add_filter(:events, _query, [:member, "event:name", list]) do
+  defp add_filter(:events, _query, [:is, "event:name", list]) do
     dynamic([e], e.name in ^list)
   end
 
-  defp add_filter(:events, _query, [:is, "event:goal", {:page, path}]) do
-    dynamic([e], e.pathname == ^path and e.name == "pageview")
-  end
-
-  defp add_filter(:events, _query, [:matches, "event:goal", {:page, expr}]) do
-    regex = page_regex(expr)
-
-    dynamic([e], fragment("match(?, ?)", e.pathname, ^regex) and e.name == "pageview")
-  end
-
-  defp add_filter(:events, _query, [:is, "event:goal", {:event, event}]) do
-    dynamic([e], e.name == ^event)
-  end
-
-  defp add_filter(:events, _query, [:member, "event:goal", clauses]) do
+  defp add_filter(:events, _query, [:is, "event:goal", clauses]) do
     {events, pages} = split_goals(clauses)
 
     dynamic([e], (e.pathname in ^pages and e.name == "pageview") or e.name in ^events)
   end
 
-  defp add_filter(:events, _query, [:matches_member, "event:goal", clauses]) do
+  defp add_filter(:events, _query, [:matches, "event:goal", clauses]) do
     {events, pages} = split_goals(clauses, &page_regex/1)
 
     event_clause =
@@ -169,39 +151,7 @@ defmodule Plausible.Stats.Filters.WhereBuilder do
     true
   end
 
-  defp filter_custom_prop(prop_name, column_name, [:is, _, "(none)"]) do
-    dynamic([t], not has_key(t, column_name, ^prop_name))
-  end
-
-  defp filter_custom_prop(prop_name, column_name, [:is, _, value]) do
-    dynamic(
-      [t],
-      has_key(t, column_name, ^prop_name) and get_by_key(t, column_name, ^prop_name) == ^value
-    )
-  end
-
-  defp filter_custom_prop(prop_name, column_name, [:is_not, _, "(none)"]) do
-    dynamic([t], has_key(t, column_name, ^prop_name))
-  end
-
-  defp filter_custom_prop(prop_name, column_name, [:is_not, _, value]) do
-    dynamic(
-      [t],
-      not has_key(t, column_name, ^prop_name) or get_by_key(t, column_name, ^prop_name) != ^value
-    )
-  end
-
-  defp filter_custom_prop(prop_name, column_name, [:matches, _, value]) do
-    regex = page_regex(value)
-
-    dynamic(
-      [t],
-      has_key(t, column_name, ^prop_name) and
-        fragment("match(?, ?)", get_by_key(t, column_name, ^prop_name), ^regex)
-    )
-  end
-
-  defp filter_custom_prop(prop_name, column_name, [:member, _, values]) do
+  defp filter_custom_prop(prop_name, column_name, [:is, _, values]) do
     none_value_included = Enum.member?(values, "(none)")
 
     dynamic(
@@ -211,7 +161,7 @@ defmodule Plausible.Stats.Filters.WhereBuilder do
     )
   end
 
-  defp filter_custom_prop(prop_name, column_name, [:not_member, _, values]) do
+  defp filter_custom_prop(prop_name, column_name, [:is_not, _, values]) do
     none_value_included = Enum.member?(values, "(none)")
 
     dynamic(
@@ -225,7 +175,7 @@ defmodule Plausible.Stats.Filters.WhereBuilder do
     )
   end
 
-  defp filter_custom_prop(prop_name, column_name, [:matches_member, _, clauses]) do
+  defp filter_custom_prop(prop_name, column_name, [:matches, _, clauses]) do
     regexes = Enum.map(clauses, &page_regex/1)
 
     dynamic(
@@ -239,42 +189,22 @@ defmodule Plausible.Stats.Filters.WhereBuilder do
     )
   end
 
-  defp filter_field(db_field, [:is, _key, value]) do
-    value = db_field_val(db_field, value)
-    dynamic([x], field(x, ^db_field) == ^value)
-  end
-
-  defp filter_field(db_field, [:is_not, _key, value]) do
-    value = db_field_val(db_field, value)
-    dynamic([x], field(x, ^db_field) != ^value)
-  end
-
-  defp filter_field(db_field, [:matches_member, _key, glob_exprs]) do
+  defp filter_field(db_field, [:matches, _key, glob_exprs]) do
     page_regexes = Enum.map(glob_exprs, &page_regex/1)
     dynamic([x], fragment("multiMatchAny(?, ?)", field(x, ^db_field), ^page_regexes))
   end
 
-  defp filter_field(db_field, [:not_matches_member, _key, glob_exprs]) do
+  defp filter_field(db_field, [:does_not_match, _key, glob_exprs]) do
     page_regexes = Enum.map(glob_exprs, &page_regex/1)
     dynamic([x], fragment("not(multiMatchAny(?, ?))", field(x, ^db_field), ^page_regexes))
   end
 
-  defp filter_field(db_field, [:matches, _key, glob_expr]) do
-    regex = page_regex(glob_expr)
-    dynamic([x], fragment("match(?, ?)", field(x, ^db_field), ^regex))
-  end
-
-  defp filter_field(db_field, [:does_not_match, _key, glob_expr]) do
-    regex = page_regex(glob_expr)
-    dynamic([x], fragment("not(match(?, ?))", field(x, ^db_field), ^regex))
-  end
-
-  defp filter_field(db_field, [:member, _key, list]) do
+  defp filter_field(db_field, [:is, _key, list]) do
     list = Enum.map(list, &db_field_val(db_field, &1))
     dynamic([x], field(x, ^db_field) in ^list)
   end
 
-  defp filter_field(db_field, [:not_member, _key, list]) do
+  defp filter_field(db_field, [:is_not, _key, list]) do
     list = Enum.map(list, &db_field_val(db_field, &1))
     dynamic([x], field(x, ^db_field) not in ^list)
   end

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -143,8 +143,6 @@ defmodule Plausible.Stats.Imported.Base do
     end
   end
 
-  defp do_decide_custom_prop_table(_query), do: nil
-
   defp do_decide_custom_prop_table(query, property) do
     has_required_name_filter? =
       query.filters

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -119,7 +119,7 @@ defmodule Plausible.Stats.Imported.Base do
   defp custom_prop_query?(query) do
     query.filters
     |> Enum.map(&Enum.at(&1, 1))
-    |> Enum.concat([query.property])
+    |> Enum.concat(query.dimensions)
     |> Enum.any?(&(&1 in @imported_custom_props))
   end
 

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -266,7 +266,7 @@ defmodule Plausible.Stats.Imported do
 
   def merge_imported(q, _, %Query{include_imported: false}, _), do: q
 
-  def merge_imported(q, site, %Query{dimensons: [dimension]} = query, metrics)
+  def merge_imported(q, site, %Query{dimensions: [dimension]} = query, metrics)
       when dimension in @imported_properties do
     dim = Plausible.Stats.Filters.without_prefix(dimension)
 

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -266,9 +266,9 @@ defmodule Plausible.Stats.Imported do
 
   def merge_imported(q, _, %Query{include_imported: false}, _), do: q
 
-  def merge_imported(q, site, %Query{property: property} = query, metrics)
-      when property in @imported_properties do
-    dim = Plausible.Stats.Filters.without_prefix(property)
+  def merge_imported(q, site, %Query{dimensons: [dimension]} = query, metrics)
+      when dimension in @imported_properties do
+    dim = Plausible.Stats.Filters.without_prefix(dimension)
 
     imported_q =
       site
@@ -302,7 +302,7 @@ defmodule Plausible.Stats.Imported do
     |> apply_order_by(metrics)
   end
 
-  def merge_imported(q, site, %Query{property: nil} = query, metrics) do
+  def merge_imported(q, site, %Query{dimensions: []} = query, metrics) do
     imported_q =
       site
       |> Imported.Base.query_imported(query)

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -208,9 +208,9 @@ defmodule Plausible.Stats.Query do
   end
 
   @spec set_dimensions(t(), list(String.t())) :: t()
-  def set_dimensions(query, property) do
+  def set_dimensions(query, dimensions) do
     query
-    |> struct!(query, property: property)
+    |> struct!(query, dimensions: dimensions)
     |> refresh_imported_opts()
   end
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -210,7 +210,7 @@ defmodule Plausible.Stats.Query do
   @spec set_dimensions(t(), list(String.t())) :: t()
   def set_dimensions(query, dimensions) do
     query
-    |> struct!(query, dimensions: dimensions)
+    |> struct!(dimensions: dimensions)
     |> refresh_imported_opts()
   end
 

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -124,14 +124,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     prop_filter = Query.get_filter_by_prefix(query, "event:props:")
 
     query_allowed? =
-      case {prop_filter, query.property, allowed_props} do
+      case {prop_filter, query.dimensions, allowed_props} do
         {_, _, :all} ->
           true
 
         {[_, "event:props:" <> prop | _], _property, allowed_props} ->
           prop in allowed_props
 
-        {_filter, "event:props:" <> prop, allowed_props} ->
+        {_filter, ["event:props:" <> prop], allowed_props} ->
           prop in allowed_props
 
         _ ->
@@ -171,10 +171,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
       Query.get_filter(query, "event:name") ->
         {:error, "Metric `#{metric}` cannot be queried when filtering by `event:name`"}
 
-      query.property == "event:page" ->
+      query.dimensions == ["event:page"] ->
         {:ok, metric}
 
-      not is_nil(query.property) ->
+      not Enum.empty?(query.dimensions) ->
         {:error,
          "Metric `#{metric}` is not supported in breakdown queries (except `event:page` breakdown)"}
 
@@ -189,7 +189,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   defp validate_metric("conversion_rate" = metric, query) do
     cond do
-      query.property == "event:goal" ->
+      query.dimensions == ["event:goal"] ->
         {:ok, metric}
 
       Query.get_filter(query, "event:goal") ->
@@ -210,7 +210,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
       Query.get_filter(query, "event:page") ->
         {:error, "Metric `#{metric}` cannot be queried with a filter on `event:page`."}
 
-      query.property != nil ->
+      not Enum.empty?(query.dimensions) ->
         {:error, "Metric `#{metric}` is not supported in breakdown queries."}
 
       true ->
@@ -230,9 +230,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   defp validate_session_metric(metric, query) do
     cond do
-      event_only_property?(query.property) ->
+      length(query.dimensions) == 1 and event_only_property?(hd(query.dimensions)) ->
         {:error,
-         "Session metric `#{metric}` cannot be queried for breakdown by `#{query.property}`."}
+         "Session metric `#{metric}` cannot be queried for breakdown by `#{query.dimensions}`."}
 
       event_only_filter = find_event_only_filter(query) ->
         {:error,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -903,7 +903,7 @@ defmodule PlausibleWeb.Api.StatsController do
       total_pageviews_query =
         query
         |> Query.remove_filters(["visit:exit_page"])
-        |> Query.put_filter([:member, "event:page", pages])
+        |> Query.put_filter([:is, "event:page", pages])
         |> Query.put_filter([:is, "event:name", "pageview"])
         |> Query.set_dimensions(["event:page"])
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -6,7 +6,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   alias Plausible.Stats
   alias Plausible.Stats.{Query, Comparisons}
-  alias Plausible.Stats.Filters.DashboardFilterParser
+  alias Plausible.Stats.Filters.LegacyDashboardFilterParser
   alias PlausibleWeb.Api.Helpers, as: H
 
   require Logger
@@ -769,7 +769,7 @@ defmodule PlausibleWeb.Api.StatsController do
     site = conn.assigns[:site]
     params = Map.put(params, "property", "visit:referrer")
 
-    referrer_filter = DashboardFilterParser.filter_value("visit:source", referrer)
+    referrer_filter = LegacyDashboardFilterParser.filter_value("visit:source", referrer)
 
     query =
       Query.from(site, params)

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -905,7 +905,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> Query.remove_filters(["visit:exit_page"])
         |> Query.put_filter([:member, "event:page", pages])
         |> Query.put_filter([:is, "event:name", "pageview"])
-        |> Query.set_property("event:page")
+        |> Query.set_dimensions(["event:page"])
 
       total_pageviews =
         Stats.breakdown(site, total_pageviews_query, [:pageviews], {limit, 1})

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -904,7 +904,7 @@ defmodule PlausibleWeb.Api.StatsController do
         query
         |> Query.remove_filters(["visit:exit_page"])
         |> Query.put_filter([:is, "event:page", pages])
-        |> Query.put_filter([:is, "event:name", "pageview"])
+        |> Query.put_filter([:is, "event:name", ["pageview"]])
         |> Query.set_dimensions(["event:page"])
 
       total_pageviews =

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -367,7 +367,12 @@ defmodule PlausibleWeb.StatsController do
 
   defp shared_link_cookie_name(slug), do: "shared-link-" <> slug
 
-  defp get_flags(_user, _site), do: %{}
+  defp get_flags(user, site),
+    do: %{
+      multiple_filters:
+        FunWithFlags.enabled?(:multiple_filters, for: user) ||
+          FunWithFlags.enabled?(:multiple_filters, for: site)
+    }
 
   defp is_dbip() do
     on_ee do

--- a/test/plausible/google/search_console/filters_test.exs
+++ b/test/plausible/google/search_console/filters_test.exs
@@ -4,19 +4,27 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
 
   test "transforms simple page filter" do
     filters = [
-      [:is, "visit:entry_page", "/page"]
+      [:is, "visit:entry_page", ["/page"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
 
     assert transformed == [
-             %{filters: [%{dimension: "page", expression: "https://plausible.io/page"}]}
+             %{
+               filters: [
+                 %{
+                   dimension: "page",
+                   operator: "includingRegex",
+                   expression: "https://plausible.io/page"
+                 }
+               ]
+             }
            ]
   end
 
   test "transforms matches page filter" do
     filters = [
-      [:matches, "visit:entry_page", "*page*"]
+      [:matches, "visit:entry_page", ["*page*"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -34,9 +42,9 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
            ]
   end
 
-  test "transforms member page filter" do
+  test "transforms is page filter" do
     filters = [
-      [:member, "visit:entry_page", ["/pageA", "/pageB"]]
+      [:is, "visit:entry_page", ["/pageA", "/pageB"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -54,9 +62,9 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
            ]
   end
 
-  test "transforms matches_member page filter" do
+  test "transforms matches multiple page filter" do
     filters = [
-      [:matches_member, "visit:entry_page", ["/pageA*", "/pageB*"]]
+      [:matches, "visit:entry_page", ["/pageA*", "/pageB*"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -76,7 +84,7 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
 
   test "transforms event:page exactly like visit:entry_page" do
     filters = [
-      [:matches_member, "event:page", ["/pageA*", "/pageB*"]]
+      [:matches, "event:page", ["/pageA*", "/pageB*"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -96,17 +104,7 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
 
   test "transforms simple visit:screen filter" do
     filters = [
-      [:is, "visit:screen", "Desktop"]
-    ]
-
-    {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
-
-    assert transformed == [%{filters: [%{dimension: "device", expression: "DESKTOP"}]}]
-  end
-
-  test "transforms member visit:screen filter" do
-    filters = [
-      [:member, "visit:screen", ["Mobile", "Tablet"]]
+      [:is, "visit:screen", ["Desktop"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -114,7 +112,23 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
     assert transformed == [
              %{
                filters: [
-                 %{dimension: "device", operator: "includingRegex", expression: "Mobile|Tablet"}
+                 %{dimension: "device", operator: "includingRegex", expression: "DESKTOP"}
+               ]
+             }
+           ]
+  end
+
+  test "transforms is visit:screen filter" do
+    filters = [
+      [:is, "visit:screen", ["Mobile", "Tablet"]]
+    ]
+
+    {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
+
+    assert transformed == [
+             %{
+               filters: [
+                 %{dimension: "device", operator: "includingRegex", expression: "MOBILE|TABLET"}
                ]
              }
            ]
@@ -122,17 +136,19 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
 
   test "transforms simple visit:country filter to alpha3" do
     filters = [
-      [:is, "visit:country", "EE"]
+      [:is, "visit:country", ["EE"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
 
-    assert transformed == [%{filters: [%{dimension: "country", expression: "EST"}]}]
+    assert transformed == [
+             %{filters: [%{dimension: "country", operator: "includingRegex", expression: "EST"}]}
+           ]
   end
 
   test "transforms member visit:country filter" do
     filters = [
-      [:member, "visit:country", ["EE", "PL"]]
+      [:is, "visit:country", ["EE", "PL"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -148,9 +164,9 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
 
   test "filters can be combined" do
     filters = [
-      [:member, "visit:country", ["EE", "PL"]],
-      [:matches, "visit:entry_page", "*web-analytics*"],
-      [:is, "visit:screen", "Desktop"]
+      [:is, "visit:country", ["EE", "PL"]],
+      [:matches, "visit:entry_page", ["*web-analytics*"]],
+      [:is, "visit:screen", ["Desktop"]]
     ]
 
     {:ok, transformed} = Filters.transform("sc-domain:plausible.io", filters)
@@ -158,7 +174,7 @@ defmodule Plausible.Google.SearchConsole.FiltersTest do
     assert transformed == [
              %{
                filters: [
-                 %{dimension: "device", expression: "DESKTOP"},
+                 %{dimension: "device", operator: "includingRegex", expression: "DESKTOP"},
                  %{
                    dimension: "page",
                    operator: "includingRegex",

--- a/test/plausible/stats/dashboard_filter_parser_test.exs
+++ b/test/plausible/stats/dashboard_filter_parser_test.exs
@@ -9,199 +9,193 @@ defmodule Plausible.Stats.DashboardFilterParserTest do
   describe "adding prefix" do
     test "adds appropriate prefix to filter" do
       %{"page" => "/"}
-      |> assert_parsed([[:is, "event:page", "/"]])
+      |> assert_parsed([[:is, "event:page", ["/"]]])
 
       %{"goal" => "Signup"}
-      |> assert_parsed([[:is, "event:goal", {:event, "Signup"}]])
+      |> assert_parsed([[:is, "event:goal", [{:event, "Signup"}]]])
 
       %{"goal" => "Visit /blog"}
-      |> assert_parsed([[:is, "event:goal", {:page, "/blog"}]])
+      |> assert_parsed([[:is, "event:goal", [{:page, "/blog"}]]])
 
       %{"source" => "Google"}
-      |> assert_parsed([[:is, "visit:source", "Google"]])
+      |> assert_parsed([[:is, "visit:source", ["Google"]]])
 
       %{"referrer" => "cnn.com"}
-      |> assert_parsed([[:is, "visit:referrer", "cnn.com"]])
+      |> assert_parsed([[:is, "visit:referrer", ["cnn.com"]]])
 
       %{"utm_medium" => "search"}
-      |> assert_parsed([[:is, "visit:utm_medium", "search"]])
+      |> assert_parsed([[:is, "visit:utm_medium", ["search"]]])
 
       %{"utm_source" => "bing"}
-      |> assert_parsed([[:is, "visit:utm_source", "bing"]])
+      |> assert_parsed([[:is, "visit:utm_source", ["bing"]]])
 
       %{"utm_content" => "content"}
-      |> assert_parsed([[:is, "visit:utm_content", "content"]])
+      |> assert_parsed([[:is, "visit:utm_content", ["content"]]])
 
       %{"utm_term" => "term"}
-      |> assert_parsed([[:is, "visit:utm_term", "term"]])
+      |> assert_parsed([[:is, "visit:utm_term", ["term"]]])
 
       %{"screen" => "Desktop"}
-      |> assert_parsed([[:is, "visit:screen", "Desktop"]])
+      |> assert_parsed([[:is, "visit:screen", ["Desktop"]]])
 
       %{"browser" => "Opera"}
-      |> assert_parsed([[:is, "visit:browser", "Opera"]])
+      |> assert_parsed([[:is, "visit:browser", ["Opera"]]])
 
       %{"browser_version" => "10.1"}
-      |> assert_parsed([[:is, "visit:browser_version", "10.1"]])
+      |> assert_parsed([[:is, "visit:browser_version", ["10.1"]]])
 
       %{"os" => "Linux"}
-      |> assert_parsed([[:is, "visit:os", "Linux"]])
+      |> assert_parsed([[:is, "visit:os", ["Linux"]]])
 
       %{"os_version" => "13.0"}
-      |> assert_parsed([[:is, "visit:os_version", "13.0"]])
+      |> assert_parsed([[:is, "visit:os_version", ["13.0"]]])
 
       %{"country" => "EE"}
-      |> assert_parsed([[:is, "visit:country", "EE"]])
+      |> assert_parsed([[:is, "visit:country", ["EE"]]])
 
       %{"region" => "EE-12"}
-      |> assert_parsed([[:is, "visit:region", "EE-12"]])
+      |> assert_parsed([[:is, "visit:region", ["EE-12"]]])
 
       %{"city" => "123"}
-      |> assert_parsed([[:is, "visit:city", "123"]])
+      |> assert_parsed([[:is, "visit:city", ["123"]]])
 
       %{"entry_page" => "/blog"}
-      |> assert_parsed([[:is, "visit:entry_page", "/blog"]])
+      |> assert_parsed([[:is, "visit:entry_page", ["/blog"]]])
 
       %{"exit_page" => "/blog"}
-      |> assert_parsed([[:is, "visit:exit_page", "/blog"]])
+      |> assert_parsed([[:is, "visit:exit_page", ["/blog"]]])
 
       %{"props" => %{"cta" => "Top"}}
-      |> assert_parsed([[:is, "event:props:cta", "Top"]])
+      |> assert_parsed([[:is, "event:props:cta", ["Top"]]])
 
       %{"hostname" => "dummy.site"}
-      |> assert_parsed([[:is, "event:hostname", "dummy.site"]])
+      |> assert_parsed([[:is, "event:hostname", ["dummy.site"]]])
     end
   end
 
   describe "escaping pipe character" do
     test "in simple is filter" do
       %{"goal" => ~S(Foo \| Bar)}
-      |> assert_parsed([[:is, "event:goal", {:event, "Foo | Bar"}]])
+      |> assert_parsed([[:is, "event:goal", [{:event, "Foo | Bar"}]]])
     end
 
     test "in member filter" do
       %{"page" => ~S(/|\|)}
-      |> assert_parsed([[:member, "event:page", ["/", "|"]]])
+      |> assert_parsed([[:is, "event:page", ["/", "|"]]])
     end
   end
 
   describe "is not filter type" do
     test "simple is not filter" do
       %{"page" => "!/"}
-      |> assert_parsed([[:is_not, "event:page", "/"]])
+      |> assert_parsed([[:is_not, "event:page", ["/"]]])
 
       %{"props" => %{"cta" => "!Top"}}
-      |> assert_parsed([[:is_not, "event:props:cta", "Top"]])
+      |> assert_parsed([[:is_not, "event:props:cta", ["Top"]]])
     end
   end
 
-  describe "member filter type" do
-    test "simple member filter" do
+  describe "is filter type" do
+    test "simple is filter" do
       %{"page" => "/|/blog"}
-      |> assert_parsed([[:member, "event:page", ["/", "/blog"]]])
+      |> assert_parsed([[:is, "event:page", ["/", "/blog"]]])
     end
 
     test "escaping pipe character" do
       %{"page" => "/|\\|"}
-      |> assert_parsed([[:member, "event:page", ["/", "|"]]])
+      |> assert_parsed([[:is, "event:page", ["/", "|"]]])
     end
 
     test "mixed goals" do
       %{"goal" => "Signup|Visit /thank-you"}
-      |> assert_parsed([[:member, "event:goal", [{:event, "Signup"}, {:page, "/thank-you"}]]])
+      |> assert_parsed([[:is, "event:goal", [{:event, "Signup"}, {:page, "/thank-you"}]]])
 
       %{"goal" => "Visit /thank-you|Signup"}
-      |> assert_parsed([[:member, "event:goal", [{:page, "/thank-you"}, {:event, "Signup"}]]])
+      |> assert_parsed([[:is, "event:goal", [{:page, "/thank-you"}, {:event, "Signup"}]]])
     end
   end
 
-  describe "matches_member filter type" do
-    test "parses matches_member filter type" do
+  describe "matches filter type" do
+    test "parses matches filter type" do
       %{"page" => "/|/blog**"}
-      |> assert_parsed([[:matches_member, "event:page", ["/", "/blog**"]]])
+      |> assert_parsed([[:matches, "event:page", ["/", "/blog**"]]])
     end
 
-    test "parses not_matches_member filter type" do
+    test "parses not_matches filter type" do
       %{"page" => "!/|/blog**"}
-      |> assert_parsed([[:not_matches_member, "event:page", ["/", "/blog**"]]])
+      |> assert_parsed([[:does_not_match, "event:page", ["/", "/blog**"]]])
     end
-  end
 
-  describe "contains filter type" do
-    test "single contains" do
+    test "single matches" do
       %{"page" => "~blog"}
-      |> assert_parsed([[:matches, "event:page", "**blog**"]])
+      |> assert_parsed([[:matches, "event:page", ["**blog**"]]])
     end
 
-    test "negated contains" do
+    test "negated matches" do
       %{"page" => "!~articles"}
-      |> assert_parsed([[:does_not_match, "event:page", "**articles**"]])
+      |> assert_parsed([[:does_not_match, "event:page", ["**articles**"]]])
     end
 
-    test "contains member" do
+    test "matches member" do
       %{"page" => "~articles|blog"}
-      |> assert_parsed([[:matches_member, "event:page", ["**articles**", "**blog**"]]])
+      |> assert_parsed([[:matches, "event:page", ["**articles**", "**blog**"]]])
     end
 
-    test "not contains member" do
+    test "not matches member" do
       %{"page" => "!~articles|blog"}
-      |> assert_parsed([[:not_matches_member, "event:page", ["**articles**", "**blog**"]]])
+      |> assert_parsed([[:does_not_match, "event:page", ["**articles**", "**blog**"]]])
+    end
+
+    test "can be used with `goal` or `page` filters" do
+      %{"page" => "/blog/post-*"}
+      |> assert_parsed([[:matches, "event:page", ["/blog/post-*"]]])
+
+      %{"goal" => "Visit /blog/post-*"}
+      |> assert_parsed([[:matches, "event:goal", [{:page, "/blog/post-*"}]]])
+    end
+
+    test "other filters default to `is` even when wildcard is present" do
+      %{"country" => "Germa**"}
+      |> assert_parsed([[:is, "visit:country", ["Germa**"]]])
+    end
+
+    test "can be used with `page` filter" do
+      %{"page" => "!/blog/post-*"}
+      |> assert_parsed([[:does_not_match, "event:page", ["/blog/post-*"]]])
+    end
+
+    test "other filters default to is_not even when wildcard is present" do
+      %{"country" => "!Germa**"}
+      |> assert_parsed([[:is_not, "visit:country", ["Germa**"]]])
     end
   end
 
-  describe "not_member filter type" do
-    test "simple not_member filter" do
+  describe "is_not filter type" do
+    test "simple is_not filter" do
       %{"page" => "!/|/blog"}
-      |> assert_parsed([[:not_member, "event:page", ["/", "/blog"]]])
+      |> assert_parsed([[:is_not, "event:page", ["/", "/blog"]]])
     end
 
     test "mixed goals" do
       %{"goal" => "!Signup|Visit /thank-you"}
       |> assert_parsed([
-        [:not_member, "event:goal", [{:event, "Signup"}, {:page, "/thank-you"}]]
+        [:is_not, "event:goal", [{:event, "Signup"}, {:page, "/thank-you"}]]
       ])
 
       %{"goal" => "!Visit /thank-you|Signup"}
       |> assert_parsed([
-        [:not_member, "event:goal", [{:page, "/thank-you"}, {:event, "Signup"}]]
+        [:is_not, "event:goal", [{:page, "/thank-you"}, {:event, "Signup"}]]
       ])
-    end
-  end
-
-  describe "matches filter type" do
-    test "can be used with `goal` or `page` filters" do
-      %{"page" => "/blog/post-*"}
-      |> assert_parsed([[:matches, "event:page", "/blog/post-*"]])
-
-      %{"goal" => "Visit /blog/post-*"}
-      |> assert_parsed([[:matches, "event:goal", {:page, "/blog/post-*"}]])
-    end
-
-    test "other filters default to `is` even when wildcard is present" do
-      %{"country" => "Germa**"}
-      |> assert_parsed([[:is, "visit:country", "Germa**"]])
-    end
-  end
-
-  describe "does_not_match filter type" do
-    test "can be used with `page` filter" do
-      %{"page" => "!/blog/post-*"}
-      |> assert_parsed([[:does_not_match, "event:page", "/blog/post-*"]])
-    end
-
-    test "other filters default to is_not even when wildcard is present" do
-      %{"country" => "!Germa**"}
-      |> assert_parsed([[:is_not, "visit:country", "Germa**"]])
     end
   end
 
   describe "contains prefix filter type" do
     test "can be used with any filter" do
       %{"page" => "~/blog/post"}
-      |> assert_parsed([[:matches, "event:page", "**/blog/post**"]])
+      |> assert_parsed([[:matches, "event:page", ["**/blog/post**"]]])
 
       %{"source" => "~facebook"}
-      |> assert_parsed([[:matches, "visit:source", "**facebook**"]])
+      |> assert_parsed([[:matches, "visit:source", ["**facebook**"]]])
     end
   end
 end

--- a/test/plausible/stats/filters_test.exs
+++ b/test/plausible/stats/filters_test.exs
@@ -12,70 +12,70 @@ defmodule Plausible.Stats.FiltersTest do
   describe "parses filter expression" do
     test "simple positive" do
       "event:name==pageview"
-      |> assert_parsed([[:is, "event:name", "pageview"]])
+      |> assert_parsed([[:is, "event:name", ["pageview"]]])
     end
 
     test "simple negative" do
       "event:name!=pageview"
-      |> assert_parsed([[:is_not, "event:name", "pageview"]])
+      |> assert_parsed([[:is_not, "event:name", ["pageview"]]])
     end
 
     test "whitespace is trimmed" do
       " event:name == pageview "
-      |> assert_parsed([[:is, "event:name", "pageview"]])
+      |> assert_parsed([[:is, "event:name", ["pageview"]]])
     end
 
     test "wildcard" do
       "event:page==/blog/post-*"
-      |> assert_parsed([[:matches, "event:page", "/blog/post-*"]])
+      |> assert_parsed([[:matches, "event:page", ["/blog/post-*"]]])
     end
 
     test "negative wildcard" do
       "event:page!=/blog/post-*"
-      |> assert_parsed([[:does_not_match, "event:page", "/blog/post-*"]])
+      |> assert_parsed([[:does_not_match, "event:page", ["/blog/post-*"]]])
     end
 
     test "custom event goal" do
       "event:goal==Signup"
-      |> assert_parsed([[:is, "event:goal", {:event, "Signup"}]])
+      |> assert_parsed([[:is, "event:goal", [{:event, "Signup"}]]])
     end
 
     test "pageview goal" do
       "event:goal==Visit /blog"
-      |> assert_parsed([[:is, "event:goal", {:page, "/blog"}]])
+      |> assert_parsed([[:is, "event:goal", [{:page, "/blog"}]]])
     end
 
-    test "member" do
+    test "is" do
       "visit:country==FR|GB|DE"
-      |> assert_parsed([[:member, "visit:country", ["FR", "GB", "DE"]]])
+      |> assert_parsed([[:is, "visit:country", ["FR", "GB", "DE"]]])
     end
 
     test "member + wildcard" do
       "event:page==/blog**|/newsletter|/*/"
-      |> assert_parsed([[:matches, "event:page", "/blog**|/newsletter|/*/"]])
+      |> assert_parsed([[:matches, "event:page", ["/blog**|/newsletter|/*/"]]])
     end
 
     test "combined with \";\"" do
       "event:page==/blog**|/newsletter|/*/ ; visit:country==FR|GB|DE"
       |> assert_parsed([
-        [:matches, "event:page", "/blog**|/newsletter|/*/"],
-        [:member, "visit:country", ["FR", "GB", "DE"]]
+        [:matches, "event:page", ["/blog**|/newsletter|/*/"]],
+        [:is, "visit:country", ["FR", "GB", "DE"]]
       ])
     end
 
     test "escaping pipe character" do
       "utm_campaign==campaign \\| 1"
-      |> assert_parsed([[:is, "utm_campaign", "campaign | 1"]])
+      |> assert_parsed([[:is, "utm_campaign", ["campaign | 1"]]])
     end
 
-    test "escaping pipe character in member filter" do
+    test "escaping pipe character in is filter" do
       "utm_campaign==campaign \\| 1|campaign \\| 2"
-      |> assert_parsed([[:member, "utm_campaign", ["campaign | 1", "campaign | 2"]]])
+      |> assert_parsed([[:is, "utm_campaign", ["campaign | 1", "campaign | 2"]]])
     end
 
-    test "keeps escape characters in member + wildcard filter" do
+    test "keeps escape characters in is + wildcard filter" do
       "event:page==/**\\|page|/other/page"
-      |> assert_parsed([[:matches, "event:page", "/**\\|page|/other/page"]])
+      |> assert_parsed([[:matches, "event:page", ["/**\\|page|/other/page"]]])
     end
 
     test "gracefully fails to parse garbage" do

--- a/test/plausible/stats/filters_test.exs
+++ b/test/plausible/stats/filters_test.exs
@@ -98,4 +98,12 @@ defmodule Plausible.Stats.FiltersTest do
       |> assert_parsed([])
     end
   end
+
+  describe "parses filters list" do
+    test "simple" do
+      [["member", "event:name", ["pageview"]]]
+      |> Jason.encode!()
+      |> assert_parsed([[:member, "event:name", ["pageview"]]])
+    end
+  end
 end

--- a/test/plausible/stats/filters_test.exs
+++ b/test/plausible/stats/filters_test.exs
@@ -101,9 +101,9 @@ defmodule Plausible.Stats.FiltersTest do
 
   describe "parses filters list" do
     test "simple" do
-      [["member", "event:name", ["pageview"]]]
+      [["is", "event:name", ["pageview"]]]
       |> Jason.encode!()
-      |> assert_parsed([[:member, "event:name", ["pageview"]]])
+      |> assert_parsed([[:is, "event:name", ["pageview"]]])
     end
   end
 end

--- a/test/plausible/stats/legacy_dashboard_filter_parser_test.exs
+++ b/test/plausible/stats/legacy_dashboard_filter_parser_test.exs
@@ -1,9 +1,9 @@
-defmodule Plausible.Stats.DashboardFilterParserTest do
+defmodule Plausible.Stats.LegacyDashboardFilterParserTest do
   use ExUnit.Case, async: true
-  alias Plausible.Stats.Filters.DashboardFilterParser
+  alias Plausible.Stats.Filters.LegacyDashboardFilterParser
 
   def assert_parsed(filters, expected_output) do
-    assert DashboardFilterParser.parse_and_prefix(filters) == expected_output
+    assert LegacyDashboardFilterParser.parse_and_prefix(filters) == expected_output
   end
 
   describe "adding prefix" do

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -136,23 +136,25 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
 
     for dimension <- Filters.event_props() do
-      test "filtering by event:#{dimension} filter" do
-        %{
-          "metrics" => ["visitors"],
-          "date_range" => "all",
-          "filters" => [
-            ["is", "event:#{unquote(dimension)}", ["foo"]]
-          ]
-        }
-        |> check_success(%{
-          metrics: [:visitors],
-          date_range: "all",
-          filters: [
-            [:is, "event:#{unquote(dimension)}", ["foo"]]
-          ],
-          dimensions: [],
-          order_by: nil
-        })
+      if dimension != "goal" do
+        test "filtering by event:#{dimension} filter" do
+          %{
+            "metrics" => ["visitors"],
+            "date_range" => "all",
+            "filters" => [
+              ["is", "event:#{unquote(dimension)}", ["foo"]]
+            ]
+          }
+          |> check_success(%{
+            metrics: [:visitors],
+            date_range: "all",
+            filters: [
+              [:is, "event:#{unquote(dimension)}", ["foo"]]
+            ],
+            dimensions: [],
+            order_by: nil
+          })
+        end
       end
     end
 
@@ -175,6 +177,25 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           order_by: nil
         })
       end
+    end
+
+    test "filtering by event:goal" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => [
+          ["is", "event:goal", ["Signup", "Visit /thank-you"]]
+        ]
+      }
+      |> check_success(%{
+        metrics: [:visitors],
+        date_range: "all",
+        filters: [
+          [:is, "event:goal", [{:event, "Signup"}, {:page, "/thank-you"}]]
+        ],
+        dimensions: [],
+        order_by: nil
+      })
     end
 
     test "invalid event filter" do

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1,0 +1,384 @@
+defmodule Plausible.Stats.Filters.QueryParserTest do
+  use ExUnit.Case, async: true
+  alias Plausible.Stats.Filters
+  import Plausible.Stats.Filters.QueryParser
+
+  def check_success(params, expected_result) do
+    assert parse(params) == {:ok, expected_result}
+  end
+
+  def check_error(params, expected_error_message) do
+    {:error, message} = parse(params)
+    assert message =~ expected_error_message
+  end
+
+  test "parsing empty map fails" do
+    %{}
+    |> check_error("No valid metrics passed")
+  end
+
+  describe "metrics validation" do
+    test "valid metrics passed" do
+      %{"metrics" => ["visitors", "events"], "date_range" => "all"}
+      |> check_success(%{
+        metrics: [:visitors, :events],
+        date_range: "all",
+        filters: [],
+        dimensions: [],
+        order_by: nil
+      })
+    end
+
+    test "invalid metric passed" do
+      %{"metrics" => ["visitors", "event:name"], "date_range" => "all"}
+      |> check_error("Unknown metric '\"event:name\"'")
+    end
+
+    test "fuller list of metrics" do
+      %{
+        "metrics" => [
+          "time_on_page",
+          "conversion_rate",
+          "visitors",
+          "pageviews",
+          "visits",
+          "events",
+          "bounce_rate",
+          "visit_duration"
+        ],
+        "date_range" => "all"
+      }
+      |> check_success(%{
+        metrics: [
+          :time_on_page,
+          :conversion_rate,
+          :visitors,
+          :pageviews,
+          :visits,
+          :events,
+          :bounce_rate,
+          :visit_duration
+        ],
+        date_range: "all",
+        filters: [],
+        dimensions: [],
+        order_by: nil
+      })
+    end
+
+    test "same metric queried multiple times" do
+      %{"metrics" => ["events", "visitors", "visitors"], "date_range" => "all"}
+      |> check_error(~r/Metrics cannot be queried multiple times/)
+    end
+  end
+
+  describe "filters validation" do
+    for operation <- [:is, :is_not, :matches, :does_not_match] do
+      test "#{operation} filter" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            [Atom.to_string(unquote(operation)), "event:name", "foo"]
+          ]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [
+            [unquote(operation), "event:name", "foo"]
+          ],
+          dimensions: [],
+          order_by: nil
+        })
+      end
+
+      test "#{operation} filter with invalid clause" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            [Atom.to_string(unquote(operation)), "event:name", ["foo"]]
+          ]
+        }
+        |> check_error(~r/Invalid filter/)
+      end
+    end
+
+    for operation <- [:member, :not_member, :matches_member, :not_matches_member] do
+      test "#{operation} filter" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            [Atom.to_string(unquote(operation)), "event:name", ["foo"]]
+          ]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [
+            [unquote(operation), "event:name", ["foo"]]
+          ],
+          dimensions: [],
+          order_by: nil
+        })
+      end
+
+      test "#{operation} filter with invalid clause" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            [Atom.to_string(unquote(operation)), "event:name", "foo"]
+          ]
+        }
+        |> check_error(~r/Invalid filter/)
+      end
+    end
+
+    test "filtering by invalid operation" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => [
+          ["exists?", "event:name", ["foo"]]
+        ]
+      }
+      |> check_error(~r/Unknown operator for filter/)
+    end
+
+    test "filtering by custom properties" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => [
+          ["member", "event:props:foobar", ["value"]]
+        ]
+      }
+      |> check_success(%{
+        metrics: [:visitors],
+        date_range: "all",
+        filters: [
+          [:member, "event:props:foobar", ["value"]]
+        ],
+        dimensions: [],
+        order_by: nil
+      })
+    end
+
+    for dimension <- Filters.event_props() do
+      test "filtering by event:#{dimension} filter" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            ["member", "event:#{unquote(dimension)}", ["foo"]]
+          ]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [
+            [:member, "event:#{unquote(dimension)}", ["foo"]]
+          ],
+          dimensions: [],
+          order_by: nil
+        })
+      end
+    end
+
+    for dimension <- Filters.visit_props() do
+      test "filtering by visit:#{dimension} filter" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "filters" => [
+            ["member", "visit:#{unquote(dimension)}", ["foo"]]
+          ]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [
+            [:member, "visit:#{unquote(dimension)}", ["foo"]]
+          ],
+          dimensions: [],
+          order_by: nil
+        })
+      end
+    end
+
+    test "invalid event filter" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => [
+          ["member", "event:device", ["foo"]]
+        ]
+      }
+      |> check_error(~r/Invalid filter /)
+    end
+
+    test "invalid visit filter" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => [
+          ["member", "visit:name", ["foo"]]
+        ]
+      }
+      |> check_error(~r/Invalid filter /)
+    end
+
+    test "invalid filter" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "filters" => "foobar"
+      }
+      |> check_error(~r/Invalid filters passed/)
+    end
+  end
+
+  describe "date range validation" do
+  end
+
+  describe "dimensions validation" do
+    for dimension <- Filters.event_props() do
+      test "event:#{dimension} dimension" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "dimensions" => ["event:#{unquote(dimension)}"]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [],
+          dimensions: ["event:#{unquote(dimension)}"],
+          order_by: nil
+        })
+      end
+    end
+
+    for dimension <- Filters.visit_props() do
+      test "visit:#{dimension} dimension" do
+        %{
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "dimensions" => ["visit:#{unquote(dimension)}"]
+        }
+        |> check_success(%{
+          metrics: [:visitors],
+          date_range: "all",
+          filters: [],
+          dimensions: ["visit:#{unquote(dimension)}"],
+          order_by: nil
+        })
+      end
+    end
+
+    test "custom properties dimension" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["event:props:foobar"]
+      }
+      |> check_success(%{
+        metrics: [:visitors],
+        date_range: "all",
+        filters: [],
+        dimensions: ["event:props:foobar"],
+        order_by: nil
+      })
+    end
+
+    test "invalid dimension name passed" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["visitors"]
+      }
+      |> check_error(~r/Invalid dimensions/)
+    end
+
+    test "invalid dimension" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => "foobar"
+      }
+      |> check_error(~r/Invalid dimensions/)
+    end
+
+    test "dimensions are not unique" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["event:name", "event:name"]
+      }
+      |> check_error(~r/Some dimensions are listed multiple times/)
+    end
+  end
+
+  describe "order_by validation" do
+    test "ordering by metric" do
+      %{
+        "metrics" => ["visitors", "events"],
+        "date_range" => "all",
+        "order_by" => [["events", "desc"], ["visitors", "asc"]]
+      }
+      |> check_success(%{
+        metrics: [:visitors, :events],
+        date_range: "all",
+        filters: [],
+        dimensions: [],
+        order_by: [{:events, :desc}, {:visitors, :asc}]
+      })
+    end
+
+    test "ordering by dimension" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["event:name"],
+        "order_by" => [["event:name", "desc"]]
+      }
+      |> check_success(%{
+        metrics: [:visitors],
+        date_range: "all",
+        filters: [],
+        dimensions: ["event:name"],
+        order_by: [{"event:name", :desc}]
+      })
+    end
+
+    test "ordering by invalid value" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "order_by" => [["visssss", "desc"]]
+      }
+      |> check_error(~r/Invalid order_by entry/)
+    end
+
+    test "ordering by not queried metric" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "order_by" => [["events", "desc"]]
+      }
+      |> check_error(~r/Entry is not a queried metric or dimension/)
+    end
+
+    test "ordering by not queried dimension" do
+      %{
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "order_by" => [["event:name", "desc"]]
+      }
+      |> check_error(~r/Entry is not a queried metric or dimension/)
+    end
+  end
+end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -79,38 +79,6 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           "metrics" => ["visitors"],
           "date_range" => "all",
           "filters" => [
-            [Atom.to_string(unquote(operation)), "event:name", "foo"]
-          ]
-        }
-        |> check_success(%{
-          metrics: [:visitors],
-          date_range: "all",
-          filters: [
-            [unquote(operation), "event:name", "foo"]
-          ],
-          dimensions: [],
-          order_by: nil
-        })
-      end
-
-      test "#{operation} filter with invalid clause" do
-        %{
-          "metrics" => ["visitors"],
-          "date_range" => "all",
-          "filters" => [
-            [Atom.to_string(unquote(operation)), "event:name", ["foo"]]
-          ]
-        }
-        |> check_error(~r/Invalid filter/)
-      end
-    end
-
-    for operation <- [:member, :not_member, :matches_member, :not_matches_member] do
-      test "#{operation} filter" do
-        %{
-          "metrics" => ["visitors"],
-          "date_range" => "all",
-          "filters" => [
             [Atom.to_string(unquote(operation)), "event:name", ["foo"]]
           ]
         }
@@ -153,14 +121,14 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         "metrics" => ["visitors"],
         "date_range" => "all",
         "filters" => [
-          ["member", "event:props:foobar", ["value"]]
+          ["is", "event:props:foobar", ["value"]]
         ]
       }
       |> check_success(%{
         metrics: [:visitors],
         date_range: "all",
         filters: [
-          [:member, "event:props:foobar", ["value"]]
+          [:is, "event:props:foobar", ["value"]]
         ],
         dimensions: [],
         order_by: nil
@@ -173,14 +141,14 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           "metrics" => ["visitors"],
           "date_range" => "all",
           "filters" => [
-            ["member", "event:#{unquote(dimension)}", ["foo"]]
+            ["is", "event:#{unquote(dimension)}", ["foo"]]
           ]
         }
         |> check_success(%{
           metrics: [:visitors],
           date_range: "all",
           filters: [
-            [:member, "event:#{unquote(dimension)}", ["foo"]]
+            [:is, "event:#{unquote(dimension)}", ["foo"]]
           ],
           dimensions: [],
           order_by: nil
@@ -194,14 +162,14 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           "metrics" => ["visitors"],
           "date_range" => "all",
           "filters" => [
-            ["member", "visit:#{unquote(dimension)}", ["foo"]]
+            ["is", "visit:#{unquote(dimension)}", ["foo"]]
           ]
         }
         |> check_success(%{
           metrics: [:visitors],
           date_range: "all",
           filters: [
-            [:member, "visit:#{unquote(dimension)}", ["foo"]]
+            [:is, "visit:#{unquote(dimension)}", ["foo"]]
           ],
           dimensions: [],
           order_by: nil
@@ -214,7 +182,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         "metrics" => ["visitors"],
         "date_range" => "all",
         "filters" => [
-          ["member", "event:device", ["foo"]]
+          ["is", "event:device", ["foo"]]
         ]
       }
       |> check_error(~r/Invalid filter /)
@@ -225,7 +193,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         "metrics" => ["visitors"],
         "date_range" => "all",
         "filters" => [
-          ["member", "visit:name", ["foo"]]
+          ["is", "visit:name", ["foo"]]
         ]
       }
       |> check_error(~r/Invalid filter /)

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -194,14 +194,14 @@ defmodule Plausible.Stats.QueryTest do
       filters = Jason.encode!(%{"goal" => "Signup"})
       q = Query.from(site, %{"period" => "6mo", "filters" => filters})
 
-      assert q.filters == [[:is, "event:goal", {:event, "Signup"}]]
+      assert q.filters == [[:is, "event:goal", [{:event, "Signup"}]]]
     end
 
     test "parses source filter", %{site: site} do
       filters = Jason.encode!(%{"source" => "Twitter"})
       q = Query.from(site, %{"period" => "6mo", "filters" => filters})
 
-      assert q.filters == [[:is, "visit:source", "Twitter"]]
+      assert q.filters == [[:is, "visit:source", ["Twitter"]]]
     end
   end
 


### PR DESCRIPTION
### Changes

This PR does a few things:
- It adds a new `multiple_filters` feature flag which allows adding multiple filters on the frontend (except for goals).
- Updates filter serialization on the frontend
- Adds new filter (and query) parsing methods (for a follow-up PR)
- Reduces number of internal filter operators we support, collapsing list and single-item operators

![image](https://github.com/plausible/analytics/assets/148820/4e56b6bc-745a-480a-91c9-f6e2c0e4d6cd)

Blocked on https://github.com/plausible/analytics/pull/4118 - will update filtering within after that PR lands.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
