### PR TITLE
Redirect to login on expired legacy session

### DIFF
--- a/lib/plausible_web/plugs/session_timeout_plug.ex
+++ b/lib/plausible_web/plugs/session_timeout_plug.ex
@@ -18,6 +18,7 @@ defmodule PlausibleWeb.SessionTimeoutPlug do
       user_id && timeout_at && now() > timeout_at ->
         conn
         |> PlausibleWeb.UserAuth.log_out_user()
+        |> Phoenix.Controller.redirect(to: "/login")
         |> halt()
 
       user_id ->

--- a/test/plausible_web/plugs/session_timeout_plug_test.exs
+++ b/test/plausible_web/plugs/session_timeout_plug_test.exs
@@ -41,5 +41,7 @@ defmodule PlausibleWeb.SessionTimeoutPlugTest do
       |> SessionTimeoutPlug.call(@opts)
 
     assert conn.private[:plug_session_info] == :renew
+    assert conn.halted
+    assert Phoenix.ConnTest.redirected_to(conn, 302) == "/login"
   end
 end


### PR DESCRIPTION
After recent update in #4463, an error slipped in where when the _legacy_ session times out, the conn is halted but no body is sent. This results in 500 error (`Plug.Conn.NotSentError`).

This PR fixes it by redirecting to login page.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added

