### PR TITLE
Update react-router to version 6

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import 'url-search-params-polyfill';
 
-import Router from './dashboard/router'
+import { RouterProvider } from 'react-router-dom';
+import { createAppRouter } from './dashboard/router'
 import ErrorBoundary from './dashboard/error-boundary'
 import * as api from './dashboard/api'
 import * as timer from './dashboard/util/realtime-update-timer'
@@ -22,13 +23,18 @@ if (container) {
     api.setSharedLinkAuth(sharedLinkAuth)
   }
 
-  filtersBackwardsCompatibilityRedirect()
-
+  try {
+    filtersBackwardsCompatibilityRedirect(window.location, window.history)
+  } catch (e) {
+    console.error('Error redirecting in a backwards compatible way', e)
+  }
+  
+  const router = createAppRouter(site);
   const app = (
     <ErrorBoundary>
       <SiteContextProvider site={site}>
         <UserContextProvider role={container.dataset.currentUserRole} loggedIn={container.dataset.loggedIn === 'true'}>
-          <Router />
+          <RouterProvider router={router} />
         </UserContextProvider>
       </SiteContextProvider>
     </ErrorBoundary>

--- a/assets/js/dashboard/comparison-input.js
+++ b/assets/js/dashboard/comparison-input.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from 'react'
-import { withRouter } from 'react-router-dom'
+import React, { Fragment, useState, useRef, useEffect } from 'react'
+import { useAppNavigate } from './navigation/use-app-navigate.js'
 import { navigateToQuery } from './query'
 import { Menu, Transition } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
@@ -21,40 +21,55 @@ const DEFAULT_COMPARISON_MODE = 'previous_period'
 
 export const COMPARISON_DISABLED_PERIODS = ['realtime', 'all']
 
-export const getStoredMatchDayOfWeek = function (domain) {
-  return storage.getItem(`comparison_match_day_of_week__${domain}`) || 'true'
+const getMatchDayOfWeekStorageKey = (domain) => storage.getDomainScopedStorageKey('comparison_match_day_of_week', domain)
+
+const storeMatchDayOfWeek = function (domain, matchDayOfWeek) {
+  storage.setItem(getMatchDayOfWeekStorageKey(domain), matchDayOfWeek.toString());
 }
 
-export const getStoredComparisonMode = function (domain) {
-  const mode = storage.getItem(`comparison_mode__${domain}`)
-  if (Object.keys(COMPARISON_MODES).includes(mode)) {
-    return mode
-  } else {
-    return null
+export const getStoredMatchDayOfWeek = function (domain, fallbackValue) {
+  const storedValue = storage.getItem(getMatchDayOfWeekStorageKey(domain));
+  if (storedValue === 'true') {
+    return true;
+  } 
+  if (storedValue === 'false') {
+    return false;
   }
+  return fallbackValue;
+}
+
+const getComparisonModeStorageKey = (domain) => storage.getDomainScopedStorageKey('comparison_mode', domain)
+
+export const getStoredComparisonMode = function (domain, fallbackValue) {
+  const storedValue = storage.getItem(getComparisonModeStorageKey(domain))
+  if (Object.keys(COMPARISON_MODES).includes(storedValue)) {
+    return storedValue
+  } 
+  
+  return fallbackValue
 }
 
 const storeComparisonMode = function (domain, mode) {
   if (mode == "custom") return
-  storage.setItem(`comparison_mode__${domain}`, mode)
+  storage.setItem(getComparisonModeStorageKey(domain), mode)
 }
 
 export const isComparisonEnabled = function (mode) {
   return mode && mode !== "off"
 }
 
-export const toggleComparisons = function (history, query, site) {
+export const toggleComparisons = function (navigate, query, site) {
   if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return
 
   if (isComparisonEnabled(query.comparison)) {
     storeComparisonMode(site.domain, "off")
-    navigateToQuery(history, query, { comparison: "off" })
+    navigateToQuery(navigate, query, { comparison: "off" })
   } else {
-    const storedMode = getStoredComparisonMode(site.domain)
+    const storedMode = getStoredComparisonMode(site.domain, null)
     const newMode = isComparisonEnabled(storedMode) ? storedMode : DEFAULT_COMPARISON_MODE
 
     storeComparisonMode(site.domain, newMode)
-    navigateToQuery(history, query, { comparison: newMode })
+    navigateToQuery(navigate, query, { comparison: newMode })
   }
 }
 
@@ -86,12 +101,13 @@ function ComparisonModeOption({ label, value, isCurrentlySelected, updateMode, s
   )
 }
 
-function MatchDayOfWeekInput({ history }) {
+function MatchDayOfWeekInput() {
+  const navigate = useAppNavigate();
   const site = useSiteContext()
   const { query } = useQueryContext()
   const click = (matchDayOfWeek) => {
-    storage.setItem(`comparison_match_day_of_week__${site.domain}`, matchDayOfWeek.toString())
-    navigateToQuery(history, query, { match_day_of_week: matchDayOfWeek.toString() })
+    storeMatchDayOfWeek(site.domain, matchDayOfWeek)
+    navigateToQuery(navigate, query, { match_day_of_week: matchDayOfWeek })
   }
 
   const buttonClass = (hover, selected) =>
@@ -116,15 +132,28 @@ function MatchDayOfWeekInput({ history }) {
   </>
 }
 
-const ComparisonInput = function ({ history }) {
+function ComparisonInput() {
   const { query } = useQueryContext();
   const site = useSiteContext();
+  const navigate = useAppNavigate();
+  const calendar = useRef(null)
+
+  const [uiMode, setUiMode] = useState("menu")
+
+  useEffect(() => {
+    let timeout = null;
+    if (uiMode == "datepicker") {
+      timeout = setTimeout(() => calendar.current?.flatpickr.open(), 100)
+    }
+    return () => timeout && clearTimeout(timeout)
+  }, [uiMode])
+  
   if (COMPARISON_DISABLED_PERIODS.includes(query.period)) return null
   if (!isComparisonEnabled(query.comparison)) return null
 
   const updateMode = (mode, from = null, to = null) => {
     storeComparisonMode(site.domain, mode)
-    navigateToQuery(history, query, { comparison: mode, compare_from: from, compare_to: to })
+    navigateToQuery(navigate, query, { comparison: mode, compare_from: from, compare_to: to })
   }
 
   const buildLabel = (site, query) => {
@@ -134,18 +163,6 @@ const ComparisonInput = function ({ history }) {
       return COMPARISON_MODES[query.comparison]
     }
   }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const calendar = React.useRef(null)
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [uiMode, setUiMode] = React.useState("menu")
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  React.useEffect(() => {
-    if (uiMode == "datepicker") {
-      setTimeout(() => calendar.current.flatpickr.open(), 100)
-    }
-  }, [uiMode])
 
   const flatpickrOptions = {
     mode: 'range',
@@ -186,7 +203,7 @@ const ComparisonInput = function ({ history }) {
                 {Object.keys(COMPARISON_MODES).map((key) => ComparisonModeOption({ label: COMPARISON_MODES[key], value: key, isCurrentlySelected: key == query.comparison, updateMode, setUiMode }))}
                 {query.comparison !== "custom" && <span>
                   <hr className="my-1" />
-                  <MatchDayOfWeekInput history={history} />
+                  <MatchDayOfWeekInput />
                 </span>}
               </Menu.Items>
             </Transition>
@@ -202,4 +219,4 @@ const ComparisonInput = function ({ history }) {
   )
 }
 
-export default withRouter(ComparisonInput)
+export default ComparisonInput

--- a/assets/js/dashboard/datepicker.js
+++ b/assets/js/dashboard/datepicker.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useState, useEffect, useCallback, useRef } from "react";
-import { withRouter } from "react-router-dom";
+import { useAppNavigate } from "./navigation/use-app-navigate";
 import Flatpickr from "react-flatpickr";
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Transition } from '@headlessui/react';
@@ -70,7 +70,7 @@ function renderArrow(query, site, period, prevDate, nextDate) {
   return (
     <div className={containerClass}>
       <QueryButton
-        to={{ date: prevDate }}
+        search={{ date: prevDate }}
         className={leftClass}
         disabled={disabledLeft}
       >
@@ -88,7 +88,7 @@ function renderArrow(query, site, period, prevDate, nextDate) {
         </svg>
       </QueryButton>
       <QueryButton
-        to={{ date: nextDate }}
+        search={{ date: nextDate }}
         className={rightClass}
         disabled={disabledRight}
       >
@@ -166,22 +166,23 @@ function DisplayPeriod() {
   return 'Realtime'
 }
 
-function DatePicker({ history }) {
+function DatePicker() {
   const { query } = useQueryContext();
   const site = useSiteContext();
   const [open, setOpen] = useState(false)
   const [mode, setMode] = useState('menu')
   const dropDownNode = useRef(null)
   const calendar = useRef(null)
+  const navigate = useAppNavigate();
 
   const handleKeydown = useCallback((e) => {
     if (shouldIgnoreKeypress(e)) return true
 
     const newSearch = {
-      period: false,
-      from: false,
-      to: false,
-      date: false
+      period: null,
+      from: null,
+      to: null,
+      date: null
     };
 
     const insertionDate = parseUTCDate(site.statsBegin);
@@ -222,28 +223,28 @@ function DatePicker({ history }) {
     setOpen(false);
 
     const keybindings = {
-      d: { date: false, period: 'day' },
+      d: { date: null, period: 'day' },
       e: { date: formatISO(shiftDays(nowForSite(site), -1)), period: 'day' },
       r: { period: 'realtime' },
-      w: { date: false, period: '7d' },
-      m: { date: false, period: 'month' },
-      y: { date: false, period: 'year' },
-      t: { date: false, period: '30d' },
-      s: { date: false, period: '6mo' },
-      l: { date: false, period: '12mo' },
-      a: { date: false, period: 'all' },
+      w: { date: null, period: '7d' },
+      m: { date: null, period: 'month' },
+      y: { date: null, period: 'year' },
+      t: { date: null, period: '30d' },
+      s: { date: null, period: '6mo' },
+      l: { date: null, period: '12mo' },
+      a: { date: null, period: 'all' },
     }
 
     const redirect = keybindings[e.key.toLowerCase()]
     if (redirect) {
-      navigateToQuery(history, query, { ...newSearch, ...redirect })
+      navigateToQuery(navigate, query, { ...newSearch, ...redirect, keybindHint: e.key.toUpperCase() })
     } else if (e.key.toLowerCase() === 'x') {
-      toggleComparisons(history, query, site)
+      toggleComparisons(navigate, query, site)
     } else if (e.key.toLowerCase() === 'c') {
       setOpen(true)
       setMode('calendar')
     } else if (newSearch.date) {
-      navigateToQuery(history, query, newSearch);
+      navigateToQuery(navigate, query, newSearch);
     }
   }, [query])
 
@@ -274,9 +275,9 @@ function DatePicker({ history }) {
       [from, to] = [parseNaiveDate(from), parseNaiveDate(to)]
 
       if (from.isSame(to)) {
-        navigateToQuery(history, query, { period: 'day', date: formatISO(from), from: false, to: false })
+        navigateToQuery(navigate, query, { period: 'day', date: formatISO(from), from: null, to: null })
       } else {
-        navigateToQuery(history, query, { period: 'custom', date: false, from: formatISO(from), to: formatISO(to) })
+        navigateToQuery(navigate, query, { period: 'custom', date: null, from: formatISO(from), to: formatISO(to) })
       }
     }
 
@@ -304,11 +305,11 @@ function DatePicker({ history }) {
       boldClass = query.period === period ? "font-bold" : "";
     }
 
-    opts.date = opts.date ? formatISO(opts.date) : false;
+    opts.date = opts.date ? formatISO(opts.date) : null;
 
     return (
       <QueryLink
-        to={{ from: false, to: false, period, ...opts }}
+        search={{ from: null, to: null, period, ...opts }}
         onClick={() => setOpen(false)}
         className={`${boldClass} px-4 py-2 text-sm leading-tight hover:bg-gray-100 hover:text-gray-900
           dark:hover:bg-gray-900 dark:hover:text-gray-100 flex items-center justify-between`}
@@ -370,7 +371,7 @@ function DatePicker({ history }) {
               <div className="py-1 date-option-group border-t border-gray-200 dark:border-gray-500">
                 <span
                   onClick={() => {
-                    toggleComparisons(history, query, site)
+                    toggleComparisons(navigate, query, site)
                     setOpen(false)
                   }}
                   className="px-4 py-2 text-sm leading-tight hover:bg-gray-100 dark:hover:bg-gray-900 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer flex items-center justify-between">
@@ -450,4 +451,4 @@ function DatePicker({ history }) {
   )
 }
 
-export default withRouter(DatePicker);
+export default DatePicker

--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -1,5 +1,8 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import { Link, withRouter } from 'react-router-dom';
+import { useQueryContext } from './query-context';
+import { useSiteContext } from './site-context';
+import { filterRoute } from './router';
+import { AppNavigationLink, useAppNavigate } from './navigation/use-app-navigate';
 import { AdjustmentsVerticalIcon, MagnifyingGlassIcon, XMarkIcon, PencilSquareIcon } from '@heroicons/react/20/solid';
 import classNames from 'classnames';
 import { Menu, Transition } from '@headlessui/react';
@@ -14,50 +17,53 @@ import {
   plainFilterText,
   styledFilterText
 } from "./util/filters";
-import { useQueryContext } from './query-context';
-import { useSiteContext } from './site-context';
 
 const WRAPSTATE = { unwrapped: 0, waiting: 1, wrapped: 2 }
 
-function removeFilter(filterIndex, history, query) {
+function removeFilter(filterIndex, navigate, query) {
   const newFilters = query.filters.filter((_filter, index) => filterIndex != index)
   const newLabels = cleanLabels(newFilters, query.labels)
 
   navigateToQuery(
-    history,
+    navigate,
     query,
     { filters: newFilters, labels: newLabels }
   )
 }
 
-function clearAllFilters(history, query) {
+function clearAllFilters(navigate, query) {
   navigateToQuery(
-    history,
+    navigate,
     query,
-    { filters: false, labels: false }
+    { filters: null, labels: null }
   );
 }
 
-function renderDropdownFilter(filterIndex, filter, site, history, query) {
+function AppliedFilterPillVertical({filterIndex, filter}) {
+  const { query } = useQueryContext();
+  const navigate = useAppNavigate();
   const [_operation, filterKey, _clauses] = filter
 
   const type = filterKey.startsWith(EVENT_PROPS_PREFIX) ? 'props' : filterKey
+
   return (
     <Menu.Item key={filterIndex}>
       <div className="px-3 md:px-4 sm:py-2 py-3 text-sm leading-tight flex items-center justify-between" key={filterIndex}>
-        <Link
+        <AppNavigationLink
           title={`Edit filter: ${plainFilterText(query, filter)}`}
-          to={{ pathname: `/filter/${FILTER_GROUP_TO_MODAL_TYPE[type]}`, search: window.location.search }}
+          path={filterRoute.path}
+          params={{field: FILTER_GROUP_TO_MODAL_TYPE[type]}}
+          search={(search) => search}
           className="group flex w-full justify-between items-center"
           style={{ width: 'calc(100% - 1.5rem)' }}
         >
           <span className="inline-block w-full truncate">{styledFilterText(query, filter)}</span>
           <PencilSquareIcon className="w-4 h-4 ml-1 cursor-pointer group-hover:text-indigo-700 dark:group-hover:text-indigo-500" />
-        </Link>
+        </AppNavigationLink>
         <b
           title={`Remove filter: ${plainFilterText(query, filter)}`}
           className="ml-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500"
-          onClick={() => removeFilter(filterIndex, history, query)}
+          onClick={() => removeFilter(filterIndex, navigate, query)}
         >
           <XMarkIcon className="w-4 h-4" />
         </b>
@@ -66,25 +72,28 @@ function renderDropdownFilter(filterIndex, filter, site, history, query) {
   )
 }
 
-function filterDropdownOption(site, option) {
+function OpenFilterGroupOptionsButton({option}) {
   return (
-    <Menu.Item key={option}>
+    <Menu.Item>
       {({ active }) => (
-        <Link
-          to={{ pathname: `/filter/${option}`, search: window.location.search }}
+        <AppNavigationLink
+          path={filterRoute.path}
+          params={{field: option}}
+          search={(search) => search}
           className={classNames(
             active ? 'bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100' : 'text-gray-800 dark:text-gray-300',
             'block px-4 py-2 text-sm font-medium'
           )}
         >
           {formatFilterGroup(option)}
-        </Link>
+        </AppNavigationLink>
       )}
     </Menu.Item>
   )
 }
 
-function DropdownContent({ history, wrapped }) {
+function DropdownContent({ wrapped }) {
+  const navigate = useAppNavigate();
   const site = useSiteContext();
   const { query } = useQueryContext();
   const [addingFilter, setAddingFilter] = useState(false);
@@ -93,7 +102,7 @@ function DropdownContent({ history, wrapped }) {
     let filterModals = { ...FILTER_MODAL_TO_FILTER_GROUP }
     if (!site.propsAvailable) delete filterModals.props
 
-    return Object.keys(filterModals).map((option) => filterDropdownOption(site, option))
+    return <>{Object.keys(filterModals).map((option) => <OpenFilterGroupOptionsButton key={option} option={option} />)}</>
   }
 
   return (
@@ -101,9 +110,9 @@ function DropdownContent({ history, wrapped }) {
       <div className="border-b border-gray-200 dark:border-gray-500 px-4 sm:py-2 py-3 text-sm leading-tight hover:text-indigo-700 dark:hover:text-indigo-500 hover:cursor-pointer" onClick={() => setAddingFilter(true)}>
         + Add filter
       </div>
-      {query.filters.map((filter, index) => renderDropdownFilter(index, filter, site, history, query))}
+      {query.filters.map((filter, index) => <AppliedFilterPillVertical key={index} filterIndex={index} filter={filter}/>)}
       <Menu.Item key="clear">
-        <div className="border-t border-gray-200 dark:border-gray-500 px-4 sm:py-2 py-3 text-sm leading-tight hover:text-indigo-700 dark:hover:text-indigo-500 hover:cursor-pointer" onClick={() => clearAllFilters(history, query)}>
+        <div className="border-t border-gray-200 dark:border-gray-500 px-4 sm:py-2 py-3 text-sm leading-tight hover:text-indigo-700 dark:hover:text-indigo-500 hover:cursor-pointer" onClick={() => clearAllFilters(navigate, query)}>
           Clear All Filters
         </div>
       </Menu.Item>
@@ -111,7 +120,8 @@ function DropdownContent({ history, wrapped }) {
   )
 }
 
-function Filters({ history }) {
+function Filters() {
+  const navigate = useAppNavigate();
   const { query } = useQueryContext();
 
   const [wrapped, setWrapped] = useState(WRAPSTATE.waiting)
@@ -142,7 +152,7 @@ function Filters({ history }) {
     if (e.ctrlKey || e.metaKey || e.altKey) return
 
     if (e.key === 'Escape') {
-      clearAllFilters(history, query)
+      clearAllFilters(navigate, query)
     }
   }
 
@@ -173,26 +183,25 @@ function Filters({ history }) {
     })
   }
 
-  function renderListFilter(filterIndex, filter) {
+  function AppliedFilterPillHorizontal({filterIndex, filter}) {
+    const { query } = useQueryContext(); 
     const [_operation, filterKey, _clauses] = filter
     const type = filterKey.startsWith(EVENT_PROPS_PREFIX) ? 'props' : filterKey
     return (
-      <span key={filterIndex} className="flex bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 shadow text-sm rounded mr-2 items-center">
-        <Link
+      <span className="flex bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 shadow text-sm rounded mr-2 items-center">
+        <AppNavigationLink
           title={`Edit filter: ${plainFilterText(query, filter)}`}
           className="flex w-full h-full items-center py-2 pl-3"
-          to={{
-            pathname: `/filter/${FILTER_GROUP_TO_MODAL_TYPE[type]}`,
-            search: window.location.search
-          }}
+          path={filterRoute.path}
+          params={{field: FILTER_GROUP_TO_MODAL_TYPE[type]}}
+          search={(search)=> search}
         >
-
           <span className="inline-block max-w-2xs md:max-w-xs truncate">{styledFilterText(query, filter)}</span>
-        </Link>
+        </AppNavigationLink>
         <span
           title={`Remove filter: ${plainFilterText(query, filter)}`}
           className="flex h-full w-full px-2 cursor-pointer hover:text-indigo-700 dark:hover:text-indigo-500 items-center"
-          onClick={() => removeFilter(filterIndex, history, query)}
+          onClick={() => removeFilter(filterIndex, navigate, query)}
         >
           <XMarkIcon className="w-4 h-4" />
         </span>
@@ -253,7 +262,7 @@ function Filters({ history }) {
                   className="rounded-md shadow-lg  bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5
                   font-medium text-gray-800 dark:text-gray-200"
                 >
-                  <DropdownContent history={history} wrapped={wrapped} />
+                  <DropdownContent wrapped={wrapped} />
                 </div>
               </Menu.Items>
             </Transition>
@@ -270,7 +279,7 @@ function Filters({ history }) {
     if (wrapped !== WRAPSTATE.wrapped) {
       return (
         <div id="filters" className="flex flex-wrap">
-          {query.filters.map((filter, index) => renderListFilter(index, filter))}
+          {query.filters.map((filter, index) => <AppliedFilterPillHorizontal key={index} filterIndex={index} filter={filter} />)}
         </div>
       )
     }
@@ -286,4 +295,4 @@ function Filters({ history }) {
   )
 }
 
-export default withRouter(Filters);
+export default Filters;

--- a/assets/js/dashboard/navigation/use-app-navigate.js
+++ b/assets/js/dashboard/navigation/use-app-navigate.js
@@ -1,0 +1,65 @@
+import React, { forwardRef, useCallback } from 'react'
+import { Link, useLocation, useNavigate, generatePath } from 'react-router-dom'
+import { parseSearch, stringifySearch } from '../util/url'
+
+const getNavigateToOptions = (
+  currentSearchString,
+  { path, params, search }
+) => {
+  const searchRecord = parseSearch(currentSearchString)
+  const updatedSearchRecord = search && search(searchRecord)
+  const updatedPath = path && generatePath(path, params)
+  return {
+    pathname: updatedPath,
+    search: updatedSearchRecord && stringifySearch(updatedSearchRecord)
+  }
+}
+
+export const useGetNavigateOptions = () => {
+  const location = useLocation()
+  /**
+   * @param path - path to target, for example `"/posts"` or `"/posts/:id"`
+   * @param params - dictionary of param keys with their values, if needed, for example `{ id: "some-id" }`
+   * @param search -
+   *   function in the form of `(currentSearchRecord) => newSearchRecord` to set link search value, for example
+   *  `(s) => s` preserves current search value,
+   *  `() => ({page: 5})` sets the search to `?page=5`,
+   *  `undefined` empties the search
+   * @returns the appropriate value for `react-router-dom` `Link` and `navigate` `to` property
+   */
+  const getToOptions = useCallback(
+    ({ path, params, search }) => {
+      return getNavigateToOptions(location.search, { path, params, search })
+    },
+    [location.search]
+  )
+  return getToOptions
+}
+
+export const useAppNavigate = () => {
+  const _navigate = useNavigate()
+  const getToOptions = useGetNavigateOptions()
+  const navigate = useCallback(
+    ({ path, params, search, ...options }) => {
+      return _navigate(getToOptions({ path, params, search }), options)
+    },
+    [getToOptions, _navigate]
+  )
+  return navigate
+}
+
+export const AppNavigationLink = forwardRef(
+  ({ path, params, search, ...options }, ref) => {
+    const getToOptions = useGetNavigateOptions()
+
+    return (
+      <Link
+        to={getToOptions({ path, params, search })}
+        {...options}
+        ref={ref}
+      />
+    )
+  }
+)
+
+AppNavigationLink.displayName = 'AppNavigationLink'

--- a/assets/js/dashboard/query-context.js
+++ b/assets/js/dashboard/query-context.js
@@ -1,9 +1,10 @@
 import React, { createContext, useMemo, useEffect, useContext, useState, useCallback } from "react";
 import { parseQuery } from "./query";
-import { withRouter } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useMountedEffect } from "./custom-hooks";
 import * as api from './api'
 import { useSiteContext } from "./site-context";
+import { parseSearch } from "./util/url";
 
 const queryContextDefaultValue = { query: {}, lastLoadTimestamp: new Date() }
 
@@ -11,13 +12,15 @@ const QueryContext = createContext(queryContextDefaultValue)
 
 export const useQueryContext = () => { return useContext(QueryContext) }
 
-function QueryContextProvider({ location, children }) {
+export default function QueryContextProvider({ children }) {
+    const location = useLocation();
     const site = useSiteContext();
-    const { search } = location;
-    const query = useMemo(() => {
-        return parseQuery(search, site)
-    }, [search, site])
+    const searchRecord = useMemo(() => parseSearch(location.search), [location.search]);
 
+    const query = useMemo(() => {
+        return parseQuery(searchRecord, site)
+    }, [searchRecord, site])
+    
     const [lastLoadTimestamp, setLastLoadTimestamp] = useState(new Date())
     const updateLastLoadTimestamp = useCallback(() => { setLastLoadTimestamp(new Date()) }, [setLastLoadTimestamp])
 
@@ -36,5 +39,3 @@ function QueryContextProvider({ location, children }) {
 
     return <QueryContext.Provider value={{ query, lastLoadTimestamp }}>{children}</QueryContext.Provider>
 };
-
-export default withRouter(QueryContextProvider);

--- a/assets/js/dashboard/router.js
+++ b/assets/js/dashboard/router.js
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react';
-import { BrowserRouter, Switch, Route, useLocation } from "react-router-dom";
+/* @format */
+import React from 'react'
+import { createBrowserRouter, Outlet } from 'react-router-dom'
 
 import Dashboard from './index'
 import SourcesModal from './stats/modals/sources'
@@ -8,17 +9,12 @@ import GoogleKeywordsModal from './stats/modals/google-keywords'
 import PagesModal from './stats/modals/pages'
 import EntryPagesModal from './stats/modals/entry-pages'
 import ExitPagesModal from './stats/modals/exit-pages'
-import LocationsModal from './stats/modals/locations-modal';
+import LocationsModal from './stats/modals/locations-modal'
 import PropsModal from './stats/modals/props'
 import ConversionsModal from './stats/modals/conversions'
 import FilterModal from './stats/modals/filter-modal'
-import QueryContextProvider from './query-context';
-import { useSiteContext } from './site-context';
-
-import {
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query'
+import QueryContextProvider from './query-context'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -28,62 +24,146 @@ const queryClient = new QueryClient({
   }
 })
 
-function ScrollToTop() {
-  const location = useLocation();
-
-  useEffect(() => {
-    if (location.state && location.state.scrollTop) {
-      window.scrollTo(0, 0);
-    }
-  }, [location]);
-
-  return null;
-}
-
-export default function Router() {
-  const site = useSiteContext()
+function DashboardElement() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename={site.shared ? `/share/${encodeURIComponent(site.domain)}` : encodeURIComponent(site.domain)}>
-        <QueryContextProvider>
-          <Route path="/">
-            <ScrollToTop />
-            <Dashboard />
-            <Switch>
-              <Route exact path={["/sources", "/utm_mediums", "/utm_sources", "/utm_campaigns", "/utm_contents", "/utm_terms"]}>
-                <SourcesModal />
-              </Route>
-              <Route exact path="/referrers/Google">
-                <GoogleKeywordsModal site={site} />
-              </Route>
-              <Route exact path="/referrers/:referrer">
-                <ReferrersDrilldownModal />
-              </Route>
-              <Route path="/pages">
-                <PagesModal />
-              </Route>
-              <Route path="/entry-pages">
-                <EntryPagesModal />
-              </Route>
-              <Route path="/exit-pages">
-                <ExitPagesModal />
-              </Route>
-              <Route exact path={["/countries", "/regions", "/cities"]}>
-                <LocationsModal />
-              </Route>
-              <Route path="/custom-prop-values/:prop_key">
-                <PropsModal />
-              </Route>
-              <Route path="/conversions">
-                <ConversionsModal />
-              </Route>
-              <Route path={["/filter/:field"]}>
-                <FilterModal site={site} />
-              </Route>
-            </Switch>
-          </Route>
-        </QueryContextProvider>
-      </BrowserRouter>
+      <QueryContextProvider>
+        <Dashboard />
+        {/** render any children of the root route below */}
+        <Outlet />
+      </QueryContextProvider>
     </QueryClientProvider>
-  );
+  )
+}
+
+export const rootRoute = {
+  path: '/',
+  element: <DashboardElement />
+}
+
+export const sourcesRoute = {
+  path: 'sources',
+  element: <SourcesModal currentView="sources" />
+}
+
+export const utmMediumsRoute = {
+  path: 'utm_mediums',
+  element: <SourcesModal currentView="utm_mediums" />
+}
+
+export const utmSourcesRoute = {
+  path: 'utm_sources',
+  element: <SourcesModal currentView="utm_sources" />
+}
+
+export const utmCampaignsRoute = {
+  path: 'utm_campaigns',
+  element: <SourcesModal currentView="utm_campaigns" />
+}
+
+export const utmContentsRoute = {
+  path: 'utm_contents',
+  element: <SourcesModal currentView="utm_contents" />
+}
+
+export const utmTermsRoute = {
+  path: 'utm_terms',
+  element: <SourcesModal currentView="utm_terms" />
+}
+
+export const referrersGoogleRoute = {
+  path: 'referrers/Google',
+  element: <GoogleKeywordsModal />
+}
+
+export const topPagesRoute = {
+  path: 'pages',
+  element: <PagesModal />
+}
+
+export const entryPagesRoute = {
+  path: 'entry-pages',
+  element: <EntryPagesModal />
+}
+
+export const exitPagesRoute = {
+  path: 'exit-pages',
+  element: <ExitPagesModal />
+}
+
+export const countriesRoute = {
+  path: 'countries',
+  element: <LocationsModal currentView="countries" />
+}
+
+export const regionsRoute = {
+  path: 'regions',
+  element: <LocationsModal currentView="regions" />
+}
+
+export const citiesRoute = {
+  path: 'cities',
+  element: <LocationsModal currentView="cities" />
+}
+
+export const conversionsRoute = {
+  path: 'conversions',
+  element: <ConversionsModal />
+}
+
+export const referrersDrilldownRoute = {
+  path: 'referrers/:referrer',
+  element: <ReferrersDrilldownModal />
+}
+
+export const customPropsRoute = {
+  path: 'custom-prop-values/:propKey',
+  element: <PropsModal />
+}
+
+export const filterRoute = {
+  path: 'filter/:field',
+  element: <FilterModal />
+}
+
+export function createAppRouter(site) {
+  const basepath = site.shared
+    ? `/share/${encodeURIComponent(site.domain)}`
+    : `/${encodeURIComponent(site.domain)}`
+
+  const router = createBrowserRouter(
+    [
+      {
+        ...rootRoute,
+        children: [
+          sourcesRoute,
+          utmMediumsRoute,
+          utmSourcesRoute,
+          utmCampaignsRoute,
+          utmContentsRoute,
+          utmTermsRoute,
+          referrersGoogleRoute,
+          referrersDrilldownRoute,
+          topPagesRoute,
+          entryPagesRoute,
+          exitPagesRoute,
+          countriesRoute,
+          regionsRoute,
+          citiesRoute,
+          conversionsRoute,
+          customPropsRoute,
+          filterRoute,
+          { path: '*', element: null }
+        ]
+      }
+    ],
+    {
+      basename: basepath,
+      future: {
+        v7_prependBasename: true
+      }
+    }
+  )
+
+  return router
 }

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -103,6 +103,7 @@ export default class SiteSwitcher extends React.Component {
       siteNum <= sites.length &&
       sites[siteNum - 1] !== site.domain
     ) {
+      // has to change window.location because Router is rendered with /${site.domain} as the basepath
       window.location = `/${encodeURIComponent(sites[siteNum - 1])}`
     }
   }

--- a/assets/js/dashboard/stats/behaviours/conversions.js
+++ b/assets/js/dashboard/stats/behaviours/conversions.js
@@ -6,6 +6,7 @@ import * as metrics from '../reports/metrics';
 import ListReport from '../reports/list';
 import { useSiteContext } from '../../site-context';
 import { useQueryContext } from '../../query-context';
+import { conversionsRoute } from '../../router';
 
 export default function Conversions({ afterFetchData, onGoalFilterClick }) {
   const site = useSiteContext();
@@ -41,7 +42,8 @@ export default function Conversions({ afterFetchData, onGoalFilterClick }) {
       keyLabel="Goal"
       onClick={onGoalFilterClick}
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath('conversions')}
+      detailsLinkProps={{ path: conversionsRoute.path, search: (search) => search }}
+      maybeHideDetails={true}
       color="bg-red-50"
       colMinWidth={90}
     />

--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -7,6 +7,7 @@ import * as api from "../../api"
 import { EVENT_PROPS_PREFIX, getGoalFilter } from "../../util/filters"
 import { useSiteContext } from "../../site-context"
 import { useQueryContext } from "../../query-context"
+import { customPropsRoute } from "../../router"
 
 export const SPECIAL_GOALS = {
   '404': { title: '404 Pages', prop: 'path' },
@@ -71,7 +72,7 @@ function SpecialPropBreakdown({ prop, afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel={prop}
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath(`custom-prop-values/${prop}`)}
+      detailsLinkProps={{ path: customPropsRoute.path, params: {propKey: prop}, search: (search) => search }}
       externalLinkDest={externalLinkDest()}
       maybeHideDetails={true}
       color="bg-red-50"

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -44,8 +44,8 @@ export default function Behaviours({ importedDataInView }) {
   const user = useUserContext();
 
   const adminAccess = ['owner', 'admin', 'super_admin'].includes(user.role)
-  const tabKey = `behavioursTab__${site.domain}`
-  const funnelKey = `behavioursTabFunnel__${site.domain}`
+  const tabKey = storage.getDomainScopedStorageKey('behavioursTab', site.domain)
+  const funnelKey = storage.getDomainScopedStorageKey('behavioursTabFunnel', site.domain)
   const [enabledModes, setEnabledModes] = useState(getEnabledModes())
   const [mode, setMode] = useState(defaultMode())
   const [loading, setLoading] = useState(true)

--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -9,6 +9,7 @@ import { EVENT_PROPS_PREFIX, getGoalFilter, FILTER_OPERATIONS, hasGoalFilter } f
 import classNames from "classnames";
 import { useQueryContext } from "../../query-context";
 import { useSiteContext } from "../../site-context";
+import { customPropsRoute } from "../../router";
 
 
 export default function Properties({ afterFetchData }) {
@@ -107,7 +108,7 @@ export default function Properties({ afterFetchData }) {
         getFilterFor={getFilterFor}
         keyLabel={propKey}
         metrics={chooseMetrics()}
-        detailsLink={url.sitePath(`custom-prop-values/${propKey}`)}
+        detailsLinkProps={{ path: customPropsRoute.path, params: { propKey }, search: (search) => search }}
         maybeHideDetails={true}
         color="bg-red-50"
         colMinWidth={90}

--- a/assets/js/dashboard/stats/current-visitors.js
+++ b/assets/js/dashboard/stats/current-visitors.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom'
+import { AppNavigationLink } from '../navigation/use-app-navigate';
 import * as api from '../api'
-import * as url from '../util/url'
 import { Tooltip } from '../util/tooltip';
 import { SecondsSinceLastLoad } from '../util/seconds-since-last-load';
 import { useQueryContext } from '../query-context';
@@ -15,7 +14,7 @@ export default function CurrentVisitors({ tooltipBoundary }) {
   const updateCount = useCallback(() => {
     api.get(`/api/stats/${encodeURIComponent(site.domain)}/current-visitors`)
       .then((res) => setCurrentVisitors(res))
-  }, [])
+  }, [site.domain])
 
   useEffect(() => {
     document.addEventListener('tick', updateCount)
@@ -23,11 +22,11 @@ export default function CurrentVisitors({ tooltipBoundary }) {
     return () => {
       document.removeEventListener('tick', updateCount)
     }
-  }, [])
+  }, [updateCount])
 
   useEffect(() => {
     updateCount()
-  }, [query])
+  }, [query, updateCount])
 
   function tooltipInfo() {
     return (
@@ -41,12 +40,12 @@ export default function CurrentVisitors({ tooltipBoundary }) {
   if (currentVisitors !== null && query.filters.length === 0) {
     return (
       <Tooltip info={tooltipInfo()} boundary={tooltipBoundary}>
-        <Link to={url.setQuery('period', 'realtime')} className="block ml-1 md:ml-2 mr-auto text-xs md:text-sm font-bold text-gray-500 dark:text-gray-300">
+        <AppNavigationLink search={(prev) => ({ ...prev, period: 'realtime' })} className="block ml-1 md:ml-2 mr-auto text-xs md:text-sm font-bold text-gray-500 dark:text-gray-300">
           <svg className="inline w-2 mr-1 md:mr-2 text-green-500 fill-current" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <circle cx="8" cy="8" r="8" />
           </svg>
           {currentVisitors} <span className="hidden sm:inline-block">current visitor{currentVisitors === 1 ? '' : 's'}</span>
-        </Link>
+        </AppNavigationLink>
       </Tooltip>
     )
   } else {

--- a/assets/js/dashboard/stats/graph/line-graph.js
+++ b/assets/js/dashboard/stats/graph/line-graph.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom'
+import { useAppNavigate } from '../../navigation/use-app-navigate';
+import { useQueryContext } from '../../query-context';
 import Chart from 'chart.js/auto';
 import { navigateToQuery } from '../../query'
 import GraphTooltip from './graph-tooltip'
@@ -225,9 +226,9 @@ class LineGraph extends React.Component {
     const date = this.props.graphData.labels[element.index] || this.props.graphData.comparison_labels[element.index]
 
     if (this.props.graphData.interval === 'month') {
-      navigateToQuery(this.props.history, this.props.query, { period: 'month', date })
+      navigateToQuery(this.props.navigate, this.props.query, { period: 'month', date })
     } else if (this.props.graphData.interval === 'date') {
-      navigateToQuery(this.props.history, this.props.query, { period: 'day', date })
+      navigateToQuery(this.props.navigate, this.props.query, { period: 'day', date })
     }
   }
 
@@ -245,4 +246,8 @@ class LineGraph extends React.Component {
   }
 }
 
-export default withRouter(LineGraph)
+export default function LineGraphWrapped(props) {
+  const { query } = useQueryContext()
+  const navigate = useAppNavigate()
+  return <LineGraph {...props} navigate={navigate} query={query} />
+}

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -151,10 +151,15 @@ export default function VisitorGraph({ updateImportedDataInView }) {
           <div className="absolute right-4 -top-8 py-1 flex items-center">
             {!isRealtime && <StatsExport />}
             <SamplingNotice samplePercent={topStatData} />
-            <WithImportedSwitch info={topStatData && topStatData.with_imported_switch} />
+            {!!topStatData?.with_imported_switch && topStatData?.with_imported_switch.visible &&
+              <WithImportedSwitch
+                tooltipMessage={topStatData.with_imported_switch.tooltip_msg}
+                disabled={!topStatData.with_imported_switch.togglable}
+              />
+            }
             <IntervalPicker onIntervalUpdate={onIntervalUpdate} />
           </div>
-          <LineGraphWithRouter graphData={graphData} darkTheme={isDarkTheme} query={query} />
+          <LineGraphWithRouter graphData={graphData} darkTheme={isDarkTheme} />
         </div>
       </FadeIn>
     </div>

--- a/assets/js/dashboard/stats/graph/with-imported-switch.js
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.js
@@ -1,38 +1,23 @@
 import React from "react"
-import { Link } from 'react-router-dom'
-import * as url from '../../util/url'
 import { BarsArrowUpIcon } from '@heroicons/react/20/solid'
 import classNames from "classnames"
 import { useQueryContext } from "../../query-context"
+import { AppNavigationLink } from "../../navigation/use-app-navigate"
 
-function LinkOrDiv({ isLink, target, children }) {
-  if (isLink) {
-    return <Link to={target}>{children}</Link>
-  } else {
-    return <div>{children}</div>
-  }
-}
-
-export default function WithImportedSwitch({ info }) {
+export default function WithImportedSwitch({ tooltipMessage, disabled }) {
   const { query } = useQueryContext();
-  if (info && info.visible) {
-    const { togglable, tooltip_msg } = info
-    const enabled = togglable && query.with_imported
-    const target = url.setQuery('with_imported', (!enabled).toString())
+  const importsSwitchedOn = query.with_imported;
+    
+  const iconClass = classNames("mt-0.5", {
+    "dark:text-gray-300 text-gray-700": importsSwitchedOn,
+    "dark:text-gray-500 text-gray-400": !importsSwitchedOn,
+  })
 
-    const iconClass = classNames("mt-0.5", {
-      "dark:text-gray-300 text-gray-700": enabled,
-      "dark:text-gray-500 text-gray-400": !enabled,
-    })
-
-    return (
-      <div tooltip={tooltip_msg} className="w-4 h-4 mx-2">
-        <LinkOrDiv isLink={togglable} target={target}>
-          <BarsArrowUpIcon className={iconClass} />
-        </LinkOrDiv>
-      </div>
-    )
-  } else {
-    return null
-  }
+  return (
+    <div tooltip={tooltipMessage} className="w-4 h-4 mx-2">
+      <AppNavigationLink search={disabled ? (search) => search : (search) => ({...search, with_imported: !importsSwitchedOn}) }>
+        <BarsArrowUpIcon className={iconClass} />
+      </AppNavigationLink>
+    </div>
+  )
 }

--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -4,12 +4,13 @@ import * as storage from '../../util/storage';
 import CountriesMap from './map';
 
 import * as api from '../../api';
-import { apiPath, sitePath } from '../../util/url';
+import { apiPath } from '../../util/url';
 import ListReport from '../reports/list';
 import * as metrics from '../reports/metrics';
 import { hasGoalFilter } from "../../util/filters";
 import { getFiltersByKeyPrefix } from '../../util/filters';
 import ImportedQueryUnsupportedWarning from '../imported-query-unsupported-warning';
+import { citiesRoute, countriesRoute, regionsRoute } from '../../router';
 
 function Countries({ query, site, onClick, afterFetchData }) {
 	function fetchData() {
@@ -43,7 +44,7 @@ function Countries({ query, site, onClick, afterFetchData }) {
 			onClick={onClick}
 			keyLabel="Country"
 			metrics={chooseMetrics()}
-			detailsLink={sitePath('countries')}
+			detailsLinkProps={{ path: countriesRoute.path, search: (search) => search }}
 			renderIcon={renderIcon}
 			color="bg-orange-50"
 		/>
@@ -82,7 +83,7 @@ function Regions({ query, site, onClick, afterFetchData }) {
 			onClick={onClick}
 			keyLabel="Region"
 			metrics={chooseMetrics()}
-			detailsLink={sitePath('regions')}
+			detailsLinkProps={{ path: regionsRoute.path, search: (search) => search }}
 			renderIcon={renderIcon}
 			color="bg-orange-50"
 		/>
@@ -120,7 +121,7 @@ function Cities({ query, site, afterFetchData }) {
 			getFilterFor={getFilterFor}
 			keyLabel="City"
 			metrics={chooseMetrics()}
-			detailsLink={sitePath('cities')}
+			detailsLinkProps={{ path: citiesRoute.path, search: (search) => search }}
 			renderIcon={renderIcon}
 			color="bg-orange-50"
 		/>
@@ -235,7 +236,7 @@ export default class Locations extends React.Component {
 						<h3 className="font-bold dark:text-gray-100">
 							{labelFor[this.state.mode] || 'Locations'}
 						</h3>
-						<ImportedQueryUnsupportedWarning loading={this.state.loading} query={this.props.query} skipImportedReason={this.state.skipImportedReason} />
+						<ImportedQueryUnsupportedWarning loading={this.state.loading} skipImportedReason={this.state.skipImportedReason} />
 					</div>
 					<div className="flex text-xs font-medium text-gray-500 dark:text-gray-400 space-x-2">
 						{this.renderPill('Map', 'map')}

--- a/assets/js/dashboard/stats/locations/map.js
+++ b/assets/js/dashboard/stats/locations/map.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Datamap from 'datamaps'
-import { withRouter } from 'react-router-dom'
 import * as d3 from "d3"
 
 import numberFormatter from '../../util/number-formatter'
@@ -10,6 +9,9 @@ import MoreLink from '../more-link'
 import * as api from '../../api'
 import { navigateToQuery } from '../../query'
 import { cleanLabels, replaceFilterByPrefix } from '../../util/filters';
+import { countriesRoute } from '../../router';
+import { useAppNavigate } from '../../navigation/use-app-navigate';
+import { useQueryContext } from '../../query-context';
 
 class Countries extends React.Component {
   constructor(props) {
@@ -124,7 +126,7 @@ class Countries extends React.Component {
             this.props.onClick()
 
             navigateToQuery(
-              this.props.history,
+              this.props.navigate,
               this.props.query,
               {
                 filters,
@@ -153,7 +155,7 @@ class Countries extends React.Component {
       return (
         <>
           <div className="mx-auto mt-4" style={{ width: '100%', maxWidth: '475px', height: '335px' }} id="map-container"></div>
-          <MoreLink list={this.state.countries} endpoint="countries" />
+          <MoreLink list={this.state.countries} linkProps={{ path: countriesRoute.path, search: (search) => search }} />
           {this.geolocationDbNotice()}
         </>
       )
@@ -174,4 +176,5 @@ class Countries extends React.Component {
   }
 }
 
-export default withRouter(Countries)
+export default function CountriesWithRouter(props) {const {query} = useQueryContext(); const navigate = useAppNavigate();
+return (<Countries {...props} query={query} navigate={navigate}/>)}

--- a/assets/js/dashboard/stats/modals/breakdown-modal.js
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.js
@@ -2,9 +2,9 @@ import React, { useState, useEffect, useRef } from "react";
 
 import { FilterLink } from "../reports/list";
 import { useQueryContext } from "../../query-context";
-import { useSiteContext } from "../../site-context";
 import { useDebounce } from "../../custom-hooks";
 import { useAPIClient } from "../../hooks/api-client";
+import { rootRoute } from "../../router";
 
 export const MIN_HEIGHT_PX = 500
 
@@ -85,7 +85,6 @@ export default function BreakdownModal({
 }) {
   const searchBoxRef = useRef(null)
   const { query } = useQueryContext();
-  const site = useSiteContext();
 
   const [search, setSearch] = useState('')
 
@@ -159,7 +158,7 @@ export default function BreakdownModal({
         <td className="w-48 md:w-80 break-all p-2 flex items-center">
           {maybeRenderIcon(item)}
           <FilterLink
-            pathname={`/${encodeURIComponent(site.domain)}`}
+            path={rootRoute.path}
             filterInfo={getFilterInfo(item)}
           >
             {item.name}

--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -1,13 +1,14 @@
-import React from "react";
-import { withRouter } from 'react-router-dom';
+import React from 'react'
+import { useParams } from 'react-router-dom';
 
 import Modal from './modal';
 import { EVENT_PROPS_PREFIX, FILTER_GROUP_TO_MODAL_TYPE, formatFilterGroup, FILTER_OPERATIONS, getFilterGroup, FILTER_MODAL_TO_FILTER_GROUP } from '../../util/filters';
-import { parseQuery } from '../../query';
-import { updatedQuery } from '../../util/url';
+import { useQueryContext } from '../../query-context';
 import { shouldIgnoreKeypress } from '../../keybinding';
 import { cleanLabels } from "../../util/filters";
 import FilterModalGroup from "./filter-modal-group";
+import { rootRoute } from '../../router';
+import { useAppNavigate } from '../../navigation/use-app-navigate';
 
 function partitionFilters(modalType, filters) {
   const otherFilters = []
@@ -44,21 +45,21 @@ class FilterModal extends React.Component {
   constructor(props) {
     super(props)
 
-    const modalType = props.match.params.field || 'page'
+    const modalType = this.props.modalType
 
-    const query = parseQuery(props.location.search, props.site)
+    const query = this.props.query
     const { filterState, otherFilters, hasRelevantFilters } = partitionFilters(modalType, query.filters)
 
     this.handleKeydown = this.handleKeydown.bind(this)
-    this.state = { query, modalType, filterState, labelState: query.labels, otherFilters, hasRelevantFilters }
+    this.state = { query, filterState, labelState: query.labels, otherFilters, hasRelevantFilters }
   }
 
   componentDidMount() {
-    document.addEventListener("keydown", this.handleKeydown)
+    document.addEventListener('keydown', this.handleKeydown)
   }
 
   componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeydown);
+    document.removeEventListener('keydown', this.handleKeydown)
   }
 
   handleKeydown(e) {
@@ -69,12 +70,13 @@ class FilterModal extends React.Component {
     }
   }
 
-  handleSubmit() {
+  handleSubmit(e) {
     const filters = Object.values(this.state.filterState)
       .filter(([_op, _key, clauses]) => clauses.length > 0)
       .concat(this.state.otherFilters)
 
     this.selectFiltersAndCloseModal(filters)
+    e.preventDefault()
   }
 
   isDisabled() {
@@ -82,12 +84,14 @@ class FilterModal extends React.Component {
   }
 
   selectFiltersAndCloseModal(filters) {
-    this.props.history.replace({
-      pathname: '/',
-      search: updatedQuery({
+    this.props.navigate({
+      path: rootRoute.path,
+      search: (search) => ({
+        ...search,
         filters: filters,
         labels: cleanLabels(filters, this.state.labelState)
-      })
+      }),
+      replace: true
     })
   }
 
@@ -110,7 +114,7 @@ class FilterModal extends React.Component {
   }
 
   onAddRow(filterGroup) {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const filter = emptyFilter(filterGroup)
       const id = `${filterGroup}${Object.keys(this.state.filterState).length}`
 
@@ -134,12 +138,14 @@ class FilterModal extends React.Component {
   render() {
     return (
       <Modal maxWidth="460px">
-        <h1 className="text-xl font-bold dark:text-gray-100">Filter by {formatFilterGroup(this.state.modalType)}</h1>
+        <h1 className="text-xl font-bold dark:text-gray-100">
+          Filter by {formatFilterGroup(this.props.modalType)}
+        </h1>
 
         <div className="mt-4 border-b border-gray-300"></div>
         <main className="modal__content">
           <form className="flex flex-col" onSubmit={this.handleSubmit.bind(this)}>
-            {FILTER_MODAL_TO_FILTER_GROUP[this.state.modalType].map((filterGroup) => (
+            {FILTER_MODAL_TO_FILTER_GROUP[this.props.modalType].map((filterGroup) => (
               <FilterModalGroup
                 key={filterGroup}
                 filterGroup={filterGroup}
@@ -169,7 +175,7 @@ class FilterModal extends React.Component {
                   }}
                 >
                   <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
-                  Remove filter{FILTER_MODAL_TO_FILTER_GROUP[this.state.modalType].length > 1 ? 's' : ''}
+                  Remove filter{FILTER_MODAL_TO_FILTER_GROUP[this.props.modalType].length > 1 ? 's' : ''}
                 </button>
               )}
             </div>
@@ -180,4 +186,16 @@ class FilterModal extends React.Component {
   }
 }
 
-export default withRouter(FilterModal)
+export default function FilterModalWithRouter(props) {
+  const navigate = useAppNavigate();
+  const { field } = useParams()
+  const { query } = useQueryContext()
+  return (
+    <FilterModal
+      {...props}
+      modalType={field || 'page'}
+      query={query}
+      navigate={navigate}
+    />
+  )
+}

--- a/assets/js/dashboard/stats/modals/locations-modal.js
+++ b/assets/js/dashboard/stats/modals/locations-modal.js
@@ -1,11 +1,10 @@
 import React, { useCallback } from "react";
-import { withRouter } from 'react-router-dom'
 
-import Modal from './modal'
+import Modal from "./modal";
 import { hasGoalFilter } from "../../util/filters";
 import BreakdownModal from "./breakdown-modal";
 import * as metrics from "../reports/metrics";
-import * as url from '../../util/url';
+import * as url from "../../util/url";
 import { useQueryContext } from "../../query-context";
 import { useSiteContext } from "../../site-context";
 
@@ -15,12 +14,9 @@ const VIEWS = {
   cities: { title: 'Top Cities', dimension: 'city', endpoint: '/cities', dimensionLabel: 'City' },
 }
 
-function LocationsModal({ location }) {
+function LocationsModal({ currentView }) {
   const { query } = useQueryContext();
   const site = useSiteContext();
-
-  const urlParts = location.pathname.split('/')
-  const currentView = urlParts[urlParts.length - 1]
 
   let reportInfo = VIEWS[currentView]
   reportInfo = {...reportInfo, endpoint: url.apiPath(site, reportInfo.endpoint)}
@@ -73,4 +69,4 @@ function LocationsModal({ location }) {
   )
 }
 
-export default withRouter(LocationsModal)
+export default LocationsModal

--- a/assets/js/dashboard/stats/modals/modal.js
+++ b/assets/js/dashboard/stats/modals/modal.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { createPortal } from "react-dom";
-import { withRouter } from 'react-router-dom';
 import { shouldIgnoreKeypress } from '../../keybinding'
+import { rootRoute } from "../../router";
+import { useAppNavigate } from "../../navigation/use-app-navigate";
 
 // This corresponds to the 'md' breakpoint on TailwindCSS.
 const MD_WIDTH = 768;
@@ -57,7 +58,10 @@ class Modal extends React.Component {
   }
 
   close() {
-    this.props.history.push(`/${this.props.location.search}`)
+    this.props.navigate({
+      path: rootRoute.path,
+      search: (search) => search,
+    })
   }
 
   /**
@@ -91,7 +95,6 @@ class Modal extends React.Component {
           >
             {this.props.children}
           </div>
-
         </div>
       </div>,
       document.getElementById("modal_root"),
@@ -99,5 +102,7 @@ class Modal extends React.Component {
   }
 }
 
-
-export default withRouter(Modal)
+export default function ModalWithRouting(props) {
+  const navigate = useAppNavigate()
+  return <Modal {...props} navigate={navigate} />
+}

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { withRouter } from 'react-router-dom'
+import { useParams } from "react-router-dom";
 
 import Modal from './modal'
 import { addFilter } from '../../query'
@@ -12,10 +12,10 @@ import { revenueAvailable } from "../../query";
 import { useQueryContext } from "../../query-context";
 import { useSiteContext } from "../../site-context";
 
-function PropsModal({ location }) {
+function PropsModal() {
   const { query } = useQueryContext();
   const site = useSiteContext();
-  const propKey = location.pathname.split('/').filter(i => i).pop()
+  const { propKey } = useParams();
 
   /*global BUILD_EXTRA*/
   const showRevenueMetrics = BUILD_EXTRA && revenueAvailable(query, site)
@@ -61,4 +61,4 @@ function PropsModal({ location }) {
   )
 }
 
-export default withRouter(PropsModal)
+export default PropsModal

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import { withRouter } from 'react-router-dom'
+import React, { useCallback } from 'react'
+import { useParams } from 'react-router-dom';
 
 import Modal from './modal'
 import { hasGoalFilter, isRealTimeDashboard } from "../../util/filters";
@@ -10,14 +10,15 @@ import { addFilter } from "../../query";
 import { useQueryContext } from "../../query-context";
 import { useSiteContext } from "../../site-context";
 
-function ReferrerDrilldownModal({ match }) {
+function ReferrerDrilldownModal() {
+  const { referrer } = useParams();
   const { query } = useQueryContext();
   const site = useSiteContext();
 
   const reportInfo = {
     title: "Referrer Drilldown",
     dimension: 'referrer',
-    endpoint: url.apiPath(site, `/referrers/${match.params.referrer}`),
+    endpoint: url.apiPath(site, `/referrers/${referrer}`),
     dimensionLabel: "Referrer"
   }
 
@@ -83,4 +84,4 @@ function ReferrerDrilldownModal({ match }) {
   )
 }
 
-export default withRouter(ReferrerDrilldownModal)
+export default ReferrerDrilldownModal

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -1,6 +1,4 @@
 import React, { useCallback } from "react";
-import { withRouter } from 'react-router-dom'
-
 import Modal from './modal'
 import { hasGoalFilter, isRealTimeDashboard } from "../../util/filters";
 import BreakdownModal from "./breakdown-modal";
@@ -39,12 +37,9 @@ const VIEWS = {
   },
 }
 
-function SourcesModal({ location }) {
+function SourcesModal({ currentView }) {
   const { query } = useQueryContext();
   const site = useSiteContext();
-
-  const urlParts = location.pathname.split('/')
-  const currentView = urlParts[urlParts.length - 1]
 
   let reportInfo = VIEWS[currentView].info
   reportInfo = {...reportInfo, endpoint: url.apiPath(site, reportInfo.endpoint)}
@@ -95,4 +90,4 @@ function SourcesModal({ location }) {
   )
 }
 
-export default withRouter(SourcesModal)
+export default SourcesModal

--- a/assets/js/dashboard/stats/more-link.js
+++ b/assets/js/dashboard/stats/more-link.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom'
+import { AppNavigationLink } from '../navigation/use-app-navigate';
 
 function detailsIcon() {
   return (
@@ -20,19 +20,19 @@ function detailsIcon() {
   )
 }
 
-export default function MoreLink({ url, list, endpoint, className, onClick }) {
+export default function MoreLink({ linkProps, list, className, onClick }) {
   if (list.length > 0) {
     return (
       <div className={`w-full text-center ${className ? className : ''}`}>
-        <Link
-          to={url || `/${endpoint}${window.location.search}`}
+        <AppNavigationLink
+          {...linkProps}
           // eslint-disable-next-line max-len
           className="leading-snug font-bold text-sm text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition tracking-wide"
           onClick={onClick}
         >
           {detailsIcon()}
           DETAILS
-        </Link>
+        </AppNavigationLink>
       </div>
     )
   }

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -9,6 +9,7 @@ import ImportedQueryUnsupportedWarning from '../imported-query-unsupported-warni
 import { hasGoalFilter } from '../../util/filters';
 import { useQueryContext } from '../../query-context';
 import { useSiteContext } from '../../site-context';
+import { entryPagesRoute, exitPagesRoute, topPagesRoute } from '../../router';
 
 function EntryPages({ afterFetchData }) {
   const { query } = useQueryContext();
@@ -42,7 +43,7 @@ function EntryPages({ afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel="Entry page"
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath('entry-pages')}
+      detailsLinkProps={{ path: entryPagesRoute.path, search: (search) => search }}
       externalLinkDest={externalLinkDest}
       color="bg-orange-50"
     />
@@ -81,7 +82,7 @@ function ExitPages({ afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel="Exit page"
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath('exit-pages')}
+      detailsLinkProps={{ path: exitPagesRoute.path, search: (search) => search }}
       externalLinkDest={externalLinkDest}
       color="bg-orange-50"
     />
@@ -120,7 +121,7 @@ function TopPages({ afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel="Page"
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath('pages')}
+      detailsLinkProps={{ path: topPagesRoute.path, search: (search) => search }}
       externalLinkDest={externalLinkDest}
       color="bg-orange-50"
     />

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { AppNavigationLink } from '../../navigation/use-app-navigate';
 import FlipMove from 'react-flip-move';
 
 import FadeIn from '../../fade-in';
@@ -7,9 +7,8 @@ import MoreLink from '../more-link';
 import Bar from '../bar';
 import LazyLoader from '../../components/lazy-loader';
 import classNames from 'classnames';
-import { trimURL, updatedQuery } from '../../util/url';
-import { plainFilterText } from '../../util/filters';
-import { cleanLabels, replaceFilterByPrefix, isRealTimeDashboard, hasGoalFilter } from '../../util/filters';
+import { trimURL } from '../../util/url';
+import { cleanLabels, replaceFilterByPrefix, isRealTimeDashboard, hasGoalFilter, plainFilterText } from '../../util/filters';
 import { useQueryContext } from '../../query-context';
 
 const MAX_ITEMS = 9
@@ -19,7 +18,7 @@ const ROW_GAP_HEIGHT = 4
 const DATA_CONTAINER_HEIGHT = (ROW_HEIGHT + ROW_GAP_HEIGHT) * (MAX_ITEMS - 1) + ROW_HEIGHT
 const COL_MIN_WIDTH = 70
 
-export function FilterLink({ pathname, filterInfo, onClick, children, extraClass }) {
+export function FilterLink({ path, filterInfo, onClick, children, extraClass }) {
   const { query } = useQueryContext();
   const className = classNames(`${extraClass}`, { 'hover:underline': !!filterInfo })
 
@@ -27,20 +26,17 @@ export function FilterLink({ pathname, filterInfo, onClick, children, extraClass
     const { prefix, filter, labels } = filterInfo
     const newFilters = replaceFilterByPrefix(query, prefix, filter)
     const newLabels = cleanLabels(newFilters, query.labels, filter[1], labels)
-    const filterQuery = updatedQuery({ filters: newFilters, labels: newLabels })
-
-    let linkTo = { search: filterQuery.toString() }
-    if (pathname) { linkTo.pathname = pathname }
 
     return (
-      <Link
+      <AppNavigationLink 
         title={`Add filter: ${plainFilterText(query, filter)}`}
-        to={linkTo}
-        onClick={onClick}
         className={className}
+        path={path}
+        onClick={onClick}
+        search={(search) => ({...search, filters: newFilters, labels: newLabels})}
       >
         {children}
-      </Link>
+      </AppNavigationLink>
     )
   } else {
     return <span className={className}>{children}</span>
@@ -87,9 +83,7 @@ function ExternalLink({ item, externalLinkDest }) {
  * OPTIONAL PROPS
  *
  * @param {Function} [onClick] - Function with additional action to be taken when a list entry is clicked.
- * @param {string} [detailsLink] - The pathname to the detailed view of this report. E.g.:
- *     `/dummy.site/pages`. If this is given as input to the ListReport, the Details button
- *     will always be rendered.
+ * @param {Object} [detailsLinkProps] - Navigation props to be passed to "More" link, if any.
  * @param {boolean} [maybeHideDetails] - Set this to `true` if the details button should be hidden on
  *     the condition that there are less than MAX_ITEMS entries in the list (i.e. nothing
  *     more to show).
@@ -111,7 +105,7 @@ function ExternalLink({ item, externalLinkDest }) {
  * | LISTITEM_1.name    | LISTITEM_1[METRIC_1.key]    | LISTITEM_1[METRIC_2.key]    | ...
  * | LISTITEM_2.name    | LISTITEM_2[METRIC_1.key]    | LISTITEM_2[METRIC_2.key]    | ...
  */
-export default function ListReport({ keyLabel, metrics, colMinWidth = COL_MIN_WIDTH, afterFetchData, detailsLink, maybeHideDetails, onClick, color, getFilterFor, renderIcon, externalLinkDest, fetchData }) {
+export default function ListReport({ keyLabel, metrics, colMinWidth = COL_MIN_WIDTH, afterFetchData, detailsLinkProps, maybeHideDetails, onClick, color, getFilterFor, renderIcon, externalLinkDest, fetchData }) {
   const { query } = useQueryContext();
   const [state, setState] = useState({ loading: true, list: null })
   const [visible, setVisible] = useState(false)
@@ -302,8 +296,8 @@ export default function ListReport({ keyLabel, metrics, colMinWidth = COL_MIN_WI
     const moreResultsAvailable = state.list.length >= MAX_ITEMS
     const hideDetails = maybeHideDetails && !moreResultsAvailable
 
-    const showDetails = detailsLink && !state.loading && !hideDetails
-    return showDetails && <MoreLink className={'mt-2'} url={detailsLink} list={state.list} />
+    const showDetails = !!detailsLinkProps && !state.loading && !hideDetails
+    return showDetails && <MoreLink className={'mt-2'} linkProps={detailsLinkProps} list={state.list} />
   }
 
   return (

--- a/assets/js/dashboard/stats/sources/referrer-list.js
+++ b/assets/js/dashboard/stats/sources/referrer-list.js
@@ -7,6 +7,7 @@ import ListReport from '../reports/list';
 import ImportedQueryUnsupportedWarning from '../../stats/imported-query-unsupported-warning';
 import { useQueryContext } from '../../query-context';
 import { useSiteContext } from '../../site-context';
+import { referrersDrilldownRoute } from '../../router';
 
 export default function Referrers({ source }) {
   const { query } = useQueryContext();
@@ -68,7 +69,7 @@ export default function Referrers({ source }) {
         getFilterFor={getFilterFor}
         keyLabel="Referrer"
         metrics={chooseMetrics()}
-        detailsLink={url.sitePath(`referrers/${encodeURIComponent(source)}`)}
+        detailsLinkProps={{ path: referrersDrilldownRoute.path, params: {referrer: source}, search: (search) => search }}
         externalLinkDest={externalLinkDest}
         renderIcon={renderIcon}
         color="bg-blue-50"

--- a/assets/js/dashboard/stats/sources/search-terms.js
+++ b/assets/js/dashboard/stats/sources/search-terms.js
@@ -6,6 +6,7 @@ import numberFormatter from '../../util/number-formatter'
 import RocketIcon from '../modals/rocket-icon'
 import * as api from '../../api'
 import LazyLoader from '../../components/lazy-loader'
+import { referrersGoogleRoute } from '../../router';
 
 export function ConfigureSearchTermsCTA({site}) {
   return (
@@ -112,7 +113,7 @@ export default class SearchTerms extends React.Component {
         <React.Fragment>
           <h3 className="font-bold dark:text-gray-100">Search Terms</h3>
           {this.renderList()}
-          <MoreLink list={this.state.searchTerms} endpoint="referrers/Google" className="w-full pb-4 absolute bottom-0 left-0" />
+          <MoreLink list={this.state.searchTerms} linkProps={{ path: referrersGoogleRoute.path, search: (search) => search }} className="w-full pb-4 absolute bottom-0 left-0" />
         </React.Fragment>
       )
     }

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import ImportedQueryUnsupportedWarning from '../imported-query-unsupported-warning';
 import { useQueryContext } from '../../query-context';
 import { useSiteContext } from '../../site-context';
+import { sourcesRoute, utmCampaignsRoute, utmContentsRoute, utmMediumsRoute, utmSourcesRoute, utmTermsRoute } from '../../router';
 
 const UTM_TAGS = {
   utm_medium: { label: 'UTM Medium', shortLabel: 'UTM Medium', endpoint: '/utm_mediums' },
@@ -24,7 +25,6 @@ const UTM_TAGS = {
 function AllSources({ afterFetchData }) {
   const { query } = useQueryContext();
   const site = useSiteContext();
-
   function fetchData() {
     return api.get(url.apiPath(site, '/sources'), query, { limit: 9 })
   }
@@ -59,7 +59,7 @@ function AllSources({ afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel="Source"
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath('sources')}
+      detailsLinkProps={{ path: sourcesRoute.path, search: (search) => search }}
       renderIcon={renderIcon}
       color="bg-blue-50"
     />
@@ -71,6 +71,14 @@ function UTMSources({ tab, afterFetchData }) {
   const site = useSiteContext();
   const utmTag = UTM_TAGS[tab]
 
+  const route = {
+    utm_medium: utmMediumsRoute,
+    utm_source: utmSourcesRoute,
+    utm_campaign: utmCampaignsRoute,
+    utm_content: utmContentsRoute,
+    utm_term: utmTermsRoute,
+    }[tab]
+    
   function fetchData() {
     return api.get(url.apiPath(site, utmTag.endpoint), query, { limit: 9 })
   }
@@ -96,7 +104,7 @@ function UTMSources({ tab, afterFetchData }) {
       getFilterFor={getFilterFor}
       keyLabel={utmTag.label}
       metrics={chooseMetrics()}
-      detailsLink={url.sitePath(utmTag.endpoint)}
+      detailsLinkProps={{ path: route?.path, search: (search) => search }}
       color="bg-blue-50"
     />
   )

--- a/assets/js/dashboard/util/storage.js
+++ b/assets/js/dashboard/util/storage.js
@@ -33,3 +33,5 @@ export function getItem(key) {
     return memStore[key]
   }
 }
+
+export const getDomainScopedStorageKey = (key, domain) => `${key}__${domain}`

--- a/assets/js/dashboard/util/url.js
+++ b/assets/js/dashboard/util/url.js
@@ -4,21 +4,6 @@ export function apiPath(site, path = '') {
   return `/api/stats/${encodeURIComponent(site.domain)}${path}/`
 }
 
-export function sitePath(path = '') {
-  return (path.startsWith('/') ? path : '/' + path) + window.location.search
-}
-
-export function setQuery(key, value) {
-  return `${window.location.pathname}?${updatedQuery({ [key]: value })}`
-}
-
-export function updatedQuery(values) {
-  const queryString = new PlausibleSearchParams(window.location.search)
-  Object.entries(values).forEach(([key, value]) => queryString.set(key, value))
-
-  return queryString.toString()
-}
-
 export function externalLinkForPage(domain, page) {
   const domainURL = new URL(`https://${domain}`)
   return `https://${domainURL.host}${page}`
@@ -80,37 +65,52 @@ export function trimURL(url, maxLength) {
   }
 }
 
-export class PlausibleSearchParams extends URLSearchParams {
-  set(key, value) {
-    if (typeof value === 'object') {
-      value = JsonURL.stringify(value)
-      if (value.length > 2) {
-        super.set(key, value)
-      } else {
-        // Empty arrays/objects are handled by defaults
-        super.delete(key)
-      }
-    } else if (value === false) {
-      super.delete(key)
-    } else {
-      super.set(key, value)
-    }
-  }
-
-  escape(value) {
-    // Less strict encoding - allow components which browsers don't require encoded and make jsonurl
-    // more readable
-    return encodeURIComponent(value)
-      .replaceAll("%2C", ",")
-      .replaceAll("%3A", ":")
-      .replaceAll("%2F", "/")
-  }
-
-  toString() {
-    const entries = Array.from(super.entries())
-    if (entries.length === 0) {
-      return ''
-    }
-    return entries.map(([key, value]) => `${this.escape(key)}=${this.escape(value)}`).join("&")
-  }
+/** 
+ * @param {String} input - value to encode for URI
+ * @returns {String} value encoded for URI
+ */
+export function encodeURIComponentPermissive(input) {
+  return encodeURIComponent(input)
+  .replaceAll("%2C", ",")
+  .replaceAll("%3A", ":")
+  .replaceAll("%2F", "/")
 }
+
+export function encodeSearchParamEntries([k, v]) {
+  return `${encodeURIComponentPermissive(k)}=${encodeURIComponentPermissive(v)}`
+}
+
+export function isSearchEntryDefined([_key, value]) {
+  return value !== undefined
+}
+
+export function stringifySearch(searchRecord) {
+    const definedSearchEntries = Object.entries(searchRecord || {}).map(stringifySearchEntry).filter(isSearchEntryDefined)
+
+    const encodedSearchEntries = definedSearchEntries.map(encodeSearchParamEntries)
+    
+    return encodedSearchEntries.length ? `?${encodedSearchEntries.join('&')}` : ''
+}
+
+export function stringifySearchEntry([key, value]) {
+  const isEmptyObjectOrArray = typeof value === 'object' && value !== null && Object.entries(value).length === 0;
+  if (  value === undefined ||
+    value === null ||
+    isEmptyObjectOrArray
+  ) {
+    return [key, undefined]
+  }
+  
+  return [key, JsonURL.stringify(value)]
+}
+
+export function parseSearchFragment(searchStringFragment) {
+  const fragmentWithEncodedEquals = searchStringFragment.replaceAll('=','%3D');
+  return JsonURL.parse(fragmentWithEncodedEquals)
+}
+
+export function parseSearch(searchString) {
+  const urlSearchParams = new URLSearchParams(searchString);
+  const searchRecord = Object.fromEntries(urlSearchParams.entries().map(([k, v]) => ([k, parseSearchFragment(v)])))
+  return searchRecord;
+} 

--- a/assets/js/dashboard/util/url.js
+++ b/assets/js/dashboard/util/url.js
@@ -111,6 +111,7 @@ export function parseSearchFragment(searchStringFragment) {
 
 export function parseSearch(searchString) {
   const urlSearchParams = new URLSearchParams(searchString);
-  const searchRecord = Object.fromEntries(urlSearchParams.entries().map(([k, v]) => ([k, parseSearchFragment(v)])))
+  const searchRecord = {};
+  urlSearchParams.forEach((v,k) => searchRecord[k] = parseSearchFragment(v))
   return searchRecord;
 } 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -37,7 +37,7 @@
         "react-popper": "^2.3.0",
         "react-router-dom": "^6.25.1",
         "react-transition-group": "^4.4.2",
-        "url-search-params-polyfill": "^8.1.1"
+        "url-search-params-polyfill": "^8.2.5"
       },
       "devDependencies": {
         "babel-eslint": "^10.1.0",
@@ -4985,8 +4985,9 @@
       }
     },
     "node_modules/url-search-params-polyfill": {
-      "version": "8.1.1",
-      "license": "MIT"
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.2.5.tgz",
+      "integrity": "sha512-FOEojW4XReTmtZOB7xqSHmJZhrNTmClhBriwLTmle4iA7bwuCo6ldSfbtsFSb8bTf3E0a3XpfonAdaur9vqq8A=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -35,7 +35,7 @@
         "react-flip-move": "^3.0.4",
         "react-intersection-observer": "^9.5.2",
         "react-popper": "^2.3.0",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^6.25.1",
         "react-transition-group": "^4.4.2",
         "url-search-params-polyfill": "^8.1.1"
       },
@@ -415,6 +415,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
+      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/aspect-ratio": {
@@ -2394,25 +2402,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -3478,17 +3467,6 @@
       "version": "1.0.7",
       "license": "MIT"
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "dev": true,
@@ -3863,37 +3841,33 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "license": "MIT",
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
+      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "license": "MIT",
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
+      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.18.0",
+        "react-router": "6.25.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {
@@ -4089,10 +4063,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -4872,14 +4842,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "dev": true,
@@ -5043,10 +5005,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/vlq": {
       "version": "0.2.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -35,7 +35,7 @@
     "react-flip-move": "^3.0.4",
     "react-intersection-observer": "^9.5.2",
     "react-popper": "^2.3.0",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.25.1",
     "react-transition-group": "^4.4.2",
     "url-search-params-polyfill": "^8.1.1"
   },

--- a/assets/package.json
+++ b/assets/package.json
@@ -37,7 +37,7 @@
     "react-popper": "^2.3.0",
     "react-router-dom": "^6.25.1",
     "react-transition-group": "^4.4.2",
-    "url-search-params-polyfill": "^8.1.1"
+    "url-search-params-polyfill": "^8.2.5"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
### Changes

Redo of https://github.com/plausible/analytics/pull/4384.

It's almost exactly the same as before, except link and navigation search parameters aren't parsed and stringified at the router level, the transforms are applied in custom components. 

* deprecates withRouter HOC
* explicitly declares all app routes
* makes navigating to each route use the route definition
* replaces PlausibleSearchParams with a stringifySearch and parseSearch method, which are applied in the wrapped Link and navigate components AppNavigationLink and useAppNavigate and in QueryContextProvider
  * NB! components are operating with and changing the parsed object
  * NB! setting search param value to false used to be the way to remove the search param, but I wasn't able to keep this behavior, now setting the value to null is the way to do it
* refactors navigation links and buttons to new navigate API

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
