### PR TITLE
Count pending ownership sites towards account usage on the upgrade page

### DIFF
--- a/lib/plausible/billing/qouta/quota.ex
+++ b/lib/plausible/billing/qouta/quota.ex
@@ -56,6 +56,8 @@ defmodule Plausible.Billing.Quota do
 
   def ensure_within_plan_limits(_, _, _), do: :ok
 
+  def eligible_for_upgrade?(usage), do: usage.sites > 0
+
   defp exceeded_limits(usage, plan, opts) do
     for {limit, exceeded?} <- [
           {:team_member_limit, not within_limit?(usage.team_members, plan.team_member_limit)},

--- a/lib/plausible/billing/qouta/usage.ex
+++ b/lib/plausible/billing/qouta/usage.ex
@@ -283,8 +283,8 @@ defmodule Plausible.Billing.Quota.Usage do
         ]
       else
         [
-          {Props, props_usage_query},
-          {RevenueGoals, revenue_goals_usage}
+          {Props, props_usage_q},
+          {RevenueGoals, revenue_goals_usage_q}
         ]
       end
 

--- a/lib/plausible/billing/qouta/usage.ex
+++ b/lib/plausible/billing/qouta/usage.ex
@@ -22,16 +22,36 @@ defmodule Plausible.Billing.Quota.Usage do
            total: non_neg_integer()
          }
 
+  @doc """
+  Returns a full usage report for the user.
+
+  ### Options
+
+  * `pending_ownership_site_ids` - a list of site IDs from which to count
+    additional usage. This allows us to look at the total usage from pending
+    ownerships and owned sites at the same time, which is useful, for example,
+    when deciding whether to let the user upgrade to a plan, or accept a site
+    ownership.
+
+  * `with_features` - when `true`, the returned map will contain features
+    usage. Also counts usage from `pending_ownership_site_ids` if that option
+    is given.
+  """
   def usage(user, opts \\ []) do
+    owned_site_ids = Plausible.Sites.owned_site_ids(user)
+    pending_ownership_site_ids = Keyword.get(opts, :pending_ownership_site_ids, [])
+    all_site_ids = Enum.uniq(owned_site_ids ++ pending_ownership_site_ids)
+
     basic_usage = %{
-      monthly_pageviews: monthly_pageview_usage(user),
-      team_members: team_member_usage(user),
-      sites: site_usage(user)
+      monthly_pageviews: monthly_pageview_usage(user, all_site_ids),
+      team_members:
+        team_member_usage(user, pending_ownership_site_ids: pending_ownership_site_ids),
+      sites: length(all_site_ids)
     }
 
     if Keyword.get(opts, :with_features) == true do
       basic_usage
-      |> Map.put(:features, features_usage(user))
+      |> Map.put(:features, features_usage(user, all_site_ids))
     else
       basic_usage
     end
@@ -151,74 +171,64 @@ defmodule Plausible.Billing.Quota.Usage do
     }
   end
 
-  @spec team_member_usage(User.t()) :: integer()
+  @spec team_member_usage(User.t(), Keyword.t()) :: non_neg_integer()
   @doc """
   Returns the total count of team members associated with the user's sites.
 
   * The given user (i.e. the owner) is not counted as a team member.
 
-  * Pending invitations are counted as team members even before accepted.
+  * Pending invitations (but not ownership transfers) are counted as team
+    members even before accepted.
 
   * Users are counted uniquely - i.e. even if an account is associated with
     many sites owned by the given user, they still count as one team member.
 
-  * Specific e-mails can be excluded from the count, so that where necessary,
-    we can ensure inviting the same person(s) to more than 1 sites is allowed
-  """
-  def team_member_usage(user, opts \\ []) do
-    {:ok, opts} = Keyword.validate(opts, site: nil, exclude_emails: [])
+  ### Options
 
-    user
-    |> team_member_usage_query(opts)
+  * `exclude_emails` - a list of emails to not count towards the usage. This
+    allows us to exclude a user from being counted as a team member when
+    checking whether a site invitation can be created for that same user.
+
+  * `pending_ownership_site_ids` - a list of site IDs from which to count
+    additional team member usage. Without this option, usage is queried only
+    across sites owned by the given user.
+  """
+  def team_member_usage(user, opts \\ [])
+
+  def team_member_usage(%User{} = user, opts) do
+    exclude_emails = Keyword.get(opts, :exclude_emails, []) ++ [user.email]
+
+    q =
+      user
+      |> Plausible.Sites.owned_site_ids()
+      |> query_team_member_emails()
+
+    q =
+      case Keyword.get(opts, :pending_ownership_site_ids) do
+        [_ | _] = site_ids -> union(q, ^query_team_member_emails(site_ids))
+        _ -> q
+      end
+
+    from(u in subquery(q),
+      where: u.email not in ^exclude_emails,
+      distinct: u.email
+    )
     |> Plausible.Repo.aggregate(:count)
   end
 
-  defp team_member_usage_query(user, opts) do
-    owned_sites_query = owned_sites_query(user)
-
-    excluded_emails =
-      opts
-      |> Keyword.get(:exclude_emails, [])
-      |> List.wrap()
-
-    site = opts[:site]
-
-    owned_sites_query =
-      if site do
-        where(owned_sites_query, [os], os.site_id == ^site.id)
-      else
-        owned_sites_query
-      end
-
-    team_members_query =
-      from os in subquery(owned_sites_query),
-        inner_join: sm in Site.Membership,
-        on: sm.site_id == os.site_id,
+  def query_team_member_emails(site_ids) do
+    memberships_q =
+      from sm in Site.Membership,
+        where: sm.site_id in ^site_ids,
         inner_join: u in assoc(sm, :user),
-        where: sm.role != :owner,
-        select: u.email
+        select: %{email: u.email}
 
-    team_members_query =
-      if excluded_emails != [] do
-        team_members_query |> where([..., u], u.email not in ^excluded_emails)
-      else
-        team_members_query
-      end
-
-    query =
+    invitations_q =
       from i in Plausible.Auth.Invitation,
-        inner_join: os in subquery(owned_sites_query),
-        on: i.site_id == os.site_id,
-        where: i.role != :owner,
-        select: i.email,
-        union: ^team_members_query
+        where: i.site_id in ^site_ids and i.role != :owner,
+        select: %{email: i.email}
 
-    if excluded_emails != [] do
-      query
-      |> where([i], i.email not in ^excluded_emails)
-    else
-      query
-    end
+    union(memberships_q, ^invitations_q)
   end
 
   @spec features_usage(User.t() | nil, list() | nil) :: [atom()]
@@ -281,11 +291,5 @@ defmodule Plausible.Billing.Quota.Usage do
     Enum.reduce(queries, [], fn {feature, query}, acc ->
       if Plausible.Repo.exists?(query), do: acc ++ [feature], else: acc
     end)
-  end
-
-  defp owned_sites_query(user) do
-    from sm in Site.Membership,
-      where: sm.role == :owner and sm.user_id == ^user.id,
-      select: %{site_id: sm.site_id}
   end
 end

--- a/lib/plausible/billing/qouta/usage.ex
+++ b/lib/plausible/billing/qouta/usage.ex
@@ -6,8 +6,7 @@ defmodule Plausible.Billing.Quota.Usage do
   alias Plausible.Users
   alias Plausible.Auth.User
   alias Plausible.Site
-  alias Plausible.Billing.{Subscriptions}
-  alias Plausible.Billing.Feature.{RevenueGoals, Funnels, Props, StatsAPI}
+  alias Plausible.Billing.{Subscriptions, Feature}
 
   @type cycles_usage() :: %{cycle() => usage_cycle()}
 
@@ -257,7 +256,7 @@ defmodule Plausible.Billing.Quota.Usage do
       |> Plausible.Repo.exists?()
 
     if stats_api_used? do
-      site_scoped_feature_usage ++ [StatsAPI]
+      site_scoped_feature_usage ++ [Feature.StatsAPI]
     else
       site_scoped_feature_usage
     end
@@ -277,14 +276,14 @@ defmodule Plausible.Billing.Quota.Usage do
         funnels_usage_q = from f in "funnels", where: f.site_id in ^site_ids
 
         [
-          {Props, props_usage_q},
-          {Funnels, funnels_usage_q},
-          {RevenueGoals, revenue_goals_usage_q}
+          {Feature.Props, props_usage_q},
+          {Feature.Funnels, funnels_usage_q},
+          {Feature.RevenueGoals, revenue_goals_usage_q}
         ]
       else
         [
-          {Props, props_usage_q},
-          {RevenueGoals, revenue_goals_usage_q}
+          {Feature.Props, props_usage_q},
+          {Feature.RevenueGoals, revenue_goals_usage_q}
         ]
       end
 

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -38,13 +38,16 @@ defmodule Plausible.Site.Memberships do
     )
   end
 
+  @spec all_pending_ownerships(String.t()) :: list()
+  def all_pending_ownerships(email) do
+    pending_ownership_invitation_q(email)
+    |> Repo.all()
+  end
+
   @spec pending_ownerships?(String.t()) :: boolean()
   def pending_ownerships?(email) do
-    Repo.exists?(
-      from(i in Plausible.Auth.Invitation,
-        where: i.email == ^email and i.role == ^:owner
-      )
-    )
+    pending_ownership_invitation_q(email)
+    |> Repo.exists?()
   end
 
   @spec any_or_pending?(Plausible.Auth.User.t()) :: boolean()
@@ -60,5 +63,11 @@ defmodule Plausible.Site.Memberships do
       select: 1
     )
     |> Repo.exists?()
+  end
+
+  defp pending_ownership_invitation_q(email) do
+    from(i in Plausible.Auth.Invitation,
+      where: i.email == ^email and i.role == ^:owner
+    )
   end
 end

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -135,7 +135,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   defp check_team_member_limit(site, _role, invitee_email) do
     site = Plausible.Repo.preload(site, :owner)
     limit = Quota.Limits.team_member_limit(site.owner)
-    usage = Quota.Usage.team_member_usage(site.owner, exclude_emails: invitee_email)
+    usage = Quota.Usage.team_member_usage(site.owner, exclude_emails: [invitee_email])
 
     if Quota.below_limit?(usage, limit),
       do: :ok,

--- a/lib/plausible/site/memberships/invitations.ex
+++ b/lib/plausible/site/memberships/invitations.ex
@@ -116,8 +116,7 @@ defmodule Plausible.Site.Memberships.Invitations do
 
   def check_feature_access(site, new_owner, false = _selfhost?) do
     missing_features =
-      site
-      |> Quota.Usage.features_usage()
+      Quota.Usage.features_usage(nil, [site.id])
       |> Enum.filter(&(&1.check_availability(new_owner) != :ok))
 
     if missing_features == [] do

--- a/lib/plausible/site/memberships/invitations.ex
+++ b/lib/plausible/site/memberships/invitations.ex
@@ -75,31 +75,12 @@ defmodule Plausible.Site.Memberships.Invitations do
       active_subscription? = Plausible.Billing.Subscriptions.active?(new_owner.subscription)
 
       if active_subscription? && plan != :free_10k do
-        usage_after_transfer = %{
-          monthly_pageviews: monthly_pageview_usage_after_transfer(site, new_owner),
-          team_members: team_member_usage_after_transfer(site, new_owner),
-          sites: Quota.Usage.site_usage(new_owner) + 1
-        }
-
-        Quota.ensure_within_plan_limits(usage_after_transfer, plan)
+        new_owner
+        |> Quota.Usage.usage(pending_ownership_site_ids: [site.id])
+        |> Quota.ensure_within_plan_limits(plan)
       else
         {:error, :no_plan}
       end
-    end
-
-    defp team_member_usage_after_transfer(site, new_owner) do
-      current_usage = Quota.Usage.team_member_usage(new_owner)
-      site_usage = Quota.Usage.team_member_usage(site.owner, site: site)
-
-      extra_usage =
-        if Plausible.Sites.is_member?(new_owner.id, site), do: 0, else: 1
-
-      current_usage + site_usage + extra_usage
-    end
-
-    defp monthly_pageview_usage_after_transfer(site, new_owner) do
-      site_ids = Plausible.Sites.owned_site_ids(new_owner) ++ [site.id]
-      Quota.Usage.monthly_pageview_usage(new_owner, site_ids)
     end
   else
     @spec ensure_can_take_ownership(Site.t(), Auth.User.t()) :: :ok

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -217,6 +217,31 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     """
   end
 
+  def pending_site_ownerships_notice(%{pending_ownership_count: count} = assigns) do
+    if count > 0 do
+      message =
+        "Your account has been invited to become the owner of " <>
+          if(count == 1, do: "a site, which is", else: "#{count} sites, which are") <>
+          " being counted towards the usage of your account."
+
+      assigns = assign(assigns, message: message)
+
+      ~H"""
+      <aside class={@class}>
+        <.notice title="Pending ownership transfers" class="shadow-md dark:shadow-none mt-4">
+          <%= @message %> To exclude pending sites from your usage, please go to
+          <.link href="https://plausible.io/sites" class="whitespace-nowrap font-semibold">
+            plausible.io/sites
+          </.link>
+          and reject the invitations.
+        </.notice>
+      </aside>
+      """
+    else
+      ~H""
+    end
+  end
+
   def growth_grandfathered(assigns) do
     ~H"""
     <div class="mt-8 space-y-3 text-sm leading-6 text-gray-600 text-justify dark:text-gray-100 xl:mt-10">

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -168,7 +168,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
     {checkout_disabled, disabled_message} =
       cond do
-        not assigns.eligible_for_upgrade? ->
+        not Quota.eligible_for_upgrade?(assigns.usage) ->
           {true, nil}
 
         change_plan_link_text == "Currently on this plan" && not subscription_deleted ->

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -21,13 +21,19 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:user, fn ->
         Users.with_subscription(user_id)
       end)
-      |> assign_new(:pending_ownerhsip_site_ids, fn %{user: user} ->
+      |> assign_new(:pending_ownership_site_ids, fn %{user: user} ->
         user.email
-        |> Plausible.Site.Memberships.all_pending_ownerships()
+        |> Site.Memberships.all_pending_ownerships()
         |> Enum.map(& &1.site_id)
       end)
-      |> assign_new(:usage, fn %{user: user} ->
-        Quota.Usage.usage(user, with_features: true)
+      |> assign_new(:usage, fn %{
+                                 user: user,
+                                 pending_ownership_site_ids: pending_ownership_site_ids
+                               } ->
+        Quota.Usage.usage(user,
+          with_features: true,
+          pending_ownership_site_ids: pending_ownership_site_ids
+        )
       end)
       |> assign_new(:owned_plan, fn %{user: %{subscription: subscription}} ->
         Plans.get_regular_plan(subscription, only_non_expired: true)
@@ -110,7 +116,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       <div class="mx-auto max-w-7xl px-6 lg:px-20">
         <Notice.pending_site_ownerships_notice
           class="pb-6"
-          pending_ownership_count={length(@pending_ownerhsip_site_ids)}
+          pending_ownership_count={length(@pending_ownership_site_ids)}
         />
         <Notice.subscription_past_due class="pb-6" subscription={@user.subscription} />
         <Notice.subscription_paused class="pb-6" subscription={@user.subscription} />

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -21,6 +21,11 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:user, fn ->
         Users.with_subscription(user_id)
       end)
+      |> assign_new(:pending_ownerhsip_site_ids, fn %{user: user} ->
+        user.email
+        |> Plausible.Site.Memberships.all_pending_ownerships()
+        |> Enum.map(& &1.site_id)
+      end)
       |> assign_new(:usage, fn %{user: user} ->
         Quota.Usage.usage(user, with_features: true)
       end)
@@ -103,6 +108,10 @@ defmodule PlausibleWeb.Live.ChoosePlan do
     ~H"""
     <div class="bg-gray-100 dark:bg-gray-900 pt-1 pb-12 sm:pb-16 text-gray-900 dark:text-gray-100">
       <div class="mx-auto max-w-7xl px-6 lg:px-20">
+        <Notice.pending_site_ownerships_notice
+          class="pb-6"
+          pending_ownership_count={length(@pending_ownerhsip_site_ids)}
+        />
         <Notice.subscription_past_due class="pb-6" subscription={@user.subscription} />
         <Notice.subscription_paused class="pb-6" subscription={@user.subscription} />
         <Notice.upgrade_ineligible :if={not @eligible_for_upgrade?} />

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -552,11 +552,8 @@ defmodule Plausible.Billing.QuotaTest do
 
       site_using_props = insert(:site, allowed_event_props: ["dummy"])
 
-      site_using_revenue_goals = insert(:site)
-      insert(:goal, currency: :USD, site: site_using_revenue_goals, event_name: "Purchase")
-
-      site_ids = [site_using_props.id, site_using_revenue_goals.id]
-      assert [Props, RevenueGoals, StatsAPI] == Quota.Usage.features_usage(user, site_ids)
+      site_ids = [site_using_props.id]
+      assert [Props, StatsAPI] == Quota.Usage.features_usage(user, site_ids)
     end
 
     on_ee do


### PR DESCRIPTION
### Changes

When the user goes to upgrade to a plan, currently we let them upgrade to a suitable plan based on the usage across their owned sites. When the user has pending ownerships however, they might not be able to accept them, even after upgrading to a seemingly suitable plan, which can be annoying/confusing.

Whenever there are pending site ownerships, a message will be shown to the user:

![image](https://github.com/plausible/analytics/assets/56999674/fa3bb0a2-1f05-46e8-aea3-4af56cdb8f0d)

Counting the usage from pending ownerships means that we are not letting them upgrade to a plan that would not accommodate all the pending sites. Same goes for warning about losing access to a feature used be a pending ownership site.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
