### PR TITLE
Change the example in the hostname block

### DIFF
--- a/lib/plausible_web/live/shields/hostname_rules.ex
+++ b/lib/plausible_web/live/shields/hostname_rules.ex
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
             <p class="text-sm mt-2 text-gray-500 dark:text-gray-200">
               You can use a wildcard (<code>*</code>) to match multiple hostnames. For example,
               <code>*<%= @site.domain %></code>
-              will record traffic on your main domain and all of its subdomains.<br /><br />
+              will only record traffic on your main domain and all of its subdomains.<br /><br />
 
               <%= if @hostname_rules_count >= 1 do %>
                 Once added, we will start accepting traffic from this hostname within a few minutes.

--- a/lib/plausible_web/live/shields/hostname_rules.ex
+++ b/lib/plausible_web/live/shields/hostname_rules.ex
@@ -93,8 +93,8 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
 
             <p class="text-sm mt-2 text-gray-500 dark:text-gray-200">
               You can use a wildcard (<code>*</code>) to match multiple hostnames. For example,
-              <code>*.<%= @site.domain %></code>
-              will match all subdomains.<br /><br />
+              <code>*<%= @site.domain %></code>
+              will record traffic on your main domain and all of its subdomains.<br /><br />
 
               <%= if @hostname_rules_count >= 1 do %>
                 Once added, we will start accepting traffic from this hostname within a few minutes.


### PR DESCRIPTION
this is to avoid people mistakenly blocking the traffic from their main domain name from being recorded 