### PR TITLE
APIv2: Aggregates, timeseries, conversion_rate, hostname

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -15,15 +15,10 @@ defmodule Plausible.Stats.Aggregate do
 
     Query.trace(query, metrics)
 
-    query_with_metrics = %Plausible.Stats.Query{
-      query
-      | metrics: Util.maybe_add_visitors_metric(metrics)
-    }
-
-    q = Plausible.Stats.SQL.QueryBuilder.build(query_with_metrics, site)
+    q = Plausible.Stats.SQL.QueryBuilder.build(query, site)
 
     time_on_page_task =
-      if :time_on_page in query_with_metrics.metrics do
+      if :time_on_page in query.metrics do
         fn -> aggregate_time_on_page(site, query) end
       else
         fn -> %{} end

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -15,10 +15,12 @@ defmodule Plausible.Stats.Aggregate do
 
     Query.trace(query, metrics)
 
-    q = Plausible.Stats.SQL.QueryBuilder.build(query, site)
+    query_with_metrics = %Query{query | metrics: metrics}
+
+    q = Plausible.Stats.SQL.QueryBuilder.build(query_with_metrics, site)
 
     time_on_page_task =
-      if :time_on_page in query.metrics do
+      if :time_on_page in query_with_metrics.metrics do
         fn -> aggregate_time_on_page(site, query) end
       else
         fn -> %{} end

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -121,6 +121,7 @@ defmodule Plausible.Stats.Base do
 
   defp select_event_metric(:percentage), do: %{}
   defp select_event_metric(:conversion_rate), do: %{}
+  defp select_event_metric(:group_conversion_rate), do: %{}
   defp select_event_metric(:total_visitors), do: %{}
 
   defp select_event_metric(unknown), do: raise("Unknown metric: #{unknown}")
@@ -344,9 +345,9 @@ defmodule Plausible.Stats.Base do
   # only if it's included in the base query - otherwise the total will be based on
   # a different data set, making the metric inaccurate. This is why we're using an
   # explicit `include_imported` argument here.
-  defp total_visitors_subquery(site, query, include_imported)
+  def total_visitors_subquery(site, query, include_imported)
 
-  defp total_visitors_subquery(site, query, true = _include_imported) do
+  def total_visitors_subquery(site, query, true = _include_imported) do
     dynamic(
       [e],
       selected_as(
@@ -357,7 +358,7 @@ defmodule Plausible.Stats.Base do
     )
   end
 
-  defp total_visitors_subquery(site, query, false = _include_imported) do
+  def total_visitors_subquery(site, query, false = _include_imported) do
     dynamic([e], selected_as(subquery(total_visitors(site, query)), :__total_visitors))
   end
 

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -87,6 +87,6 @@ defmodule Plausible.Stats.Filters do
     property
     |> String.split(":")
     |> List.last()
-    |> String.to_atom()
+    |> String.to_existing_atom()
   end
 end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -299,8 +299,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp validate_metrics(query) do
-    validate_list(query.metrics, &validate_metric(&1, query))
-
     with :ok <- validate_list(query.metrics, &validate_metric(&1, query)) do
       validate_no_metrics_filters_conflict(query)
     end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -228,7 +228,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_time("time:hour"), do: {:ok, "time:hour"}
   defp parse_time("time:day"), do: {:ok, "time:day"}
   defp parse_time("time:month"), do: {:ok, "time:month"}
-  defp parse_time("time:year"), do: {:ok, "time:year"}
   defp parse_time(_), do: :error
 
   defp parse_order_direction([_, "asc"]), do: {:ok, :asc}

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -105,39 +105,39 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_date_range(_site, "7d", last) do
-    first = last |> Timex.shift(days: -6)
+    first = last |> Date.add(-6)
     {:ok, Date.range(first, last)}
   end
 
   defp parse_date_range(_site, "30d", last) do
-    first = last |> Timex.shift(days: -30)
+    first = last |> Date.add(-30)
     {:ok, Date.range(first, last)}
   end
 
   defp parse_date_range(_site, "month", today) do
-    last = today |> Timex.end_of_month()
-    first = last |> Timex.beginning_of_month()
+    last = today |> Date.end_of_month()
+    first = last |> Date.beginning_of_month()
     {:ok, Date.range(first, last)}
   end
 
   defp parse_date_range(_site, "6mo", today) do
-    last = today |> Timex.end_of_month()
+    last = today |> Date.end_of_month()
 
     first =
       last
       |> Timex.shift(months: -5)
-      |> Timex.beginning_of_month()
+      |> Date.beginning_of_month()
 
     {:ok, Date.range(first, last)}
   end
 
   defp parse_date_range(_site, "12mo", today) do
-    last = today |> Timex.end_of_month()
+    last = today |> Date.end_of_month()
 
     first =
       last
       |> Timex.shift(months: -11)
-      |> Timex.beginning_of_month()
+      |> Date.beginning_of_month()
 
     {:ok, Date.range(first, last)}
   end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -296,7 +296,11 @@ defmodule Plausible.Stats.Filters.QueryParser do
       Enum.any?(filters, fn [_, filter_key | _rest] -> filter_key == "event:goal" end)
 
     if goal_filters? or Enum.member?(dimensions, "event:goal") do
-      Filters.Utils.load_goals(site)
+      Plausible.Goals.for_site(site)
+      |> Enum.map(fn
+        %{page_path: path} when is_binary(path) -> {:page, path}
+        %{event_name: event_name} -> {:event, event_name}
+      end)
     else
       []
     end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -381,12 +381,21 @@ defmodule Plausible.Stats.Filters.QueryParser do
     {_event_metrics, sessions_metrics, _other_metrics} =
       TableDecider.partition_metrics(query.metrics, query)
 
-    if Enum.empty?(sessions_metrics) or not TableDecider.event_dimensions?(query) do
+    if Enum.empty?(sessions_metrics) or
+         not event_dimensions_not_allowing_session_metrics?(query.dimensions) do
       :ok
     else
       {:error,
        "Session metric(s) `#{sessions_metrics |> Enum.join(", ")}` cannot be queried along with event dimensions"}
     end
+  end
+
+  def event_dimensions_not_allowing_session_metrics?(dimensions) do
+    Enum.any?(dimensions, fn
+      "event:page" -> false
+      "event:" <> _ -> true
+      _ -> false
+    end)
   end
 
   defp parse_list(list, parser_function) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -323,7 +323,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
       :ok
     else
       {:error,
-       "Session metric(s) `#{sessions_metrics |> Enum.join(", ")}` cannot be queried along with event filters or dimensions"}
+       "Session metric(s) `#{sessions_metrics |> Enum.join(", ")}` cannot be queried along with event dimensions"}
     end
   end
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -89,7 +89,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
        do: parse_clauses_list(filter)
 
   defp parse_clauses_list([_operation, filter_key, list] = filter) when is_list(list) do
-    all_strings? = Enum.all?(list, &is_bitstring/1)
+    all_strings? = Enum.all?(list, &is_binary/1)
 
     cond do
       filter_key == "event:goal" && all_strings? -> {:ok, [Filters.Utils.wrap_goal_value(list)]}
@@ -155,7 +155,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_date_range(_site, [from_date_string, to_date_string], _date)
-       when is_bitstring(from_date_string) and is_bitstring(to_date_string) do
+       when is_binary(from_date_string) and is_binary(to_date_string) do
     with {:ok, from_date} <- Date.from_iso8601(from_date_string),
          {:ok, to_date} <- Date.from_iso8601(to_date_string) do
       {:ok, Date.range(from_date, to_date)}
@@ -165,7 +165,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_date_range(site, %{"period" => period, "to_date" => to_date_string}, _date)
-       when is_bitstring(period) and is_bitstring(to_date_string) do
+       when is_binary(period) and is_binary(to_date_string) do
     with {:ok, to_date} <- Date.from_iso8601(to_date_string) do
       parse_date_range(site, period, to_date)
     end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -164,13 +164,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
-  defp parse_date_range(site, %{"period" => period, "to_date" => to_date_string}, _date)
-       when is_binary(period) and is_binary(to_date_string) do
-    with {:ok, to_date} <- Date.from_iso8601(to_date_string) do
-      parse_date_range(site, period, to_date)
-    end
-  end
-
   defp parse_date_range(_site, unknown, _),
     do: {:error, "Invalid date_range '#{inspect(unknown)}'"}
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -161,6 +161,13 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
+  defp parse_date_range(site, %{"period" => period, "to_date" => to_date_string}, _date)
+       when is_bitstring(period) and is_bitstring(to_date_string) do
+    with {:ok, to_date} <- Date.from_iso8601(to_date_string) do
+      parse_date_range(site, period, to_date)
+    end
+  end
+
   defp parse_date_range(_site, unknown, _),
     do: {:error, "Invalid date_range '#{inspect(unknown)}'"}
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -49,6 +49,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_metric("visits"), do: {:ok, :visits}
   defp parse_metric("bounce_rate"), do: {:ok, :bounce_rate}
   defp parse_metric("visit_duration"), do: {:ok, :visit_duration}
+  defp parse_metric("views_per_visit"), do: {:ok, :views_per_visit}
   defp parse_metric(unknown_metric), do: {:error, "Unknown metric '#{inspect(unknown_metric)}'"}
 
   def parse_filters(filters) when is_list(filters) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -313,6 +313,19 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
+  defp validate_metric(:views_per_visit = metric, query) do
+    cond do
+      not is_nil(Query.get_filter(query, "event:page")) ->
+        {:error, "Metric `#{metric}` cannot be queried with a filter on `event:page`"}
+
+      length(query.dimensions) > 0 ->
+        {:error, "Metric `#{metric}` cannot be queried with `dimensions`"}
+
+      true ->
+        :ok
+    end
+  end
+
   defp validate_metric(_, _), do: :ok
 
   defp validate_no_metrics_filters_conflict(query) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -321,7 +321,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
     {_event_metrics, sessions_metrics, _other_metrics} =
       TableDecider.partition_metrics(query.metrics, query)
 
-    if Enum.empty?(sessions_metrics) or not TableDecider.event_filters?(query) do
+    if Enum.empty?(sessions_metrics) or not TableDecider.event_dimensions?(query) do
       :ok
     else
       {:error,

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -46,6 +46,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp parse_metric("time_on_page"), do: {:ok, :time_on_page}
   defp parse_metric("conversion_rate"), do: {:ok, :conversion_rate}
+  defp parse_metric("group_conversion_rate"), do: {:ok, :group_conversion_rate}
   defp parse_metric("visitors"), do: {:ok, :visitors}
   defp parse_metric("pageviews"), do: {:ok, :pageviews}
   defp parse_metric("events"), do: {:ok, :events}
@@ -355,7 +356,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
-  defp validate_metric(:conversion_rate = metric, query) do
+  defp validate_metric(metric, query) when metric in [:conversion_rate, :group_conversion_rate] do
     if Enum.member?(query.dimensions, "event:goal") or
          not is_nil(Query.get_filter(query, "event:goal")) do
       :ok

--- a/lib/plausible/stats/filters/utils.ex
+++ b/lib/plausible/stats/filters/utils.ex
@@ -67,14 +67,6 @@ defmodule Plausible.Stats.Filters.Utils do
   def unwrap_goal_value({:page, page}), do: "Visit " <> page
   def unwrap_goal_value({:event, event}), do: event
 
-  def load_goals(site) do
-    Plausible.Goals.for_site(site)
-    |> Enum.map(fn
-      %{page_path: path} when is_binary(path) -> {:page, path}
-      %{event_name: event_name} -> {:event, event_name}
-    end)
-  end
-
   def split_goals(goals) do
     Enum.split_with(goals, fn {type, _} -> type == :event end)
   end

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -336,7 +336,7 @@ defmodule Plausible.Stats.Imported do
     )
     |> select_joined_dimension(dim, query)
     |> select_joined_metrics(metrics)
-    |> apply_order_by(metrics)
+    |> apply_order_by(query, metrics)
   end
 
   def merge_imported(q, site, %Query{dimensions: []} = query, metrics) do
@@ -882,12 +882,14 @@ defmodule Plausible.Stats.Imported do
     |> select_joined_metrics(rest)
   end
 
-  defp apply_order_by(q, [:visitors | rest]) do
+  defp apply_order_by(q, %Query{v2: true}, _), do: q
+
+  defp apply_order_by(q, query, [:visitors | rest]) do
     order_by(q, [s, i], desc: s.visitors + i.visitors)
-    |> apply_order_by(rest)
+    |> apply_order_by(query, rest)
   end
 
-  defp apply_order_by(q, _), do: q
+  defp apply_order_by(q, _query, _), do: q
 
   defp naive_dimension_join(q1, q2, metrics) do
     from(a in Ecto.Query.subquery(q1),

--- a/lib/plausible/stats/metrics.ex
+++ b/lib/plausible/stats/metrics.ex
@@ -16,6 +16,7 @@ defmodule Plausible.Stats.Metrics do
                  :visit_duration,
                  :events,
                  :conversion_rate,
+                 :group_conversion_rate,
                  :time_on_page
                ] ++ on_ee(do: Plausible.Stats.Goal.Revenue.revenue_metrics(), else: [])
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -17,7 +17,8 @@ defmodule Plausible.Stats.Query do
             metrics: [],
             order_by: nil,
             timezone: nil,
-            v2: false
+            v2: false,
+            preloaded_goals: []
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{Filters, Interval, Imported}

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -15,7 +15,7 @@ defmodule Plausible.Stats.Query do
             experimental_reduced_joins?: false,
             latest_import_end_date: nil,
             metrics: [],
-            order_by: [],
+            order_by: nil,
             timezone: nil,
             v2: false
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -238,6 +238,12 @@ defmodule Plausible.Stats.Query do
     |> refresh_imported_opts()
   end
 
+  def set_order_by(query, order_by) do
+    query
+    |> struct!(order_by: order_by)
+    |> refresh_imported_opts()
+  end
+
   def put_filter(query, filter) do
     query
     |> struct!(filters: query.filters ++ [filter])

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -232,6 +232,12 @@ defmodule Plausible.Stats.Query do
     |> refresh_imported_opts()
   end
 
+  def set_metrics(query, metrics) do
+    query
+    |> struct!(metrics: metrics)
+    |> refresh_imported_opts()
+  end
+
   def put_filter(query, filter) do
     query
     |> struct!(filters: query.filters ++ [filter])

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -16,7 +16,8 @@ defmodule Plausible.Stats.QueryOptimizer do
   defp pipeline() do
     [
       &update_group_by_time/1,
-      &add_missing_order_by/1
+      &add_missing_order_by/1,
+      &update_time_in_order_by/1
     ]
   end
 
@@ -50,4 +51,17 @@ defmodule Plausible.Stats.QueryOptimizer do
   end
 
   defp update_group_by_time(query), do: query
+
+  defp update_time_in_order_by(%Query{dimensions: ["time:" <> _ = time_dimension | _]} = query) do
+    order_by =
+      query.order_by
+      |> Enum.map(fn
+        {"time", direction} -> {time_dimension, direction}
+        entry -> entry
+      end)
+
+    %Query{query | order_by: order_by}
+  end
+
+  defp update_time_in_order_by(query), do: query
 end

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -3,8 +3,9 @@ defmodule Plausible.Stats.QueryOptimizer do
     This module manipulates an existing query, updating it according to business logic.
 
     For example, it:
-    1. Adds a missing order_by clause to a query
-    2. Figures out what the right granularity to group by is
+    1. Figures out what the right granularity to group by time is
+    2. Adds a missing order_by clause to a query
+    3. Updating "time" dimension in order_by to the right granularity
   """
 
   alias Plausible.Stats.Query
@@ -17,7 +18,8 @@ defmodule Plausible.Stats.QueryOptimizer do
     [
       &update_group_by_time/1,
       &add_missing_order_by/1,
-      &update_time_in_order_by/1
+      &update_time_in_order_by/1,
+      &extend_hostname_filters_to_visit/1
     ]
   end
 
@@ -67,6 +69,48 @@ defmodule Plausible.Stats.QueryOptimizer do
       end)
 
     %Query{query | order_by: order_by}
+  end
+
+  @dimensions_hostname_map %{
+    "visit:source" => "visit:entry_page_hostname",
+    "visit:entry_page" => "visit:entry_page_hostname",
+    "visit:utm_medium" => "visit:entry_page_hostname",
+    "visit:utm_source" => "visit:entry_page_hostname",
+    "visit:utm_campaign" => "visit:entry_page_hostname",
+    "visit:utm_content" => "visit:entry_page_hostname",
+    "visit:utm_term" => "visit:entry_page_hostname",
+    "visit:referrer" => "visit:entry_page_hostname",
+    "visit:exit_page" => "visit:exit_page_hostname"
+  }
+
+  # To avoid showing referrers across hostnames when event:hostname
+  # filter is present for breakdowns, add entry/exit page hostname
+  # filters
+  defp extend_hostname_filters_to_visit(query) do
+    hostname_filters =
+      query.filters
+      |> Enum.filter(fn [_operation, filter_key | _rest] -> filter_key == "event:hostname" end)
+
+    if length(hostname_filters) > 0 do
+      extra_filters =
+        query.dimensions
+        |> Enum.flat_map(&hostname_filters_for_dimension(&1, hostname_filters))
+
+      %Query{query | filters: query.filters ++ extra_filters}
+    else
+      query
+    end
+  end
+
+  defp hostname_filters_for_dimension(dimension, hostname_filters) do
+    if Map.has_key?(@dimensions_hostname_map, dimension) do
+      filter_key = Map.get(@dimensions_hostname_map, dimension)
+
+      hostname_filters
+      |> Enum.map(fn [operation, _filter_key | rest] -> [operation, filter_key | rest] end)
+    else
+      []
+    end
   end
 
   defp time_dimension(query) do

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -26,7 +26,8 @@ defmodule Plausible.Stats.QueryOptimizer do
 
   defp add_missing_order_by(query), do: query
 
-  defp missing_order_by(metrics, ["time" | dimensions]) do
+  defp missing_order_by(metrics, [time_dimension | dimensions])
+       when time_dimension in ["time", "time:hour", "time:day", "time:month"] do
     [{"time", :asc}] ++ missing_order_by(metrics, dimensions)
   end
 
@@ -42,7 +43,6 @@ defmodule Plausible.Stats.QueryOptimizer do
       cond do
         Timex.diff(last, first, :hours) <= 48 -> "time:hour"
         Timex.diff(last, first, :days) <= 14 -> "time:day"
-        Timex.diff(last, first, :weeks) <= 8 -> "time:week"
         Timex.diff(last, first, :months) < 24 -> "time:month"
         true -> "time:year"
       end

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -15,8 +15,8 @@ defmodule Plausible.Stats.QueryOptimizer do
 
   defp pipeline() do
     [
-      &add_missing_order_by/1,
-      &update_group_by_time/1
+      &update_group_by_time/1,
+      &add_missing_order_by/1
     ]
   end
 
@@ -27,8 +27,8 @@ defmodule Plausible.Stats.QueryOptimizer do
   defp add_missing_order_by(query), do: query
 
   defp missing_order_by(metrics, [time_dimension | dimensions])
-       when time_dimension in ["time", "time:hour", "time:day", "time:month"] do
-    [{"time", :asc}] ++ missing_order_by(metrics, dimensions)
+       when time_dimension in ["time:hour", "time:day", "time:month"] do
+    [{time_dimension, :asc}] ++ missing_order_by(metrics, dimensions)
   end
 
   defp missing_order_by([metric | _rest], _dimensions), do: [{metric, :desc}]
@@ -42,9 +42,8 @@ defmodule Plausible.Stats.QueryOptimizer do
     time_dimension =
       cond do
         Timex.diff(last, first, :hours) <= 48 -> "time:hour"
-        Timex.diff(last, first, :days) <= 14 -> "time:day"
-        Timex.diff(last, first, :months) < 24 -> "time:month"
-        true -> "time:year"
+        Timex.diff(last, first, :days) <= 40 -> "time:day"
+        true -> "time:month"
       end
 
     %Query{query | dimensions: [time_dimension | dimensions]}

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -15,7 +15,7 @@ defmodule Plausible.Stats.QueryResult do
       results
       |> Enum.map(fn entry ->
         %{
-          dimensions: Enum.map(query.dimensions, &map_dimension(&1, entry, query)),
+          dimensions: Enum.map(query.dimensions, &dimension_label(&1, entry, query)),
           metrics: Enum.map(query.metrics, &Map.get(entry, &1))
         }
       end)
@@ -44,17 +44,17 @@ defmodule Plausible.Stats.QueryResult do
 
   defp meta(_), do: %{}
 
-  defp map_dimension("event:goal", entry, query) do
+  defp dimension_label("event:goal", entry, query) do
     {events, paths} = Filters.Utils.split_goals(query.preloaded_goals)
 
+    # Closely coupled logic with Plausible.Stats.SQL.Expression.event_goal_join/2
     cond do
-      entry.goal == 0 -> "N/A"
       entry.goal < 0 -> Enum.at(events, -entry.goal - 1) |> Filters.Utils.unwrap_goal_value()
       entry.goal > 0 -> Enum.at(paths, entry.goal - 1) |> Filters.Utils.unwrap_goal_value()
     end
   end
 
-  defp map_dimension(dimension, entry, _query) do
+  defp dimension_label(dimension, entry, _query) do
     Map.get(entry, QueryBuilder.shortname(dimension))
   end
 

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -1,6 +1,7 @@
 defmodule Plausible.Stats.QueryResult do
   @moduledoc false
 
+  alias Plausible.Stats.Util
   alias Plausible.Stats.SQL.QueryBuilder
   alias Plausible.Stats.Filters
   alias Plausible.Stats.Query
@@ -54,8 +55,8 @@ defmodule Plausible.Stats.QueryResult do
     end
   end
 
-  defp dimension_label(dimension, entry, _query) do
-    Map.get(entry, QueryBuilder.shortname(dimension))
+  defp dimension_label(dimension, entry, query) do
+    Map.get(entry, Util.shortname(query, dimension))
   end
 
   defp serializable_filter([operation, "event:goal", clauses]) do

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -2,7 +2,6 @@ defmodule Plausible.Stats.QueryResult do
   @moduledoc false
 
   alias Plausible.Stats.Util
-  alias Plausible.Stats.SQL.QueryBuilder
   alias Plausible.Stats.Filters
   alias Plausible.Stats.Query
 

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -47,10 +47,12 @@ defmodule Plausible.Stats.QueryResult do
   defp dimension_label("event:goal", entry, query) do
     {events, paths} = Filters.Utils.split_goals(query.preloaded_goals)
 
+    goal_index = Map.get(entry, Util.shortname(query, "event:goal"))
+
     # Closely coupled logic with Plausible.Stats.SQL.Expression.event_goal_join/2
     cond do
-      entry.goal < 0 -> Enum.at(events, -entry.goal - 1) |> Filters.Utils.unwrap_goal_value()
-      entry.goal > 0 -> Enum.at(paths, entry.goal - 1) |> Filters.Utils.unwrap_goal_value()
+      goal_index < 0 -> Enum.at(events, -goal_index - 1) |> Filters.Utils.unwrap_goal_value()
+      goal_index > 0 -> Enum.at(paths, goal_index - 1) |> Filters.Utils.unwrap_goal_value()
     end
   end
 

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -89,4 +89,21 @@ defmodule Plausible.Stats.SQL.Expression do
   def dimension("visit:country", _query), do: dynamic([t], t.country)
   def dimension("visit:region", _query), do: dynamic([t], t.region)
   def dimension("visit:city", _query), do: dynamic([t], t.city)
+
+  defmacro event_goal_join(events, page_regexes) do
+    quote do
+      fragment(
+        """
+        arrayPushFront(
+          CAST(multiMatchAllIndices(?, ?) AS Array(Int64)),
+          -indexOf(?, ?)
+        )
+        """,
+        e.pathname,
+        type(^unquote(page_regexes), {:array, :string}),
+        type(^unquote(events), {:array, :string}),
+        e.name
+      )
+    end
+  end
 end

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -1,5 +1,8 @@
 defmodule Plausible.Stats.SQL.Expression do
-  @moduledoc false
+  @moduledoc """
+  This module is responsible for generating SQL/Ecto expressions
+  for dimensions used in query select, group_by and order_by.
+  """
 
   import Ecto.Query
 

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -140,7 +140,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   end
 
   defp build_order_by(q, query, mode) do
-    Enum.reduce(query.order_by, q, &build_order_by(&2, query, &1, mode))
+    Enum.reduce(query.order_by || [], q, &build_order_by(&2, query, &1, mode))
   end
 
   def build_order_by(q, query, {metric_or_dimension, order_direction}, :inner) do

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -25,6 +25,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   end
 
   def shortname(metric) when is_atom(metric), do: metric
+  def shortname("time:" <> _), do: :time
   def shortname(dimension), do: Plausible.Stats.Filters.without_prefix(dimension)
 
   defp build_events_query(_, _, []), do: nil

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -233,6 +233,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
         query
         |> Query.remove_filters(["event:goal", "event:props"])
         |> Query.set_metrics([:visitors])
+        |> Query.set_order_by([])
 
       from(e in subquery(q),
         left_join: c in subquery(build(group_totals_query, site)),
@@ -240,11 +241,14 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
         select_merge: %{
           total_visitors: c.visitors,
           group_conversion_rate:
-            fragment(
-              "if(? > 0, round(? / ? * 100, 1), 0)",
-              c.visitors,
-              e.visitors,
-              c.visitors
+            selected_as(
+              fragment(
+                "if(? > 0, round(? / ? * 100, 1), 0)",
+                c.visitors,
+                e.visitors,
+                c.visitors
+              ),
+              :group_conversion_rate
             )
         }
       )

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -199,7 +199,6 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
         |> Query.remove_filters(["event:goal", "event:props"])
         |> Query.set_dimensions([])
 
-      # :TRICKY: Subquery is used due to event:goal breakdown above doing an UNION ALL
       q
       |> select_merge(
         ^%{
@@ -223,6 +222,17 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     end
   end
 
+  # This function injects a group_conversion_rate metric into
+  # a dimensional query. It is calculated as X / Y, where:
+  #
+  #   * X is the number of conversions for a set of dimensions
+  #     result (conversion = number of visitors who
+  #     completed the filtered goal with the filtered
+  #     custom properties).
+  #
+  #  * Y is the number of all visitors for this set of dimensions
+  #    result without the `event:goal` and `event:props:*`
+  #    filters.
   def maybe_add_group_conversion_rate(q, site, query, event_metrics) do
     if :group_conversion_rate in query.metrics do
       group_totals_query =

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -114,16 +114,16 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     Enum.reduce(query.dimensions, q, &dimension_group_by(&2, query, &1))
   end
 
-  defp dimension_group_by(q, query, "event:goal") do
+  defp dimension_group_by(q, query, "event:goal" = dimension) do
     {events, page_regexes} = Filters.Utils.split_goals_query_expressions(query.preloaded_goals)
 
     from(e in q,
       array_join: goal in Expression.event_goal_join(events, page_regexes),
-      group_by: goal,
-      where: goal != 0,
       select_merge: %{
-        goal: fragment("?", goal)
-      }
+        ^shortname(query, dimension) => fragment("?", goal)
+      },
+      group_by: goal,
+      where: goal != 0
     )
   end
 

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -5,51 +5,45 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
 
   import Ecto.Query
   import Plausible.Stats.Imported
+  import Plausible.Stats.Util
 
-  alias Plausible.Stats.{Base, Query, TableDecider, Util, Filters, Metrics}
+  alias Plausible.Stats.{Base, Query, QueryOptimizer, TableDecider, Filters, Metrics}
   alias Plausible.Stats.SQL.Expression
 
   require Plausible.Stats.SQL.Expression
 
   def build(query, site) do
-    {event_metrics, sessions_metrics, _other_metrics} =
-      query.metrics
-      |> Util.maybe_add_visitors_metric()
-      |> TableDecider.partition_metrics(query)
+    {event_query, sessions_query} = QueryOptimizer.split(query)
+
+    event_q = build_events_query(site, event_query)
+    sessions_q = build_sessions_query(site, sessions_query)
 
     join_query_results(
-      build_events_query(site, query, event_metrics),
-      event_metrics,
-      build_sessions_query(site, query, sessions_metrics),
-      sessions_metrics,
-      query
+      {event_q, event_query},
+      {sessions_q, sessions_query}
     )
   end
 
-  def shortname(metric) when is_atom(metric), do: metric
-  def shortname("time:" <> _), do: :time
-  def shortname(dimension), do: Plausible.Stats.Filters.without_prefix(dimension)
+  defp build_events_query(_site, %Query{metrics: []}), do: nil
 
-  defp build_events_query(_, _, []), do: nil
-
-  defp build_events_query(site, query, event_metrics) do
+  defp build_events_query(site, events_query) do
     q =
       from(
         e in "events_v2",
-        where: ^Filters.WhereBuilder.build(:events, site, query),
-        select: ^Base.select_event_metrics(event_metrics)
+        where: ^Filters.WhereBuilder.build(:events, site, events_query),
+        select: ^Base.select_event_metrics(events_query.metrics)
       )
 
     on_ee do
-      q = Plausible.Stats.Sampling.add_query_hint(q, query)
+      q = Plausible.Stats.Sampling.add_query_hint(q, events_query)
     end
 
     q
-    |> join_sessions_if_needed(site, query)
-    |> build_group_by(query)
-    |> merge_imported(site, query, event_metrics)
-    |> maybe_add_global_conversion_rate(site, query)
-    |> maybe_add_group_conversion_rate(site, query, event_metrics)
+    |> join_sessions_if_needed(site, events_query)
+    |> build_group_by(events_query)
+    |> merge_imported(site, events_query, events_query.metrics)
+    |> maybe_add_global_conversion_rate(site, events_query)
+    |> maybe_add_group_conversion_rate(site, events_query)
   end
 
   defp join_sessions_if_needed(q, site, query) do
@@ -72,24 +66,24 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     end
   end
 
-  def build_sessions_query(_, _, []), do: nil
+  defp build_sessions_query(_site, %Query{metrics: []}), do: nil
 
-  def build_sessions_query(site, query, session_metrics) do
+  defp build_sessions_query(site, sessions_query) do
     q =
       from(
         e in "sessions_v2",
-        where: ^Filters.WhereBuilder.build(:sessions, site, query),
-        select: ^Base.select_session_metrics(session_metrics, query)
+        where: ^Filters.WhereBuilder.build(:sessions, site, sessions_query),
+        select: ^Base.select_session_metrics(sessions_query.metrics, sessions_query)
       )
 
     on_ee do
-      q = Plausible.Stats.Sampling.add_query_hint(q, query)
+      q = Plausible.Stats.Sampling.add_query_hint(q, sessions_query)
     end
 
     q
-    |> join_events_if_needed(site, query)
-    |> build_group_by(query)
-    |> merge_imported(site, query, session_metrics)
+    |> join_events_if_needed(site, sessions_query)
+    |> build_group_by(sessions_query)
+    |> merge_imported(site, sessions_query, sessions_query.metrics)
   end
 
   def join_events_if_needed(q, site, query) do
@@ -135,7 +129,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
 
   defp dimension_group_by(q, query, dimension) do
     q
-    |> select_merge(^%{shortname(dimension) => Expression.dimension(dimension, query)})
+    |> select_merge(^%{shortname(query, dimension) => Expression.dimension(dimension, query)})
     |> group_by(^Expression.dimension(dimension, query))
   end
 
@@ -151,36 +145,36 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
         order_direction,
         if(
           Metrics.metric?(metric_or_dimension),
-          do: dynamic([], selected_as(^shortname(metric_or_dimension))),
+          do: dynamic([], selected_as(^shortname(query, metric_or_dimension))),
           else: Expression.dimension(metric_or_dimension, query)
         )
       }
     )
   end
 
-  def build_order_by(q, _query, {metric_or_dimension, order_direction}, :outer) do
+  def build_order_by(q, query, {metric_or_dimension, order_direction}, :outer) do
     order_by(
       q,
       [t],
       ^{
         order_direction,
-        dynamic([], selected_as(^shortname(metric_or_dimension)))
+        dynamic([], selected_as(^shortname(query, metric_or_dimension)))
       }
     )
   end
 
-  defmacrop select_join_fields(q, list, table_name) do
+  defmacrop select_join_fields(q, query, list, table_name) do
     quote do
       Enum.reduce(unquote(list), unquote(q), fn metric_or_dimension, q ->
         select_merge(
           q,
           ^%{
-            shortname(metric_or_dimension) =>
+            shortname(unquote(query), metric_or_dimension) =>
               dynamic(
                 [e, s],
                 selected_as(
-                  field(unquote(table_name), ^shortname(metric_or_dimension)),
-                  ^shortname(metric_or_dimension)
+                  field(unquote(table_name), ^shortname(unquote(query), metric_or_dimension)),
+                  ^shortname(unquote(query), metric_or_dimension)
                 )
               )
           }
@@ -233,7 +227,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   #  * Y is the number of all visitors for this set of dimensions
   #    result without the `event:goal` and `event:props:*`
   #    filters.
-  def maybe_add_group_conversion_rate(q, site, query, event_metrics) do
+  def maybe_add_group_conversion_rate(q, site, query) do
     if :group_conversion_rate in query.metrics do
       group_totals_query =
         query
@@ -254,29 +248,29 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
             )
         }
       )
-      |> select_join_fields(query.dimensions, e)
-      |> select_join_fields(List.delete(event_metrics, :group_conversion_rate), e)
+      |> select_join_fields(query, query.dimensions, e)
+      |> select_join_fields(query, List.delete(query.metrics, :group_conversion_rate), e)
     else
       q
     end
   end
 
-  defp join_query_results(nil, _, nil, _, _query), do: nil
+  defp join_query_results({nil, _}, {nil, _}), do: nil
 
-  defp join_query_results(events_q, _, nil, _, query),
-    do: events_q |> build_order_by(query, :inner)
+  defp join_query_results({events_q, events_query}, {nil, _}),
+    do: events_q |> build_order_by(events_query, :inner)
 
-  defp join_query_results(nil, _, sessions_q, _, query),
-    do: sessions_q |> build_order_by(query, :inner)
+  defp join_query_results({nil, _}, {sessions_q, sessions_query}),
+    do: sessions_q |> build_order_by(sessions_query, :inner)
 
-  defp join_query_results(events_q, event_metrics, sessions_q, sessions_metrics, query) do
+  defp join_query_results({events_q, events_query}, {sessions_q, sessions_query}) do
     join(subquery(events_q), :left, [e], s in subquery(sessions_q),
-      on: ^build_group_by_join(query)
+      on: ^build_group_by_join(events_query)
     )
-    |> select_join_fields(query.dimensions, e)
-    |> select_join_fields(event_metrics, e)
-    |> select_join_fields(List.delete(sessions_metrics, :sample_percent), s)
-    |> build_order_by(query, :outer)
+    |> select_join_fields(events_query, events_query.dimensions, e)
+    |> select_join_fields(events_query, events_query.metrics, e)
+    |> select_join_fields(sessions_query, List.delete(sessions_query.metrics, :sample_percent), s)
+    |> build_order_by(events_query, :outer)
   end
 
   defp build_group_by_join(%Query{dimensions: []}), do: true
@@ -284,7 +278,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   defp build_group_by_join(query) do
     query.dimensions
     |> Enum.map(fn dim ->
-      dynamic([e, s], field(e, ^shortname(dim)) == field(s, ^shortname(dim)))
+      dynamic([e, s], field(e, ^shortname(query, dim)) == field(s, ^shortname(query, dim)))
     end)
     |> Enum.reduce(fn condition, acc -> dynamic([], ^acc and ^condition) end)
   end

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -14,11 +14,6 @@ defmodule Plausible.Stats.TableDecider do
     |> Enum.any?(&(filters_partitioner(query, &1) == :session))
   end
 
-  def event_dimensions?(query) do
-    query.dimensions
-    |> Enum.any?(&(filters_partitioner(query, &1) == :event))
-  end
-
   def partition_metrics(metrics, query) do
     %{
       event: event_only_metrics,

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -14,9 +14,8 @@ defmodule Plausible.Stats.TableDecider do
     |> Enum.any?(&(filters_partitioner(query, &1) == :session))
   end
 
-  def event_filters?(query) do
-    query
-    |> filter_keys()
+  def event_dimensions?(query) do
+    query.dimensions
     |> Enum.any?(&(filters_partitioner(query, &1) == :event))
   end
 

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -63,6 +63,7 @@ defmodule Plausible.Stats.TableDecider do
   end
 
   defp metric_partitioner(_, :conversion_rate), do: :event
+  defp metric_partitioner(_, :group_conversion_rate), do: :event
   defp metric_partitioner(_, :average_revenue), do: :event
   defp metric_partitioner(_, :total_revenue), do: :event
   defp metric_partitioner(_, :pageviews), do: :event

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -41,7 +41,8 @@ defmodule Plausible.Stats.Util do
   for any of the other metrics to be calculated.
   """
   def maybe_add_visitors_metric(metrics) do
-    needed? = Enum.any?([:conversion_rate, :time_on_page], &(&1 in metrics))
+    needed? =
+      Enum.any?([:conversion_rate, :group_conversion_rate, :time_on_page], &(&1 in metrics))
 
     if needed? and :visitors not in metrics do
       metrics ++ [:visitors]

--- a/lib/plausible/stats/util.ex
+++ b/lib/plausible/stats/util.ex
@@ -49,4 +49,12 @@ defmodule Plausible.Stats.Util do
       metrics
     end
   end
+
+  def shortname(_query, metric) when is_atom(metric), do: metric
+  def shortname(_query, "time:" <> _), do: :time
+
+  def shortname(query, dimension) do
+    index = Enum.find_index(query.dimensions, &(&1 == dimension))
+    :"dim#{index}"
+  end
 end

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -1,0 +1,101 @@
+defmodule Plausible.Stats.IntervalTest do
+  use Plausible.DataCase, async: true
+
+  alias Plausible.Stats.{Query, QueryOptimizer}
+
+  @default_params %{metrics: [:visitors]}
+
+  def perform(params) do
+    params = Map.merge(@default_params, params) |> Map.to_list()
+    struct!(Query, params) |> QueryOptimizer.optimize()
+  end
+
+  describe "add_missing_order_by" do
+    test "does nothing if order_by passed" do
+      assert perform(%{order_by: [visitors: :desc]}).order_by == [{:visitors, :desc}]
+    end
+
+    test "adds first metric to order_by if order_by not specified" do
+      assert perform(%{metrics: [:pageviews, :visitors]}).order_by == [{:pageviews, :desc}]
+
+      assert perform(%{metrics: [:pageviews, :visitors], dimensions: ["event:page"]}).order_by ==
+               [{:pageviews, :desc}]
+    end
+
+    test "adds time and first metric to order_by if order_by not specified" do
+      assert perform(%{metrics: [:pageviews, :visitors], dimensions: ["time", "event:page"]}).order_by ==
+               [{"time", :asc}, {:pageviews, :desc}]
+    end
+  end
+
+  describe "update_group_by_time" do
+    test "does nothing if `time` dimension not passed" do
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-05 00:00:00]),
+               dimensions: ["time:month"]
+             }).dimensions == ["time:month"]
+    end
+
+    test "updating time dimension" do
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-01 05:00:00]),
+               dimensions: ["time"]
+             }).dimensions == ["time:hour"]
+
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-02 00:00:00]),
+               dimensions: ["time"]
+             }).dimensions == ["time:hour"]
+
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-02 16:00:00]),
+               dimensions: ["time"]
+             }).dimensions == ["time:hour"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-01-04]),
+               dimensions: ["time"]
+             }).dimensions == ["time:day"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-01-10]),
+               dimensions: ["time"]
+             }).dimensions == ["time:day"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-01-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:week"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-02-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:week"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-03-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:month"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2022-03-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:month"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2023-11-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:month"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2024-01-16]),
+               dimensions: ["time"]
+             }).dimensions == ["time:year"]
+
+      assert perform(%{
+               date_range: Date.range(~D[2022-01-01], ~D[2026-01-01]),
+               dimensions: ["time"]
+             }).dimensions == ["time:year"]
+    end
+  end
+end

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -65,12 +65,12 @@ defmodule Plausible.Stats.IntervalTest do
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2022-01-16]),
                dimensions: ["time"]
-             }).dimensions == ["time:week"]
+             }).dimensions == ["time:month"]
 
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2022-02-16]),
                dimensions: ["time"]
-             }).dimensions == ["time:week"]
+             }).dimensions == ["time:month"]
 
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2022-03-16]),

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -112,4 +112,36 @@ defmodule Plausible.Stats.IntervalTest do
              }).order_by == [{"time:hour", :asc}]
     end
   end
+
+  describe "extend_hostname_filters_to_visit" do
+    test "updates filters it filtering by event:hostname and visit:referrer and visit:exit_page dimensions" do
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-01 05:00:00]),
+               filters: [
+                 [:is, "event:hostname", ["example.com"]],
+                 [:matches, "event:hostname", ["*.com"]]
+               ],
+               dimensions: ["visit:referrer", "visit:exit_page"]
+             }).filters == [
+               [:is, "event:hostname", ["example.com"]],
+               [:matches, "event:hostname", ["*.com"]],
+               [:is, "visit:entry_page_hostname", ["example.com"]],
+               [:matches, "visit:entry_page_hostname", ["*.com"]],
+               [:is, "visit:exit_page_hostname", ["example.com"]],
+               [:matches, "visit:exit_page_hostname", ["*.com"]]
+             ]
+    end
+
+    test "does not update filters if not needed" do
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-01 05:00:00]),
+               filters: [
+                 [:is, "event:hostname", ["example.com"]]
+               ],
+               dimensions: ["time", "event:hostname"]
+             }).filters == [
+               [:is, "event:hostname", ["example.com"]]
+             ]
+    end
+  end
 end

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -102,4 +102,14 @@ defmodule Plausible.Stats.IntervalTest do
              }).dimensions == ["time:month"]
     end
   end
+
+  describe "update_time_in_order_by" do
+    test "updates explicit time dimension in order_by" do
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-01-01 05:00:00]),
+               dimensions: ["time:hour"],
+               order_by: [{"time", :asc}]
+             }).order_by == [{"time:hour", :asc}]
+    end
+  end
 end

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -23,8 +23,12 @@ defmodule Plausible.Stats.IntervalTest do
     end
 
     test "adds time and first metric to order_by if order_by not specified" do
-      assert perform(%{metrics: [:pageviews, :visitors], dimensions: ["time", "event:page"]}).order_by ==
-               [{"time", :asc}, {:pageviews, :desc}]
+      assert perform(%{
+               date_range: Date.range(~N[2022-01-01 00:00:00], ~N[2022-02-01 00:00:00]),
+               metrics: [:pageviews, :visitors],
+               dimensions: ["time", "event:page"]
+             }).order_by ==
+               [{"time:day", :asc}, {:pageviews, :desc}]
     end
   end
 
@@ -65,7 +69,7 @@ defmodule Plausible.Stats.IntervalTest do
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2022-01-16]),
                dimensions: ["time"]
-             }).dimensions == ["time:month"]
+             }).dimensions == ["time:day"]
 
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2022-02-16]),
@@ -90,12 +94,12 @@ defmodule Plausible.Stats.IntervalTest do
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2024-01-16]),
                dimensions: ["time"]
-             }).dimensions == ["time:year"]
+             }).dimensions == ["time:month"]
 
       assert perform(%{
                date_range: Date.range(~D[2022-01-01], ~D[2026-01-01]),
                dimensions: ["time"]
-             }).dimensions == ["time:year"]
+             }).dimensions == ["time:month"]
     end
   end
 end

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -1,4 +1,4 @@
-defmodule Plausible.Stats.IntervalTest do
+defmodule Plausible.Stats.QueryOptimizerTest do
   use Plausible.DataCase, async: true
 
   alias Plausible.Stats.{Query, QueryOptimizer}

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -6,15 +6,29 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
 
   setup [:create_user, :create_new_site]
 
-  @date_range Date.range(Timex.today(), Timex.today())
+  @today ~D[2021-05-05]
+  @date_range Date.range(@today, @today)
 
   def check_success(params, site, expected_result) do
-    assert parse(site, params) == {:ok, expected_result}
+    assert parse(site, params, @today) == {:ok, expected_result}
   end
 
   def check_error(params, site, expected_error_message) do
-    {:error, message} = parse(site, params)
+    {:error, message} = parse(site, params, @today)
     assert message =~ expected_error_message
+  end
+
+  def check_date_range(date_range, site, expected_date_range) do
+    %{"metrics" => ["visitors", "events"], "date_range" => date_range}
+    |> check_success(site, %{
+      metrics: [:visitors, :events],
+      date_range: expected_date_range,
+      filters: [],
+      dimensions: [],
+      order_by: nil,
+      timezone: site.timezone,
+      imported_data_requested: false
+    })
   end
 
   test "parsing empty map fails", %{site: site} do
@@ -303,6 +317,42 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
   end
 
   describe "date range validation" do
+    test "parsing shortcut options", %{site: site} do
+      check_date_range("day", site, Date.range(~D[2021-05-05], ~D[2021-05-05]))
+      check_date_range("7d", site, Date.range(~D[2021-04-29], ~D[2021-05-05]))
+      check_date_range("30d", site, Date.range(~D[2021-04-05], ~D[2021-05-05]))
+      check_date_range("month", site, Date.range(~D[2021-05-01], ~D[2021-05-31]))
+      check_date_range("6mo", site, Date.range(~D[2020-12-01], ~D[2021-05-31]))
+      check_date_range("12mo", site, Date.range(~D[2020-06-01], ~D[2021-05-31]))
+      check_date_range("year", site, Date.range(~D[2021-01-01], ~D[2021-12-31]))
+    end
+
+    test "parsing `all` with previous data", %{site: site} do
+      site = Map.put(site, :stats_start_date, ~D[2020-01-01])
+      check_date_range("all", site, Date.range(~D[2020-01-01], ~D[2021-05-05]))
+    end
+
+    test "parsing `all` with no previous data", %{site: site} do
+      site = Map.put(site, :stats_start_date, nil)
+
+      check_date_range("all", site, Date.range(~D[2021-05-05], ~D[2021-05-05]))
+    end
+
+    test "parsing custom date range", %{site: site} do
+      check_date_range(
+        ["2021-05-05", "2021-05-05"],
+        site,
+        Date.range(~D[2021-05-05], ~D[2021-05-05])
+      )
+    end
+
+    test "parsing invalid custom date range", %{site: site} do
+      %{"date_range" => "foo", "metrics" => ["visitors"]}
+      |> check_error(site, ~r/Invalid date_range '\"foo\"'/)
+
+      %{"date_range" => ["21415-00", "eee"], "metrics" => ["visitors"]}
+      |> check_error(site, ~r/Invalid date_range /)
+    end
   end
 
   describe "dimensions validation" do

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -27,7 +27,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       dimensions: [],
       order_by: nil,
       timezone: site.timezone,
-      imported_data_requested: false
+      imported_data_requested: false,
+      preloaded_goals: []
     })
   end
 
@@ -46,7 +47,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -83,7 +85,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -112,7 +115,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          imported_data_requested: false
+          imported_data_requested: false,
+          preloaded_goals: []
         })
       end
 
@@ -156,7 +160,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -179,7 +184,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
             dimensions: [],
             order_by: nil,
             timezone: site.timezone,
-            imported_data_requested: false
+            imported_data_requested: false,
+            preloaded_goals: []
           })
         end
       end
@@ -203,7 +209,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          imported_data_requested: false
+          imported_data_requested: false,
+          preloaded_goals: []
         })
       end
     end
@@ -254,7 +261,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: true
+        imported_data_requested: true,
+        preloaded_goals: []
       })
     end
 
@@ -289,7 +297,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: [{:page, "/thank-you"}, {:event, "Signup"}]
       })
     end
 
@@ -370,7 +379,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:#{unquote(dimension)}"],
           order_by: nil,
           timezone: site.timezone,
-          imported_data_requested: false
+          imported_data_requested: false,
+          preloaded_goals: []
         })
       end
     end
@@ -389,7 +399,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["visit:#{unquote(dimension)}"],
           order_by: nil,
           timezone: site.timezone,
-          imported_data_requested: false
+          imported_data_requested: false,
+          preloaded_goals: []
         })
       end
     end
@@ -407,7 +418,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:props:foobar"],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -462,7 +474,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: [{:events, :desc}, {:visitors, :asc}],
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -480,7 +493,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:name"],
         order_by: [{"event:name", :desc}],
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -575,7 +589,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: [event: "Signup"]
       })
     end
 
@@ -594,7 +609,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:goal"],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: [event: "Signup"]
       })
     end
   end
@@ -615,7 +631,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: [event: "Signup"]
       })
     end
 
@@ -658,7 +675,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["visit:device"],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
 
@@ -687,7 +705,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        imported_data_requested: false
+        imported_data_requested: false,
+        preloaded_goals: []
       })
     end
   end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -692,6 +692,24 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       )
     end
 
+    test "does not fail if using session metric with event:page dimension", %{site: site} do
+      %{
+        "metrics" => ["bounce_rate"],
+        "date_range" => "all",
+        "dimensions" => ["event:page"]
+      }
+      |> check_success(site, %{
+        metrics: [:bounce_rate],
+        date_range: @date_range,
+        filters: [],
+        dimensions: ["event:page"],
+        order_by: nil,
+        timezone: site.timezone,
+        imported_data_requested: false,
+        preloaded_goals: []
+      })
+    end
+
     test "does not fail if using session metric with event filter", %{site: site} do
       %{
         "metrics" => ["bounce_rate"],

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -579,16 +579,21 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       )
     end
 
-    test "fails if using session metric with event filter", %{site: site} do
+    test "does not fail if using session metric with event filter", %{site: site} do
       %{
         "metrics" => ["bounce_rate"],
         "date_range" => "all",
         "filters" => [["is", "event:props:foo", ["(none)"]]]
       }
-      |> check_error(
-        site,
-        "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
-      )
+      |> check_success(site, %{
+        metrics: [:bounce_rate],
+        date_range: @date_range,
+        filters: [[:is, "event:props:foo", ["(none)"]]],
+        dimensions: [],
+        order_by: nil,
+        timezone: site.timezone,
+        imported_data_requested: false
+      })
     end
   end
 end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -575,7 +575,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
+        "Session metric(s) `bounce_rate` cannot be queried along with event dimensions"
       )
     end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3541,67 +3541,54 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       assert results == [%{"dimensions" => ["Mobile"], "metrics" => [4, 6]}]
     end
 
-    # :TODO: Imports with event:goal breakdown
-    # test "returns custom event goals and pageview goals", %{conn: conn, site: site} do
-    #   insert(:goal, site: site, event_name: "Purchase")
-    #   insert(:goal, site: site, page_path: "/test")
+    test "returns custom event goals and pageview goals", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, page_path: "/test")
 
-    #   site_import = insert(:site_import, site: site)
+      site_import = insert(:site_import, site: site)
 
-    #   populate_stats(site, site_import.id, [
-    #     build(:pageview,
-    #       timestamp: ~N[2021-01-01 00:00:01],
-    #       pathname: "/test"
-    #     ),
-    #     build(:event,
-    #       name: "Purchase",
-    #       timestamp: ~N[2021-01-01 00:00:03]
-    #     ),
-    #     build(:event,
-    #       name: "Purchase",
-    #       timestamp: ~N[2021-01-01 00:00:03]
-    #     ),
-    #     build(:imported_custom_events,
-    #       name: "Purchase",
-    #       visitors: 3,
-    #       events: 5,
-    #       date: ~D[2021-01-01]
-    #     ),
-    #     build(:imported_pages,
-    #       page: "/test",
-    #       visitors: 2,
-    #       pageviews: 2,
-    #       date: ~D[2021-01-01]
-    #     ),
-    #     build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
-    #   ])
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
 
-    #   conn =
-    #     post(conn, "/api/v2/query", %{
-    #       "site_id" => site.domain,
-    #       "date_range" => "all",
-    #       "dimensions" => ["event:goal"],
-    #       "metrics" => ["visitors", "events", "pageviews", "conversion_rate"],
-    #       "include" => %{"imports" => true}
-    #     })
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "dimensions" => ["event:goal"],
+          "metrics" => ["visitors", "events", "pageviews", "conversion_rate"],
+          "include" => %{"imports" => true}
+        })
 
-    #   assert json_response(conn, 200)["results"] == [
-    #            %{
-    #              "goal" => "Purchase",
-    #              "visitors" => 5,
-    #              "events" => 7,
-    #              "pageviews" => 0,
-    #              "conversion_rate" => 62.5
-    #            },
-    #            %{
-    #              "goal" => "Visit /test",
-    #              "visitors" => 3,
-    #              "events" => 3,
-    #              "pageviews" => 3,
-    #              "conversion_rate" => 37.5
-    #            }
-    #          ]
-    # end
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["Purchase"], "metrics" => [5, 7, 0, 62.5]},
+               %{"dimensions" => ["Visit /test"], "metrics" => [3, 3, 3, 37.5]}
+             ]
+    end
 
     test "pageviews are returned as events for breakdown reports other than custom events", %{
       conn: conn,

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -156,7 +156,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       assert json_response(conn, 400)["error"] =~ "Unknown metric '\"baa\"'"
     end
 
-    test "session metrics cannot be used with event:name property", %{conn: conn, site: site} do
+    test "session metrics cannot be used with event:name dimension", %{conn: conn, site: site} do
       conn =
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
@@ -169,29 +169,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
                "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
     end
 
-    test "session metrics cannot be used with event:props:* property", %{conn: conn, site: site} do
+    test "session metrics cannot be used with event:props:* dimension", %{conn: conn, site: site} do
       conn =
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "bounce_rate"],
           "date_range" => "all",
           "dimensions" => ["event:props:url"]
-        })
-
-      assert json_response(conn, 400)["error"] =~
-               "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
-    end
-
-    test "session metrics cannot be used with event:name filter", %{conn: conn, site: site} do
-      conn =
-        post(conn, "/api/v2/query", %{
-          "site_id" => site.domain,
-          "metrics" => ["visitors", "bounce_rate"],
-          "date_range" => "all",
-          "dimensions" => ["visit:device"],
-          "filters" => [
-            ["is", "event:name", ["pageview"]]
-          ]
         })
 
       assert json_response(conn, 400)["error"] =~

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -1778,33 +1778,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   #          }
   # end
 
-  # test "breakdown by event:page when there are no events in the second page", %{
-  #   conn: conn,
-  #   site: site
-  # } do
-  #   populate_stats(site, [
-  #     build(:pageview, pathname: "/", timestamp: ~N[2021-01-01 00:00:00]),
-  #     build(:pageview, pathname: "/", timestamp: ~N[2021-01-01 00:25:00]),
-  #     build(:pageview,
-  #       pathname: "/plausible.io",
-  #       timestamp: ~N[2021-01-01 00:00:00]
-  #     )
-  #   ])
-
-  #   conn =
-  #     get(conn, "/api/v1/stats/breakdown", %{
-  #       "site_id" => site.domain,
-  #       "period" => "day",
-  #       "date" => "2021-01-01",
-  #       "property" => "event:page",
-  #       "metrics" => "visitors,bounce_rate",
-  #       "page" => 2,
-  #       "limit" => 2
-  #     })
-
-  #   assert json_response(conn, 200) == %{"results" => []}
-  # end
-
   test "attempting to breakdown by event:hostname returns an error", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview, hostname: "a.example.com"),
@@ -2334,183 +2307,87 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
                %{"dimensions" => ["(none)"], "metrics" => [1]}
              ]
     end
-
-    #   test "breakdown by custom event property, limited", %{conn: conn, site: site} do
-    #     populate_stats(site, [
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["16"],
-    #         timestamp: ~N[2021-01-01 00:00:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["18"],
-    #         timestamp: ~N[2021-01-01 00:25:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["14"],
-    #         timestamp: ~N[2021-01-01 00:25:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["14"],
-    #         timestamp: ~N[2021-01-01 00:26:00]
-    #       )
-    #     ])
-
-    #     conn =
-    #       get(conn, "/api/v1/stats/breakdown", %{
-    #         "site_id" => site.domain,
-    #         "period" => "day",
-    #         "date" => "2021-01-01",
-    #         "property" => "event:props:cost",
-    #         "filters" => "event:name==Purchase",
-    #         "limit" => 2
-    #       })
-
-    #     assert json_response(conn, 200) == %{
-    #              "results" => [
-    #                %{"cost" => "14", "visitors" => 2},
-    #                %{"cost" => "16", "visitors" => 1}
-    #              ]
-    #            }
-    #   end
-
-    #   test "breakdown by custom event property, paginated", %{conn: conn, site: site} do
-    #     populate_stats(site, [
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["16"],
-    #         timestamp: ~N[2021-01-01 00:00:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["16"],
-    #         timestamp: ~N[2021-01-01 00:00:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["18"],
-    #         timestamp: ~N[2021-01-01 00:25:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["14"],
-    #         timestamp: ~N[2021-01-01 00:25:00]
-    #       ),
-    #       build(:event,
-    #         name: "Purchase",
-    #         "meta.key": ["cost"],
-    #         "meta.value": ["14"],
-    #         timestamp: ~N[2021-01-01 00:26:00]
-    #       )
-    #     ])
-
-    #     conn =
-    #       get(conn, "/api/v1/stats/breakdown", %{
-    #         "site_id" => site.domain,
-    #         "period" => "day",
-    #         "date" => "2021-01-01",
-    #         "property" => "event:props:cost",
-    #         "filters" => "event:name==Purchase",
-    #         "limit" => 2,
-    #         "page" => 2
-    #       })
-
-    #     assert json_response(conn, 200) == %{
-    #              "results" => [
-    #                %{"cost" => "18", "visitors" => 1}
-    #              ]
-    #            }
-    #   end
   end
 
-  # describe "breakdown by event:goal" do
-  #   test "returns custom event goals and pageview goals", %{conn: conn, site: site} do
-  #     insert(:goal, %{site: site, event_name: "Purchase"})
-  #     insert(:goal, %{site: site, page_path: "/test"})
+  describe "breakdown by event:goal" do
+    test "returns custom event goals and pageview goals", %{conn: conn, site: site} do
+      insert(:goal, %{site: site, event_name: "Purchase"})
+      insert(:goal, %{site: site, page_path: "/test"})
 
-  #     populate_stats(site, [
-  #       build(:pageview,
-  #         timestamp: ~N[2021-01-01 00:00:01],
-  #         pathname: "/test"
-  #       ),
-  #       build(:event,
-  #         name: "Purchase",
-  #         timestamp: ~N[2021-01-01 00:00:03]
-  #       ),
-  #       build(:event,
-  #         name: "Purchase",
-  #         timestamp: ~N[2021-01-01 00:00:03]
-  #       )
-  #     ])
+      populate_stats(site, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        )
+      ])
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "period" => "day",
-  #         "date" => "2021-01-01",
-  #         "property" => "event:goal"
-  #       })
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["visitors"],
+          "dimensions" => ["event:goal"]
+        })
 
-  #     assert [
-  #              %{"goal" => "Purchase", "visitors" => 2},
-  #              %{"goal" => "Visit /test", "visitors" => 1}
-  #            ] = json_response(conn, 200)["results"]
-  #   end
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["Purchase"], "metrics" => [2]},
+               %{"dimensions" => ["Visit /test"], "metrics" => [1]}
+             ]
+    end
 
-  #   test "returns pageview goals containing wildcards", %{conn: conn, site: site} do
-  #     insert(:goal, %{site: site, page_path: "/**/post"})
-  #     insert(:goal, %{site: site, page_path: "/blog**"})
+    test "returns pageview goals containing wildcards", %{conn: conn, site: site} do
+      insert(:goal, %{site: site, page_path: "/**/post"})
+      insert(:goal, %{site: site, page_path: "/blog**"})
 
-  #     populate_stats(site, [
-  #       build(:pageview, pathname: "/blog", user_id: @user_id),
-  #       build(:pageview, pathname: "/blog/post-1", user_id: @user_id),
-  #       build(:pageview, pathname: "/blog/post-2", user_id: @user_id),
-  #       build(:pageview, pathname: "/blog/something/post"),
-  #       build(:pageview, pathname: "/different/page/post")
-  #     ])
+      populate_stats(site, [
+        build(:pageview, pathname: "/blog", user_id: @user_id),
+        build(:pageview, pathname: "/blog/post-1", user_id: @user_id),
+        build(:pageview, pathname: "/blog/post-2", user_id: @user_id),
+        build(:pageview, pathname: "/blog/something/post"),
+        build(:pageview, pathname: "/different/page/post")
+      ])
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "metrics" => "visitors,pageviews",
-  #         "property" => "event:goal"
-  #       })
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["visitors", "pageviews"],
+          "dimensions" => ["event:goal"],
+          "order_by" => [["pageviews", "desc"]]
+        })
 
-  #     assert [
-  #              %{"goal" => "Visit /**/post", "visitors" => 2, "pageviews" => 2},
-  #              %{"goal" => "Visit /blog**", "visitors" => 2, "pageviews" => 4}
-  #            ] = json_response(conn, 200)["results"]
-  #   end
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 4]},
+               %{"dimensions" => ["Visit /**/post"], "metrics" => [2, 2]}
+             ]
+    end
 
-  #   test "does not return goals that are not configured for the site", %{conn: conn, site: site} do
-  #     populate_stats(site, [
-  #       build(:pageview, pathname: "/register"),
-  #       build(:event, name: "Signup")
-  #     ])
+    test "does not return goals that are not configured for the site", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/register"),
+        build(:event, name: "Signup")
+      ])
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "metrics" => "visitors,pageviews",
-  #         "property" => "event:goal"
-  #       })
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["visitors", "pageviews"],
+          "dimensions" => ["event:goal"]
+        })
 
-  #     assert [] = json_response(conn, 200)["results"]
-  #   end
-  # end
+      assert json_response(conn, 200)["results"] == []
+    end
+  end
 
-  # describe "filtering" do
   test "event:goal filter returns 400 when goal not configured", %{conn: conn, site: site} do
     conn =
       post(conn, "/api/v2/query", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3488,11 +3488,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "site_id" => site.domain,
           "metrics" => [
             "visitors",
-            # "visits",
+            "visits",
             "pageviews",
-            "events"
-            # "bounce_rate",
-            # "visit_duration"
+            "events",
+            "bounce_rate",
+            "visit_duration"
           ],
           "date_range" => "all",
           "dimensions" => ["event:page"]
@@ -3501,8 +3501,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       %{"results" => results} = json_response(conn, 200)
 
       assert results == [
-               %{"dimensions" => ["/"], "metrics" => [2, 2, 2]},
-               %{"dimensions" => ["/plausible.io"], "metrics" => [2, 2, 2]}
+               %{"dimensions" => ["/"], "metrics" => [2, 2, 2, 2, 50, 300]},
+               %{"dimensions" => ["/plausible.io"], "metrics" => [2, 1, 2, 2, 100, 0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -166,7 +166,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         })
 
       assert json_response(conn, 400)["error"] =~
-               "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
+               "Session metric(s) `bounce_rate` cannot be queried along with event dimensions"
     end
 
     test "session metrics cannot be used with event:props:* dimension", %{conn: conn, site: site} do
@@ -179,7 +179,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         })
 
       assert json_response(conn, 400)["error"] =~
-               "Session metric(s) `bounce_rate` cannot be queried along with event filters or dimensions"
+               "Session metric(s) `bounce_rate` cannot be queried along with event dimensions"
     end
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -1127,10 +1127,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
-          "date_range" => %{
-            "period" => "7d",
-            "to_date" => "2021-01-07"
-          },
+          "date_range" => ["2021-01-01", "2021-01-07"],
           "dimensions" => ["time"]
         })
 
@@ -1152,10 +1149,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
-          "date_range" => %{
-            "period" => "6mo",
-            "to_date" => "2021-01-01"
-          },
+          "date_range" => ["2020-07-01", "2021-01-31"],
           "dimensions" => ["time"]
         })
 
@@ -1178,10 +1172,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
-          "date_range" => %{
-            "to_date" => "2021-01-01",
-            "period" => "12mo"
-          },
+          "date_range" => ["2020-01-01", "2021-01-01"],
           "dimensions" => ["time"]
         })
 
@@ -1204,10 +1195,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
-          "date_range" => %{
-            "to_date" => "2021-01-01",
-            "period" => "12mo"
-          },
+          "date_range" => ["2020-01-01", "2021-01-07"],
           "dimensions" => ["time:day"]
         })
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3463,48 +3463,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
                %{"dimensions" => ["Chrome"], "metrics" => [1]}
              ]
     end
-
-    test "all metrics for breakdown by event prop", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview,
-          user_id: 1,
-          pathname: "/",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          user_id: 1,
-          pathname: "/plausible.io",
-          timestamp: ~N[2021-01-01 00:10:00]
-        ),
-        build(:pageview, pathname: "/", timestamp: ~N[2021-01-01 00:25:00]),
-        build(:pageview,
-          pathname: "/plausible.io",
-          timestamp: ~N[2021-01-01 00:00:00]
-        )
-      ])
-
-      conn =
-        post(conn, "/api/v2/query", %{
-          "site_id" => site.domain,
-          "metrics" => [
-            "visitors",
-            "visits",
-            "pageviews",
-            "events",
-            "bounce_rate",
-            "visit_duration"
-          ],
-          "date_range" => "all",
-          "dimensions" => ["event:page"]
-        })
-
-      %{"results" => results} = json_response(conn, 200)
-
-      assert results == [
-               %{"dimensions" => ["/"], "metrics" => [2, 2, 2, 2, 50, 300]},
-               %{"dimensions" => ["/plausible.io"], "metrics" => [2, 1, 2, 2, 100, 0]}
-             ]
-    end
   end
 
   describe "imported data" do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3688,8 +3688,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         conn =
           post(conn, "/api/v2/query", %{
             "site_id" => site.domain,
-            "metrics" => ["visitors", "events"],
-            # "metrics" => ["visitors", "events", "conversion_rate"],
+            "metrics" => ["visitors", "events", "conversion_rate"],
             "date_range" => "all",
             "dimensions" => ["event:props:url"],
             "filters" => [
@@ -3699,8 +3698,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           })
 
         assert json_response(conn, 200)["results"] == [
-                 %{"dimensions" => ["https://two.com"], "metrics" => [5, 10]},
-                 %{"dimensions" => ["https://one.com"], "metrics" => [3, 6]}
+                 %{"dimensions" => ["https://two.com"], "metrics" => [5, 10, 50]},
+                 %{"dimensions" => ["https://one.com"], "metrics" => [3, 6, 30]}
                ]
 
         refute json_response(conn, 200)["meta"]["warning"]
@@ -3741,8 +3740,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         conn =
           post(conn, "/api/v2/query", %{
             "site_id" => site.domain,
-            "metrics" => ["visitors", "events"],
-            # "metrics" => ["visitors", "events", "conversion_rate"],
+            "metrics" => ["visitors", "events", "conversion_rate"],
             "date_range" => "all",
             "dimensions" => ["event:props:path"],
             "filters" => [
@@ -3752,8 +3750,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           })
 
         assert json_response(conn, 200)["results"] == [
-                 %{"dimensions" => ["/two"], "metrics" => [5, 10]},
-                 %{"dimensions" => ["/one"], "metrics" => [3, 6]}
+                 %{"dimensions" => ["/two"], "metrics" => [5, 10, 50]},
+                 %{"dimensions" => ["/one"], "metrics" => [3, 6, 30]}
                ]
 
         refute json_response(conn, 200)["meta"]["warning"]

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3631,6 +3631,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       assert %{"dimensions" => ["Desktop"], "metrics" => [1]} =
                breakdown_and_first.("visit:device")
 
+      # :TODO: These should not pass validation - not available on events.
+      # visit dimension and event-only metric
       # assert %{"dimensions" => ["/test"], "metrics" => [1]} = breakdown_and_first.("visit:entry_page")
       # assert %{"dimensions" => ["/test"], "metrics" => [1]} = breakdown_and_first.("visit:exit_page")
       assert %{"dimensions" => ["EE"], "metrics" => [1]} = breakdown_and_first.("visit:country")

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3160,130 +3160,96 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   end
 
   # describe "metrics" do
-  #   test "returns conversion_rate in an event:goal breakdown", %{conn: conn, site: site} do
-  #     populate_stats(site, [
-  #       build(:event, name: "Signup", user_id: 1),
-  #       build(:event, name: "Signup", user_id: 1),
-  #       build(:pageview, pathname: "/blog"),
-  #       build(:pageview, pathname: "/blog/post"),
-  #       build(:pageview)
-  #     ])
+  test "returns conversion_rate in an event:goal breakdown", %{conn: conn, site: site} do
+    populate_stats(site, [
+      build(:event, name: "Signup", user_id: 1),
+      build(:event, name: "Signup", user_id: 1),
+      build(:pageview, pathname: "/blog"),
+      build(:pageview, pathname: "/blog/post"),
+      build(:pageview)
+    ])
 
-  #     insert(:goal, %{site: site, event_name: "Signup"})
-  #     insert(:goal, %{site: site, page_path: "/blog**"})
+    insert(:goal, %{site: site, event_name: "Signup"})
+    insert(:goal, %{site: site, page_path: "/blog**"})
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "period" => "day",
-  #         "property" => "event:goal",
-  #         "metrics" => "visitors,events,conversion_rate"
-  #       })
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "date_range" => "all",
+        "metrics" => ["visitors", "events", "conversion_rate"],
+        "dimensions" => ["event:goal"]
+      })
 
-  #     assert json_response(conn, 200) == %{
-  #              "results" => [
-  #                %{
-  #                  "goal" => "Visit /blog**",
-  #                  "visitors" => 2,
-  #                  "events" => 2,
-  #                  "conversion_rate" => 50
-  #                },
-  #                %{
-  #                  "goal" => "Signup",
-  #                  "visitors" => 1,
-  #                  "events" => 2,
-  #                  "conversion_rate" => 25
-  #                }
-  #              ]
-  #            }
-  #   end
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 2, 50.0]},
+             %{"dimensions" => ["Signup"], "metrics" => [1, 2, 25.0]}
+           ]
+  end
 
-  #   test "returns conversion_rate alone in an event:goal breakdown", %{conn: conn, site: site} do
-  #     populate_stats(site, [
-  #       build(:event, name: "Signup", user_id: 1),
-  #       build(:pageview)
-  #     ])
+  test "returns conversion_rate alone in an event:goal breakdown", %{conn: conn, site: site} do
+    populate_stats(site, [
+      build(:event, name: "Signup", user_id: 1),
+      build(:pageview)
+    ])
 
-  #     insert(:goal, %{site: site, event_name: "Signup"})
+    insert(:goal, %{site: site, event_name: "Signup"})
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "period" => "day",
-  #         "property" => "event:goal",
-  #         "metrics" => "conversion_rate"
-  #       })
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "date_range" => "all",
+        "metrics" => ["conversion_rate"],
+        "dimensions" => ["event:goal"]
+      })
 
-  #     assert json_response(conn, 200) == %{
-  #              "results" => [
-  #                %{
-  #                  "goal" => "Signup",
-  #                  "conversion_rate" => 50
-  #                }
-  #              ]
-  #            }
-  #   end
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["Signup"], "metrics" => [50.0]}
+           ]
+  end
 
-  #   test "returns conversion_rate in a goal filtered custom prop breakdown", %{
-  #     conn: conn,
-  #     site: site
-  #   } do
-  #     populate_stats(site, [
-  #       build(:pageview, pathname: "/blog/1", "meta.key": ["author"], "meta.value": ["Uku"]),
-  #       build(:pageview, pathname: "/blog/2", "meta.key": ["author"], "meta.value": ["Uku"]),
-  #       build(:pageview, pathname: "/blog/3", "meta.key": ["author"], "meta.value": ["Uku"]),
-  #       build(:pageview, pathname: "/blog/1", "meta.key": ["author"], "meta.value": ["Marko"]),
-  #       build(:pageview,
-  #         pathname: "/blog/2",
-  #         "meta.key": ["author"],
-  #         "meta.value": ["Marko"],
-  #         user_id: 1
-  #       ),
-  #       build(:pageview,
-  #         pathname: "/blog/3",
-  #         "meta.key": ["author"],
-  #         "meta.value": ["Marko"],
-  #         user_id: 1
-  #       ),
-  #       build(:pageview, pathname: "/blog"),
-  #       build(:pageview, "meta.key": ["author"], "meta.value": ["Marko"]),
-  #       build(:pageview)
-  #     ])
+  test "returns conversion_rate in a goal filtered custom prop breakdown", %{
+    conn: conn,
+    site: site
+  } do
+    populate_stats(site, [
+      build(:pageview, pathname: "/blog/1", "meta.key": ["author"], "meta.value": ["Uku"]),
+      build(:pageview, pathname: "/blog/2", "meta.key": ["author"], "meta.value": ["Uku"]),
+      build(:pageview, pathname: "/blog/3", "meta.key": ["author"], "meta.value": ["Uku"]),
+      build(:pageview, pathname: "/blog/1", "meta.key": ["author"], "meta.value": ["Marko"]),
+      build(:pageview,
+        pathname: "/blog/2",
+        "meta.key": ["author"],
+        "meta.value": ["Marko"],
+        user_id: 1
+      ),
+      build(:pageview,
+        pathname: "/blog/3",
+        "meta.key": ["author"],
+        "meta.value": ["Marko"],
+        user_id: 1
+      ),
+      build(:pageview, pathname: "/blog"),
+      build(:pageview, "meta.key": ["author"], "meta.value": ["Marko"]),
+      build(:pageview)
+    ])
 
-  #     insert(:goal, %{site: site, page_path: "/blog**"})
+    insert(:goal, %{site: site, page_path: "/blog**"})
 
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "period" => "day",
-  #         "property" => "event:props:author",
-  #         "filters" => "event:goal==Visit /blog**",
-  #         "metrics" => "visitors,events,conversion_rate"
-  #       })
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "date_range" => "all",
+        "filters" => [["matches", "event:goal", ["Visit /blog**"]]],
+        "metrics" => ["visitors", "events", "conversion_rate"],
+        "dimensions" => ["event:props:author"]
+      })
 
-  #     assert json_response(conn, 200) == %{
-  #              "results" => [
-  #                %{
-  #                  "author" => "Uku",
-  #                  "visitors" => 3,
-  #                  "events" => 3,
-  #                  "conversion_rate" => 37.5
-  #                },
-  #                %{
-  #                  "author" => "Marko",
-  #                  "visitors" => 2,
-  #                  "events" => 3,
-  #                  "conversion_rate" => 25
-  #                },
-  #                %{
-  #                  "author" => "(none)",
-  #                  "visitors" => 1,
-  #                  "events" => 1,
-  #                  "conversion_rate" => 12.5
-  #                }
-  #              ]
-  #            }
-  #   end
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["Uku"], "metrics" => [3, 3, 37.5]},
+             %{"dimensions" => ["Marko"], "metrics" => [2, 3, 25.0]},
+             %{"dimensions" => ["(none)"], "metrics" => [1, 1, 12.5]}
+           ]
+  end
 
   test "returns conversion_rate alone in a goal filtered custom prop breakdown", %{
     conn: conn,
@@ -3354,70 +3320,70 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   #            }
   #   end
 
-  #   test "returns conversion_rate alone in a goal filtered event:page breakdown", %{
-  #     conn: conn,
-  #     site: site
-  #   } do
-  #     populate_stats(site, [
-  #       build(:event, pathname: "/en/register", name: "pageview"),
-  #       build(:event, pathname: "/en/register", name: "Signup")
-  #     ])
-
-  #     insert(:goal, %{site: site, event_name: "Signup"})
-
-  #     conn =
-  #       get(conn, "/api/v1/stats/breakdown", %{
-  #         "site_id" => site.domain,
-  #         "period" => "day",
-  #         "property" => "event:page",
-  #         "filters" => "event:goal==Signup",
-  #         "metrics" => "conversion_rate"
-  #       })
-
-  #     assert json_response(conn, 200) == %{
-  #              "results" => [
-  #                %{
-  #                  "page" => "/en/register",
-  #                  "conversion_rate" => 50
-  #                }
-  #              ]
-  #            }
-  #   end
-
-  # test "returns conversion_rate in a multi-goal filtered visit:screen_size breakdown", %{
+  # test "returns conversion_rate alone in a goal filtered event:page breakdown", %{
   #   conn: conn,
   #   site: site
   # } do
   #   populate_stats(site, [
-  #     build(:event, screen_size: "Mobile", name: "pageview"),
-  #     build(:event, screen_size: "Mobile", name: "AddToCart"),
-  #     build(:event, screen_size: "Mobile", name: "AddToCart"),
-  #     build(:event, screen_size: "Desktop", name: "AddToCart", user_id: 1),
-  #     build(:event, screen_size: "Desktop", name: "Purchase", user_id: 1),
-  #     build(:event, screen_size: "Desktop", name: "pageview")
+  #     build(:event, pathname: "/en/register", name: "pageview"),
+  #     build(:event, pathname: "/en/register", name: "Signup")
   #   ])
 
-  #   # Make sure that revenue goals are treated the same
-  #   # way as regular custom event goals
-  #   insert(:goal, %{site: site, event_name: "Purchase", currency: :EUR})
-  #   insert(:goal, %{site: site, event_name: "AddToCart"})
+  #   insert(:goal, %{site: site, event_name: "Signup"})
 
   #   conn =
   #     post(conn, "/api/v2/query", %{
   #       "site_id" => site.domain,
-  #       "metrics" => ["visitors", "events", "conversion_rate"],
   #       "date_range" => "all",
-  #       "dimensions" => ["visit:device"],
-  #       "filters" => [["is", "event:goal", ["AddToCart", "Purchase"]]]
+  #       "filters" => [["is", "event:goal", ["Signup"]]],
+  #       "metrics" => ["group_conversion_rate"],
+  #       "dimensions" => ["event:page"]
   #     })
 
-  #   %{"results" => results} = json_response(conn, 200)
-
-  #   assert results == [
-  #     %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.7]},
-  #     %{"dimensions" => ["Desktop"], "metrics" => [1, 2, 50]},
-  #           ]
+  #   assert json_response(conn, 200) == %{
+  #            "results" => [
+  #              %{
+  #                "page" => "/en/register",
+  #                "conversion_rate" => 50
+  #              }
+  #            ]
+  #          }
   # end
+
+  test "returns conversion_rate in a multi-goal filtered visit:screen_size breakdown", %{
+    conn: conn,
+    site: site
+  } do
+    populate_stats(site, [
+      build(:event, screen_size: "Mobile", name: "pageview"),
+      build(:event, screen_size: "Mobile", name: "AddToCart"),
+      build(:event, screen_size: "Mobile", name: "AddToCart"),
+      build(:event, screen_size: "Desktop", name: "AddToCart", user_id: 1),
+      build(:event, screen_size: "Desktop", name: "Purchase", user_id: 1),
+      build(:event, screen_size: "Desktop", name: "pageview")
+    ])
+
+    # Make sure that revenue goals are treated the same
+    # way as regular custom event goals
+    insert(:goal, %{site: site, event_name: "Purchase", currency: :EUR})
+    insert(:goal, %{site: site, event_name: "AddToCart"})
+
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "events", "group_conversion_rate"],
+        "date_range" => "all",
+        "dimensions" => ["visit:device"],
+        "filters" => [["is", "event:goal", ["AddToCart", "Purchase"]]]
+      })
+
+    %{"results" => results} = json_response(conn, 200)
+
+    assert results == [
+             %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.7]},
+             %{"dimensions" => ["Desktop"], "metrics" => [1, 2, 50]}
+           ]
+  end
 
   test "returns conversion_rate alone in a goal filtered visit:screen_size breakdown", %{
     conn: conn,


### PR DESCRIPTION
### Changes

- Aggregates now use new QueryBuilder
- Limited timeseries support in APIv2 - everything works, but results are only returned in bucket they're active in
- `conversion_rate` and `group_conversion_rate` metrics support
- Imports-related changes to support apiv2 - next PR will re-simplify
- Goals are preloaded into `Query` object for validation purposes
- event:goal breakdowns support. Now a single query and system is more flexible for renaming goals.
- event:page breakdows support. QueryOptimizer.split now splits query to two - sessions query uses visit:entry page
- fixed the memory leak around event:props:x creating symbols