### PR TITLE
Fix Dockerfile warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # platform specific, it makes sense to build it in the docker
 
 #### Builder
-FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6 as buildcontainer
+FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6 AS buildcontainer
 
 ARG MIX_ENV=ce
 


### PR DESCRIPTION
### Changes

This PR fixes a warning shown in newer Docker versions:

```
=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI