### PR TITLE
Remove Timex.now

### DIFF
--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -99,7 +99,7 @@ defmodule Plausible.Auth.UserAdmin do
         "ended"
 
       %{end_date: %Date{} = end_date} ->
-        days_left = Timex.diff(end_date, Timex.now(), :days)
+        days_left = Timex.diff(end_date, DateTime.utc_now(), :days)
         "#{days_left} days left"
     end
   end

--- a/lib/plausible/data_migration/populate_event_session_columns.ex
+++ b/lib/plausible/data_migration/populate_event_session_columns.ex
@@ -98,7 +98,7 @@ defmodule Plausible.DataMigration.PopulateEventSessionColumns do
     {:ok, %{rows: [[merges]]}} = run_sql("get-merges-progress")
     {:ok, %{rows: disks}} = run_sql("get-disks")
 
-    IO.puts("\n\n#{Timex.now() |> DateTime.to_iso8601()}")
+    IO.puts("\n\n#{DateTime.utc_now() |> DateTime.to_iso8601()}")
 
     # List partitions that need to run
     IO.puts(

--- a/lib/plausible/data_migration/versioned_sessions.ex
+++ b/lib/plausible/data_migration/versioned_sessions.ex
@@ -19,7 +19,7 @@ defmodule Plausible.DataMigration.VersionedSessions do
   def run(opts \\ []) do
     run_exchange? = Keyword.get(opts, :run_exchange?, true)
 
-    unique_suffix = Timex.now() |> Calendar.strftime(@suffix_format)
+    unique_suffix = DateTime.utc_now() |> Calendar.strftime(@suffix_format)
 
     cluster? = Plausible.IngestRepo.clustered_table?("sessions_v2")
 

--- a/lib/plausible/google/api.ex
+++ b/lib/plausible/google/api.ex
@@ -131,7 +131,7 @@ defmodule Plausible.Google.API do
   end
 
   defp needs_to_refresh_token?(%NaiveDateTime{} = expires_at) do
-    thirty_seconds_ago = DateTime.shift(Timex.now(), second: 30)
+    thirty_seconds_ago = DateTime.shift(DateTime.utc_now(), second: 30)
     Timex.before?(expires_at, thirty_seconds_ago)
   end
 

--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Session.Salts do
   defp generate_and_persist_new_salt() do
     salt = :crypto.strong_rand_bytes(16)
 
-    Repo.insert_all("salts", [%{salt: salt, inserted_at: Timex.now()}])
+    Repo.insert_all("salts", [%{salt: salt, inserted_at: DateTime.utc_now()}])
     salt
   end
 

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -61,7 +61,7 @@ defmodule Plausible.Stats.Comparisons do
   def compare(%Plausible.Site{} = site, %Stats.Query{} = source_query, mode, opts \\ []) do
     opts =
       opts
-      |> Keyword.put_new(:now, Timex.now(site.timezone))
+      |> Keyword.put_new(:now, DateTime.now!(site.timezone))
       |> Keyword.put_new(:match_day_of_week?, false)
 
     source_date_range = DateTimeRange.to_date_range(source_query.date_range)

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -239,12 +239,12 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
   end
 
   defp today(tz) do
-    Timex.now(tz) |> Timex.to_date()
+    DateTime.now!(tz) |> Timex.to_date()
   end
 
   defp parse_single_date(tz, params) do
     case params["date"] do
-      "today" -> Timex.now(tz) |> Timex.to_date()
+      "today" -> DateTime.now!(tz) |> Timex.to_date()
       date when is_binary(date) -> Date.from_iso8601!(date)
       _ -> today(tz)
     end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -263,14 +263,14 @@ defmodule PlausibleWeb.Api.StatsController do
     case query.interval do
       "hour" ->
         current_date =
-          Timex.now(site.timezone)
+          DateTime.now!(site.timezone)
           |> Calendar.strftime("%Y-%m-%d %H:00:00")
 
         Enum.find_index(dates, &(&1 == current_date))
 
       "day" ->
         current_date =
-          Timex.now(site.timezone)
+          DateTime.now!(site.timezone)
           |> Timex.to_date()
           |> Date.to_string()
 
@@ -278,7 +278,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
       "week" ->
         current_date =
-          Timex.now(site.timezone)
+          DateTime.now!(site.timezone)
           |> Timex.to_date()
           |> Time.date_or_weekstart(query)
           |> Date.to_string()
@@ -287,7 +287,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
       "month" ->
         current_date =
-          Timex.now(site.timezone)
+          DateTime.now!(site.timezone)
           |> Timex.to_date()
           |> Timex.beginning_of_month()
           |> Date.to_string()
@@ -296,7 +296,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
       "minute" ->
         current_date =
-          Timex.now(site.timezone)
+          DateTime.now!(site.timezone)
           |> Calendar.strftime("%Y-%m-%d %H:%M:00")
 
         Enum.find_index(dates, &(&1 == current_date))

--- a/lib/workers/schedule_email_reports.ex
+++ b/lib/workers/schedule_email_reports.ex
@@ -49,7 +49,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
   end
 
   def monday_9am(timezone) do
-    Timex.now(timezone)
+    DateTime.now!(timezone)
     |> DateTime.shift(week: 1)
     |> Timex.beginning_of_week()
     |> DateTime.shift(hour: 9)
@@ -89,7 +89,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
   end
 
   def first_of_month_9am(timezone) do
-    Timex.now(timezone)
+    DateTime.now!(timezone)
     |> DateTime.shift(month: 1)
     |> Timex.beginning_of_month()
     |> DateTime.shift(hour: 9)

--- a/lib/workers/send_email_report.ex
+++ b/lib/workers/send_email_report.ex
@@ -58,7 +58,7 @@ defmodule Plausible.Workers.SendEmailReport do
 
   defp put_last_month_query(%{site: site} = assigns) do
     last_month =
-      Timex.now(site.timezone)
+      DateTime.now!(site.timezone)
       |> DateTime.shift(month: -1)
       |> Timex.beginning_of_month()
       |> Date.to_iso8601()
@@ -69,7 +69,7 @@ defmodule Plausible.Workers.SendEmailReport do
   end
 
   defp put_last_week_query(%{site: site} = assigns) do
-    today = Timex.now(site.timezone) |> DateTime.to_date()
+    today = DateTime.now!(site.timezone) |> DateTime.to_date()
     date = Date.shift(today, week: -1) |> Timex.end_of_week() |> Date.to_iso8601()
     query = Query.from(site, %{"period" => "7d", "date" => date})
 

--- a/lib/workers/send_site_setup_emails.ex
+++ b/lib/workers/send_site_setup_emails.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Workers.SendSiteSetupEmails do
     for site <- Repo.all(q) do
       owner = Plausible.Users.with_subscription(site.owner)
       setup_completed = Plausible.Sites.has_stats?(site)
-      hours_passed = Timex.diff(Timex.now(), site.inserted_at, :hours)
+      hours_passed = Timex.diff(DateTime.utc_now(), site.inserted_at, :hours)
 
       if !setup_completed && hours_passed > 47 do
         send_setup_help_email(owner, site)

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -153,7 +153,8 @@ defmodule Plausible.Stats.QueryTest do
       expected_first_datetime = DateTime.new!(~D[2020-01-01], ~T[00:00:00], site.timezone)
 
       expected_last_datetime =
-        Timex.today(site.timezone)
+        DateTime.now!(site.timezone)
+        |> DateTime.to_date()
         |> DateTime.new!(~T[23:59:59], site.timezone)
 
       assert query.date_range.first == expected_first_datetime


### PR DESCRIPTION
Continues https://github.com/plausible/analytics/pull/4338

### Changes

This PR continues [the removal of Timex](https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/7479197128) by replacing Timex.now with ~~equivalent~~ (one test had to change, so I guess not exactly equivalent) Date and DateTime functions:

- Timex.now/0 is replaced by [DateTime.utc_now](https://hexdocs.pm/elixir/DateTime.html#utc_now/1) which Timex was already [delegating to](https://github.com/bitwalker/timex/blob/c45b9a734074ac2a56355ec52ebf931b932223b7/lib/timex.ex#L59-L63)
- Timex.now/1 is replaced by [DateTime.now!](https://hexdocs.pm/elixir/DateTime.html#now!/2) which differs from what Timex [was doing](https://github.com/bitwalker/timex/blob/c45b9a734074ac2a56355ec52ebf931b932223b7/lib/timex.ex#L65-L78) (~DateTime.now) in that it raises an exception on invalid timezone, instead of returning an error tuple (which was inconsistent), and it also parses Etc/GMT+- correctly: https://github.com/plausible/analytics/pull/4546#discussion_r1747998399

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI