### PR TITLE
Link to the correct CRM page from User Settings > People

### DIFF
--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -23,7 +23,7 @@
                 <PlausibleWeb.Components.Generic.styled_link
                   :if={ee?() and Plausible.Auth.is_super_admin?(@current_user)}
                   new_tab={true}
-                  href={PlausibleWeb.Endpoint.url() <> "/crm/auth/user/#{@current_user.id}"}
+                  href={PlausibleWeb.Endpoint.url() <> "/crm/auth/user/#{membership.user.id}"}
                 >
                   CRM
                 </PlausibleWeb.Components.Generic.styled_link>


### PR DESCRIPTION
### Changes

Currently the CRM links in User Settings > People always open up the user profile of the current user in the CRM. We want those links to take us to that user's page instead.