### PR TITLE
Breakdown modal search shortcut

### DIFF
--- a/assets/js/dashboard/components/search-input.tsx
+++ b/assets/js/dashboard/components/search-input.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import React, { ChangeEventHandler, useCallback, useRef } from 'react'
+import React, { ChangeEventHandler, useCallback, useState, useRef } from 'react'
 import { isModifierPressed, Keybind } from '../keybinding'
 import { useDebounce } from '../custom-hooks'
 import classNames from 'classnames'
@@ -13,6 +13,7 @@ export const SearchInput = ({
   onSearch: (value: string) => void
 }) => {
   const searchBoxRef = useRef<HTMLInputElement>(null)
+  const [isFocused, setIsFocused] = useState(false)
 
   const onSearchInputChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
@@ -22,13 +23,25 @@ export const SearchInput = ({
   )
   const debouncedOnSearchInputChange = useDebounce(onSearchInputChange)
 
-  const blurSearchBox = useCallback((event: KeyboardEvent) => {
-    const searchBox = searchBoxRef.current
-    if (searchBox?.contains(event.target as HTMLElement)) {
-      searchBox.blur()
-      event.stopPropagation()
-    }
-  }, [])
+  const blurSearchBox = useCallback(
+    (event: KeyboardEvent) => {
+      if (isFocused) {
+        searchBoxRef.current?.blur()
+        event.stopPropagation()
+      }
+    },
+    [isFocused]
+  )
+
+  const focusSearchBox = useCallback(
+    (event: KeyboardEvent) => {
+      if (!isFocused) {
+        searchBoxRef.current?.focus()
+        event.stopPropagation()
+      }
+    },
+    [isFocused]
+  )
 
   return (
     <>
@@ -38,10 +51,18 @@ export const SearchInput = ({
         handler={blurSearchBox}
         shouldIgnoreWhen={[isModifierPressed]}
       />
+      <Keybind
+        keyboardKey="/"
+        type="keyup"
+        handler={focusSearchBox}
+        shouldIgnoreWhen={[isModifierPressed]}
+      />
       <input
+        onBlur={() => setIsFocused(false)}
+        onFocus={() => setIsFocused(true)}
         ref={searchBoxRef}
         type="text"
-        placeholder="Search"
+        placeholder={isFocused ? 'Search' : 'Press / to search'}
         className={classNames(
           'shadow-sm dark:bg-gray-900 dark:text-gray-100 focus:ring-indigo-500 focus:border-indigo-500 block sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800 w-48',
           className

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -170,7 +170,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
     <BreakdownTable<TListItem>
       title={reportInfo.title}
       {...apiState}
-      onSearch={setSearch}
+      onSearch={searchEnabled ? setSearch : undefined}
       columns={columns}
     />
   )


### PR DESCRIPTION
### Changes

Adds the ability to focus the search input by pressing the `/` key in breakdown modals.

Also stops rendering the search input box in screen sizes modal (currently on master it's rendered but not functional). It's not needed since the list will never have more than 5 entries.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
