### PR TITLE
fix(suggestions): Properly provide suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix access to Stats API feature in CE plausible/analytics#4244
+- Fix filter suggestions when same filter previously applied
 
 ## v2.1.1 - 2024-06-06
 

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -160,9 +160,16 @@ export function fetchSuggestions(apiPath, query, input, additionalFilter) {
 
 function queryForSuggestions(query, additionalFilter) {
   let filters = query.filters
-  if (additionalFilter && additionalFilter[2].length > 0) {
-    filters = filters.concat([additionalFilter])
+
+  if (additionalFilter) {
+    const [_operation, filterKey, clauses] = additionalFilter
+
+    filters = filters.filter(([_op, key, _clauses]) => key != filterKey)
+    if (clauses.length > 0) {
+      filters = filters.concat([additionalFilter])
+    }
   }
+
   return { ...query, filters }
 }
 

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -160,16 +160,16 @@ export function fetchSuggestions(apiPath, query, input, additionalFilter) {
 
 function queryForSuggestions(query, additionalFilter) {
   let filters = query.filters
-
   if (additionalFilter) {
     const [_operation, filterKey, clauses] = additionalFilter
 
-    filters = filters.filter(([_op, key, _clauses]) => key != filterKey)
+    // For suggestions, we remove already-applied filter with same key from query and add new filter (if feasible)
     if (clauses.length > 0) {
-      filters = filters.concat([additionalFilter])
+      filters = replaceFilterByPrefix(query, filterKey, additionalFilter)
+    } else {
+      filters = omitFiltersByKeyPrefix(query, filterKey)
     }
   }
-
   return { ...query, filters }
 }
 


### PR DESCRIPTION
Previously, if a filter was applied then filter modal suggestions would _always_ apply the previous suggestion. Now when say applying a `page` filter suggestions we remove the previous `page` filter.