### PR TITLE
Better Google error messages in CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Sources like 'google' and 'facebook' are now stored in capitalized forms ('Google', 'Facebook') plausible/analytics#4417
 - `DATABASE_CACERTFILE` now forces TLS for PostgreSQL connections, so you don't need to add `?ssl=true` in `DATABASE_URL`
 - Change auth session cookies to token-based ones with server-side expiration management.
+- Improve Google error messages in CE plausible/analytics#4485
 
 ### Fixed
 

--- a/fixture/ga4_api_disabled_error.json
+++ b/fixture/ga4_api_disabled_error.json
@@ -1,0 +1,27 @@
+{
+  "error": {
+    "code": 403,
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/analyticsadmin.googleapis.com/overview?project=752168887897"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "domain": "googleapis.com",
+        "metadata": {
+          "consumer": "projects/752168887897",
+          "service": "analyticsadmin.googleapis.com"
+        },
+        "reason": "SERVICE_DISABLED"
+      }
+    ],
+    "message": "Google Analytics Admin API has not been used in project 752168887897 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/analyticsadmin.googleapis.com/overview?project=752168887897 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED"
+  }
+}

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -57,12 +57,20 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         )
         |> redirect(external: redirect_route)
 
-      {:error, :authentication_failed} ->
-        conn
-        |> put_flash(
-          :error,
+      {:error, {:authentication_failed, message}} ->
+        default_message =
           "We were unable to authenticate your Google Analytics account. Please check that you have granted us permission to 'See and download your Google Analytics data' and try again."
-        )
+
+        message =
+          if Plausible.ce?() do
+            message || default_message
+          else
+            default_message
+          end
+
+        conn
+        |> put_flash(:ttl, :timer.seconds(5))
+        |> put_flash(:error, message)
         |> redirect(external: redirect_route)
 
       {:error, :timeout} ->
@@ -128,12 +136,20 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         )
         |> redirect(external: redirect_route)
 
-      {:error, :authentication_failed} ->
-        conn
-        |> put_flash(
-          :error,
+      {:error, {:authentication_failed, message}} ->
+        default_message =
           "Google Analytics authentication seems to have expired. Please try again."
-        )
+
+        message =
+          if Plausible.ce?() do
+            message || default_message
+          else
+            default_message
+          end
+
+        conn
+        |> put_flash(:ttl, :timer.seconds(5))
+        |> put_flash(:error, message)
         |> redirect(external: redirect_route)
 
       {:error, :timeout} ->
@@ -192,12 +208,20 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         )
         |> redirect(external: redirect_route)
 
-      {:error, :authentication_failed} ->
-        conn
-        |> put_flash(
-          :error,
+      {:error, {:authentication_failed, message}} ->
+        default_message =
           "Google Analytics authentication seems to have expired. Please try again."
-        )
+
+        message =
+          if Plausible.ce?() do
+            message || default_message
+          else
+            default_message
+          end
+
+        conn
+        |> put_flash(:ttl, :timer.seconds(5))
+        |> put_flash(:error, message)
         |> redirect(external: redirect_route)
 
       {:error, :timeout} ->

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -25,6 +25,10 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
                     |> Enum.map(&File.read!/1)
                     |> Enum.map(&Jason.decode!/1)
 
+  if Plausible.ce?() do
+    @moduletag :capture_log
+  end
+
   setup :verify_on_exit!
 
   describe "parse_args/1 and import_data/2" do


### PR DESCRIPTION
### Changes

Right now the Google's error message for 401 and 403 responses is replaced by 

> We were unable to authenticate your Google Analytics account. Please check that you have granted us permission to 'See and download your Google Analytics data' and try again.

This error message is not helpful in CE where extra configuration steps are involved.
This PR makes the real error message be displayed in the Plausible CE instead:

> Google Analytics Admin API has not been used in project 381312896460 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/analyticsadmin.googleapis.com/overview?project=381312896460 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.

It looks ugly but provides valuable information.

<img width="1581" alt="Screenshot 2024-08-29 at 14 31 56" src="https://github.com/user-attachments/assets/e3d53cec-2869-428d-831a-ce80a916f740">
<img width="1581" alt="Screenshot 2024-08-29 at 14 32 22" src="https://github.com/user-attachments/assets/9b070ab3-6d8f-47b6-9c0c-55cdb016be4d">

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode