### PR TITLE
Show number of owned sites in HS integration with a link to sites list in CRM

### DIFF
--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -78,7 +78,12 @@ defmodule Plausible.HelpScout do
          status_link:
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id),
          plan_label: plan_label(user.subscription, plan),
-         plan_link: plan_link(user.subscription)
+         plan_link: plan_link(user.subscription),
+         sites_count: Plausible.Sites.owned_sites_count(user),
+         sites_link:
+           Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
+             search: user.email
+           )
        }}
     end
   end

--- a/extra/lib/plausible_web/views/help_scout_view.ex
+++ b/extra/lib/plausible_web/views/help_scout_view.ex
@@ -54,6 +54,12 @@ defmodule PlausibleWeb.HelpScoutView do
               <a href={@plan_link} target="_blank"><%= @plan_label %></a>
             </p>
           </div>
+
+          <div class="sites">
+            <p class="label">
+              Owner of <b><a href={@sites_link} target="_blank"><%= @sites_count %> sites</a></b>
+            </p>
+          </div>
         <% end %>
       </body>
     </html>

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -17,6 +17,7 @@ defmodule Plausible.SiteAdmin do
   def custom_index_query(_conn, _schema, query) do
     from(r in query,
       inner_join: o in assoc(r, :owner),
+      as: :owner,
       preload: [owner: o, memberships: :user]
     )
   end

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -59,12 +59,17 @@ defmodule Plausible.HelpScoutTest do
 
         crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/auth/user/#{user_id}"
 
+        owned_sites_url =
+          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?search=#{URI.encode_www_form(email)}"
+
         assert {:ok,
                 %{
                   status_link: ^crm_url,
                   status_label: "Trial",
                   plan_link: "#",
-                  plan_label: "None"
+                  plan_label: "None",
+                  sites_count: 0,
+                  sites_link: ^owned_sites_url
                 }} = HelpScout.get_customer_details("500")
       end
 
@@ -270,7 +275,8 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Dashboard locked",
                   plan_link: _,
-                  plan_label: "10k Plan (€10 monthly)"
+                  plan_label: "10k Plan (€10 monthly)",
+                  sites_count: 1
                 }} = HelpScout.get_customer_details("500")
       end
 


### PR DESCRIPTION
### Changes

Further refinement of HelpScout integration introducing number of owned sites with a link to sites list CRM filtered by owner email.

### Tests
- [x] Automated tests have been added

