### PR TITLE
Fix applying city filters

### DIFF
--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -119,7 +119,7 @@ defmodule Plausible.Stats.FilterSuggestions do
       city = Location.get_city(c)
 
       %{
-        value: Integer.to_string(c),
+        value: c,
         label: (city && city.name) || "N/A"
       }
     end)
@@ -145,12 +145,7 @@ defmodule Plausible.Stats.FilterSuggestions do
       city && String.contains?(String.downcase(city.name), filter_search)
     end)
     |> Enum.slice(0..24)
-    |> Enum.map(fn c ->
-      %{
-        value: Integer.to_string(c.id),
-        label: c.name
-      }
-    end)
+    |> Enum.map(fn c -> %{value: c.id, label: c.name} end)
   end
 
   def filter_suggestions(site, _query, "goal", filter_search) do

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -131,7 +131,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
           "/api/stats/#{site.domain}/suggestions/city?q=Kär"
         )
 
-      assert json_response(conn, 200) == [%{"value" => "591632", "label" => "Kärdla"}]
+      assert json_response(conn, 200) == [%{"value" => 591_632, "label" => "Kärdla"}]
     end
 
     test "returns suggestions for countries without country in search", %{conn: conn, site: site} do
@@ -883,8 +883,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
           )
 
         assert json_response(conn, 200) == [
-                 %{"value" => "588409", "label" => "Tallinn"},
-                 %{"value" => "591632", "label" => "Kärdla"}
+                 %{"value" => 588_409, "label" => "Tallinn"},
+                 %{"value" => 591_632, "label" => "Kärdla"}
                ]
       end
     end
@@ -912,7 +912,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
           "/api/stats/#{site.domain}/suggestions/city?filters=#{filters}&q=&with_imported=true"
         )
 
-      assert json_response(conn, 200) == [%{"value" => "591632", "label" => "Kärdla"}]
+      assert json_response(conn, 200) == [%{"value" => 591_632, "label" => "Kärdla"}]
     end
 
     test "queries imported cities when filtering by city", %{
@@ -932,7 +932,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
           "/api/stats/#{site.domain}/suggestions/city?period=month&date=2019-01-01&filters=#{filters}&q=&with_imported=true"
         )
 
-      assert json_response(conn, 200) == [%{"value" => "591632", "label" => "Kärdla"}]
+      assert json_response(conn, 200) == [%{"value" => 591_632, "label" => "Kärdla"}]
     end
 
     test "ignores imported city data when not requested", %{


### PR DESCRIPTION
### Changes

Currently, when clicking on a city in the Locations report to filter by it, the city code will become an integer in the filter.

However, when applying the city filter from the filter modal, the city code will become a string in the filter, because the value returned from city filter suggestions is a string.

When applying filters only from the filter modal, it works. But when applying a filter first by clicking on a city in the Locations report, then editing the filter, and adding another city - it breaks because string and integer types are mixed.

This PR fixes that by returning integers instead of strings from the filter suggestions API. It's also consistent with the cities breakdown report where integers are returned.

### Tests
- [x] Automated tests have been adjusted

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
