### PR TITLE
Improve PG unix sockets configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Deprecate `ECTO_IPV6` and `ECTO_CH_IPV6` env vars in CE plausible/analytics#4245
 - Remove support for importing data from no longer available Universal Analytics
+- Soft-deprecate `DATABASE_SOCKET_DIR` plausible/analytics#4202
 
 ### Changed
+- Support Unix sockets in `DATABASE_URL` plausible/analytics#4202
 
 - Realtime and hourly graphs now show visits lasting their whole duration instead when specific events occur
 - Increase hourly request limit for API keys in CE from 600 to 1000000 (practically removing the limit) plausible/analytics#4200

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -349,10 +349,11 @@ defmodule Plausible.ConfigTest do
 
   describe "postgres" do
     test "default" do
-      config = runtime_config(_env = [])
+      env = [{"DATABASE_URL", nil}]
+      config = runtime_config(env)
 
       assert get_in(config, [:plausible, Plausible.Repo]) == [
-               url: "postgres://postgres:postgres@127.0.0.1:5432/plausible_test?pool_size=40",
+               url: "postgres://postgres:postgres@plausible_db:5432/plausible_db",
                socket_options: [],
                ssl_opts: [
                  cacertfile: CAStore.file_path(),


### PR DESCRIPTION
### Changes

This PR standardizes PostgreSQL connection configuration on DATABASE_URL by soft-deprecating DATABASE_SOCKET_DIR and adding Unix sockets support in DATABASE_URL.

Relevant: https://github.com/plausible/community-edition/pull/136

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI