### PR TITLE
move site imports migration to clickhouse repo

### DIFF
--- a/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
@@ -1,14 +1,26 @@
 defmodule Plausible.IngestRepo.Migrations.MigrateSiteImports do
-  use Plausible
   use Ecto.Migration
 
   def up do
-    if ce?() do
+    if Plausible.ce?() do
       Ecto.Migrator.with_repo(Plausible.Repo, fn _repo ->
-        {:ok, _, _} =
-          Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
-            Plausible.DataMigration.SiteImports.run(dry_run?: false)
-          end)
+        %Postgrex.Result{rows: rows} =
+          Plausible.Repo.query!(
+            "select inserted_at from schema_migrations where version=20240528115149"
+          )
+
+        case rows do
+          [[already_ran_at]] ->
+            IO.puts(
+              "skipping site_imports migration since it has already been run at #{already_ran_at}"
+            )
+
+          [] ->
+            {:ok, _, _} =
+              Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
+                Plausible.DataMigration.SiteImports.run(dry_run?: false)
+              end)
+        end
       end)
     end
   end

--- a/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
@@ -15,6 +15,8 @@ defmodule Plausible.IngestRepo.Migrations.MigrateSiteImports do
               "skipping site_imports migration since it has already been run at #{already_ran_at}"
             )
 
+            nil
+
           [] ->
             {:ok, _, _} =
               Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->

--- a/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/ingest_repo/migrations/20240528115149_migrate_site_imports.exs
@@ -1,0 +1,19 @@
+defmodule Plausible.IngestRepo.Migrations.MigrateSiteImports do
+  use Plausible
+  use Ecto.Migration
+
+  def up do
+    if ce?() do
+      Ecto.Migrator.with_repo(Plausible.Repo, fn _repo ->
+        {:ok, _, _} =
+          Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
+            Plausible.DataMigration.SiteImports.run(dry_run?: false)
+          end)
+      end)
+    end
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -1,17 +1,5 @@
 defmodule Plausible.Repo.Migrations.MigrateSiteImports do
-  use Plausible
-  use Ecto.Migration
-
-  def up do
-    if ce?() do
-      {:ok, _, _} =
-        Ecto.Migrator.with_repo(Plausible.ClickhouseRepo, fn _repo ->
-          Plausible.DataMigration.SiteImports.run(dry_run?: false)
-        end)
-    end
-  end
-
-  def down do
-    raise "Irreversible"
-  end
+  # moved to IngestRepo
+  def up, do: :ok
+  def down, do: :ok
 end

--- a/priv/repo/migrations/20240528115149_migrate_site_imports.exs
+++ b/priv/repo/migrations/20240528115149_migrate_site_imports.exs
@@ -1,5 +1,0 @@
-defmodule Plausible.Repo.Migrations.MigrateSiteImports do
-  # moved to IngestRepo
-  def up, do: :ok
-  def down, do: :ok
-end


### PR DESCRIPTION
### Changes

When upgrading from v2.0.0 to v2.1.1 site_imports data migration fails because `import_id` columns are missing from ClickHouse tables at the time of the migration. This happens because PostgreSQL migrations run before ClickHouse migrations that add import_id columns. This PR moves site_imports data migration from PostgreSQL migrations to Clickhouse migrations.

Converting this to Draft to test the following scenarios:
- [ ] Plausible Cloud: how removing existing repo/ migration affects Plausible.Repo (would rollback ignore it or fail?)
- [ ] Upgrading Plausible CE from v2.1.1: check how migration is skipped
- [ ] Upgrading Plausible CE from v2.0.0: check how nested with_repo interact

Reviews are still welcome!

### Tests
- [ ] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
