### PR TITLE
Remove Timex.today

### DIFF
--- a/lib/mix/tasks/download_country_database.ex
+++ b/lib/mix/tasks/download_country_database.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.DownloadCountryDatabase do
   def run(_) do
     Application.ensure_all_started(:httpoison)
     Application.ensure_all_started(:timex)
-    this_month = Timex.today()
+    this_month = Date.utc_today()
     last_month = Date.shift(this_month, month: -1)
     this_month = this_month |> Date.to_iso8601() |> binary_part(0, 7)
     last_month = last_month |> Date.to_iso8601() |> binary_part(0, 7)

--- a/lib/plausible/auth/grace_period.ex
+++ b/lib/plausible/auth/grace_period.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Auth.GracePeriod do
   """
   def start_changeset(%User{} = user) do
     grace_period = %__MODULE__{
-      end_date: Date.shift(Timex.today(), day: 7),
+      end_date: Date.shift(Date.utc_today(), day: 7),
       is_over: false,
       manual_lock: false
     }
@@ -82,7 +82,7 @@ defmodule Plausible.Auth.GracePeriod do
   def active?(user)
 
   def active?(%User{grace_period: %__MODULE__{end_date: %Date{} = end_date}}) do
-    Timex.diff(end_date, Timex.today(), :days) >= 0
+    Timex.diff(end_date, Date.utc_today(), :days) >= 0
   end
 
   def active?(%User{grace_period: %__MODULE__{manual_lock: true}}) do

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -164,7 +164,7 @@ defmodule Plausible.Auth.User do
   end
 
   def end_trial(user) do
-    change(user, trial_expiry_date: Timex.today() |> Date.shift(day: -1))
+    change(user, trial_expiry_date: Date.utc_today() |> Date.shift(day: -1))
   end
 
   def password_strength(changeset) do
@@ -253,9 +253,9 @@ defmodule Plausible.Auth.User do
 
   defp trial_expiry() do
     on_ee do
-      Timex.today() |> Date.shift(day: 30)
+      Date.utc_today() |> Date.shift(day: 30)
     else
-      Timex.today() |> Date.shift(year: 100)
+      Date.utc_today() |> Date.shift(year: 100)
     end
   end
 

--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -98,8 +98,8 @@ defmodule Plausible.Billing.PaddleApi do
       vendor_auth_code: config[:vendor_auth_code],
       subscription_id: subscription.paddle_subscription_id,
       is_paid: 1,
-      from: Date.shift(Timex.today(), year: -5) |> Timex.format!("{YYYY}-{0M}-{0D}"),
-      to: Date.shift(Timex.today(), day: 1) |> Timex.format!("{YYYY}-{0M}-{0D}")
+      from: Date.shift(Date.utc_today(), year: -5) |> Timex.format!("{YYYY}-{0M}-{0D}"),
+      to: Date.shift(Date.utc_today(), day: 1) |> Timex.format!("{YYYY}-{0M}-{0D}")
     }
 
     with {:ok, %{body: body}} <- HTTPClient.post(invoices_url(), @headers, params),

--- a/lib/plausible/billing/qouta/usage.ex
+++ b/lib/plausible/billing/qouta/usage.ex
@@ -111,7 +111,7 @@ defmodule Plausible.Billing.Quota.Usage do
   end
 
   @spec usage_cycle(User.t(), :last_30_days | cycle(), list() | nil, Date.t()) :: usage_cycle()
-  def usage_cycle(user, cycle, owned_site_ids \\ nil, today \\ Timex.today())
+  def usage_cycle(user, cycle, owned_site_ids \\ nil, today \\ Date.utc_today())
 
   def usage_cycle(user, cycle, nil, today) do
     usage_cycle(user, cycle, Plausible.Sites.owned_site_ids(user), today)

--- a/lib/plausible/billing/subscriptions.ex
+++ b/lib/plausible/billing/subscriptions.ex
@@ -27,7 +27,7 @@ defmodule Plausible.Billing.Subscriptions do
 
   def expired?(%Subscription{next_bill_date: next_bill_date} = subscription) do
     deleted? = Subscription.Status.deleted?(subscription)
-    expired? = Timex.compare(next_bill_date, Timex.today()) < 0
+    expired? = Timex.compare(next_bill_date, Date.utc_today()) < 0
 
     deleted? && expired?
   end

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -215,7 +215,7 @@ defmodule Plausible.Google.GA4.HTTP do
         %{
           property: "#{property}",
           dateRanges: [
-            %{startDate: @earliest_valid_date, endDate: Date.to_iso8601(Timex.today())}
+            %{startDate: @earliest_valid_date, endDate: Date.to_iso8601(Date.utc_today())}
           ],
           dimensions: [%{name: "date"}],
           metrics: [%{name: "screenPageViews"}],

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -198,7 +198,8 @@ defmodule Plausible.Imported do
 
   @spec get_cutoff_date(Site.t()) :: Date.t()
   def get_cutoff_date(site) do
-    Plausible.Sites.native_stats_start_date(site) || DateTime.to_date(DateTime.now!(site.timezone))
+    Plausible.Sites.native_stats_start_date(site) ||
+      DateTime.to_date(DateTime.now!(site.timezone))
   end
 
   defp find_free_ranges(start_date, end_date, occupied_ranges) do

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -198,7 +198,7 @@ defmodule Plausible.Imported do
 
   @spec get_cutoff_date(Site.t()) :: Date.t()
   def get_cutoff_date(site) do
-    Plausible.Sites.native_stats_start_date(site) || Timex.today(site.timezone)
+    Plausible.Sites.native_stats_start_date(site) || DateTime.to_date(DateTime.now!(site.timezone))
   end
 
   defp find_free_ranges(start_date, end_date, occupied_ranges) do

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -25,7 +25,7 @@ defmodule Plausible.Users do
 
   @spec trial_days_left(Auth.User.t()) :: integer()
   def trial_days_left(user) do
-    Timex.diff(user.trial_expiry_date, Timex.today(), :days)
+    Timex.diff(user.trial_expiry_date, Date.utc_today(), :days)
   end
 
   @spec update_accept_traffic_until(Auth.User.t()) :: Auth.User.t()

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -269,7 +269,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     invited_user? = is_nil(user.trial_expiry_date)
 
     trial_active_or_ended_recently? =
-      not invited_user? && Timex.diff(Timex.today(), user.trial_expiry_date, :days) <= 10
+      not invited_user? && Timex.diff(Date.utc_today(), user.trial_expiry_date, :days) <= 10
 
     limit_checking_opts =
       cond do

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -109,7 +109,7 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def grace_period_end(%{grace_period: %{end_date: %Date{} = date}}) do
-    case Timex.diff(date, Timex.today(), :days) do
+    case Timex.diff(date, Date.utc_today(), :days) do
       0 -> "today"
       1 -> "tomorrow"
       n -> "within #{n} days"

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Workers.CheckUsage do
   end
 
   @impl Oban.Worker
-  def perform(_job, usage_mod \\ Quota.Usage, today \\ Timex.today()) do
+  def perform(_job, usage_mod \\ Quota.Usage, today \\ Date.utc_today()) do
     yesterday = today |> Date.shift(day: -1)
 
     active_subscribers =

--- a/lib/workers/send_trial_notifications.ex
+++ b/lib/workers/send_trial_notifications.ex
@@ -20,7 +20,7 @@ defmodule Plausible.Workers.SendTrialNotifications do
       )
 
     for user <- users do
-      case Timex.diff(user.trial_expiry_date, Timex.today(), :days) do
+      case Timex.diff(user.trial_expiry_date, Date.utc_today(), :days) do
         7 ->
           if Plausible.Auth.has_active_sites?(user, [:owner]) do
             send_one_week_reminder(user)


### PR DESCRIPTION
Continues #4338

### Changes

This PR continues [the removal of Timex](https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/7479197128) by replacing [`Timex.today/0`](https://hexdocs.pm/timex/Timex.html#today/0) with `Date.utc_today/0` which was already being [delegated to.](https://github.com/bitwalker/timex/blob/c45b9a734074ac2a56355ec52ebf931b932223b7/lib/timex.ex#L47-L51) Additionally, it replaces a single instance of [`Timex.today/1`](https://hexdocs.pm/timex/Timex.html#today/1) with [similar `DateTime` functions.](https://github.com/bitwalker/timex/blob/c45b9a734074ac2a56355ec52ebf931b932223b7/lib/timex.ex#L53-L78) I'm using "similar" and not "equivalent" because now we raise an error on an invalid timezone instead of returning an error tuple, which previously could cause match errors downstream thus hiding the actual issue.

### Tests
- [x] The tests are still kept unchanged for now to ensure that there are no unforeseen differences.

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI