### PR TITLE
Fix present_index for daily, weekly and monthly intervals

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -276,6 +276,7 @@ defmodule PlausibleWeb.Api.StatsController do
         current_date =
           Timex.now(site.timezone)
           |> Timex.to_date()
+          |> Date.to_string()
 
         Enum.find_index(dates, &(&1 == current_date))
 
@@ -284,6 +285,7 @@ defmodule PlausibleWeb.Api.StatsController do
           Timex.now(site.timezone)
           |> Timex.to_date()
           |> date_or_weekstart(query)
+          |> Date.to_string()
 
         Enum.find_index(dates, &(&1 == current_date))
 
@@ -292,6 +294,7 @@ defmodule PlausibleWeb.Api.StatsController do
           Timex.now(site.timezone)
           |> Timex.to_date()
           |> Timex.beginning_of_month()
+          |> Date.to_string()
 
         Enum.find_index(dates, &(&1 == current_date))
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -1426,4 +1426,43 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
              ]
     end
   end
+
+  describe "present_index" do
+    setup [:create_user, :log_in, :create_new_site]
+
+    test "exists for a date range that includes the current day", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview)
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&metric=pageviews"
+        )
+
+      assert %{"present_index" => present_index} = json_response(conn, 200)
+
+      assert present_index >= 0
+    end
+
+    test "is null for a date range that does not include the current day", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview)
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=pageviews"
+        )
+
+      assert %{"present_index" => present_index} = json_response(conn, 200)
+
+      refute present_index
+    end
+  end
 end


### PR DESCRIPTION
### Changes

In the main graph, the 'current' interval should be shown with a dotted line instead of a solid line. This is accomplished with the `present_index` variable which broke recently.



### Tests
- [x] Automated tests have been added

### Changelog
- Since this behaviour was broken and fixed during a single CE release cycle, no changelog is needed.

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
