### PR TITLE
Refactor and consolidate user session logic

### DIFF
--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -8,21 +8,16 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   use Plausible.Funnel
 
   alias Plausible.{Sites, Goals, Funnels}
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{"site_id" => site_id, "domain" => domain} = session,
+        %{"site_id" => site_id, "domain" => domain},
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:all_funnels, fn %{site: %{id: ^site_id} = site} ->
         Funnels.list(site)
@@ -105,8 +100,8 @@ defmodule PlausibleWeb.Live.FunnelSettings do
   end
 
   def handle_event("delete-funnel", %{"funnel-id" => id}, socket) do
-    user_id = socket.assigns.user_session.user_id
-    site = Sites.get_for_user!(user_id, socket.assigns.domain, [:owner, :admin])
+    site =
+      Sites.get_for_user!(socket.assigns.current_user, socket.assigns.domain, [:owner, :admin])
 
     id = String.to_integer(id)
     :ok = Funnels.delete(site, id)

--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -50,7 +50,6 @@ defmodule PlausibleWeb.Live.FunnelSettings do
           PlausibleWeb.Live.FunnelSettings.Form,
           id: "funnels-form",
           session: %{
-            "current_user_id" => @current_user_id,
             "domain" => @domain,
             "funnel_id" => @funnel_id
           }

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -10,9 +10,11 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
 
   import PlausibleWeb.Live.Components.Form
   alias Plausible.{Sites, Goals, Funnels}
+  alias PlausibleWeb.UserAuth
 
-  def mount(_params, %{"current_user_id" => user_id, "domain" => domain} = session, socket) do
-    site = Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+  def mount(_params, %{"domain" => domain} = session, socket) do
+    {:ok, user_session} = UserAuth.get_user_session(session)
+    site = Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
 
     # We'll have the options trimmed to only the data we care about, to keep
     # it minimal at the socket assigns, yet, we want to retain specific %Goal{}

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -10,11 +10,10 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
 
   import PlausibleWeb.Live.Components.Form
   alias Plausible.{Sites, Goals, Funnels}
-  alias PlausibleWeb.UserAuth
 
   def mount(_params, %{"domain" => domain} = session, socket) do
-    {:ok, user_session} = UserAuth.get_user_session(session)
-    site = Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+    site =
+      Sites.get_for_user!(socket.assigns.current_user, domain, [:owner, :admin, :super_admin])
 
     # We'll have the options trimmed to only the data we care about, to keep
     # it minimal at the socket assigns, yet, we want to retain specific %Goal{}

--- a/lib/plausible/auth/user_session.ex
+++ b/lib/plausible/auth/user_session.ex
@@ -1,0 +1,13 @@
+defmodule Plausible.Auth.UserSession do
+  @moduledoc """
+  Schema for storing user session data.
+  """
+
+  use Ecto.Schema
+
+  @type t() :: %__MODULE__{}
+
+  embedded_schema do
+    field :user_id, :integer
+  end
+end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -287,7 +287,17 @@ defmodule Plausible.Sites do
     base <> domain <> "?auth=" <> link.slug
   end
 
-  def get_for_user!(user_id, domain, roles \\ [:owner, :admin, :viewer]) do
+  @spec get_for_user!(Auth.User.t() | pos_integer(), String.t(), [
+          :super_admin | :owner | :admin | :viewer
+        ]) ::
+          Site.t()
+  def get_for_user!(user, domain, roles \\ [:owner, :admin, :viewer])
+
+  def get_for_user!(%Auth.User{id: user_id}, domain, roles) do
+    get_for_user!(user_id, domain, roles)
+  end
+
+  def get_for_user!(user_id, domain, roles) do
     if :super_admin in roles and Auth.is_super_admin?(user_id) do
       get_by_domain!(domain)
     else
@@ -297,7 +307,17 @@ defmodule Plausible.Sites do
     end
   end
 
-  def get_for_user(user_id, domain, roles \\ [:owner, :admin, :viewer]) do
+  @spec get_for_user(Auth.User.t() | pos_integer(), String.t(), [
+          :super_admin | :owner | :admin | :viewer
+        ]) ::
+          Site.t() | nil
+  def get_for_user(user, domain, roles \\ [:owner, :admin, :viewer])
+
+  def get_for_user(%Auth.User{id: user_id}, domain, roles) do
+    get_for_user(user_id, domain, roles)
+  end
+
+  def get_for_user(user_id, domain, roles) do
     if :super_admin in roles and Auth.is_super_admin?(user_id) do
       get_by_domain(domain)
     else

--- a/lib/plausible_web.ex
+++ b/lib/plausible_web.ex
@@ -9,6 +9,8 @@ defmodule PlausibleWeb do
         use PlausibleWeb.Live.SentryContext
       end
 
+      use PlausibleWeb.Live.AuthContext
+
       alias PlausibleWeb.Router.Helpers, as: Routes
       alias Phoenix.LiveView.JS
     end

--- a/lib/plausible_web/components/billing/billing.ex
+++ b/lib/plausible_web/components/billing/billing.ex
@@ -193,7 +193,8 @@ defmodule PlausibleWeb.Components.Billing do
       </div>
       <.styled_link
         :if={
-          not (Plausible.Auth.enterprise_configured?(@user) && Subscriptions.halted?(@subscription))
+          not (Plausible.Auth.enterprise_configured?(@user) &&
+                 Subscriptions.halted?(@subscription))
         }
         id="#upgrade-or-change-plan-link"
         href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -750,12 +750,10 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site, params, debug_metadata(conn))
 
     is_admin =
-      case PlausibleWeb.UserAuth.get_user_session(conn) do
-        {:ok, user_session} ->
-          Plausible.Sites.has_admin_access?(user_session.user_id, site)
-
-        _ ->
-          false
+      if current_user = conn.assigns[:current_user] do
+        Plausible.Sites.has_admin_access?(current_user.id, site)
+      else
+        false
       end
 
     pagination = {

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -749,8 +749,14 @@ defmodule PlausibleWeb.Api.StatsController do
 
     query = Query.from(site, params, debug_metadata(conn))
 
-    user_id = get_session(conn, :current_user_id)
-    is_admin = user_id && Plausible.Sites.has_admin_access?(user_id, site)
+    is_admin =
+      case PlausibleWeb.UserAuth.get_user_session(conn) do
+        {:ok, user_session} ->
+          Plausible.Sites.has_admin_access?(user_session.user_id, site)
+
+        _ ->
+          false
+      end
 
     pagination = {
       to_int(params["limit"], 9),

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -552,25 +552,25 @@ defmodule PlausibleWeb.AuthController do
   end
 
   defp render_settings(conn, opts) do
+    current_user = conn.assigns.current_user
     settings_changeset = Keyword.fetch!(opts, :settings_changeset)
     email_changeset = Keyword.fetch!(opts, :email_changeset)
-
-    user = Plausible.Users.with_subscription(conn.assigns[:current_user])
+    api_keys = Repo.preload(current_user, :api_keys).api_keys
 
     render(conn, "user_settings.html",
-      user: user |> Repo.preload(:api_keys),
+      api_keys: api_keys,
       settings_changeset: settings_changeset,
       email_changeset: email_changeset,
-      subscription: user.subscription,
-      invoices: Plausible.Billing.paddle_api().get_invoices(user.subscription),
-      theme: user.theme || "system",
-      team_member_limit: Quota.Limits.team_member_limit(user),
-      team_member_usage: Quota.Usage.team_member_usage(user),
-      site_limit: Quota.Limits.site_limit(user),
-      site_usage: Quota.Usage.site_usage(user),
-      pageview_limit: Quota.Limits.monthly_pageview_limit(user),
-      pageview_usage: Quota.Usage.monthly_pageview_usage(user),
-      totp_enabled?: Auth.TOTP.enabled?(user)
+      subscription: current_user.subscription,
+      invoices: Plausible.Billing.paddle_api().get_invoices(current_user.subscription),
+      theme: current_user.theme || "system",
+      team_member_limit: Quota.Limits.team_member_limit(current_user),
+      team_member_usage: Quota.Usage.team_member_usage(current_user),
+      site_limit: Quota.Limits.site_limit(current_user),
+      site_usage: Quota.Usage.site_usage(current_user),
+      pageview_limit: Quota.Limits.monthly_pageview_limit(current_user),
+      pageview_usage: Quota.Usage.monthly_pageview_usage(current_user),
+      totp_enabled?: Auth.TOTP.enabled?(current_user)
     )
   end
 

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -33,5 +33,11 @@ defmodule PlausibleWeb.ControllerHelpers do
   end
 
   defp get_user_id(_conn, %{current_user: user}), do: user.id
-  defp get_user_id(conn, _assigns), do: get_session(conn, :current_user_id)
+
+  defp get_user_id(conn, _assigns) do
+    case PlausibleWeb.UserAuth.get_user_session(conn) do
+      {:ok, session} -> session.user_id
+      _ -> nil
+    end
+  end
 end

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -36,7 +36,7 @@ defmodule PlausibleWeb.ControllerHelpers do
 
   defp get_user_id(conn, _assigns) do
     case PlausibleWeb.UserAuth.get_user_session(conn) do
-      {:ok, session} -> session.user_id
+      {:ok, user_session} -> user_session.user_id
       _ -> nil
     end
   end

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.Live.AuthContext do
   @moduledoc """
   This module supplies LiveViews with currently logged in user data _if_ session
   data contains a valid token.
+
+  Must be kept in sync with `PlausibleWeb.AuthPlug`.
   """
 
   import Phoenix.Component

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -1,0 +1,37 @@
+defmodule PlausibleWeb.Live.AuthContext do
+  @moduledoc """
+  This module supplies LiveViews with currently logged in user data _if_ session
+  data contains a valid token.
+  """
+
+  import Phoenix.Component
+
+  alias PlausibleWeb.UserAuth
+
+  defmacro __using__(_) do
+    quote do
+      on_mount unquote(__MODULE__)
+    end
+  end
+
+  def on_mount(:default, _params, session, socket) do
+    socket =
+      socket
+      |> assign_new(:current_user_session, fn ->
+        case UserAuth.get_user_session(session) do
+          {:ok, user_session} -> user_session
+          _ -> nil
+        end
+      end)
+      |> assign_new(:current_user, fn context ->
+        with %{} = user_session <- context.current_user_session,
+             {:ok, user} <- UserAuth.get_user(user_session) do
+          user
+        else
+          _ -> nil
+        end
+      end)
+
+    {:cont, socket}
+  end
+end

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -11,15 +11,17 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   alias Plausible.Site
   alias Plausible.Users
   alias Plausible.Billing.{Plans, Quota}
+  alias PlausibleWeb.UserAuth
 
   @contact_link "https://plausible.io/contact"
   @billing_faq_link "https://plausible.io/docs/billing"
 
-  def mount(_params, %{"current_user_id" => user_id, "remote_ip" => remote_ip}, socket) do
+  def mount(_params, %{"remote_ip" => remote_ip} = session, socket) do
     socket =
       socket
       |> assign_new(:user, fn ->
-        Users.with_subscription(user_id)
+        {:ok, user} = UserAuth.get_user(session)
+        Users.with_subscription(user)
       end)
       |> assign_new(:pending_ownership_site_ids, fn %{user: user} ->
         user.email

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -9,7 +9,6 @@ defmodule PlausibleWeb.Live.CSVImport do
   require Plausible.Imported.SiteImport
   alias Plausible.Imported.CSVImporter
   alias Plausible.Imported
-  alias PlausibleWeb.UserAuth
 
   # :not_mounted_at_router ensures we have already done auth checks in the controller
   # if this liveview becomes available from the router, please make sure
@@ -63,10 +62,6 @@ defmodule PlausibleWeb.Live.CSVImport do
 
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
       |> assign(
         site_id: site_id,
         storage: storage,
@@ -218,17 +213,16 @@ defmodule PlausibleWeb.Live.CSVImport do
     %{
       storage: storage,
       site: site,
-      user_session: user_session,
+      current_user: current_user,
       clamped_date_range: clamped_date_range,
       upload_consumer: upload_consumer
     } =
       socket.assigns
 
-    user = Plausible.Repo.get!(Plausible.Auth.User, user_session.user_id)
     uploads = consume_uploaded_entries(socket, :import, upload_consumer)
 
     {:ok, _job} =
-      CSVImporter.new_import(site, user,
+      CSVImporter.new_import(site, current_user,
         start_date: clamped_date_range.first,
         end_date: clamped_date_range.last,
         uploads: uploads,

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -7,21 +7,16 @@ defmodule PlausibleWeb.Live.GoalSettings do
 
   alias Plausible.{Sites, Goals}
   alias PlausibleWeb.Live.Components.Modal
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{"site_id" => site_id, "domain" => domain} = session,
+        %{"site_id" => site_id, "domain" => domain},
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, session} = UserAuth.get_user_session(session)
-        session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        user_session.user_id
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        current_user
         |> Sites.get_for_user!(domain, [:owner, :admin, :super_admin])
         |> Plausible.Imported.load_import_data()
       end)
@@ -38,9 +33,6 @@ defmodule PlausibleWeb.Live.GoalSettings do
           exclude: exclude,
           limit: :unlimited
         )
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok,

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -8,16 +8,21 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
 
   alias Plausible.Sites
   alias Plausible.Plugins.API.Tokens
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{"domain" => domain, "current_user_id" => user_id} = session,
+        %{"domain" => domain} = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:displayed_tokens, fn %{site: site} ->
         Tokens.list(site)

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -27,8 +27,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
      assign(socket,
        domain: domain,
        add_token?: not is_nil(session["new_token"]),
-       token_description: session["new_token"] || "",
-       current_user_id: user_id
+       token_description: session["new_token"] || ""
      )}
   end
 
@@ -42,7 +41,6 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
         PlausibleWeb.Live.Plugins.API.TokenForm,
         id: "token-form",
         session: %{
-          "current_user_id" => @current_user_id,
           "domain" => @domain,
           "token_description" => @token_description,
           "rendered_by" => self()

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -8,21 +8,12 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
 
   alias Plausible.Sites
   alias Plausible.Plugins.API.Tokens
-  alias PlausibleWeb.UserAuth
 
-  def mount(
-        _params,
-        %{"domain" => domain} = session,
-        socket
-      ) do
+  def mount(_params, %{"domain" => domain} = session, socket) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:displayed_tokens, fn %{site: site} ->
         Tokens.list(site)

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -5,10 +5,8 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
   use PlausibleWeb, live_view: :no_sentry_context
   import PlausibleWeb.Live.Components.Form
 
-  alias Plausible.Repo
   alias Plausible.Sites
   alias Plausible.Plugins.API.{Token, Tokens}
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
@@ -16,20 +14,13 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
           "token_description" => token_description,
           "domain" => domain,
           "rendered_by" => pid
-        } = session,
+        },
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, session} = UserAuth.get_user_session(session)
-        session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Repo.get(Plausible.Auth.User, user_session.user_id)
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
 
     token = Token.generate()

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -7,21 +7,12 @@ defmodule PlausibleWeb.Live.PropsSettings do
   use Phoenix.HTML
 
   alias PlausibleWeb.Live.Components.ComboBox
-  alias PlausibleWeb.UserAuth
 
-  def mount(
-        _params,
-        %{"site_id" => site_id, "domain" => domain} = session,
-        socket
-      ) do
+  def mount(_params, %{"site_id" => site_id, "domain" => domain}, socket) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Plausible.Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Plausible.Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:all_props, fn %{site: site} ->
         site.allowed_event_props || []

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -7,16 +7,21 @@ defmodule PlausibleWeb.Live.PropsSettings do
   use Phoenix.HTML
 
   alias PlausibleWeb.Live.Components.ComboBox
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{"site_id" => site_id, "domain" => domain, "current_user_id" => user_id},
+        %{"site_id" => site_id, "domain" => domain} = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Plausible.Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Plausible.Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:all_props, fn %{site: site} ->
         site.allowed_event_props || []

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -29,7 +29,6 @@ defmodule PlausibleWeb.Live.PropsSettings do
      assign(socket,
        site_id: site_id,
        domain: domain,
-       current_user_id: user_id,
        add_prop?: false,
        filter_text: ""
      )}
@@ -45,7 +44,6 @@ defmodule PlausibleWeb.Live.PropsSettings do
           PlausibleWeb.Live.PropsSettings.Form,
           id: "props-form",
           session: %{
-            "current_user_id" => @current_user_id,
             "domain" => @domain,
             "site_id" => @site_id,
             "rendered_by" => self()

--- a/lib/plausible_web/live/props_settings/form.ex
+++ b/lib/plausible_web/live/props_settings/form.ex
@@ -5,7 +5,6 @@ defmodule PlausibleWeb.Live.PropsSettings.Form do
   use PlausibleWeb, :live_view
   import PlausibleWeb.Live.Components.Form
   alias PlausibleWeb.Live.Components.ComboBox
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
@@ -13,17 +12,13 @@ defmodule PlausibleWeb.Live.PropsSettings.Form do
           "site_id" => _site_id,
           "domain" => domain,
           "rendered_by" => pid
-        } = session,
+        },
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Plausible.Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Plausible.Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:form, fn %{site: site} ->
         new_form(site)

--- a/lib/plausible_web/live/sentry_context.ex
+++ b/lib/plausible_web/live/sentry_context.ex
@@ -49,12 +49,14 @@ defmodule PlausibleWeb.Live.SentryContext do
 
       Sentry.Context.set_request_context(request_context)
 
-      user_id = session["current_user_id"]
+      case PlausibleWeb.UserAuth.get_user_session(session) do
+        {:ok, user_session} ->
+          Sentry.Context.set_user_context(%{
+            id: user_session.user_id
+          })
 
-      if user_id do
-        Sentry.Context.set_user_context(%{
-          id: user_id
-        })
+        _ ->
+          :pass
       end
     end
 

--- a/lib/plausible_web/live/shields/countries.ex
+++ b/lib/plausible_web/live/shields/countries.ex
@@ -7,25 +7,27 @@ defmodule PlausibleWeb.Live.Shields.Countries do
 
   alias Plausible.Shields
   alias Plausible.Sites
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{
-          "domain" => domain,
-          "current_user_id" => user_id
-        },
+        %{"domain" => domain} = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:country_rules_count, fn %{site: site} ->
         Shields.count_country_rules(site)
       end)
-      |> assign_new(:current_user, fn ->
-        Plausible.Repo.get(Plausible.Auth.User, user_id)
+      |> assign_new(:current_user, fn %{user_session: user_session} ->
+        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}

--- a/lib/plausible_web/live/shields/countries.ex
+++ b/lib/plausible_web/live/shields/countries.ex
@@ -7,27 +7,19 @@ defmodule PlausibleWeb.Live.Shields.Countries do
 
   alias Plausible.Shields
   alias Plausible.Sites
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{"domain" => domain} = session,
+        %{"domain" => domain},
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:country_rules_count, fn %{site: site} ->
         Shields.count_country_rules(site)
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}
@@ -42,7 +34,7 @@ defmodule PlausibleWeb.Live.Shields.Countries do
         current_user={@current_user}
         country_rules_count={@country_rules_count}
         site={@site}
-        id="country-rules-#{@current_user.id}"
+        id={"country-rules-#{@current_user.id}"}
       />
     </div>
     """

--- a/lib/plausible_web/live/shields/hostnames.ex
+++ b/lib/plausible_web/live/shields/hostnames.ex
@@ -7,25 +7,27 @@ defmodule PlausibleWeb.Live.Shields.Hostnames do
 
   alias Plausible.Shields
   alias Plausible.Sites
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{
-          "domain" => domain,
-          "current_user_id" => user_id
-        },
+        %{"domain" => domain} = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:hostname_rules_count, fn %{site: site} ->
         Shields.count_hostname_rules(site)
       end)
-      |> assign_new(:current_user, fn ->
-        Plausible.Repo.get(Plausible.Auth.User, user_id)
+      |> assign_new(:current_user, fn %{user_session: user_session} ->
+        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}

--- a/lib/plausible_web/live/shields/hostnames.ex
+++ b/lib/plausible_web/live/shields/hostnames.ex
@@ -7,27 +7,15 @@ defmodule PlausibleWeb.Live.Shields.Hostnames do
 
   alias Plausible.Shields
   alias Plausible.Sites
-  alias PlausibleWeb.UserAuth
 
-  def mount(
-        _params,
-        %{"domain" => domain} = session,
-        socket
-      ) do
+  def mount(_params, %{"domain" => domain}, socket) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:hostname_rules_count, fn %{site: site} ->
         Shields.count_hostname_rules(site)
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}
@@ -42,7 +30,7 @@ defmodule PlausibleWeb.Live.Shields.Hostnames do
         current_user={@current_user}
         hostname_rules_count={@hostname_rules_count}
         site={@site}
-        id="hostname-rules-#{@current_user.id}"
+        id={"hostname-rules-#{@current_user.id}"}
       />
     </div>
     """

--- a/lib/plausible_web/live/shields/ip_addresses.ex
+++ b/lib/plausible_web/live/shields/ip_addresses.ex
@@ -7,26 +7,30 @@ defmodule PlausibleWeb.Live.Shields.IPAddresses do
 
   alias Plausible.Shields
   alias Plausible.Sites
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
         %{
           "remote_ip" => remote_ip,
-          "domain" => domain,
-          "current_user_id" => user_id
-        },
+          "domain" => domain
+        } = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:ip_rules_count, fn %{site: site} ->
         Shields.count_ip_rules(site)
       end)
-      |> assign_new(:current_user, fn ->
-        Plausible.Repo.get(Plausible.Auth.User, user_id)
+      |> assign_new(:current_user, fn %{user_session: user_session} ->
+        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
       |> assign_new(:remote_ip, fn -> remote_ip end)
 

--- a/lib/plausible_web/live/shields/ip_addresses.ex
+++ b/lib/plausible_web/live/shields/ip_addresses.ex
@@ -7,30 +7,22 @@ defmodule PlausibleWeb.Live.Shields.IPAddresses do
 
   alias Plausible.Shields
   alias Plausible.Sites
-  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
         %{
           "remote_ip" => remote_ip,
           "domain" => domain
-        } = session,
+        },
         socket
       ) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:ip_rules_count, fn %{site: site} ->
         Shields.count_ip_rules(site)
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
       |> assign_new(:remote_ip, fn -> remote_ip end)
 
@@ -47,7 +39,7 @@ defmodule PlausibleWeb.Live.Shields.IPAddresses do
         ip_rules_count={@ip_rules_count}
         site={@site}
         remote_ip={@remote_ip}
-        id="ip-rules-#{@current_user.id}"
+        id={"ip-rules-#{@current_user.id}"}
       />
     </div>
     """

--- a/lib/plausible_web/live/shields/pages.ex
+++ b/lib/plausible_web/live/shields/pages.ex
@@ -7,25 +7,27 @@ defmodule PlausibleWeb.Live.Shields.Pages do
 
   alias Plausible.Shields
   alias Plausible.Sites
+  alias PlausibleWeb.UserAuth
 
   def mount(
         _params,
-        %{
-          "domain" => domain,
-          "current_user_id" => user_id
-        },
+        %{"domain" => domain} = session,
         socket
       ) do
     socket =
       socket
-      |> assign_new(:site, fn ->
-        Sites.get_for_user!(user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:user_session, fn ->
+        {:ok, user_session} = UserAuth.get_user_session(session)
+        user_session
+      end)
+      |> assign_new(:site, fn %{user_session: user_session} ->
+        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:page_rules_count, fn %{site: site} ->
         Shields.count_page_rules(site)
       end)
-      |> assign_new(:current_user, fn ->
-        Plausible.Repo.get(Plausible.Auth.User, user_id)
+      |> assign_new(:current_user, fn %{user_session: user_session} ->
+        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}

--- a/lib/plausible_web/live/shields/pages.ex
+++ b/lib/plausible_web/live/shields/pages.ex
@@ -7,27 +7,15 @@ defmodule PlausibleWeb.Live.Shields.Pages do
 
   alias Plausible.Shields
   alias Plausible.Sites
-  alias PlausibleWeb.UserAuth
 
-  def mount(
-        _params,
-        %{"domain" => domain} = session,
-        socket
-      ) do
+  def mount(_params, %{"domain" => domain}, socket) do
     socket =
       socket
-      |> assign_new(:user_session, fn ->
-        {:ok, user_session} = UserAuth.get_user_session(session)
-        user_session
-      end)
-      |> assign_new(:site, fn %{user_session: user_session} ->
-        Sites.get_for_user!(user_session.user_id, domain, [:owner, :admin, :super_admin])
+      |> assign_new(:site, fn %{current_user: current_user} ->
+        Sites.get_for_user!(current_user, domain, [:owner, :admin, :super_admin])
       end)
       |> assign_new(:page_rules_count, fn %{site: site} ->
         Shields.count_page_rules(site)
-      end)
-      |> assign_new(:current_user, fn %{user_session: user_session} ->
-        Plausible.Repo.get(Plausible.Auth.User, user_session.user_id)
       end)
 
     {:ok, socket}
@@ -42,7 +30,7 @@ defmodule PlausibleWeb.Live.Shields.Pages do
         current_user={@current_user}
         page_rules_count={@page_rules_count}
         site={@site}
-        id="page-rules-#{@current_user.id}"
+        id={"page-rules-#{@current_user.id}"}
       />
     </div>
     """

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -10,12 +10,12 @@ defmodule PlausibleWeb.Live.Sites do
   import PlausibleWeb.Live.Components.Pagination
 
   alias Plausible.Auth
-  alias Plausible.Repo
   alias Plausible.Site
   alias Plausible.Sites
   alias Plausible.Site.Memberships.Invitations
+  alias PlausibleWeb.UserAuth
 
-  def mount(params, %{"current_user_id" => user_id}, socket) do
+  def mount(params, session, socket) do
     uri =
       ("/sites?" <> URI.encode_query(Map.take(params, ["filter_text"])))
       |> URI.new!()
@@ -24,7 +24,10 @@ defmodule PlausibleWeb.Live.Sites do
       socket
       |> assign(:uri, uri)
       |> assign(:filter_text, params["filter_text"] || "")
-      |> assign(:user, Repo.get!(Auth.User, user_id))
+      |> assign_new(:user, fn ->
+        {:ok, user} = UserAuth.get_user(session)
+        user
+      end)
 
     {:ok, socket}
   end

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -13,9 +13,8 @@ defmodule PlausibleWeb.Live.Sites do
   alias Plausible.Site
   alias Plausible.Sites
   alias Plausible.Site.Memberships.Invitations
-  alias PlausibleWeb.UserAuth
 
-  def mount(params, session, socket) do
+  def mount(params, _session, socket) do
     uri =
       ("/sites?" <> URI.encode_query(Map.take(params, ["filter_text"])))
       |> URI.new!()
@@ -24,10 +23,6 @@ defmodule PlausibleWeb.Live.Sites do
       socket
       |> assign(:uri, uri)
       |> assign(:filter_text, params["filter_text"] || "")
-      |> assign_new(:user, fn ->
-        {:ok, user} = UserAuth.get_user(session)
-        user
-      end)
 
     {:ok, socket}
   end
@@ -37,17 +32,17 @@ defmodule PlausibleWeb.Live.Sites do
       socket
       |> assign(:params, params)
       |> load_sites()
-      |> assign_new(:has_sites?, fn %{user: user} ->
-        Site.Memberships.any_or_pending?(user)
+      |> assign_new(:has_sites?, fn %{current_user: current_user} ->
+        Site.Memberships.any_or_pending?(current_user)
       end)
-      |> assign_new(:needs_to_upgrade, fn %{user: user, sites: sites} ->
+      |> assign_new(:needs_to_upgrade, fn %{current_user: current_user, sites: sites} ->
         user_owns_sites =
           Enum.any?(sites.entries, fn site ->
             List.first(site.memberships ++ site.invitations).role == :owner
           end) ||
-            Auth.user_owns_sites?(user)
+            Auth.user_owns_sites?(current_user)
 
-        user_owns_sites && Plausible.Billing.check_needs_to_upgrade(user)
+        user_owns_sites && Plausible.Billing.check_needs_to_upgrade(current_user)
       end)
 
     {:noreply, socket}
@@ -115,10 +110,7 @@ defmodule PlausibleWeb.Live.Sites do
         >
           Total of <span class="font-medium"><%= @sites.total_entries %></span> sites
         </.pagination>
-        <.invitation_modal
-          :if={Enum.any?(@sites.entries, &(&1.entry_type == "invitation"))}
-          user={@user}
-        />
+        <.invitation_modal :if={Enum.any?(@sites.entries, &(&1.entry_type == "invitation"))} />
       </div>
     </div>
     """
@@ -348,8 +340,6 @@ defmodule PlausibleWeb.Live.Sites do
     """
   end
 
-  attr :user, Plausible.Auth.User, required: true
-
   def invitation_modal(assigns) do
     ~H"""
     <div
@@ -569,7 +559,7 @@ defmodule PlausibleWeb.Live.Sites do
 
     if site do
       socket =
-        case Sites.toggle_pin(socket.assigns.user, site) do
+        case Sites.toggle_pin(socket.assigns.current_user, site) do
           {:ok, preference} ->
             flash_message =
               if preference.pinned_at do
@@ -602,7 +592,7 @@ defmodule PlausibleWeb.Live.Sites do
       {:noreply, socket}
     else
       Sentry.capture_message("Attempting to toggle pin for invalid domain.",
-        extra: %{domain: domain, user: socket.assigns.user.id}
+        extra: %{domain: domain, user: socket.assigns.current_user.id}
       )
 
       {:noreply, socket}
@@ -637,7 +627,7 @@ defmodule PlausibleWeb.Live.Sites do
 
   defp load_sites(%{assigns: assigns} = socket) do
     sites =
-      Sites.list_with_invitations(assigns.user, assigns.params,
+      Sites.list_with_invitations(assigns.current_user, assigns.params,
         filter_by_domain: assigns.filter_text
       )
 
@@ -651,7 +641,7 @@ defmodule PlausibleWeb.Live.Sites do
         end)
       end
 
-    invitations = extract_invitations(sites.entries, assigns.user)
+    invitations = extract_invitations(sites.entries, assigns.current_user)
 
     assign(
       socket,

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -1,4 +1,11 @@
 defmodule PlausibleWeb.AuthPlug do
+  @moduledoc """
+  Plug for populating conn assigns with user data
+  on the basis of authenticated session token.
+
+  Must be kept in sync with `PlausibleWeb.Live.AuthContext`.
+  """
+
   import Plug.Conn
   use Plausible.Repo
 

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -2,18 +2,22 @@ defmodule PlausibleWeb.AuthPlug do
   import Plug.Conn
   use Plausible.Repo
 
+  alias PlausibleWeb.UserAuth
+
   def init(options) do
     options
   end
 
   def call(conn, _opts) do
-    with id when is_integer(id) <- get_session(conn, :current_user_id),
-         %Plausible.Auth.User{} = user <- Plausible.Users.with_subscription(id) do
-      Plausible.OpenTelemetry.add_user_attributes(user)
-      Sentry.Context.set_user_context(%{id: user.id, name: user.name, email: user.email})
-      assign(conn, :current_user, user)
-    else
-      nil -> conn
+    case UserAuth.get_user(conn) do
+      {:ok, user} ->
+        user = Plausible.Users.with_subscription(user)
+        Plausible.OpenTelemetry.add_user_attributes(user)
+        Sentry.Context.set_user_context(%{id: user.id, name: user.name, email: user.email})
+        assign(conn, :current_user, user)
+
+      _ ->
+        conn
     end
   end
 end

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -20,7 +20,12 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
     if !site do
       PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt
     else
-      user_id = get_session(conn, :current_user_id)
+      user_id =
+        case PlausibleWeb.UserAuth.get_user_session(conn) do
+          {:ok, user_session} -> user_session.user_id
+          _ -> nil
+        end
+
       membership_role = user_id && Plausible.Sites.role(user_id, site)
 
       role =

--- a/lib/plausible_web/plugs/require_logged_out.ex
+++ b/lib/plausible_web/plugs/require_logged_out.ex
@@ -8,6 +8,7 @@ defmodule PlausibleWeb.RequireLoggedOutPlug do
   def call(conn, _opts) do
     if conn.assigns[:current_user] do
       conn
+      |> PlausibleWeb.UserAuth.set_logged_in_cookie()
       |> Phoenix.Controller.redirect(to: "/sites")
       |> halt()
     else

--- a/lib/plausible_web/plugs/require_logged_out.ex
+++ b/lib/plausible_web/plugs/require_logged_out.ex
@@ -1,23 +1,17 @@
 defmodule PlausibleWeb.RequireLoggedOutPlug do
   import Plug.Conn
 
-  def init(options) do
-    options
+  def init(opts \\ []) do
+    opts
   end
 
   def call(conn, _opts) do
-    cond do
-      conn.assigns[:current_user] ->
-        conn
-        |> put_resp_cookie("logged_in", "true",
-          http_only: false,
-          max_age: 60 * 60 * 24 * 365 * 5000
-        )
-        |> Phoenix.Controller.redirect(to: "/sites")
-        |> halt
-
-      :else ->
-        conn
+    if conn.assigns[:current_user] do
+      conn
+      |> Phoenix.Controller.redirect(to: "/sites")
+      |> halt()
+    else
+      conn
     end
   end
 end

--- a/lib/plausible_web/plugs/session_timeout_plug.ex
+++ b/lib/plausible_web/plugs/session_timeout_plug.ex
@@ -1,4 +1,9 @@
 defmodule PlausibleWeb.SessionTimeoutPlug do
+  @moduledoc """
+  NOTE: This plug will be replaced with a different
+  session expiration mechanism once server-side persisted
+  sessions are rolled out.
+  """
   import Plug.Conn
 
   alias PlausibleWeb.UserAuth

--- a/lib/plausible_web/plugs/session_timeout_plug.ex
+++ b/lib/plausible_web/plugs/session_timeout_plug.ex
@@ -1,13 +1,20 @@
 defmodule PlausibleWeb.SessionTimeoutPlug do
   import Plug.Conn
 
+  alias PlausibleWeb.UserAuth
+
   def init(opts \\ []) do
     opts
   end
 
   def call(conn, opts) do
     timeout_at = get_session(conn, :session_timeout_at)
-    user_id = get_session(conn, :current_user_id)
+
+    user_id =
+      case UserAuth.get_user_session(conn) do
+        {:ok, session} -> session.user_id
+        _ -> nil
+      end
 
     cond do
       user_id && timeout_at && now() > timeout_at ->

--- a/lib/plausible_web/plugs/session_timeout_plug.ex
+++ b/lib/plausible_web/plugs/session_timeout_plug.ex
@@ -11,9 +11,7 @@ defmodule PlausibleWeb.SessionTimeoutPlug do
 
     cond do
       user_id && timeout_at && now() > timeout_at ->
-        conn
-        |> configure_session(drop: true)
-        |> delete_resp_cookie("logged_in")
+        PlausibleWeb.UserAuth.log_out_user(conn)
 
       user_id ->
         put_session(

--- a/lib/plausible_web/plugs/super_admin_only_plug.ex
+++ b/lib/plausible_web/plugs/super_admin_only_plug.ex
@@ -9,15 +9,11 @@ defmodule PlausibleWeb.SuperAdminOnlyPlug do
   end
 
   def call(conn, _opts) do
-    case PlausibleWeb.UserAuth.get_user(conn) do
-      {:ok, user} ->
-        if Plausible.Auth.is_super_admin?(user.id) do
-          assign(conn, :current_user, user)
-        else
-          conn |> send_resp(403, "Not allowed") |> halt
-        end
-
-      {:error, _} ->
+    with {:ok, user} <- PlausibleWeb.UserAuth.get_user(conn),
+         true <- Plausible.Auth.is_super_admin?(user) do
+      assign(conn, :current_user, user)
+    else
+      _ ->
         conn |> send_resp(403, "Not allowed") |> halt
     end
   end

--- a/lib/plausible_web/plugs/super_admin_only_plug.ex
+++ b/lib/plausible_web/plugs/super_admin_only_plug.ex
@@ -9,18 +9,16 @@ defmodule PlausibleWeb.SuperAdminOnlyPlug do
   end
 
   def call(conn, _opts) do
-    case get_session(conn, :current_user_id) do
-      nil ->
-        conn |> send_resp(403, "Not allowed") |> halt
-
-      id ->
-        user = Repo.get_by(Plausible.Auth.User, id: id)
-
-        if user && Plausible.Auth.is_super_admin?(user.id) do
+    case PlausibleWeb.UserAuth.get_user(conn) do
+      {:ok, user} ->
+        if Plausible.Auth.is_super_admin?(user.id) do
           assign(conn, :current_user, user)
         else
           conn |> send_resp(403, "Not allowed") |> halt
         end
+
+      {:error, _} ->
+        conn |> send_resp(403, "Not allowed") |> halt
     end
   end
 end

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -27,13 +27,13 @@
       <div class="my-4 border-b border-gray-400"></div>
 
       <PlausibleWeb.Components.Billing.Notice.subscription_cancelled
-        user={@user}
+        user={@current_user}
         dismissable={false}
       />
 
       <div class="flex flex-col items-center justify-between mt-8 sm:flex-row sm:items-start">
         <PlausibleWeb.Components.Billing.monthly_quota_box
-          user={@user}
+          user={@current_user}
           subscription={@subscription}
         />
         <div
@@ -105,7 +105,7 @@
           </div>
         <% true -> %>
           <div class="mt-8">
-            <PlausibleWeb.Components.Billing.upgrade_link user={@user} />
+            <PlausibleWeb.Components.Billing.upgrade_link />
           </div>
       <% end %>
     </div>
@@ -334,7 +334,7 @@
     <div class="flex flex-col mt-6">
       <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-          <%= if Enum.any?(@user.api_keys) do %>
+          <%= if Enum.any?(@api_keys) do %>
             <div class="overflow-hidden border-b border-gray-200 shadow dark:border-gray-900 sm:rounded-lg">
               <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-900">
                 <thead class="bg-gray-50 dark:bg-gray-900">
@@ -357,7 +357,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <%= for api_key <- @user.api_keys do %>
+                  <%= for api_key <- @api_keys do %>
                     <tr class="bg-white dark:bg-gray-800">
                       <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
                         <%= api_key.name %>

--- a/lib/plausible_web/templates/billing/choose_plan.html.heex
+++ b/lib/plausible_web/templates/billing/choose_plan.html.heex
@@ -1,4 +1,4 @@
 <%= live_render(@conn, PlausibleWeb.Live.ChoosePlan,
   id: "choose-plan",
-  session: %{"current_user_id" => @user.id, "remote_ip" => PlausibleWeb.RemoteIP.get(@conn)}
+  session: %{"remote_ip" => PlausibleWeb.RemoteIP.get(@conn)}
 ) %>

--- a/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
+++ b/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
@@ -66,7 +66,7 @@
         <PlausibleWeb.Components.Billing.paddle_button
           id="paddle-button"
           paddle_product_id={@latest_enterprise_plan.paddle_plan_id}
-          user={@user}
+          user={@current_user}
         >
           <svg fill="currentColor" viewBox="0 0 20 20" class="inline w-4 h-4 mr-2">
             <path

--- a/lib/plausible_web/templates/site/csv_import.html.heex
+++ b/lib/plausible_web/templates/site/csv_import.html.heex
@@ -17,7 +17,6 @@
   <%= live_render(@conn, PlausibleWeb.Live.CSVImport,
     session: %{
       "site_id" => @site.id,
-      "current_user_id" => @current_user.id,
       "storage" => on_ee(do: "s3", else: "local")
     }
   ) %>

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -1,6 +1,18 @@
 defmodule PlausibleWeb.UserAuth do
   @moduledoc """
   Functions for user session management.
+
+  In it's current shape, both current (legacy) and soon to be implemented (new)
+  user sessions are supported side by side.
+
+  Once the token-based sessions are implemented, `create_user_session/1` will
+  start returning new token instead of the legacy one. At the same time,
+  `put_token_in_session/2` will always set the new token. The legacy token will
+  still be accepted from the session cookie. Once 14 days pass (the current time
+  window for which session cookie is valid without any activity), the legacy
+  cookies won't be accepted anymore (token retrieval will most likely be
+  instrumented to confirm the usage falls in the mentioned time window as
+  expected) and the logic will be cleaned of branching for legacy session.
   """
 
   alias Plausible.Auth
@@ -128,6 +140,9 @@ defmodule PlausibleWeb.UserAuth do
   end
 
   defp create_user_session(user) do
+    # NOTE: a temporary fix for for dialyzer
+    # complaining about unreachable code
+    # path.
     if :erlang.phash2(1, 1) == 0 do
       {{:legacy, user.id}, %{}}
     else

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -1,0 +1,96 @@
+defmodule PlausibleWeb.UserAuth do
+  @moduledoc """
+  Functions for user session management.
+  """
+
+  alias Plausible.Auth
+  alias PlausibleWeb.TwoFactor
+
+  alias PlausibleWeb.Router.Helpers, as: Routes
+
+  @spec log_in_user(Plug.Conn.t(), Auth.User.t(), String.t() | nil) :: Plug.Conn.t()
+  def log_in_user(conn, user, redirect_path \\ nil) do
+    login_dest =
+      redirect_path || Plug.Conn.get_session(conn, :login_dest) || Routes.site_path(conn, :index)
+
+    conn
+    |> set_user_session(user)
+    |> set_logged_in_cookie()
+    |> Phoenix.Controller.redirect(external: login_dest)
+  end
+
+  @spec log_out_user(Plug.Conn.t()) :: Plug.Conn.t()
+  def log_out_user(conn) do
+    conn
+    |> get_user_token()
+    |> remove_user_session()
+
+    if live_socket_id = Plug.Conn.get_session(conn, :live_socket_id) do
+      PlausibleWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    end
+
+    conn
+    |> renew_session()
+    |> clear_logged_in_cookie()
+  end
+
+  defp set_user_session(conn, user) do
+    {token, _} = create_user_session(user)
+
+    conn
+    |> renew_session()
+    |> TwoFactor.Session.clear_2fa_user()
+    |> put_token_in_session(token)
+  end
+
+  defp renew_session(conn) do
+    Phoenix.Controller.delete_csrf_token()
+
+    conn
+    |> Plug.Conn.configure_session(renew: true)
+    |> Plug.Conn.clear_session()
+  end
+
+  defp set_logged_in_cookie(conn) do
+    Plug.Conn.put_resp_cookie(conn, "logged_in", "true",
+      http_only: false,
+      max_age: 60 * 60 * 24 * 365 * 5000
+    )
+  end
+
+  defp clear_logged_in_cookie(conn) do
+    Plug.Conn.delete_resp_cookie(conn, "logged_in")
+  end
+
+  defp put_token_in_session(conn, {:new, token}) do
+    conn
+    |> Plug.Conn.put_session(:user_token, token)
+    |> Plug.Conn.put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
+  end
+
+  defp put_token_in_session(conn, {:legacy, user_id}) do
+    Plug.Conn.put_session(conn, :current_user_id, user_id)
+  end
+
+  defp get_user_token(conn) do
+    case Enum.map([:user_token, :current_user_id], &Plug.Conn.get_session(conn, &1)) do
+      [token, nil] when is_binary(token) -> {:new, token}
+      [nil, current_user_id] when is_integer(current_user_id) -> {:legacy, current_user_id}
+      [nil, nil] -> nil
+    end
+  end
+
+  defp create_user_session(user) do
+    if :erlang.phash2(1, 1) == 0 do
+      {{:legacy, user.id}, %{}}
+    else
+      {{:new, "disabled-for-now"}, %{}}
+    end
+  end
+
+  defp remove_user_session(nil), do: :ok
+
+  defp remove_user_session(_token) do
+    :ok
+  end
+end

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -59,6 +59,21 @@ defmodule PlausibleWeb.UserAuth do
     end
   end
 
+  @doc """
+  Sets the `logged_in` cookie share with the static site for determining
+  whether client is authenticated.
+
+  As it's a separate cookie, there's a chance it might fall out of sync
+  with session cookie state due to manual deletion or premature expiration.
+  """
+  @spec set_logged_in_cookie(Plug.Conn.t()) :: Plug.Conn.t()
+  def set_logged_in_cookie(conn) do
+    Plug.Conn.put_resp_cookie(conn, "logged_in", "true",
+      http_only: false,
+      max_age: 60 * 60 * 24 * 365 * 5000
+    )
+  end
+
   defp get_session_by_token({:legacy, user_id}) do
     {:ok, %Auth.UserSession{user_id: user_id}}
   end
@@ -82,13 +97,6 @@ defmodule PlausibleWeb.UserAuth do
     conn
     |> Plug.Conn.configure_session(renew: true)
     |> Plug.Conn.clear_session()
-  end
-
-  defp set_logged_in_cookie(conn) do
-    Plug.Conn.put_resp_cookie(conn, "logged_in", "true",
-      http_only: false,
-      max_age: 60 * 60 * 24 * 365 * 5000
-    )
   end
 
   defp clear_logged_in_cookie(conn) do

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -35,11 +35,19 @@ defmodule PlausibleWeb.UserAuth do
     |> clear_logged_in_cookie()
   end
 
-  @spec get_user(Plug.Conn.t() | map()) ::
+  @spec get_user(Plug.Conn.t() | Auth.UserSession.t() | map()) ::
           {:ok, Auth.User.t()} | {:error, :no_valid_token | :session_not_found | :user_not_found}
+  def get_user(%Auth.UserSession{} = user_session) do
+    if user = Plausible.Users.with_subscription(user_session.user_id) do
+      {:ok, user}
+    else
+      {:error, :user_not_found}
+    end
+  end
+
   def get_user(conn_or_session) do
-    with {:ok, session} <- get_user_session(conn_or_session) do
-      Auth.get_user_by(id: session.user_id)
+    with {:ok, user_session} <- get_user_session(conn_or_session) do
+      get_user(user_session)
     end
   end
 

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.UserAuth do
   end
 
   defp get_session_by_token({:legacy, user_id}) do
-    {:ok, %{user_id: user_id}}
+    {:ok, %Auth.UserSession{user_id: user_id}}
   end
 
   defp get_session_by_token({:new, _token}) do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -953,11 +953,11 @@ defmodule PlausibleWeb.SiteControllerTest do
   end
 
   describe "PUT /:website/settings/features/visibility/:setting" do
-    def build_conn_with_some_url(context) do
-      {:ok, Map.put(context, :conn, build_conn(:get, "/some_parent_path"))}
+    def query_conn_with_some_url(context) do
+      {:ok, Map.put(context, :conn, get(context.conn, "/some_parent_path"))}
     end
 
-    setup [:build_conn_with_some_url, :create_user, :log_in]
+    setup [:create_user, :log_in, :query_conn_with_some_url]
 
     for {title, setting} <- %{
           "Goals" => :conversions_enabled,

--- a/test/plausible_web/plugs/session_timeout_plug_test.exs
+++ b/test/plausible_web/plugs/session_timeout_plug_test.exs
@@ -30,6 +30,6 @@ defmodule PlausibleWeb.SessionTimeoutPlugTest do
       |> init_test_session(%{current_user_id: 1, session_timeout_at: 1})
       |> SessionTimeoutPlug.call(@opts)
 
-    assert conn.private[:plug_session_info] == :drop
+    assert conn.private[:plug_session_info] == :renew
   end
 end

--- a/test/plausible_web/user_auth_test.exs
+++ b/test/plausible_web/user_auth_test.exs
@@ -1,0 +1,153 @@
+defmodule PlausibleWeb.UserAuthTest do
+  use PlausibleWeb.ConnCase, async: true
+
+  alias PlausibleWeb.UserAuth
+
+  alias PlausibleWeb.Router.Helpers, as: Routes
+
+  describe "log_in_user/2,3" do
+    setup [:create_user]
+
+    test "sets up user session and redirects to sites list", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> init_session()
+        |> UserAuth.log_in_user(user)
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+      assert conn.private[:plug_session_info] == :renew
+      assert conn.resp_cookies["logged_in"].max_age > 0
+      assert get_session(conn, :current_user_id) == user.id
+      assert get_session(conn, :login_dest) == nil
+    end
+
+    test "redirects to `login_dest` if present", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> init_session()
+        |> put_session("login_dest", "/next")
+        |> UserAuth.log_in_user(user)
+
+      assert redirected_to(conn, 302) == "/next"
+    end
+
+    test "redirects to `redirect_path` if present", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> init_session()
+        |> UserAuth.log_in_user(user, "/next")
+
+      assert redirected_to(conn, 302) == "/next"
+    end
+
+    test "redirect_path` has precednce over `login_dest`", %{conn: conn, user: user} do
+      conn =
+        conn
+        |> init_session()
+        |> put_session("login_dest", "/ignored")
+        |> UserAuth.log_in_user(user, "/next")
+
+      assert redirected_to(conn, 302) == "/next"
+    end
+  end
+
+  describe "log_out_user/1" do
+    setup [:create_user, :log_in]
+
+    test "logs user out", %{conn: conn} do
+      conn =
+        conn
+        |> init_session()
+        |> put_session("login_dest", "/ignored")
+        |> UserAuth.log_out_user()
+
+      assert conn.private[:plug_session_info] == :renew
+      assert conn.resp_cookies["logged_in"].max_age == 0
+      assert get_session(conn, :current_user_id) == nil
+      assert get_session(conn, :login_dest) == nil
+    end
+  end
+
+  describe "get_user/1" do
+    setup [:create_user, :log_in]
+
+    test "gets user from session data in conn", %{conn: conn, user: user} do
+      assert {:ok, session_user} = UserAuth.get_user(conn)
+      assert session_user.id == user.id
+    end
+
+    test "gets user from session data map", %{user: user} do
+      assert {:ok, session_user} = UserAuth.get_user(%{"current_user_id" => user.id})
+      assert session_user.id == user.id
+    end
+
+    test "gets user from session schema", %{user: user} do
+      assert {:ok, session_user} =
+               UserAuth.get_user(%Plausible.Auth.UserSession{user_id: user.id})
+
+      assert session_user.id == user.id
+    end
+
+    test "returns error on invalid or missing session data" do
+      conn = init_session(build_conn())
+      assert {:error, :no_valid_token} = UserAuth.get_user(conn)
+      assert {:error, :no_valid_token} = UserAuth.get_user(%{})
+    end
+
+    test "returns error on missing user", %{conn: conn, user: user} do
+      Plausible.Repo.delete!(user)
+
+      assert {:error, :user_not_found} = UserAuth.get_user(conn)
+      assert {:error, :user_not_found} = UserAuth.get_user(%{"current_user_id" => user.id})
+
+      assert {:error, :user_not_found} =
+               UserAuth.get_user(%Plausible.Auth.UserSession{user_id: user.id})
+    end
+
+    test "returns error on missing session (new token scaffold; to be revised)" do
+      conn = build_conn() |> init_session() |> put_session(:user_token, "does_not_exist")
+
+      assert {:error, :session_not_found} = UserAuth.get_user(conn)
+      assert {:error, :session_not_found} = UserAuth.get_user(%{"user_token" => "does_not_exist"})
+    end
+  end
+
+  describe "get_user_session/1" do
+    setup [:create_user, :log_in]
+
+    test "gets session from session data in conn", %{conn: conn, user: user} do
+      assert {:ok, user_session} = UserAuth.get_user_session(conn)
+      assert user_session.user_id == user.id
+    end
+
+    test "gets session from session data map", %{user: user} do
+      assert {:ok, user_session} = UserAuth.get_user_session(%{"current_user_id" => user.id})
+      assert user_session.user_id == user.id
+    end
+
+    test "returns error on invalid or missing session data" do
+      conn = init_session(build_conn())
+      assert {:error, :no_valid_token} = UserAuth.get_user_session(conn)
+      assert {:error, :no_valid_token} = UserAuth.get_user_session(%{})
+    end
+
+    test "returns error on missing session (new token scaffold; to be revised)" do
+      conn = build_conn() |> init_session() |> put_session(:user_token, "does_not_exist")
+
+      assert {:error, :session_not_found} = UserAuth.get_user_session(conn)
+
+      assert {:error, :session_not_found} =
+               UserAuth.get_user_session(%{"user_token" => "does_not_exist"})
+    end
+  end
+
+  describe "set_logged_in_cookie/1" do
+    test "sets logged_in_cookie", %{conn: conn} do
+      conn = UserAuth.set_logged_in_cookie(conn)
+
+      assert cookie = conn.resp_cookies["logged_in"]
+      assert cookie.max_age > 0
+      assert cookie.value == "true"
+    end
+  end
+end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -100,7 +100,11 @@ defmodule Plausible.TestUtils do
 
   def log_in(%{user: user, conn: conn}) do
     conn =
-      init_session(conn)
+      conn
+      |> PlausibleWeb.UserAuth.set_logged_in_cookie()
+      |> Phoenix.ConnTest.recycle()
+      |> Map.put(:secret_key_base, secret_key_base())
+      |> init_session()
       |> Plug.Conn.put_session(:current_user_id, user.id)
 
     {:ok, conn: conn}
@@ -287,5 +291,11 @@ defmodule Plausible.TestUtils do
     def maybe_fake_minio(_context) do
       :ok
     end
+  end
+
+  defp secret_key_base() do
+    :plausible
+    |> Application.fetch_env!(PlausibleWeb.Endpoint)
+    |> Keyword.fetch!(:secret_key_base)
   end
 end


### PR DESCRIPTION
### Changes

This PR refactors and creates a groundwork for implementing persisted user sessions.

Review can be done commit-by-commit for convenience.

- User session management and retrieval is completely abstracted behind `PlausibleWeb.UserAuth`. The module takes care of managing cookies (currently the defaults session when and "logged_in" cookie shared with static site). There are also extension points introduced already for supporting persisted sessions and transition from the current (legacy) cookies to the new, token based ones which will be persisted using `Plausible.Auth.UserSession` (currently an embedded schema - just enough to support existing cookie auth).
- Cookies are now always renewed/reset, reducing the potential risk of [session fixation attacks](https://en.wikipedia.org/wiki/Session_fixation).
- There's a new assign introduced, called `live_socket_id`. Once the token based authentication is implemented, it will allow disconnecting LV clients on either explicit logout or after revoking the relevant token(s). More details in [the docs](https://hexdocs.pm/phoenix_live_view/security-model.html#disconnecting-all-instances-of-a-live-user). NOTE: As Phoenix PubSub is not fully setup, we might still not be able to fully benefit from that mechanism.
- The `current_user_id` value is no longer explicitly passed via `live_render`'s `session` option. All existing session keys are passed through implicitly, to this was redundant.
- `PlausibleWeb.Live.AuthContext` is now automatically populating `current_user` (and `current_user_session`) in LV context on mount - provided it's not provided by the `AuthPlug` already which is sooner in the overall pipeline.
- Both `Live.AuthContext` and `AuthPlug` ensure the shape of the loaded user is the same, always with an active subscription preloaded if there is one.
- Any direct references to `current_user_id` session value got removed from LV in favor of retrieving `current_user` implicitly set by the auth plug or context.
- The `current_user` from the context is used more consistently in a number of spots (mostly around billing where user was refetched and set under a different key, like `user`).

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
