### PR TITLE
Do not try querying imported data for unsupported props

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -51,8 +51,10 @@ defmodule Plausible.Imported do
 
   @spec imported_custom_props() :: [String.t()]
   def imported_custom_props do
-    Plausible.Props.internal_keys()
-    |> Enum.map(&("event:props:" <> &1))
+    # NOTE: Keep up to date with `Plausible.Props.internal_keys/1`,
+    # but _ignore_ unsupported keys. Currently, `search_query` is
+    # not supported in imported queries.
+    Enum.map(~w(url path), &("event:props:" <> &1))
   end
 
   @spec goals_with_url() :: [String.t()]

--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -16,7 +16,9 @@ defmodule Plausible.Props do
   @max_prop_value_length 2000
   def max_prop_value_length, do: @max_prop_value_length
 
+  # NOTE: Keep up to date with `Plausible.Imported.imported_custom_props/0`.
   @internal_keys ~w(url path search_query)
+
   @doc """
   Lists prop keys used internally.
 

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -1145,12 +1145,12 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
       conn: conn,
       site: site
     } do
-      insert(:goal, event_name: unquote("WP Search Queries"), site: site)
+      insert(:goal, event_name: "WP Search Queries", site: site)
       site_import = insert(:site_import, site: site)
 
       populate_stats(site, site_import.id, [
         build(:event,
-          name: unquote("WP Search Queries"),
+          name: "WP Search Queries",
           "meta.key": ["search_query", "result_count"],
           "meta.value": ["some phrase", "12"]
         ),
@@ -1162,7 +1162,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
         build(:imported_visitors, visitors: 9)
       ])
 
-      filters = Jason.encode!(%{goal: unquote("WP Search Queries")})
+      filters = Jason.encode!(%{goal: "WP Search Queries"})
 
       conn =
         get(


### PR DESCRIPTION
### Changes

This PR addresses a problem of a property not (currently) supported for imported data being queried for in imported logic, resulting in a crash.

### Tests
- [x] Automated tests have been added

