### PR TITLE
Map lowercase tagged sources to capitalized form during ingestion

### DIFF
--- a/lib/mix/tasks/send_pageview.ex
+++ b/lib/mix/tasks/send_pageview.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.SendPageview do
   @default_referrer "https://google.com"
   @default_event "pageview"
   @default_props "{}"
+  @default_queryparams ""
   @options [
     ip: :string,
     user_agent: :string,
@@ -28,7 +29,8 @@ defmodule Mix.Tasks.SendPageview do
     event: :string,
     props: :string,
     revenue_currency: :string,
-    revenue_amount: :string
+    revenue_amount: :string,
+    queryparams: :string
   ]
 
   def run(opts) do
@@ -88,6 +90,7 @@ defmodule Mix.Tasks.SendPageview do
     event = Keyword.get(opts, :event, @default_event)
     props = Keyword.get(opts, :props, @default_props)
     hostname = Keyword.get(opts, :hostname, domain)
+    queryparams = Keyword.get(opts, :queryparams, @default_queryparams)
 
     revenue =
       if Keyword.get(opts, :revenue_currency) do
@@ -99,7 +102,7 @@ defmodule Mix.Tasks.SendPageview do
 
     %{
       name: event,
-      url: "http://#{hostname}#{page}",
+      url: "http://#{hostname}#{page}?#{queryparams}",
       domain: domain,
       referrer: referrer,
       props: props,

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -105,6 +105,7 @@ defmodule Plausible.Application do
 
     setup_geolocation()
     Location.load_all()
+    Plausible.Ingestion.Acquisition.init()
     Plausible.Geo.await_loader()
 
     Supervisor.start_link(List.flatten(children), opts)

--- a/lib/plausible/ingestion/acquisition.ex
+++ b/lib/plausible/ingestion/acquisition.ex
@@ -1,0 +1,25 @@
+defmodule Plausible.Ingestion.Acquisition do
+  def init() do
+    :ets.new(__MODULE__, [
+      :named_table,
+      :set,
+      :public,
+      {:read_concurrency, true}
+    ])
+
+    [{"referers.yml", map}] = RefInspector.Database.list(:default)
+
+    Enum.flat_map(map, fn {_, entries} ->
+      Enum.map(entries, fn {_, _, _, _, _, _, name} ->
+        :ets.insert(__MODULE__, {String.downcase(name), name})
+      end)
+    end)
+  end
+
+  def find_mapping(source) do
+    case :ets.lookup(__MODULE__, source) do
+      [{_, name}] -> name
+      _ -> source
+    end
+  end
+end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -385,12 +385,16 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp get_referrer_source(request, ref) do
-    source =
+    tagged_source =
       request.query_params["utm_source"] ||
         request.query_params["source"] ||
         request.query_params["ref"]
 
-    source || PlausibleWeb.RefInspector.parse(ref)
+    if tagged_source do
+      Plausible.Ingestion.Acquisition.find_mapping(tagged_source)
+    else
+      PlausibleWeb.RefInspector.parse(ref)
+    end
   end
 
   defp clean_referrer(nil), do: nil

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -239,7 +239,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert event.browser_version == "70.0"
     end
 
-    test "parses referrer", %{conn: conn, site: site} do
+    test "parses referrer source", %{conn: conn, site: site} do
       params = %{
         name: "pageview",
         url: "http://example.com/",
@@ -405,6 +405,22 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert session.referrer_source == "betalist"
+    end
+
+    test "if utm_source matches a capitalized form from ref_inspector, the capitalized form is recorded",
+         %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?utm_source=facebook",
+        domain: site.domain
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert session.referrer_source == "Facebook"
     end
 
     test "utm tags are stored", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

This work is in preparation of a bigger project - [Acquisition Channel](https://feedback.plausible.io/175).

This PR changes how we handle manually tagged acquisition data. When links are manually tagged, usually the `utm_source` parameter has a value like `google` or `facebook`. However, when we automatically detect sources based on the Referer header, we store the `source` field as `Google` or Facebook`. So then we have dashboards that have both sources `google` and `Google` where the first is manually tagged traffic and the second is automatically detected.

However, both are coming from the same source so we would like to merge the lowercase and the capitalized entry in sources.

The way I've decided to tackle it here is to build a lookup table from the `RefInspector` library that stores all sources in a table like:

```
lowercase(source) -> source
```

We use this table to lookup `google -> Google` during ingestion, for example.

The logic is that if the manually passed `utm_source` matches the lowercase form of any known traffic source, it gets transformed and stored as the capitalized form like automatically added sources.

We have also discussed a data migration for historical data to apply the same transformation. I'll look into that next.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
