### PR TITLE
Proper fix for realtime timeseries queries

### DIFF
--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -31,7 +31,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
            date_range: date_range,
            dimensions: dimensions,
            order_by: order_by,
-           timezone: site.timezone,
+           timezone: date_range.first.time_zone,
            preloaded_goals: preloaded_goals,
            include: include
          },

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -211,7 +211,8 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp date_range_from_timestamps(from, to) do
     with {:ok, from_datetime} <- datetime_from_timestamp(from),
-         {:ok, to_datetime} <- datetime_from_timestamp(to) do
+         {:ok, to_datetime} <- datetime_from_timestamp(to),
+         true <- from_datetime.time_zone == to_datetime.time_zone do
       {:ok, DateTimeRange.new!(from_datetime, to_datetime)}
     else
       _ -> {:error, "Invalid date_range '#{i([from, to])}'."}

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -13,8 +13,9 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
     query =
       Query
-      |> struct!(now: now, timezone: site.timezone, debug_metadata: debug_metadata)
+      |> struct!(now: now, debug_metadata: debug_metadata)
       |> put_period(site, params)
+      |> put_timezone()
       |> put_dimensions(params)
       |> put_interval(params)
       |> put_parsed_filters(params)
@@ -154,6 +155,10 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
   defp put_period(query, site, params) do
     put_period(query, site, Map.merge(params, %{"period" => "30d"}))
+  end
+
+  defp put_timezone(query) do
+    struct!(query, timezone: query.date_range.first.time_zone)
   end
 
   defp put_dimensions(query, params) do

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -84,28 +84,6 @@ defmodule Plausible.Stats.SQL.Expression do
   end
 
   # :NOTE: This is not exposed in Query APIv2
-  def select_dimension(q, key, "time:minute", :sessions, %Query{period: period})
-      when period in ["realtime", "30m"] do
-    q
-    |> join(
-      :inner,
-      [s],
-      time_slot in fragment(
-        "timeSlots(?, toUInt32(timeDiff(?, ?)), toUInt32(60))",
-        s.start,
-        s.start,
-        s.timestamp
-      ),
-      as: :time_slot,
-      hints: "ARRAY",
-      on: true
-    )
-    |> select_merge_as([s, time_slot: time_slot], %{
-      key => fragment("?", time_slot)
-    })
-  end
-
-  # :NOTE: This is not exposed in Query APIv2
   def select_dimension(q, key, "time:minute", :sessions, query) do
     q
     |> join(:inner, [s], time_slot in time_slots(query, 60),
@@ -115,14 +93,6 @@ defmodule Plausible.Stats.SQL.Expression do
     )
     |> select_merge_as([s, time_slot: time_slot], %{
       key => fragment("?", time_slot)
-    })
-  end
-
-  # :NOTE: This is not exposed in Query APIv2
-  def select_dimension(q, key, "time:minute", _table, %Query{period: period})
-      when period in ["realtime", "30m"] do
-    select_merge_as(q, [t], %{
-      key => fragment("toStartOfMinute(?)", t.timestamp)
     })
   end
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -55,23 +55,24 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     assert message == expected_error_message
   end
 
-  def check_date_range(date_params, site, expected_date_range, schema_type \\ :public) do
-    %{"site_id" => site.domain, "metrics" => ["visitors", "events"]}
-    |> Map.merge(date_params)
-    |> check_success(
-      site,
+  def check_date_range(date_params, site, expected_fields, schema_type \\ :public) do
+    params =
+      %{"site_id" => site.domain, "metrics" => ["visitors", "events"]}
+      |> Map.merge(date_params)
+
+    expected_parsed =
       %{
         metrics: [:visitors, :events],
-        date_range: expected_date_range,
+        date_range: expected_fields.date_range,
         filters: [],
         dimensions: [],
         order_by: nil,
-        timezone: site.timezone,
+        timezone: Map.get(expected_fields, :timezone, site.timezone),
         include: %{imports: false, time_labels: false},
         preloaded_goals: []
-      },
-      schema_type
-    )
+      }
+
+    check_success(params, site, expected_parsed, schema_type)
   end
 
   test "parsing empty map fails", %{site: site} do
@@ -522,18 +523,44 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
 
   describe "date range validation" do
     test "parsing shortcut options", %{site: site} do
-      check_date_range(%{"date_range" => "day"}, site, @date_range_day)
-      check_date_range(%{"date_range" => "7d"}, site, @date_range_7d)
-      check_date_range(%{"date_range" => "30d"}, site, @date_range_30d)
-      check_date_range(%{"date_range" => "month"}, site, @date_range_month)
-      check_date_range(%{"date_range" => "6mo"}, site, @date_range_6mo)
-      check_date_range(%{"date_range" => "12mo"}, site, @date_range_12mo)
-      check_date_range(%{"date_range" => "year"}, site, @date_range_year)
+      check_date_range(%{"date_range" => "day"}, site, %{date_range: @date_range_day})
+      check_date_range(%{"date_range" => "7d"}, site, %{date_range: @date_range_7d})
+      check_date_range(%{"date_range" => "30d"}, site, %{date_range: @date_range_30d})
+      check_date_range(%{"date_range" => "month"}, site, %{date_range: @date_range_month})
+      check_date_range(%{"date_range" => "6mo"}, site, %{date_range: @date_range_6mo})
+      check_date_range(%{"date_range" => "12mo"}, site, %{date_range: @date_range_12mo})
+      check_date_range(%{"date_range" => "year"}, site, %{date_range: @date_range_year})
     end
 
     test "30m and realtime are available in internal API", %{site: site} do
-      check_date_range(%{"date_range" => "30m"}, site, @date_range_30m, :internal)
-      check_date_range(%{"date_range" => "realtime"}, site, @date_range_realtime, :internal)
+      check_date_range(%{"date_range" => "30m"}, site, %{date_range: @date_range_30m}, :internal)
+
+      check_date_range(
+        %{"date_range" => "realtime"},
+        site,
+        %{date_range: @date_range_realtime},
+        :internal
+      )
+    end
+
+    test "timezone is UTC instead of site.timezone for realtime and 30m periods", %{
+      site: site
+    } do
+      site = struct!(site, timezone: "Europe/Tallinn")
+
+      check_date_range(
+        %{"date_range" => "30m"},
+        site,
+        %{date_range: @date_range_30m, timezone: "UTC"},
+        :internal
+      )
+
+      check_date_range(
+        %{"date_range" => "realtime"},
+        site,
+        %{date_range: @date_range_realtime, timezone: "UTC"},
+        :internal
+      )
     end
 
     test "30m and realtime date_ranges are unavailable in public API", %{
@@ -548,26 +575,31 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     test "parsing `all` with previous data", %{site: site} do
       site = Map.put(site, :stats_start_date, ~D[2020-01-01])
       expected_date_range = DateTimeRange.new!(~D[2020-01-01], ~D[2021-05-05], "UTC")
-      check_date_range(%{"date_range" => "all"}, site, expected_date_range)
+      check_date_range(%{"date_range" => "all"}, site, %{date_range: expected_date_range})
     end
 
     test "parsing `all` with no previous data", %{site: site} do
       site = Map.put(site, :stats_start_date, nil)
-      check_date_range(%{"date_range" => "all"}, site, @date_range_day)
+      check_date_range(%{"date_range" => "all"}, site, %{date_range: @date_range_day})
     end
 
     test "parsing custom date range from simple date strings", %{site: site} do
-      check_date_range(%{"date_range" => ["2021-05-05", "2021-05-05"]}, site, @date_range_day)
+      check_date_range(%{"date_range" => ["2021-05-05", "2021-05-05"]}, site, %{
+        date_range: @date_range_day
+      })
     end
 
     test "parsing custom date range from iso8601 timestamps", %{site: site} do
       check_date_range(
         %{"date_range" => ["2024-01-01T00:00:00 UTC", "2024-01-02T23:59:59 UTC"]},
         site,
-        DateTimeRange.new!(
-          DateTime.new!(~D[2024-01-01], ~T[00:00:00], "UTC"),
-          DateTime.new!(~D[2024-01-02], ~T[23:59:59], "UTC")
-        )
+        %{
+          date_range:
+            DateTimeRange.new!(
+              DateTime.new!(~D[2024-01-01], ~T[00:00:00], "UTC"),
+              DateTime.new!(~D[2024-01-02], ~T[23:59:59], "UTC")
+            )
+        }
       )
 
       check_date_range(
@@ -578,10 +610,14 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           ]
         },
         site,
-        DateTimeRange.new!(
-          DateTime.new!(~D[2024-08-29], ~T[07:12:34], "America/Los_Angeles"),
-          DateTime.new!(~D[2024-08-29], ~T[10:12:34], "America/Los_Angeles")
-        )
+        %{
+          date_range:
+            DateTimeRange.new!(
+              DateTime.new!(~D[2024-08-29], ~T[07:12:34], "America/Los_Angeles"),
+              DateTime.new!(~D[2024-08-29], ~T[10:12:34], "America/Los_Angeles")
+            ),
+          timezone: "America/Los_Angeles"
+        }
       )
     end
 
@@ -672,7 +708,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
             {"year", @date_range_year}
           ] do
         %{"date_range" => date_range_shortcut, "date" => date}
-        |> check_date_range(site, expected_date_range, :internal)
+        |> check_date_range(site, %{date_range: expected_date_range}, :internal)
       end
     end
 
@@ -698,7 +734,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         )
 
       %{"date_range" => ["2022-09-11", "2022-09-11"]}
-      |> check_date_range(site, expected_date_range)
+      |> check_date_range(site, %{date_range: expected_date_range})
     end
 
     test "parses date_range.first into the latest of ambiguous datetimes in site.timezone", %{
@@ -716,7 +752,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         )
 
       %{"date_range" => ["2023-11-05", "2023-11-05"]}
-      |> check_date_range(site, expected_date_range)
+      |> check_date_range(site, %{date_range: expected_date_range})
     end
 
     test "parses date_range.last into the earliest of ambiguous datetimes in site.timezone", %{
@@ -734,7 +770,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         )
 
       %{"date_range" => ["2024-03-23", "2024-03-23"]}
-      |> check_date_range(site, expected_date_range)
+      |> check_date_range(site, %{date_range: expected_date_range})
     end
   end
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -607,15 +607,27 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       )
     end
 
-    test "custom date range is invalid when timestamp timezone is invalid", %{site: site} do
+    test "custom date range is invalid when timestamp timezones are different", %{site: site} do
       %{
         "site_id" => site.domain,
-        "date_range" => ["2021-02-03T00:00:00 Fake/Timezone", "2021-02-03T23:59:59 UTC"],
+        "date_range" => ["2021-02-03T00:00:00 Europe/Tallinn", "2021-02-03T23:59:59 UTC"],
         "metrics" => ["visitors"]
       }
       |> check_error(
         site,
-        "Invalid date_range '[\"2021-02-03T00:00:00 Fake/Timezone\", \"2021-02-03T23:59:59 UTC\"]'."
+        "Invalid date_range '[\"2021-02-03T00:00:00 Europe/Tallinn\", \"2021-02-03T23:59:59 UTC\"]'."
+      )
+    end
+
+    test "custom date range is invalid when timestamp timezone is invalid", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "date_range" => ["2021-02-03T00:00:00 Fake/Timezone", "2021-02-03T23:59:59 Fake/Timezone"],
+        "metrics" => ["visitors"]
+      }
+      |> check_error(
+        site,
+        "Invalid date_range '[\"2021-02-03T00:00:00 Fake/Timezone\", \"2021-02-03T23:59:59 Fake/Timezone\"]'."
       )
     end
 


### PR DESCRIPTION
### Changes

Follow up to https://github.com/plausible/analytics/pull/4508 with a proper fix that will also work for API v2.

The solution is actually much simpler than what I essentially did in that PR. The problem was that we were selecting the time dimensions by shifting the timestamps into `query.timezone` **which was always `site.timezone`, and yet the actual `query.date_range` for realtime was in UTC**.

So eventually the bug surfaced in `Plausible.Stats.Timeseries.build_timeseries_result` from something like this:

```elixir
%Plausible.Stats.QueryResult{
  # returned dimensions are in site.timezone
  results: [%{metrics: [1], dimensions: ["2024-09-03 08:30:00"]}],
  # the time labels are created with a minute step starting from `query.date_range.first` and are in UTC
  meta: %{
    time_labels: ["2024-09-03 05:20:00", "2024-09-03 05:21:00", ..., "2024-09-03 05:49:00"]
  },
  ...
}

```

**The fix**

`query.timezone` does not have to be equivalent to `site.timezone`, so the fix is simply to make sure that `query.timezone` is in UTC for realtime queries. Doing that, we'll be converting from UTC to UTC when selecting the time dimensions, which is a no-op.

What I've done now is rely on `query.date_range.first` to determine `query.timezone` in both `Legacy.QueryBuilder` and `Query.build`. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
