### PR TITLE
Fix with imported switch + warning bubble renders

### DIFF
--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -333,9 +333,9 @@ export default function Behaviours(props) {
 
   function renderImportedQueryUnsupportedWarning() {
     if (mode === CONVERSIONS) {
-      return <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
+      return <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
     } else if (mode === PROPS) {
-      return <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
+      return <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
     } else {
       return <ImportedQueryUnsupportedWarning alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
     }

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -48,7 +48,7 @@ export default function Behaviours(props) {
 
   const [showingPropsForGoalFilter, setShowingPropsForGoalFilter] = useState(false)
 
-  const [importedQueryUnsupported, setImportedQueryUnsupported] = useState(false)
+  const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   const onGoalFilterClick = useCallback((e) => {
     const goalName = e.target.innerHTML
@@ -173,8 +173,7 @@ export default function Behaviours(props) {
   }
 
   function afterFetchData(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    setImportedQueryUnsupported(unsupportedQuery && !isRealtime())
+    setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
   function renderConversions() {
@@ -332,6 +331,16 @@ export default function Behaviours(props) {
     }
   }
 
+  function renderImportedQueryUnsupportedWarning() {
+    if (mode === CONVERSIONS) {
+      return <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
+    } else if (mode === PROPS) {
+      return <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
+    } else {
+      return <ImportedQueryUnsupportedWarning alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
+    }
+  }
+
   if (mode) {
     return (
       <div className="items-start justify-between block w-full mt-6 md:flex">
@@ -341,9 +350,7 @@ export default function Behaviours(props) {
               <h3 className="font-bold dark:text-gray-100">
                 {sectionTitle() + (isRealtime() ? ' (last 30min)' : '')}
               </h3>
-              <ImportedQueryUnsupportedWarning condition={mode === CONVERSIONS  && importedQueryUnsupported}/>
-              <ImportedQueryUnsupportedWarning condition={mode === PROPS && importedQueryUnsupported} message="Imported data is unavailable in this view"/>
-              <ImportedQueryUnsupportedWarning condition={mode === FUNNELS && props.importedDataInView} message="Imported data is unavailable in this view"/>
+              { renderImportedQueryUnsupportedWarning()}
             </div>
             {tabs()}
           </div>

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -341,7 +341,7 @@ export default function Behaviours(props) {
     } else if (mode === PROPS) {
       return <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
     } else {
-      return <ImportedQueryUnsupportedWarning loading={loading} alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
+      return <ImportedQueryUnsupportedWarning alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
     }
   }
 

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -341,7 +341,7 @@ export default function Behaviours(props) {
     } else if (mode === PROPS) {
       return <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
     } else {
-      return <ImportedQueryUnsupportedWarning alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
+      return <ImportedQueryUnsupportedWarning altCondition={props.importedDataInView} message="Imported data is unavailable in this view"/>
     }
   }
 

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -42,6 +42,7 @@ export default function Behaviours(props) {
   const funnelKey = `behavioursTabFunnel__${site.domain}`
   const [enabledModes, setEnabledModes] = useState(getEnabledModes())
   const [mode, setMode] = useState(defaultMode())
+  const [loading, setLoading] = useState(true)
 
   const [funnelNames, _setFunnelNames] = useState(site.funnels.map(({ name }) => name))
   const [selectedFunnel, setSelectedFunnel] = useState(defaultSelectedFunnel())
@@ -72,6 +73,8 @@ export default function Behaviours(props) {
   useEffect(() => {
     setMode(defaultMode())
   }, [enabledModes])
+
+  useEffect(() => setLoading(true), [query, mode])
 
   function disableMode(mode) {
     setEnabledModes(enabledModes.filter((m) => { return m !== mode }))
@@ -173,6 +176,7 @@ export default function Behaviours(props) {
   }
 
   function afterFetchData(apiResponse) {
+    setLoading(false)
     setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
@@ -333,11 +337,11 @@ export default function Behaviours(props) {
 
   function renderImportedQueryUnsupportedWarning() {
     if (mode === CONVERSIONS) {
-      return <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
+      return <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason}/>
     } else if (mode === PROPS) {
-      return <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
+      return <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason} message="Imported data is unavailable in this view"/>
     } else {
-      return <ImportedQueryUnsupportedWarning alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
+      return <ImportedQueryUnsupportedWarning loading={loading} alt_condition={props.importedDataInView} message="Imported data is unavailable in this view"/>
     }
   }
 

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -167,7 +167,7 @@ export default function Devices(props) {
   const tabKey = `deviceTab__${site.domain}`
   const storedTab = storage.getItem(tabKey)
   const [mode, setMode] = useState(storedTab || 'browser')
-  const [importedQueryUnsupported, setImportedQueryUnsupported] = useState(false)
+  const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function switchTab(mode) {
     storage.setItem(tabKey, mode)
@@ -175,9 +175,7 @@ export default function Devices(props) {
   }
 
   function afterFetchData(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    const isRealtime = query.period === 'realtime'
-    setImportedQueryUnsupported(unsupportedQuery && !isRealtime)
+    setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
   function renderContent() {
@@ -226,7 +224,7 @@ export default function Devices(props) {
       <div className="flex justify-between w-full">
         <div className="flex gap-x-1">
           <h3 className="font-bold dark:text-gray-100">Devices</h3>
-          <ImportedQueryUnsupportedWarning condition={importedQueryUnsupported}/>
+          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
         </div>
         <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Browser', 'browser')}

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -224,7 +224,7 @@ export default function Devices(props) {
       <div className="flex justify-between w-full">
         <div className="flex gap-x-1">
           <h3 className="font-bold dark:text-gray-100">Devices</h3>
-          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
+          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
         </div>
         <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Browser', 'browser')}

--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import * as storage from '../../util/storage'
 import { getFiltersByKeyPrefix, isFilteringOnFixedValue } from '../../util/filters'
 import ListReport from '../reports/list'
@@ -167,6 +167,7 @@ export default function Devices(props) {
   const tabKey = `deviceTab__${site.domain}`
   const storedTab = storage.getItem(tabKey)
   const [mode, setMode] = useState(storedTab || 'browser')
+  const [loading, setLoading] = useState(true)
   const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function switchTab(mode) {
@@ -175,8 +176,11 @@ export default function Devices(props) {
   }
 
   function afterFetchData(apiResponse) {
+    setLoading(false)
     setSkipImportedReason(apiResponse.skip_imported_reason)
   }
+
+  useEffect(() => setLoading(true), [query, mode])
 
   function renderContent() {
     switch (mode) {
@@ -224,7 +228,7 @@ export default function Devices(props) {
       <div className="flex justify-between w-full">
         <div className="flex gap-x-1">
           <h3 className="font-bold dark:text-gray-100">Devices</h3>
-          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
+          <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason}/>
         </div>
         <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Browser', 'browser')}

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -143,7 +143,7 @@ export default function VisitorGraph(props) {
           <div className="absolute right-4 -top-8 py-1 flex items-center">
             {!isRealtime && <StatsExport site={site} query={query} />}
             <SamplingNotice samplePercent={topStatData}/>
-            <WithImportedSwitch site={site} topStatData={topStatData} />
+            <WithImportedSwitch query={query} info={topStatData && topStatData.with_imported_switch} />
             <IntervalPicker site={site} query={query} onIntervalUpdate={onIntervalUpdate} />
           </div>
           <LineGraphWithRouter graphData={graphData} darkTheme={isDarkTheme} query={query} />

--- a/assets/js/dashboard/stats/graph/with-imported-switch.js
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.js
@@ -3,36 +3,27 @@ import { parseNaiveDate, isBefore } from '../../util/date'
 import { Link } from 'react-router-dom'
 import * as url from '../../util/url'
 import { BarsArrowUpIcon } from '@heroicons/react/20/solid'
+import classNames from "classnames"
 
-export default function WithImportedSwitch({site, topStatData}) {
-  if (!topStatData?.imports_exist) {
-    return null
-  }
+export default function WithImportedSwitch({query, info}) {
+  if (info && info.visible) {
+    const {togglable, tooltip_msg} = info
+    const enabled = togglable && query.with_imported
+    const target = url.setQuery('with_imported', (!enabled).toString())
 
-  function isBeforeNativeStats(date) {
-    if (!date) return false
-
-    const nativeStatsBegin = parseNaiveDate(site.nativeStatsBegin)
-    const parsedDate = parseNaiveDate(date)
-
-    return isBefore(parsedDate, nativeStatsBegin, "day")
-  }
-
-  const isQueryingImportedPeriod = isBeforeNativeStats(topStatData.from)
-  const isComparingImportedPeriod = isBeforeNativeStats(topStatData.comparing_from)
-
-  if (isQueryingImportedPeriod || isComparingImportedPeriod) {
-    const withImported = topStatData.includes_imported;
-    const toggleColor = withImported ? " dark:text-gray-300 text-gray-700" : " dark:text-gray-500 text-gray-400"
-    const target = url.setQuery('with_imported', (!withImported).toString())
-    const tip = withImported ? "" : "do not ";
-
+    const linkClass = classNames({
+      "dark:text-gray-300 text-gray-700": enabled,
+      "dark:text-gray-500 text-gray-400": !enabled,
+      "cursor-pointer": togglable,
+      "pointer-events-none": !togglable,
+    })
+    
     return (
-      <Link to={target} className="w-4 h-4 mx-2">
-        <div tooltip={`Stats ${tip}include imported data.`} className="cursor-pointer w-4 h-4">
-          <BarsArrowUpIcon className={"absolute " + toggleColor} />
-        </div>
-      </Link>
+      <div tooltip={tooltip_msg} className="w-4 h-4 mx-2">
+        <Link to={target} className={linkClass}>
+          <BarsArrowUpIcon className="mt-0.5"/>
+        </Link>
+      </div>
     )
   } else {
     return null

--- a/assets/js/dashboard/stats/graph/with-imported-switch.js
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { parseNaiveDate, isBefore } from '../../util/date'
 import { Link } from 'react-router-dom'
 import * as url from '../../util/url'
 import { BarsArrowUpIcon } from '@heroicons/react/20/solid'

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -4,7 +4,7 @@ import FadeIn from "../fade-in";
 
 export default function ImportedQueryUnsupportedWarning({query, loading, skipImportedReason, alt_condition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
-  const show = query && query.with_imported && skipImportedReason === "unsupported_query"
+  const show = query && query.with_imported && skipImportedReason === "unsupported_query" && query.period !== 'realtime'
 
   if (show || alt_condition) {
     return (

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -1,20 +1,18 @@
 import React from "react";
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
+import FadeIn from "../fade-in";
 
-export default function ImportedQueryUnsupportedWarning({query, skipImportedReason, alt_condition, message}) {
+export default function ImportedQueryUnsupportedWarning({query, loading, skipImportedReason, alt_condition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
-
-  if (query && query.with_imported && skipImportedReason === "unsupported_query") {
+  const show = query && query.with_imported && skipImportedReason === "unsupported_query"
+  
+  if (show || alt_condition) {
     return (
-      <span tooltip={tooltipMessage}>
-        <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />
-      </span>
-    )
-  } else if (alt_condition) {
-    return (
-      <span tooltip={tooltipMessage}>
-        <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />
-      </span>
+      <FadeIn show={!loading}>
+        <span tooltip={tooltipMessage}>
+          <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />
+        </span>
+      </FadeIn>
     )
   } else {
     return null

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -2,11 +2,11 @@ import React from "react";
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
 import FadeIn from "../fade-in";
 
-export default function ImportedQueryUnsupportedWarning({query, loading, skipImportedReason, alt_condition, message}) {
+export default function ImportedQueryUnsupportedWarning({query, loading, skipImportedReason, altCondition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
   const show = query && query.with_imported && skipImportedReason === "unsupported_query" && query.period !== 'realtime'
 
-  if (show || alt_condition) {
+  if (show || altCondition) {
     return (
       <FadeIn show={!loading} className="h-6">
         <span tooltip={tooltipMessage}>

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -5,10 +5,10 @@ import FadeIn from "../fade-in";
 export default function ImportedQueryUnsupportedWarning({query, loading, skipImportedReason, alt_condition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
   const show = query && query.with_imported && skipImportedReason === "unsupported_query"
-  
+
   if (show || alt_condition) {
     return (
-      <FadeIn show={!loading}>
+      <FadeIn show={!loading} className="h-6">
         <span tooltip={tooltipMessage}>
           <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />
         </span>

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
 
-export default function ImportedQueryUnsupportedWarning({skipImportedReason, alt_condition, message}) {
+export default function ImportedQueryUnsupportedWarning({query, skipImportedReason, alt_condition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
-  
-  if (skipImportedReason === "unsupported_query") {
+
+  if (query && query.with_imported && skipImportedReason === "unsupported_query") {
     return (
       <span tooltip={tooltipMessage}>
         <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />

--- a/assets/js/dashboard/stats/imported-query-unsupported-warning.js
+++ b/assets/js/dashboard/stats/imported-query-unsupported-warning.js
@@ -1,10 +1,16 @@
 import React from "react";
 import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
 
-export default function ImportedQueryUnsupportedWarning({condition, message}) {
+export default function ImportedQueryUnsupportedWarning({skipImportedReason, alt_condition, message}) {
   const tooltipMessage = message || "Imported data is excluded due to applied filters"
   
-  if (condition) {
+  if (skipImportedReason === "unsupported_query") {
+    return (
+      <span tooltip={tooltipMessage}>
+        <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />
+      </span>
+    )
+  } else if (alt_condition) {
     return (
       <span tooltip={tooltipMessage}>
         <ExclamationCircleIcon className="w-6 h-6 dark:text-gray-100" />

--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -211,7 +211,7 @@ export default class Locations extends React.Component {
             <h3 className="font-bold dark:text-gray-100">
               {labelFor[this.state.mode] || 'Locations'}
             </h3>
-            <ImportedQueryUnsupportedWarning skipImportedReason={this.state.skipImportedReason} />
+            <ImportedQueryUnsupportedWarning query={this.props.query} skipImportedReason={this.state.skipImportedReason} />
           </div>
           <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
             { this.renderPill('Map', 'map') }

--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -125,11 +125,12 @@ export default class Locations extends React.Component {
     const storedTab = storage.getItem(this.tabKey)
     this.state = {
       mode: storedTab || 'map',
+      loading: true,
       skipImportedReason: null
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const isRemovingFilter = (filterName) => {
       return getFiltersByKeyPrefix(prevProps.query, filterName).length > 0 &&
         getFiltersByKeyPrefix(this.props.query, filterName).length == 0
@@ -141,6 +142,10 @@ export default class Locations extends React.Component {
 
     if (this.state.mode === 'regions' && isRemovingFilter('country')) {
       this.setMode(this.countriesRestoreMode || 'countries')()
+    }
+
+    if (this.props.query !== prevProps.query || this.state.mode !== prevState.mode) {
+      this.setState({loading: true})
     }
   }
 
@@ -163,7 +168,7 @@ export default class Locations extends React.Component {
   }
 
   afterFetchData(apiResponse) {
-    this.setState({skipImportedReason: apiResponse.skip_imported_reason})
+    this.setState({loading: false, skipImportedReason: apiResponse.skip_imported_reason})
   }
 
 	renderContent() {
@@ -211,7 +216,7 @@ export default class Locations extends React.Component {
             <h3 className="font-bold dark:text-gray-100">
               {labelFor[this.state.mode] || 'Locations'}
             </h3>
-            <ImportedQueryUnsupportedWarning query={this.props.query} skipImportedReason={this.state.skipImportedReason} />
+            <ImportedQueryUnsupportedWarning loading={this.state.loading} query={this.props.query} skipImportedReason={this.state.skipImportedReason} />
           </div>
           <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
             { this.renderPill('Map', 'map') }

--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -125,7 +125,7 @@ export default class Locations extends React.Component {
     const storedTab = storage.getItem(this.tabKey)
     this.state = {
       mode: storedTab || 'map',
-      importedQueryUnsupported: false
+      skipImportedReason: null
     }
   }
 
@@ -163,9 +163,7 @@ export default class Locations extends React.Component {
   }
 
   afterFetchData(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    const isRealtime = this.props.query.period === 'realtime'
-    this.setState({importedQueryUnsupported: unsupportedQuery && !isRealtime})
+    this.setState({skipImportedReason: apiResponse.skip_imported_reason})
   }
 
 	renderContent() {
@@ -213,7 +211,7 @@ export default class Locations extends React.Component {
             <h3 className="font-bold dark:text-gray-100">
               {labelFor[this.state.mode] || 'Locations'}
             </h3>
-            <ImportedQueryUnsupportedWarning condition={this.state.importedQueryUnsupported} />
+            <ImportedQueryUnsupportedWarning skipImportedReason={this.state.skipImportedReason} />
           </div>
           <div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
             { this.renderPill('Map', 'map') }

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -111,7 +111,7 @@ export default function Pages(props) {
   const tabKey = `pageTab__${site.domain}`
   const storedTab = storage.getItem(tabKey)
   const [mode, setMode] = useState(storedTab || 'pages')
-  const [importedQueryUnsupported, setImportedQueryUnsupported] = useState(false)
+  const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function switchTab(mode) {
     storage.setItem(tabKey, mode)
@@ -119,9 +119,7 @@ export default function Pages(props) {
   }
 
   function afterFetchData(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    const isRealtime = query.period === 'realtime'
-    setImportedQueryUnsupported(unsupportedQuery && !isRealtime)
+    setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
   function renderContent() {
@@ -168,7 +166,7 @@ export default function Pages(props) {
           <h3 className="font-bold dark:text-gray-100">
             {labelFor[mode] || 'Page Visits'}
           </h3>
-          <ImportedQueryUnsupportedWarning condition={importedQueryUnsupported}/>
+          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason} />
         </div>
         <div className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Top Pages', 'pages')}

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import * as storage from '../../util/storage'
 import * as url from '../../util/url'
@@ -111,6 +111,7 @@ export default function Pages(props) {
   const tabKey = `pageTab__${site.domain}`
   const storedTab = storage.getItem(tabKey)
   const [mode, setMode] = useState(storedTab || 'pages')
+  const [loading, setLoading] = useState(true)
   const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function switchTab(mode) {
@@ -119,8 +120,11 @@ export default function Pages(props) {
   }
 
   function afterFetchData(apiResponse) {
+    setLoading(false)
     setSkipImportedReason(apiResponse.skip_imported_reason)
   }
+
+  useEffect(() => setLoading(true), [query, mode])
 
   function renderContent() {
     switch (mode) {
@@ -166,7 +170,7 @@ export default function Pages(props) {
           <h3 className="font-bold dark:text-gray-100">
             {labelFor[mode] || 'Page Visits'}
           </h3>
-          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason} />
+          <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason} />
         </div>
         <div className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Top Pages', 'pages')}

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -166,7 +166,7 @@ export default function Pages(props) {
           <h3 className="font-bold dark:text-gray-100">
             {labelFor[mode] || 'Page Visits'}
           </h3>
-          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason} />
+          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason} />
         </div>
         <div className="flex font-medium text-xs text-gray-500 dark:text-gray-400 space-x-2">
           {renderPill('Top Pages', 'pages')}

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -6,16 +6,14 @@ import ListReport from '../reports/list'
 import ImportedQueryUnsupportedWarning from '../../stats/imported-query-unsupported-warning'
 
 export default function Referrers({source, site, query}) {
-  const [importedQueryUnsupported, setImportedQueryUnsupported] = useState(false)
+  const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function fetchReferrers() {
     return api.get(url.apiPath(site, `/referrers/${encodeURIComponent(source)}`), query, {limit: 9})
   }
 
   function afterFetchReferrers(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    const isRealtime = query.period === 'realtime'
-    setImportedQueryUnsupported(unsupportedQuery && !isRealtime)
+    setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
   function externalLinkDest(referrer) {
@@ -46,7 +44,7 @@ export default function Referrers({source, site, query}) {
     <div className="flex flex-col flex-grow">
       <div className="flex gap-x-1">
         <h3 className="font-bold dark:text-gray-100">Top Referrers</h3>
-        <ImportedQueryUnsupportedWarning condition={importedQueryUnsupported}/>
+        <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
       </div>
       <ListReport
         fetchData={fetchReferrers}

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as api from '../../api'
 import * as url from '../../util/url'
 import { VISITORS_METRIC, maybeWithCR } from '../reports/metrics'
@@ -7,12 +7,16 @@ import ImportedQueryUnsupportedWarning from '../../stats/imported-query-unsuppor
 
 export default function Referrers({source, site, query}) {
   const [skipImportedReason, setSkipImportedReason] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => setLoading(true), [query])
 
   function fetchReferrers() {
     return api.get(url.apiPath(site, `/referrers/${encodeURIComponent(source)}`), query, {limit: 9})
   }
 
   function afterFetchReferrers(apiResponse) {
+    setLoading(false)
     setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
@@ -44,7 +48,7 @@ export default function Referrers({source, site, query}) {
     <div className="flex flex-col flex-grow">
       <div className="flex gap-x-1">
         <h3 className="font-bold dark:text-gray-100">Top Referrers</h3>
-        <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
+        <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason}/>
       </div>
       <ListReport
         fetchData={fetchReferrers}

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -44,7 +44,7 @@ export default function Referrers({source, site, query}) {
     <div className="flex flex-col flex-grow">
       <div className="flex gap-x-1">
         <h3 className="font-bold dark:text-gray-100">Top Referrers</h3>
-        <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
+        <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
       </div>
       <ListReport
         fetchData={fetchReferrers}

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -174,7 +174,7 @@ export default function SourceList(props) {
           <h3 className="font-bold dark:text-gray-100">
             Top Sources
           </h3>
-          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
+          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
         </div>
         {renderTabs()}
       </div>

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 
 import * as storage from '../../util/storage'
 import * as url from '../../util/url'
@@ -90,7 +90,10 @@ export default function SourceList(props) {
   const tabKey = 'sourceTab__' + props.site.domain
   const storedTab = storage.getItem(tabKey)
   const [currentTab, setCurrentTab] = useState(storedTab || 'all')
+  const [loading, setLoading] = useState(true)
   const [skipImportedReason, setSkipImportedReason] = useState(null)
+
+  useEffect(() => setLoading(true), [query, currentTab])
 
   function setTab(tab) {
     return () => {
@@ -163,6 +166,7 @@ export default function SourceList(props) {
   }
 
   function afterFetchData(apiResponse) {
+    setLoading(false)
     setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
@@ -174,7 +178,7 @@ export default function SourceList(props) {
           <h3 className="font-bold dark:text-gray-100">
             Top Sources
           </h3>
-          <ImportedQueryUnsupportedWarning query={query} skipImportedReason={skipImportedReason}/>
+          <ImportedQueryUnsupportedWarning loading={loading} query={query} skipImportedReason={skipImportedReason}/>
         </div>
         {renderTabs()}
       </div>

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -90,7 +90,7 @@ export default function SourceList(props) {
   const tabKey = 'sourceTab__' + props.site.domain
   const storedTab = storage.getItem(tabKey)
   const [currentTab, setCurrentTab] = useState(storedTab || 'all')
-  const [importedQueryUnsupported, setImportedQueryUnsupported] = useState(false)
+  const [skipImportedReason, setSkipImportedReason] = useState(null)
 
   function setTab(tab) {
     return () => {
@@ -163,9 +163,7 @@ export default function SourceList(props) {
   }
 
   function afterFetchData(apiResponse) {
-    const unsupportedQuery = apiResponse.skip_imported_reason === 'unsupported_query'
-    const isRealtime = query.period === 'realtime'
-    setImportedQueryUnsupported(unsupportedQuery && !isRealtime)
+    setSkipImportedReason(apiResponse.skip_imported_reason)
   }
 
   return (
@@ -176,7 +174,7 @@ export default function SourceList(props) {
           <h3 className="font-bold dark:text-gray-100">
             Top Sources
           </h3>
-          <ImportedQueryUnsupportedWarning condition={importedQueryUnsupported}/>
+          <ImportedQueryUnsupportedWarning skipImportedReason={skipImportedReason}/>
         </div>
         {renderTabs()}
       </div>

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -169,7 +169,8 @@ defmodule Plausible.Stats.Comparisons do
       :ok ->
         struct!(query,
           imported_data_requested: true,
-          include_imported: true
+          include_imported: true,
+          skip_imported_reason: nil
         )
 
       {:error, reason} ->

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -301,14 +301,14 @@ defmodule Plausible.Stats.Query do
   end
 
   @spec ensure_include_imported(t(), boolean()) ::
-          :ok | {:error, :not_requested | :no_imported_data | :out_of_range | :unsupported_query}
+          :ok | {:error, :no_imported_data | :out_of_range | :unsupported_query | :not_requested}
   def ensure_include_imported(query, requested?) do
     cond do
-      not requested? -> {:error, :not_requested}
       is_nil(query.latest_import_end_date) -> {:error, :no_imported_data}
       Date.after?(query.date_range.first, query.latest_import_end_date) -> {:error, :out_of_range}
       not Imported.schema_supports_query?(query) -> {:error, :unsupported_query}
       query.period == "realtime" -> {:error, :unsupported_query}
+      not requested? -> {:error, :not_requested}
       true -> :ok
     end
   end


### PR DESCRIPTION
### Changes

The main goal of this PR was to fix some behaviour with the dashboard "with-imported" switch and move its logic into the backend, making its intent more clear and easily testable. I've also included some other changes that I saw necessary. Here's a summary:

* Change the tooltip message when the icon is hovered:
  * "Stats do not include imported data" -> "Click to include imported data" 
  * "Stats include imported data" -> "Click to exclude imported data"
* Slight refactor: instead of keeping a boolean state of whether the imported query is unsupported, keep the `skipImportedReason` in the state instead and let the `ImportedQueryUnsupportedWarning` component decide how to interpret that.
* When the query does not support imported data and imported data is excluded, disable clicking the imported-switch and render a tooltip saying "Imported data cannot be included"

Before (with imported switch still clickable when filters are unsupported, when clicked, also triggers an update):

https://github.com/plausible/analytics/assets/56999674/1e45e336-0583-4a21-8d12-6c89e57c022e

After (the icon is disabled when filters are unsupported):

https://github.com/plausible/analytics/assets/56999674/9d21f127-8f3b-440f-b99a-2092d0806c72

* Hide the `ImportedQueryUnsupportedWarning` bubble whenever the query or tab changes

Before (notice how the bubble keeps hanging, and then disappears suddenly):

https://github.com/plausible/analytics/assets/56999674/9e981974-05fc-41be-a4c8-64fad13ed8d1

After: (bubble not displayed by default, fades in when the request finishes)

https://github.com/plausible/analytics/assets/56999674/7a31f3e4-624f-4540-a276-6d788ff1e009

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
