### PR TITLE
Bump cache version for Elixir CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_VERSION: v7
+  CACHE_VERSION: v8
   PERSISTENT_CACHE_DIR: cached
 
 jobs:


### PR DESCRIPTION
This might fix Dialyzer failing in recent PRs.
