### PR TITLE
Add `search_query` to internal props

### DIFF
--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Props do
   @max_prop_value_length 2000
   def max_prop_value_length, do: @max_prop_value_length
 
-  @internal_keys ~w(url path)
+  @internal_keys ~w(url path search_query)
   @doc """
   Lists prop keys used internally.
 

--- a/test/plausible/props_test.exs
+++ b/test/plausible/props_test.exs
@@ -269,10 +269,15 @@ defmodule Plausible.PropsTest do
         name: "404",
         "meta.key": ["path", "with_error"],
         "meta.value": ["/i-dont-exist", "true"]
+      ),
+      build(:event,
+        name: "WP Search Queries",
+        "meta.key": ["search_query", "result_count"],
+        "meta.value": ["something", "12"]
       )
     ])
 
-    assert ["first_time_customer", "logged_in", "with_error"] ==
+    assert ["first_time_customer", "logged_in", "result_count", "with_error"] ==
              site |> Plausible.Props.suggest_keys_to_allow() |> Enum.sort()
   end
 


### PR DESCRIPTION
### Changes

This PR adds `search_query` among internal props. Our official Wordpress integration tracks search events, sending "WP Search Queries" event along with `search_query` property. This change makes breaking down by `search_query` property always available, regardless of customer plan.

### Tests
- [x] Automated tests have been added

