### PR TITLE
Reassert tuples in query JSON schema

### DIFF
--- a/lib/plausible/stats/json_schema.ex
+++ b/lib/plausible/stats/json_schema.ex
@@ -17,11 +17,11 @@ defmodule Plausible.Stats.JSONSchema do
   @internal_query_schema @raw_public_schema
                          # Add overrides for things allowed in the internal API
                          |> JSONPointer.add!(
-                           "#/definitions/filter_entry/oneOf/0/items/0/enum/0",
+                           "#/definitions/filter_operation_without_goals/enum/0",
                            "matches_wildcard"
                          )
                          |> JSONPointer.add!(
-                           "#/definitions/filter_entry/oneOf/0/items/0/enum/0",
+                           "#/definitions/filter_operation_without_goals/enum/0",
                            "matches_wildcard_not"
                          )
                          |> JSONPointer.add!("#/definitions/metric/oneOf/0", %{

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -29,9 +29,7 @@
     },
     "filters": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/filter_entry"
-      },
+      "items": { "$ref": "#/definitions/filter_tree" },
       "description": "How to drill into your data"
     },
     "order_by": {
@@ -54,11 +52,7 @@
       }
     }
   },
-  "required": [
-    "site_id",
-    "metrics",
-    "date_range"
-  ],
+  "required": ["site_id", "metrics", "date_range"],
   "additionalProperties": false,
   "definitions": {
     "date_range": {
@@ -97,23 +91,21 @@
         },
         {
           "type": "array",
+          "additionalItems": false,
+          "minItems": 2,
+          "maxItems": 2,
           "items": {
             "type": "string",
             "pattern": "^\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}\\s[A-Za-z/_]+)?$"
           },
           "markdownDescription": "A list of two elements to determine the query date range. Both elements should have the same format - either `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss <timezone>`",
           "examples": [
-            [
-              "2024-01-01",
-              "2024-01-31"
-            ],
+            ["2024-01-01", "2024-01-31"],
             [
               "2024-01-01T00:00:00 Europe/Tallinn",
               "2024-01-01T12:00:00 Europe/Tallinn"
             ]
-          ],
-          "minItems": 2,
-          "maxItems": 2
+          ]
         }
       ]
     },
@@ -196,10 +188,7 @@
       "type": "string",
       "pattern": "^event:props:.+",
       "markdownDescription": "Custom property. See [documentation](https://plausible.io/docs/custom-props/introduction) for more information",
-      "examples": [
-        "event:props:url",
-        "event:props:path"
-      ]
+      "examples": ["event:props:url", "event:props:path"]
     },
     "goal_dimension": {
       "const": "event:goal",
@@ -207,28 +196,14 @@
     },
     "time_dimensions": {
       "type": "string",
-      "enum": [
-        "time",
-        "time:month",
-        "time:week",
-        "time:day",
-        "time:hour"
-      ]
+      "enum": ["time", "time:month", "time:week", "time:day", "time:hour"]
     },
     "dimensions": {
       "oneOf": [
-        {
-          "$ref": "#/definitions/simple_filter_dimensions"
-        },
-        {
-          "$ref": "#/definitions/custom_property_filter_dimensions"
-        },
-        {
-          "$ref": "#/definitions/goal_dimension"
-        },
-        {
-          "$ref": "#/definitions/time_dimensions"
-        }
+        { "$ref": "#/definitions/simple_filter_dimensions" },
+        { "$ref": "#/definitions/custom_property_filter_dimensions" },
+        { "$ref": "#/definitions/goal_dimension" },
+        { "$ref": "#/definitions/time_dimensions" }
       ]
     },
     "clauses": {
@@ -237,129 +212,108 @@
         "type": ["string", "integer"]
       }
     },
+    "filter_operation_without_goals": {
+      "type": "string",
+      "enum": ["is_not", "contains_not", "matches", "matches_not"],
+      "description": "filter operation"
+    },
+    "filter_operation_with_goals": {
+      "type": "string",
+      "enum": ["is", "contains"],
+      "description": "filter operation"
+    },
+    "filter_without_goals": {
+      "type": "array",
+      "additionalItems": false,
+      "minItems": 3,
+      "maxItems": 3,
+      "items": [
+        { "$ref": "#/definitions/filter_operation_without_goals" },
+        {
+          "oneOf": [
+            { "$ref": "#/definitions/simple_filter_dimensions" },
+            { "$ref": "#/definitions/custom_property_filter_dimensions" }
+          ]
+        },
+        { "$ref": "#/definitions/clauses" }
+      ]
+    },
+    "filter_with_goals": {
+      "type": "array",
+      "additionalItems": false,
+      "minItems": 3,
+      "maxItems": 3,
+      "items": [
+        {
+          "$ref": "#/definitions/filter_operation_with_goals"
+        },
+        {
+          "oneOf": [
+            { "$ref": "#/definitions/goal_dimension" },
+            { "$ref": "#/definitions/simple_filter_dimensions" },
+            { "$ref": "#/definitions/custom_property_filter_dimensions" }
+          ]
+        },
+        {
+          "$ref": "#/definitions/clauses"
+        }
+      ]
+    },
     "filter_entry": {
       "oneOf": [
-        {
-          "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "enum": [
-                "is_not",
-                "contains_not",
-                "matches",
-                "matches_not"
-              ],
-              "description": "filter operation"
-            },
-            {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/simple_filter_dimensions"
-                },
-                {
-                  "$ref": "#/definitions/custom_property_filter_dimensions"
-                }
-              ]
-            },
-            {
-              "$ref": "#/definitions/clauses"
-            }
-          ]
-        },
-        {
-          "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "enum": [
-                "is",
-                "contains"
-              ],
-              "description": "filter operation"
-            },
-            {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/goal_dimension"
-                },
-                {
-                  "$ref": "#/definitions/simple_filter_dimensions"
-                },
-                {
-                  "$ref": "#/definitions/custom_property_filter_dimensions"
-                }
-              ]
-            },
-            {
-              "$ref": "#/definitions/clauses"
-            }
-          ]
-        },
-        {
-          "$ref": "#/definitions/filter_and_or"
-        },
-        {
-          "$ref": "#/definitions/filter_not"
-        }
+        { "$ref": "#/definitions/filter_without_goals" },
+        { "$ref": "#/definitions/filter_with_goals" }
+      ]
+    },
+    "filter_tree": {
+      "oneOf": [
+        { "$ref": "#/definitions/filter_entry" },
+        { "$ref": "#/definitions/filter_and_or" },
+        { "$ref": "#/definitions/filter_not" }
       ]
     },
     "filter_not": {
       "type": "array",
-      "items": [
-        {
-          "const": "not"
-        },
-        {
-          "$ref": "#/definitions/filter_entry"
-        }
-      ]
+      "additionalItems": false,
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [{ "const": "not" }, { "$ref": "#/definitions/filter_tree" }]
     },
     "filter_and_or": {
       "type": "array",
+      "additionalItems": false,
+      "minItems": 2,
+      "maxItems": 2,
       "items": [
         {
           "type": "string",
-          "enum": [
-            "and",
-            "or"
-          ]
+          "enum": ["and", "or"]
         },
         {
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/filter_entry"
-          },
+          "items": { "$ref": "#/definitions/filter_tree" },
           "minItems": 1
         }
       ]
     },
     "order_by_entry": {
       "type": "array",
+      "additionalItems": false,
+      "minItems": 2,
+      "maxItems": 2,
       "items": [
         {
           "oneOf": [
-            {
-              "$ref": "#/definitions/metric"
-            },
-            {
-              "$ref": "#/definitions/simple_filter_dimensions"
-            },
-            {
-              "$ref": "#/definitions/custom_property_filter_dimensions"
-            },
-            {
-              "$ref": "#/definitions/time_dimensions"
-            }
+            { "$ref": "#/definitions/metric" },
+            { "$ref": "#/definitions/simple_filter_dimensions" },
+            { "$ref": "#/definitions/custom_property_filter_dimensions" },
+            { "$ref": "#/definitions/time_dimensions" }
           ],
           "markdownDescription": "Metric or dimension to order by. Must be listed under `metrics` or `dimensions`"
         },
         {
           "type": "string",
-          "enum": [
-            "asc",
-            "desc"
-          ],
+          "enum": ["asc", "desc"],
           "description": "Sorting order"
         }
       ]


### PR DESCRIPTION
### Changes

This reasserts the tuples in the json schemas, so the autocomplete / autoverify in the playground would inform users when they are constructing invalid filters.
* Some whitespace changes due to prettier.
* Slight refactor to lift out filtering operation definitions (benefit: simpler references)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI

### Schema verification without this PR:
<img width="595" alt="Screenshot 2024-09-06 at 13 06 13" src="https://github.com/user-attachments/assets/8d7b09fd-77d7-4ae7-b5dc-52fabeef0d2c">

### Schema verification with this PR:
<img width="565" alt="Screenshot 2024-09-06 at 13 07 21" src="https://github.com/user-attachments/assets/31d18dc4-45ba-4533-b758-1d208e8f7f7b">
