### PR TITLE
fix relay-without-auth mua config

### DIFF
--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -159,9 +159,25 @@ defmodule Plausible.ConfigTest do
 
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
                {:adapter, Bamboo.Mua},
-               {:auth, [username: "neo", password: "one"]},
                {:relay, "localhost"},
-               {:port, 2525}
+               {:port, 2525},
+               {:auth, [username: "neo", password: "one"]}
+             ]
+    end
+
+    test "Bamboo.Mua (no auth relay config)" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.Mua"},
+        {"SMTP_HOST_ADDR", "localhost"},
+        {"SMTP_HOST_PORT", "2525"},
+        {"SMTP_USER_NAME", nil},
+        {"SMTP_USER_PWD", nil}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               adapter: Bamboo.Mua,
+               relay: "localhost",
+               port: 2525
              ]
     end
 


### PR DESCRIPTION
### Changes

This PR fixes the error reported in https://github.com/plausible/analytics/pull/4289#issuecomment-2198601831 by allowing using SMTP relays without authentication.

### Tests
- [x] Tests have been updated.

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI