### PR TITLE
Add mappings for short sources (fb, ig)

### DIFF
--- a/lib/plausible/ingestion/acquisition.ex
+++ b/lib/plausible/ingestion/acquisition.ex
@@ -6,6 +6,10 @@ defmodule Plausible.Ingestion.Acquisition do
                      |> NimbleCSV.RFC4180.parse_string(skip_headers: false)
                      |> Enum.map(fn [source, category] -> {source, category} end)
                      |> Enum.into(%{})
+  @mapping_overrides [
+    {"fb", "Facebook"},
+    {"ig", "Instagram"}
+  ]
 
   def init() do
     :ets.new(__MODULE__, [
@@ -17,10 +21,14 @@ defmodule Plausible.Ingestion.Acquisition do
 
     [{"referers.yml", map}] = RefInspector.Database.list(:default)
 
-    Enum.flat_map(map, fn {_, entries} ->
-      Enum.map(entries, fn {_, _, _, _, _, _, name} ->
+    Enum.each(map, fn {_, entries} ->
+      Enum.each(entries, fn {_, _, _, _, _, _, name} ->
         :ets.insert(__MODULE__, {String.downcase(name), name})
       end)
+    end)
+
+    Enum.each(@mapping_overrides, fn override ->
+      :ets.insert(__MODULE__, override)
     end)
   end
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -423,6 +423,40 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert session.referrer_source == "Facebook"
     end
 
+    test "utm_source fb is detected as Facebook",
+         %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?utm_source=fb",
+        domain: site.domain
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert session.referrer_source == "Facebook"
+      assert session.channel == "Organic Social"
+    end
+
+    test "utm_source ig is detected as Instagram",
+         %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?utm_source=ig",
+        domain: site.domain
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert session.referrer_source == "Instagram"
+      assert session.channel == "Organic Social"
+    end
+
     test "utm tags are stored", %{conn: conn, site: site} do
       params = %{
         name: "pageview",


### PR DESCRIPTION
### Changes

Follow-up for https://github.com/plausible/analytics/pull/4417 based on [this request](https://feedback.plausible.io/483). Adds the following source mappings:

```
fb -> Facebook
ig -> Instagram
```