### PR TITLE
Verification tweaks

### DIFF
--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -125,7 +125,7 @@ defmodule Plausible.Verification.Diagnostics do
         },
         _url
       ) do
-    error(@errors.timeout)
+    error(@errors.generic)
   end
 
   def interpret(
@@ -158,7 +158,7 @@ defmodule Plausible.Verification.Diagnostics do
         },
         _url
       ) do
-    error(@errors.old_script)
+    error(@errors.generic)
   end
 
   def interpret(

--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -121,6 +121,16 @@ defmodule Plausible.Verification.Diagnostics do
   def interpret(
         %__MODULE__{
           plausible_installed?: false,
+          service_error: :timeout
+        },
+        _url
+      ) do
+    error(@errors.timeout)
+  end
+
+  def interpret(
+        %__MODULE__{
+          plausible_installed?: false,
           service_error: service_error
         },
         _url

--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -51,6 +51,13 @@ defmodule Plausible.Verification.Diagnostics do
   end
 
   def interpret(
+        %__MODULE__{plausible_installed?: false, gtm_likely?: true, disallowed_via_csp?: true},
+        _url
+      ) do
+    error(@errors.csp)
+  end
+
+  def interpret(
         %__MODULE__{plausible_installed?: false, gtm_likely?: true, cookie_banner_likely?: true},
         _url
       ) do

--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -96,6 +96,21 @@ defmodule Plausible.Verification.Diagnostics do
 
   def interpret(
         %__MODULE__{
+          plausible_installed?: true,
+          snippets_found_in_head: 0,
+          snippets_found_in_body: 0,
+          body_fetched?: true,
+          gtm_likely?: false,
+          callback_status: callback_status
+        },
+        _url
+      )
+      when is_integer(callback_status) and callback_status > 202 do
+    error(@errors.no_snippet)
+  end
+
+  def interpret(
+        %__MODULE__{
           plausible_installed?: false,
           snippets_found_in_head: 0,
           snippets_found_in_body: 0,

--- a/lib/plausible/verification/errors.ex
+++ b/lib/plausible/verification/errors.ex
@@ -46,6 +46,13 @@ defmodule Plausible.Verification.Errors do
       url:
         "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
     },
+    timeout: %{
+      message: "We couldn't verify your website",
+      recommendation:
+        "We've tried several times, but your website is very slow to respond to us and we had to give up",
+      url:
+        "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+    },
     old_script: %{
       message: "We couldn't verify your website",
       recommendation:

--- a/lib/plausible/verification/errors.ex
+++ b/lib/plausible/verification/errors.ex
@@ -46,19 +46,12 @@ defmodule Plausible.Verification.Errors do
       url:
         "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
     },
-    timeout: %{
-      message: "We couldn't verify your website",
+    generic: %{
+      message: "We couldn't automatically verify your website",
       recommendation:
-        "We've tried several times, but your website is very slow to respond to us and we had to give up",
+        "Please manually check your integration by following the instructions provided",
       url:
         "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
-    },
-    old_script: %{
-      message: "We couldn't verify your website",
-      recommendation:
-        "You're running an older version of our script so we cannot verify it automatically. Please update to the latest script",
-      url:
-        "https://plausible.io/docs/troubleshoot-integration#are-you-using-an-older-version-of-our-script"
     },
     old_script_wp_no_plugin: %{
       message: "We couldn't verify your website",

--- a/priv/verification/verify_plausible_installed.js
+++ b/priv/verification/verify_plausible_installed.js
@@ -8,7 +8,7 @@ export default async function({ page, context }) {
 	await page.goto(context.url);
 
 	try {
-		await page.waitForFunction('window.plausible', { timeout: 4000 });
+		await page.waitForFunction('window.plausible', { timeout: 5000 });
 		await page.evaluate(() => {
 			window.__plausible = true;
 			window.plausible('verification-agent-test', {
@@ -19,7 +19,7 @@ export default async function({ page, context }) {
 		});
 
 		try {
-			await page.waitForFunction('window.plausibleCallbackResult', { timeout: 3000 });
+			await page.waitForFunction('window.plausibleCallbackResult', { timeout: 5000 });
 			const status = await page.evaluate(() => { return window.plausibleCallbackResult() });
 			return { data: { plausibleInstalled: true, callbackStatus: status } };
 		} catch ({ err, message }) {

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -524,6 +524,21 @@ defmodule Plausible.Verification.ChecksTest do
     </html>
     """
 
+    test "disallowd via content-security-policy and GTM should make CSP a priority" do
+      stub_fetch_body(fn conn ->
+        conn
+        |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
+        |> put_resp_content_type("text/html")
+        |> send_resp(200, @gtm_body)
+      end)
+
+      stub_installation(200, plausible_installed(false))
+
+      run_checks()
+      |> Checks.interpret_diagnostics()
+      |> assert_error(@errors.csp)
+    end
+
     test "detecting gtm" do
       stub_fetch_body(200, @gtm_body)
       stub_installation(200, plausible_installed(false))

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -788,6 +788,29 @@ defmodule Plausible.Verification.ChecksTest do
       |> interpret_sentry_case()
       |> assert_error(@errors.old_script_wp_no_plugin)
     end
+
+    test "service timeout" do
+      %Plausible.Verification.Diagnostics{
+        plausible_installed?: false,
+        snippets_found_in_head: 1,
+        snippets_found_in_body: 0,
+        snippet_found_after_busting_cache?: false,
+        snippet_unknown_attributes?: false,
+        disallowed_via_csp?: false,
+        service_error: :timeout,
+        body_fetched?: true,
+        wordpress_likely?: true,
+        cookie_banner_likely?: false,
+        gtm_likely?: false,
+        callback_status: 0,
+        proxy_likely?: true,
+        manual_script_extension?: false,
+        data_domain_mismatch?: false,
+        wordpress_plugin?: false
+      }
+      |> interpret_sentry_case()
+      |> assert_error(@errors.timeout)
+    end
   end
 
   defp interpret_sentry_case(diagnostics) do

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -704,7 +704,7 @@ defmodule Plausible.Verification.ChecksTest do
 
       run_checks()
       |> Checks.interpret_diagnostics()
-      |> assert_error(@errors.old_script)
+      |> assert_error(@errors.generic)
     end
 
     test "callback handling not found for wordpress site" do
@@ -809,7 +809,7 @@ defmodule Plausible.Verification.ChecksTest do
         wordpress_plugin?: false
       }
       |> interpret_sentry_case()
-      |> assert_error(@errors.timeout)
+      |> assert_error(@errors.generic)
     end
   end
 

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -811,6 +811,29 @@ defmodule Plausible.Verification.ChecksTest do
       |> interpret_sentry_case()
       |> assert_error(@errors.generic)
     end
+
+    test "malformed snippet code, that headless somewhat accepts" do
+      %Plausible.Verification.Diagnostics{
+        plausible_installed?: true,
+        snippets_found_in_head: 0,
+        snippets_found_in_body: 0,
+        snippet_found_after_busting_cache?: false,
+        snippet_unknown_attributes?: false,
+        disallowed_via_csp?: false,
+        service_error: nil,
+        body_fetched?: true,
+        wordpress_likely?: false,
+        cookie_banner_likely?: false,
+        gtm_likely?: false,
+        callback_status: 405,
+        proxy_likely?: false,
+        manual_script_extension?: false,
+        data_domain_mismatch?: false,
+        wordpress_plugin?: false
+      }
+      |> interpret_sentry_case()
+      |> assert_error(@errors.no_snippet)
+    end
   end
 
   defp interpret_sentry_case(diagnostics) do


### PR DESCRIPTION
### Changes

This PR adds more cases to the verification diagnostics verdict.
  - Prioritize CSP over GTM if both are present
  - Tweak timeouts for the headless run a little
  - Introduce generic error message that we'll channel all the known but obscure errors into
  - Handle malformed script tag such as `<script defer= data-domain="..."></script>` that will be accepted by the headless browser but is going to fail with our server-side parser

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
