### PR TITLE
APIv2: Support `timezone` query parameter 

### DIFF
--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -58,10 +58,10 @@ defmodule Plausible.Stats.Comparisons do
       January 1st. Defaults to false.
 
   """
-  def compare(%Plausible.Site{} = site, %Stats.Query{} = source_query, mode, opts \\ []) do
+  def compare(%Plausible.Site{} = _site, %Stats.Query{} = source_query, mode, opts \\ []) do
     opts =
       opts
-      |> Keyword.put_new(:now, DateTime.now!(site.timezone))
+      |> Keyword.put_new(:now, DateTime.now!(source_query.timezone))
       |> Keyword.put_new(:match_day_of_week?, false)
 
     source_date_range = Query.date_range(source_query)
@@ -69,7 +69,11 @@ defmodule Plausible.Stats.Comparisons do
     with :ok <- validate_mode(source_query, mode),
          {:ok, comparison_date_range} <- get_comparison_date_range(source_date_range, mode, opts) do
       new_range =
-        DateTimeRange.new!(comparison_date_range.first, comparison_date_range.last, site.timezone)
+        DateTimeRange.new!(
+          comparison_date_range.first,
+          comparison_date_range.last,
+          source_query.timezone
+        )
         |> DateTimeRange.to_timezone("Etc/UTC")
 
       comparison_query =

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.Api.StatsController do
         end
 
       labels = label_timeseries(timeseries_result, comparison_result)
-      present_index = present_index_for(site, query, labels)
+      present_index = present_index_for(query, labels)
       full_intervals = build_full_intervals(query, labels)
 
       json(conn, %{
@@ -265,18 +265,18 @@ defmodule PlausibleWeb.Api.StatsController do
     end
   end
 
-  defp present_index_for(site, query, dates) do
+  defp present_index_for(query, dates) do
     case query.interval do
       "hour" ->
         current_date =
-          DateTime.now!(site.timezone)
+          DateTime.now!(query.timezone)
           |> Calendar.strftime("%Y-%m-%d %H:00:00")
 
         Enum.find_index(dates, &(&1 == current_date))
 
       "day" ->
         current_date =
-          DateTime.now!(site.timezone)
+          DateTime.now!(query.timezone)
           |> Timex.to_date()
           |> Date.to_string()
 
@@ -286,7 +286,7 @@ defmodule PlausibleWeb.Api.StatsController do
         date_range = Query.date_range(query)
 
         current_date =
-          DateTime.now!(site.timezone)
+          DateTime.now!(query.timezone)
           |> Timex.to_date()
           |> Time.date_or_weekstart(date_range)
           |> Date.to_string()
@@ -295,7 +295,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
       "month" ->
         current_date =
-          DateTime.now!(site.timezone)
+          DateTime.now!(query.timezone)
           |> Timex.to_date()
           |> Timex.beginning_of_month()
           |> Date.to_string()
@@ -304,7 +304,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
       "minute" ->
         current_date =
-          DateTime.now!(site.timezone)
+          DateTime.now!(query.timezone)
           |> Calendar.strftime("%Y-%m-%d %H:%M:00")
 
         Enum.find_index(dates, &(&1 == current_date))

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -50,6 +50,15 @@
           "type": "boolean"
         }
       }
+    },
+    "timezone": {
+      "type": "string",
+      "description": "Time zone for query results to be reported in. Defaults to site timezone.",
+      "examples": [
+        "Europe/Tallinn",
+        "US/Eastern",
+        "UTC"
+      ]
     }
   },
   "required": ["site_id", "metrics", "date_range"],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_validations_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_validations_test.exs
@@ -258,5 +258,23 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryValidationsTest do
                  "Invalid visit:country filter, visit:country needs to be a valid 2-letter country code."
              }
     end
+
+    test "handles invalid timezones", %{
+      conn: conn,
+      site: site
+    } do
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["pageviews"],
+          "timezone" => "invalid"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "Invalid time zone `\"invalid\"`. Check IANA time zone database for a list of supported timezones."
+             }
+    end
   end
 end


### PR DESCRIPTION
This parameter determines what time zone the query result is in and how custom date ranges are parsed.

Mentioned in a user request.