### PR TITLE
Allow configuring `AuthorizeSiteAccess` plug site param

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,7 @@ config :plausible, PlausibleWeb.Endpoint,
   watchers: [
     esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]},
-    npm: ["--prefix", "assets", "run", "typecheck", "--", "--watch"],
+    npm: ["--prefix", "assets", "run", "typecheck", "--", "--watch", "--preserveWatchOutput"],
     npm: [
       "run",
       "deploy",

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -84,6 +84,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
 
   defp get_domain(conn, site_param) do
     domain = conn.params[site_param]
+
     if is_binary(domain) do
       {:ok, domain}
     else

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -83,7 +83,8 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   end
 
   defp get_domain(conn, site_param) do
-    if is_binary(domain = conn.params[site_param]) do
+    domain = conn.params[site_param]
+    if is_binary(domain) do
       {:ok, domain}
     else
       error_not_found(conn)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
 
     if !is_binary(site_param) && !is_nil(site_param) do
-      raise ArgumentError, "Invalid site param given: #{inspect(site_param)}"
+      raise ArgumentError, "Invalid site param configured: #{inspect(site_param)}"
     end
 
     {allowed_roles, site_param}
@@ -83,7 +83,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   end
 
   defp get_domain(conn, site_param) do
-    if domain = conn.params[site_param] do
+    if is_binary(domain = conn.params[site_param]) do
       {:ok, domain}
     else
       error_not_found(conn)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
 
   def init([]), do: @all_roles
 
-  def init(allowed_roles) do
+  def init(allowed_roles) when is_list(allowed_roles) do
     unknown_roles = allowed_roles -- @all_roles
 
     if unknown_roles != [] do
@@ -22,10 +22,23 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     allowed_roles
   end
 
-  def call(conn, allowed_roles) do
+  def init({allowed_roles, conn_params_domain_accessor})
+      when is_list(allowed_roles) and is_binary(conn_params_domain_accessor) do
+    {init(allowed_roles), conn_params_domain_accessor}
+  end
+
+  def call(conn, options) do
     current_user = conn.assigns[:current_user]
 
-    with {:ok, %{site: site, role: membership_role}} <- get_site_with_role(conn, current_user),
+    {allowed_roles, conn_params_domain_accessor} =
+      if is_tuple(options) do
+        options
+      else
+        {options, nil}
+      end
+
+    with {:ok, %{site: site, role: membership_role}} <-
+           get_site_with_role(conn, current_user, conn_params_domain_accessor),
          {:ok, shared_link} <- maybe_get_shared_link(conn, site) do
       role =
         cond do
@@ -63,12 +76,16 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
-  defp get_site_with_role(conn, current_user) do
-    # addition is flimsy, do we need an extra argument on plug init to control where we look for the domain?
-    domain =
-      conn.path_params["domain"] ||
-        (conn.method == "POST" && conn.path_info == ["api", "docs", "query"] &&
-           conn.params["site_id"])
+  defp get_domain_from_conn(conn, nil) do
+    conn.path_params["domain"] || conn.path_params["website"]
+  end
+
+  defp get_domain_from_conn(conn, conn_params_domain_accessor) do
+    conn.params[conn_params_domain_accessor]
+  end
+
+  defp get_site_with_role(conn, current_user, conn_params_domain_accessor) do
+    domain = get_domain_from_conn(conn, conn_params_domain_accessor)
 
     site_query =
       from(

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -16,8 +16,14 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     init({allowed_roles, nil})
   end
 
-  def init({allowed_roles, site_param})
-      when is_list(allowed_roles) do
+  def init({allowed_roles, site_param}) when is_list(allowed_roles) do
+    allowed_roles =
+      if allowed_roles == [] do
+        @all_roles
+      else
+        allowed_roles
+      end
+
     unknown_roles = allowed_roles -- @all_roles
 
     if unknown_roles != [] do

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -1,6 +1,36 @@
 defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   @moduledoc """
   Plug restricting access to site and shared link, when present.
+
+  In order to permit access to site regardless of role:
+
+  ```elixir
+  plug #{inspect(__MODULE__)}
+  ```
+
+  or
+
+  ```elixir
+  plug #{inspect(__MODULE__)}, :all_roles
+  ```
+
+  Permit access for a subset of roles only:
+
+  ```elixir
+  plug #{inspect(__MODULE__)}, [:admin, :owner, :super_admin]
+  ```
+
+  Permit access using a custom site param:
+
+  ```elixir
+  plug #{inspect(__MODULE__)}, {[:admin, :owner, :super_admin], "site_id"}
+  ```
+
+  or in case where any role is allowed:
+
+  ```elixir
+  plug #{inspect(__MODULE__)}, {:all_roles, "site_id"}
+  ```
   """
 
   use Plausible.Repo
@@ -12,8 +42,14 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
 
   def init([]), do: {@all_roles, nil}
 
+  def init(:all_roles), do: {@all_roles, nil}
+
   def init(allowed_roles) when is_list(allowed_roles) do
     init({allowed_roles, nil})
+  end
+
+  def init({:all_roles, site_param}) do
+    init({@all_roles, site_param})
   end
 
   def init({allowed_roles, site_param}) when is_list(allowed_roles) do

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -5,31 +5,31 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   In order to permit access to site regardless of role:
 
   ```elixir
-  plug #{inspect(__MODULE__)}
+  plug AuthorizeSiteAccess
   ```
 
   or
 
   ```elixir
-  plug #{inspect(__MODULE__)}, :all_roles
+  plug AuthorizeSiteAccess, :all_roles
   ```
 
   Permit access for a subset of roles only:
 
   ```elixir
-  plug #{inspect(__MODULE__)}, [:admin, :owner, :super_admin]
+  plug AuthorizeSiteAccess, [:admin, :owner, :super_admin]
   ```
 
   Permit access using a custom site param:
 
   ```elixir
-  plug #{inspect(__MODULE__)}, {[:admin, :owner, :super_admin], "site_id"}
+  plug AuthorizeSiteAccess, {[:admin, :owner, :super_admin], "site_id"}
   ```
 
   or in case where any role is allowed:
 
   ```elixir
-  plug #{inspect(__MODULE__)}, {:all_roles, "site_id"}
+  plug AuthorizeSiteAccess, {:all_roles, "site_id"}
   ```
   """
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -50,7 +50,7 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["json"]
     plug :fetch_session
     plug PlausibleWeb.AuthPlug
-    plug PlausibleWeb.Plugs.AuthorizeSiteAccess, [:admin, :super_admin, :owner]
+    plug PlausibleWeb.Plugs.AuthorizeSiteAccess, {[:admin, :super_admin, :owner], "site_id"}
     plug PlausibleWeb.Plugs.NoRobots
   end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -99,6 +99,26 @@ defmodule PlausibleWeb.Router do
     end
   end
 
+  # Routes for plug integration testing
+  if Mix.env() in [:test, :ce_test] do
+    scope "/plug-tests", PlausibleWeb do
+      scope [] do
+        pipe_through :browser
+
+        get("/basic", TestController, :browser)
+        get("/:domain/shared-link/:slug", TestController, :browser)
+        get("/:domain/with-domain", TestController, :browser)
+      end
+
+      scope [] do
+        pipe_through :api
+
+        get("/api-basic", TestController, :api)
+        get("/:domain/api-with-domain", TestController, :api)
+      end
+    end
+  end
+
   scope path: "/api/plugins", as: :plugins_api do
     pipeline :plugins_api_auth do
       plug(PlausibleWeb.Plugs.AuthorizePluginsAPI)

--- a/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
@@ -48,7 +48,7 @@ defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
       ])
 
       conn =
-        post(conn, "/api/docs/query", %{
+        post(conn, "/api/docs/query?site_id=ignored", %{
           "site_id" => site.domain,
           "metrics" => ["pageviews"],
           "date_range" => "all"

--- a/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
@@ -40,7 +40,20 @@ defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
              }
     end
 
-    test "returns aggregated metrics", %{conn: conn, site: site} do
+    test "rejects when using invalid param name", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/docs/query", %{
+          "domain" => site.domain,
+          "metrics" => ["pageviews"],
+          "date_range" => "all"
+        })
+
+      assert json_response(conn, 404) == %{
+               "error" => "Site does not exist or user does not have sufficient access."
+             }
+    end
+
+    test "returns aggregated metrics when site id given", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:25:00]),
@@ -48,13 +61,31 @@ defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
       ])
 
       conn =
-        post(conn, "/api/docs/query?site_id=ignored", %{
+        post(conn, "/api/docs/query?site_id=ignored_when_site_id_present_in_body", %{
           "site_id" => site.domain,
           "metrics" => ["pageviews"],
           "date_range" => "all"
         })
 
       assert json_response(conn, 200)["results"] == [%{"metrics" => [3], "dimensions" => []}]
+    end
+
+    # not ideal that it succeeds
+    test "succeeds when site_id missing in body, but present in query params", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/docs/query?site_id=#{site.domain}", %{
+          "metrics" => ["pageviews"],
+          "date_range" => "all"
+        })
+
+      assert json_response(conn, 200)["results"] == [%{"metrics" => [1], "dimensions" => []}]
     end
   end
 end

--- a/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
-  use PlausibleWeb.ConnCase, async: false
+  use PlausibleWeb.ConnCase, async: true
   use Plausible.Repo
   @user_id Enum.random(1000..9999)
 

--- a/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/docs_query_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
-  use PlausibleWeb.ConnCase, async: true
+  use PlausibleWeb.ConnCase, async: false
   use Plausible.Repo
   @user_id Enum.random(1000..9999)
 
@@ -70,7 +70,6 @@ defmodule PlausibleWeb.Api.InternalController.DocsQueryTest do
       assert json_response(conn, 200)["results"] == [%{"metrics" => [3], "dimensions" => []}]
     end
 
-    # not ideal that it succeeds
     test "succeeds when site_id missing in body, but present in query params", %{
       conn: conn,
       site: site

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -10,28 +10,83 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     end
   end
 
+  for init_argument <- [[], {[:public, :viewer, :admin, :super_admin, :owner], nil}] do
+    test "init resolves to expected options with argument #{inspect(init_argument)}" do
+      assert {[:public, :viewer, :admin, :super_admin, :owner], nil} ==
+               AuthorizeSiteAccess.init(unquote(init_argument))
+    end
+  end
+
+  for invalid_site_param <- [[], 1, :invalid] do
+    test "init rejects invalid site_param #{inspect(invalid_site_param)}" do
+      assert_raise ArgumentError, fn ->
+        AuthorizeSiteAccess.init({[:super_admin], unquote(invalid_site_param)})
+      end
+    end
+  end
+
   test "returns 404 on non-existent site", %{conn: conn} do
+    opts = AuthorizeSiteAccess.init(_all_allowed_roles = [])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/invalid.domain")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert html_response(conn, 404)
   end
 
   test "rejects user completely unrelated to the site", %{conn: conn} do
+    opts = AuthorizeSiteAccess.init(_all_allowed_roles = [])
+
     site = insert(:site, members: [build(:user)])
 
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert html_response(conn, 404)
+  end
+
+  test "can be configured to expect site domain at conn.params['some_key'], fails when this is not met",
+       %{
+         conn: conn,
+         site: site
+       } do
+    opts =
+      AuthorizeSiteAccess.init({[:public, :viewer, :admin, :super_admin, :owner], "some_key"})
+
+    conn =
+      conn
+      |> bypass_through(PlausibleWeb.Router)
+      |> get("/api/docs/query/schema.json", %{"wrong_key" => site.domain})
+      |> AuthorizeSiteAccess.call(opts)
+
+    assert conn.halted
+    assert conn.status == 404
+  end
+
+  test "can be configured to expect site domain at conn.params['some_key'], succeeds when it is met",
+       %{
+         conn: conn,
+         site: site
+       } do
+    opts =
+      AuthorizeSiteAccess.init({[:public, :viewer, :admin, :super_admin, :owner], "some_key"})
+
+    conn =
+      conn
+      |> bypass_through(PlausibleWeb.Router)
+      |> get("/api/docs/query/schema.json", %{"some_key" => site.domain})
+      |> AuthorizeSiteAccess.call(opts)
+
+    assert conn.status == 200
+    assert conn.assigns.site.id == site.id
   end
 
   test "doesn't allow bypassing :domain in path with :domain in query param", %{
@@ -40,13 +95,15 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   } do
     other_site = insert(:site, members: [build(:user)])
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:admin, :owner])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/sites/#{other_site.domain}/change-domain", %{
         "domain" => site.domain
       })
-      |> AuthorizeSiteAccess.call(_allowed_roles = [:admin, :owner])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert conn.status == 404
@@ -56,11 +113,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "returns 404 with custom error message for failed API routes", %{conn: conn, user: user} do
     site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
 
+    opts = AuthorizeSiteAccess.init([:admin, :owner, :super_admin])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/api/stats/#{site.domain}/main-graph")
-      |> AuthorizeSiteAccess.call([:admin, :owner, :super_admin])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
 
@@ -77,11 +136,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
     params = %{"shared_link" => %{"name" => "some name"}}
 
+    opts = AuthorizeSiteAccess.init([:super_admin, :admin, :owner])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> put("/sites/#{site.domain}/shared-links/#{shared_link_other_site.slug}", params)
-      |> AuthorizeSiteAccess.call(_allowed_roles = [:super_admin, :admin, :owner])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert conn.status == 404
@@ -96,11 +157,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     shared_link = insert(:shared_link, site: site)
     other_site = insert(:site, members: [user])
 
+    opts = AuthorizeSiteAccess.init([:super_admin, :admin, :owner])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{other_site.domain}", %{"auth" => shared_link.slug})
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert conn.status == 404
@@ -119,11 +182,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       "auth" => shared_link.slug
     }
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:super_admin, :admin, :owner])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> put("/sites/#{site.domain}/shared-links/#{shared_link_other_site.slug}", params)
-      |> AuthorizeSiteAccess.call(_allowed_roles = [:super_admin, :admin, :owner])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert conn.status == 404
@@ -133,11 +198,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site =
       insert(:site, memberships: [build(:site_membership, user: user, role: :admin)])
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:owner])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:owner])
+      |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
     assert html_response(conn, 404)
@@ -148,11 +215,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       site =
         insert(:site, memberships: [build(:site_membership, user: user, role: unquote(role))])
 
+      opts = AuthorizeSiteAccess.init(_allowed_roles = [unquote(role)])
+
       conn =
         conn
         |> bypass_through(PlausibleWeb.Router)
         |> get("/#{site.domain}")
-        |> AuthorizeSiteAccess.call(_all_allowed_roles = [unquote(role)])
+        |> AuthorizeSiteAccess.call(opts)
 
       refute conn.halted
       assert conn.assigns.site.id == site.id
@@ -166,11 +235,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
     patch_env(:super_admin_user_ids, [user.id])
 
+    opts = AuthorizeSiteAccess.init([:super_admin])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:super_admin])
+      |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
@@ -180,11 +251,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "allows user based on website visibility (authenticated user)", %{conn: conn} do
     site = insert(:site, members: [build(:user)], public: true)
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:public])
+      |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
@@ -193,11 +266,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "allows user based on website visibility (anonymous request)" do
     site = insert(:site, members: [build(:user)], public: true)
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+
     conn =
       build_conn()
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}")
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:public])
+      |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
@@ -207,11 +282,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site = insert(:site, members: [build(:user)])
     shared_link = insert(:shared_link, site: site)
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}", %{"auth" => shared_link.slug})
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:public])
+      |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
@@ -221,11 +298,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site = insert(:site, members: [build(:user)])
     shared_link = insert(:shared_link, site: site)
 
+    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+
     conn =
       build_conn()
       |> bypass_through(PlausibleWeb.Router)
       |> get("/#{site.domain}", %{"auth" => shared_link.slug})
-      |> AuthorizeSiteAccess.call(_all_allowed_roles = [:public])
+      |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
     assert conn.assigns.site.id == site.id

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/invalid.domain")
+      |> get("/plug-tests/invalid.domain/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -46,7 +46,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}")
+      |> get("/plug-tests/#{site.domain}/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -64,7 +64,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/api/docs/query/schema.json", %{"wrong_key" => site.domain})
+      |> get("/plug-tests/basic", %{"wrong_key" => site.domain})
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -82,10 +82,10 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/api/docs/query/schema.json", %{"some_key" => site.domain})
+      |> get("/plug-tests/basic", %{"some_key" => site.domain})
       |> AuthorizeSiteAccess.call(opts)
 
-    assert conn.status == 200
+    refute conn.halted
     assert conn.assigns.site.id == site.id
   end
 
@@ -100,7 +100,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/sites/#{other_site.domain}/change-domain", %{
+      |> get("/plug-tests/#{other_site.domain}/with-domain", %{
         "domain" => site.domain
       })
       |> AuthorizeSiteAccess.call(opts)
@@ -118,7 +118,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/api/stats/#{site.domain}/main-graph")
+      |> get("/plug-tests/#{site.domain}/api-with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -141,7 +141,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> put("/sites/#{site.domain}/shared-links/#{shared_link_other_site.slug}", params)
+      |> get("/plug-tests/#{site.domain}/shared-link/#{shared_link_other_site.slug}", params)
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -162,7 +162,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{other_site.domain}", %{"auth" => shared_link.slug})
+      |> get("/plug-tests/#{other_site.domain}/with-domain", %{"auth" => shared_link.slug})
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -187,7 +187,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> put("/sites/#{site.domain}/shared-links/#{shared_link_other_site.slug}", params)
+      |> get("/plug-tests/#{site.domain}/shared-link/#{shared_link_other_site.slug}", params)
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -203,7 +203,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}")
+      |> get("/plug-tests/#{site.domain}/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     assert conn.halted
@@ -220,7 +220,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       conn =
         conn
         |> bypass_through(PlausibleWeb.Router)
-        |> get("/#{site.domain}")
+        |> get("/plug-tests/#{site.domain}/with-domain")
         |> AuthorizeSiteAccess.call(opts)
 
       refute conn.halted
@@ -240,7 +240,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}")
+      |> get("/plug-tests/#{site.domain}/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
@@ -256,7 +256,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}")
+      |> get("/plug-tests/#{site.domain}/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
@@ -271,7 +271,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       build_conn()
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}")
+      |> get("/plug-tests/#{site.domain}/with-domain")
       |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
@@ -287,7 +287,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       conn
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}", %{"auth" => shared_link.slug})
+      |> get("/plug-tests/#{site.domain}/with-domain", %{"auth" => shared_link.slug})
       |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted
@@ -303,7 +303,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn =
       build_conn()
       |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{site.domain}", %{"auth" => shared_link.slug})
+      |> get("/plug-tests/#{site.domain}/with-domain", %{"auth" => shared_link.slug})
       |> AuthorizeSiteAccess.call(opts)
 
     refute conn.halted

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
          site: site
        } do
     opts =
-      AuthorizeSiteAccess.init({[:public, :viewer, :admin, :super_admin, :owner], "some_key"})
+      AuthorizeSiteAccess.init({[], "some_key"})
 
     conn =
       conn
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
          site: site
        } do
     opts =
-      AuthorizeSiteAccess.init({[:public, :viewer, :admin, :super_admin, :owner], "some_key"})
+      AuthorizeSiteAccess.init({[], "some_key"})
 
     conn =
       conn

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -10,7 +10,12 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     end
   end
 
-  for init_argument <- [[], {[], nil}, {[:public, :viewer, :admin, :super_admin, :owner], nil}] do
+  for init_argument <- [
+        [],
+        :all_roles,
+        {:all_roles, nil},
+        {[:public, :viewer, :admin, :super_admin, :owner], nil}
+      ] do
     test "init resolves to expected options with argument #{inspect(init_argument)}" do
       assert {[:public, :viewer, :admin, :super_admin, :owner], nil} ==
                AuthorizeSiteAccess.init(unquote(init_argument))
@@ -26,7 +31,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "returns 404 on non-existent site", %{conn: conn} do
-    opts = AuthorizeSiteAccess.init(_all_allowed_roles = [])
+    opts = AuthorizeSiteAccess.init(:all_roles)
 
     conn =
       conn
@@ -39,7 +44,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "rejects user completely unrelated to the site", %{conn: conn} do
-    opts = AuthorizeSiteAccess.init(_all_allowed_roles = [])
+    opts = AuthorizeSiteAccess.init(:all_roles)
 
     site = insert(:site, members: [build(:user)])
 
@@ -59,7 +64,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
          site: site
        } do
     opts =
-      AuthorizeSiteAccess.init({[], "some_key"})
+      AuthorizeSiteAccess.init({:all_roles, "some_key"})
 
     conn =
       conn
@@ -77,7 +82,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
          site: site
        } do
     opts =
-      AuthorizeSiteAccess.init({[], "some_key"})
+      AuthorizeSiteAccess.init({:all_roles, "some_key"})
 
     conn =
       conn
@@ -95,7 +100,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   } do
     other_site = insert(:site, members: [build(:user)])
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:admin, :owner])
+    opts = AuthorizeSiteAccess.init([:admin, :owner])
 
     conn =
       conn
@@ -182,7 +187,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       "auth" => shared_link.slug
     }
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:super_admin, :admin, :owner])
+    opts = AuthorizeSiteAccess.init([:super_admin, :admin, :owner])
 
     conn =
       conn
@@ -198,7 +203,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site =
       insert(:site, memberships: [build(:site_membership, user: user, role: :admin)])
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:owner])
+    opts = AuthorizeSiteAccess.init([:owner])
 
     conn =
       conn
@@ -215,7 +220,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       site =
         insert(:site, memberships: [build(:site_membership, user: user, role: unquote(role))])
 
-      opts = AuthorizeSiteAccess.init(_allowed_roles = [unquote(role)])
+      opts = AuthorizeSiteAccess.init([unquote(role)])
 
       conn =
         conn
@@ -251,7 +256,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "allows user based on website visibility (authenticated user)", %{conn: conn} do
     site = insert(:site, members: [build(:user)], public: true)
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+    opts = AuthorizeSiteAccess.init([:public])
 
     conn =
       conn
@@ -266,7 +271,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "allows user based on website visibility (anonymous request)" do
     site = insert(:site, members: [build(:user)], public: true)
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+    opts = AuthorizeSiteAccess.init([:public])
 
     conn =
       build_conn()
@@ -282,7 +287,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site = insert(:site, members: [build(:user)])
     shared_link = insert(:shared_link, site: site)
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+    opts = AuthorizeSiteAccess.init([:public])
 
     conn =
       conn
@@ -298,7 +303,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     site = insert(:site, members: [build(:user)])
     shared_link = insert(:shared_link, site: site)
 
-    opts = AuthorizeSiteAccess.init(_allowed_roles = [:public])
+    opts = AuthorizeSiteAccess.init([:public])
 
     conn =
       build_conn()

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     end
   end
 
-  for init_argument <- [[], {[:public, :viewer, :admin, :super_admin, :owner], nil}] do
+  for init_argument <- [[], {[], nil}, {[:public, :viewer, :admin, :super_admin, :owner], nil}] do
     test "init resolves to expected options with argument #{inspect(init_argument)}" do
       assert {[:public, :viewer, :admin, :super_admin, :owner], nil} ==
                AuthorizeSiteAccess.init(unquote(init_argument))

--- a/test/support/test_controller.ex
+++ b/test/support/test_controller.ex
@@ -1,0 +1,11 @@
+defmodule PlausibleWeb.TestController do
+  use PlausibleWeb, :controller
+
+  def browser_basic(conn, _params) do
+    send_resp(conn, 200, "ok")
+  end
+
+  def api_basic(conn, _params) do
+    send_resp(conn, 200, Jason.encode!(%{"ok" => true}))
+  end
+end


### PR DESCRIPTION
### Changes

- Allow auth site access plug to specify that domain is found in request body at some key, needed for api/docs/query endpoint where :domain or :website does not appear in path params
- Nuisance: Stop typescript --watch command clearing previous server stdout when running make server

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
