### PR TITLE
Set postgres pool size to 2*cores for test env

### DIFF
--- a/config/.env.test
+++ b/config/.env.test
@@ -1,4 +1,4 @@
-DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_test?pool_size=40
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_test
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_test
 SECRET_KEY_BASE=/njrhntbycvastyvtk1zycwfm981vpo/0xrvwjjvemdakc/vsvbrevlwsc6u8rcg
 TOTP_VAULT_KEY=1Jah1HEOnCEnmBE+4/OgbJRraJIppPmYCNbZoFJboZs=

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,7 +6,9 @@ config :plausible, PlausibleWeb.Endpoint, server: false
 
 config :bcrypt_elixir, :log_rounds, 4
 
-config :plausible, Plausible.Repo, pool: Ecto.Adapters.SQL.Sandbox
+config :plausible, Plausible.Repo,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: System.schedulers_online() * 2
 
 config :plausible, Plausible.ClickhouseRepo,
   loggers: [Ecto.LogEntry],


### PR DESCRIPTION
This should help with random pool timeouts, at least on AMD Linux with 24 cores.
Helps narrowing down more test flakiness later on.


![image](https://github.com/user-attachments/assets/5dd6b675-364a-41ba-ad8b-de3065d17135)


![image](https://github.com/user-attachments/assets/3219b38f-c37d-457f-97f3-9b9adcc06139)
