### PR TITLE
Allow site creation for users owning the `domain_changed_from`

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -85,7 +85,7 @@ defmodule Plausible.Site do
     )
     |> unique_constraint(:domain,
       name: "domain_change_disallowed",
-            message: @domain_unique_error
+      message: @domain_unique_error
     )
     |> put_change(
       :ingest_rate_limit_threshold,

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -85,7 +85,7 @@ defmodule Plausible.Site do
     )
     |> unique_constraint(:domain,
       name: "domain_change_disallowed",
-      message: @domain_unique_error
+            message: @domain_unique_error
     )
     |> put_change(
       :ingest_rate_limit_threshold,

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -436,6 +436,31 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html_response(conn, 200) =~
                "This domain cannot be registered. Perhaps one of your colleagues registered it?"
     end
+
+    test "allows creating the site if domain was changed by the owner", %{
+      conn: conn,
+      user: user
+    } do
+      :site
+      |> insert(
+        domain: "example.com",
+        memberships: [
+          build(:site_membership, user: user, role: :owner)
+        ]
+      )
+      |> Plausible.Site.Domain.change("new.example.com")
+
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "domain" => "example.com",
+            "timezone" => "Europe/London"
+          }
+        })
+
+      assert redirected_to(conn) ==
+               "/example.com/snippet?site_created=true"
+    end
   end
 
   describe "GET /:website/snippet" do


### PR DESCRIPTION
### Changes

This change allows the following flow:

1. create site domain=A
2. change domain=A to domain=B
3. create site domain=A

So basically bypassing the 72h transition period, if, and only if, the old domain=A is frozen by the same owner.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
