### PR TITLE
Bugfix: custom props modal opens up with no filters

### DIFF
--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -98,7 +98,7 @@ export default function Properties(props) {
           BUILD_EXTRA && { name: 'total_revenue', label: 'Revenue', hiddenOnMobile: true },
           BUILD_EXTRA && { name: 'average_revenue', label: 'Average', hiddenOnMobile: true }
         ]}
-        detailsLink={`/custom-prop-values/${propKey}`}
+        detailsLink={url.sitePath(`custom-prop-values/${propKey}`)}
         maybeHideDetails={true}
         query={query}
         color="bg-red-50"


### PR DESCRIPTION
Another regression planted via #4278 

Custom Props modal shows up without carrying over window.location.search (filters).