### PR TITLE
Require src attribute when seeking snippet for verification

### DIFF
--- a/lib/plausible/verification/checks/snippet.ex
+++ b/lib/plausible/verification/checks/snippet.ex
@@ -11,8 +11,8 @@ defmodule Plausible.Verification.Checks.Snippet do
 
   @impl true
   def perform(%State{assigns: %{document: document}} = state) do
-    in_head = Floki.find(document, "head script[data-domain]")
-    in_body = Floki.find(document, "body script[data-domain]")
+    in_head = Floki.find(document, "head script[data-domain][src]")
+    in_body = Floki.find(document, "body script[data-domain][src]")
 
     all = in_head ++ in_body
 

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -246,6 +246,26 @@ defmodule Plausible.Verification.ChecksTest do
       |> assert_error(@errors.multiple_snippets)
     end
 
+    @no_src_scripts """
+    <html>
+    <head>
+    <script defer data-domain="example.com"></script>
+    </head>
+    <body>
+    Hello
+    <script defer data-domain="example.com"></script>
+    </body>
+    </html>
+    """
+    test "no src attr doesn't count as snippet" do
+      stub_fetch_body(200, @no_src_scripts)
+      stub_installation(200, plausible_installed(false))
+
+      run_checks()
+      |> Checks.interpret_diagnostics()
+      |> assert_error(@errors.no_snippet)
+    end
+
     @many_snippets_ok """
     <html>
     <head>


### PR DESCRIPTION
### Changes

This change requires src attribute when looking for snippet during verification

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
