### PR TITLE
Fix auth issue with POST /api/docs/query

### DIFF
--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -64,7 +64,11 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   end
 
   defp get_site_with_role(conn, current_user) do
-    domain = conn.path_params["domain"] || conn.path_params["website"]
+    # addition is flimsy, do we need an extra argument on plug init to control where we look for the domain?
+    domain =
+      conn.path_params["domain"] || conn.path_params["website"] ||
+        (conn.method == "POST" && conn.path_info == ["api", "docs", "query"] &&
+           conn.params["site_id"])
 
     site_query =
       from(

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -50,9 +50,7 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["json"]
     plug :fetch_session
     plug PlausibleWeb.AuthPlug
-
     plug PlausibleWeb.Plugs.AuthorizeSiteAccess, [:admin, :super_admin, :owner]
-
     plug PlausibleWeb.Plugs.NoRobots
   end
 

--- a/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
@@ -1,0 +1,60 @@
+defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
+  use PlausibleWeb.ConnCase, async: true
+  use Plausible.Repo
+  @user_id Enum.random(1000..9999)
+
+  describe "POST /api/docs/query not logged in" do
+    setup [:create_user, :create_new_site]
+
+    test "rejects request when not logged in", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/docs/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["pageviews"],
+          "date_range" => "all"
+        })
+
+      assert json_response(conn, 404) == %{
+               "error" => "Site does not exist or user does not have sufficient access."
+             }
+    end
+  end
+
+  describe "POST /api/docs/query logged in" do
+    setup [:create_user, :create_new_site, :log_in]
+
+    test "rejects when accessing any other site", %{conn: conn} do
+      conn =
+        post(conn, "/api/docs/query", %{
+          "site_id" => "any.other.site",
+          "metrics" => ["pageviews"],
+          "date_range" => "all"
+        })
+
+      assert json_response(conn, 404) == %{
+               "error" => "Site does not exist or user does not have sufficient access."
+             }
+    end
+
+    test "returns aggregated metrics", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:25:00]),
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/docs/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["pageviews"],
+          "date_range" => "all"
+        })
+
+      assert json_response(conn, 200)["results"] == [%{"metrics" => [3], "dimensions" => []}]
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Makes the authorize site access plug aware of another way to pass the domain. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
