### PR TITLE
Fix enterprise plan CRM form prefill for case with literal input

### DIFF
--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -49,7 +49,7 @@ defmodule Plausible.CrmExtensions do
         Phoenix.HTML.raw("""
         <script type="text/javascript">
           (async () => {
-            const userIdField = document.getElementById("enterprise_plan_user_id")
+            const userIdField = document.getElementById("enterprise_plan_user_id") || document.getElementById("user_id")
             let planRequest
             let lastValue = Number(userIdField.value)
             let scheduledCheck


### PR DESCRIPTION
### Changes

Kaffy uses inconsistent field ID when changing between select and standard input for large datasets.

This PR accounts for that change when applying prefill.

