### PR TITLE
Add data migration cleaning up referrer source for demo site

### DIFF
--- a/lib/plausible/data_migration/clean_up_demo_site_referrer_source.ex
+++ b/lib/plausible/data_migration/clean_up_demo_site_referrer_source.ex
@@ -1,0 +1,25 @@
+defmodule Plausible.DataMigration.CleanUpDemoSiteReferrerSource do
+  @moduledoc """
+  Clean up referrer_source entries for demo site with
+  `Direct / None` for value populated by dogfooding
+  Plausible stats.
+  """
+
+  alias Plausible.IngestRepo
+  alias Plausible.Repo
+
+  def run(timeout \\ 60_000) do
+    demo_domain = PlausibleWeb.Endpoint.host()
+    %{id: demo_site_id} = Repo.get_by(Plausible.Site, domain: demo_domain)
+
+    for table <- ["sessions_v2", "events_v2"] do
+      IngestRepo.query!(
+        "ALTER TABLE {$0:Identifier} UPDATE referrer_source = '' " <>
+          "WHERE site_id = {$1:UInt64} AND referrer_source = 'Direct / None'",
+        [table, demo_site_id],
+        settings: [mutations_sync: 1],
+        timeout: timeout
+      )
+    end
+  end
+end

--- a/lib/plausible/data_migration/clean_up_demo_site_referrer_source.ex
+++ b/lib/plausible/data_migration/clean_up_demo_site_referrer_source.ex
@@ -14,8 +14,8 @@ defmodule Plausible.DataMigration.CleanUpDemoSiteReferrerSource do
 
     for table <- ["sessions_v2", "events_v2"] do
       IngestRepo.query!(
-        "ALTER TABLE {$0:Identifier} UPDATE referrer_source = '' " <>
-          "WHERE site_id = {$1:UInt64} AND referrer_source = 'Direct / None'",
+        "ALTER TABLE {$0:Identifier} UPDATE referrer_source = '' WHERE " <>
+          "site_id = {$1:UInt64} AND referrer_source = 'Direct / None'",
         [table, demo_site_id],
         settings: [mutations_sync: 1],
         timeout: timeout


### PR DESCRIPTION
### Changes

Cleans up referrer_source for demo site in cases where `Direct / None` was recorded as an explicit value due to dogfooding of Plausible stats against analytics (the dogfooding is already fixed by ignoring URL params entirely in #4217).

