### PR TITLE
Populate log_comment with debug information, /debug/clickhouse route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 - Add `does_not_contain` filter support to dashboard
 - Traffic drop notifications plausible/analytics#4300
 - Add search and pagination functionality into Google Keywords > Details modal
+- ClickHouse system.query_log table log_comment column now contains information about source of queries. Useful for debugging
+- New /debug/clickhouse route for super admins which shows information on clickhouse queries executed by user
 
 ### Removed
 - Deprecate `ECTO_IPV6` and `ECTO_CH_IPV6` env vars in CE plausible/analytics#4245

--- a/lib/plausible/clickhouse_repo.ex
+++ b/lib/plausible/clickhouse_repo.ex
@@ -30,4 +30,17 @@ defmodule Plausible.ClickhouseRepo do
     |> Enum.to_list()
     |> Keyword.values()
   end
+
+  @impl true
+  def prepare_query(_operation, query, opts) do
+    {plausible_query, opts} = Keyword.pop(opts, :query)
+    log_comment = if(plausible_query, do: Jason.encode!(plausible_query.debug_metadata), else: "")
+
+    opts =
+      Keyword.update(opts, :settings, [log_comment: log_comment], fn settings ->
+        [{:log_comment, log_comment} | settings]
+      end)
+
+    {query, opts}
+  end
 end

--- a/lib/plausible/data_migration/locations_sync.ex
+++ b/lib/plausible/data_migration/locations_sync.ex
@@ -88,7 +88,7 @@ defmodule Plausible.DataMigration.LocationsSync do
   end
 
   def run() do
-    cluster? = Plausible.MigrationUtils.clustered_table?("sessions_v2")
+    cluster? = Plausible.IngestRepo.clustered_table?("sessions_v2")
 
     {:ok, _} = run_sql("truncate-location-data-table", cluster?: cluster?)
     {:ok, _} = run_sql("create-location-data-table", cluster?: cluster?)

--- a/lib/plausible/data_migration/populate_event_session_columns.ex
+++ b/lib/plausible/data_migration/populate_event_session_columns.ex
@@ -22,7 +22,7 @@ defmodule Plausible.DataMigration.PopulateEventSessionColumns do
   }
 
   def run(opts \\ []) do
-    cluster? = Plausible.MigrationUtils.clustered_table?("sessions_v2")
+    cluster? = Plausible.IngestRepo.clustered_table?("sessions_v2")
 
     {:ok, _} =
       run_sql("create-sessions-dictionary",
@@ -54,7 +54,7 @@ defmodule Plausible.DataMigration.PopulateEventSessionColumns do
   end
 
   def kill(opts \\ []) do
-    cluster? = Plausible.MigrationUtils.clustered_table?("events_v2")
+    cluster? = Plausible.IngestRepo.clustered_table?("events_v2")
 
     report_progress(opts)
 

--- a/lib/plausible/data_migration/versioned_sessions.ex
+++ b/lib/plausible/data_migration/versioned_sessions.ex
@@ -21,7 +21,7 @@ defmodule Plausible.DataMigration.VersionedSessions do
 
     unique_suffix = Timex.now() |> Calendar.strftime(@suffix_format)
 
-    cluster? = Plausible.MigrationUtils.clustered_table?("sessions_v2")
+    cluster? = Plausible.IngestRepo.clustered_table?("sessions_v2")
 
     {:ok, %{rows: partitions}} = run_sql("list-partitions")
     partitions = Enum.map(partitions, fn [part] -> part end)

--- a/lib/plausible/ingest_repo.ex
+++ b/lib/plausible/ingest_repo.ex
@@ -14,4 +14,11 @@ defmodule Plausible.IngestRepo do
       import Ecto.Query, only: [from: 1, from: 2]
     end
   end
+
+  def clustered_table?(table) do
+    case query("SELECT 1 FROM system.replicas WHERE table = '#{table}'") do
+      {:ok, %{rows: []}} -> false
+      {:ok, _} -> true
+    end
+  end
 end

--- a/lib/plausible/migration_utils.ex
+++ b/lib/plausible/migration_utils.ex
@@ -3,20 +3,15 @@ defmodule Plausible.MigrationUtils do
   Base module for to use in Clickhouse migrations
   """
 
-  def on_cluster_statement(table) do
-    if(clustered_table?(table), do: "ON CLUSTER '{cluster}'", else: "")
-  end
+  alias Plausible.IngestRepo
 
-  def clustered_table?(table) do
-    case Plausible.IngestRepo.query("SELECT 1 FROM system.replicas WHERE table = '#{table}'") do
-      {:ok, %{rows: []}} -> false
-      {:ok, _} -> true
-    end
+  def on_cluster_statement(table) do
+    if(IngestRepo.clustered_table?(table), do: "ON CLUSTER '{cluster}'", else: "")
   end
 
   # See https://clickhouse.com/docs/en/sql-reference/dictionaries#clickhouse for context
   def dictionary_connection_params() do
-    Plausible.IngestRepo.config()
+    IngestRepo.config()
     |> Enum.map(fn
       {:database, database} -> "DB '#{database}'"
       {:username, username} -> "USER '#{username}'"

--- a/lib/plausible/stats.ex
+++ b/lib/plausible/stats.ex
@@ -22,7 +22,7 @@ defmodule Plausible.Stats do
 
     optimized_query
     |> SQL.QueryBuilder.build(site)
-    |> ClickhouseRepo.all()
+    |> ClickhouseRepo.all(query: query)
     |> QueryResult.from(optimized_query)
   end
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Stats.Breakdown do
 
     q
     |> apply_pagination(pagination)
-    |> ClickhouseRepo.all()
+    |> ClickhouseRepo.all(query: query)
     |> QueryResult.from(query_with_metrics)
     |> build_breakdown_result(query_with_metrics, metrics)
     |> maybe_add_time_on_page(site, query_with_metrics, metrics)
@@ -150,7 +150,7 @@ defmodule Plausible.Stats.Breakdown do
       end
 
     timed_pages_q
-    |> Plausible.ClickhouseRepo.all()
+    |> Plausible.ClickhouseRepo.all(query: query)
     |> Map.new()
   end
 

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -5,12 +5,12 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
   alias Plausible.Stats.{Filters, Interval, Query}
 
-  def from(site, params) do
+  def from(site, params, debug_metadata) do
     now = NaiveDateTime.utc_now(:second)
 
     query =
       Query
-      |> struct!(now: now, timezone: site.timezone)
+      |> struct!(now: now, timezone: site.timezone, debug_metadata: debug_metadata)
       |> put_period(site, params)
       |> put_dimensions(params)
       |> put_interval(params)

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -39,7 +39,7 @@ defmodule Plausible.Stats.Timeseries do
     q = SQL.QueryBuilder.build(query_with_metrics, site)
 
     q
-    |> ClickhouseRepo.all()
+    |> ClickhouseRepo.all(query: query)
     |> QueryResult.from(query_with_metrics)
     |> build_timeseries_result(query_with_metrics, currency)
     |> transform_keys(%{group_conversion_rate: :conversion_rate})

--- a/lib/plausible_web/controllers/api/external_query_api_controller.ex
+++ b/lib/plausible_web/controllers/api/external_query_api_controller.ex
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
   def query(conn, params) do
     site = Repo.preload(conn.assigns.site, :owner)
 
-    case Query.build(site, params) do
+    case Query.build(site, params, debug_metadata(conn)) do
       {:ok, query} ->
         results = Plausible.Stats.query(site, query)
         json(conn, results)

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -16,7 +16,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
-         query <- Query.from(site, params),
+         query <- Query.from(site, params, debug_metadata(conn)),
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do
@@ -55,7 +55,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          :ok <- validate_property(params),
-         query <- Query.from(site, params),
+         query <- Query.from(site, params, debug_metadata(conn)),
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          {:ok, limit} <- validate_or_default_limit(params),
@@ -262,7 +262,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
          :ok <- validate_interval(params),
-         query <- Query.from(site, params),
+         query <- Query.from(site, params, debug_metadata(conn)),
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do

--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -8,39 +8,65 @@ defmodule PlausibleWeb.DebugController do
   plug(PlausibleWeb.RequireAccountPlug)
   plug(PlausibleWeb.SuperAdminOnlyPlug)
 
+  @columns [
+    "query",
+    "log_comment",
+    "type",
+    "event_time",
+    "query_duration_ms",
+    "query_id",
+    "result_rows",
+    "memory_usage",
+    "read_bytes",
+    "result_bytes"
+  ]
+
   def clickhouse(conn, params) do
     user_id = Map.get(params, "user_id", conn.assigns.current_user.id)
 
+    cluster? = Plausible.MigrationUtils.clustered_table?("events_v2")
+    on_cluster = if(cluster?, do: "ON CLUSTER '{cluster}'", else: "")
+
     # Ensure last logs are flushed
-    IngestRepo.query("SYSTEM FLUSH LOGS")
+    IngestRepo.query("SYSTEM FLUSH LOGS #{on_cluster}")
+
+    table_expression =
+      if(cluster?,
+        do: "clusterAllReplicas('{cluster}', system.query_log)",
+        else: "system.query_log"
+      )
+
+    %Ch.Result{rows: rows} =
+      IngestRepo.query!(
+        """
+          SELECT
+            formatQuery(query) AS query,
+            log_comment,
+            type,
+            event_time,
+            query_duration_ms,
+            query_id,
+            result_rows,
+            formatReadableSize(memory_usage) AS memory_usage,
+            formatReadableSize(read_bytes) AS read_bytes,
+            formatReadableSize(result_bytes) AS result_bytes
+          FROM #{table_expression}
+          WHERE type > 1
+            AND JSONExtractString(log_comment, 'user_id') = {$0:String}
+            AND event_time > now() - toIntervalMinute(15)
+          ORDER BY event_time DESC
+        """,
+        [user_id]
+      )
 
     queries =
-      from(
-        l in "query_log",
-        prefix: "system",
-        select: %{
-          query: fragment("formatQuery(?)", l.query),
-          log_comment: l.log_comment,
-          type: l.type,
-          event_time: l.event_time,
-          query_duration_ms: l.query_duration_ms,
-          query_id: l.query_id,
-          memory_usage: fragment("formatReadableSize(?)", l.memory_usage),
-          read_bytes: fragment("formatReadableSize(?)", l.read_bytes),
-          result_bytes: fragment("formatReadableSize(?)", l.result_bytes),
-          result_rows: l.result_rows
-        },
-        where:
-          l.type > 1 and
-            fragment("JSONExtractInt(?, \'user_id\') = ?", l.log_comment, ^user_id) and
-            fragment("event_time > now() - toIntervalMinute(15)"),
-        order_by: [desc: l.event_time]
-      )
-      |> IngestRepo.all()
-      |> Enum.map(fn data ->
-        Jason.decode!(data.log_comment)
-        |> Map.merge(data)
-        |> Map.delete(:log_comment)
+      rows
+      |> Enum.map(fn row ->
+        data = Enum.zip(@columns, row) |> Enum.into(%{})
+
+        data
+        |> Map.merge(Jason.decode!(data["log_comment"]))
+        |> Map.delete("log_comment")
       end)
       |> IO.inspect()
 

--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -1,0 +1,54 @@
+defmodule PlausibleWeb.DebugController do
+  use PlausibleWeb, :controller
+  use Plausible.IngestRepo
+  use Plausible
+
+  import Ecto.Query
+
+  plug(PlausibleWeb.RequireAccountPlug)
+  plug(PlausibleWeb.SuperAdminOnlyPlug)
+
+  def clickhouse(conn, params) do
+    user_id = Map.get(params, "user_id", conn.assigns.current_user.id)
+
+    # Ensure last logs are flushed
+    IngestRepo.query("SYSTEM FLUSH LOGS")
+
+    queries =
+      from(
+        l in "query_log",
+        prefix: "system",
+        select: %{
+          query: fragment("formatQuery(?)", l.query),
+          log_comment: l.log_comment,
+          type: l.type,
+          event_time: l.event_time,
+          query_duration_ms: l.query_duration_ms,
+          query_id: l.query_id,
+          memory_usage: fragment("formatReadableSize(?)", l.memory_usage),
+          read_bytes: fragment("formatReadableSize(?)", l.read_bytes),
+          result_bytes: fragment("formatReadableSize(?)", l.result_bytes),
+          result_rows: l.result_rows
+        },
+        where:
+          l.type > 1 and
+            fragment("JSONExtractInt(?, \'user_id\') = ?", l.log_comment, ^user_id) and
+            fragment("event_time > now() - toIntervalMinute(15)"),
+        order_by: [desc: l.event_time]
+      )
+      |> IngestRepo.all()
+      |> Enum.map(fn data ->
+        Jason.decode!(data.log_comment)
+        |> Map.merge(data)
+        |> Map.delete(:log_comment)
+      end)
+      |> IO.inspect()
+
+    conn
+    |> render("clickhouse.html",
+      queries: queries,
+      user_id: user_id,
+      layout: {PlausibleWeb.LayoutView, "focus.html"}
+    )
+  end
+end

--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -3,8 +3,6 @@ defmodule PlausibleWeb.DebugController do
   use Plausible.IngestRepo
   use Plausible
 
-  import Ecto.Query
-
   plug(PlausibleWeb.RequireAccountPlug)
   plug(PlausibleWeb.SuperAdminOnlyPlug)
 
@@ -68,7 +66,6 @@ defmodule PlausibleWeb.DebugController do
         |> Map.merge(Jason.decode!(data["log_comment"]))
         |> Map.delete("log_comment")
       end)
-      |> IO.inspect()
 
     conn
     |> render("clickhouse.html",

--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.DebugController do
   plug(PlausibleWeb.SuperAdminOnlyPlug)
 
   def clickhouse(conn, params) do
-    cluster? = Plausible.MigrationUtils.clustered_table?("events_v2")
+    cluster? = Plausible.IngestRepo.clustered_table?("events_v2")
     on_cluster = if(cluster?, do: "ON CLUSTER '{cluster}'", else: "")
 
     # Ensure last logs are flushed

--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -3,75 +3,72 @@ defmodule PlausibleWeb.DebugController do
   use Plausible.IngestRepo
   use Plausible
 
+  import Ecto.Query
+
   plug(PlausibleWeb.RequireAccountPlug)
   plug(PlausibleWeb.SuperAdminOnlyPlug)
 
-  @columns [
-    "query",
-    "log_comment",
-    "type",
-    "event_time",
-    "query_duration_ms",
-    "query_id",
-    "result_rows",
-    "memory_usage",
-    "read_bytes",
-    "result_bytes"
-  ]
-
   def clickhouse(conn, params) do
-    user_id = Map.get(params, "user_id", conn.assigns.current_user.id)
-
     cluster? = Plausible.MigrationUtils.clustered_table?("events_v2")
     on_cluster = if(cluster?, do: "ON CLUSTER '{cluster}'", else: "")
 
     # Ensure last logs are flushed
     IngestRepo.query("SYSTEM FLUSH LOGS #{on_cluster}")
 
-    table_expression =
-      if(cluster?,
-        do: "clusterAllReplicas('{cluster}', system.query_log)",
-        else: "system.query_log"
-      )
-
-    %Ch.Result{rows: rows} =
-      IngestRepo.query!(
-        """
-          SELECT
-            formatQuery(query) AS query,
-            log_comment,
-            type,
-            event_time,
-            query_duration_ms,
-            query_id,
-            result_rows,
-            formatReadableSize(memory_usage) AS memory_usage,
-            formatReadableSize(read_bytes) AS read_bytes,
-            formatReadableSize(result_bytes) AS result_bytes
-          FROM #{table_expression}
-          WHERE type > 1
-            AND JSONExtractString(log_comment, 'user_id') = {$0:String}
-            AND event_time > now() - toIntervalMinute(15)
-          ORDER BY event_time DESC
-        """,
-        [user_id]
-      )
-
     queries =
-      rows
-      |> Enum.map(fn row ->
-        data = Enum.zip(@columns, row) |> Enum.into(%{})
-
-        data
-        |> Map.merge(Jason.decode!(data["log_comment"]))
-        |> Map.delete("log_comment")
+      from(
+        l in from_query_log(cluster?),
+        select: %{
+          query: fragment("formatQuery(?)", l.query),
+          log_comment: l.log_comment,
+          type: l.type,
+          event_time: l.event_time,
+          query_duration_ms: l.query_duration_ms,
+          query_id: l.query_id,
+          memory_usage: fragment("formatReadableSize(?)", l.memory_usage),
+          read_bytes: fragment("formatReadableSize(?)", l.read_bytes),
+          result_bytes: fragment("formatReadableSize(?)", l.result_bytes),
+          result_rows: l.result_rows
+        },
+        where: l.type > 1 and fragment("event_time > now() - toIntervalMinute(15)"),
+        order_by: [desc: l.event_time]
+      )
+      |> filter_by_params(conn, params)
+      |> IngestRepo.all()
+      |> Enum.map(fn data ->
+        Jason.decode!(data.log_comment)
+        |> Map.merge(data)
+        |> Map.delete(:log_comment)
       end)
 
     conn
     |> render("clickhouse.html",
       queries: queries,
-      user_id: user_id,
       layout: {PlausibleWeb.LayoutView, "focus.html"}
     )
   end
+
+  defp from_query_log(cluster?) do
+    case cluster? do
+      true -> from(l in fragment("clusterAllReplicas('{cluster}', system.query_log)"))
+      false -> from(l in fragment("system.query_log"))
+    end
+  end
+
+  defp filter_by_params(q, _conn, %{"user_id" => user_id}),
+    do: where(q, [l], fragment("JSONExtractInt(?, \'user_id\') = ?", l.log_comment, ^user_id))
+
+  defp filter_by_params(q, _conn, %{"site_id" => site_id}),
+    do: where(q, [l], fragment("JSONExtractInt(?, \'site_id\') = ?", l.log_comment, ^site_id))
+
+  defp filter_by_params(q, _conn, %{"site_domain" => site_domain}),
+    do:
+      where(
+        q,
+        [l],
+        fragment("JSONExtractInt(?, \'site_domain\') = ?", l.log_comment, ^site_domain)
+      )
+
+  defp filter_by_params(q, conn, _),
+    do: filter_by_params(q, conn, %{"user_id" => conn.assigns.current_user.id})
 end

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -18,4 +18,17 @@ defmodule PlausibleWeb.ControllerHelpers do
 
   defp error_layout,
     do: Application.get_env(:plausible, PlausibleWeb.Endpoint)[:render_errors][:layout]
+
+  def debug_metadata(conn) do
+    %{
+      request_method: conn.method,
+      request_path: conn.request_path,
+      params: conn.params,
+      phoenix_controller: conn.private.phoenix_controller |> to_string(),
+      phoenix_action: conn.private.phoenix_action |> to_string(),
+      site_id: conn.assigns.site.id,
+      site_domain: conn.assigns.site.domain,
+      user_id: get_session(conn, :current_user_id)
+    }
+  end
 end

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -28,7 +28,10 @@ defmodule PlausibleWeb.ControllerHelpers do
       phoenix_action: conn.private.phoenix_action |> to_string(),
       site_id: conn.assigns.site.id,
       site_domain: conn.assigns.site.domain,
-      user_id: get_session(conn, :current_user_id)
+      user_id: get_user_id(conn, conn.assigns)
     }
   end
+
+  defp get_user_id(_conn, %{current_user: user}), do: user.id
+  defp get_user_id(conn, _assigns), do: get_session(conn, :current_user_id)
 end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -112,7 +112,7 @@ defmodule PlausibleWeb.StatsController do
   def csv_export(conn, params) do
     if is_nil(params["interval"]) or Plausible.Stats.Interval.valid?(params["interval"]) do
       site = Plausible.Repo.preload(conn.assigns.site, :owner)
-      query = Query.from(site, params)
+      query = Query.from(site, params, debug_metadata(conn))
 
       filename =
         ~c"Plausible export #{params["domain"]} #{Date.to_iso8601(query.date_range.first)}  to #{Date.to_iso8601(query.date_range.last)} .zip"

--- a/lib/plausible_web/plugs/super_admin_only_plug.ex
+++ b/lib/plausible_web/plugs/super_admin_only_plug.ex
@@ -1,4 +1,4 @@
-defmodule PlausibleWeb.CRMAuthPlug do
+defmodule PlausibleWeb.SuperAdminOnlyPlug do
   import Plug.Conn
   use Plausible.Repo
 

--- a/lib/plausible_web/plugs/super_admin_only_plug.ex
+++ b/lib/plausible_web/plugs/super_admin_only_plug.ex
@@ -1,4 +1,6 @@
 defmodule PlausibleWeb.SuperAdminOnlyPlug do
+  @moduledoc false
+
   import Plug.Conn
   use Plausible.Repo
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -429,6 +429,8 @@ defmodule PlausibleWeb.Router do
     get "/:website/download/export", SiteController, :download_export
     get "/:website/settings/import", SiteController, :csv_import
 
+    get "/debug/clickhouse", DebugController, :clickhouse
+
     get "/:domain/export", StatsController, :csv_export
     get "/:domain/*path", StatsController, :stats
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Router do
       plug PlausibleWeb.Plugs.NoRobots
       plug :fetch_session
 
-      plug PlausibleWeb.CRMAuthPlug
+      plug PlausibleWeb.SuperAdminOnlyPlug
     end
   end
 
@@ -69,7 +69,7 @@ defmodule PlausibleWeb.Router do
   on_ee do
     use Kaffy.Routes,
       scope: "/crm",
-      pipe_through: [PlausibleWeb.Plugs.NoRobots, PlausibleWeb.CRMAuthPlug]
+      pipe_through: [PlausibleWeb.Plugs.NoRobots, PlausibleWeb.SuperAdminOnlyPlug]
   end
 
   on_ee do

--- a/lib/plausible_web/templates/debug/clickhouse.html.heex
+++ b/lib/plausible_web/templates/debug/clickhouse.html.heex
@@ -3,7 +3,7 @@
     <%= for log <- @queries do %>
       <details class="group py-1">
         <summary class="flex cursor-pointer flex-row items-center justify-between py-1 font-semibold text-gray-600 marker:[font-size:0px]">
-          <%= log["request_method"] %> <%= log["phoenix_controller"] |> String.split(".") |> List.last %>.<%= log["phoenix_action"] %> (<%= log[:query_duration_ms] %>ms)
+          <%= log["request_method"] %> <%= log["phoenix_controller"] |> String.split(".") |> List.last %>.<%= log["phoenix_action"] %> (<%= log["query_duration_ms"] %>ms)
           <svg class="h-6 w-6 rotate-0 transform text-gray-400 group-open:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
           </svg>
@@ -15,7 +15,7 @@
                 <td class="table-cell p-2"><%= key %></td>
                 <td class="table-cell p-2">
                   <%= case key do %>
-                    <% :query -> %>
+                    <% "query" -> %>
                       <pre class="whitespace-pre-wrap"><%= value %></pre>
                     <% "params" -> %>
                       <pre><%= Jason.encode!(value, pretty: true) %></pre>

--- a/lib/plausible_web/templates/debug/clickhouse.html.heex
+++ b/lib/plausible_web/templates/debug/clickhouse.html.heex
@@ -1,0 +1,37 @@
+<div class="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-md rounde p-8 mb-4 mt-8 mx-auto">
+  <section class="grid grid-cols-1 gap-y-3 divide-y">
+    <%= for log <- @queries do %>
+      <details class="group py-1">
+        <summary class="flex cursor-pointer flex-row items-center justify-between py-1 font-semibold text-gray-600 marker:[font-size:0px]">
+          <%= log["request_method"] %> <%= log["phoenix_controller"] |> String.split(".") |> List.last %>.<%= log["phoenix_action"] %> (<%= log[:query_duration_ms] %>ms)
+          <svg class="h-6 w-6 rotate-0 transform text-gray-400 group-open:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </summary>
+        <table class="table table-striped table-auto">
+          <tbody>
+            <%= for {key, value} <- log do%>
+              <tr class="table-row">
+                <td class="table-cell p-2"><%= key %></td>
+                <td class="table-cell p-2">
+                  <%= case key do %>
+                    <% :query -> %>
+                      <pre class="whitespace-pre-wrap"><%= value %></pre>
+                    <% "params" -> %>
+                      <pre><%= Jason.encode!(value, pretty: true) %></pre>
+                    <% _ -> %>
+                      <%= value %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </details>
+    <% end %>
+  </section>
+
+  <%= if length(@queries) == 0 do %>
+    <p class="text-gray-500">No queries run by user <%= @user_id %> in the last few minutes. Try opening a dashboard</p>
+  <% end %>
+</div>

--- a/lib/plausible_web/templates/debug/clickhouse.html.heex
+++ b/lib/plausible_web/templates/debug/clickhouse.html.heex
@@ -1,9 +1,9 @@
-<div class="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-md rounde p-8 mb-4 mt-8 mx-auto">
+<div class="w-full max-w-4xl bg-white dark:bg-gray-800 shadow-md rounded p-8 mb-4 mt-8 mx-auto">
   <section class="grid grid-cols-1 gap-y-3 divide-y">
     <%= for log <- @queries do %>
       <details class="group py-1">
         <summary class="flex cursor-pointer flex-row items-center justify-between py-1 font-semibold text-gray-600 marker:[font-size:0px]">
-          <%= log["request_method"] %> <%= log["phoenix_controller"] |> String.split(".") |> List.last %>.<%= log["phoenix_action"] %> (<%= log["query_duration_ms"] %>ms)
+          <%= log["request_method"] %> <%= controller_name(log["phoenix_controller"]) %>.<%= log["phoenix_action"] %> (<%= log[:query_duration_ms] %>ms)
           <svg class="h-6 w-6 rotate-0 transform text-gray-400 group-open:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
           </svg>
@@ -15,7 +15,7 @@
                 <td class="table-cell p-2"><%= key %></td>
                 <td class="table-cell p-2">
                   <%= case key do %>
-                    <% "query" -> %>
+                    <% :query -> %>
                       <pre class="whitespace-pre-wrap"><%= value %></pre>
                     <% "params" -> %>
                       <pre><%= Jason.encode!(value, pretty: true) %></pre>
@@ -32,6 +32,6 @@
   </section>
 
   <%= if length(@queries) == 0 do %>
-    <p class="text-gray-500">No queries run by user <%= @user_id %> in the last few minutes. Try opening a dashboard</p>
+    <p class="text-gray-500">No queries run by user in the last few minutes. Try opening a dashboard</p>
   <% end %>
 </div>

--- a/lib/plausible_web/templates/debug/clickhouse.html.heex
+++ b/lib/plausible_web/templates/debug/clickhouse.html.heex
@@ -3,14 +3,24 @@
     <%= for log <- @queries do %>
       <details class="group py-1">
         <summary class="flex cursor-pointer flex-row items-center justify-between py-1 font-semibold text-gray-600 marker:[font-size:0px]">
-          <%= log["request_method"] %> <%= controller_name(log["phoenix_controller"]) %>.<%= log["phoenix_action"] %> (<%= log[:query_duration_ms] %>ms)
-          <svg class="h-6 w-6 rotate-0 transform text-gray-400 group-open:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+          <%= log["request_method"] %> <%= controller_name(log["phoenix_controller"]) %>.<%= log[
+            "phoenix_action"
+          ] %> (<%= log[:query_duration_ms] %>ms)
+          <svg
+            class="h-6 w-6 rotate-0 transform text-gray-400 group-open:rotate-180"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
           </svg>
         </summary>
         <table class="table table-striped table-auto">
           <tbody>
-            <%= for {key, value} <- log do%>
+            <%= for {key, value} <- log do %>
               <tr class="table-row">
                 <td class="table-cell p-2"><%= key %></td>
                 <td class="table-cell p-2">
@@ -32,6 +42,8 @@
   </section>
 
   <%= if length(@queries) == 0 do %>
-    <p class="text-gray-500">No queries run by user in the last few minutes. Try opening a dashboard</p>
+    <p class="text-gray-500">
+      No queries run by user in the last few minutes. Try opening a dashboard
+    </p>
   <% end %>
 </div>

--- a/lib/plausible_web/views/debug_view.ex
+++ b/lib/plausible_web/views/debug_view.ex
@@ -1,0 +1,3 @@
+defmodule PlausibleWeb.DebugView do
+  use PlausibleWeb, :view
+end

--- a/lib/plausible_web/views/debug_view.ex
+++ b/lib/plausible_web/views/debug_view.ex
@@ -1,3 +1,11 @@
 defmodule PlausibleWeb.DebugView do
   use PlausibleWeb, :view
+
+  def controller_name(phoenix_controller_name) do
+    phoenix_controller_name
+    |> String.to_existing_atom()
+    |> Module.split()
+    |> Enum.drop_while(&String.starts_with?(&1, "Plausible"))
+    |> Enum.join(".")
+  end
 end

--- a/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
+++ b/priv/ingest_repo/migrations/20240423094014_add_imported_custom_events.exs
@@ -6,7 +6,7 @@ defmodule Plausible.IngestRepo.Migrations.AddImportedCustomEvents do
     on_cluster = Plausible.MigrationUtils.on_cluster_statement("imported_pages")
 
     settings =
-      if Plausible.MigrationUtils.clustered_table?("imported_pages") do
+      if Plausible.IngestRepo.clustered_table?("imported_pages") do
         """
         ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/tables/{shard}/{database}/imported_custom_events', '{replica}')
         ORDER BY (site_id, import_id, date, name)


### PR DESCRIPTION
### Changes

This PR:
- Starts populating Clickhouse system.query_log table log_comment column with metadata about the query. This will be useful for debugging performance issues and using clickhouse for query performance analysis.
- Adds a /debug/clickhouse route which shows a table containing information about recent queries by user

![image](https://github.com/user-attachments/assets/039d88e5-2d3e-4503-a08e-ffdecf0badf7)

### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change