### PR TITLE
Minor refactor: Remove skip_refresh_imported_opts from query modifying functions

### DIFF
--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -291,17 +291,16 @@ defmodule Plausible.Stats.Base do
     |> select([e], total_visitors: fragment(@uniq_users_expression, e.user_id))
   end
 
-  # `total_visitors_subquery` returns a subquery to fetch the total number
-  # of visitors. The number returned is used as the denominator in the
-  # calculation of `conversion_rate` and `percentage` metrics.
+  # `total_visitors_subquery` returns a subquery which selects `total_visitors` -
+  # the number used as the denominator in the calculation of `conversion_rate` and
+  # `percentage` metrics.
 
-  # Usually, when calculating the totals, a new query is passed into this
-  # function, where certain filters (e.g. goal, props) are removed. That
-  # might make the query able to include imported data. However, we always
-  # want to include imported data only if it's included in the base query -
-  # otherwise the total will be based on a different data set, making the
-  # metrics inaccurate. This is we're using an explicit `include_imported`
-  # argument here.
+  # Usually, when calculating the totals, a new query is passed into this function,
+  # where certain filters (e.g. goal, props) are removed. That might make the query
+  # able to include imported data. However, we always want to include imported data
+  # only if it's included in the base query - otherwise the total will be based on
+  # a different data set, making the metric inaccurate. This is why we're using an
+  # explicit `include_imported` argument here.
   @spec total_visitors_subquery(Plausible.Site.t(), Query.t(), boolean()) :: :ok
   defp total_visitors_subquery(site, query, include_imported)
 

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -325,7 +325,9 @@ defmodule Plausible.Stats.Base do
       total_query = Query.set_property(query, nil)
 
       q
-      |> select_merge(^%{__total_visitors: total_visitors_subquery(site, total_query, query.include_imported)})
+      |> select_merge(
+        ^%{__total_visitors: total_visitors_subquery(site, total_query, query.include_imported)}
+      )
       |> select_merge(%{
         percentage:
           fragment(
@@ -352,7 +354,9 @@ defmodule Plausible.Stats.Base do
 
       # :TRICKY: Subquery is used due to event:goal breakdown above doing an UNION ALL
       subquery(q)
-      |> select_merge(^%{total_visitors: total_visitors_subquery(site, total_query, query.include_imported)})
+      |> select_merge(
+        ^%{total_visitors: total_visitors_subquery(site, total_query, query.include_imported)}
+      )
       |> select_merge([e], %{
         conversion_rate:
           fragment(

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -291,7 +291,21 @@ defmodule Plausible.Stats.Base do
     |> select([e], total_visitors: fragment(@uniq_users_expression, e.user_id))
   end
 
-  defp total_visitors_subquery(site, %Query{include_imported: true} = query) do
+  # `total_visitors_subquery` returns a subquery to fetch the total number
+  # of visitors. The number returned is used as the denominator in the
+  # calculation of `conversion_rate` and `percentage` metrics.
+
+  # Usually, when calculating the totals, a new query is passed into this
+  # function, where certain filters (e.g. goal, props) are removed. That
+  # might make the query able to include imported data. However, we always
+  # want to include imported data only if it's included in the base query -
+  # otherwise the total will be based on a different data set, making the
+  # metrics inaccurate. This is we're using an explicit `include_imported`
+  # argument here.
+  @spec total_visitors_subquery(Plausible.Site.t(), Query.t(), boolean()) :: :ok
+  defp total_visitors_subquery(site, query, include_imported)
+
+  defp total_visitors_subquery(site, query, true = _include_imported) do
     dynamic(
       [e],
       selected_as(
@@ -302,16 +316,16 @@ defmodule Plausible.Stats.Base do
     )
   end
 
-  defp total_visitors_subquery(site, query) do
+  defp total_visitors_subquery(site, query, false = _include_imported) do
     dynamic([e], selected_as(subquery(total_visitors(site, query)), :__total_visitors))
   end
 
   def add_percentage_metric(q, site, query, metrics) do
     if :percentage in metrics do
-      total_query = Query.set_property(query, nil, skip_refresh_imported_opts: true)
+      total_query = Query.set_property(query, nil)
 
       q
-      |> select_merge(^%{__total_visitors: total_visitors_subquery(site, total_query)})
+      |> select_merge(^%{__total_visitors: total_visitors_subquery(site, total_query, query.include_imported)})
       |> select_merge(%{
         percentage:
           fragment(
@@ -333,12 +347,12 @@ defmodule Plausible.Stats.Base do
     if :conversion_rate in metrics do
       total_query =
         query
-        |> Query.remove_filters(["event:goal", "event:props"], skip_refresh_imported_opts: true)
-        |> Query.set_property(nil, skip_refresh_imported_opts: true)
+        |> Query.remove_filters(["event:goal", "event:props"])
+        |> Query.set_property(nil)
 
       # :TRICKY: Subquery is used due to event:goal breakdown above doing an UNION ALL
       subquery(q)
-      |> select_merge(^%{total_visitors: total_visitors_subquery(site, total_query)})
+      |> select_merge(^%{total_visitors: total_visitors_subquery(site, total_query, query.include_imported)})
       |> select_merge([e], %{
         conversion_rate:
           fragment(

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -203,13 +203,11 @@ defmodule Plausible.Stats.Query do
     struct!(query, filters: Filters.parse(params["filters"]))
   end
 
-  @spec set_property(t(), String.t() | nil, Keyword.t()) :: t()
-  def set_property(query, property, opts \\ []) do
-    query = struct!(query, property: property)
-
-    if Keyword.get(opts, :skip_refresh_imported_opts),
-      do: query,
-      else: refresh_imported_opts(query)
+  @spec set_property(t(), String.t() | nil) :: t()
+  def set_property(query, property) do
+    query
+    |> struct!(property: property)
+    |> refresh_imported_opts()
   end
 
   def put_filter(query, filter) do
@@ -218,17 +216,15 @@ defmodule Plausible.Stats.Query do
     |> refresh_imported_opts()
   end
 
-  def remove_filters(query, prefixes, opts \\ []) do
+  def remove_filters(query, prefixes) do
     new_filters =
       Enum.reject(query.filters, fn [_, filter_key | _rest] ->
         Enum.any?(prefixes, &String.starts_with?(filter_key, &1))
       end)
 
-    query = struct!(query, filters: new_filters)
-
-    if Keyword.get(opts, :skip_refresh_imported_opts),
-      do: query,
-      else: refresh_imported_opts(query)
+    query
+    |> struct!(filters: new_filters)
+    |> refresh_imported_opts()
   end
 
   def exclude_imported(query) do

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -314,9 +314,14 @@ defmodule Plausible.Stats.Timeseries do
 
   defp maybe_add_timeseries_conversion_rate(q, site, query, metrics) do
     if :conversion_rate in metrics do
+      # Having removed some filters, the query might become eligible
+      # for including imported data. However, we still want to make
+      # sure that that include_imported is in sync between original
+      # and the totals query.
       totals_query =
         query
-        |> Query.remove_filters(["event:goal", "event:props"], skip_refresh_imported_opts: true)
+        |> Query.remove_filters(["event:goal", "event:props"])
+        |> struct!(include_imported: query.include_imported)
 
       totals_timeseries_q =
         from(e in base_event_query(site, totals_query),


### PR DESCRIPTION
### Changes

As pointed out by @macobo, some "include imported or not" logic is leaking into general query modifying functions and requires the developer to understand the logic behind it whenever doing operations such as `remove_filters` or `set_property`. This PR aims to avoid that, making it explicit and more close to the business logic where it's used.

I've also included comments in the relevant places and improved test coverage for timeseries.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
