### PR TITLE
Wrap data migration using with_repo to ensure ClickhouseRepo is running

### DIFF
--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -4,7 +4,10 @@ defmodule Plausible.Repo.Migrations.MigrateSiteImports do
 
   def up do
     if ce?() do
-      Plausible.DataMigration.SiteImports.run(dry_run?: false)
+      {:ok, _, _} =
+        Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
+          Plausible.DataMigration.SiteImports.run(dry_run?: false)
+        end)
     end
   end
 


### PR DESCRIPTION
### Changes

This PR restores the fix https://github.com/plausible/analytics/pull/4155/commits/14fbfc0e52f70d3552224754107b296c86ec7704 for the data migration added in https://github.com/plausible/analytics/pull/4155
### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI