### PR TITLE
Update runtime.exs To allow Plausible.Mailer tls false via environment variable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -483,7 +483,11 @@ case mailer_adapter do
       port: get_var_from_path_or_env(config_dir, "SMTP_HOST_PORT", "25"),
       username: get_var_from_path_or_env(config_dir, "SMTP_USER_NAME"),
       password: get_var_from_path_or_env(config_dir, "SMTP_USER_PWD"),
-      tls: :if_available,
+      tls: case get_var_from_path_or_env(config_dir, "SMTP_HOST_TLS_ENABLED", "if_available") do
+        "true" -> :always
+        "false" -> false
+        _ -> :if_available
+      end,
       allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
       ssl: get_var_from_path_or_env(config_dir, "SMTP_HOST_SSL_ENABLED") || false,
       retries: get_var_from_path_or_env(config_dir, "SMTP_RETRIES") || 2,


### PR DESCRIPTION
### Why

my self-hosted plausible was upgraded and stopped sending email and I tracked down that this is the setting that needs to change. I need to set tls to false since I'm sending email on port 25.

### Changes
### Proposed Change Description

#### Context

The `Bamboo.SMTPAdapter` configuration in the `Plausible.Mailer` setup currently has a hardcoded `tls` setting. This setting determines how the adapter handles TLS (Transport Layer Security) when connecting to the SMTP server. The possible values for the `tls` setting are:

- `:if_available`: Attempt to use TLS if the SMTP server supports it.
- `:always`: Always use TLS for the connection. If the server does not support TLS, the connection will fail.
- `false`: Do not use TLS for the connection.

#### Problem

The current configuration does not allow for dynamic control over the `tls` setting based on environment variables. This can be problematic in environments where the TLS requirement may vary, such as development, testing, and production environments.

#### Solution

The proposed change introduces a new environment variable `SMTP_HOST_TLS_ENABLED` to dynamically control the `tls` setting. The `tls` setting will be determined based on the value of this environment variable, with a default value of `:if_available` if the variable is not set.

#### Code Change

The following code snippet shows the proposed change to the `Plausible.Mailer` configuration:

```elixir
config :plausible, Plausible.Mailer,
  adapter: Bamboo.SMTPAdapter,
  server: get_var_from_path_or_env(config_dir, "SMTP_HOST_ADDR", "mail"),
  hostname: base_url.host,
  port: get_var_from_path_or_env(config_dir, "SMTP_HOST_PORT", "25"),
  username: get_var_from_path_or_env(config_dir, "SMTP_USER_NAME"),
  password: get_var_from_path_or_env(config_dir, "SMTP_USER_PWD"),
  tls: case get_var_from_path_or_env(config_dir, "SMTP_HOST_TLS_ENABLED", "if_available") do
    "true" -> :always
    "false" -> false
    _ -> :if_available
  end,
  allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
  ssl: get_var_from_path_or_env(config_dir, "SMTP_HOST_SSL_ENABLED") || false,
  retries: get_var_from_path_or_env(config_dir, "SMTP_RETRIES") || 2,
  no_mx_lookups: get_var_from_path_or_env(config_dir, "SMTP_MX_LOOKUPS_ENABLED") || true,
  ssl_opts: [verify: :verify_none] # This will ignore SSL verification (not recommended for production)
```

#### Explanation

- The `tls` setting is now determined by the `SMTP_HOST_TLS_ENABLED` environment variable.
- If `SMTP_HOST_TLS_ENABLED` is set to `"true"`, the `tls` setting will be `:always`.
- If `SMTP_HOST_TLS_ENABLED` is set to `"false"`, the `tls` setting will be `false`.
- If `SMTP_HOST_TLS_ENABLED` is not set or has any other value, the `tls` setting will default to `:if_available`.

### Pull Request Body

#### Title

Add dynamic control for TLS setting in Bamboo.SMTPAdapter configuration

#### Description

This pull request introduces a new environment variable `SMTP_HOST_TLS_ENABLED` to dynamically control the `tls` setting in the `Bamboo.SMTPAdapter` configuration for `Plausible.Mailer`. The `tls` setting determines how TLS (Transport Layer Security) is handled when connecting to the SMTP server.

#### Changes

- Added a new environment variable `SMTP_HOST_TLS_ENABLED`.
- Updated the `Plausible.Mailer` configuration to use the `SMTP_HOST_TLS_ENABLED` environment variable to determine the `tls` setting.
- The `tls` setting will be:
  - `:always` if `SMTP_HOST_TLS_ENABLED` is set to `"true"`.
  - `false` if `SMTP_HOST_TLS_ENABLED` is set to `"false"`.
  - `:if_available` if `SMTP_HOST_TLS_ENABLED` is not set or has any other value.

#### Rationale

This change allows for dynamic control over the `tls` setting based on environment variables, making it easier to configure the application for different environments (development, testing, production) without modifying the source code.

#### Example Usage

To disable TLS, set the following environment variable in your `docker-compose.yml` or environment configuration:

```yaml

      SMTP_HOST_ADDR: "smtp.example.com"
      SMTP_HOST_PORT: 25
      SMTP_USER_NAME: "your_username"
      SMTP_USER_PWD: "your_password"
      SMTP_HOST_SSL_ENABLED: "false"
      SMTP_HOST_TLS_ENABLED: "false" # explicitly disable TLS
      SMTP_RETRIES: 2
      SMTP_MX_LOOKUPS_ENABLED: "true"
```

To always use TLS, set the following environment variable:

```yaml

      SMTP_HOST_ADDR: "smtp.example.com"
      SMTP_HOST_PORT: 25
      SMTP_USER_NAME: "your_username"
      SMTP_USER_PWD: "your_password"
      SMTP_HOST_SSL_ENABLED: "true"
      SMTP_HOST_TLS_ENABLED: "true" # always use TLS
      SMTP_RETRIES: 2
      SMTP_MX_LOOKUPS_ENABLED: "true"
```

If `SMTP_HOST_TLS_ENABLED` is not set, the `tls` setting will default to `:if_available`.

#### Conclusion

This change enhances the flexibility and configurability of the `Plausible.Mailer` setup, allowing for better adaptation to different environments and requirements.

I need to disable this option for my email to go out for reset password links.
### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
