### PR TITLE
Dashboard: Fix countries/regions/cities tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - Fix property filter suggestions 500 error when property hasn't been selected
 - Bamboo.Mua: add Date and Message-ID headers if missing plausible/analytics#4474
 - Fix migration order across `plausible_db` and `plausible_events_db` databases plausible/analytics#4466
+- Fix tooltips for countries/cities/regions links in dashboard
 
 ## v2.1.1 - 2024-06-06
 

--- a/assets/js/dashboard/stats/reports/list.js
+++ b/assets/js/dashboard/stats/reports/list.js
@@ -28,8 +28,8 @@ export function FilterLink({ path, filterInfo, onClick, children, extraClass }) 
     const newLabels = cleanLabels(newFilters, query.labels, filter[1], labels)
 
     return (
-      <AppNavigationLink 
-        title={`Add filter: ${plainFilterText(query, filter)}`}
+      <AppNavigationLink
+        title={`Add filter: ${plainFilterText({ ...query, labels: newLabels }, filter)}`}
         className={className}
         path={path}
         onClick={onClick}


### PR DESCRIPTION
Previously these tooltips said `Add filter: Country is undefined` because new labels were yet to be in `query`.

cc @apata - curious on your thoughts on if or how best test this

Basecamp: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7816925449