### PR TITLE
Safeguard queries relying on `sign` from faulty old session entries

### DIFF
--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -252,6 +252,7 @@ defmodule Plausible.Stats.SQL.Expression do
     wrap_alias([], %{
       bounce_rate:
         fragment(
+         # :TRICKY: Before PR #4493, we could have sessions where sum(is_bounce * sign) is negative, leading to an underflow and >100% bounce rate. This works around that issue. 
           "toUInt32(greatest(ifNotFinite(round(sumIf(is_bounce * sign, ?) / sumIf(sign, ?) * 100), 0), 0))",
           ^condition,
           ^condition

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -252,30 +252,39 @@ defmodule Plausible.Stats.SQL.Expression do
     wrap_alias([], %{
       bounce_rate:
         fragment(
-          "toUInt32(ifNotFinite(round(sumIf(is_bounce * sign, ?) / sumIf(sign, ?) * 100), 0))",
+          "toUInt32(greatest(ifNotFinite(round(sumIf(is_bounce * sign, ?) / sumIf(sign, ?) * 100), 0), 0))",
           ^condition,
           ^condition
         ),
-      __internal_visits: fragment("toUInt32(sum(sign))")
+      __internal_visits: fragment("toUInt32(greatest(sum(sign), 0))")
     })
   end
 
   def session_metric(:visits, _query) do
     wrap_alias([s], %{
-      visits: fragment("toUInt64(round(sum(?) * any(_sample_factor)))", s.sign)
+      visits: fragment("toUInt64(round(greatest(sum(?), 0) * any(_sample_factor)))", s.sign)
     })
   end
 
   def session_metric(:pageviews, _query) do
     wrap_alias([s], %{
       pageviews:
-        fragment("toUInt64(round(sum(? * ?) * any(_sample_factor)))", s.sign, s.pageviews)
+        fragment(
+          "toUInt64(round(greatest(sum(? * ?), 0) * any(_sample_factor)))",
+          s.sign,
+          s.pageviews
+        )
     })
   end
 
   def session_metric(:events, _query) do
     wrap_alias([s], %{
-      events: fragment("toUInt64(round(sum(? * ?) * any(_sample_factor)))", s.sign, s.events)
+      events:
+        fragment(
+          "toUInt64(round(greatest(sum(? * ?), 0) * any(_sample_factor)))",
+          s.sign,
+          s.events
+        )
     })
   end
 
@@ -288,8 +297,8 @@ defmodule Plausible.Stats.SQL.Expression do
   def session_metric(:visit_duration, _query) do
     wrap_alias([], %{
       visit_duration:
-        fragment("toUInt32(ifNotFinite(round(sum(duration * sign) / sum(sign)), 0))"),
-      __internal_visits: fragment("toUInt32(sum(sign))")
+        fragment("toUInt32(greatest(ifNotFinite(round(sum(duration * sign) / sum(sign)), 0), 0))"),
+      __internal_visits: fragment("toUInt32(greatest(sum(sign), 0))")
     })
   end
 
@@ -297,12 +306,12 @@ defmodule Plausible.Stats.SQL.Expression do
     wrap_alias([s], %{
       views_per_visit:
         fragment(
-          "ifNotFinite(round(sum(? * ?) / sum(?), 2), 0)",
+          "greatest(ifNotFinite(round(sum(? * ?) / sum(?), 2), 0), 0)",
           s.sign,
           s.pageviews,
           s.sign
         ),
-      __internal_visits: fragment("toUInt32(sum(sign))")
+      __internal_visits: fragment("toUInt32(greatest(sum(sign), 0))")
     })
   end
 

--- a/lib/plausible/stats/sql/fragments.ex
+++ b/lib/plausible/stats/sql/fragments.ex
@@ -38,7 +38,7 @@ defmodule Plausible.Stats.SQL.Fragments do
 
   defmacro visit_duration() do
     quote do
-      fragment("toUInt32(greatest(ifNotFinite(round(avg(duration * sign)), 0), 0))")
+      fragment("toUInt32(ifNotFinite(round(avg(duration * sign)), 0))")
     end
   end
 

--- a/lib/plausible/stats/sql/fragments.ex
+++ b/lib/plausible/stats/sql/fragments.ex
@@ -31,6 +31,9 @@ defmodule Plausible.Stats.SQL.Fragments do
   defmacro bounce_rate() do
     quote do
       fragment(
+        # :TRICKY: Before PR #4493, we could have sessions where `sum(is_bounce * sign)`
+        # is negative, leading to an underflow and >100% bounce rate. This works around
+        # that issue.
         "toUInt32(greatest(ifNotFinite(round(sum(is_bounce * sign) / sum(sign) * 100), 0), 0))"
       )
     end

--- a/lib/plausible/stats/sql/fragments.ex
+++ b/lib/plausible/stats/sql/fragments.ex
@@ -30,13 +30,15 @@ defmodule Plausible.Stats.SQL.Fragments do
 
   defmacro bounce_rate() do
     quote do
-      fragment("toUInt32(ifNotFinite(round(sum(is_bounce * sign) / sum(sign) * 100), 0))")
+      fragment(
+        "toUInt32(greatest(ifNotFinite(round(sum(is_bounce * sign) / sum(sign) * 100), 0), 0))"
+      )
     end
   end
 
   defmacro visit_duration() do
     quote do
-      fragment("toUInt32(ifNotFinite(round(avg(duration * sign)), 0))")
+      fragment("toUInt32(greatest(ifNotFinite(round(avg(duration * sign)), 0), 0))")
     end
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -3161,7 +3161,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       conn: conn,
       site: site
     } do
-      user_id = 123
+      user_id = System.unique_integer([:positive])
 
       populate_stats(site, [
         build(:pageview,

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -3161,6 +3161,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       conn: conn,
       site: site
     } do
+      # NOTE: At the time of this test is added, it appears it does _not_
+      # catch the regression on MacOS (ARM), regardless if Clickhouse is run
+      # natively or from a docker container. The test still does catch
+      # that regression when ran on Linux for instance (including CI).
       user_id = System.unique_integer([:positive])
 
       populate_stats(site, [

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -3156,63 +3156,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                ]
              }
     end
-
-    test "bounce rate calculation handles invalid session data gracefully", %{
-      conn: conn,
-      site: site
-    } do
-      # NOTE: At the time of this test is added, it appears it does _not_
-      # catch the regression on MacOS (ARM), regardless if Clickhouse is run
-      # natively or from a docker container. The test still does catch
-      # that regression when ran on Linux for instance (including CI).
-      user_id = System.unique_integer([:positive])
-
-      populate_stats(site, [
-        build(:pageview,
-          user_id: user_id,
-          pathname: "/",
-          timestamp: ~N[2021-01-01 00:00:00]
-        )
-      ])
-
-      first_session = Plausible.Cache.Adapter.get(:sessions, {site.id, user_id})
-
-      populate_stats(site, [
-        build(:pageview,
-          user_id: user_id,
-          pathname: "/",
-          timestamp: ~N[2021-01-01 00:01:00]
-        )
-      ])
-
-      Plausible.Cache.Adapter.put(:sessions, {site.id, user_id}, first_session)
-
-      populate_stats(site, [
-        build(:pageview,
-          user_id: user_id,
-          pathname: "/",
-          timestamp: ~N[2021-01-01 00:01:00]
-        )
-      ])
-
-      conn =
-        get(conn, "/api/v1/stats/breakdown", %{
-          "site_id" => site.domain,
-          "period" => "day",
-          "date" => "2021-01-01",
-          "property" => "event:page",
-          "metrics" => "bounce_rate"
-        })
-
-      assert json_response(conn, 200) == %{
-               "results" => [
-                 %{
-                   "page" => "/",
-                   "bounce_rate" => 0
-                 }
-               ]
-             }
-    end
   end
 
   describe "imported data" do

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -3156,6 +3156,59 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                ]
              }
     end
+
+    test "bounce rate calculation handles invalid session data gracefully", %{
+      conn: conn,
+      site: site
+    } do
+      user_id = 123
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: user_id,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      first_session = Plausible.Cache.Adapter.get(:sessions, {site.id, user_id})
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: user_id,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:01:00]
+        )
+      ])
+
+      Plausible.Cache.Adapter.put(:sessions, {site.id, user_id}, first_session)
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: user_id,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:01:00]
+        )
+      ])
+
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "period" => "day",
+          "date" => "2021-01-01",
+          "property" => "event:page",
+          "metrics" => "bounce_rate"
+        })
+
+      assert json_response(conn, 200) == %{
+               "results" => [
+                 %{
+                   "page" => "/",
+                   "bounce_rate" => 0
+                 }
+               ]
+             }
+    end
   end
 
   describe "imported data" do


### PR DESCRIPTION
### Changes

Since #4493 got deployed, faulty session records stopped appearing. This PR introduces a change to bounce computation (for native stats), which safeguards against negative bounce rate value overflow for historical records, ultimately caused by those races occurring in the past. 

### Tests
- [x] Automated tests have been added

