### PR TITLE
Fix ALIAS migration warning

### DIFF
--- a/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs
+++ b/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs
@@ -1,5 +1,5 @@
 defmodule Plausible.IngestRepo.Migrations.AliasApiPropNames do
-  """
+  @moduledoc """
   Migration adds a ALIAS columns needed to keep DB schema and api
   property naming in sync to reduce overhead in code.
   """


### PR DESCRIPTION
### Changes

This PR fixes the following warning when running migrations:

```
warning: code block contains unused literal "Migration adds a ALIAS columns needed to keep DB schema and api\nproperty naming in sync to reduce overhead in code.\n" (remove the literal or assign it to _ to avoid warnings)
└─ lib/plausible-0.0.1/priv/ingest_repo/migrations/20240502115822_alias_api_prop_names.exs: Plausible.IngestRepo.Migrations.AliasApiPropNames (module)
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI