### PR TITLE
Improve how long URLs are displayed in dashboard

### DIFF
--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -10,11 +10,9 @@ import {
   cleanLabels,
   FILTER_MODAL_TO_FILTER_GROUP,
   formatFilterGroup,
-  formattedFilters,
   EVENT_PROPS_PREFIX,
-  getPropertyKeyFromFilterKey,
-  getLabel,
-  FILTER_OPERATIONS_DISPLAY_NAMES
+  plainFilterText,
+  styledFilterText
 } from "./util/filters";
 import { useQueryContext } from './query-context';
 import { useSiteContext } from './site-context';
@@ -38,32 +36,6 @@ function clearAllFilters(history, query) {
     query,
     { filters: false, labels: false }
   );
-}
-
-function plainFilterText(query, [operation, filterKey, clauses]) {
-  const formattedFilter = formattedFilters[filterKey]
-
-  if (formattedFilter) {
-    return `${formattedFilter} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.map((value) => getLabel(query.labels, filterKey, value)).reduce((prev, curr) => `${prev} or ${curr}`)}`
-  } else if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
-    const propKey = getPropertyKeyFromFilterKey(filterKey)
-    return `Property ${propKey} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.reduce((prev, curr) => `${prev} or ${curr}`)}`
-  }
-
-  throw new Error(`Unknown filter: ${filterKey}`)
-}
-
-function styledFilterText(query, [operation, filterKey, clauses]) {
-  const formattedFilter = formattedFilters[filterKey]
-
-  if (formattedFilter) {
-    return <>{formattedFilter} {FILTER_OPERATIONS_DISPLAY_NAMES[operation]} {clauses.map((value) => <b key={value}>{getLabel(query.labels, filterKey, value)}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
-  } else if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
-    const propKey = getPropertyKeyFromFilterKey(filterKey)
-    return <>Property <b>{propKey}</b> {FILTER_OPERATIONS_DISPLAY_NAMES[operation]} {clauses.map((label) => <b key={label}>{label}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
-  }
-
-  throw new Error(`Unknown filter: ${filterKey}`)
 }
 
 function renderDropdownFilter(filterIndex, filter, site, history, query) {

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -40,7 +40,20 @@ function clearAllFilters(history, query) {
   );
 }
 
-function filterText(query, [operation, filterKey, clauses]) {
+function plainFilterText(query, [operation, filterKey, clauses]) {
+  const formattedFilter = formattedFilters[filterKey]
+
+  if (formattedFilter) {
+    return `${formattedFilter} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.map((value) => getLabel(query.labels, filterKey, value)).reduce((prev, curr) => `${prev} or ${curr}`)}`
+  } else if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
+    const propKey = getPropertyKeyFromFilterKey(filterKey)
+    return `Property ${propKey} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.reduce((prev, curr) => `${prev} or ${curr}`)}`
+  }
+
+  throw new Error(`Unknown filter: ${filterKey}`)
+}
+
+function styledFilterText(query, [operation, filterKey, clauses]) {
   const formattedFilter = formattedFilters[filterKey]
 
   if (formattedFilter) {
@@ -61,16 +74,16 @@ function renderDropdownFilter(filterIndex, filter, site, history, query) {
     <Menu.Item key={filterIndex}>
       <div className="px-3 md:px-4 sm:py-2 py-3 text-sm leading-tight flex items-center justify-between" key={filterIndex}>
         <Link
-          title={`Edit filter: ${formattedFilters[type]}`}
+          title={`Edit filter: ${plainFilterText(query, filter)}`}
           to={{ pathname: `/filter/${FILTER_GROUP_TO_MODAL_TYPE[type]}`, search: window.location.search }}
           className="group flex w-full justify-between items-center"
           style={{ width: 'calc(100% - 1.5rem)' }}
         >
-          <span className="inline-block w-full truncate">{filterText(query, filter)}</span>
+          <span className="inline-block w-full truncate">{styledFilterText(query, filter)}</span>
           <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
         </Link>
         <b
-          title={`Remove filter: ${formattedFilters[type]}`}
+          title={`Remove filter: ${plainFilterText(query, filter)}`}
           className="ml-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500"
           onClick={() => removeFilter(filterIndex, history, query)}
         >
@@ -189,23 +202,23 @@ function Filters({ history }) {
   }
 
   function renderListFilter(filterIndex, filter) {
-    const text = filterText(query, filter)
     const [_operation, filterKey, _clauses] = filter
     const type = filterKey.startsWith(EVENT_PROPS_PREFIX) ? 'props' : filterKey
     return (
       <span key={filterIndex} className="flex bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 shadow text-sm rounded mr-2 items-center">
         <Link
-          title={`Edit filter: ${formattedFilters[type]}`}
+          title={`Edit filter: ${plainFilterText(query, filter)}`}
           className="flex w-full h-full items-center py-2 pl-3"
           to={{
             pathname: `/filter/${FILTER_GROUP_TO_MODAL_TYPE[type]}`,
             search: window.location.search
           }}
         >
-          <span className="inline-block max-w-2xs md:max-w-xs truncate">{text}</span>
+
+          <span className="inline-block max-w-2xs md:max-w-xs truncate">{styledFilterText(query, filter)}</span>
         </Link>
         <span
-          title={`Remove filter: ${formattedFilters[type]}`}
+          title={`Remove filter: ${plainFilterText(query, filter)}`}
           className="flex h-full w-full px-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500 items-center"
           onClick={() => removeFilter(filterIndex, history, query)}
         >

--- a/assets/js/dashboard/stats/modals/breakdown-modal.js
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
 
-import { trimURL } from '../../util/url'
 import { FilterLink } from "../reports/list";
 import { useQueryContext } from "../../query-context";
 import { useSiteContext } from "../../site-context";
@@ -51,7 +50,7 @@ export const MIN_HEIGHT_PX = 500
 //     is filtered by. If a list item is not supposed to be a filter link, this
 //     function should return `null` for that item.
 
-// ### Optional Props 
+// ### Optional Props
 
 //   * `renderIcon` - a function that renders an icon for the given list item.
 
@@ -101,7 +100,7 @@ export default function BreakdownModal({
     key: [reportInfo.endpoint, {query, search}],
     getRequestParams: (key) => {
       const [_endpoint, {query, search}] = key
-      
+
       let queryWithSearchFilter = {...query}
 
       if (searchEnabled && search !== '') {
@@ -157,13 +156,13 @@ export default function BreakdownModal({
   function renderRow(item) {
     return (
       <tr className="text-sm dark:text-gray-200" key={item.name}>
-        <td className="p-2 truncate flex items-center group">
+        <td className="w-48 md:w-64 break-all p-2 flex items-center">
           {maybeRenderIcon(item)}
           <FilterLink
             pathname={`/${encodeURIComponent(site.domain)}`}
             filterInfo={getFilterInfo(item)}
           >
-            {trimURL(item.name, 40)}
+            {item.name}
           </FilterLink>
           {maybeRenderExternalLink(item)}
         </td>
@@ -230,7 +229,7 @@ export default function BreakdownModal({
             <thead>
               <tr>
                 <th
-                  className="p-2 w-48 md:w-56 lg:w-1/3 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400"
+                  className="p-2 w-48 md:w-64 text-xs tracking-wide font-bold text-gray-500 dark:text-gray-400"
                   align="left"
                 >
                   {reportInfo.dimensionLabel}

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -8,6 +8,7 @@ import Bar from '../bar';
 import LazyLoader from '../../components/lazy-loader';
 import classNames from 'classnames';
 import { trimURL, updatedQuery } from '../../util/url';
+import { plainFilterText } from '../../util/filters';
 import { cleanLabels, replaceFilterByPrefix, isRealTimeDashboard, hasGoalFilter } from '../../util/filters';
 import { useQueryContext } from '../../query-context';
 
@@ -32,7 +33,12 @@ export function FilterLink({ pathname, filterInfo, onClick, children, extraClass
     if (pathname) { linkTo.pathname = pathname }
 
     return (
-      <Link to={linkTo} onClick={onClick} className={className}>
+      <Link
+        title={`Add filter: ${plainFilterText(query, filter)}`}
+        to={linkTo}
+        onClick={onClick}
+        className={className}
+      >
         {children}
       </Link>
     )
@@ -60,14 +66,14 @@ function ExternalLink({ item, externalLinkDest }) {
 }
 
 /**
- * 
+ *
  * REQUIRED PROPS
  *
  * @param {Function} fetchData - A function that defines the data
  *    to be rendered, and should return a list of objects under a `results` key. Think of
  *    these objects as rows. The number of columns that are **actually rendered** is also
  *    configurable through the `metrics` prop, which also defines the keys under which
- *    column values are read, and how they're rendered. 
+ *    column values are read, and how they're rendered.
  * @param {*} keyLabel - What each entry in the list represents (for UI only).
  * @param {Array.<Metric>} metrics - A list of `Metric` class objects, containing at least the `key,`
  *    `renderLabel`, and `renderValue` fields. Optionally, a Metric object can contain
@@ -77,9 +83,9 @@ function ExternalLink({ item, externalLinkDest }) {
  *    that should be applied when the list item is clicked. All existing filters matching prefix
  *    are removed. If a list item is not supposed to be clickable, this function should
  *    return `null` for that list item.
- * 
+ *
  * OPTIONAL PROPS
- * 
+ *
  * @param {Function} [onClick] - Function with additional action to be taken when a list entry is clicked.
  * @param {string} [detailsLink] - The pathname to the detailed view of this report. E.g.:
  *     `/dummy.site/pages`. If this is given as input to the ListReport, the Details button
@@ -98,7 +104,7 @@ function ExternalLink({ item, externalLinkDest }) {
  *     hooking into the request lifecycle and doing actions with returned metadata. For
  *     example, the parent component might want to control what happens when imported data
  *     is included or not.
- *  
+ *
  * @returns {HTMLElement} Table of metrics, in the following format:
  * | keyLabel           | METRIC_1.renderLabel(query) | METRIC_2.renderLabel(query) | ...
  * |--------------------|-----------------------------|-----------------------------| ---

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import React, { useMemo } from "react"
 import * as api from '../api'
 import { useQueryContext } from '../query-context'
 
@@ -113,6 +113,32 @@ export function isRealTimeDashboard(query) {
 export function useIsRealtimeDashboard() {
   const { query: { period } } = useQueryContext();
   return useMemo(() => isRealTimeDashboard({ period }), [period]);
+}
+
+export function plainFilterText(query, [operation, filterKey, clauses]) {
+  const formattedFilter = formattedFilters[filterKey]
+
+  if (formattedFilter) {
+    return `${formattedFilter} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.map((value) => getLabel(query.labels, filterKey, value)).reduce((prev, curr) => `${prev} or ${curr}`)}`
+  } else if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
+    const propKey = getPropertyKeyFromFilterKey(filterKey)
+    return `Property ${propKey} ${FILTER_OPERATIONS_DISPLAY_NAMES[operation]} ${clauses.reduce((prev, curr) => `${prev} or ${curr}`)}`
+  }
+
+  throw new Error(`Unknown filter: ${filterKey}`)
+}
+
+export function styledFilterText(query, [operation, filterKey, clauses]) {
+  const formattedFilter = formattedFilters[filterKey]
+
+  if (formattedFilter) {
+    return <>{formattedFilter} {FILTER_OPERATIONS_DISPLAY_NAMES[operation]} {clauses.map((value) => <b key={value}>{getLabel(query.labels, filterKey, value)}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
+  } else if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
+    const propKey = getPropertyKeyFromFilterKey(filterKey)
+    return <>Property <b>{propKey}</b> {FILTER_OPERATIONS_DISPLAY_NAMES[operation]} {clauses.map((label) => <b key={label}>{label}</b>).reduce((prev, curr) => [prev, ' or ', curr])} </>
+  }
+
+  throw new Error(`Unknown filter: ${filterKey}`)
 }
 
 


### PR DESCRIPTION
### Changes

Improves readability for long URLs:
1. In modals, do not truncate URLs (screenshots below)
2. When displaying filters, show the full filter value in tooltip

Before:

<img width="1003" alt="Screenshot 2024-07-30 at 16 50 52" src="https://github.com/user-attachments/assets/af58543c-43f7-4ee9-8567-13b64f80cb62">

After:

<img width="971" alt="Screenshot 2024-07-30 at 16 50 44" src="https://github.com/user-attachments/assets/bcd2a36a-695a-459d-af77-8eb8104dd79a">


### Tests
- [x] This PR does not require tests

### Changelog
- [x] A small change, no changelog needed

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
