### PR TITLE
Handle more special characters in parseSearchFragment

### DIFF
--- a/assets/js/dashboard/util/url-search-params.test.ts
+++ b/assets/js/dashboard/util/url-search-params.test.ts
@@ -118,7 +118,9 @@ describe(`${parseSearchFragment.name}`, () => {
     // Non-JSON strings that should return as string
     ['undefined', 'undefined'],
     ['not_json', 'not_json'],
-    ['plainstring', 'plainstring']
+    ['plainstring', 'plainstring'],
+    ['a|b', 'a|b'],
+    ['foo bar#', 'foo bar#']
   ])(
     'when searchStringFragment is %p, returns %p',
     (searchStringFragment, expected) => {

--- a/assets/js/dashboard/util/url.ts
+++ b/assets/js/dashboard/util/url.ts
@@ -131,6 +131,9 @@ export function parseSearchFragment(
     /* @ts-expect-error API supposedly not present in compilation target */
     .replaceAll('=', encodeURIComponent('='))
     .replaceAll('#', encodeURIComponent('#'))
+    .replaceAll('|', encodeURIComponent('|'))
+    .replaceAll(' ', encodeURIComponent(' '))
+
   try {
     return JsonURL.parse(fragmentWithReEncodedSymbols)
   } catch (error) {


### PR DESCRIPTION
Some old filters with spaces and | characters broke. Solves https://github.com/plausible/analytics/issues/4518