### PR TITLE
Implement UI to edit existing funnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- UI to edit funnels
 - Add a search functionality in all Details views, except for Goal Conversions, Countries, Regions, Cities and Google Search terms
 - Icons for browsers plausible/analytics#4239
 - Automatic custom property selection in the dashboard Properties report

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
     "./js/**/*.js",
     "../lib/*_web.ex",
     "../lib/*_web/**/*.*ex",
-    "../extra/**/*.ex",
+    "../extra/**/*.*ex",
   ],
   safelist: [
     // PlausibleWeb.StatsView.stats_container_class/1 uses this class

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -6,8 +6,7 @@ module.exports = {
     "./js/**/*.js",
     "../lib/*_web.ex",
     "../lib/*_web/**/*.*ex",
-    "../extra/*_web.ex",
-    "../extra/*_web/**/*.*ex"
+    "../extra/**/*.ex",
   ],
   safelist: [
     // PlausibleWeb.StatsView.stats_container_class/1 uses this class
@@ -52,9 +51,9 @@ module.exports = {
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),
-    plugin(({addVariant}) => addVariant("phx-no-feedback", [".phx-no-feedback&", ".phx-no-feedback &"])),
-    plugin(({addVariant}) => addVariant("phx-click-loading", [".phx-click-loading&", ".phx-click-loading &"])),
-    plugin(({addVariant}) => addVariant("phx-submit-loading", [".phx-submit-loading&", ".phx-submit-loading &"])),
-    plugin(({addVariant}) => addVariant("phx-change-loading", [".phx-change-loading&", ".phx-change-loading &"])),
+    plugin(({ addVariant }) => addVariant("phx-no-feedback", [".phx-no-feedback&", ".phx-no-feedback &"])),
+    plugin(({ addVariant }) => addVariant("phx-click-loading", [".phx-click-loading&", ".phx-click-loading &"])),
+    plugin(({ addVariant }) => addVariant("phx-submit-loading", [".phx-submit-loading&", ".phx-submit-loading &"])),
+    plugin(({ addVariant }) => addVariant("phx-change-loading", [".phx-change-loading&", ".phx-change-loading &"])),
   ]
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,9 +15,12 @@ config :plausible, PlausibleWeb.Endpoint,
     ]
   ],
   live_reload: [
+    dirs: [
+      "extra"
+    ],
     patterns: [
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
-      ~r"lib/plausible_web/(controllers|live|components|templates|views|plugs)/.*(ex|heex)$"
+      ~r"lib/plausible_web/(controllers|live|components|templates|views|plugs)/.*(ex|heex)$",
     ]
   ]
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -20,7 +20,7 @@ config :plausible, PlausibleWeb.Endpoint,
     ],
     patterns: [
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
-      ~r"lib/plausible_web/(controllers|live|components|templates|views|plugs)/.*(ex|heex)$",
+      ~r"lib/plausible_web/(controllers|live|components|templates|views|plugs)/.*(ex|heex)$"
     ]
   ]
 

--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
      assign(socket,
        domain: domain,
        displayed_funnels: socket.assigns.all_funnels,
-       add_funnel?: false,
+       setup_funnel?: false,
        filter_text: "",
        current_user_id: user_id,
        funnel_id: nil
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
     <div id="funnel-settings-main">
       <.flash_messages flash={@flash} />
 
-      <%= if @add_funnel? do %>
+      <%= if @setup_funnel? do %>
         <%= live_render(
           @socket,
           PlausibleWeb.Live.FunnelSettings.Form,
@@ -95,11 +95,11 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   end
 
   def handle_event("add-funnel", _value, socket) do
-    {:noreply, assign(socket, add_funnel?: true)}
+    {:noreply, assign(socket, setup_funnel?: true)}
   end
 
   def handle_event("edit-funnel", %{"funnel-id" => id}, socket) do
-    {:noreply, assign(socket, add_funnel?: true, funnel_id: String.to_integer(id))}
+    {:noreply, assign(socket, setup_funnel?: true, funnel_id: String.to_integer(id))}
   end
 
   def handle_event("delete-funnel", %{"funnel-id" => id}, socket) do
@@ -124,14 +124,14 @@ defmodule PlausibleWeb.Live.FunnelSettings do
 
     {:noreply,
      assign(socket,
-       add_funnel?: false,
+       setup_funnel?: false,
        all_funnels: funnels,
        funnel_id: nil,
        displayed_funnels: funnels
      )}
   end
 
-  def handle_info(:cancel_add_funnel, socket) do
-    {:noreply, assign(socket, add_funnel?: false, funnel_id: nil)}
+  def handle_info(:cancel_setup_funnel, socket) do
+    {:noreply, assign(socket, setup_funnel?: false, funnel_id: nil)}
   end
 end

--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -56,24 +56,24 @@ defmodule PlausibleWeb.Live.FunnelSettings do
           }
         ) %>
       <% end %>
-        <div :if={@goal_count >= Funnel.min_steps()}>
-          <.live_component
-            module={PlausibleWeb.Live.FunnelSettings.List}
-            id="funnels-list"
-            funnels={@displayed_funnels}
-            filter_text={@filter_text}
-          />
-        </div>
+      <div :if={@goal_count >= Funnel.min_steps()}>
+        <.live_component
+          module={PlausibleWeb.Live.FunnelSettings.List}
+          id="funnels-list"
+          funnels={@displayed_funnels}
+          filter_text={@filter_text}
+        />
+      </div>
 
-        <div :if={@goal_count < Funnel.min_steps()}>
-          <PlausibleWeb.Components.Generic.notice class="mt-4" title="Not enough goals">
-            You need to define at least two goals to create a funnel. Go ahead and <%= link(
-              "add goals",
-              to: PlausibleWeb.Router.Helpers.site_path(@socket, :settings_goals, @domain),
-              class: "text-indigo-500 w-full text-center"
-            ) %> to proceed.
-          </PlausibleWeb.Components.Generic.notice>
-        </div>
+      <div :if={@goal_count < Funnel.min_steps()}>
+        <PlausibleWeb.Components.Generic.notice class="mt-4" title="Not enough goals">
+          You need to define at least two goals to create a funnel. Go ahead and <%= link(
+            "add goals",
+            to: PlausibleWeb.Router.Helpers.site_path(@socket, :settings_goals, @domain),
+            class: "text-indigo-500 w-full text-center"
+          ) %> to proceed.
+        </PlausibleWeb.Components.Generic.notice>
+      </div>
     </div>
     """
   end

--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
             "funnel_id" => @funnel_id
           }
         ) %>
-      <% else %>
+      <% end %>
         <div :if={@goal_count >= Funnel.min_steps()}>
           <.live_component
             module={PlausibleWeb.Live.FunnelSettings.List}
@@ -74,7 +74,6 @@ defmodule PlausibleWeb.Live.FunnelSettings do
             ) %> to proceed.
           </PlausibleWeb.Components.Generic.notice>
         </div>
-      <% end %>
     </div>
     """
   end

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -22,7 +22,8 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
       site
       |> Goals.for_site()
       |> Enum.map(fn goal ->
-        {goal.id, struct!(Plausible.Goal, Map.take(goal, [:id, :event_name, :page_path, :currency]))}
+        {goal.id,
+         struct!(Plausible.Goal, Map.take(goal, [:id, :event_name, :page_path, :currency]))}
       end)
 
     socket =

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -280,7 +280,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
   end
 
   def handle_event("cancel-add-funnel", _value, socket) do
-    send(socket.parent_pid, :cancel_add_funnel)
+    send(socket.parent_pid, :cancel_setup_funnel)
     {:noreply, socket}
   end
 

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
     >
     </div>
     <div class="fixed inset-0 flex items-center justify-center mt-16 z-50 overlofw-y-auto overflow-x-hidden">
-      <div class="w-2/3 h-full">
+      <div class="md:w-1/2 max-w-md h-full">
         <div id="funnel-form">
           <.form
             :let={f}

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
     >
     </div>
     <div class="fixed inset-0 flex items-center justify-center mt-16 z-50 overlofw-y-auto overflow-x-hidden">
-      <div class="w-2/5 h-full">
+      <div class="w-2/3 h-full">
         <div id="funnel-form">
           <.form
             :let={f}

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
       site
       |> Goals.for_site()
       |> Enum.map(fn goal ->
-        {goal.id, struct!(Plausible.Goal, Map.take(goal, [:id, :event_name, :page_path]))}
+        {goal.id, struct!(Plausible.Goal, Map.take(goal, [:id, :event_name, :page_path, :currency]))}
       end)
 
     socket =

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
     >
     </div>
     <div class="fixed inset-0 flex items-center justify-center mt-16 z-50 overlofw-y-auto overflow-x-hidden">
-      <div class="md:w-1/2 max-w-md h-full">
+      <div class="md:w-2/3 max-w-lg h-full">
         <div id="funnel-form">
           <.form
             :let={f}
@@ -195,11 +195,11 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
           class="border-dotted border-b border-gray-400 "
           tooltip="Sample calculation for last month"
         >
-          Entering Visitors: <strong><%= @result.entering_visitors %></strong>
+          <span class="hidden md:inline">Entering Visitors: </span><strong><%= PlausibleWeb.StatsView.large_number_format(@result.entering_visitors) %></strong>
         </span>
       </span>
       <span :if={step && @at > 0}>
-        Dropoff: <strong><%= Map.get(step, :dropoff_percentage) %>%</strong>
+        <span class="hidden md:inline">Dropoff: </span><strong><%= Map.get(step, :dropoff_percentage) %>%</strong>
       </span>
     </span>
     """
@@ -226,7 +226,8 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
 
     send(self(), :evaluate_funnel)
 
-    {:noreply, assign(socket, step_ids: step_ids, selections_made: selections_made, funnel_modified?: true)}
+    {:noreply,
+     assign(socket, step_ids: step_ids, selections_made: selections_made, funnel_modified?: true)}
   end
 
   def handle_event("validate", %{"funnel" => params}, socket) do

--- a/extra/lib/plausible_web/live/funnel_settings/list.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/list.ex
@@ -54,30 +54,35 @@ defmodule PlausibleWeb.Live.FunnelSettings.List do
                   <%= funnel.steps_count %>-step funnel
                 </span>
               </span>
-              <button
-                id={"delete-funnel-#{funnel.id}"}
-                phx-click="delete-funnel"
-                phx-value-funnel-id={funnel.id}
-                class="text-sm text-red-600"
-                data-confirm={"Are you sure you want to remove funnel '#{funnel.name}'? This will just affect the UI, all of your analytics data will stay intact."}
-              >
-                <svg
-                  class="feather feather-sm"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+              <div class="flex items-center gap-x-4">
+                <a href="#" phx-click="edit-funnel" phx-value-funnel-id={funnel.id}>
+                  <Heroicons.pencil_square class="feather feather-sm text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300" />
+                </a>
+                <button
+                  id={"delete-funnel-#{funnel.id}"}
+                  phx-click="delete-funnel"
+                  phx-value-funnel-id={funnel.id}
+                  class="text-sm text-red-600"
+                  data-confirm={"Are you sure you want to remove funnel '#{funnel.name}'? This will just affect the UI, all of your analytics data will stay intact."}
                 >
-                  <polyline points="3 6 5 6 21 6"></polyline>
-                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2">
-                  </path>
-                  <line x1="10" y1="11" x2="10" y2="17"></line>
-                  <line x1="14" y1="11" x2="14" y2="17"></line>
-                </svg>
-              </button>
+                  <svg
+                    class="feather feather-sm"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="3 6 5 6 21 6"></polyline>
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2">
+                    </path>
+                    <line x1="10" y1="11" x2="10" y2="17"></line>
+                    <line x1="14" y1="11" x2="14" y2="17"></line>
+                  </svg>
+                </button>
+              </div>
             </div>
           <% end %>
         </div>

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -43,7 +43,8 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
 
   def update(assigns, socket) do
     socket =
-      assign(socket, assigns)
+      socket
+      |> assign(assigns)
       |> select_default()
 
     socket =
@@ -64,7 +65,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
   attr(:submit_name, :string, required: true)
   attr(:display_value, :string, default: "")
   attr(:submit_value, :string, default: "")
-  attr(:select, :any, default: nil)
+  attr(:selected, :any)
   attr(:suggest_fun, :any, required: true)
   attr(:suggestions_limit, :integer)
   attr(:class, :string, default: "")

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -42,7 +42,9 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
   @default_suggestions_limit 15
 
   def update(assigns, socket) do
-    socket = assign(socket, assigns)
+    socket =
+      assign(socket, assigns)
+      |> select_default()
 
     socket =
       if connected?(socket) do
@@ -62,6 +64,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
   attr(:submit_name, :string, required: true)
   attr(:display_value, :string, default: "")
   attr(:submit_value, :string, default: "")
+  attr(:select, :any, default: nil)
   attr(:suggest_fun, :any, required: true)
   attr(:suggestions_limit, :integer)
   attr(:class, :string, default: "")
@@ -351,6 +354,16 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
       )
     else
       socket
+    end
+  end
+
+  defp select_default(socket) do
+    case {socket.assigns[:selected], socket.assigns[:submit_value]} do
+      {{submit_value, display_value}, nil} ->
+        assign(socket, submit_value: submit_value, display_value: display_value)
+
+      _ ->
+        socket
     end
   end
 

--- a/test/plausible/funnels_test.exs
+++ b/test/plausible/funnels_test.exs
@@ -55,6 +55,28 @@ defmodule Plausible.FunnelsTest do
         assert fg3.step_order == 3
       end
 
+      test "update funnel", %{site: site, steps: [g1, g2, g3, g4, g5 | _]} do
+        {:ok, funnel1} =
+          Funnels.create(
+            site,
+            "Sample funnel",
+            [g1, g2, g3]
+          )
+
+        {:ok, funnel2} = Funnels.update(funnel1, "Updated funnel", [g4, g5])
+
+        assert funnel2.name == "Updated funnel"
+        assert [fg1, fg2] = funnel2.steps
+
+        assert fg1.goal_id == g4["goal_id"]
+        assert fg2.goal_id == g5["goal_id"]
+
+        assert fg1.step_order == 1
+        assert fg2.step_order == 2
+
+        assert funnel1.id == funnel2.id
+      end
+
       test "retrieve a funnel by id and site, get steps in order", %{
         site: site,
         steps: [g1, g2, g3 | _]

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -24,6 +24,18 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
       end
     end
 
+    test "renders preselected default value" do
+      options = new_options(10)
+      assert doc = render_sample_component(options, selected: List.last(options))
+
+      assert element_exists?(doc, "input[type=hidden][name=test-submit-name][value=10]")
+
+      assert element_exists?(
+               doc,
+               ~s|input[type=text][name=display-test-component][value="TestOption 10"]|
+             )
+    end
+
     test "renders up to 15 suggestions by default" do
       assert doc = render_sample_component(new_options(20))
 

--- a/test/plausible_web/live/funnel_settings/form_test.exs
+++ b/test/plausible_web/live/funnel_settings/form_test.exs
@@ -97,11 +97,6 @@ defmodule PlausibleWeb.Live.FunnelSettings.FormTest do
 
       assert text_of_element(doc, "ul#dropdown-step-1 li") =~ "Hello World"
     end
-
-    # test "editing existing funnel updates it", , %{conn: conn, site: site} do
-    #   {:ok, [_, _, g3]} = setup_goals(site, ["Hello World", "Plausible", "Another World"])
-    # end
-    #
   end
 
   defp get_liveview(conn, site) do

--- a/test/plausible_web/live/funnel_settings/form_test.exs
+++ b/test/plausible_web/live/funnel_settings/form_test.exs
@@ -97,6 +97,11 @@ defmodule PlausibleWeb.Live.FunnelSettings.FormTest do
 
       assert text_of_element(doc, "ul#dropdown-step-1 li") =~ "Hello World"
     end
+
+    # test "editing existing funnel updates it", , %{conn: conn, site: site} do
+    #   {:ok, [_, _, g3]} = setup_goals(site, ["Hello World", "Plausible", "Another World"])
+    # end
+    #
   end
 
   defp get_liveview(conn, site) do


### PR DESCRIPTION
### Changes

This PR adds the option to edit exiting funnels and btw fixes the UI CSS quirks as a result of improper tailwind build configuration. The modal now displays nicer.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
