### PR TITLE
Fix URLs breaking on date picker navigation

### DIFF
--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -52,7 +52,7 @@ export function navigateToQuery(history, queryFrom, newData) {
   // if we update any data that we store in localstorage, make sure going back in history will
   // revert them
   if (newData.period && newData.period !== queryFrom.period) {
-    history.replace({ search: updatedQuery({ period: queryFrom.period}) })
+    history.replace({ search: updatedQuery({ period: queryFrom.period }) })
   }
 
   // then push the new query to the history
@@ -135,7 +135,7 @@ export function filtersBackwardsCompatibilityRedirect() {
 }
 
 function QueryLink(props) {
-  const {query, history, to, className, children} = props
+  const { query, history, to, className, children } = props
 
   function onClick(e) {
     e.preventDefault()
@@ -167,7 +167,7 @@ function QueryButton({ history, query, to, disabled, className, children, onClic
         event.preventDefault()
         navigateToQuery(history, query, to)
         if (onClick) onClick(event)
-        history.push({ pathname: window.location.pathname, search: updatedQuery(to) })
+        history.push({ search: updatedQuery(to) })
       }}
       type="button"
       disabled={disabled}


### PR DESCRIPTION
This prevents the date picker from updating the URL with data domain on each subsequent use. Only the query string should be updated.

Possibly regression introduced via #4278 