### PR TITLE
Make sure initial load re-evaluates viewport width

### DIFF
--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -127,6 +127,8 @@ function Filters(props) {
   const [viewport, setViewport] = useState(1080)
 
   useEffect(() => {
+    handleResize()
+
     window.addEventListener('resize', handleResize, false)
     document.addEventListener('keyup', handleKeyup)
   


### PR DESCRIPTION
### Changes

Another regression caused by the class component refactor in `filters.js`. On the initial load on mobile screens, the `viewport` is left to the default `1080` while it should be re-evaluated.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
