### PR TITLE
Limit docs query API, return 401 for API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 - Improve Google error messages in CE plausible/analytics#4485
 - Better compress static assets in CE plausible/analytics#4476
 - Return domain-less cookies in CE plausible/analytics#4482
-- Internal stats API routes now return 401 over 404 in case of invalid access.
+- Internal stats API routes now return a JSON error over HTML in case of invalid access.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Improve Google error messages in CE plausible/analytics#4485
 - Better compress static assets in CE plausible/analytics#4476
 - Return domain-less cookies in CE plausible/analytics#4482
+- Internal stats API routes now return 401 over 404 in case of invalid access.
 
 ### Fixed
 

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -66,7 +66,10 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
   defp fail(conn) do
     case get_format(conn) do
       "json" ->
-        PlausibleWeb.Api.Helpers.unauthorized(conn, "User does not have sufficient access.")
+        PlausibleWeb.Api.Helpers.not_found(
+          conn,
+          "Site does not exist or user does not have sufficient access."
+        )
 
       _ ->
         PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -1,5 +1,6 @@
 defmodule PlausibleWeb.AuthorizeSiteAccess do
   import Plug.Conn
+  import Phoenix.Controller, only: [get_format: 1]
   use Plausible.Repo
 
   def init([]), do: [:public, :viewer, :admin, :super_admin, :owner]
@@ -18,7 +19,7 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
       shared_link_auth && Repo.get_by(Plausible.Site.SharedLink, slug: shared_link_auth)
 
     if !site do
-      PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt
+      fail(conn)
     else
       user_id =
         case PlausibleWeb.UserAuth.get_user_session(conn) do
@@ -57,8 +58,18 @@ defmodule PlausibleWeb.AuthorizeSiteAccess do
 
         merge_assigns(conn, site: site, current_user_role: role)
       else
-        PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt
+        fail(conn)
       end
+    end
+  end
+
+  defp fail(conn) do
+    case get_format(conn) do
+      "json" ->
+        PlausibleWeb.Api.Helpers.unauthorized(conn, "User does not have sufficient access.")
+
+      _ ->
+        PlausibleWeb.ControllerHelpers.render_error(conn, 404) |> halt
     end
   end
 end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -48,6 +48,16 @@ defmodule PlausibleWeb.Router do
     plug PlausibleWeb.Plugs.NoRobots
   end
 
+  pipeline :docs_stats_api do
+    plug :accepts, ["json"]
+    plug :fetch_session
+    plug PlausibleWeb.AuthPlug
+
+    plug PlausibleWeb.AuthorizeSiteAccess, [:admin, :super_admin, :owner]
+
+    plug PlausibleWeb.Plugs.NoRobots
+  end
+
   pipeline :public_api do
     plug :accepts, ["json"]
   end
@@ -191,7 +201,7 @@ defmodule PlausibleWeb.Router do
     get "/query/schema.json", ExternalQueryApiController, :schema
 
     scope [] do
-      pipe_through :internal_stats_api
+      pipe_through :docs_stats_api
 
       post "/query", ExternalQueryApiController, :query
     end

--- a/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
@@ -2,19 +2,19 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
   use PlausibleWeb.ConnCase
 
   describe "API authorization - as anonymous user" do
-    test "Sends 404 Not found for a site that doesn't exist", %{conn: conn} do
+    test "Sends 401 Unauthorized for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
       conn = get(conn, "/api/stats/fake-site.com/main-graph")
 
-      assert conn.status == 404
+      assert conn.status == 401
     end
 
-    test "Sends 404 Not found for private site", %{conn: conn} do
+    test "Sends 401 Unauthorized for private site", %{conn: conn} do
       conn = init_session(conn)
       site = insert(:site, public: false)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
-      assert conn.status == 404
+      assert conn.status == 401
     end
 
     test "returns stats for public site", %{conn: conn} do
@@ -29,18 +29,18 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
   describe "API authorization - as logged in user" do
     setup [:create_user, :log_in]
 
-    test "Sends 404 Not found for a site that doesn't exist", %{conn: conn} do
+    test "Sends 401 Unauthorized for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
       conn = get(conn, "/api/stats/fake-site.com/main-graph/")
 
-      assert conn.status == 404
+      assert conn.status == 401
     end
 
-    test "Sends 404 Not found when user does not have access to site", %{conn: conn} do
+    test "Sends 401 Unauthorized when user does not have access to site", %{conn: conn} do
       site = insert(:site)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
-      assert conn.status == 404
+      assert conn.status == 401
     end
 
     test "returns stats for public site", %{conn: conn} do

--- a/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
@@ -2,19 +2,19 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
   use PlausibleWeb.ConnCase
 
   describe "API authorization - as anonymous user" do
-    test "Sends 401 Unauthorized for a site that doesn't exist", %{conn: conn} do
+    test "Sends 404 Not found for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
       conn = get(conn, "/api/stats/fake-site.com/main-graph")
 
-      assert conn.status == 401
+      assert conn.status == 404
     end
 
-    test "Sends 401 Unauthorized for private site", %{conn: conn} do
+    test "Sends 404 Not found for private site", %{conn: conn} do
       conn = init_session(conn)
       site = insert(:site, public: false)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
-      assert conn.status == 401
+      assert conn.status == 404
     end
 
     test "returns stats for public site", %{conn: conn} do
@@ -29,18 +29,18 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
   describe "API authorization - as logged in user" do
     setup [:create_user, :log_in]
 
-    test "Sends 401 Unauthorized for a site that doesn't exist", %{conn: conn} do
+    test "Sends 404 Not found for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
       conn = get(conn, "/api/stats/fake-site.com/main-graph/")
 
-      assert conn.status == 401
+      assert conn.status == 404
     end
 
-    test "Sends 401 Unauthorized when user does not have access to site", %{conn: conn} do
+    test "Sends 404 Not found when user does not have access to site", %{conn: conn} do
       site = insert(:site)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
-      assert conn.status == 401
+      assert conn.status == 404
     end
 
     test "returns stats for public site", %{conn: conn} do

--- a/test/plausible_web/plugs/authorise_site_access_test.exs
+++ b/test/plausible_web/plugs/authorise_site_access_test.exs
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.AuthorizeSiteAccessTest do
     assert conn.path_params == %{"website" => other_site.domain}
   end
 
-  test "returns 401 for failed API routes", %{conn: conn, user: user} do
+  test "returns 404 with custom error message for failed API routes", %{conn: conn, user: user} do
     site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
 
     conn =
@@ -31,7 +31,9 @@ defmodule PlausibleWeb.AuthorizeSiteAccessTest do
       |> AuthorizeSiteAccess.call([:admin, :owner, :super_admin])
 
     assert conn.halted
-    assert conn.status == 401
-    assert conn.resp_body == "{\"error\":\"User does not have sufficient access.\"}"
+    assert conn.status == 404
+
+    assert conn.resp_body ==
+             "{\"error\":\"Site does not exist or user does not have sufficient access.\"}"
   end
 end

--- a/test/plausible_web/plugs/authorise_site_access_test.exs
+++ b/test/plausible_web/plugs/authorise_site_access_test.exs
@@ -14,10 +14,24 @@ defmodule PlausibleWeb.AuthorizeSiteAccessTest do
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{other_site.domain}/settings", %{"domain" => my_site.domain})
-      |> AuthorizeSiteAccess.call(_allowed_roles = [:admin, :owner])
+      |> AuthorizeSiteAccess.call([:admin, :owner])
 
     assert conn.halted
     assert conn.status == 404
     assert conn.path_params == %{"website" => other_site.domain}
+  end
+
+  test "returns 401 for failed API routes", %{conn: conn, user: user} do
+    site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
+
+    conn =
+      conn
+      |> bypass_through(PlausibleWeb.Router)
+      |> get("/api/stats/#{site.domain}/main-graph")
+      |> AuthorizeSiteAccess.call([:admin, :owner, :super_admin])
+
+    assert conn.halted
+    assert conn.status == 401
+    assert conn.resp_body == "{\"error\":\"User does not have sufficient access.\"}"
   end
 end


### PR DESCRIPTION
### Changes

After this:
- Docs Query API routes are not queriable by viewers/public
- API routes return a JSON error over html page

Solves https://3.basecamp.com/5308029/buckets/37310803/card_tables/cards/7782351091

There might be a follow-up docs change to tweak behavior when user has insufficient access or isn't logged in.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change