### PR TITLE
Update Postgrex SSL config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - `bounce_rate` metric now returns 0 instead of null for event:page breakdown when page has never been entry page.
 - Make `TOTP_VAULT_KEY` optional plausible/analytics#4317
 - Sources like 'google' and 'facebook' are now stored in capitalized forms ('Google', 'Facebook') plausible/analytics#4417
+- `DATABASE_CACERTFILE` now forces TLS for PostgreSQL connections, so you don't need to add `?ssl=true` in `DATABASE_URL`
 
 ### Fixed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -353,7 +353,7 @@ if db_socket_dir = get_var_from_path_or_env(config_dir, "DATABASE_SOCKET_DIR") d
   """)
 end
 
-db_cacertfile = get_var_from_path_or_env(config_dir, "DATABASE_CACERTFILE", CAStore.file_path())
+db_cacertfile = get_var_from_path_or_env(config_dir, "DATABASE_CACERTFILE")
 %URI{host: db_host} = db_uri = URI.parse(db_url)
 db_socket_dir? = String.starts_with?(db_host, "%2F") or db_host == ""
 
@@ -382,8 +382,11 @@ if db_socket_dir? do
 else
   config :plausible, Plausible.Repo,
     url: db_url,
-    socket_options: db_maybe_ipv6,
-    ssl: [cacertfile: db_cacertfile]
+    socket_options: db_maybe_ipv6
+
+  if db_cacertfile do
+    config :plausible, Plausible.Repo, ssl: [cacertfile: db_cacertfile]
+  end
 end
 
 sentry_app_version = runtime_metadata[:version] || app_version

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -383,13 +383,7 @@ else
   config :plausible, Plausible.Repo,
     url: db_url,
     socket_options: db_maybe_ipv6,
-    ssl_opts: [
-      cacertfile: db_cacertfile,
-      verify: :verify_peer,
-      customize_hostname_check: [
-        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-      ]
-    ]
+    ssl: [cacertfile: db_cacertfile]
 end
 
 sentry_app_version = runtime_metadata[:version] || app_version

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -359,14 +359,7 @@ defmodule Plausible.ConfigTest do
 
       assert get_in(config, [:plausible, Plausible.Repo]) == [
                url: "postgres://postgres:postgres@plausible_db:5432/plausible_db",
-               socket_options: [],
-               ssl_opts: [
-                 cacertfile: CAStore.file_path(),
-                 verify: :verify_peer,
-                 customize_hostname_check: [
-                   match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-                 ]
-               ]
+               socket_options: []
              ]
     end
 
@@ -408,14 +401,24 @@ defmodule Plausible.ConfigTest do
       assert get_in(config, [:plausible, Plausible.Repo]) == [
                url:
                  "postgresql://your_username:your_password@cluster-do-user-1234567-0.db.ondigitalocean.com:25060/defaultdb",
+               socket_options: []
+             ]
+    end
+
+    test "DATABASE_CACERTFILE enables SSL" do
+      env = [
+        {"DATABASE_URL",
+         "postgresql://your_username:your_password@cluster-do-user-1234567-0.db.ondigitalocean.com:25060/defaultdb"},
+        {"DATABASE_CACERTFILE", "/path/to/cacert.pem"}
+      ]
+
+      config = runtime_config(env)
+
+      assert get_in(config, [:plausible, Plausible.Repo]) == [
+               url:
+                 "postgresql://your_username:your_password@cluster-do-user-1234567-0.db.ondigitalocean.com:25060/defaultdb",
                socket_options: [],
-               ssl_opts: [
-                 cacertfile: CAStore.file_path(),
-                 verify: :verify_peer,
-                 customize_hostname_check: [
-                   match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-                 ]
-               ]
+               ssl: [cacertfile: "/path/to/cacert.pem"]
              ]
     end
   end


### PR DESCRIPTION
### Changes

This PR removes `ssl_opts` that are no longer necessary after https://github.com/elixir-ecto/postgrex/pull/677 (and https://github.com/plausible/analytics/pull/4457)

### Tests
- [x] Config test has been updated

### Changelog
- [x] Changelog has been updated

### Documentation
- [x] Docs don't need updates (`DATABASE_CACERTFILE` is not documented right now)

### Dark mode
- [x] This PR does not change the UI
