### PR TITLE
Update 20240801091615_capitalize_known_sources.exs migration

### DIFF
--- a/priv/ingest_repo/migrations/20240801091615_capitalize_known_sources.exs
+++ b/priv/ingest_repo/migrations/20240801091615_capitalize_known_sources.exs
@@ -5,28 +5,35 @@ defmodule Plausible.IngestRepo.Migrations.CapitalizeKnownSources do
     {:ok, _} = Application.ensure_all_started(:ref_inspector)
     [{"referers.yml", map}] = RefInspector.Database.list(:default)
 
-    sources =
+    {downcased_sources, sources} =
       Enum.flat_map(map, fn {_, entries} ->
-        Enum.map(entries, fn {_, _, _, _, _, _, name} ->
-          {String.downcase(name), name}
-        end)
+        Enum.map(entries, fn {_, _, _, _, _, _, name} -> name end)
       end)
-      |> Enum.into(%{})
+      |> Enum.flat_map(fn name ->
+        downcased_name = String.downcase(name)
+
+        if name != downcased_name do
+          [{downcased_name, name}]
+        else
+          []
+        end
+      end)
+      |> Enum.unzip()
 
     events_sql = """
       ALTER TABLE events_v2
-      UPDATE referrer_source = {$0:Map(String, String)}[referrer_source]
-      WHERE {$0:Map(String, String)}[referrer_source] != ''
+      UPDATE referrer_source = transform(referrer_source, {$0:Array(String)}, {$1:Array(String)})
+      WHERE ascii(referrer_source) BETWEEN 97 AND 122
     """
 
     sessions_sql = """
       ALTER TABLE sessions_v2
-      UPDATE referrer_source = {$0:Map(String, String)}[referrer_source]
-      WHERE {$0:Map(String, String)}[referrer_source] != ''
+      UPDATE referrer_source = transform(referrer_source, {$0:Array(String)}, {$1:Array(String)})
+      WHERE ascii(referrer_source) BETWEEN 97 AND 122
     """
 
-    execute(fn -> repo().query!(events_sql, [sources]) end)
-    execute(fn -> repo().query!(sessions_sql, [sources]) end)
+    execute(fn -> repo().query!(events_sql, [downcased_sources, sources]) end)
+    execute(fn -> repo().query!(sessions_sql, [downcased_sources, sources]) end)
   end
 
   def down do


### PR DESCRIPTION
Previous migration took forever on prod, likely because Map lookups are linear time in complexity. `transform/3` helps achieve the same functionality with the help of a hash table and updated WHERE clause allows skipping most rows which dont need updating.

I've tested the migration on a dummy table on prod. Updated a months data in 2022 in seconds where the previous migration ran for hours with little progress before we cancelled it.