### PR TITLE
Use empty string for direct channel

### DIFF
--- a/lib/plausible/ingestion/acquisition.ex
+++ b/lib/plausible/ingestion/acquisition.ex
@@ -50,7 +50,7 @@ defmodule Plausible.Ingestion.Acquisition do
       sms?(request) -> "SMS"
       mobile_push_notifications?(request, source) -> "Mobile Push Notifications"
       referral?(request, source) -> "Referral"
-      true -> "Direct"
+      true -> ""
     end
   end
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1940,7 +1940,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Direct"
+      assert session.channel == ""
     end
   end
 


### PR DESCRIPTION
For two reasons:
1. Consistency with other dimensions where we map empty string to "Direct" "(none)" or other
2. Historical sessions all have empty string as the channel so we need to map that value anyways