### PR TITLE
Fix flaky auth rate limit tests

### DIFF
--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -9,17 +9,17 @@ defmodule Plausible.Auth do
   alias Plausible.RateLimit
 
   @rate_limits %{
-    :login_ip => %{
+    login_ip: %{
       prefix: "login:ip",
       limit: 5,
       interval: :timer.seconds(60)
     },
-    :login_user => %{
+    login_user: %{
       prefix: "login:user",
       limit: 5,
       interval: :timer.seconds(60)
     },
-    :email_change_user => %{
+    email_change_user: %{
       prefix: "email-change:user",
       limit: 2,
       interval: :timer.hours(1)

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -34,14 +34,14 @@ defmodule Plausible.Auth do
   def rate_limits(), do: @rate_limits
 
   @spec rate_limit(rate_limit_type(), Auth.User.t() | Plug.Conn.t()) ::
-          :ok | {:error, {:rate_limit, String.t()}}
+          :ok | {:error, {:rate_limit, rate_limit_type()}}
   def rate_limit(limit_type, key) when limit_type in @rate_limit_types do
     %{prefix: prefix, limit: limit, interval: interval} = @rate_limits[limit_type]
     full_key = "#{prefix}:#{rate_limit_key(key)}"
 
     case RateLimit.check_rate(full_key, interval, limit) do
       {:allow, _} -> :ok
-      {:deny, _} -> {:error, {:rate_limit, prefix}}
+      {:deny, _} -> {:error, {:rate_limit, limit_type}}
     end
   end
 

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -1,7 +1,49 @@
 defmodule Plausible.Auth do
+  @moduledoc """
+  Functions for user authentication context.
+  """
+
   use Plausible
   use Plausible.Repo
   alias Plausible.Auth
+  alias Plausible.RateLimit
+
+  @rate_limits %{
+    :login_ip => %{
+      prefix: "login:ip",
+      limit: 5,
+      interval: :timer.seconds(60)
+    },
+    :login_user => %{
+      prefix: "login:user",
+      limit: 5,
+      interval: :timer.seconds(60)
+    },
+    :email_change_user => %{
+      prefix: "email-change:user",
+      limit: 2,
+      interval: :timer.hours(1)
+    }
+  }
+
+  @rate_limit_types Map.keys(@rate_limits)
+
+  @type rate_limit_type() :: unquote(Enum.reduce(@rate_limit_types, &{:|, [], [&1, &2]}))
+
+  @spec rate_limits() :: map()
+  def rate_limits(), do: @rate_limits
+
+  @spec rate_limit(rate_limit_type(), Auth.User.t() | Plug.Conn.t()) ::
+          :ok | {:error, {:rate_limit, String.t()}}
+  def rate_limit(limit_type, key) when limit_type in @rate_limit_types do
+    %{prefix: prefix, limit: limit, interval: interval} = @rate_limits[limit_type]
+    full_key = "#{prefix}:#{rate_limit_key(key)}"
+
+    case RateLimit.check_rate(full_key, interval, limit) do
+      {:allow, _} -> :ok
+      {:deny, _} -> {:error, {:rate_limit, prefix}}
+    end
+  end
 
   def create_user(name, email, pwd) do
     Auth.User.new(%{name: name, email: email, password: pwd, password_confirmation: pwd})
@@ -113,4 +155,7 @@ defmodule Plausible.Auth do
       {:error, :invalid_api_key}
     end
   end
+
+  defp rate_limit_key(%Auth.User{id: id}), do: id
+  defp rate_limit_key(%Plug.Conn{} = conn), do: PlausibleWeb.RemoteIP.get(conn)
 end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -259,7 +259,7 @@ defmodule PlausibleWeb.AuthController do
         )
 
       {:rate_limit, _} ->
-        maybe_log_failed_login_attempts("too many logging attempts for #{email}")
+        maybe_log_failed_login_attempts("too many login attempts for #{email}")
 
         render_error(
           conn,
@@ -514,7 +514,7 @@ defmodule PlausibleWeb.AuthController do
           {:ok, user}
         else
           {:rate_limit, _} ->
-            maybe_log_failed_login_attempts("too many logging attempts for #{user.email}")
+            maybe_log_failed_login_attempts("too many login attempts for #{user.email}")
 
             conn
             |> TwoFactor.Session.clear_2fa_user()

--- a/test/plausible_web/controllers/auth_controller/logs_test.exs
+++ b/test/plausible_web/controllers/auth_controller/logs_test.exs
@@ -48,7 +48,7 @@ defmodule PlausibleWeb.AuthController.LogsTest do
           |> post("/login", email: user.email, password: "wrong")
         end)
 
-      assert logs =~ "[warning] [login] too many logging attempts for #{user.email}"
+      assert logs =~ "[warning] [login] too many login attempts for #{user.email}"
     end
   end
 end

--- a/test/plausible_web/controllers/auth_controller/logs_test.exs
+++ b/test/plausible_web/controllers/auth_controller/logs_test.exs
@@ -29,6 +29,7 @@ defmodule PlausibleWeb.AuthController.LogsTest do
       assert logs =~ "[warning] [login] wrong password for #{user.email}"
     end
 
+    @tag :auth_rate_limit
     test "logs on too many login attempts", %{conn: conn} do
       user = insert(:user, password: "password")
 

--- a/test/plausible_web/controllers/auth_controller/logs_test.exs
+++ b/test/plausible_web/controllers/auth_controller/logs_test.exs
@@ -29,24 +29,31 @@ defmodule PlausibleWeb.AuthController.LogsTest do
       assert logs =~ "[warning] [login] wrong password for #{user.email}"
     end
 
-    @tag :auth_rate_limit
-    test "logs on too many login attempts", %{conn: conn} do
+    test "logs on too many login attempts" do
       user = insert(:user, password: "password")
 
-      capture_log(fn ->
-        for _ <- 1..5 do
-          build_conn()
-          |> put_req_header("x-forwarded-for", "1.1.1.1")
-          |> post("/login", email: user.email, password: "wrong")
-        end
-      end)
+      conn =
+        build_conn()
+        |> put_req_header("x-forwarded-for", "1.1.1.1")
 
       logs =
-        capture_log(fn ->
-          conn
-          |> put_req_header("x-forwarded-for", "1.1.1.1")
-          |> post("/login", email: user.email, password: "wrong")
-        end)
+        eventually(
+          fn ->
+            capture_log(fn ->
+              Enum.each(1..5, fn _ ->
+                post(conn, "/login", email: user.email, password: "wrong")
+              end)
+            end)
+
+            {conn, logs} =
+              with_log(fn ->
+                post(conn, "/login", email: user.email, password: "wrong")
+              end)
+
+            {conn.status == 429, logs}
+          end,
+          500
+        )
 
       assert logs =~ "[warning] [login] too many login attempts for #{user.email}"
     end

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -417,6 +417,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert html_response(conn, 200) =~ "Enter your email and password"
     end
 
+    @tag :auth_rate_limit
     test "limits login attempts to 5 per minute" do
       user = insert(:user, password: "password")
 
@@ -1826,6 +1827,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert conn.resp_cookies["session_2fa"].max_age == 0
     end
 
+    @tag :auth_rate_limit
     test "limits verification attempts to 5 per minute", %{conn: conn} do
       user = insert(:user, email: "ratio#{Ecto.UUID.generate()}@example.com")
 
@@ -1997,6 +1999,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert conn.resp_cookies["session_2fa"].max_age == 0
     end
 
+    @tag :auth_rate_limit
     test "limits verification attempts to 5 per minute", %{conn: conn} do
       user = insert(:user, email: "ratio#{Ecto.UUID.generate()}@example.com")
 

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -417,37 +417,26 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert html_response(conn, 200) =~ "Enter your email and password"
     end
 
-    @tag :auth_rate_limit
     test "limits login attempts to 5 per minute" do
       user = insert(:user, password: "password")
 
-      build_conn()
-      |> put_req_header("x-forwarded-for", "1.2.3.5")
-      |> post("/login", email: user.email, password: "wrong")
+      conn = put_req_header(build_conn(), "x-forwarded-for", "1.2.3.5")
 
-      build_conn()
-      |> put_req_header("x-forwarded-for", "1.2.3.5")
-      |> post("/login", email: user.email, password: "wrong")
+      response =
+        eventually(
+          fn ->
+            Enum.each(1..5, fn _ ->
+              post(conn, "/login", email: user.email, password: "wrong")
+            end)
 
-      build_conn()
-      |> put_req_header("x-forwarded-for", "1.2.3.5")
-      |> post("/login", email: user.email, password: "wrong")
+            conn = post(conn, "/login", email: user.email, password: "wrong")
 
-      build_conn()
-      |> put_req_header("x-forwarded-for", "1.2.3.5")
-      |> post("/login", email: user.email, password: "wrong")
+            {conn.status == 429, conn}
+          end,
+          500
+        )
 
-      build_conn()
-      |> put_req_header("x-forwarded-for", "1.2.3.5")
-      |> post("/login", email: user.email, password: "wrong")
-
-      conn =
-        build_conn()
-        |> put_req_header("x-forwarded-for", "1.2.3.5")
-        |> post("/login", email: user.email, password: "wrong")
-
-      assert get_session(conn, :current_user_id) == nil
-      assert html_response(conn, 429) =~ "Too many login attempts"
+      assert html_response(response, 429) =~ "Too many login attempts"
     end
   end
 
@@ -1827,7 +1816,6 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert conn.resp_cookies["session_2fa"].max_age == 0
     end
 
-    @tag :auth_rate_limit
     test "limits verification attempts to 5 per minute", %{conn: conn} do
       user = insert(:user, email: "ratio#{Ecto.UUID.generate()}@example.com")
 
@@ -1835,37 +1823,29 @@ defmodule PlausibleWeb.AuthControllerTest do
       {:ok, user, _} = Auth.TOTP.initiate(user)
       {:ok, user, _} = Auth.TOTP.enable(user, :skip_verify)
 
-      conn = login_with_cookie(conn, user.email, "password")
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
-      |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
-      |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
-      |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
-      |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.1.1.1")
-      |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
-
       conn =
         conn
+        |> login_with_cookie(user.email, "password")
         |> put_req_header("x-forwarded-for", "1.1.1.1")
-        |> post(Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
 
-      assert get_session(conn, :current_user_id) == nil
+      response =
+        eventually(
+          fn ->
+            Enum.each(1..5, fn _ ->
+              post(conn, Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
+            end)
+
+            conn = post(conn, Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
+
+            {conn.status == 429, conn}
+          end,
+          500
+        )
+
+      assert get_session(response, :current_user_id) == nil
       # 2FA session terminated
-      assert conn.resp_cookies["session_2fa"].max_age == 0
-      assert html_response(conn, 429) =~ "Too many login attempts"
+      assert response.resp_cookies["session_2fa"].max_age == 0
+      assert html_response(response, 429) =~ "Too many login attempts"
     end
   end
 
@@ -1999,7 +1979,6 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert conn.resp_cookies["session_2fa"].max_age == 0
     end
 
-    @tag :auth_rate_limit
     test "limits verification attempts to 5 per minute", %{conn: conn} do
       user = insert(:user, email: "ratio#{Ecto.UUID.generate()}@example.com")
 
@@ -2007,37 +1986,34 @@ defmodule PlausibleWeb.AuthControllerTest do
       {:ok, user, _} = Auth.TOTP.initiate(user)
       {:ok, user, _} = Auth.TOTP.enable(user, :skip_verify)
 
-      conn = login_with_cookie(conn, user.email, "password")
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.2.3.4")
-      |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.2.3.4")
-      |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.2.3.4")
-      |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.2.3.4")
-      |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
-
-      conn
-      |> put_req_header("x-forwarded-for", "1.2.3.4")
-      |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
-
       conn =
         conn
+        |> login_with_cookie(user.email, "password")
         |> put_req_header("x-forwarded-for", "1.2.3.4")
-        |> post(Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
 
-      assert get_session(conn, :current_user_id) == nil
+      response =
+        eventually(
+          fn ->
+            Enum.each(1..5, fn _ ->
+              post(conn, Routes.auth_path(conn, :verify_2fa_recovery_code), %{
+                recovery_code: "invalid"
+              })
+            end)
+
+            conn =
+              post(conn, Routes.auth_path(conn, :verify_2fa_recovery_code), %{
+                recovery_code: "invalid"
+              })
+
+            {conn.status == 429, conn}
+          end,
+          500
+        )
+
+      assert get_session(response, :current_user_id) == nil
       # 2FA session terminated
-      assert conn.resp_cookies["session_2fa"].max_age == 0
-      assert html_response(conn, 429) =~ "Too many login attempts"
+      assert response.resp_cookies["session_2fa"].max_age == 0
+      assert html_response(response, 429) =~ "Too many login attempts"
     end
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -47,9 +47,9 @@ defmodule PlausibleWeb.ConnCase do
     # rate limit counter.
     if tags[:auth_rate_limit] do
       now = System.system_time(:millisecond)
-      interval = 60_000
+      interval = Plausible.Auth.rate_limits().login_ip.interval
 
-      if rem(now, interval) != rem(now + 500, interval) do
+      if div(now, interval) != div(now + 500, interval) do
         Process.sleep(500)
       end
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -37,23 +37,6 @@ defmodule PlausibleWeb.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, {:shared, self()})
     end
 
-    # Tag intended for reducing risk of flaky
-    # test result when specifically testing for
-    # auth rate limiting. The way `Plausible.RateLimit`
-    # does time-based bucketing makes logic simpler
-    # at the cost of tests running into flakiness
-    # if the fixed time bucket changes right in the
-    # middle of test run, effectively resetting the
-    # rate limit counter.
-    if tags[:auth_rate_limit] do
-      now = System.system_time(:millisecond)
-      interval = Plausible.Auth.rate_limits().login_ip.interval
-
-      if div(now, interval) != div(now + 500, interval) do
-        Process.sleep(500)
-      end
-    end
-
     # randomize client ip to avoid accidentally hitting
     # rate limiting during tests
     conn =


### PR DESCRIPTION
### Changes

This PR adds a safeguard against flaky auth rate limiting due to fixed time rate limit buckets.

### Tests
- [x] Automated tests have been added

