### PR TITLE
Migration: Increase the precision of subscription timestamp fields

### DIFF
--- a/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
+++ b/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
@@ -1,5 +1,8 @@
 defmodule Plausible.Repo.Migrations.IncreaseSubscriptionTimestampsPrecision do
   use Ecto.Migration
+  
+  @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def up do
     alter table(:subscriptions) do

--- a/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
+++ b/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
@@ -1,0 +1,17 @@
+defmodule Plausible.Repo.Migrations.IncreaseSubscriptionTimestampsPrecision do
+  use Ecto.Migration
+
+  def up do
+    alter table(:subscriptions) do
+      modify :inserted_at, :naive_datetime_usec
+      modify :updated_at, :naive_datetime_usec
+    end
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      modify :inserted_at, :naive_datetime
+      modify :updated_at, :naive_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
+++ b/priv/repo/migrations/20240617102748_increase_subscription_timestamps_precision.exs
@@ -1,6 +1,6 @@
 defmodule Plausible.Repo.Migrations.IncreaseSubscriptionTimestampsPrecision do
   use Ecto.Migration
-  
+
   @disable_ddl_transaction true
   @disable_migration_lock true
 


### PR DESCRIPTION
### Changes

Motivation: Paddle sometimes sends us two webhooks at the same time when a subscription is updated. We only need to count the latest one of those, for which we need more precision than 1s.

The migration will set both `inserted_at` and `updated_at` columns in the `subscriptions` table to use the `:naive_datetime_usec` type instead of just `:naive_datetime`. In practice, we currently need more precision only on the `updated_at` field. But I suppose it's better to keep the type between both timestamp fields consistent.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
