### PR TITLE
Fix invalid parameter destructuring in `navigate` calls

### DIFF
--- a/assets/js/dashboard/filters.js
+++ b/assets/js/dashboard/filters.js
@@ -24,7 +24,7 @@ function removeFilter(filterIndex, navigate, query) {
   const newLabels = cleanLabels(newFilters, query.labels)
 
   navigate({
-    search: ({ search }) => ({
+    search: (search) => ({
       ...search,
       filters: newFilters,
       labels: newLabels
@@ -34,7 +34,7 @@ function removeFilter(filterIndex, navigate, query) {
 
 function clearAllFilters(navigate) {
   navigate({
-    search: ({ search }) => ({
+    search: (search) => ({
       ...search,
       filters: null,
       labels: null
@@ -178,7 +178,7 @@ function Filters() {
   }
 
   function AppliedFilterPillHorizontal({filterIndex, filter}) {
-    const { query } = useQueryContext(); 
+    const { query } = useQueryContext();
     const [_operation, filterKey, _clauses] = filter
     const type = filterKey.startsWith(EVENT_PROPS_PREFIX) ? 'props' : filterKey
     return (

--- a/assets/js/dashboard/stats/graph/line-graph.js
+++ b/assets/js/dashboard/stats/graph/line-graph.js
@@ -226,11 +226,11 @@ class LineGraph extends React.Component {
 
     if (this.props.graphData.interval === 'month') {
       this.props.navigate({
-        search: ({ search }) => ({ ...search, period: 'month', date })
+        search: (search) => ({ ...search, period: 'month', date })
       })
     } else if (this.props.graphData.interval === 'day') {
       this.props.navigate({
-        search: ({ search }) => ({ ...search, period: 'day', date })
+        search: (search) => ({ ...search, period: 'day', date })
       })
     }
   }


### PR DESCRIPTION
### Changes

The destructuring results in ignoring existing search params which are not modified by a given navigation call - in case of removing filters it's date range and in case of time range selection from graph, it's filters.

### Tests
- [x] Tested manually
