### PR TITLE
validate that all checks passed

### DIFF
--- a/.github/workflows/all-checks-pass.yml
+++ b/.github/workflows/all-checks-pass.yml
@@ -1,0 +1,15 @@
+name: All checks pass
+
+on:
+  pull_request:
+
+jobs:
+  enforce-all-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+    steps:
+      - name: GitHub Checks
+        uses: poseidon/wait-for-status-checks@v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to check that all checks pass before merging a PR.
GitHub does not currently support requiring all checks to pass by default. You will need to manually configure any required checks in the branch protection rule.