### PR TITLE
use GH runner instead of buildjet to overcome docker hub rate limits

### DIFF
--- a/.github/workflows/build-private-images-ghcr.yml
+++ b/.github/workflows/build-private-images-ghcr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'preview') }}
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/build-public-images-ghcr.yml
+++ b/.github/workflows/build-public-images-ghcr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/build-public-images.yml
+++ b/.github/workflows/build-public-images.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - name: Docker meta

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build and test
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tracker.yml
+++ b/.github/workflows/tracker.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     timeout-minutes: 15
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
