### PR TITLE
Fix race condition merging session data when cache returns

### DIFF
--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -52,6 +52,7 @@ defmodule Plausible.Session.CacheStore do
   defp persist_session(session) do
     key = {session.site_id, session.user_id}
     Plausible.Cache.Adapter.put(:sessions, key, session, dirty?: true)
+    session
   end
 
   defp update_session(session, event) do


### PR DESCRIPTION
`persist_session/1` is used in `populate_native_stats/1` test helper to merge session data. It sometimes gets `:ok` instead of the actual session data so that tests randomly fail with:

```
** (BadMapError) expected a map, got: :ok
code: populate_stats(site, [build(:pageview)])
stacktrace:
(elixir 1.17.1) lib/map.ex:486: Map.take/2
(plausible 0.0.1) lib/plausible/clickhouse_event_v2.ex:92: Plausible.ClickhouseEventV2.merge_session/2
(plausible 0.0.1) test/support/test_utils.ex:188: anonymous fn/2 in Plausible.TestUtils.populate_native_stats/1
(elixir 1.17.1) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
(plausible 0.0.1) test/support/test_utils.ex:184: Plausible.TestUtils.populate_native_stats/1
(plausible 0.0.1) test/support/test_utils.ex:179: Plausible.TestUtils.populate_stats/1
test/workers/send_site_setup_emails_test.exs:46: (test)
```

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
