### PR TITLE
Fix pagination is Sites CRM

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -17,8 +17,7 @@ defmodule Plausible.SiteAdmin do
   def custom_index_query(_conn, _schema, query) do
     from(r in query,
       inner_join: o in assoc(r, :owner),
-      inner_join: m in assoc(r, :memberships),
-      preload: [owner: o, memberships: {m, :user}]
+      preload: [owner: o, memberships: :user]
     )
   end
 

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -7,7 +7,11 @@ defmodule Plausible.Site.AdminTest do
 
   setup do
     admin_user = insert(:user)
-    conn = %Plug.Conn{assigns: %{current_user: admin_user}}
+
+    conn =
+      %Plug.Conn{assigns: %{current_user: admin_user}}
+      |> Plug.Conn.fetch_query_params()
+
     transfer_action = Plausible.SiteAdmin.list_actions(conn)[:transfer_ownership][:action]
 
     transfer_direct_action =

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -27,6 +27,39 @@ defmodule PlausibleWeb.AdminControllerTest do
     end
   end
 
+  describe "GET /crm/sites/site" do
+    setup [:create_user, :log_in]
+
+    @tag :ee_only
+    test "pagination works correctly when multiple memberships per site present", %{
+      conn: conn,
+      user: user
+    } do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      s1 = insert(:site)
+      insert_list(3, :site_membership, site: s1)
+      s2 = insert(:site)
+      insert_list(3, :site_membership, site: s2)
+      s3 = insert(:site)
+      insert_list(3, :site_membership, site: s3)
+
+      conn1 = get(conn, "/crm/sites/site", %{"limit" => "2"})
+      page1_html = html_response(conn1, 200)
+
+      assert page1_html =~ s1.domain
+      assert page1_html =~ s2.domain
+      refute page1_html =~ s3.domain
+
+      conn2 = get(conn, "/crm/sites/site", %{"page" => "2", "limit" => "2"})
+      page2_html = html_response(conn2, 200)
+
+      refute page2_html =~ s1.domain
+      refute page2_html =~ s2.domain
+      assert page2_html =~ s3.domain
+    end
+  end
+
   describe "POST /crm/sites/site/:site_id" do
     setup [:create_user, :log_in]
 


### PR DESCRIPTION
### Changes

This PR addresses a problem of broken pagination in Sites CRM due to inner join of 1:n relationship of site memberships. Changing the join into a full preload should help avoid issues when applying limit/offset based approach which does not play out well in such cases.

### Tests
- [x] Automated tests have been added

