### PR TITLE
Migration: turn google auth tokens into text column type

### DIFF
--- a/priv/repo/migrations/20240809100853_turn_google_auth_tokens_into_text.exs
+++ b/priv/repo/migrations/20240809100853_turn_google_auth_tokens_into_text.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.Repo.Migrations.TurnGoogleAuthTokensIntoText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:google_auth) do
+      modify :refresh_token, :text
+      modify :access_token, :text
+    end
+  end
+end


### PR DESCRIPTION
To address occasional ERROR 22001 (string_data_right_truncation)  [Sentry](https://sentry.plausible.io/organizations/plausible/issues/437)