### PR TITLE
Solve build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN apk upgrade --no-cache
 RUN apk add --no-cache openssl ncurses libstdc++ libgcc ca-certificates \
   && if [ "$MIX_ENV" = "ce" ]; then apk add --no-cache certbot; fi
 
-COPY --from=buildcontainer --chmod=a+rX /app/_build/${MIX_ENV}/rel/plausible /app
+COPY --from=buildcontainer --chmod=555 /app/_build/${MIX_ENV}/rel/plausible /app
 COPY --chmod=755 ./rel/docker-entrypoint.sh /entrypoint.sh
 
 # we need to allow "others" access to app folder, because


### PR DESCRIPTION
Building Dockerfile seems to be failing now with the following error:
```
Dockerfile:72
--------------------
  70 |       && if [ "$MIX_ENV" = "ce" ]; then apk add --no-cache certbot; fi
  71 |
  72 | >>> COPY --from=buildcontainer --chmod=a+rX /app/_build/${MIX_ENV}/rel/plausible /app
  73 |     COPY --chmod=755 ./rel/docker-entrypoint.sh /entrypoint.sh
  74 |
--------------------
ERROR: failed to solve: invalid chmod parameter: 'a+rX'. it should be octal string and between 0 and 07777
```

Link: https://github.com/plausible/analytics/actions/runs/10898788870/job/30242872415

~~Not sure _why_ given this line hasn't changed in ages, but perhaps something to do with buildx changes. If preview deploy succeeds in this, it should fix the issue.~~

From @zoldar:
> https://github.com/moby/buildkit/issues/5322 seems like non-octal chmod wasn't accepted before either but was just silently ignored?
> https://github.com/moby/buildkit/pull/5148 the change that started validating chmod, fwiw

Not confident this won't cause issues if the previous default that buildx used was 777.