### PR TITLE
Edit goals with display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- UI to edit goals along with display names
 - Support contains filter for goals
 - UI to edit funnels
 - Add Details views for browsers, browser versions, os-s, os versions, and screen sizes reports

--- a/assets/js/liveview/combo-box.js
+++ b/assets/js/liveview/combo-box.js
@@ -6,12 +6,17 @@ export default (id) => ({
   id: id,
   focus: null,
   selectionInProgress: false,
+  firstFocusRegistered: false,
   setFocus(f) {
     this.focus = f;
   },
   initFocus() {
     if (this.focus === null) {
       this.setFocus(this.leastFocusableIndex())
+      if (!this.firstFocusRegistered) {
+        document.getElementById(this.id).select();
+        this.firstFocusRegistered = true;
+      }
     }
   },
   trackSubmitValueChange() {

--- a/assets/js/liveview/phx_events.js
+++ b/assets/js/liveview/phx_events.js
@@ -11,3 +11,8 @@ window.addEventListener(`phx:js-exec`, ({ detail }) => {
     window.liveSocket.execJS(el, el.getAttribute(detail.attr))
   })
 })
+
+window.addEventListener(`phx:notify-selection-change`, (event) => {
+  let el = document.getElementById(event.detail.id)
+  el.dispatchEvent(new CustomEvent("selection-change", { detail: event.detail }))
+})

--- a/extra/lib/plausible/goal/revenue.ex
+++ b/extra/lib/plausible/goal/revenue.ex
@@ -14,9 +14,18 @@ defmodule Plausible.Goal.Revenue do
   def currency_options() do
     options =
       for code <- valid_currencies() do
-        {code, "#{code} - #{Cldr.Currency.display_name!(code)}"}
+        {code, display(code)}
       end
 
     options
+  end
+
+  def currency_option(code) do
+    true = "#{code}" in valid_currencies()
+    {"#{code}", display(code)}
+  end
+
+  def display(code) do
+    "#{code} - #{Cldr.Currency.display_name!(code)}"
   end
 end

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -41,7 +41,8 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
           Enum.map(page.entries, fn goal ->
             %{
               id: goal.id,
-              display_name: Goal.display_name(goal),
+              # XXX breaking change, cleared with Daan
+              display_name: goal.display_name,
               goal_type: Goal.type(goal),
               event_name: goal.event_name,
               page_path: goal.page_path

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -41,7 +41,6 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
           Enum.map(page.entries, fn goal ->
             %{
               id: goal.id,
-              # XXX breaking change, cleared with Daan
               display_name: goal.display_name,
               goal_type: Goal.type(goal),
               event_name: goal.event_name,

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -23,7 +23,10 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
       |> Goals.for_site()
       |> Enum.map(fn goal ->
         {goal.id,
-         struct!(Plausible.Goal, Map.take(goal, [:id, :event_name, :page_path, :currency]))}
+         struct!(
+           Plausible.Goal,
+           Map.take(goal, [:id, :display_name, :event_name, :page_path, :currency])
+         )}
       end)
 
     socket =

--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -49,6 +49,11 @@ defmodule Plausible.Goal do
     |> maybe_drop_currency()
   end
 
+  @spec display_name(t()) :: String.t()
+  def display_name(goal) do
+    goal.display_name
+  end
+
   @spec type(t()) :: :event | :page
   def type(%{event_name: event_name}) when is_binary(event_name), do: :event
   def type(%{page_path: page_path}) when is_binary(page_path), do: :page

--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -135,7 +135,7 @@ end
 
 defimpl String.Chars, for: Plausible.Goal do
   def to_string(goal) do
-    "#{goal.display_name}"
+    goal.display_name
   end
 end
 

--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -8,6 +8,7 @@ defmodule Plausible.Goal do
   schema "goals" do
     field :event_name, :string
     field :page_path, :string
+    field :display_name, :string
 
     on_ee do
       field :currency, Ecto.Enum, values: Money.Currency.known_current_currencies()
@@ -22,7 +23,8 @@ defmodule Plausible.Goal do
     timestamps()
   end
 
-  @fields [:id, :site_id, :event_name, :page_path] ++ on_ee(do: [:currency], else: [])
+  @fields [:id, :site_id, :event_name, :page_path, :display_name] ++
+            on_ee(do: [:currency], else: [])
 
   @max_event_name_length 120
 
@@ -35,10 +37,10 @@ defmodule Plausible.Goal do
     |> cast_assoc(:site)
     |> update_leading_slash()
     |> validate_event_name_and_page_path()
-    |> update_change(:event_name, &String.trim/1)
-    |> update_change(:page_path, &String.trim/1)
+    |> maybe_put_display_name()
     |> unique_constraint(:event_name, name: :goals_event_name_unique)
     |> unique_constraint(:page_path, name: :goals_page_path_unique)
+    |> unique_constraint(:display_name, name: :goals_site_id_display_name_index)
     |> validate_length(:event_name, max: @max_event_name_length)
     |> check_constraint(:event_name,
       name: :check_event_name_or_page_path,
@@ -48,12 +50,8 @@ defmodule Plausible.Goal do
   end
 
   @spec display_name(t()) :: String.t()
-  def display_name(%{page_path: path}) when is_binary(path) do
-    "Visit " <> path
-  end
-
-  def display_name(%{event_name: name}) when is_binary(name) do
-    name
+  def display_name(goal) do
+    goal.display_name
   end
 
   @spec type(t()) :: :event | :page
@@ -76,6 +74,8 @@ defmodule Plausible.Goal do
   defp validate_event_name_and_page_path(changeset) do
     if validate_page_path(changeset) || validate_event_name(changeset) do
       changeset
+      |> update_change(:event_name, &String.trim/1)
+      |> update_change(:page_path, &String.trim/1)
     else
       changeset
       |> add_error(:event_name, "this field is required and cannot be blank")
@@ -100,6 +100,24 @@ defmodule Plausible.Goal do
       changeset
     end
   end
+
+  defp maybe_put_display_name(changeset) do
+    clause =
+      Enum.map([:display_name, :page_path, :event_name], &get_field(changeset, &1))
+
+    case clause do
+      [nil, path, _] when is_binary(path) ->
+        put_change(changeset, :display_name, "Visit " <> path)
+
+      [nil, _, event_name] when is_binary(event_name) ->
+        put_change(changeset, :display_name, event_name)
+
+      _ ->
+        changeset
+    end
+    |> update_change(:display_name, &String.trim/1)
+    |> validate_required(:display_name)
+  end
 end
 
 defimpl Jason.Encoder, for: Plausible.Goal do
@@ -110,14 +128,14 @@ defimpl Jason.Encoder, for: Plausible.Goal do
     |> Map.put(:goal_type, Plausible.Goal.type(value))
     |> Map.take([:id, :goal_type, :event_name, :page_path])
     |> Map.put(:domain, domain)
-    |> Map.put(:display_name, Plausible.Goal.display_name(value))
+    |> Map.put(:display_name, value.display_name)
     |> Jason.Encode.map(opts)
   end
 end
 
 defimpl String.Chars, for: Plausible.Goal do
   def to_string(goal) do
-    Plausible.Goal.display_name(goal)
+    "#{goal.display_name}"
   end
 end
 

--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -49,11 +49,6 @@ defmodule Plausible.Goal do
     |> maybe_drop_currency()
   end
 
-  @spec display_name(t()) :: String.t()
-  def display_name(goal) do
-    goal.display_name
-  end
-
   @spec type(t()) :: :event | :page
   def type(%{event_name: event_name}) when is_binary(event_name), do: :event
   def type(%{page_path: page_path}) when is_binary(page_path), do: :page

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -64,15 +64,13 @@ defmodule Plausible.Goals do
     end
   end
 
-  def find_or_create(
-        site,
-        %{
-          "goal_type" => "event",
-          "event_name" => event_name,
-          "currency" => currency
-        } = params
-      )
+  def find_or_create(site, %{
+        "goal_type" => "event",
+        "event_name" => event_name,
+        "currency" => currency
+      } = params)
       when is_binary(event_name) and is_binary(currency) do
+
     with {:ok, goal} <- create(site, params, upsert?: true) do
       if to_string(goal.currency) == currency do
         {:ok, goal}

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -64,13 +64,15 @@ defmodule Plausible.Goals do
     end
   end
 
-  def find_or_create(site, %{
-        "goal_type" => "event",
-        "event_name" => event_name,
-        "currency" => currency
-      } = params)
+  def find_or_create(
+        site,
+        %{
+          "goal_type" => "event",
+          "event_name" => event_name,
+          "currency" => currency
+        } = params
+      )
       when is_binary(event_name) and is_binary(currency) do
-
     with {:ok, goal} <- create(site, params, upsert?: true) do
       if to_string(goal.currency) == currency do
         {:ok, goal}

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -52,9 +52,10 @@ defmodule Plausible.Goals do
   @spec update(Plausible.Goal.t(), map()) ::
           {:ok, Goal.t()} | {:error, Ecto.Changeset.t()} | {:error, :upgrade_required}
   def update(goal, params) do
-    with changeset <- Goal.changeset(goal, params),
-         site <- Repo.preload(goal, :site).site,
-         :ok <- maybe_check_feature_access(site, changeset),
+    changeset = Goal.changeset(goal, params)
+    site = Repo.preload(goal, :site).site
+
+    with :ok <- maybe_check_feature_access(site, changeset),
          {:ok, goal} <- Repo.update(changeset) do
       on_ee do
         {:ok, Repo.preload(goal, :funnels)}

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -10,10 +10,13 @@ defmodule Plausible.Goals do
 
   @spec get(Plausible.Site.t(), pos_integer()) :: nil | Plausible.Goal.t()
   def get(site, id) when is_integer(id) do
-    site
-    |> get_query()
-    |> where([g], g.id == ^id)
-    |> Repo.one()
+    q =
+      from g in Plausible.Goal,
+        where: g.site_id == ^site.id,
+        order_by: [desc: g.id],
+        where: g.id == ^id
+
+    Repo.one(q)
   end
 
   @spec create(Plausible.Site.t(), map(), Keyword.t()) ::
@@ -286,12 +289,5 @@ defmodule Plausible.Goals do
 
   defp maybe_trim(other) do
     other
-  end
-
-  defp get_query(site) do
-    from g in Plausible.Goal,
-      where: g.site_id == ^site.id,
-      order_by: [desc: g.id],
-      group_by: g.id
   end
 end

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -68,9 +68,8 @@ defmodule Plausible.Goals do
         "goal_type" => "event",
         "event_name" => event_name,
         "currency" => currency
-      })
+      } = params)
       when is_binary(event_name) and is_binary(currency) do
-    params = %{"event_name" => event_name, "currency" => currency}
 
     with {:ok, goal} <- create(site, params, upsert?: true) do
       if to_string(goal.currency) == currency do
@@ -90,15 +89,15 @@ defmodule Plausible.Goals do
     end
   end
 
-  def find_or_create(site, %{"goal_type" => "event", "event_name" => event_name})
+  def find_or_create(site, %{"goal_type" => "event", "event_name" => event_name} = params)
       when is_binary(event_name) do
-    create(site, %{"event_name" => event_name}, upsert?: true)
+    create(site, params, upsert?: true)
   end
 
   def find_or_create(_, %{"goal_type" => "event"}), do: {:missing, "event_name"}
 
-  def find_or_create(site, %{"goal_type" => "page", "page_path" => page_path}) do
-    create(site, %{"page_path" => page_path}, upsert?: true)
+  def find_or_create(site, %{"goal_type" => "page", "page_path" => _} = params) do
+    create(site, params, upsert?: true)
   end
 
   def find_or_create(_, %{"goal_type" => "page"}), do: {:missing, "page_path"}

--- a/lib/plausible/plugins/api/goals.ex
+++ b/lib/plausible/plugins/api/goals.ex
@@ -5,7 +5,6 @@ defmodule Plausible.Plugins.API.Goals do
   """
   use Plausible
 
-  import Ecto.Query
   import Plausible.Pagination
 
   alias Plausible.Repo
@@ -36,10 +35,7 @@ defmodule Plausible.Plugins.API.Goals do
 
   @spec get(Plausible.Site.t(), pos_integer()) :: nil | Plausible.Goal.t()
   def get(site, id) when is_integer(id) do
-    site
-    |> get_query()
-    |> where([g], g.id == ^id)
-    |> Repo.one()
+    Plausible.Goals.get(site, id)
   end
 
   @spec delete(Plausible.Site.t(), [pos_integer()] | pos_integer()) :: :ok
@@ -53,13 +49,6 @@ defmodule Plausible.Plugins.API.Goals do
     end)
 
     :ok
-  end
-
-  defp get_query(site) do
-    from g in Plausible.Goal,
-      where: g.site_id == ^site.id,
-      order_by: [desc: g.id],
-      group_by: g.id
   end
 
   defp convert_to_create_params(%CreateRequest.CustomEvent{goal: %{event_name: event_name}}) do

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -155,7 +155,7 @@ defmodule Plausible.Stats.FilterSuggestions do
   def filter_suggestions(site, _query, "goal", filter_search) do
     site
     |> Plausible.Goals.for_site()
-    |> Enum.map(&Plausible.Goal.display_name/1)
+    |> Enum.map(& &1.display_name)
     |> Enum.filter(fn goal ->
       String.contains?(
         String.downcase(goal),

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -341,8 +341,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   defp validate_filter(site, [_type, "event:goal", goal_filter]) do
     configured_goals =
-      Plausible.Goals.for_site(site)
-      |> Enum.map(&Plausible.Goal.display_name/1)
+      site
+      |> Plausible.Goals.for_site()
+      |> Enum.map(& &1.display_name)
 
     goals_in_filter = List.wrap(goal_filter)
 

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -104,6 +104,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
             name={"display-#{@id}"}
             placeholder={@placeholder}
             x-on:focus="open"
+            x-on:selection-change={assigns[:"x-on-selection-change"]}
             phx-change="search"
             x-on:keydown="open"
             phx-target={@myself}
@@ -268,8 +269,14 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
     """
   end
 
-  def select_option(js \\ %JS{}, _id, submit_value, display_value) do
+  def select_option(js \\ %JS{}, id, submit_value, display_value) do
     js
+    |> JS.dispatch("phx:notify-selection-change",
+      detail: %{
+        id: id,
+        value: %{"submitValue" => submit_value, "displayValue" => display_value}
+      }
+    )
     |> JS.push("select-option",
       value: %{"submit-value" => submit_value, "display-value" => display_value}
     )
@@ -362,6 +369,12 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
     case {socket.assigns[:selected], socket.assigns[:submit_value]} do
       {{submit_value, display_value}, nil} ->
         assign(socket, submit_value: submit_value, display_value: display_value)
+
+      {submit_and_display_value, nil} when is_binary(submit_and_display_value) ->
+        assign(socket,
+          submit_value: submit_and_display_value,
+          display_value: submit_and_display_value
+        )
 
       _ ->
         socket

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -127,7 +127,8 @@ defmodule PlausibleWeb.Live.Components.Modal do
         # established. Otherwise, there will be problems
         # with live components relying on ID for setup
         # on mount (using AlpineJS, for instance).
-        load_content?: true,
+        load_content?: assigns.preload?,
+        preload?: assigns.preload?,
         modal_sequence_id: 0
       )
 
@@ -136,6 +137,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
 
   attr :id, :any, required: true
   attr :class, :string, default: ""
+  attr :preload?, :boolean, default: true
   slot :inner_block, required: true
 
   def render(assigns) do
@@ -179,6 +181,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
           }, 200);
         }
       }"
+      x-init={"firstLoadDone = #{not @preload?}"}
       x-on:open-modal.window={"if ($event.detail === '#{@id}') openModal()"}
       x-on:close-modal.window={"if ($event.detail === '#{@id}') closeModal()"}
       data-onopen={LiveView.JS.push("open", target: @myself)}

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -119,6 +119,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
   @impl true
   def update(assigns, socket) do
     preload? = Map.get(assigns, :preload?, true)
+
     socket =
       assign(socket,
         id: assigns.id,

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -118,6 +118,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
 
   @impl true
   def update(assigns, socket) do
+    preload? = Map.get(assigns, :preload?, true)
     socket =
       assign(socket,
         id: assigns.id,
@@ -127,8 +128,8 @@ defmodule PlausibleWeb.Live.Components.Modal do
         # established. Otherwise, there will be problems
         # with live components relying on ID for setup
         # on mount (using AlpineJS, for instance).
-        load_content?: assigns.preload?,
-        preload?: assigns.preload?,
+        load_content?: preload?,
+        preload?: preload?,
         modal_sequence_id: 0
       )
 

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -179,7 +179,6 @@ defmodule PlausibleWeb.Live.Components.Modal do
         modalOpen: false,
         modalPreopen: false,
         preopenModal() {
-          console.log('test');
           document.body.style['overflow-y'] = 'hidden';
 
           this.modalPreopen = true;

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -52,13 +52,22 @@ defmodule PlausibleWeb.Live.Components.Modal do
   be skipped if embedded component handles state reset explicitly
   (via, for instance, `phx-click-away` callback).
 
-  `Modal` exposes two functions for managing window state:
+  `Modal` exposes a number of functions for managing window state:
 
+    * `Modal.JS.preopen/1` - to preopen the modal on the frontend.
+      Useful when the actual opening is done server-side with
+      `Modal.open/2` - helps avoid lack of feedback to the end user
+      when server-side state change before opening the modal is
+      still in progress.
     * `Modal.JS.open/1` - to open the modal from the frontend. It's
       important to make sure the element triggering that call is
       wrapped in an Alpine UI component - or is an Alpine component
       itself - adding `x-data` attribute without any value is enough
       to ensure that.
+    * `Modal.open/2` - to open the modal from the backend; usually
+      called from `handle_event/2` of component wrapping the modal
+      and providing the state. Should be used together with
+      `Modal.JS.preopen/1` for optimal user experience.
     * `Modal.close/2` - to close the modal from the backend; usually
       done inside wrapped component's `handle_event/2`. The example
       quoted above shows one way to implement this, under that assumption
@@ -103,6 +112,11 @@ defmodule PlausibleWeb.Live.Components.Modal do
     @spec open(String.t()) :: String.t()
     def open(id) do
       "$dispatch('open-modal', '#{id}')"
+    end
+
+    @spec preopen(String.t()) :: String.t()
+    def preopen(id) do
+      "$dispatch('preopen-modal', '#{id}')"
     end
   end
 
@@ -163,6 +177,13 @@ defmodule PlausibleWeb.Live.Components.Modal do
       x-data="{
         firstLoadDone: false,
         modalOpen: false,
+        modalPreopen: false,
+        preopenModal() {
+          console.log('test');
+          document.body.style['overflow-y'] = 'hidden';
+
+          this.modalPreopen = true;
+        },
         openModal() {
           document.body.style['overflow-y'] = 'hidden';
 
@@ -172,9 +193,11 @@ defmodule PlausibleWeb.Live.Components.Modal do
             this.firstLoadDone = true;
           }
 
+          this.modalPreopen = false;
           this.modalOpen = true;
         },
         closeModal() {
+          this.modalPreopen = false;
           this.modalOpen = false;
           liveSocket.execJS($el, $el.dataset.onclose);
 
@@ -184,6 +207,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
         }
       }"
       x-init={"firstLoadDone = #{not @preload?}"}
+      x-on:preopen-modal.window={"if ($event.detail === '#{@id}') preopenModal()"}
       x-on:open-modal.window={"if ($event.detail === '#{@id}') openModal()"}
       x-on:close-modal.window={"if ($event.detail === '#{@id}') closeModal()"}
       data-onopen={LiveView.JS.push("open", target: @myself)}
@@ -193,7 +217,7 @@ defmodule PlausibleWeb.Live.Components.Modal do
       aria-modal="true"
     >
       <div
-        x-show="modalOpen"
+        x-show="modalOpen || modalPreopen"
         x-transition:enter="transition ease-out duration-300"
         x-transition:enter-start="bg-opacity-0"
         x-transition:enter-end="bg-opacity-75"
@@ -202,6 +226,16 @@ defmodule PlausibleWeb.Live.Components.Modal do
         x-transition:leave-end="bg-opacity-0"
         class="fixed inset-0 bg-gray-500 bg-opacity-75 z-50"
       >
+      </div>
+      <div
+        x-show="modalPreopen"
+        class="fixed flex inset-0 items-start z-50 overflow-y-auto overflow-x-hidden"
+      >
+        <div class="modal-pre-loading w-full self-center">
+          <div class="text-center">
+            <PlausibleWeb.Components.Generic.spinner class="inline-block h-8 w-8" />
+          </div>
+        </div>
       </div>
       <div
         x-show="modalOpen"

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
     <div id="goal-settings-main">
       <.flash_messages flash={@flash} />
 
-      <.live_component :let={modal_unique_id} module={Modal} id="goals-form-modal">
+      <.live_component :let={modal_unique_id} module={Modal} id="goals-form-modal" preload?={false}>
         <.live_component
           module={PlausibleWeb.Live.GoalSettings.Form}
           id={"goals-form-#{modal_unique_id}"}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
        domain: domain,
        displayed_goals: socket.assigns.all_goals,
        filter_text: "",
-       goal_id: nil
+       form_goal: nil
      )}
   end
 
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
           site={@site}
           current_user={@current_user}
           existing_goals={@all_goals}
-          goal_id={@goal_id}
+          goal={@form_goal}
           on_save_goal={
             fn goal, socket ->
               send(self(), {:goal_added, goal})
@@ -107,12 +107,15 @@ defmodule PlausibleWeb.Live.GoalSettings do
   end
 
   def handle_event("edit-goal", %{"goal-id" => goal_id}, socket) do
-    socket = socket |> assign(goal_id: goal_id) |> Modal.open("goals-form-modal")
+    goal_id = String.to_integer(goal_id)
+    form_goal = Plausible.Goals.get(socket.assigns.site, goal_id)
+
+    socket = socket |> assign(form_goal: form_goal) |> Modal.open("goals-form-modal")
     {:noreply, socket}
   end
 
   def handle_event("add-goal", _, socket) do
-    socket = socket |> assign(goal_id: nil) |> Modal.open("goals-form-modal")
+    socket = socket |> assign(form_goal: nil) |> Modal.open("goals-form-modal")
     {:noreply, socket}
   end
 
@@ -155,7 +158,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
         event_name_options:
           Enum.reject(socket.assigns.event_name_options, &(&1 == goal.event_name)),
         displayed_goals: all_goals,
-        goal_id: nil
+        form_goal: nil
       )
       |> put_live_flash(:success, "Goal saved successfully")
 

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
     <div id="goal-settings-main">
       <.flash_messages flash={@flash} />
 
-      <.live_component :let={modal_unique_id} module={Modal} id="goals-form-modal" preload?={false}>
+      <.live_component :let={modal_unique_id} module={Modal} id="goals-form-modal">
         <.live_component
           module={PlausibleWeb.Live.GoalSettings.Form}
           id={"goals-form-#{modal_unique_id}"}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -11,23 +11,20 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   alias Plausible.Repo
 
   def update(assigns, socket) do
-    site = Repo.preload(assigns.site, [:owner])
+    site = Repo.preload(assigns.site, :owner)
     owner = Plausible.Users.with_subscription(site.owner)
     site = %{site | owner: owner}
 
     has_access_to_revenue_goals? =
       Plausible.Billing.Feature.RevenueGoals.check_availability(owner) == :ok
 
-    goal_id = if assigns.goal_id, do: String.to_integer(assigns.goal_id)
-    goal = goal_id && Plausible.Goals.get(site, goal_id)
-
     form =
-      (goal || %Plausible.Goal{})
+      (assigns.goal || %Plausible.Goal{})
       |> Plausible.Goal.changeset()
       |> to_form()
 
     selected_tab =
-      if goal && goal.page_path do
+      if assigns.goal && assigns.goal.page_path do
         "pageviews"
       else
         "custom_events"
@@ -50,8 +47,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         existing_goals: assigns.existing_goals,
         on_save_goal: assigns.on_save_goal,
         on_autoconfigure: assigns.on_autoconfigure,
-        goal_id: goal_id,
-        goal: goal
+        goal: assigns.goal
       )
 
     {:ok, socket}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -328,12 +328,10 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         disabled={not @has_access_to_revenue_goals? or not is_nil(@goal)}
       >
         <span
-          id={"currency-switcher-1-#{:erlang.phash2(@f)}"}
           class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
           x-bind:class="active ? 'bg-indigo-600' : 'dark:bg-gray-700 bg-gray-200'"
         >
           <span
-            id={"currency-switcher-2-#{:erlang.phash2(@f)}"}
             aria-hidden="true"
             class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
             x-bind:class="active ? 'dark:bg-gray-800 translate-x-5' : 'dark:bg-gray-800 translate-x-0'"
@@ -347,13 +345,13 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
               else: "text-gray-500 dark:text-gray-300"
             )
           ]}
-          id={"enable-revenue-tracking-#{:erlang.phash2(@f)}"}
+          id="enable-revenue-tracking"
         >
           Enable Revenue Tracking
         </span>
       </button>
 
-      <div x-show="active" id={"revenue-input-#{:erlang.phash2(@f)}"}>
+      <div x-show="active" id="revenue-input">
         <.live_component
           id={"currency_input_#{@suffix}"}
           submit_name={@f[:currency].name}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -292,18 +292,16 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   end
 
   def revenue_goal_settings(assigns) do
-    assigns = assign(assigns, :selected_currency, currency_option(assigns.goal))
+    js_data =
+      Jason.encode!(%{
+        active: !!assigns.f[:currency].value and assigns.f[:currency].value != "",
+        currency: assigns.f[:currency].value
+      })
+
+    assigns = assign(assigns, selected_currency: currency_option(assigns.goal), js_data: js_data)
 
     ~H"""
-    <div
-      class="mt-6 space-y-3"
-      x-data={
-        Jason.encode!(%{
-          active: !!@f[:currency].value and @f[:currency].value != "",
-          currency: @f[:currency].value
-        })
-      }
-    >
+    <div class="mt-6 space-y-3" x-data={@js_data}>
       <PlausibleWeb.Components.Billing.Notice.premium_feature
         billable_user={@site.owner}
         current_user={@current_user}
@@ -312,6 +310,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         class="rounded-b-md"
       />
       <button
+        id={"currency-toggle-#{@suffix}"}
         class={[
           "flex items-center w-max mb-3",
           if @has_access_to_revenue_goals? and is_nil(@goal) do
@@ -328,10 +327,12 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         disabled={not @has_access_to_revenue_goals? or not is_nil(@goal)}
       >
         <span
+          id={"currency-container1-#{@suffix}"}
           class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
           x-bind:class="active ? 'bg-indigo-600' : 'dark:bg-gray-700 bg-gray-200'"
         >
           <span
+            id={"currency-container2-#{@suffix}"}
             aria-hidden="true"
             class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
             x-bind:class="active ? 'dark:bg-gray-800 translate-x-5' : 'dark:bg-gray-800 translate-x-0'"
@@ -351,7 +352,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         </span>
       </button>
 
-      <div x-show="active" id="revenue-input">
+      <div x-show="active" id={"revenue-input-#{@suffix}"}>
         <.live_component
           id={"currency_input_#{@suffix}"}
           submit_name={@f[:currency].name}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -72,7 +72,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           <%= if @goal, do: "Edit", else: "Add" %> Goal for <%= @domain %>
         </h2>
 
-        <.tabs goal={@goal} selected_tab={@selected_tab} myself={@myself} />
+        <.tabs :if={is_nil(@goal)} selected_tab={@selected_tab} myself={@myself} />
 
         <.custom_event_fields
           :if={@selected_tab == "custom_events"}
@@ -320,13 +320,11 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
   def tabs(assigns) do
     ~H"""
-    <%= if is_nil(@goal) do %>
-      <div class="mt-6 font-medium dark:text-gray-100">Goal Trigger</div>
-      <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
-        <.custom_events_tab selected?={@selected_tab == "custom_events"} myself={@myself} />
-        <.pageviews_tab selected?={@selected_tab == "pageviews"} myself={@myself} />
-      </div>
-    <% end %>
+    <div class="mt-6 font-medium dark:text-gray-100">Goal Trigger</div>
+    <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
+      <.custom_events_tab selected?={@selected_tab == "custom_events"} myself={@myself} />
+      <.pageviews_tab selected?={@selected_tab == "pageviews"} myself={@myself} />
+    </div>
     """
   end
 

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -269,7 +269,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
             type="button"
             x-on:click="active = !active; currency = ''"
             x-bind:aria-checked="active"
-            disabled={(not @has_access_to_revenue_goals? or not is_nil(@goal)) && "disabled"}
+            disabled={not @has_access_to_revenue_goals? or not is_nil(@goal)}
           >
             <span
               id={"currency-switcher-1-#{:erlang.phash2(@f)}"}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -188,7 +188,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         suggest_fun={fn input, _options -> suggest_page_paths(input, @site) end}
         selected={if @goal && @goal.page_path, do: @goal.page_path}
         creatable
-        x-on-selection-change="document.getElementById('display_name_input').setAttribute('value', 'Visit ' + $event.detail.value.displayValue)"
+        x-on-selection-change="document.getElementById('pageview_display_name_input').setAttribute('value', 'Visit ' + $event.detail.value.displayValue)"
       />
 
       <.error :for={msg <- Enum.map(@f[:page_path].errors, &translate_error/1)}>
@@ -196,12 +196,12 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       </.error>
 
       <div class="mt-2">
-        <.label for={"display_name_input_#{@suffix}"}>
+        <.label for="pageview_display_name_input">
           Display Name
         </.label>
 
         <.input
-          id="display_name_input"
+          id="pageview_display_name_input"
           field={@f[:display_name]}
           type="text"
           x-data="{ firstFocus: true }"
@@ -263,7 +263,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         </div>
 
         <div class="mt-2">
-          <.label for={"custom_event_display_name_input_#{@suffix}"}>
+          <.label for="custom_event_display_name_input">
             Display Name
           </.label>
 

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -51,7 +51,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         on_save_goal: assigns.on_save_goal,
         on_autoconfigure: assigns.on_autoconfigure,
         goal_id: goal_id,
-        goal: goal_id && goal
+        goal: goal
       )
 
     {:ok, socket}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -18,10 +18,20 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     has_access_to_revenue_goals? =
       Plausible.Billing.Feature.RevenueGoals.check_availability(owner) == :ok
 
+    goal_id = if assigns.goal_id, do: String.to_integer(assigns.goal_id)
+    goal = goal_id && Plausible.Goals.get(site, goal_id)
+
     form =
-      %Plausible.Goal{}
+      (goal || %Plausible.Goal{})
       |> Plausible.Goal.changeset()
       |> to_form()
+
+    selected_tab =
+      if goal && goal.page_path do
+        "pageviews"
+      else
+        "custom_events"
+      end
 
     socket =
       socket
@@ -33,13 +43,15 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         event_name_options: Enum.map(assigns.event_name_options, &{&1, &1}),
         current_user: assigns.current_user,
         domain: assigns.domain,
-        selected_tab: "custom_events",
+        selected_tab: selected_tab,
         tab_sequence_id: 0,
         site: site,
         has_access_to_revenue_goals?: has_access_to_revenue_goals?,
         existing_goals: assigns.existing_goals,
         on_save_goal: assigns.on_save_goal,
-        on_autoconfigure: assigns.on_autoconfigure
+        on_autoconfigure: assigns.on_autoconfigure,
+        goal_id: goal_id,
+        goal: goal_id && goal
       )
 
     {:ok, socket}
@@ -60,9 +72,11 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           x-show="tabSelectionInProgress"
         />
 
-        <h2 class="text-xl font-black dark:text-gray-100">Add Goal for <%= @domain %></h2>
+        <h2 class="text-xl font-black dark:text-gray-100">
+          <%= if @goal, do: "Edit", else: "Add" %> Goal for <%= @domain %>
+        </h2>
 
-        <.tabs selected_tab={@selected_tab} myself={@myself} />
+        <.tabs goal={@goal} selected_tab={@selected_tab} myself={@myself} />
 
         <.custom_event_fields
           :if={@selected_tab == "custom_events"}
@@ -71,6 +85,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           suffix={suffix(@context_unique_id, @tab_sequence_id)}
           current_user={@current_user}
           site={@site}
+          goal={@goal}
           existing_goals={@existing_goals}
           goal_options={@event_name_options}
           has_access_to_revenue_goals?={@has_access_to_revenue_goals?}
@@ -80,6 +95,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           :if={@selected_tab == "pageviews"}
           x-show="!tabSelectionInProgress"
           f={f}
+          goal={@goal}
           suffix={suffix(@context_unique_id, @tab_sequence_id)}
           site={@site}
           x-init="tabSelectionInProgress = false"
@@ -87,12 +103,12 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
         <div class="py-4" x-show="!tabSelectionInProgress">
           <PlausibleWeb.Components.Generic.button type="submit" class="w-full">
-            Add Goal →
+            <%= if @goal, do: "Update", else: "Add" %> Goal →
           </PlausibleWeb.Components.Generic.button>
         </div>
 
         <button
-          :if={@selected_tab == "custom_events" && @event_name_options_count > 0}
+          :if={@selected_tab == "custom_events" && @event_name_options_count > 0 && is_nil(@goal)}
           x-show="!tabSelectionInProgress"
           class="mt-2 text-sm hover:underline text-indigo-600 dark:text-indigo-400 text-left"
           phx-click="autoconfigure"
@@ -113,7 +129,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   attr(:f, Phoenix.HTML.Form)
   attr(:site, Plausible.Site)
   attr(:suffix, :string)
-
+  attr(:goal, Plausible.Goal)
   attr(:rest, :global)
 
   def pageview_fields(assigns) do
@@ -131,14 +147,29 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         ]}
         module={ComboBox}
         suggest_fun={fn input, _options -> suggest_page_paths(input, @site) end}
+        selected={if @goal && @goal.page_path, do: @goal.page_path}
         creatable
+        x-on-selection-change="document.getElementById('display_name_input').setAttribute('value', 'Visit ' + $event.detail.value.displayValue)"
       />
 
-      <.error :for={{msg, opts} <- @f[:page_path].errors}>
-        <%= Enum.reduce(opts, msg, fn {key, value}, acc ->
-          String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-        end) %>
+      <.error :for={msg <- Enum.map(@f[:page_path].errors, &translate_error/1)}>
+        <%= msg %>
       </.error>
+
+      <div class="mt-2">
+        <.label for={"display_name_input_#{@suffix}"}>
+          Display Name
+        </.label>
+
+        <.input
+          id="display_name_input"
+          field={@f[:display_name]}
+          type="text"
+          x-data="{ firstFocus: true }"
+          x-on:focus="if (firstFocus) { $el.select(); firstFocus = false; }"
+          class="mt-2 dark:bg-gray-900 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-300"
+        />
+      </div>
     </div>
     """
   end
@@ -149,6 +180,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   attr(:suffix, :string)
   attr(:existing_goals, :list)
   attr(:goal_options, :list)
+  attr(:goal, Plausible.Goal)
   attr(:has_access_to_revenue_goals?, :boolean)
 
   attr(:rest, :global)
@@ -181,7 +213,28 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
             module={ComboBox}
             suggest_fun={fn input, _options -> suggest_event_names(input, @site, @existing_goals) end}
             options={@goal_options}
+            selected={if @goal && @goal.event_name, do: @goal.event_name}
             creatable
+            x-on-selection-change="document.getElementById('custom_event_display_name_input').setAttribute('value', $event.detail.value.displayValue)"
+          />
+
+          <.error :for={msg <- Enum.map(@f[:event_name].errors, &translate_error/1)}>
+            <%= msg %>
+          </.error>
+        </div>
+
+        <div class="mt-2">
+          <.label for={"custom_event_display_name_input_#{@suffix}"}>
+            Display Name
+          </.label>
+
+          <.input
+            id="custom_event_display_name_input"
+            field={@f[:display_name]}
+            type="text"
+            x-data="{ firstFocus: true }"
+            x-on:focus="if (firstFocus) { $el.select(); firstFocus = false; }"
+            class="mt-2 dark:bg-gray-900 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-300"
           />
         </div>
 
@@ -205,7 +258,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           <button
             class={[
               "flex items-center w-max mb-3",
-              if @has_access_to_revenue_goals? do
+              if @has_access_to_revenue_goals? and is_nil(@goal) do
                 "cursor-pointer"
               else
                 "cursor-not-allowed"
@@ -216,13 +269,15 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
             type="button"
             x-on:click="active = !active; currency = ''"
             x-bind:aria-checked="active"
-            disabled={not @has_access_to_revenue_goals?}
+            disabled={(not @has_access_to_revenue_goals? or not is_nil(@goal)) && "disabled"}
           >
             <span
+              id={"currency-switcher-1-#{:erlang.phash2(@f)}"}
               class="relative inline-flex h-6 w-11 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2"
               x-bind:class="active ? 'bg-indigo-600' : 'dark:bg-gray-700 bg-gray-200'"
             >
               <span
+                id={"currency-switcher-2-#{:erlang.phash2(@f)}"}
                 aria-hidden="true"
                 class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
                 x-bind:class="active ? 'dark:bg-gray-800 translate-x-5' : 'dark:bg-gray-800 translate-x-0'"
@@ -236,17 +291,18 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
                   else: "text-gray-500 dark:text-gray-300"
                 )
               ]}
-              id="enable-revenue-tracking"
+              id={"enable-revenue-tracking-#{:erlang.phash2(@f)}"}
             >
               Enable Revenue Tracking
             </span>
           </button>
 
-          <div x-show="active">
+          <div x-show="active" id={"revenue-input-#{:erlang.phash2(@f)}"}>
             <.live_component
               id={"currency_input_#{@suffix}"}
               submit_name={@f[:currency].name}
               module={ComboBox}
+              selected={if revenue?(@goal), do: currency_option(@goal)}
               suggest_fun={
                 on_ee do
                   fn
@@ -261,12 +317,6 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
             />
           </div>
         </div>
-
-        <.error :for={{msg, opts} <- @f[:event_name].errors}>
-          <%= Enum.reduce(opts, msg, fn {key, value}, acc ->
-            String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-          end) %>
-        </.error>
       </div>
     </div>
     """
@@ -274,11 +324,13 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
   def tabs(assigns) do
     ~H"""
-    <div class="mt-6 font-medium dark:text-gray-100">Goal Trigger</div>
-    <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
-      <.custom_events_tab selected?={@selected_tab == "custom_events"} myself={@myself} />
-      <.pageviews_tab selected?={@selected_tab == "pageviews"} myself={@myself} />
-    </div>
+    <%= if is_nil(@goal) do %>
+      <div class="mt-6 font-medium dark:text-gray-100">Goal Trigger</div>
+      <div class="my-3 w-full flex rounded border border-gray-300 dark:border-gray-500">
+        <.custom_events_tab selected?={@selected_tab == "custom_events"} myself={@myself} />
+        <.pageviews_tab selected?={@selected_tab == "pageviews"} myself={@myself} />
+      </div>
+    <% end %>
     """
   end
 
@@ -330,13 +382,29 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     {:noreply, socket}
   end
 
-  def handle_event("save-goal", %{"goal" => goal}, socket) do
-    case Plausible.Goals.create(socket.assigns.site, goal) do
+  def handle_event("save-goal", %{"goal" => goal_params}, %{assigns: %{goal: nil}} = socket) do
+    case Plausible.Goals.create(socket.assigns.site, goal_params) do
       {:ok, goal} ->
         socket =
           goal
           |> Map.put(:funnels, [])
           |> socket.assigns.on_save_goal.(socket)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  def handle_event(
+        "save-goal",
+        %{"goal" => goal_params},
+        %{assigns: %{goal: %Plausible.Goal{} = goal}} = socket
+      ) do
+    case Plausible.Goals.update(goal, goal_params) do
+      {:ok, goal} ->
+        socket = socket.assigns.on_save_goal.(goal, socket)
 
         {:noreply, socket}
 
@@ -370,5 +438,18 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
   defp suffix(context_unique_id, tab_sequence_id) do
     "#{context_unique_id}-tabseq#{tab_sequence_id}"
+  end
+
+  on_ee do
+    defp revenue?(goal) do
+      goal && Plausible.Goal.Revenue.revenue?(goal)
+    end
+
+    defp currency_option(goal) do
+      Plausible.Goal.Revenue.currency_option(goal.currency)
+    end
+  else
+    defp revenue?(_), do: false
+    defp currency_option(_), do: nil
   end
 end

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -51,35 +51,38 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
         <div class="mt-12">
           <%= for goal <- @goals do %>
             <div class="border-b border-gray-300 dark:border-gray-500 py-3 flex justify-between items-center h-16">
-              <span class="text-sm font-medium text-gray-900 dark:text-gray-100 w-2/3 cursor-help">
+              <span class="text-sm font-medium text-gray-900 dark:text-gray-100 w-2/3 cursor-help pr-4">
                 <div class="flex" title={goal.page_path || goal.event_name}>
-                  <span class="truncate">
-                    <span class="text-xs text-gray-400 block mb-1 font-normal">
+                  <div class="truncate block">
+                    <div class="text-xs text-gray-400 block mb-1 font-normal">
                       <.goal_description goal={goal} revenue_goals_enabled?={@revenue_goals_enabled?} />
-                    </span>
+                    </div>
                     <%= if not @revenue_goals_enabled? && goal.currency do %>
                       <div class="text-gray-600 flex items-center">
                         <Heroicons.lock_closed class="w-4 h-4 mr-1 inline" />
-                        <span><%= goal %></span>
+                        <div class="truncate"><%= goal %></div>
                       </div>
                     <% else %>
-                      <span><%= goal %></span>
+                      <div class="truncate"><%= goal %></div>
                     <% end %>
-                  </span>
+                  </div>
                 </div>
               </span>
 
-              <div class="flex items-center">
-                <div class="text-xs w-28 mr-6 text-gray-400">
-                  <div :if={goal.page_path} class="text-gray-600">Pageview</div>
-                  <div :if={goal.event_name && !goal.currency} class="text-gray-600">
-                    Custom Event
+              <div class="flex items-center w-1/3">
+                <div class="text-xs w-full mr-6 text-gray-400">
+                  <div class="hidden md:block">
+                    <div :if={goal.page_path} class="text-gray-600">Pageview</div>
+                    <div :if={goal.event_name && !goal.currency} class="text-gray-600">
+                      Custom Event
+                    </div>
+                    <div :if={goal.currency} class="text-gray-600">
+                      Revenue Goal (<%= goal.currency %>)
+                    </div>
+                    <div :if={not Enum.empty?(goal.funnels)}>Belongs to funnel(s)</div>
                   </div>
-                  <div :if={goal.currency} class="text-gray-600">
-                    Revenue Goal (<%= goal.currency %>)
-                  </div>
-                  <div :if={not Enum.empty?(goal.funnels)}>Belongs to funnel(s)</div>
                 </div>
+
                 <button
                   :if={!goal.currency || (goal.currency && @revenue_goals_enabled?)}
                   phx-click="edit-goal"

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -5,8 +5,6 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
   use Phoenix.LiveComponent, global_prefixes: ~w(x-)
   use Phoenix.HTML
 
-  alias PlausibleWeb.Live.Components.Modal
-
   attr(:goals, :list, required: true)
   attr(:domain, :string, required: true)
   attr(:filter_text, :string)
@@ -14,8 +12,7 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
 
   def render(assigns) do
     revenue_goals_enabled? = Plausible.Billing.Feature.RevenueGoals.enabled?(assigns.site)
-    goals = Enum.map(assigns.goals, &{goal_label(&1), &1})
-    assigns = assign(assigns, goals: goals, revenue_goals_enabled?: revenue_goals_enabled?)
+    assigns = assign(assigns, revenue_goals_enabled?: revenue_goals_enabled?)
 
     ~H"""
     <div>
@@ -45,54 +42,72 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
           </div>
         </form>
         <div class="mt-4 flex sm:ml-4 sm:mt-0">
-          <PlausibleWeb.Components.Generic.button
-            id="add-goal-button"
-            x-data
-            x-on:click={Modal.JS.open("goals-form-modal")}
-          >
+          <PlausibleWeb.Components.Generic.button id="add-goal-button" phx-click="add-goal">
             + Add Goal
           </PlausibleWeb.Components.Generic.button>
         </div>
       </div>
       <%= if Enum.count(@goals) > 0 do %>
         <div class="mt-12">
-          <%= for {goal_label, goal} <- @goals do %>
-            <div class="border-b border-gray-300 dark:border-gray-500 py-3 flex justify-between">
-              <span class="text-sm font-medium text-gray-900 dark:text-gray-100 w-3/4">
-                <div class="flex">
+          <%= for goal <- @goals do %>
+            <div class="border-b border-gray-300 dark:border-gray-500 py-3 flex justify-between items-center h-16">
+              <span class="text-sm font-medium text-gray-900 dark:text-gray-100 w-2/3 cursor-help">
+                <div class="flex" title={goal.page_path || goal.event_name}>
                   <span class="truncate">
+                    <span class="text-xs text-gray-400 block mb-1 font-normal">
+                      <.goal_description goal={goal} revenue_goals_enabled?={@revenue_goals_enabled?} />
+                    </span>
                     <%= if not @revenue_goals_enabled? && goal.currency do %>
                       <div class="text-gray-600 flex items-center">
                         <Heroicons.lock_closed class="w-4 h-4 mr-1 inline" />
-                        <span><%= goal_label %></span>
+                        <span><%= goal %></span>
                       </div>
                     <% else %>
-                      <%= goal_label %>
+                      <span><%= goal %></span>
                     <% end %>
-                    <span class="text-sm text-gray-400 block mt-1 font-normal">
-                      <span :if={goal.page_path}>Pageview</span>
-                      <span :if={goal.event_name && !goal.currency}>Custom Event</span>
-                      <span :if={goal.currency && @revenue_goals_enabled?}>
-                        Revenue Goal
-                      </span>
-                      <span :if={goal.currency && not @revenue_goals_enabled?} class="text-red-600">
-                        Unlock Revenue Goals by upgrading to a business plan
-                      </span>
-                      <span :if={not Enum.empty?(goal.funnels)}> - belongs to funnel(s)</span>
-                    </span>
                   </span>
                 </div>
               </span>
-              <button
-                id={"delete-goal-#{goal.id}"}
-                phx-click="delete-goal"
-                phx-value-goal-id={goal.id}
-                phx-value-goal-name={goal.event_name}
-                class="text-sm text-red-600"
-                data-confirm={delete_confirmation_text(goal)}
-              >
-                <Heroicons.trash class="feather feather-sm" />
-              </button>
+
+              <div class="flex items-center">
+                <div class="text-xs w-28 mr-6 text-gray-400">
+                  <div :if={goal.page_path} class="text-gray-600">Pageview</div>
+                  <div :if={goal.event_name && !goal.currency} class="text-gray-600">
+                    Custom Event
+                  </div>
+                  <div :if={goal.currency} class="text-gray-600">
+                    Revenue Goal (<%= goal.currency %>)
+                  </div>
+                  <div :if={not Enum.empty?(goal.funnels)}>Belongs to funnel(s)</div>
+                </div>
+                <button
+                  :if={!goal.currency || (goal.currency && @revenue_goals_enabled?)}
+                  phx-click="edit-goal"
+                  phx-value-goal-id={goal.id}
+                  id={"edit-goal-#{goal.id}"}
+                >
+                  <Heroicons.pencil_square class="mr-4 feather feather-sm text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300" />
+                </button>
+
+                <button
+                  :if={goal.currency && !@revenue_goals_enabled?}
+                  id={"edit-goal-#{goal.id}-disabled"}
+                  disabled
+                  class="cursor-not-allowed"
+                >
+                  <Heroicons.pencil_square class="mr-4 feather feather-sm text-gray-400 dark:text-gray-600" />
+                </button>
+                <button
+                  id={"delete-goal-#{goal.id}"}
+                  phx-click="delete-goal"
+                  phx-value-goal-id={goal.id}
+                  phx-value-goal-name={goal.event_name}
+                  class="text-sm text-red-600"
+                  data-confirm={delete_confirmation_text(goal)}
+                >
+                  <Heroicons.trash class="feather feather-sm" />
+                </button>
+              </div>
             </div>
           <% end %>
         </div>
@@ -117,12 +132,33 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
     """
   end
 
-  defp goal_label(%{currency: currency} = goal) when not is_nil(currency) do
-    to_string(goal) <> " (#{currency})"
+  def pageview_description(goal) do
+    path = goal.page_path
+
+    case goal.display_name do
+      "Visit " <> ^path -> ""
+      _ -> "#{path}"
+    end
   end
 
-  defp goal_label(goal) do
-    to_string(goal)
+  def custom_event_description(goal) do
+    if goal.display_name == goal.event_name, do: "", else: goal.event_name
+  end
+
+  def goal_description(assigns) do
+    ~H"""
+    <span :if={@goal.page_path} class="block w-full truncate">
+      <%= pageview_description(@goal) %>
+    </span>
+
+    <span :if={@goal.event_name}>
+      <%= custom_event_description(@goal) %>
+    </span>
+
+    <span :if={@goal.currency && not @revenue_goals_enabled?} class="text-red-600">
+      Unlock Revenue Goals by upgrading to a business plan
+    </span>
+    """
   end
 
   defp delete_confirmation_text(goal) do

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -5,6 +5,8 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
   use Phoenix.LiveComponent, global_prefixes: ~w(x-)
   use Phoenix.HTML
 
+  alias PlausibleWeb.Live.Components.Modal
+
   attr(:goals, :list, required: true)
   attr(:domain, :string, required: true)
   attr(:filter_text, :string)
@@ -42,7 +44,12 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
           </div>
         </form>
         <div class="mt-4 flex sm:ml-4 sm:mt-0">
-          <PlausibleWeb.Components.Generic.button id="add-goal-button" phx-click="add-goal">
+          <PlausibleWeb.Components.Generic.button
+            id="add-goal-button"
+            phx-click="add-goal"
+            x-data
+            x-on:click={Modal.JS.preopen("goals-form-modal")}
+          >
             + Add Goal
           </PlausibleWeb.Components.Generic.button>
         </div>
@@ -85,6 +92,8 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
 
                 <button
                   :if={!goal.currency || (goal.currency && @revenue_goals_enabled?)}
+                  x-data
+                  x-on:click={Modal.JS.preopen("goals-form-modal")}
                   phx-click="edit-goal"
                   phx-value-goal-id={goal.id}
                   id={"edit-goal-#{goal.id}"}

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -88,17 +88,18 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
                   phx-click="edit-goal"
                   phx-value-goal-id={goal.id}
                   id={"edit-goal-#{goal.id}"}
+                  class="mr-4"
                 >
-                  <Heroicons.pencil_square class="mr-4 feather feather-sm text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300" />
+                  <Heroicons.pencil_square class="feather feather-sm text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300" />
                 </button>
 
                 <button
                   :if={goal.currency && !@revenue_goals_enabled?}
                   id={"edit-goal-#{goal.id}-disabled"}
                   disabled
-                  class="cursor-not-allowed"
+                  class="mr-4 cursor-not-allowed"
                 >
-                  <Heroicons.pencil_square class="mr-4 feather feather-sm text-gray-400 dark:text-gray-600" />
+                  <Heroicons.pencil_square class="feather feather-sm text-gray-400 dark:text-gray-600" />
                 </button>
                 <button
                   id={"delete-goal-#{goal.id}"}

--- a/lib/plausible_web/plugins/api/views/goal.ex
+++ b/lib/plausible_web/plugins/api/views/goal.ex
@@ -34,7 +34,7 @@ defmodule PlausibleWeb.Plugins.API.Views.Goal do
       goal_type: "Goal.Pageview",
       goal: %{
         id: pageview.id,
-        display_name: to_string(pageview),
+        display_name: pageview.display_name,
         path: pageview.page_path
       }
     }
@@ -47,7 +47,7 @@ defmodule PlausibleWeb.Plugins.API.Views.Goal do
       goal_type: "Goal.CustomEvent",
       goal: %{
         id: custom_event.id,
-        display_name: to_string(custom_event),
+        display_name: custom_event.display_name,
         event_name: custom_event.event_name
       }
     }
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Plugins.API.Views.Goal do
       goal_type: "Goal.Revenue",
       goal: %{
         id: revenue_goal.id,
-        display_name: to_string(revenue_goal),
+        display_name: revenue_goal.display_name,
         event_name: revenue_goal.event_name,
         currency: revenue_goal.currency
       }

--- a/lib/plausible_web/views/error_helpers.ex
+++ b/lib/plausible_web/views/error_helpers.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.ErrorHelpers do
 
   def error_tag(%{errors: errors}, field) do
     Enum.map(Keyword.get_values(errors, field), fn error ->
-      content_tag(:div, translate_error(error), class: "mt-2 text-sm text-red-600")
+      content_tag(:div, translate_error(error), class: "mt-2 text-sm text-red-500")
     end)
   end
 
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.ErrorHelpers do
     error = assigns[field]
 
     if error do
-      content_tag(:div, error, class: "mt-2 text-sm text-red-600")
+      content_tag(:div, error, class: "mt-2 text-sm text-red-500")
     end
   end
 

--- a/priv/repo/migrations/20240801052903_make_goal_display_names_unique.exs
+++ b/priv/repo/migrations/20240801052903_make_goal_display_names_unique.exs
@@ -1,0 +1,37 @@
+defmodule Plausible.Repo.Migrations.MakeGoalDisplayNamesUnique do
+  use Ecto.Migration
+
+  def up do
+    fill_display_names()
+
+    alter table(:goals) do
+      modify :display_name, :text, null: false
+    end
+
+    create unique_index(:goals, [:site_id, :display_name])
+  end
+
+  def down do
+    drop unique_index(:goals, [:site_id, :display_name])
+
+    alter table(:goals) do
+      modify :display_name, :text, null: true
+    end
+
+    execute """
+    UPDATE goals
+    SET display_name = NULL
+    """
+  end
+
+  def fill_display_names do
+    execute """
+    UPDATE goals
+    SET display_name = 
+      CASE
+    WHEN page_path IS NOT NULL THEN 'Visit ' || page_path
+    WHEN event_name IS NOT NULL THEN event_name
+    END
+    """
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,6 +10,10 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
+words =
+  for i <- 0..(:erlang.system_info(:atom_count) - 1),
+      do: :erlang.binary_to_term(<<131, 75, i::24>>)
+
 user = Plausible.Factory.insert(:user, email: "user@plausible.test", password: "plausible")
 
 native_stats_range =
@@ -32,8 +36,13 @@ imported_stats_range =
 
 long_random_paths =
   for _ <- 1..100 do
-    l = Enum.random(40..300)
-    "/long/#{l}/path/#{String.duplicate("0x", l)}/end"
+    path =
+      words
+      |> Enum.shuffle()
+      |> Enum.take(Enum.random(1..20))
+      |> Enum.join("/")
+
+    "/#{path}.html"
   end
 
 long_random_urls =
@@ -74,8 +83,17 @@ seeded_token = Plausible.Plugins.API.Token.generate("seed-token")
 
 {:ok, goal1} = Plausible.Goals.create(site, %{"page_path" => "/"})
 {:ok, goal2} = Plausible.Goals.create(site, %{"page_path" => "/register"})
-{:ok, goal3} = Plausible.Goals.create(site, %{"page_path" => "/login"})
-{:ok, goal4} = Plausible.Goals.create(site, %{"event_name" => "Purchase", "currency" => "USD"})
+
+{:ok, goal3} =
+  Plausible.Goals.create(site, %{"page_path" => "/login", "display_name" => "User logs in"})
+
+{:ok, goal4} =
+  Plausible.Goals.create(site, %{
+    "event_name" => "Purchase",
+    "currency" => "USD",
+    "display_name" => "North America Purchases"
+  })
+
 {:ok, _goal5} = Plausible.Goals.create(site, %{"page_path" => Enum.random(long_random_paths)})
 {:ok, outbound} = Plausible.Goals.create(site, %{"event_name" => "Outbound Link: Click"})
 

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -7,9 +7,11 @@ defmodule Plausible.GoalsTest do
     site = insert(:site)
     {:ok, goal} = Goals.create(site, %{"page_path" => "/foo bar "})
     assert goal.page_path == "/foo bar"
+    assert goal.display_name == "Visit /foo bar"
 
-    {:ok, goal} = Goals.create(site, %{"event_name" => "  some event name   "})
+    {:ok, goal} = Goals.create(site, %{"event_name" => "  some event name   ", "display_name" => " DisplayName   "})
     assert goal.event_name == "some event name"
+    assert goal.display_name == "DisplayName"
   end
 
   test "create/2 creates pageview goal and adds a leading slash if missing" do
@@ -90,6 +92,15 @@ defmodule Plausible.GoalsTest do
              Goals.create(site, %{"event_name" => "Purchase", "currency" => "Euro"})
 
     assert [currency: {"is invalid", _}] = changeset.errors
+  end
+
+  test "update/2 updates a goal" do
+    site = insert(:site)
+    {:ok, goal1} = Goals.create(site, %{"page_path" => "/foo bar "})
+    {:ok, goal2} = Goals.update(goal1, %{"page_path" => "/", "display_name" => "Homepage"})
+    assert goal1.id == goal2.id
+    assert goal2.page_path == "/"
+    assert goal2.display_name == "Homepage"
   end
 
   @tag :ee_only

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -9,7 +9,12 @@ defmodule Plausible.GoalsTest do
     assert goal.page_path == "/foo bar"
     assert goal.display_name == "Visit /foo bar"
 
-    {:ok, goal} = Goals.create(site, %{"event_name" => "  some event name   ", "display_name" => " DisplayName   "})
+    {:ok, goal} =
+      Goals.create(site, %{
+        "event_name" => "  some event name   ",
+        "display_name" => " DisplayName   "
+      })
+
     assert goal.event_name == "some event name"
     assert goal.display_name == "DisplayName"
   end

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -305,6 +305,38 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert res["domain"] == new_domain
       end
 
+      test "can add a goal as event with display name", %{conn: conn, site: site} do
+        conn =
+          put(conn, "/api/v1/sites/goals", %{
+            site_id: site.domain,
+            goal_type: "event",
+            event_name: "Signup",
+            display_name: "Customer Acquired"
+          })
+
+        res = json_response(conn, 200)
+        assert res["goal_type"] == "event"
+        assert res["event_name"] == "Signup"
+        assert res["display_name"] == "Customer Acquired"
+        assert res["domain"] == site.domain
+      end
+
+      test "can add a goal as page with display name", %{conn: conn, site: site} do
+        conn =
+          put(conn, "/api/v1/sites/goals", %{
+            site_id: site.domain,
+            goal_type: "page",
+            page_path: "/foo",
+            display_name: "Visit the foo page"
+          })
+
+        res = json_response(conn, 200)
+        assert res["goal_type"] == "page"
+        assert res["display_name"] == "Visit the foo page"
+        assert res["page_path"] == "/foo"
+        assert res["domain"] == site.domain
+      end
+
       test "is idempotent find or create op", %{conn: conn, site: site} do
         conn =
           put(conn, "/api/v1/sites/goals", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -415,7 +415,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         build(:pageview, timestamp: today)
       ])
 
-      insert(:goal, %{site: site, event_name: "Signup"})
+      insert(:goal, %{site: site, event_name: "Signup", display_name: "Signup Display Name"})
 
       conn =
         get(conn, "/api/v1/stats/aggregate", %{
@@ -423,7 +423,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "period" => "day",
           "date" => "2023-05-05",
           "metrics" => "conversion_rate",
-          "filters" => "event:goal==Signup",
+          "filters" => "event:goal==Signup Display Name",
           "compare" => "previous_period"
         })
 
@@ -712,7 +712,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
 
     test "returns stats with page + pageview goal filter",
          %{conn: conn, site: site, site_import: site_import} do
-      insert(:goal, site: site, page_path: "/blog/**")
+      insert(:goal, site: site, page_path: "/blog/**", display_name: "Blog Visit")
 
       populate_stats(site, site_import.id, [
         build(:imported_pages, page: "/blog/1", visitors: 1, pageviews: 1),
@@ -725,7 +725,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           "site_id" => site.domain,
           "period" => "day",
           "metrics" => "visitors,events,conversion_rate",
-          "filters" => "event:page==/blog/2;event:goal==Visit /blog/**",
+          "filters" => "event:page==/blog/2;event:goal==Blog Visit",
           "with_imported" => "true"
         })
 

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
       end
     end
 
-    test "renders preselected default value" do
+    test "renders preselected default value (tuple)" do
       options = new_options(10)
       assert doc = render_sample_component(options, selected: List.last(options))
 
@@ -33,6 +33,18 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
       assert element_exists?(
                doc,
                ~s|input[type=text][name=display-test-component][value="TestOption 10"]|
+             )
+    end
+
+    test "renders preselected default value (string)" do
+      options = [{"a", "a"}, {"b", "b"}, {"c", "c"}]
+      assert doc = render_sample_component(options, selected: "b")
+
+      assert element_exists?(doc, "input[type=hidden][name=test-submit-name][value=b]")
+
+      assert element_exists?(
+               doc,
+               ~s|input[type=text][name=display-test-component][value="b"]|
              )
     end
 

--- a/test/plausible_web/live/goal_settings/form_test.exs
+++ b/test/plausible_web/live/goal_settings/form_test.exs
@@ -27,68 +27,65 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
     setup [:create_user, :log_in, :create_site]
 
     @tag :ee_only
-    test "renders form fields (with currency)", %{conn: conn, site: site} do
+    test "renders form fields per tab, with currency", %{conn: conn, site: site} do
       lv = get_liveview(conn, site)
       html = render(lv)
 
-      event_name_display = find(html, "form input#event_name_input_modalseq0-tabseq0")
-      assert name_of(event_name_display) == "display-event_name_input_modalseq0-tabseq0"
+      refute element_exists?(html, "#pageviews-form")
 
-      event_name = find(html, "form input#submit-event_name_input_modalseq0-tabseq0")
-      assert name_of(event_name) == "goal[event_name]"
+      input_names = html |> find("#custom-events-form input") |> Enum.map(&name_of/1)
 
-      currency_display = find(html, "form input#currency_input_modalseq0-tabseq0")
-      assert name_of(currency_display) == "display-currency_input_modalseq0-tabseq0"
-
-      currency_submit = find(html, "form input#submit-currency_input_modalseq0-tabseq0")
-      assert name_of(currency_submit) == "goal[currency]"
-
-      display_name = find(html, "form input#custom_event_display_name_input")
-      assert name_of(display_name) == "goal[display_name]"
+      assert input_names ==
+               [
+                 "display-event_name_input_modalseq0-tabseq0",
+                 "goal[event_name]",
+                 "goal[display_name]",
+                 "display-currency_input_modalseq0-tabseq0",
+                 "goal[currency]"
+               ]
 
       lv |> element(~s/a#pageview-tab/) |> render_click()
+      html = lv |> render()
 
-      html = render(lv)
+      refute element_exists?(html, "#custom-events-form")
 
-      page_path_display = find(html, "form input#page_path_input_modalseq0-tabseq1")
-      assert name_of(page_path_display) == "display-page_path_input_modalseq0-tabseq1"
+      input_names = html |> find("#pageviews-form input") |> Enum.map(&name_of/1)
 
-      page_path_submit = find(html, "form input#submit-page_path_input_modalseq0-tabseq1")
-      assert name_of(page_path_submit) == "goal[page_path]"
-
-      display_name = find(html, "form input#display_name_input")
-      assert name_of(display_name) == "goal[display_name]"
+      assert input_names == [
+               "display-page_path_input_modalseq0-tabseq1",
+               "goal[page_path]",
+               "goal[display_name]"
+             ]
     end
 
     @tag :ce_build_only
-    test "renders form fields (no currency)", %{conn: conn, site: site} do
+    test "renders form fields per tab (no currency)", %{conn: conn, site: site} do
       lv = get_liveview(conn, site)
       html = render(lv)
 
-      event_name_display = find(html, "form input#event_name_input_modalseq0-tabseq0")
-      assert name_of(event_name_display) == "display-event_name_input_modalseq0-tabseq0"
+      refute element_exists?(html, "#pageviews-form")
 
-      event_name = find(html, "form input#submit-event_name_input_modalseq0-tabseq0")
-      assert name_of(event_name) == "goal[event_name]"
+      input_names = html |> find("#custom-events-form input") |> Enum.map(&name_of/1)
 
-      refute element_exists?(html, "form input#currency_input_modalseq0-tabseq0")
-      refute element_exists?(html, "form input#submit-currency_input_modalseq0-tabseq0")
-
-      display_name = find(html, "form input#custom_event_display_name_input")
-      assert name_of(display_name) == "goal[display_name]"
+      assert input_names ==
+               [
+                 "display-event_name_input_modalseq0-tabseq0",
+                 "goal[event_name]",
+                 "goal[display_name]"
+               ]
 
       lv |> element(~s/a#pageview-tab/) |> render_click()
+      html = lv |> render()
 
-      html = render(lv)
+      refute element_exists?(html, "#custom-events-form")
 
-      page_path_display = find(html, "form input#page_path_input_modalseq0-tabseq1")
-      assert name_of(page_path_display) == "display-page_path_input_modalseq0-tabseq1"
+      input_names = html |> find("#pageviews-form input") |> Enum.map(&name_of/1)
 
-      page_path_submit = find(html, "form input#submit-page_path_input_modalseq0-tabseq1")
-      assert name_of(page_path_submit) == "goal[page_path]"
-
-      display_name = find(html, "form input#display_name_input")
-      assert name_of(display_name) == "goal[display_name]"
+      assert input_names == [
+               "display-page_path_input_modalseq0-tabseq1",
+               "goal[page_path]",
+               "goal[display_name]"
+             ]
     end
 
     test "renders error on empty submission", %{conn: conn, site: site} do

--- a/test/plausible_web/live/goal_settings/form_test.exs
+++ b/test/plausible_web/live/goal_settings/form_test.exs
@@ -205,6 +205,8 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       |> element("#goals-form-modalseq0 form")
       |> render_submit(%{goal: %{event_name: "Updated", display_name: "UPDATED"}})
 
+      _html = render(lv)
+
       updated = Plausible.Goals.get(site, g.id)
       assert updated.event_name == "Updated"
       assert updated.display_name == "UPDATED"
@@ -226,6 +228,8 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       |> element("#goals-form-modalseq0 form")
       |> render_submit(%{goal: %{event_name: "Updated", currency: "USD"}})
 
+      _html = render(lv)
+
       updated = Plausible.Goals.get(site, g.id)
       assert updated.event_name == "Updated"
       assert updated.display_name == "Purchase"
@@ -246,6 +250,8 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       lv
       |> element("#goals-form-modalseq0 form")
       |> render_submit(%{goal: %{page_path: "/updated", display_name: "Visit /updated"}})
+
+      _html = render(lv)
 
       updated = Plausible.Goals.get(site, g.id)
       assert updated.page_path == "/updated"

--- a/test/plausible_web/live/goal_settings/form_test.exs
+++ b/test/plausible_web/live/goal_settings/form_test.exs
@@ -199,7 +199,7 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       lv |> element(~s/button#edit-goal-#{g.id}/) |> render_click()
 
       html = render(lv)
-      assert element_exists?(html, "#event_name_input_modalseq0-tabseq0[value=Signup]")
+      assert element_exists?(html, "#event_name_input_modalseq0[value=Signup]")
 
       lv
       |> element("#goals-form-modalseq0 form")
@@ -219,8 +219,8 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       lv |> element(~s/button#edit-goal-#{g.id}/) |> render_click()
 
       html = render(lv)
-      assert element_exists?(html, "#event_name_input_modalseq0-tabseq0[value=Purchase]")
-      assert element_exists?(html, ~s/#currency_input_modalseq0-tabseq0[value="EUR - Euro"]/)
+      assert element_exists?(html, "#event_name_input_modalseq0[value=Purchase]")
+      assert element_exists?(html, ~s/#currency_input_modalseq0[value="EUR - Euro"]/)
 
       lv
       |> element("#goals-form-modalseq0 form")
@@ -241,7 +241,7 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       lv |> element(~s/button#edit-goal-#{g.id}/) |> render_click()
 
       html = render(lv)
-      assert element_exists?(html, ~s|#page_path_input_modalseq0-tabseq0[value="/go/to/blog/**"|)
+      assert element_exists?(html, ~s|#page_path_input_modalseq0[value="/go/to/blog/**"|)
 
       lv
       |> element("#goals-form-modalseq0 form")

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -41,9 +41,14 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
       assert g3.currency
       assert resp =~ to_string(g3)
       assert resp =~ "Unlock Revenue Goals by upgrading to a business plan"
+
+      refute element_exists?(
+               resp,
+               ~s/button[phx-click="edit-goal"][phx-value-goal-id=#{g3.id}]#edit-goal-#{g3.id}/
+             )
     end
 
-    test "lists goals with delete actions", %{conn: conn, site: site} do
+    test "lists goals with actions", %{conn: conn, site: site} do
       {:ok, goals} = setup_goals(site)
       conn = get(conn, "/#{site.domain}/settings/goals")
       resp = html_response(conn, 200)
@@ -52,6 +57,11 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
         assert element_exists?(
                  resp,
                  ~s/button[phx-click="delete-goal"][phx-value-goal-id=#{g.id}]#delete-goal-#{g.id}/
+               )
+
+        assert element_exists?(
+                 resp,
+                 ~s/button[phx-click="edit-goal"][phx-value-goal-id=#{g.id}]#edit-goal-#{g.id}/
                )
       end
     end
@@ -75,10 +85,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
     test "add goal button is rendered", %{conn: conn, site: site} do
       conn = get(conn, "/#{site.domain}/settings/goals")
       resp = html_response(conn, 200)
-      assert element_exists?(resp, ~s/button#add-goal-button[x-data]/)
-      attr = text_of_attr(resp, ~s/button#add-goal-button/, "x-on:click")
-      assert attr =~ "open-modal"
-      assert attr =~ "goals-form-modal"
+      assert element_exists?(resp, ~s/button#add-goal-button[phx-click="add-goal"]/)
     end
 
     test "search goals input is rendered", %{conn: conn, site: site} do

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
 
       refute element_exists?(
                resp,
-               ~s/button[phx-click="edit-goal"][phx-value-goal-id=#{g3.id}]#edit-goal-#{g3.id}/
+               ~s/button[phx-click="edit-goal"][phx-value-goal-id=#{g3.id}][disabled]#edit-goal-#{g3.id}/
              )
     end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -107,8 +107,32 @@ defmodule Plausible.Factory do
     }
   end
 
-  def goal_factory do
-    %Plausible.Goal{}
+  def goal_factory(attrs) do
+    display_name_provided? = Map.has_key?(attrs, :display_name)
+
+    attrs =
+      case {attrs, display_name_provided?} do
+        {%{page_path: path}, false} when is_binary(path) ->
+          Map.put(attrs, :display_name, "Visit " <> path)
+
+        {%{page_path: path}, false} when is_function(path, 0) ->
+          attrs
+          |> Map.put(:display_name, "Visit " <> path.())
+          |> Map.put(:page_path, path.())
+
+        {%{event_name: event_name}, false} when is_binary(event_name) ->
+          Map.put(attrs, :display_name, event_name)
+
+        {%{event_name: event_name}, false} when is_function(event_name, 0) ->
+          attrs
+          |> Map.put(:display_name, event_name.())
+          |> Map.put(:event_name, event_name.())
+
+        _ ->
+          attrs
+      end
+
+    merge_attributes(%Plausible.Goal{}, attrs)
   end
 
   def subscription_factory do


### PR DESCRIPTION
### Changes

This PR introduces new capabilities of:

- editing goals
- setting up display names for goals

![image](https://github.com/user-attachments/assets/9304ff2a-86fb-4bf8-a4d5-1422c26a65df)

![image](https://github.com/user-attachments/assets/50451f5a-d69a-496c-ac3b-2a938c4a5f12)

The display name is meant to decouple event names (used in tracking integration) from what dashboard/site settings users see. Especially useful in case of long/cryptic page paths, allowing marketing-oriented users quickly identify their meaning.

It's also used in the Stats/Sites API as the primary filtering identifier, replacing conditional naming used thus far. The API docs will need an update, a relevant PR will be referenced here.

By design, it's not possible to change the goal type when editing. So for example a custom event cannot be turned into a revenue goal or a pageview. We only allow editing initially provided set of data, otherwise goal deletion is recommended.

#### Migration

By default, all the pre-existing goals are migrated, such that:

- pageviews' display names become "Visit #{page_path}"
- custom events' display names identical to event name

Migrations extracted to: #4425 and #4426 

#### UI changes

##### LiveView

The PR updates LiveView for listing and editing goals too. The form is now conditionally updated, depending on whether a `goal_id` has been passed (which effectively means edition attempt). For that reason, the optimization implemented via `PlausibleWeb.Live.Components.Modal` may not be fully applicable - the form is initially preloaded for new goal insertion, but on edit, it's updated via websocket messages to skip rendering irrelevant bits.

The optimizations mentioned were initially done to speed up modal loading in poor latency conditions. Those can be simulated locally by invoking  `liveSocket.enableLatencySim(500)` in the web inspector console, after navigating to goals site settings area.

There is one quirky bit there - applying `phash2` to DOM identifiers, so that AlpineJS picks up the changes made behind the scenes by LV. I couldn't find another way to do that. Without it, after navigating to goal settings and selecting the edit action first, the form modal won't be rendered correctly.

##### Minor UI changes

For convenience, in edit mode, clicking the display name for the first time will select the whole text input contents to allow quicker corrections.

The goals list now contains a whole lot of new information, so the list layout has been changed to accommodate them, at the same time aiming to skip display redundant info. For example, in case of pageview goal "/long_url" with display name "Visit /long_url", just the display name is shown, whilst in case of "/long_url" with display name "Pageview Alias", both will be visible.

#### Plugins API note

There should be no breaking changes other than displaying revenue goals differently in the Plugins API (used by our WordPress plugin) - the display name no longer contains currency, so "Purchase (EUR)" becomes "Purchase". This has been cleared with Daan and should cause no regressions with existing WordPress installations. 

#### How to test locally?

Re-seed the database with `mix ecto.reset`, visit goal settings, add & edit goals. Wherever goal names were used thus far, the display name should appear (dashboard, funnel settings).

#### What bugs I haven't solved yet

- [ ] ~~When editing a goal on chromium-based browsers, holding LMB to select the ComboBox dropdown contents and dragging outside of the modal window, and then releasing the LMB, triggers "click away" behaviour effectively closing the modal~~. https://github.com/alpinejs/alpine/discussions/807#discussioncomment-92461
- ~~[ ] In goal settings list, on Safari (that I don't have access to), the tooltips from `title=` attribute are not appearing on hover. Reason unknown yet. Those tooltips reportedly don't work in existing Shields sections as well.~~ not a bug, filed improvement issue separately

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
