### PR TITLE
Unify default pricing currency selection

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -24,6 +24,10 @@ defmodule Plausible.Application do
       Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
       Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
       ReferrerBlocklist,
+      Plausible.Cache.Adapter.child_spec(:customer_currency, :cache_customer_currency,
+        ttl_check_interval: :timer.minutes(5),
+        global_ttl: :timer.minutes(60)
+      ),
       Plausible.Cache.Adapter.child_spec(:user_agents, :cache_user_agents,
         ttl_check_interval: :timer.seconds(5),
         global_ttl: :timer.minutes(60)

--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -119,8 +119,10 @@ defmodule Plausible.Billing.PaddleApi do
     end
   end
 
-  def fetch_prices([_ | _] = product_ids) do
-    case HTTPClient.impl().get(prices_url(), @headers, %{product_ids: Enum.join(product_ids, ",")}) do
+  def fetch_prices([_ | _] = product_ids, customer_ip) do
+    params = %{product_ids: Enum.join(product_ids, ","), customer_ip: customer_ip}
+
+    case HTTPClient.impl().get(prices_url(), @headers, params) do
       {:ok, %{body: %{"success" => true, "response" => %{"products" => products}}}} ->
         products =
           Enum.into(products, %{}, fn %{

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -71,7 +71,8 @@ defmodule Plausible.Billing.Plans do
 
     plans =
       if Keyword.get(opts, :with_prices) do
-        with_prices(plans)
+        customer_ip = Keyword.fetch!(opts, :customer_ip)
+        with_prices(plans, customer_ip)
       else
         plans
       end
@@ -107,7 +108,7 @@ defmodule Plausible.Billing.Plans do
     end
   end
 
-  def latest_enterprise_plan_with_price(user) do
+  def latest_enterprise_plan_with_price(user, customer_ip) do
     enterprise_plan =
       Repo.one!(
         from(e in EnterprisePlan,
@@ -117,7 +118,7 @@ defmodule Plausible.Billing.Plans do
         )
       )
 
-    {enterprise_plan, get_price_for(enterprise_plan)}
+    {enterprise_plan, get_price_for(enterprise_plan, customer_ip)}
   end
 
   def subscription_interval(subscription) do
@@ -143,10 +144,10 @@ defmodule Plausible.Billing.Plans do
   response, fills in the `monthly_cost` and `yearly_cost` fields for each
   given plan and returns the new list of plans with completed information.
   """
-  def with_prices([_ | _] = plans) do
+  def with_prices([_ | _] = plans, customer_ip) do
     product_ids = Enum.flat_map(plans, &[&1.monthly_product_id, &1.yearly_product_id])
 
-    case Plausible.Billing.paddle_api().fetch_prices(product_ids) do
+    case Plausible.Billing.paddle_api().fetch_prices(product_ids, customer_ip) do
       {:ok, prices} ->
         Enum.map(plans, fn plan ->
           plan
@@ -171,8 +172,8 @@ defmodule Plausible.Billing.Plans do
     end
   end
 
-  def get_price_for(%EnterprisePlan{paddle_plan_id: product_id}) do
-    case Plausible.Billing.paddle_api().fetch_prices([product_id]) do
+  def get_price_for(%EnterprisePlan{paddle_plan_id: product_id}, customer_ip) do
+    case Plausible.Billing.paddle_api().fetch_prices([product_id], customer_ip) do
       {:ok, prices} -> Map.fetch!(prices, product_id)
       {:error, :api_error} -> nil
     end

--- a/lib/plausible/cache/adapter.ex
+++ b/lib/plausible/cache/adapter.ex
@@ -52,6 +52,15 @@ defmodule Plausible.Cache.Adapter do
       nil
   end
 
+  @spec fetch(atom(), any(), (-> any())) :: any()
+  def fetch(cache_name, key, fallback_fn) do
+    ConCache.fetch_or_store(cache_name, key, fallback_fn)
+  catch
+    :exit, _ ->
+      Logger.error("Error fetching key from '#{inspect(cache_name)}'")
+      nil
+  end
+
   @spec put(atom(), any(), any()) :: any()
   def put(cache_name, key, value) do
     :ok = ConCache.put(cache_name, key, value)

--- a/lib/plausible_release.ex
+++ b/lib/plausible_release.ex
@@ -85,7 +85,7 @@ defmodule Plausible.Release do
 
     plans =
       Plausible.Billing.Plans.all()
-      |> Plausible.Billing.Plans.with_prices()
+      |> Plausible.Billing.Plans.with_prices("127.0.0.1")
       |> Enum.map(fn plan ->
         plan = Map.from_struct(plan)
 

--- a/lib/plausible_web/controllers/api/paddle_controller.ex
+++ b/lib/plausible_web/controllers/api/paddle_controller.ex
@@ -54,7 +54,6 @@ defmodule PlausibleWeb.Api.PaddleController do
       {:ok, currency} ->
         conn
         |> put_status(200)
-        |> Plug.Conn.put_resp_header("cache-control", "max-age=86400, must-revalidate)")
         |> json(%{currency: Cldr.Currency.currency_for_code!(currency).narrow_symbol})
 
       {:error, :fetch_prices_failed} ->

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -31,7 +31,8 @@ defmodule PlausibleWeb.BillingController do
   def upgrade_to_enterprise_plan(conn, _params) do
     user = Plausible.Users.with_subscription(conn.assigns.current_user)
 
-    {latest_enterprise_plan, price} = Plans.latest_enterprise_plan_with_price(user)
+    {latest_enterprise_plan, price} =
+      Plans.latest_enterprise_plan_with_price(user, PlausibleWeb.RemoteIP.get(conn))
 
     subscription_resumable? = Plausible.Billing.Subscriptions.resumable?(user.subscription)
 

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -15,7 +15,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   @contact_link "https://plausible.io/contact"
   @billing_faq_link "https://plausible.io/docs/billing"
 
-  def mount(_params, %{"current_user_id" => user_id}, socket) do
+  def mount(_params, %{"current_user_id" => user_id, "remote_ip" => remote_ip}, socket) do
     socket =
       socket
       |> assign_new(:user, fn ->
@@ -57,7 +57,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         current_user_subscription_interval(user.subscription)
       end)
       |> assign_new(:available_plans, fn %{user: user} ->
-        Plans.available_plans_for(user, with_prices: true)
+        Plans.available_plans_for(user, with_prices: true, customer_ip: remote_ip)
       end)
       |> assign_new(:available_volumes, fn %{available_plans: available_plans} ->
         get_available_volumes(available_plans)

--- a/lib/plausible_web/remote_ip.ex
+++ b/lib/plausible_web/remote_ip.ex
@@ -4,26 +4,26 @@ defmodule PlausibleWeb.RemoteIP do
   """
 
   def get(conn) do
-    x_plausible_ip = List.first(Plug.Conn.get_req_header(conn, "x-plausible-ip"))
-    cf_connecting_ip = List.first(Plug.Conn.get_req_header(conn, "cf-connecting-ip"))
-    x_forwarded_for = List.first(Plug.Conn.get_req_header(conn, "x-forwarded-for"))
-    b_forwarded_for = List.first(Plug.Conn.get_req_header(conn, "b-forwarded-for"))
-    forwarded = List.first(Plug.Conn.get_req_header(conn, "forwarded"))
+    x_plausible_ip = List.first(Plug.Conn.get_req_header(conn, "x-plausible-ip")) || ""
+    cf_connecting_ip = List.first(Plug.Conn.get_req_header(conn, "cf-connecting-ip")) || ""
+    x_forwarded_for = List.first(Plug.Conn.get_req_header(conn, "x-forwarded-for")) || ""
+    b_forwarded_for = List.first(Plug.Conn.get_req_header(conn, "b-forwarded-for")) || ""
+    forwarded = List.first(Plug.Conn.get_req_header(conn, "forwarded")) || ""
 
     cond do
-      x_plausible_ip ->
+      byte_size(x_plausible_ip) > 0 ->
         clean_ip(x_plausible_ip)
 
-      cf_connecting_ip ->
+      byte_size(cf_connecting_ip) > 0 ->
         clean_ip(cf_connecting_ip)
 
-      b_forwarded_for ->
+      byte_size(b_forwarded_for) > 0 ->
         parse_forwarded_for(b_forwarded_for)
 
-      x_forwarded_for ->
+      byte_size(x_forwarded_for) > 0 ->
         parse_forwarded_for(x_forwarded_for)
 
-      forwarded ->
+      byte_size(forwarded) > 0 ->
         Regex.named_captures(~r/for=(?<for>[^;,]+).*$/, forwarded)
         |> Map.get("for")
         # IPv6 addresses are enclosed in quote marks and square brackets: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -197,6 +197,7 @@ defmodule PlausibleWeb.Router do
     get "/system", Api.ExternalController, :info
 
     post "/paddle/webhook", Api.PaddleController, :webhook
+    get "/paddle/currency", Api.PaddleController, :currency
 
     get "/:domain/status", Api.InternalController, :domain_status
     put "/:domain/disable-feature", Api.InternalController, :disable_feature

--- a/lib/plausible_web/templates/billing/choose_plan.html.heex
+++ b/lib/plausible_web/templates/billing/choose_plan.html.heex
@@ -1,4 +1,5 @@
+<% remote_ip = PlausibleWeb.RemoteIP.get(@conn) %>
 <%= live_render(@conn, PlausibleWeb.Live.ChoosePlan,
   id: "choose-plan",
-  session: %{"current_user_id" => @user.id}
+  session: %{"current_user_id" => @user.id, "remote_ip" => remote_ip}
 ) %>

--- a/lib/plausible_web/templates/billing/choose_plan.html.heex
+++ b/lib/plausible_web/templates/billing/choose_plan.html.heex
@@ -1,5 +1,4 @@
-<% remote_ip = PlausibleWeb.RemoteIP.get(@conn) %>
 <%= live_render(@conn, PlausibleWeb.Live.ChoosePlan,
   id: "choose-plan",
-  session: %{"current_user_id" => @user.id, "remote_ip" => remote_ip}
+  session: %{"current_user_id" => @user.id, "remote_ip" => PlausibleWeb.RemoteIP.get(@conn)}
 ) %>

--- a/test/plausible/billing/paddle_api_test.exs
+++ b/test/plausible/billing/paddle_api_test.exs
@@ -23,7 +23,10 @@ defmodule Plausible.Billing.PaddleApiTest do
         end
       )
 
-      assert Plausible.Billing.PaddleApi.fetch_prices(["19878", "20127", "20657", "20658"]) ==
+      assert Plausible.Billing.PaddleApi.fetch_prices(
+               ["19878", "20127", "20657", "20658"],
+               "127.0.0.1"
+             ) ==
                {:ok,
                 %{
                   "19878" => Money.new(:EUR, "6.0"),

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -123,7 +123,7 @@ defmodule Plausible.Billing.PlansTest do
       user = insert(:user, subscription: build(:subscription, paddle_plan_id: @v2_plan_id))
 
       %{growth: growth_plans, business: business_plans} =
-        Plans.available_plans_for(user, with_prices: true)
+        Plans.available_plans_for(user, with_prices: true, customer_ip: "127.0.0.1")
 
       assert Enum.find(growth_plans, fn plan ->
                (%Money{} = plan.monthly_cost) && plan.monthly_product_id == @v2_plan_id
@@ -156,7 +156,7 @@ defmodule Plausible.Billing.PlansTest do
         inserted_at: Timex.shift(Timex.now(), minutes: -2)
       )
 
-      {enterprise_plan, price} = Plans.latest_enterprise_plan_with_price(user)
+      {enterprise_plan, price} = Plans.latest_enterprise_plan_with_price(user, "127.0.0.1")
 
       assert enterprise_plan.paddle_plan_id == "123"
       assert price == Money.new(:EUR, "10.0")

--- a/test/support/paddle_api_mock.ex
+++ b/test/support/paddle_api_mock.ex
@@ -75,7 +75,7 @@ defmodule Plausible.PaddleApi.Mock do
   # to give a reasonable testing structure for monthly and yearly plan
   # prices, this function returns prices with the following logic:
   # 10, 100, 20, 200, 30, 300, ...and so on.
-  def fetch_prices([_ | _] = product_ids) do
+  def fetch_prices([_ | _] = product_ids, _customer_ip) do
     {prices, _index} =
       Enum.reduce(product_ids, {%{}, 1}, fn p, {acc, i} ->
         price =


### PR DESCRIPTION
### Changes

This PR queries Paddle prices with customer IP, in order to utilise their geolocation-based currency selection.
Additionally, `/api/paddle/currency` endpoint is exposed, so that [currency displayed on the website](https://github.com/plausible/website/pull/579) is the same.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
