### PR TITLE
fix CE Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY mix.lock ./
 COPY config ./config
 RUN mix local.hex --force && \
   mix local.rebar --force && \
-  mix deps.get --only prod && \
+  mix deps.get --only ${MIX_ENV} && \
   mix deps.compile
 
 COPY assets/package.json assets/package-lock.json ./assets/


### PR DESCRIPTION
### Changes

This PR allows to get CE-only deps like [happy_tcp.](https://github.com/plausible/analytics/pull/4245) Right now the build fails with

```
14.81 Unchecked dependencies for environment ce:
14.81 * happy_tcp (https://github.com/ruslandoga/happy_tcp.git)
14.81   the dependency is not available, run "mix deps.get"
14.82 ** (Mix) Can't continue due to errors on dependencies
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI