### PR TITLE
Fix legacy compatibility redirect

### DIFF
--- a/assets/js/dashboard/query.js
+++ b/assets/js/dashboard/query.js
@@ -107,7 +107,6 @@ export function filtersBackwardsCompatibilityRedirect(windowLocation, windowHist
     if (LEGACY_URL_PARAMETERS.hasOwnProperty(key)) {
       const filter = parseLegacyFilter(key, value)
       filters.push(filter)
-
       const labelsKey = LEGACY_URL_PARAMETERS[key]
       if (labelsKey && getValue(labelsKey)) {
         const clauses = filter[2]
@@ -126,7 +125,7 @@ export function filtersBackwardsCompatibilityRedirect(windowLocation, windowHist
   }
 
   if (filters.length > 0) {
-    changedSearchRecordEntries.push([['filters', filters], ['labels', labels]])
+    changedSearchRecordEntries.push(['filters', filters], ['labels', labels])
     windowHistory.pushState({}, null, `${windowLocation.pathname}${stringifySearch(Object.fromEntries(changedSearchRecordEntries))}`)
   }
 }


### PR DESCRIPTION
### Changes

https://github.com/plausible/analytics/pull/4408 move away from PlausibleSearchParams ([link](https://github.com/plausible/analytics/pull/4408/files#diff-8dcef7f492b734b83bc8ccb460c4e9d06a27a056b4ef986ead16673ab5aca1ffR129)) caused a bug that resulted in the new filters being constructed wrong, and not being applied properly. 

This fixes the issue.

### Tests
- [x] Manually tested

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
