### PR TITLE
Small fix for the with-imported-icon on safari

### DIFF
--- a/assets/js/dashboard/stats/graph/with-imported-switch.js
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.js
@@ -4,24 +4,30 @@ import * as url from '../../util/url'
 import { BarsArrowUpIcon } from '@heroicons/react/20/solid'
 import classNames from "classnames"
 
+function LinkOrDiv({isLink, target, children}) {
+  if (isLink) {
+    return <Link to={target}>{ children }</Link>
+  } else {
+    return <div>{ children }</div>
+  }
+}
+
 export default function WithImportedSwitch({query, info}) {
   if (info && info.visible) {
     const {togglable, tooltip_msg} = info
     const enabled = togglable && query.with_imported
     const target = url.setQuery('with_imported', (!enabled).toString())
 
-    const linkClass = classNames({
+    const iconClass = classNames("mt-0.5", {
       "dark:text-gray-300 text-gray-700": enabled,
       "dark:text-gray-500 text-gray-400": !enabled,
-      "cursor-pointer": togglable,
-      "pointer-events-none": !togglable,
     })
     
     return (
       <div tooltip={tooltip_msg} className="w-4 h-4 mx-2">
-        <Link to={target} className={linkClass}>
-          <BarsArrowUpIcon className="mt-0.5"/>
-        </Link>
+        <LinkOrDiv isLink={togglable} target={target}>
+          <BarsArrowUpIcon className={iconClass}/>
+        </LinkOrDiv>
       </div>
     )
   } else {


### PR DESCRIPTION
### Changes

Follow-up fix to https://github.com/plausible/analytics/pull/4187

The `pointer-events-none` class didn't take effect on Safari, leaving the imported switch still clickable when it was actually supposed to be disabled. This PR changes to an alternate implementation to accomplish the same. Tested manually on Safari, Chrome, and Firefox.