### PR TITLE
Fix sending endpoint prop from sources and countries modals

### DIFF
--- a/assets/js/dashboard/stats/modals/locations-modal.js
+++ b/assets/js/dashboard/stats/modals/locations-modal.js
@@ -23,7 +23,7 @@ function LocationsModal({ location }) {
   const currentView = urlParts[urlParts.length - 1]
 
   let reportInfo = VIEWS[currentView]
-  reportInfo.endpoint = url.apiPath(site, reportInfo.endpoint)
+  reportInfo = {...reportInfo, endpoint: url.apiPath(site, reportInfo.endpoint)}
 
   const getFilterInfo = useCallback((listItem) => {
     return {

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -47,7 +47,7 @@ function SourcesModal({ location }) {
   const currentView = urlParts[urlParts.length - 1]
 
   let reportInfo = VIEWS[currentView].info
-  reportInfo.endpoint = url.apiPath(site, reportInfo.endpoint)
+  reportInfo = {...reportInfo, endpoint: url.apiPath(site, reportInfo.endpoint)}
 
   const getFilterInfo = useCallback((listItem) => {
     return {


### PR DESCRIPTION
### Changes

Fixes a bug introduced a moment ago in #4361. Currently opening a sources or countries modal > closing it > opening it again will result in a 404. This PR makes sure we're sending reportInfo as a new object and not modifying the source of truth itself.

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
