### PR TITLE
Drop event explicitly on session lock timeout 

### DIFF
--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -11,7 +11,7 @@ defmodule Plausible.Session.CacheStore do
   def on_event(event, session_attributes, prev_user_id, buffer_insert \\ &WriteBuffer.insert/1) do
     lock_requested_at = System.monotonic_time()
 
-    Plausible.Cache.Adapter.with_lock!(
+    Plausible.Cache.Adapter.with_lock(
       :sessions,
       {event.site_id, event.user_id},
       @lock_timeout,

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -278,6 +278,46 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :payment_required
   end
 
+  @tag :slow
+  test "drops events on session lock timeout" do
+    site = insert(:site)
+
+    very_slow_buffer = fn sessions ->
+      Process.sleep(1000)
+      Plausible.Session.WriteBuffer.insert(sessions)
+    end
+
+    first_conn =
+      build_conn(:post, "/api/events", %{
+        name: "pageview",
+        url: "http://dummy.site",
+        d: "#{site.domain}"
+      })
+
+    assert {:ok, first_request} = Request.build(first_conn)
+
+    second_conn =
+      build_conn(:post, "/api/events", %{
+        name: "page_scrolled",
+        url: "http://dummy.site",
+        d: "#{site.domain}"
+      })
+
+    assert {:ok, second_request} = Request.build(second_conn)
+
+    Task.start(fn ->
+      assert {:ok, %{buffered: [_event], dropped: []}} =
+               Event.build_and_buffer(first_request,
+                 session_write_buffer_insert: very_slow_buffer
+               )
+    end)
+
+    Process.sleep(100)
+
+    assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(second_request)
+    assert dropped.drop_reason == :lock_timeout
+  end
+
   @tag :ee_only
   test "saves revenue amount" do
     site = insert(:site)

--- a/test/plausible/session/cache_store_test.exs
+++ b/test/plausible/session/cache_store_test.exs
@@ -1,8 +1,6 @@
 defmodule Plausible.Session.CacheStoreTest do
   use Plausible.DataCase
 
-  import ExUnit.CaptureLog
-
   alias Plausible.Session.CacheStore
 
   setup do
@@ -156,9 +154,7 @@ defmodule Plausible.Session.CacheStoreTest do
         CacheStore.on_event(event3, session_params, nil, buffer)
       end)
 
-    capture_log(fn ->
-      Task.await_many([async1, async2, async3])
-    end) =~ "Timeout while executing with lock on key in ':sessions'"
+    Task.await_many([async1, async2, async3])
 
     assert_receive({:very_slow_buffer, :insert, [[_session]]})
     refute_receive({:buffer, :insert, [[_updated_session]]})

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
   alias Plausible.Billing.Feature
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "feature access" do
     test "cannot filter by a custom prop without access to the props feature", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   use PlausibleWeb.ConnCase
   alias Plausible.Billing.Feature
 
-  @user_id 1231
+  @user_id Enum.random(1000..9999)
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 1231
+  @user_id Enum.random(1000..9999)
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 1231
+  @user_id Enum.random(1000..9999)
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 1231
+  @user_id Enum.random(1000..9999)
 
   setup [:create_user, :create_new_site, :create_api_key, :use_api_key]
 

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -114,7 +114,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     end
   end
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
+
   test "shows hourly data for a certain date", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "GET /api/stats/:domain/conversions" do
     setup [:create_user, :log_in, :create_new_site]

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -4,8 +4,8 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
   @moduletag :ee_only
 
   on_ee do
-    @user_id 123
-    @other_user_id 456
+    @user_id Enum.random(1000..9999)
+    @other_user_id @user_id + 1
 
     @build_funnel_with [
       {"page_path", "/blog/announcement"},

--- a/test/plausible_web/controllers/api/stats_controller/imported_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/imported_test.exs
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
   use PlausibleWeb.ConnCase
   use Timex
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   defp import_data(ga_data, site_id, import_id, table_name) do
     ga_data

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "GET /api/stats/main-graph - plot" do
     setup [:create_user, :log_in, :create_new_site, :create_legacy_site_import]

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController.PagesTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "GET /api/stats/:domain/pages" do
     setup [:create_user, :log_in, :create_new_site, :create_legacy_site_import]

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController.SourcesTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "GET /api/stats/:domain/sources" do
     setup [:create_user, :log_in, :create_new_site, :create_legacy_site_import]

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1,7 +1,7 @@
 defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
   use PlausibleWeb.ConnCase
 
-  @user_id 123
+  @user_id Enum.random(1000..9999)
 
   describe "GET /api/stats/top-stats - default" do
     setup [:create_user, :log_in, :create_new_site]

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -182,7 +182,7 @@ defmodule Plausible.TestUtils do
 
   defp populate_native_stats(events) do
     for event_params <- events do
-      session = Plausible.Session.CacheStore.on_event(event_params, event_params, nil)
+      {:ok, session} = Plausible.Session.CacheStore.on_event(event_params, event_params, nil)
 
       event_params
       |> Plausible.ClickhouseEventV2.merge_session(session)


### PR DESCRIPTION
### Changes

Currently, the `CacheStore.on_event` call for timed out lock case returns `:ok` instead of session, which leads to a pretty opaque error when trying to merge session data with event.

This change makes timeout handling explicit and drops the timed out event with `:lock_timeout` set as reason.

### Tests
- [x] Automated tests have been added

