### PR TITLE
Add backlinks between CRM, dashboard and site members

### DIFF
--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -25,6 +25,26 @@ defmodule Plausible.CrmExtensions do
       ]
     end
 
+    def javascripts(%{assigns: %{context: "sites", resource: "site", entry: %{domain: domain}}}) do
+      base_url = PlausibleWeb.Endpoint.url()
+
+      [
+        Phoenix.HTML.raw("""
+        <script type="text/javascript">
+          (() => {
+            const cardBody = document.querySelector(".card-body")
+            if (cardBody) {
+              const buttonDOM = document.createElement("div")
+              buttonDOM.className = "mb-3 w-full text-right"
+              buttonDOM.innerHTML = '<div><a class="btn btn-outline-primary" href="#{base_url <> "/" <> domain}" target="_blank">Open Dashboard</a></div>'
+              cardBody.prepend(buttonDOM)
+            }
+          })()
+        </script>
+        """)
+      ]
+    end
+
     def javascripts(%{assigns: %{context: "billing", resource: "enterprise_plan", changeset: %{}}}) do
       [
         Phoenix.HTML.raw("""

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -27,6 +27,18 @@
         <%= cond do %>
           <% @conn.assigns[:current_user] -> %>
             <ul class="flex items-center w-full sm:w-auto">
+              <li :if={
+                ee?() && @conn.assigns[:site] &&
+                  Plausible.Auth.is_super_admin?(@conn.assigns[:current_user])
+              }>
+                <.styled_link
+                  class="text-sm"
+                  href={PlausibleWeb.Endpoint.url() <> "/crm/sites/site/#{@conn.assigns[:site].id}"}
+                  new_tab={true}
+                >
+                  CRM
+                </.styled_link>
+              </li>
               <li
                 :if={ee?() and Plausible.Users.on_trial?(@conn.assigns[:current_user])}
                 class="hidden mr-6 sm:block"

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -20,6 +20,13 @@
             <div class="flex-1 min-w-0">
               <p class="text-sm font-medium text-gray-900 dark:text-gray-50 truncate">
                 <%= membership.user.name %>
+                <PlausibleWeb.Components.Generic.styled_link
+                  :if={ee?() and Plausible.Auth.is_super_admin?(@current_user)}
+                  new_tab={true}
+                  href={PlausibleWeb.Endpoint.url() <> "/crm/auth/user/#{@current_user.id}"}
+                >
+                  CRM
+                </PlausibleWeb.Components.Generic.styled_link>
               </p>
               <p class="text-sm text-gray-400 truncate">
                 <%= membership.user.email %>

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -488,6 +488,31 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
+  describe "GET /:website/settings/people" do
+    setup [:create_user, :log_in, :create_site]
+
+    @tag :ee_only
+    test "shows members page with links to CRM for super admin", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      conn = get(conn, "/#{site.domain}/settings/people")
+      resp = html_response(conn, 200)
+
+      assert resp =~ "/crm/auth/user/#{user.id}"
+    end
+
+    test "does not show CRM links to non-super admin user", %{conn: conn, user: user, site: site} do
+      conn = get(conn, "/#{site.domain}/settings/people")
+      resp = html_response(conn, 200)
+
+      refute resp =~ "/crm/auth/user/#{user.id}"
+    end
+  end
+
   describe "GET /:website/settings/goals" do
     setup [:create_user, :log_in, :create_site]
 

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -99,6 +99,11 @@ defmodule PlausibleWeb.StatsControllerTest do
       conn = get(conn, "/" <> site.domain)
       assert html_response(conn, 404) =~ "There's nothing here"
     end
+
+    test "does not show CRM link to the site", %{conn: conn, site: site} do
+      conn = get(conn, "/" <> site.domain)
+      refute html_response(conn, 200) =~ "/crm/sites/site/#{site.id}"
+    end
   end
 
   describe "GET /:website - as a super admin" do
@@ -151,6 +156,12 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       [{"div", attrs, _}] = find(resp, @react_container)
       assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
+    end
+
+    test "shows CRM link to the site", %{conn: conn} do
+      site = insert(:site)
+      conn = get(conn, "/" <> site.domain)
+      assert html_response(conn, 200) =~ "/crm/sites/site/#{site.id}"
     end
   end
 


### PR DESCRIPTION
### Changes

Implements links for easy navigation between CRM and respective entities - sites and members in "People" settings of the site. Only visible to the superadmins.

### Tests
- [x] Automated tests have been added

