### PR TITLE
Fix React combobox debounce

### DIFF
--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -53,7 +53,9 @@ export default function PlausibleCombobox(props) {
   }
 
   useDebouncedEffect(() => {
-    fetchOptions()
+    if (isOpen) {
+      fetchOptions()
+    }
   }, [search], 200)
 
   const fetchOptions = useCallback(() => {

--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -101,7 +101,6 @@ export default function PlausibleCombobox(props) {
 
   function fetchOptions(query) {
     setLoading(true)
-    setOpen(true)
 
     return props.fetchOptions(query).then((loadedOptions) => {
       setLoading(false)
@@ -120,11 +119,12 @@ export default function PlausibleCombobox(props) {
 
   function toggleOpen() {
     if (!isOpen) {
+      setOpen(true)
       fetchOptions(input)
       searchRef.current.focus()
     } else {
-      setInput('')
       setOpen(false)
+      setInput('')
     }
   }
 

--- a/assets/js/dashboard/custom-hooks.js
+++ b/assets/js/dashboard/custom-hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 // A custom hook that behaves like `useEffect`, but
 // the function does not run on the initial render.
@@ -14,20 +14,16 @@ export function useMountedEffect(fn, deps) {
   }, deps)
 }
 
-// A custom hook that debounces the function calls by a given delay.
-// The first function call is not delayed. Every subsequent call is
-// delayed by `delay_ms`, and if another function is called before
-// the delay timeout, the previous function call gets cancelled.
-export function useDebouncedEffect(fn, deps, delay_ms) {
-  const callback = useCallback(fn, deps)
-  const delay = useRef(0)
+const DEBOUNCE_DELAY = 300
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      delay.current = delay_ms
-      callback()
-    }, delay.current)
+export function useDebounce(fn, delay = DEBOUNCE_DELAY) {
+  const timerRef = useRef(null)
 
-    return () => clearTimeout(timeout)
-  }, [callback, delay_ms])
+  return useCallback((...args) => {
+    clearTimeout(timerRef.current)
+
+    timerRef.current = setTimeout(() => {
+      fn(...args)
+    }, delay)
+  }, [fn, delay])
 }

--- a/assets/js/dashboard/custom-hooks.js
+++ b/assets/js/dashboard/custom-hooks.js
@@ -14,14 +14,20 @@ export function useMountedEffect(fn, deps) {
   }, deps)
 }
 
-// A custom hook that debounces the function calls by
-// a given delay. Cancels all function calls that have
-// a following call within `delay_ms`.
+// A custom hook that debounces the function calls by a given delay.
+// The first function call is not delayed. Every subsequent call is
+// delayed by `delay_ms`, and if another function is called before
+// the delay timeout, the previous function call gets cancelled.
 export function useDebouncedEffect(fn, deps, delay_ms) {
   const callback = useCallback(fn, deps)
+  const delay = useRef(0)
 
   useEffect(() => {
-    const timeout = setTimeout(callback, delay_ms)
+    const timeout = setTimeout(() => {
+      delay.current = delay_ms
+      callback()
+    }, delay.current)
+
     return () => clearTimeout(timeout)
   }, [callback, delay_ms])
 }

--- a/assets/js/dashboard/stats/modals/breakdown-modal.js
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.js
@@ -91,7 +91,6 @@ export default function BreakdownModal({
   
   const [initialLoading, setInitialLoading] = useState(true)
   const [loading, setLoading] = useState(true)
-  const [searchInput, setSearchInput] = useState('')
   const [search, setSearch] = useState('')
   const [results, setResults] = useState([])
   const [page, setPage] = useState(1)
@@ -101,10 +100,9 @@ export default function BreakdownModal({
   useMountedEffect(() => { fetchNextPage() }, [page])
 
   useDebouncedEffect(() => {
-    setSearch(searchInput)
-  }, [searchInput], 300)
-  
-  useEffect(() => { fetchData() }, [search])
+    setLoading(true)
+    fetchData()
+  }, [search], 300)
 
   useEffect(() => {
     if (!searchEnabled) { return }
@@ -126,7 +124,6 @@ export default function BreakdownModal({
   }, [])
 
   const fetchData = useCallback(() => {
-    setLoading(true)
     api.get(endpoint, withSearch(query), { limit: LIMIT, page: 1, detailed: true })
       .then((response) => {
         if (typeof afterFetchData === 'function') {
@@ -236,7 +233,7 @@ export default function BreakdownModal({
   }
 
   function handleInputChange(e) {
-    setSearchInput(e.target.value)
+    setSearch(e.target.value)
   }
 
   function renderSearchInput() {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -24,7 +24,6 @@
         "classnames": "^2.3.1",
         "datamaps": "^0.5.9",
         "dayjs": "^1.11.7",
-        "debounce-promise": "^3.1.2",
         "iframe-resizer": "^4.3.2",
         "phoenix": "^1.7.2",
         "phoenix_html": "^3.3.1",
@@ -1039,10 +1038,6 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.7",
-      "license": "MIT"
-    },
-    "node_modules/debounce-promise": {
-      "version": "3.1.2",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -24,7 +24,6 @@
     "classnames": "^2.3.1",
     "datamaps": "^0.5.9",
     "dayjs": "^1.11.7",
-    "debounce-promise": "^3.1.2",
     "iframe-resizer": "^4.3.2",
     "phoenix": "^1.7.2",
     "phoenix_html": "^3.3.1",

--- a/priv/repo/migrations/20240708120453_create_help_scout_credentials.exs
+++ b/priv/repo/migrations/20240708120453_create_help_scout_credentials.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Repo.Migrations.CreateHelpscoutCredentials do
+  use Plausible
+  use Ecto.Migration
+
+  def change do
+    if ee?() do
+      create table(:help_scout_credentials) do
+        add :access_token, :binary, null: false
+
+        timestamps()
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Changes

In the `PlausibleCombobox` component (used in the filter menus and the `prop_key` picker), we're currently making too many API calls to fetch selectable options. Currently, we're calling the API for every keystroke. This PR fixes that - we will only make a request once 200ms has passed from the last keystroke (reusing the `useDebouncedCallback` custom hook introduced in #4318).

Also in this PR:

* Alter the `useDebouncedEffect` custom hook to not set a delay for the initial function call. Currently the search in all breakdown modals is waiting 300ms before calling the API for the first time. This fixes that.
* Remove redundant doubled "search" state from the BreakdownModal component.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
