### PR TITLE
Return domain-less cookies in CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Change auth session cookies to token-based ones with server-side expiration management.
 - Improve Google error messages in CE plausible/analytics#4485
 - Better compress static assets in CE plausible/analytics#4476
+- Return domain-less cookies in CE plausible/analytics#4482
 
 ### Fixed
 

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Endpoint do
     # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
     max_age: 60 * 60 * 24 * 365 * 5,
     extra: "SameSite=Lax"
-    # domain added dynamically via RuntimeSessionAdapter, see below
+    # in EE domain is added dynamically via RuntimeSessionAdapter, see below
   ]
 
   socket("/live", Phoenix.LiveView.Socket,
@@ -103,12 +103,19 @@ defmodule PlausibleWeb.Endpoint do
   end
 
   def runtime_session_opts() do
-    # `host()` provided by Phoenix.Endpoint's compilation hooks
-    # is used to inject the domain - this way we can authenticate
-    # websocket requests within single root domain, in case websocket_url()
-    # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
-    @session_options
-    |> Keyword.put(:domain, host())
+    session_options =
+      on_ee do
+        # `host()` provided by Phoenix.Endpoint's compilation hooks
+        # is used to inject the domain - this way we can authenticate
+        # websocket requests within single root domain, in case websocket_url()
+        # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
+        Keyword.put(@session_options, :domain, host())
+      else
+        # CE setup is simpler and we don't need to worry about WS domain being different
+        @session_options
+      end
+
+    session_options
     |> Keyword.put(:key, "_plausible_#{Application.fetch_env!(:plausible, :environment)}")
     |> Keyword.put(:secure, secure_cookie?())
   end


### PR DESCRIPTION
### Changes

This PR removes `domain` option from cookies in CE making it possible to access dashboards from non-BASE_URL websites.

- https://github.com/plausible/analytics/issues/4126
- https://github.com/plausible/community-edition/issues/146

### Tests
- [x] This PR does not need tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI