### PR TITLE
Minor verification improvements

### DIFF
--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -216,26 +216,28 @@ defmodule Plausible.Verification.Diagnostics do
   def interpret(
         %__MODULE__{
           plausible_installed?: true,
-          callback_status: 202,
+          callback_status: callback_status,
           snippet_found_after_busting_cache?: true,
           wordpress_likely?: true,
           wordpress_plugin?: true
         },
         _url
-      ) do
+      )
+      when callback_status in [200, 202] do
     error(@errors.cache_wp_plugin)
   end
 
   def interpret(
         %__MODULE__{
           plausible_installed?: true,
-          callback_status: 202,
+          callback_status: callback_status,
           snippet_found_after_busting_cache?: true,
           wordpress_likely?: true,
           wordpress_plugin?: false
         },
         _url
-      ) do
+      )
+      when callback_status in [200, 202] do
     error(@errors.cache_wp_no_plugin)
   end
 

--- a/lib/plausible/verification/errors.ex
+++ b/lib/plausible/verification/errors.ex
@@ -107,7 +107,7 @@ defmodule Plausible.Verification.Errors do
     },
     different_data_domain: %{
       message: "Your data-domain is different",
-      recommendation: "Please ensure that the data-domain is an exact match to <%= @domain %>",
+      recommendation: "Please ensure that the data-domain matches <%= @domain %> exactly",
       url:
         "https://plausible.io/docs/troubleshoot-integration#have-you-added-the-correct-data-domain-attribute-in-the-plausible-snippet"
     },

--- a/lib/plausible_web/live/components/verification.ex
+++ b/lib/plausible_web/live/components/verification.ex
@@ -67,7 +67,11 @@ defmodule PlausibleWeb.Live.Components.Verification do
         </p>
         <p :if={not @finished?} class="mt-2 animate-pulse" id="progress"><%= @message %></p>
 
-        <p :if={@finished? and not @success? and @interpretation} class="mt-2" id="recommendation">
+        <p
+          :if={@finished? and not @success? and @interpretation}
+          class="mt-2 text-ellipsis overflow-hidden"
+          id="recommendation"
+        >
           <span><%= List.first(@interpretation.recommendations).text %>.&nbsp;</span>
           <.styled_link href={List.first(@interpretation.recommendations).url} new_tab={true}>
             Learn more


### PR DESCRIPTION
### Changes

This PR:

  - puts an ellipsis and disables text overflow in case of very long data-domain, upon verification error when the recommendation includes it
  - accepts 200 callback status from WordPress sites

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
