### PR TITLE
Remove Timex.diff

### DIFF
--- a/lib/plausible/auth/grace_period.ex
+++ b/lib/plausible/auth/grace_period.ex
@@ -82,7 +82,7 @@ defmodule Plausible.Auth.GracePeriod do
   def active?(user)
 
   def active?(%User{grace_period: %__MODULE__{end_date: %Date{} = end_date}}) do
-    Timex.diff(end_date, Date.utc_today(), :days) >= 0
+    Date.diff(end_date, Date.utc_today()) >= 0
   end
 
   def active?(%User{grace_period: %__MODULE__{manual_lock: true}}) do

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -99,7 +99,7 @@ defmodule Plausible.Auth.UserAdmin do
         "ended"
 
       %{end_date: %Date{} = end_date} ->
-        days_left = Timex.diff(end_date, Timex.now(), :days)
+        days_left = Date.diff(end_date, Date.utc_today())
         "#{days_left} days left"
     end
   end

--- a/lib/plausible/plugins/api/token.ex
+++ b/lib/plausible/plugins/api/token.ex
@@ -81,7 +81,7 @@ defmodule Plausible.Plugins.API.Token do
     diff =
       if token.last_used_at do
         now = NaiveDateTime.utc_now()
-        Timex.diff(now, token.last_used_at, :minutes)
+        DateTime.diff(now, token.last_used_at, :minute)
       end
 
     cond do

--- a/lib/plausible/plugins/api/tokens.ex
+++ b/lib/plausible/plugins/api/tokens.ex
@@ -63,7 +63,7 @@ defmodule Plausible.Plugins.API.Tokens do
     now = NaiveDateTime.truncate(now, :second)
     last_used = token.last_used_at
 
-    if is_nil(last_used) or Timex.diff(now, last_used, :minutes) > 5 do
+    if is_nil(last_used) or NaiveDateTime.diff(now, last_used, :minute) > 5 do
       token
       |> Ecto.Changeset.change(%{last_used_at: now})
       |> Repo.update()

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Session.CacheStore do
         nil
 
       session ->
-        if Timex.diff(event.timestamp, session.timestamp, :minutes) <= 30 do
+        if NaiveDateTime.diff(event.timestamp, session.timestamp, :minute) <= 30 do
           session
         end
     end
@@ -73,7 +73,7 @@ defmodule Plausible.Session.CacheStore do
         exit_page_hostname:
           if(event.name == "pageview", do: event.hostname, else: session.exit_page_hostname),
         is_bounce: false,
-        duration: Timex.diff(event.timestamp, session.start, :second) |> abs,
+        duration: NaiveDateTime.diff(event.timestamp, session.start) |> abs,
         pageviews:
           if(event.name == "pageview", do: session.pageviews + 1, else: session.pageviews),
         events: session.events + 1

--- a/lib/plausible/stats/interval.ex
+++ b/lib/plausible/stats/interval.ex
@@ -47,7 +47,7 @@ defmodule Plausible.Stats.Interval do
       Timex.diff(last, first, :months) > 0 ->
         "month"
 
-      Timex.diff(last, first, :days) > 0 ->
+      Date.diff(last, first) > 0 ->
         "day"
 
       true ->

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -78,9 +78,9 @@ defmodule Plausible.Stats.QueryOptimizer do
 
   defp resolve_time_dimension(first, last) do
     cond do
-      Timex.diff(last, first, :hours) <= 48 -> "time:hour"
-      Timex.diff(last, first, :days) <= 40 -> "time:day"
-      Timex.diff(last, first, :weeks) <= 52 -> "time:week"
+      NaiveDateTime.diff(last, first, :hour) <= 48 -> "time:hour"
+      NaiveDateTime.diff(last, first, :day) <= 40 -> "time:day"
+      NaiveDateTime.diff(last, first, :day) <= 52 * 7 -> "time:week"
       true -> "time:month"
     end
   end

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -25,7 +25,7 @@ defmodule Plausible.Users do
 
   @spec trial_days_left(Auth.User.t()) :: integer()
   def trial_days_left(user) do
-    Timex.diff(user.trial_expiry_date, Date.utc_today(), :days)
+    Date.diff(user.trial_expiry_date, Date.utc_today())
   end
 
   @spec update_accept_traffic_until(Auth.User.t()) :: Auth.User.t()

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -270,7 +270,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
     trial_active_or_ended_recently? =
       not invited_user? &&
-        Timex.diff(Date.utc_today(), current_user.trial_expiry_date, :days) <= 10
+        Date.diff(Date.utc_today(), current_user.trial_expiry_date) <= 10
 
     limit_checking_opts =
       cond do

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -109,7 +109,7 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def grace_period_end(%{grace_period: %{end_date: %Date{} = date}}) do
-    case Timex.diff(date, Date.utc_today(), :days) do
+    case Date.diff(date, Date.utc_today()) do
       0 -> "today"
       1 -> "tomorrow"
       n -> "within #{n} days"

--- a/lib/workers/send_site_setup_emails.ex
+++ b/lib/workers/send_site_setup_emails.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
     for site <- Repo.all(q) do
       owner = Plausible.Users.with_subscription(site.owner)
       setup_completed = Plausible.Sites.has_stats?(site)
-      hours_passed = Timex.diff(Timex.now(), site.inserted_at, :hours)
+      hours_passed = NaiveDateTime.diff(NaiveDateTime.utc_now(), site.inserted_at, :hour)
 
       if !setup_completed && hours_passed > 47 do
         send_setup_help_email(owner, site)

--- a/lib/workers/send_trial_notifications.ex
+++ b/lib/workers/send_trial_notifications.ex
@@ -20,7 +20,7 @@ defmodule Plausible.Workers.SendTrialNotifications do
       )
 
     for user <- users do
-      case Timex.diff(user.trial_expiry_date, Date.utc_today(), :days) do
+      case Date.diff(user.trial_expiry_date, Date.utc_today()) do
         7 ->
           if Plausible.Auth.has_active_sites?(user, [:owner]) do
             send_one_week_reminder(user)


### PR DESCRIPTION
Continues https://github.com/plausible/analytics/pull/4338

### Changes

This PR continues [the removal of Timex](https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/7479197128) by replacing [Timex.diff/3](https://github.com/bitwalker/timex/blob/c45b9a734074ac2a56355ec52ebf931b932223b7/lib/comparable/comparable.ex#L139) with equivalent Date and NaiveDateTime functions.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI