### PR TITLE
Support order_by in URL params of breakdown endpoints

### DIFF
--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -20,6 +20,7 @@ defmodule Plausible.Stats.Breakdown do
       Query.set(
         query,
         metrics: transformed_metrics,
+        # Concat client requested order with default order, overriding only if client explicitly requests it
         order_by:
           Enum.concat(query.order_by || [], infer_order_by(transformed_metrics, dimension))
           |> Enum.uniq_by(&elem(&1, 0)),

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -20,7 +20,9 @@ defmodule Plausible.Stats.Breakdown do
       Query.set(
         query,
         metrics: transformed_metrics,
-        order_by: infer_order_by(transformed_metrics, dimension),
+        order_by:
+          Enum.concat(query.order_by || [], infer_order_by(transformed_metrics, dimension))
+          |> Enum.uniq_by(&elem(&1, 0)),
         dimensions: transform_dimensions(dimension),
         filters: query.filters ++ dimension_filters(dimension),
         v2: true,
@@ -174,7 +176,8 @@ defmodule Plausible.Stats.Breakdown do
     end)
   end
 
-  defp infer_order_by(metrics, "event:goal"), do: [{metric_to_order_by(metrics), :desc}]
+  defp infer_order_by(metrics, "event:goal"),
+    do: [{metric_to_order_by(metrics), :desc}]
 
   defp infer_order_by(metrics, dimension),
     do: [{metric_to_order_by(metrics), :desc}, {dimension, :asc}]

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -1,9 +1,12 @@
 defmodule Plausible.Stats.Legacy.QueryBuilder do
-  @moduledoc false
+  @moduledoc """
+  Module used to parse URL search params to a valid Query, used to power the API for the dashboard.
+  @deprecated
+  """
 
   use Plausible
 
-  alias Plausible.Stats.{Filters, Interval, Query, DateTimeRange}
+  alias Plausible.Stats.{Filters, Interval, Query, DateTimeRange, Metrics}
 
   def from(site, params, debug_metadata) do
     now = DateTime.utc_now(:second)
@@ -16,6 +19,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_interval(params)
       |> put_parsed_filters(params)
       |> put_preloaded_goals(site)
+      |> put_order_by(params)
       |> Query.put_experimental_reduced_joins(site, params)
       |> Query.put_imported_opts(site, params)
 
@@ -158,6 +162,61 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     else
       struct!(query, dimensions: Map.get(params, "dimensions", []))
     end
+  end
+
+  @doc """
+  ### Examples:
+    iex> QueryBuilder.parse_order_by(nil)
+    []
+
+    iex> QueryBuilder.parse_order_by("")
+    []
+
+    iex> QueryBuilder.parse_order_by("0")
+    []
+
+    iex> QueryBuilder.parse_order_by("[}")
+    []
+
+    iex> QueryBuilder.parse_order_by(~s({"any":"object"}))
+    []
+
+    iex> QueryBuilder.parse_order_by(~s([["visitors","invalid"]]))
+    []
+
+    iex> QueryBuilder.parse_order_by(~s([["visitors","desc"]]))
+    [{:visitors, :desc}]
+
+    iex> QueryBuilder.parse_order_by(~s([["visitors","asc"],["visit:source","desc"]]))
+    [{:visitors, :asc}, {"visit:source", :desc}]
+  """
+  def parse_order_by(order_by) when is_binary(order_by) do
+    case Jason.decode(order_by) do
+      {:ok, parsed} when is_list(parsed) ->
+        Enum.flat_map(parsed, &parse_order_by_pair/1)
+
+      _ ->
+        []
+    end
+  end
+
+  def parse_order_by(_) do
+    []
+  end
+
+  defp parse_order_by_pair([metric_or_dimension, direction]) when direction in ["asc", "desc"] do
+    case Metrics.from_string(metric_or_dimension) do
+      {:ok, metric} -> [{metric, String.to_existing_atom(direction)}]
+      :error -> [{metric_or_dimension, String.to_existing_atom(direction)}]
+    end
+  end
+
+  defp parse_order_by_pair(_) do
+    []
+  end
+
+  defp put_order_by(query, %{} = params) do
+    struct!(query, order_by: parse_order_by(params["order_by"]))
   end
 
   defp put_interval(%{:period => "all"} = query, params) do

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -1,6 +1,9 @@
 defmodule Plausible.Stats.QueryTest do
   use Plausible.DataCase, async: true
   alias Plausible.Stats.{Query, DateTimeRange}
+  alias Plausible.Stats.Legacy.QueryBuilder
+
+  doctest Plausible.Stats.Legacy.QueryBuilder
 
   setup do
     user = insert(:user)


### PR DESCRIPTION
### Changes

* Adds support for order_by in URL params of breakdown endpoints

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Does not need a changelog entry

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
