### PR TITLE
Ignore `site_imports` query traces when sampling for OpenTelemetry

### DIFF
--- a/lib/plausible/open_telemetry/sampler.ex
+++ b/lib/plausible/open_telemetry/sampler.ex
@@ -18,7 +18,7 @@ defmodule Plausible.OpenTelemetry.Sampler do
   require OpenTelemetry.Tracer, as: Tracer
 
   @routes_to_ignore ["/api/event", "/api/event/"]
-  @tables_to_ignore ["oban_jobs"]
+  @tables_to_ignore ["oban_jobs", "site_imports"]
 
   @impl true
   def setup(%{ratio: ratio}) when is_number(ratio) do


### PR DESCRIPTION
### Changes

Slight adjustment to OTEL sampler so that excessive traces triggered by `site_imports` queries are avoided.


