### PR TITLE
Fix realtime periods returning wrong date range for non-UTC timezone sites

### DIFF
--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -84,6 +84,24 @@ defmodule Plausible.Stats.SQL.Expression do
   end
 
   # :NOTE: This is not exposed in Query APIv2
+  def select_dimension(q, key, "time:minute", :sessions, %Query{period: period}) when period in ["realtime", "30m"] do
+    q
+    |> join(:inner, [s], time_slot in fragment(
+        "timeSlots(?, toUInt32(timeDiff(?, ?)), toUInt32(60))",
+        s.start,
+        s.start,
+        s.timestamp
+      ),
+      as: :time_slot,
+      hints: "ARRAY",
+      on: true
+    )
+    |> select_merge_as([s, time_slot: time_slot], %{
+      key => fragment("?", time_slot)
+    })
+  end
+
+  # :NOTE: This is not exposed in Query APIv2
   def select_dimension(q, key, "time:minute", :sessions, query) do
     q
     |> join(:inner, [s], time_slot in time_slots(query, 60),
@@ -93,6 +111,13 @@ defmodule Plausible.Stats.SQL.Expression do
     )
     |> select_merge_as([s, time_slot: time_slot], %{
       key => fragment("?", time_slot)
+    })
+  end
+
+  # :NOTE: This is not exposed in Query APIv2
+  def select_dimension(q, key, "time:minute", _table, %Query{period: period}) when period in ["realtime", "30m"] do
+    select_merge_as(q, [t], %{
+      key => fragment("toStartOfMinute(?)", t.timestamp)
     })
   end
 

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -84,9 +84,13 @@ defmodule Plausible.Stats.SQL.Expression do
   end
 
   # :NOTE: This is not exposed in Query APIv2
-  def select_dimension(q, key, "time:minute", :sessions, %Query{period: period}) when period in ["realtime", "30m"] do
+  def select_dimension(q, key, "time:minute", :sessions, %Query{period: period})
+      when period in ["realtime", "30m"] do
     q
-    |> join(:inner, [s], time_slot in fragment(
+    |> join(
+      :inner,
+      [s],
+      time_slot in fragment(
         "timeSlots(?, toUInt32(timeDiff(?, ?)), toUInt32(60))",
         s.start,
         s.start,
@@ -115,7 +119,8 @@ defmodule Plausible.Stats.SQL.Expression do
   end
 
   # :NOTE: This is not exposed in Query APIv2
-  def select_dimension(q, key, "time:minute", _table, %Query{period: period}) when period in ["realtime", "30m"] do
+  def select_dimension(q, key, "time:minute", _table, %Query{period: period})
+      when period in ["realtime", "30m"] do
     select_merge_as(q, [t], %{
       key => fragment("toStartOfMinute(?)", t.timestamp)
     })

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -20,7 +20,10 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert Enum.any?(plot, fn pageviews -> pageviews > 0 end)
     end
 
-    test "displays pageviews for the last 30 minutes for a non-UTC timezone site", %{conn: conn, site: site} do
+    test "displays pageviews for the last 30 minutes for a non-UTC timezone site", %{
+      conn: conn,
+      site: site
+    } do
       Plausible.Site.changeset(site, %{timezone: "Europe/Tallinn"})
       |> Plausible.Repo.update()
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -20,6 +20,23 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert Enum.any?(plot, fn pageviews -> pageviews > 0 end)
     end
 
+    test "displays pageviews for the last 30 minutes for a non-UTC timezone site", %{conn: conn, site: site} do
+      Plausible.Site.changeset(site, %{timezone: "Europe/Tallinn"})
+      |> Plausible.Repo.update()
+
+      populate_stats(site, [
+        build(:pageview, timestamp: relative_time(minutes: -5))
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/main-graph?period=realtime&metric=pageviews")
+
+      assert %{"plot" => plot, "labels" => labels} = json_response(conn, 200)
+
+      assert labels == Enum.to_list(-30..-1)
+      assert Enum.count(plot) == 30
+      assert Enum.any?(plot, fn pageviews -> pageviews > 0 end)
+    end
+
     test "displays pageviews for a day", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),


### PR DESCRIPTION
### Changes

Quick fix to account for realtime periods to select timeslots in UTC rather than site.timezone. Needs a proper fix to also work for API v2 (which doesn't have the `query.period` field set).

realtime periods are currently not supported in API v2 so that's not a real issue yet.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
