### PR TITLE
Remove verification related feature flags

### DIFF
--- a/config/.env.test
+++ b/config/.env.test
@@ -23,3 +23,5 @@ S3_REGION=us-east-1
 S3_ENDPOINT=http://localhost:10000
 S3_EXPORTS_BUCKET=test-exports
 S3_IMPORTS_BUCKET=test-imports
+
+VERIFICATION_ENABLED=true

--- a/lib/plausible/verification.ex
+++ b/lib/plausible/verification.ex
@@ -4,14 +4,8 @@ defmodule Plausible.Verification do
   """
   use Plausible
 
-  @feature_flag :verification
-
-  def enabled?(user) do
-    enabled_via_config? =
-      :plausible |> Application.fetch_env!(__MODULE__) |> Keyword.fetch!(:enabled?)
-
-    enabled_for_user? = not is_nil(user) and FunWithFlags.enabled?(@feature_flag, for: user)
-    enabled_via_config? or enabled_for_user?
+  def enabled?() do
+    :plausible |> Application.fetch_env!(__MODULE__) |> Keyword.fetch!(:enabled?)
   end
 
   on_ee do

--- a/lib/plausible_web/templates/site/settings_email_reports.html.heex
+++ b/lib/plausible_web/templates/site/settings_email_reports.html.heex
@@ -206,15 +206,13 @@
   type: :spike
 ) %>
 
-<%= if FunWithFlags.enabled?(:traffic_drop_notifications, for: @site) do %>
-  <%= render("traffic_change_form",
-    conn: @conn,
-    notification: @drop_notification,
-    site: @site,
-    heading: "Traffic Drop Notifications",
-    subtitle: "Get notified when your site has unusually low number of visitors within 12 hours",
-    toggle_text: "Send notifications of traffic drops",
-    threshold_label: "12 hours visitor threshold",
-    type: :drop
-  ) %>
-<% end %>
+<%= render("traffic_change_form",
+  conn: @conn,
+  notification: @drop_notification,
+  site: @site,
+  heading: "Traffic Drop Notifications",
+  subtitle: "Get notified when your site has unusually low number of visitors within 12 hours",
+  toggle_text: "Send notifications of traffic drops",
+  threshold_label: "12 hours visitor threshold",
+  type: :drop
+) %>

--- a/lib/plausible_web/templates/site/settings_general.html.heex
+++ b/lib/plausible_web/templates/site/settings_general.html.heex
@@ -109,7 +109,7 @@
       </a>
     </div>
 
-    <div :if={Plausible.Verification.enabled?(@current_user)}>
+    <div :if={Plausible.Verification.enabled?()}>
       <%= live_render(@conn, PlausibleWeb.Live.Verification,
         session: %{
           "open_modal?" => !!@conn.params["launch_verification"],

--- a/lib/plausible_web/templates/site/snippet.html.heex
+++ b/lib/plausible_web/templates/site/snippet.html.heex
@@ -7,11 +7,11 @@
   <%= form_for @conn, "/", [class: "max-w-lg w-full mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8"], fn f -> %>
     <h2 class="text-xl font-bold dark:text-gray-100">Add JavaScript snippet</h2>
     <div class="mt-4">
-      <p :if={Plausible.Verification.enabled?(@current_user)} class="dark:text-gray-100">
+      <p :if={Plausible.Verification.enabled?()} class="dark:text-gray-100">
         Include this snippet in the <code>&lt;head&gt;</code>
         section of your website.<br />To verify your integration, click the button below to confirm that everything is working correctly.
       </p>
-      <p :if={not Plausible.Verification.enabled?(@current_user)} class="dark:text-gray-100">
+      <p :if={not Plausible.Verification.enabled?()} class="dark:text-gray-100">
         Paste this snippet in the <code>&lt;head&gt;</code> of your website.
       </p>
 
@@ -65,7 +65,7 @@
       </p>
     </div>
     <% button_label =
-      if Plausible.Verification.enabled?(@current_user) do
+      if Plausible.Verification.enabled?() do
         "Verify your integration to start collecting data →"
       else
         "Start collecting data →"

--- a/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
+++ b/lib/plausible_web/templates/stats/waiting_first_pageview.html.heex
@@ -22,7 +22,7 @@
     </div>
   <% end %>
   <div
-    :if={not Plausible.Verification.enabled?(assigns[:current_user])}
+    :if={not Plausible.Verification.enabled?()}
     class="bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-16 relative text-center"
   >
     <h2 class="text-xl font-bold dark:text-gray-100">Waiting for first pageview</h2>
@@ -61,7 +61,7 @@
     </div>
   </div>
 
-  <%= if Plausible.Verification.enabled?(assigns[:current_user]),
+  <%= if Plausible.Verification.enabled?(),
     do:
       live_render(@conn, PlausibleWeb.Live.Verification,
         session: %{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,3 @@
-FunWithFlags.enable(:verification)
-
 if not Enum.empty?(Path.wildcard("lib/**/*_test.exs")) do
   raise "Oops, test(s) found in `lib/` directory. Move them to `test/`."
 end


### PR DESCRIPTION
 - `:verification` flag is no longer needed, however we'll keep the old "awaiting first pageview" flow for Community Edition where verification is not enabled by default
 - `:traffic_drop_notifications` have been tested and can be enabled for everyone