### PR TITLE
Fix handling filtering by imported special properties

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -57,6 +57,7 @@ defmodule Plausible.Imported do
   @spec imported_custom_props() :: [String.t()]
   def imported_custom_props do
     Plausible.Props.internal_keys()
+    |> Enum.map(&("event:props:" <> &1))
   end
 
   @spec goals_with_url() :: [String.t()]

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -14,7 +14,8 @@ defmodule Plausible.Stats.Imported do
 
   @property_to_table_mappings Imported.Base.property_to_table_mappings()
 
-  @imported_properties Map.keys(@property_to_table_mappings)
+  @imported_properties Map.keys(@property_to_table_mappings) ++
+                         Plausible.Imported.imported_custom_props()
 
   @goals_with_url Plausible.Imported.goals_with_url()
 
@@ -273,7 +274,6 @@ defmodule Plausible.Stats.Imported do
       site
       |> Imported.Base.query_imported(query)
       |> where([i], i.visitors > 0)
-      |> maybe_apply_filter(query, property, dim)
       |> group_imported_by(dim)
       |> select_imported_metrics(metrics)
 
@@ -355,13 +355,6 @@ defmodule Plausible.Stats.Imported do
     site
     |> Imported.Base.query_imported(query)
     |> select_merge([i], %{total_visitors: fragment("sum(?)", i.visitors)})
-  end
-
-  defp maybe_apply_filter(q, query, property, dim) do
-    case Query.get_filter(query, property) do
-      [:member, _, list] -> where(q, [i], field(i, ^dim) in ^list)
-      _ -> q
-    end
   end
 
   defp select_imported_metrics(q, []), do: q


### PR DESCRIPTION
### Changes

This PR fixes two bugs:

* stop adding an additional filter in imported.ex through the `maybe_apply_filter` function which was used before imported filtering was possible. This currently crashes in a situation where we're trying to filter by `:member` of the `url` property for example.
* When props are included in the query, we are currently only accounting for the situation where the breakdown property is a special prop - we need to do the same if there's a custom property in filters.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
