### PR TITLE
Add "Show more" link to browse more than 12 invoices

### DIFF
--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -108,7 +108,6 @@ defmodule Plausible.Billing.PaddleApi do
       Enum.sort(response, fn %{"payout_date" => d1}, %{"payout_date" => d2} ->
         Date.compare(Date.from_iso8601!(d1), Date.from_iso8601!(d2)) == :gt
       end)
-      |> Enum.take(12)
       |> then(&{:ok, &1})
     else
       error ->

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -121,7 +121,10 @@
           </p>
         </div>
       <% {:ok, invoice_list} when is_list(invoice_list) -> %>
-        <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-orange-200 rounded rounded-t-none shadow-md dark:bg-gray-800">
+        <div
+          class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-orange-200 rounded rounded-t-none shadow-md dark:bg-gray-800"
+          x-data="{showAll: false}"
+        >
           <h2 class="text-xl font-black dark:text-gray-100">Invoices</h2>
           <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
           <table class="min-w-full divide-y divide-gray-200">
@@ -147,9 +150,9 @@
                 </th>
               </tr>
             </thead>
-            <%= for invoice <- format_invoices(invoice_list) do %>
-              <tbody class="divide-y divide-gray-200">
-                <tr>
+            <%= for {invoice, idx} <- Enum.with_index(format_invoices(invoice_list)) do %>
+              <tbody class={["divide-y divide-gray-200"]}>
+                <tr x-show={"showAll || #{idx} < 12"}>
                   <td class="py-4 text-sm text-gray-800 dark:text-gray-200 font-medium">
                     <%= invoice.date %>
                   </td>
@@ -158,6 +161,17 @@
                   </td>
                   <td class="py-4 text-sm text-indigo-500">
                     <%= link("Link", to: invoice.url, target: "_blank") %>
+                  </td>
+                </tr>
+                <tr :if={idx == 12 && length(invoice_list) > 12} x-show="!showAll">
+                  <td colspan="3" class="text-center">
+                    <button
+                      x-on:click="showAll = true"
+                      x-show="!showAll"
+                      class="mt-4 text-indigo-500 hover:text-indigo-600"
+                    >
+                      Show More
+                    </button>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
### Changes

We used to limit the amount of show paddle invoices to 12 - not anymore.
The limit is removed completely. In case there are more than 12 invoices, we'll display a "Show more" link unfolding the remaining ones.

https://github.com/plausible/analytics/assets/173738/f1c7765e-4536-451b-9046-f731efbe3111

Not sure if there's a good way to unit test this, open to suggestions.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
