### PR TITLE
Add CRM QoL improvements around usage info and linking Paddle

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -606,6 +606,7 @@ if config_env() in [:dev, :staging, :prod, :test] do
     ecto_repo: Plausible.Repo,
     router: PlausibleWeb.Router,
     admin_title: "Plausible Admin",
+    extensions: [Plausible.CrmExtensions],
     resources: [
       auth: [
         resources: [

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -36,7 +36,6 @@ defmodule Plausible.Auth.UserAdmin do
       trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},
       subscription_plan: %{value: &subscription_plan/1},
       subscription_status: %{value: &subscription_status/1},
-      usage: %{value: &usage_link/1},
       grace_period: %{value: &grace_period_status/1},
       accept_traffic_until: %{
         name: "Accept traffic until",
@@ -138,15 +137,6 @@ defmodule Plausible.Auth.UserAdmin do
   defp manage_url(%{paddle_subscription_id: paddle_id} = _subscription) do
     Plausible.Billing.PaddleApi.vendors_domain() <>
       "/subscriptions/customers/manage/" <> paddle_id
-  end
-
-  on_ee do
-    defp usage_link(user) do
-      path = PlausibleWeb.Router.Helpers.admin_path(PlausibleWeb.Endpoint, :usage, user.id)
-      {:safe, ~s(<a href="#{path}">Usage</a>)}
-    end
-  else
-    defp usage_link(_), do: nil
   end
 
   defp format_date(nil), do: "--"

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -7,25 +7,22 @@ defmodule Plausible.CrmExtensions do
 
   on_ee do
     def javascripts(%{assigns: %{context: "auth", resource: "user", entry: %{} = user}}) do
-      Enum.map(
-        [
-          """
-          <script type="text/javascript">
-            (async () => {
-              const response = await fetch("/crm/auth/user/#{user.id}/usage?embed=true")
-              const usageHTML = await response.text()
-              const cardBody = document.querySelector(".card-body")
-              if (cardBody) {
-                const usageDOM = document.createElement("div")
-                usageDOM.innerHTML = usageHTML
-                cardBody.prepend(usageDOM)
-              }
-            })()
-          </script>
-          """
-        ],
-        &Phoenix.HTML.raw/1
-      )
+      [
+        Phoenix.HTML.raw("""
+        <script type="text/javascript">
+          (async () => {
+            const response = await fetch("/crm/auth/user/#{user.id}/usage?embed=true")
+            const usageHTML = await response.text()
+            const cardBody = document.querySelector(".card-body")
+            if (cardBody) {
+              const usageDOM = document.createElement("div")
+              usageDOM.innerHTML = usageHTML
+              cardBody.prepend(usageDOM)
+            }
+          })()
+        </script>
+        """)
+      ]
     end
   end
 

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -1,0 +1,35 @@
+defmodule Plausible.CrmExtensions do
+  @moduledoc """
+  Extensions for Kaffy CRM
+  """
+
+  use Plausible
+
+  on_ee do
+    def javascripts(%{assigns: %{context: "auth", resource: "user", entry: %{} = user}}) do
+      Enum.map(
+        [
+          """
+          <script type="text/javascript">
+            (async () => {
+              const response = await fetch("/crm/auth/user/#{user.id}/usage?embed=true")
+              const usageHTML = await response.text()
+              const cardBody = document.querySelector(".card-body")
+              if (cardBody) {
+                const usageDOM = document.createElement("div")
+                usageDOM.innerHTML = usageHTML
+                cardBody.prepend(usageDOM)
+              }
+            })()
+          </script>
+          """
+        ],
+        &Phoenix.HTML.raw/1
+      )
+    end
+  end
+
+  def javascripts(_) do
+    []
+  end
+end

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -17,39 +17,47 @@ defmodule PlausibleWeb.AdminController do
       team_members: Quota.Limits.team_member_limit(user)
     }
 
-    html_response = usage_and_limits_html(user, usage, limits)
+    html_response = usage_and_limits_html(user, usage, limits, params["embed"] == "true")
 
     conn
     |> put_resp_content_type("text/html")
     |> send_resp(200, html_response)
   end
 
-  defp usage_and_limits_html(user, usage, limits) do
-    """
-    <!DOCTYPE html>
-    <html lang="en">
-
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Usage - user:#{user.id}</title>
-      <style>
-        ul, li {margin-top: 10px;}
-        body {padding-top: 10px;}
-      </style>
-    </head>
-
-    <body>
+  defp usage_and_limits_html(user, usage, limits, embed?) do
+    content = """
       <ul>
         <li>Sites: <b>#{usage.sites}</b> / #{limits.sites}</li>
         <li>Team members: <b>#{usage.team_members}</b> / #{limits.team_members}</li>
         <li>Features: #{features_usage(usage.features)}</li>
         <li>Monthly pageviews: #{monthly_pageviews_usage(usage.monthly_pageviews, limits.monthly_pageviews)}</li>
       </ul>
-    </body>
-
-    </html>
     """
+
+    if embed? do
+      content
+    else
+      """
+      <!DOCTYPE html>
+      <html lang="en">
+
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Usage - user:#{user.id}</title>
+        <style>
+          ul, li {margin-top: 10px;}
+          body {padding-top: 10px;}
+        </style>
+      </head>
+
+      <body>
+        #{content}
+      </body>
+
+      </html>
+      """
+    end
   end
 
   defp features_usage(features_module_list) do

--- a/lib/plausible_web/views/auth_view.ex
+++ b/lib/plausible_web/views/auth_view.ex
@@ -9,14 +9,20 @@ defmodule PlausibleWeb.AuthView do
   def subscription_quota(nil, _options), do: "Free trial"
 
   def subscription_quota(subscription, options) do
-    subscription
-    |> Plausible.Billing.Quota.Limits.monthly_pageview_limit()
-    |> PlausibleWeb.StatsView.large_number_format()
-    |> then(fn quota ->
-      if Keyword.get(options, :format) == :long,
-        do: "#{quota} pageviews",
-        else: quota
-    end)
+    pageview_limit = Plausible.Billing.Quota.Limits.monthly_pageview_limit(subscription)
+
+    quota =
+      if pageview_limit == :unlimited do
+        "unlimited"
+      else
+        PlausibleWeb.StatsView.large_number_format(pageview_limit)
+      end
+
+    if Keyword.get(options, :format) == :long do
+      "#{quota} pageviews"
+    else
+      quota
+    end
   end
 
   def subscription_interval(subscription) do

--- a/lib/plausible_web/views/stats_view.ex
+++ b/lib/plausible_web/views/stats_view.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.StatsView do
           "#{billions}B"
         end
 
-      true ->
+      is_integer(n) ->
         Integer.to_string(n)
     end
   end

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -11,6 +11,20 @@ defmodule PlausibleWeb.AdminControllerTest do
       conn = get(conn, "/crm/auth/user/1/usage")
       assert response(conn, 403) == "Not allowed"
     end
+
+    @tag :ee_only
+    test "returns usage data as a standalone page", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+      conn = get(conn, "/crm/auth/user/#{user.id}/usage")
+      assert response(conn, 200) =~ "<html"
+    end
+
+    @tag :ee_only
+    test "returns usage data in embeddable form when requested", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+      conn = get(conn, "/crm/auth/user/#{user.id}/usage?embed=true")
+      refute response(conn, 200) =~ "<html"
+    end
   end
 
   describe "POST /crm/sites/site/:site_id" do


### PR DESCRIPTION
### Changes

A bunch of small improvements to the CRM.

- display usage info directly above user form instead of a separate page opened from list view
- link to respective Paddle subscription profile from `Status` column as well any time paddle ID is available, regardless of the actual status

