### PR TITLE
Don't attempt to create a database if it already exists

### DIFF
--- a/lib/plausible_release.ex
+++ b/lib/plausible_release.ex
@@ -141,10 +141,10 @@ defmodule Plausible.Release do
     IO.puts("Success!")
   end
 
-  def createdb do
+  def createdb(repos \\ repos()) do
     prepare()
 
-    for repo <- repos() do
+    for repo <- repos do
       :ok = ensure_repo_created(repo)
     end
 

--- a/lib/plausible_release.ex
+++ b/lib/plausible_release.ex
@@ -225,12 +225,25 @@ defmodule Plausible.Release do
   end
 
   defp ensure_repo_created(repo) do
-    IO.puts("create #{inspect(repo)} database if it doesn't exist")
+    config = repo.config()
+    adapter = repo.__adapter__()
 
-    case repo.__adapter__.storage_up(repo.config) do
-      :ok -> :ok
-      {:error, :already_up} -> :ok
-      {:error, term} -> {:error, term}
+    case adapter.storage_status(config) do
+      :up ->
+        IO.puts("#{inspect(repo)} database already exists")
+        :ok
+
+      :down ->
+        IO.puts("Creating #{inspect(repo)} database..")
+
+        case adapter.storage_up(config) do
+          :ok -> :ok
+          {:error, :already_up} -> :ok
+          {:error, _reason} = error -> error
+        end
+
+      {:error, _reason} = error ->
+        error
     end
   end
 


### PR DESCRIPTION
### Changes

This PR adds a status check before creating the database. This way we don't attempt to create one when it already exists.

This removes these errors from the logs:

> plausible_events_db-1  | 2024.08.02 15:38:17.634785 [ 49 ] {c466dd00-dd1e-44a5-81e6-d7819cd7393d} <Error> DynamicQueryHandler: Code: 82. DB::Exception: Database plausible_events_db already exists. (DATABASE_ALREADY_EXISTS), Stack trace (when copying this message, always include the lines below):

As suggested in https://github.com/plausible/analytics/discussions/3077#discussioncomment-9540178

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI