### PR TITLE
Include imported page paths in pageview goal suggestions

### DIFF
--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -16,7 +16,9 @@ defmodule PlausibleWeb.Live.GoalSettings do
     socket =
       socket
       |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+        user_id
+        |> Sites.get_for_user!(domain, [:owner, :admin, :super_admin])
+        |> Plausible.Imported.load_import_data()
       end)
       |> assign_new(:all_goals, fn %{site: site} ->
         Goals.for_site(site, preload_funnels?: true)

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -319,7 +319,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   end
 
   def suggest_page_paths(input, _options, site) do
-    query = Plausible.Stats.Query.from(site, %{})
+    query = Plausible.Stats.Query.from(site, %{"with_imported" => "true", "period" => "all"})
 
     site
     |> Plausible.Stats.filter_suggestions(query, "page", input)


### PR DESCRIPTION
### Changes

In addition to including imported pages in the suggestions, the scope of the suggestion query now spans over "all"-time period, not just last 30 days.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
