### PR TITLE
Remove Timex.format

### DIFF
--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -142,6 +142,6 @@ defmodule Plausible.Auth.UserAdmin do
   defp format_date(nil), do: "--"
 
   defp format_date(date) do
-    Timex.format!(date, "{Mshort} {D}, {YYYY}")
+    Calendar.strftime(date, "%b %-d, %Y")
   end
 end

--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -98,8 +98,8 @@ defmodule Plausible.Billing.PaddleApi do
       vendor_auth_code: config[:vendor_auth_code],
       subscription_id: subscription.paddle_subscription_id,
       is_paid: 1,
-      from: Date.shift(Date.utc_today(), year: -5) |> Timex.format!("{YYYY}-{0M}-{0D}"),
-      to: Date.shift(Date.utc_today(), day: 1) |> Timex.format!("{YYYY}-{0M}-{0D}")
+      from: Date.shift(Date.utc_today(), year: -5) |> Calendar.strftime("%Y-%m-%d"),
+      to: Date.shift(Date.utc_today(), day: 1) |> Calendar.strftime("%Y-%m-%d")
     }
 
     with {:ok, %{body: body}} <- HTTPClient.post(invoices_url(), @headers, params),

--- a/lib/plausible/data_migration/populate_event_session_columns.ex
+++ b/lib/plausible/data_migration/populate_event_session_columns.ex
@@ -94,7 +94,7 @@ defmodule Plausible.DataMigration.PopulateEventSessionColumns do
     {:ok, %{rows: [[merges]]}} = run_sql("get-merges-progress")
     {:ok, %{rows: disks}} = run_sql("get-disks")
 
-    IO.puts("\n\n#{Timex.now() |> Timex.format!("{ISO:Extended}")}")
+    IO.puts("\n\n#{Timex.now() |> DateTime.to_iso8601()}")
 
     # List partitions that need to run
     IO.puts(

--- a/lib/plausible/data_migration/versioned_sessions.ex
+++ b/lib/plausible/data_migration/versioned_sessions.ex
@@ -10,7 +10,7 @@ defmodule Plausible.DataMigration.VersionedSessions do
   """
   use Plausible.DataMigration, dir: "VersionedSessions", repo: Plausible.IngestRepo
 
-  @suffix_format "{YYYY}{0M}{0D}{h24}{m}{s}"
+  @suffix_format "%Y%m%d%H%M%S"
   @versioned_table_engines [
     "ReplicatedVersionedCollapsingMergeTree",
     "VersionedCollapsingMergeTree"
@@ -19,7 +19,7 @@ defmodule Plausible.DataMigration.VersionedSessions do
   def run(opts \\ []) do
     run_exchange? = Keyword.get(opts, :run_exchange?, true)
 
-    unique_suffix = Timex.now() |> Timex.format!(@suffix_format)
+    unique_suffix = Timex.now() |> Calendar.strftime(@suffix_format)
 
     cluster? = Plausible.MigrationUtils.clustered_table?("sessions_v2")
 

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -220,8 +220,8 @@ defmodule Plausible.Exports do
 
     suffix =
       if date_range do
-        first_date = Timex.format!(date_range.first, "{YYYY}{0M}{0D}")
-        last_date = Timex.format!(date_range.last, "{YYYY}{0M}{0D}")
+        first_date = Calendar.strftime(date_range.first, "%Y%m%d")
+        last_date = Calendar.strftime(date_range.last, "%Y%m%d")
         "_#{first_date}_#{last_date}" <> extname
       else
         extname

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -158,7 +158,7 @@ defmodule Plausible.SiteAdmin do
   end
 
   defp format_date(date) do
-    Timex.format!(date, "{Mshort} {D}, {YYYY}")
+    Calendar.strftime(date, "%b %-d, %Y")
   end
 
   defp get_owner(site) do

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -58,7 +58,7 @@ defmodule Plausible.Stats.Time do
   def format_datetime(%Date{} = date), do: Date.to_string(date)
 
   def format_datetime(%DateTime{} = datetime),
-    do: Timex.format!(datetime, "{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+    do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M:%S")
 
   # Realtime graphs return numbers
   def format_datetime(other), do: other

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -264,7 +264,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     else
       ~H"""
       <p>
-        You have access to your stats until <span class="font-semibold inline"><%= Timex.format!(@user.subscription.next_bill_date, "{Mshort} {D}, {YYYY}") %></span>.
+        You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@user.subscription.next_bill_date, "%b %-d, %Y") %></span>.
         <.link
           class="underline inline-block"
           href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -268,7 +268,7 @@ defmodule PlausibleWeb.Api.StatsController do
       "hour" ->
         current_date =
           Timex.now(site.timezone)
-          |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:00:00")
+          |> Calendar.strftime("%Y-%m-%d %H:00:00")
 
         Enum.find_index(dates, &(&1 == current_date))
 
@@ -301,7 +301,7 @@ defmodule PlausibleWeb.Api.StatsController do
       "minute" ->
         current_date =
           Timex.now(site.timezone)
-          |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{0m}:00")
+          |> Calendar.strftime("%Y-%m-%d %H:%M:00")
 
         Enum.find_index(dates, &(&1 == current_date))
     end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -115,7 +115,7 @@ defmodule PlausibleWeb.StatsController do
       query = Query.from(site, params)
 
       filename =
-        ~c"Plausible export #{params["domain"]} #{Timex.format!(query.date_range.first, "{ISOdate} ")} to #{Timex.format!(query.date_range.last, "{ISOdate} ")}.zip"
+        ~c"Plausible export #{params["domain"]} #{Date.to_iso8601(query.date_range.first)}  to #{Date.to_iso8601(query.date_range.last)} .zip"
 
       params = Map.merge(params, %{"limit" => "300", "csv" => "True", "detailed" => "True"})
       limited_params = Map.merge(params, %{"limit" => "100"})

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -192,7 +192,7 @@ defmodule PlausibleWeb.Email do
   end
 
   def yearly_renewal_notification(user) do
-    date = Timex.format!(user.subscription.next_bill_date, "{Mfull} {D}, {YYYY}")
+    date = Calendar.strftime(user.subscription.next_bill_date, "%B %-d, %Y")
 
     priority_email()
     |> to(user)
@@ -207,12 +207,12 @@ defmodule PlausibleWeb.Email do
   end
 
   def yearly_expiration_notification(user) do
-    next_bill_date = Timex.format!(user.subscription.next_bill_date, "{Mfull} {D}, {YYYY}")
+    next_bill_date = Calendar.strftime(user.subscription.next_bill_date, "%B %-d, %Y")
 
     accept_traffic_until =
       user
       |> Plausible.Users.accept_traffic_until()
-      |> Timex.format!("{Mfull} {D}, {YYYY}")
+      |> Calendar.strftime("%B %-d, %Y")
 
     priority_email()
     |> to(user)

--- a/lib/plausible_web/live/shields/country_rules.ex
+++ b/lib/plausible_web/live/shields/country_rules.ex
@@ -241,6 +241,6 @@ defmodule PlausibleWeb.Live.Shields.CountryRules do
   defp format_added_at(dt, tz) do
     dt
     |> Plausible.Timezones.to_datetime_in_timezone(tz)
-    |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
   end
 end

--- a/lib/plausible_web/live/shields/hostname_rules.ex
+++ b/lib/plausible_web/live/shields/hostname_rules.ex
@@ -263,7 +263,7 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
   defp format_added_at(dt, tz) do
     dt
     |> Plausible.Timezones.to_datetime_in_timezone(tz)
-    |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
   end
 
   def suggest_hostnames(input, _options, site) do

--- a/lib/plausible_web/live/shields/ip_rules.ex
+++ b/lib/plausible_web/live/shields/ip_rules.ex
@@ -290,6 +290,6 @@ defmodule PlausibleWeb.Live.Shields.IPRules do
   defp format_added_at(dt, tz) do
     dt
     |> Plausible.Timezones.to_datetime_in_timezone(tz)
-    |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
   end
 end

--- a/lib/plausible_web/live/shields/page_rules.ex
+++ b/lib/plausible_web/live/shields/page_rules.ex
@@ -255,7 +255,7 @@ defmodule PlausibleWeb.Live.Shields.PageRules do
   defp format_added_at(dt, tz) do
     dt
     |> Plausible.Timezones.to_datetime_in_timezone(tz)
-    |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
   end
 
   def suggest_page_paths(input, _options, site) do

--- a/lib/plausible_web/mjml/templates/stats_report.mjml.eex
+++ b/lib/plausible_web/mjml/templates/stats_report.mjml.eex
@@ -22,7 +22,7 @@
           <%= @site.domain %>
         </mj-text>
         <mj-text mj-class="text-sm" padding="0 25px 0 25px">
-          <%= @name %> Report (<%= Timex.format!(@query.date_range.last, "{D} {Mshort} {YYYY}") %>)
+          <%= @name %> Report (<%= Calendar.strftime(@query.date_range.last, "%-d %b %Y") %>)
         </mj-text>
       </mj-column>
     </mj-section>

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -60,7 +60,7 @@
 
           <%= if @subscription && @subscription.next_bill_date && Plausible.Billing.Subscription.Status.in?(@subscription, [Plausible.Billing.Subscription.Status.active(), Plausible.Billing.Subscription.Status.past_due()]) do %>
             <div class="py-2 text-xl font-medium dark:text-gray-100">
-              <%= Timex.format!(@subscription.next_bill_date, "{Mshort} {D}, {YYYY}") %>
+              <%= Calendar.strftime(@subscription.next_bill_date, "%b %-d, %Y") %>
             </div>
             <span class="text-gray-600 dark:text-gray-400">
               (<%= subscription_interval(@subscription) %> billing)

--- a/lib/plausible_web/views/auth_view.ex
+++ b/lib/plausible_web/views/auth_view.ex
@@ -32,8 +32,7 @@ defmodule PlausibleWeb.AuthView do
   def format_invoices(invoice_list) do
     Enum.map(invoice_list, fn invoice ->
       %{
-        date:
-          invoice["payout_date"] |> Date.from_iso8601!() |> Timex.format!("{Mshort} {D}, {YYYY}"),
+        date: invoice["payout_date"] |> Date.from_iso8601!() |> Calendar.strftime("%b %-d, %Y"),
         amount: (invoice["amount"] / 1) |> :erlang.float_to_binary(decimals: 2),
         currency: invoice["currency"] |> PlausibleWeb.BillingView.present_currency(),
         url: invoice["receipt_url"]

--- a/lib/plausible_web/views/billing_view.ex
+++ b/lib/plausible_web/views/billing_view.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.BillingView do
 
   def present_date(date) do
     Date.from_iso8601!(date)
-    |> Timex.format!("{D} {Mshort} {YYYY}")
+    |> Calendar.strftime("%-d %b %Y")
   end
 
   def present_currency("USD"), do: "$"

--- a/lib/plausible_web/views/email_view.ex
+++ b/lib/plausible_web/views/email_view.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.EmailView do
   def greet_recipient(_), do: "Hey,"
 
   def date_format(date) do
-    Timex.format!(date, "{D} {Mshort} {YYYY}")
+    Calendar.strftime(date, "%-d %b %Y")
   end
 
   def sentry_link(trace_id, dsn \\ Sentry.Config.dsn()) do

--- a/lib/plausible_web/views/text_helpers.ex
+++ b/lib/plausible_web/views/text_helpers.ex
@@ -42,6 +42,6 @@ defmodule PlausibleWeb.TextHelpers do
   end
 
   def format_date(date) do
-    Timex.format!(date, "{Mshort} {D}, {YYYY}")
+    Calendar.strftime(date, "%b %-d, %Y")
   end
 end

--- a/lib/workers/send_email_report.ex
+++ b/lib/workers/send_email_report.ex
@@ -61,7 +61,7 @@ defmodule Plausible.Workers.SendEmailReport do
       Timex.now(site.timezone)
       |> DateTime.shift(month: -1)
       |> Timex.beginning_of_month()
-      |> Timex.format!("{ISOdate}")
+      |> Date.to_iso8601()
 
     query = Query.from(site, %{"period" => "month", "date" => last_month})
 
@@ -77,7 +77,7 @@ defmodule Plausible.Workers.SendEmailReport do
   end
 
   defp put_monthly_report_name(%{query: query} = assigns) do
-    Map.put(assigns, :name, Timex.format!(query.date_range.first, "{Mfull}"))
+    Map.put(assigns, :name, Calendar.strftime(query.date_range.first, "%B"))
   end
 
   defp put_stats(%{site: site, query: query} = assigns) do


### PR DESCRIPTION
Continues #4338

### Changes

This PR continues [the removal of Timex](https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/7479197128) by replacing `Timex.format!/2` with `Calendar.strftime/2` and, in some cases, `Date.to_iso8601/1`.

### Tests
- [x] The tests are still kept unchanged for now to ensure that there are no unforeseen differences.

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI