### PR TITLE
Fix test failing due to timestamp setup

### DIFF
--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -571,15 +571,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           referrer_source: "C",
           timestamp: ~N[2024-08-10 10:00:30]
         ),
-        build(:pageview, referrer_source: "A"),
-        build(:pageview, referrer_source: "A"),
-        build(:pageview, referrer_source: "Z")
+        build(:pageview, referrer_source: "A", timestamp: ~N[2024-08-10 10:00:30]),
+        build(:pageview, referrer_source: "A", timestamp: ~N[2024-08-10 10:00:30]),
+        build(:pageview, referrer_source: "Z", timestamp: ~N[2024-08-10 10:00:30])
       ])
 
       order_by_asc = Jason.encode!([["visit_duration", "asc"], ["visit:source", "desc"]])
 
       conn1 =
-        get(conn, "/api/stats/#{site.domain}/sources?detailed=true&order_by=#{order_by_asc}")
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_asc}"
+        )
 
       assert json_response(conn1, 200)["results"] == [
                %{"name" => "Z", "visitors" => 1, "bounce_rate" => 100, "visit_duration" => 0},
@@ -591,7 +594,10 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       order_by_flipped = Jason.encode!([["visit_duration", "desc"], ["visit:source", "asc"]])
 
       conn2 =
-        get(conn, "/api/stats/#{site.domain}/sources?detailed=true&order_by=#{order_by_flipped}")
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_flipped}"
+        )
 
       assert json_response(conn2, 200)["results"] == [
                %{"name" => "B", "visitors" => 1, "bounce_rate" => 0, "visit_duration" => 45},


### PR DESCRIPTION
### Changes

Today one test started consistently failing across local dev envs and CI:

```
   1) test GET /api/stats/:domain/sources order_by [[visit_duration, asc], [visit:source, desc]]] is respected and flipping the sort orders works (PlausibleWeb.Api.StatsController.SourcesTest)
Error:      test/plausible_web/controllers/api/stats_controller/sources_test.exs:544
     Assertion with == failed
     code:  assert json_response(conn1, 200)["results"] == [
              %{"name" => "Z", "visitors" => 1, "bounce_rate" => 100, "visit_duration" => 0},
              %{"name" => "A", "visitors" => 2, "bounce_rate" => 100, "visit_duration" => 0},
              %{"name" => "C", "visitors" => 1, "bounce_rate" => 0, "visit_duration" => 30},
              %{"name" => "B", "visitors" => 1, "bounce_rate" => 0, "visit_duration" => 45}
            ]
     left:  [
              %{
                "bounce_rate" => 100,
                "name" => "Z",
                "visit_duration" => 0,
                "visitors" => 1
              },
              %{
                "bounce_rate" => 100,
                "name" => "A",
                "visit_duration" => 0,
                "visitors" => 2
              }
            ]
     right: [
              %{
                "bounce_rate" => 100,
                "name" => "Z",
                "visit_duration" => 0,
                "visitors" => 1
              },
              %{
                "bounce_rate" => 100,
                "name" => "A",
                "visit_duration" => 0,
                "visitors" => 2
              },
              %{
                "bounce_rate" => 0,
                "name" => "C",
                "visit_duration" => 30,
                "visitors" => 1
              },
              %{
                "bounce_rate" => 0,
                "name" => "B",
                "visit_duration" => 45,
                "visitors" => 1
              }
            ]
     stacktrace:
       test/plausible_web/controllers/api/stats_controller/sources_test.exs:584: (test)
```

Ultimately it turned out the setup had part of events with timestamp setup explicitly to 2024-10-08 and part not, while the endpoint query used implicit date (today) and implicit period (last 30 days). Once the fixed timestamp entries went beyond 30 days since 2024-08-10, the test started failing. This PR changes the test to use fixed time consistently.