### PR TITLE
Use `:domain` uniformly for all routes instead of `:website`

### DIFF
--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -104,8 +104,8 @@ defmodule PlausibleWeb.SiteController do
     end
   end
 
-  def settings(conn, %{"website" => website}) do
-    redirect(conn, to: Routes.site_path(conn, :settings_general, website))
+  def settings(conn, %{"domain" => domain}) do
+    redirect(conn, to: Routes.site_path(conn, :settings_general, domain))
   end
 
   def settings_general(conn, _params) do

--- a/lib/plausible_web/controllers/unsubscribe_controller.ex
+++ b/lib/plausible_web/controllers/unsubscribe_controller.ex
@@ -3,8 +3,8 @@ defmodule PlausibleWeb.UnsubscribeController do
   use Plausible.Repo
   alias Plausible.Site.{WeeklyReport, MonthlyReport}
 
-  def weekly_report(conn, %{"website" => website, "email" => email}) do
-    site = Repo.get_by(Plausible.Site, domain: website)
+  def weekly_report(conn, %{"domain" => domain, "email" => email}) do
+    site = Repo.get_by(Plausible.Site, domain: domain)
     weekly_report = site && Repo.get_by(WeeklyReport, site_id: site.id)
 
     if weekly_report do
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.UnsubscribeController do
     |> assign(:skip_plausible_tracking, true)
     |> render("success.html",
       interval: "weekly",
-      site: site || %{domain: website}
+      site: site || %{domain: domain}
     )
   end
 
@@ -25,8 +25,8 @@ defmodule PlausibleWeb.UnsubscribeController do
     render_error(conn, 400)
   end
 
-  def monthly_report(conn, %{"website" => website, "email" => email}) do
-    site = Repo.get_by(Plausible.Site, domain: website)
+  def monthly_report(conn, %{"domain" => domain, "email" => email}) do
+    site = Repo.get_by(Plausible.Site, domain: domain)
     monthly_report = site && Repo.get_by(MonthlyReport, site_id: site.id)
 
     if monthly_report do
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.UnsubscribeController do
     |> assign(:skip_plausible_tracking, true)
     |> render("success.html",
       interval: "monthly",
-      site: site || %{domain: website}
+      site: site || %{domain: domain}
     )
   end
 

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.Live.Installation do
   def script_extension_params, do: @script_extension_params
 
   def mount(
-        %{"website" => domain} = params,
+        %{"domain" => domain} = params,
         _session,
         socket
       ) do

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Live.Verification do
   @slowdown_for_frequent_checking :timer.seconds(5)
 
   def mount(
-        %{"website" => domain} = params,
+        %{"domain" => domain} = params,
         _session,
         socket
       ) do

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -66,7 +66,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   defp get_site_with_role(conn, current_user) do
     # addition is flimsy, do we need an extra argument on plug init to control where we look for the domain?
     domain =
-      conn.path_params["domain"] || conn.path_params["website"] ||
+      conn.path_params["domain"] ||
         (conn.method == "POST" && conn.path_info == ["api", "docs", "query"] &&
            conn.params["site_id"])
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -340,72 +340,72 @@ defmodule PlausibleWeb.Router do
 
     get "/sites/new", SiteController, :new
     post "/sites", SiteController, :create_site
-    get "/sites/:website/change-domain", SiteController, :change_domain
-    put "/sites/:website/change-domain", SiteController, :change_domain_submit
-    post "/sites/:website/make-public", SiteController, :make_public
-    post "/sites/:website/make-private", SiteController, :make_private
-    post "/sites/:website/weekly-report/enable", SiteController, :enable_weekly_report
-    post "/sites/:website/weekly-report/disable", SiteController, :disable_weekly_report
-    post "/sites/:website/weekly-report/recipients", SiteController, :add_weekly_report_recipient
+    get "/sites/:domain/change-domain", SiteController, :change_domain
+    put "/sites/:domain/change-domain", SiteController, :change_domain_submit
+    post "/sites/:domain/make-public", SiteController, :make_public
+    post "/sites/:domain/make-private", SiteController, :make_private
+    post "/sites/:domain/weekly-report/enable", SiteController, :enable_weekly_report
+    post "/sites/:domain/weekly-report/disable", SiteController, :disable_weekly_report
+    post "/sites/:domain/weekly-report/recipients", SiteController, :add_weekly_report_recipient
 
-    delete "/sites/:website/weekly-report/recipients/:recipient",
+    delete "/sites/:domain/weekly-report/recipients/:recipient",
            SiteController,
            :remove_weekly_report_recipient
 
-    post "/sites/:website/monthly-report/enable", SiteController, :enable_monthly_report
-    post "/sites/:website/monthly-report/disable", SiteController, :disable_monthly_report
+    post "/sites/:domain/monthly-report/enable", SiteController, :enable_monthly_report
+    post "/sites/:domain/monthly-report/disable", SiteController, :disable_monthly_report
 
-    post "/sites/:website/monthly-report/recipients",
+    post "/sites/:domain/monthly-report/recipients",
          SiteController,
          :add_monthly_report_recipient
 
-    delete "/sites/:website/monthly-report/recipients/:recipient",
+    delete "/sites/:domain/monthly-report/recipients/:recipient",
            SiteController,
            :remove_monthly_report_recipient
 
-    post "/sites/:website/traffic-change-notification/:type/enable",
+    post "/sites/:domain/traffic-change-notification/:type/enable",
          SiteController,
          :enable_traffic_change_notification
 
-    post "/sites/:website/traffic-change-notification/:type/disable",
+    post "/sites/:domain/traffic-change-notification/:type/disable",
          SiteController,
          :disable_traffic_change_notification
 
-    put "/sites/:website/traffic-change-notification/:type",
+    put "/sites/:domain/traffic-change-notification/:type",
         SiteController,
         :update_traffic_change_notification
 
-    post "/sites/:website/traffic-change-notification/:type/recipients",
+    post "/sites/:domain/traffic-change-notification/:type/recipients",
          SiteController,
          :add_traffic_change_notification_recipient
 
-    delete "/sites/:website/traffic-change-notification/:type/recipients/:recipient",
+    delete "/sites/:domain/traffic-change-notification/:type/recipients/:recipient",
            SiteController,
            :remove_traffic_change_notification_recipient
 
-    get "/sites/:website/shared-links/new", SiteController, :new_shared_link
-    post "/sites/:website/shared-links", SiteController, :create_shared_link
-    get "/sites/:website/shared-links/:slug/edit", SiteController, :edit_shared_link
-    put "/sites/:website/shared-links/:slug", SiteController, :update_shared_link
-    delete "/sites/:website/shared-links/:slug", SiteController, :delete_shared_link
+    get "/sites/:domain/shared-links/new", SiteController, :new_shared_link
+    post "/sites/:domain/shared-links", SiteController, :create_shared_link
+    get "/sites/:domain/shared-links/:slug/edit", SiteController, :edit_shared_link
+    put "/sites/:domain/shared-links/:slug", SiteController, :update_shared_link
+    delete "/sites/:domain/shared-links/:slug", SiteController, :delete_shared_link
 
-    get "/sites/:website/memberships/invite", Site.MembershipController, :invite_member_form
-    post "/sites/:website/memberships/invite", Site.MembershipController, :invite_member
+    get "/sites/:domain/memberships/invite", Site.MembershipController, :invite_member_form
+    post "/sites/:domain/memberships/invite", Site.MembershipController, :invite_member
 
     post "/sites/invitations/:invitation_id/accept", InvitationController, :accept_invitation
 
     post "/sites/invitations/:invitation_id/reject", InvitationController, :reject_invitation
 
-    delete "/sites/:website/invitations/:invitation_id", InvitationController, :remove_invitation
+    delete "/sites/:domain/invitations/:invitation_id", InvitationController, :remove_invitation
 
-    get "/sites/:website/transfer-ownership", Site.MembershipController, :transfer_ownership_form
-    post "/sites/:website/transfer-ownership", Site.MembershipController, :transfer_ownership
+    get "/sites/:domain/transfer-ownership", Site.MembershipController, :transfer_ownership_form
+    post "/sites/:domain/transfer-ownership", Site.MembershipController, :transfer_ownership
 
-    put "/sites/:website/memberships/:id/role/:new_role", Site.MembershipController, :update_role
-    delete "/sites/:website/memberships/:id", Site.MembershipController, :remove_member
+    put "/sites/:domain/memberships/:id/role/:new_role", Site.MembershipController, :update_role
+    delete "/sites/:domain/memberships/:id", Site.MembershipController, :remove_member
 
-    get "/sites/:website/weekly-report/unsubscribe", UnsubscribeController, :weekly_report
-    get "/sites/:website/monthly-report/unsubscribe", UnsubscribeController, :monthly_report
+    get "/sites/:domain/weekly-report/unsubscribe", UnsubscribeController, :weekly_report
+    get "/sites/:domain/monthly-report/unsubscribe", UnsubscribeController, :monthly_report
 
     scope alias: Live, assigns: %{connect_live_socket: true} do
       pipe_through [:app_layout, PlausibleWeb.RequireAccountPlug]
@@ -413,60 +413,60 @@ defmodule PlausibleWeb.Router do
       scope assigns: %{
               dogfood_page_path: "/:website/installation"
             } do
-        live "/:website/installation", Installation, :installation, as: :site
+        live "/:domain/installation", Installation, :installation, as: :site
       end
 
       scope assigns: %{
               dogfood_page_path: "/:website/verification"
             } do
-        live "/:website/verification", Verification, :verification, as: :site
+        live "/:domain/verification", Verification, :verification, as: :site
       end
     end
 
-    get "/:website/settings", SiteController, :settings
-    get "/:website/settings/general", SiteController, :settings_general
-    get "/:website/settings/people", SiteController, :settings_people
-    get "/:website/settings/visibility", SiteController, :settings_visibility
-    get "/:website/settings/goals", SiteController, :settings_goals
-    get "/:website/settings/properties", SiteController, :settings_props
+    get "/:domain/settings", SiteController, :settings
+    get "/:domain/settings/general", SiteController, :settings_general
+    get "/:domain/settings/people", SiteController, :settings_people
+    get "/:domain/settings/visibility", SiteController, :settings_visibility
+    get "/:domain/settings/goals", SiteController, :settings_goals
+    get "/:domain/settings/properties", SiteController, :settings_props
 
     on_ee do
-      get "/:website/settings/funnels", SiteController, :settings_funnels
+      get "/:domain/settings/funnels", SiteController, :settings_funnels
     end
 
-    get "/:website/settings/email-reports", SiteController, :settings_email_reports
-    get "/:website/settings/danger-zone", SiteController, :settings_danger_zone
-    get "/:website/settings/integrations", SiteController, :settings_integrations
-    get "/:website/settings/shields/:shield", SiteController, :settings_shields
-    get "/:website/settings/imports-exports", SiteController, :settings_imports_exports
+    get "/:domain/settings/email-reports", SiteController, :settings_email_reports
+    get "/:domain/settings/danger-zone", SiteController, :settings_danger_zone
+    get "/:domain/settings/integrations", SiteController, :settings_integrations
+    get "/:domain/settings/shields/:shield", SiteController, :settings_shields
+    get "/:domain/settings/imports-exports", SiteController, :settings_imports_exports
 
-    put "/:website/settings/features/visibility/:setting",
+    put "/:domain/settings/features/visibility/:setting",
         SiteController,
         :update_feature_visibility
 
-    put "/:website/settings", SiteController, :update_settings
-    put "/:website/settings/google", SiteController, :update_google_auth
-    delete "/:website/settings/google-search", SiteController, :delete_google_auth
-    delete "/:website/settings/google-import", SiteController, :delete_google_auth
-    delete "/:website", SiteController, :delete_site
-    delete "/:website/stats", SiteController, :reset_stats
+    put "/:domain/settings", SiteController, :update_settings
+    put "/:domain/settings/google", SiteController, :update_google_auth
+    delete "/:domain/settings/google-search", SiteController, :delete_google_auth
+    delete "/:domain/settings/google-import", SiteController, :delete_google_auth
+    delete "/:domain", SiteController, :delete_site
+    delete "/:domain/stats", SiteController, :reset_stats
 
-    get "/:website/import/google-analytics/property",
+    get "/:domain/import/google-analytics/property",
         GoogleAnalyticsController,
         :property_form
 
-    post "/:website/import/google-analytics/property",
+    post "/:domain/import/google-analytics/property",
          GoogleAnalyticsController,
          :property
 
-    get "/:website/import/google-analytics/confirm", GoogleAnalyticsController, :confirm
-    post "/:website/settings/google-import", GoogleAnalyticsController, :import
+    get "/:domain/import/google-analytics/confirm", GoogleAnalyticsController, :confirm
+    post "/:domain/settings/google-import", GoogleAnalyticsController, :import
 
-    delete "/:website/settings/forget-imported", SiteController, :forget_imported
-    delete "/:website/settings/forget-import/:import_id", SiteController, :forget_import
+    delete "/:domain/settings/forget-imported", SiteController, :forget_imported
+    delete "/:domain/settings/forget-import/:import_id", SiteController, :forget_import
 
-    get "/:website/download/export", SiteController, :download_export
-    get "/:website/settings/import", SiteController, :csv_import
+    get "/:domain/download/export", SiteController, :download_export
+    get "/:domain/settings/import", SiteController, :csv_import
 
     get "/debug/clickhouse", DebugController, :clickhouse
 

--- a/test/plausible_web/controllers/google_analytics_controller_test.exs
+++ b/test/plausible_web/controllers/google_analytics_controller_test.exs
@@ -16,7 +16,7 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
 
   setup :verify_on_exit!
 
-  describe "GET /:website/import/google-analytics/property" do
+  describe "GET /:domain/import/google-analytics/property" do
     setup [:create_user, :log_in, :create_new_site]
 
     test "lists Google Analytics properties", %{conn: conn, site: site} do
@@ -206,7 +206,7 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
     end
   end
 
-  describe "POST /:website/import/google-analytics/property" do
+  describe "POST /:domain/import/google-analytics/property" do
     setup [:create_user, :log_in, :create_new_site]
 
     test "redirects to confirmation", %{conn: conn, site: site} do
@@ -504,7 +504,7 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
     end
   end
 
-  describe "GET /:website/import/google-analytics/confirm" do
+  describe "GET /:domain/import/google-analytics/confirm" do
     setup [:create_user, :log_in, :create_new_site]
 
     test "renders confirmation form for Google Analytics 4 import", %{conn: conn, site: site} do
@@ -729,7 +729,7 @@ defmodule PlausibleWeb.GoogleAnalyticsControllerTest do
     end
   end
 
-  describe "POST /:website/settings/google-import" do
+  describe "POST /:domain/settings/google-import" do
     setup [:create_user, :log_in, :create_new_site]
 
     test "creates Google Analytics 4 site import instance", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -152,7 +152,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
     end
   end
 
-  describe "DELETE /sites/:website/invitations/:invitation_id" do
+  describe "DELETE /sites/:domain/invitations/:invitation_id" do
     test "removes the invitation", %{conn: conn, user: user} do
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :admin)])
 

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
   setup [:create_user, :log_in]
 
-  describe "GET /sites/:website/memberships/invite" do
+  describe "GET /sites/:domain/memberships/invite" do
     test "shows invite form", %{conn: conn, user: user} do
       site = insert(:site, members: [user])
 
@@ -41,7 +41,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     end
   end
 
-  describe "POST /sites/:website/memberships/invite" do
+  describe "POST /sites/:domain/memberships/invite" do
     test "creates invitation", %{conn: conn, user: user} do
       site = insert(:site, members: [user])
 
@@ -199,7 +199,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     end
   end
 
-  describe "GET /sites/:website/transfer-ownership" do
+  describe "GET /sites/:domain/transfer-ownership" do
     test "shows ownership transfer form", %{conn: conn, user: user} do
       site = insert(:site, members: [user])
 
@@ -209,7 +209,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     end
   end
 
-  describe "POST /sites/:website/transfer-ownership" do
+  describe "POST /sites/:domain/transfer-ownership" do
     test "creates invitation with :owner role", %{conn: conn, user: user} do
       site = insert(:site, members: [user])
 
@@ -416,7 +416,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     end
   end
 
-  describe "DELETE /sites/:website/memberships/:id" do
+  describe "DELETE /sites/:domain/memberships/:id" do
     test "removes a member from a site", %{conn: conn, user: user} do
       admin = insert(:user)
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -461,7 +461,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/installation" do
+  describe "GET /:domain/installation" do
     setup [:create_user, :log_in, :create_site]
 
     test "static render - spinner determining installation type", %{
@@ -474,7 +474,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/general" do
+  describe "GET /:domain/settings/general" do
     setup [:create_user, :log_in, :create_site]
 
     setup_patch_env(:google, client_id: "some", api_url: "https://www.googleapis.com")
@@ -489,7 +489,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/people" do
+  describe "GET /:domain/settings/people" do
     setup [:create_user, :log_in, :create_site]
 
     @tag :ee_only
@@ -514,7 +514,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/goals" do
+  describe "GET /:domain/settings/goals" do
     setup [:create_user, :log_in, :create_site]
 
     test "lists goals for the site", %{conn: conn, site: site} do
@@ -538,7 +538,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "PUT /:website/settings" do
+  describe "PUT /:domain/settings" do
     setup [:create_user, :log_in, :create_site]
 
     test "updates the timezone", %{conn: conn, site: site} do
@@ -555,7 +555,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/make-public" do
+  describe "POST /sites/:domain/make-public" do
     setup [:create_user, :log_in, :create_site]
 
     test "makes the site public", %{conn: conn, site: site} do
@@ -589,7 +589,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/make-private" do
+  describe "POST /sites/:domain/make-private" do
     setup [:create_user, :log_in, :create_site]
 
     test "makes the site private", %{conn: conn, site: site} do
@@ -603,7 +603,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /:website" do
+  describe "DELETE /:domain" do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes the site", %{conn: conn, user: user} do
@@ -645,7 +645,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "PUT /:website/settings/google" do
+  describe "PUT /:domain/settings/google" do
     setup [:create_user, :log_in, :create_site]
 
     test "updates google auth property", %{conn: conn, user: user, site: site} do
@@ -664,7 +664,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /:website/settings/google" do
+  describe "DELETE /:domain/settings/google" do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes associated google auth", %{conn: conn, user: user, site: site} do
@@ -690,7 +690,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/imports-exports" do
+  describe "GET /:domain/settings/imports-exports" do
     setup [:create_user, :log_in, :create_site, :maybe_fake_minio]
 
     test "renders empty imports list", %{conn: conn, site: site} do
@@ -803,7 +803,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/imports-exports when object storage is unreachable" do
+  describe "GET /:domain/settings/imports-exports when object storage is unreachable" do
     setup [:create_user, :log_in, :create_site]
 
     setup tags do
@@ -824,7 +824,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/settings/integrations for self-hosting" do
+  describe "GET /:domain/settings/integrations for self-hosting" do
     setup [:create_user, :log_in, :create_site]
 
     setup_patch_env(:google,
@@ -842,7 +842,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:website/integrations (search-console)" do
+  describe "GET /:domain/integrations (search-console)" do
     setup [:create_user, :log_in, :create_site]
 
     setup_patch_env(:google, client_id: "some", api_url: "https://www.googleapis.com")
@@ -955,7 +955,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "PUT /:website/settings/features/visibility/:setting" do
+  describe "PUT /:domain/settings/features/visibility/:setting" do
     def query_conn_with_some_url(context) do
       {:ok, Map.put(context, :conn_with_url, get(context.conn, "/some_parent_path"))}
     end
@@ -1077,7 +1077,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/weekly-report/enable" do
+  describe "POST /sites/:domain/weekly-report/enable" do
     setup [:create_user, :log_in, :create_site]
 
     test "creates a weekly report record with the user email", %{
@@ -1106,7 +1106,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/weekly-report/disable" do
+  describe "POST /sites/:domain/weekly-report/disable" do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes the weekly report record", %{conn: conn, site: site} do
@@ -1127,7 +1127,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/weekly-report/recipients" do
+  describe "POST /sites/:domain/weekly-report/recipients" do
     setup [:create_user, :log_in, :create_site]
 
     test "adds a recipient to the weekly report", %{conn: conn, site: site} do
@@ -1140,7 +1140,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /sites/:website/weekly-report/recipients/:recipient" do
+  describe "DELETE /sites/:domain/weekly-report/recipients/:recipient" do
     setup [:create_user, :log_in, :create_site]
 
     test "removes a recipient from the weekly report", %{conn: conn, site: site} do
@@ -1167,7 +1167,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/monthly-report/enable" do
+  describe "POST /sites/:domain/monthly-report/enable" do
     setup [:create_user, :log_in, :create_site]
 
     test "creates a monthly report record with the user email", %{
@@ -1196,7 +1196,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/monthly-report/disable" do
+  describe "POST /sites/:domain/monthly-report/disable" do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes the monthly report record", %{conn: conn, site: site} do
@@ -1208,7 +1208,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/monthly-report/recipients" do
+  describe "POST /sites/:domain/monthly-report/recipients" do
     setup [:create_user, :log_in, :create_site]
 
     test "adds a recipient to the monthly report", %{conn: conn, site: site} do
@@ -1221,7 +1221,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /sites/:website/monthly-report/recipients/:recipient" do
+  describe "DELETE /sites/:domain/monthly-report/recipients/:recipient" do
     setup [:create_user, :log_in, :create_site]
 
     test "removes a recipient from the monthly report", %{conn: conn, site: site} do
@@ -1253,7 +1253,7 @@ defmodule PlausibleWeb.SiteControllerTest do
   end
 
   for type <- [:spike, :drop] do
-    describe "POST /sites/:website/traffic-change-notification/#{type}/enable" do
+    describe "POST /sites/:domain/traffic-change-notification/#{type}/enable" do
       setup [:create_user, :log_in, :create_site]
 
       test "creates a #{type} notification record with the user email", %{
@@ -1288,7 +1288,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       end
     end
 
-    describe "POST /sites/:website/traffic-change-notification/#{type}/disable" do
+    describe "POST /sites/:domain/traffic-change-notification/#{type}/disable" do
       setup [:create_user, :log_in, :create_site]
 
       test "deletes the #{type} notification record", %{conn: conn, site: site} do
@@ -1300,7 +1300,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       end
     end
 
-    describe "PUT /sites/:website/traffic-change-notification/#{type}" do
+    describe "PUT /sites/:domain/traffic-change-notification/#{type}" do
       setup [:create_user, :log_in, :create_site]
 
       test "updates #{type} notification threshold", %{conn: conn, site: site} do
@@ -1320,7 +1320,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       end
     end
 
-    describe "POST /sites/:website/traffic-change-notification/#{type}/recipients" do
+    describe "POST /sites/:domain/traffic-change-notification/#{type}/recipients" do
       setup [:create_user, :log_in, :create_site]
 
       test "adds a recipient to the #{type} notification", %{conn: conn, site: site} do
@@ -1342,7 +1342,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       end
     end
 
-    describe "DELETE /sites/:website/traffic-change-notification/#{type}/recipients/:recipient" do
+    describe "DELETE /sites/:domain/traffic-change-notification/#{type}/recipients/:recipient" do
       setup [:create_user, :log_in, :create_site]
 
       test "removes a recipient from the #{type} notification", %{conn: conn, site: site} do
@@ -1395,7 +1395,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /sites/:website/shared-links/new" do
+  describe "GET /sites/:domain/shared-links/new" do
     setup [:create_user, :log_in, :create_site]
 
     test "shows form for new shared link", %{conn: conn, site: site} do
@@ -1405,7 +1405,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "POST /sites/:website/shared-links" do
+  describe "POST /sites/:domain/shared-links" do
     setup [:create_user, :log_in, :create_site]
 
     test "creates shared link without password", %{conn: conn, site: site} do
@@ -1433,7 +1433,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /sites/:website/shared-links/edit" do
+  describe "GET /sites/:domain/shared-links/edit" do
     setup [:create_user, :log_in, :create_site]
 
     test "shows form to edit shared link", %{conn: conn, site: site} do
@@ -1444,7 +1444,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "PUT /sites/:website/shared-links/:slug" do
+  describe "PUT /sites/:domain/shared-links/:slug" do
     setup [:create_user, :log_in, :create_site]
 
     test "can update link name", %{conn: conn, site: site} do
@@ -1460,7 +1460,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /sites/:website/shared-links/:slug" do
+  describe "DELETE /sites/:domain/shared-links/:slug" do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes shared link", %{conn: conn, site: site} do
@@ -1484,7 +1484,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /:website/settings/:forget_import/:import_id" do
+  describe "DELETE /:domain/settings/:forget_import/:import_id" do
     setup [:create_user, :log_in, :create_new_site, :create_legacy_site_import]
 
     test "removes site import, associated data and cancels oban job for a particular import", %{
@@ -1562,7 +1562,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "DELETE /:website/settings/forget_imported" do
+  describe "DELETE /:domain/settings/forget_imported" do
     setup [:create_user, :log_in, :create_new_site]
 
     test "removes actual imported data from Clickhouse", %{conn: conn, user: user, site: site} do

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
   @react_container "div#stats-react-container"
 
-  describe "GET /:website - anonymous user" do
+  describe "GET /:domain - anonymous user" do
     test "public site - shows site stats", %{conn: conn} do
       site = insert(:site, public: true)
       populate_stats(site, [build(:pageview)])
@@ -80,7 +80,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /:website - as a logged in user" do
+  describe "GET /:domain - as a logged in user" do
     setup [:create_user, :log_in, :create_site]
 
     test "can view stats of a website I've created", %{conn: conn, site: site} do
@@ -119,7 +119,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /:website - as a super admin" do
+  describe "GET /:domain - as a super admin" do
     @describetag :ee_only
     setup [:create_user, :make_user_super_admin, :log_in]
 
@@ -181,7 +181,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     Application.put_env(:plausible, :super_admin_user_ids, [user.id])
   end
 
-  describe "GET /:website/export" do
+  describe "GET /:domain/export" do
     setup [:create_user, :create_new_site, :log_in]
 
     test "exports all the necessary CSV files", %{conn: conn, site: site} do
@@ -590,7 +590,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     |> Enum.map(&String.split(&1, ","))
   end
 
-  describe "GET /:website/export - via shared link" do
+  describe "GET /:domain/export - via shared link" do
     test "exports data in zipped csvs", %{conn: conn} do
       site = insert(:site, domain: "new-site.com")
       link = insert(:shared_link, site: site)
@@ -601,7 +601,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /:website/export - for past 6 months" do
+  describe "GET /:domain/export - for past 6 months" do
     setup [:create_user, :create_new_site, :log_in]
 
     test "exports 6 months of data in zipped csvs", %{conn: conn, site: site} do
@@ -611,7 +611,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /:website/export - with path filter" do
+  describe "GET /:domain/export - with path filter" do
     setup [:create_user, :create_new_site, :log_in]
 
     test "exports filtered data in zipped csvs", %{conn: conn, site: site} do
@@ -623,7 +623,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
   end
 
-  describe "GET /:website/export - with a custom prop filter" do
+  describe "GET /:domain/export - with a custom prop filter" do
     setup [:create_user, :create_new_site, :log_in]
 
     test "custom-props.csv only returns the prop and its value in filter", %{
@@ -751,7 +751,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     insert(:goal, %{site: site, event_name: "Signup"})
   end
 
-  describe "GET /:website/export - with goal filter" do
+  describe "GET /:domain/export - with goal filter" do
     setup [:create_user, :create_new_site, :log_in]
 
     test "exports goal-filtered data in zipped csvs", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/unsubscribe_controller_test.exs
+++ b/test/plausible_web/controllers/unsubscribe_controller_test.exs
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.UnsubscribeControllerTest do
 
   setup {PlausibleWeb.FirstLaunchPlug.Test, :skip}
 
-  describe "GET /sites/:website/weekly-report/unsubscribe" do
+  describe "GET /sites/:domain/weekly-report/unsubscribe" do
     test "removes a recipient from the weekly report without them having to log in", %{conn: conn} do
       site = insert(:site)
       insert(:weekly_report, site: site, recipients: ["recipient@email.com"])
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.UnsubscribeControllerTest do
     end
   end
 
-  describe "GET /sites/:website/monthly-report/unsubscribe" do
+  describe "GET /sites/:domain/monthly-report/unsubscribe" do
     test "removes a recipient from the weekly report without them having to log in", %{conn: conn} do
       site = insert(:site)
       insert(:monthly_report, site: site, recipients: ["recipient@email.com"])

--- a/test/plausible_web/live/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings_test.exs
@@ -7,7 +7,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
-    describe "GET /:website/settings/funnels" do
+    describe "GET /:domain/settings/funnels" do
       setup [:create_user, :log_in, :create_site]
 
       test "lists funnels for the site and renders help link", %{conn: conn, site: site} do

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
   import Phoenix.LiveViewTest
   import Plausible.Test.Support.HTML
 
-  describe "GET /:website/settings/goals" do
+  describe "GET /:domain/settings/goals" do
     setup [:create_user, :log_in, :create_site]
 
     @tag :ee_only

--- a/test/plausible_web/live/plugins_api_tokens_test.exs
+++ b/test/plausible_web/live/plugins_api_tokens_test.exs
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
 
   alias Plausible.Plugins.API.Tokens
 
-  describe "GET /:website/settings/integrations" do
+  describe "GET /:domain/settings/integrations" do
     setup [:create_user, :log_in, :create_site]
 
     test "does not display the Plugins API section by default", %{conn: conn, site: site} do

--- a/test/plausible_web/live/props_settings_test.exs
+++ b/test/plausible_web/live/props_settings_test.exs
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Live.PropsSettingsTest do
   import Phoenix.LiveViewTest
   import Plausible.Test.Support.HTML
 
-  describe "GET /:website/settings/properties" do
+  describe "GET /:domain/settings/properties" do
     setup [:create_user, :log_in, :create_site]
 
     test "lists props for the site and renders links", %{conn: conn, site: site} do

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -34,27 +34,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     assert html_response(conn, 404)
   end
 
-  test "doesn't allow bypassing :domain in path with :website or :domain in query param", %{
-    conn: conn,
-    site: site
-  } do
-    other_site = insert(:site, members: [build(:user)])
-
-    conn =
-      conn
-      |> bypass_through(PlausibleWeb.Router)
-      |> get("/#{other_site.domain}/export", %{
-        "domain" => site.domain,
-        "website" => site.domain
-      })
-      |> AuthorizeSiteAccess.call(_allowed_roles = [:admin, :owner])
-
-    assert conn.halted
-    assert html_response(conn, 404)
-    assert conn.path_params == %{"domain" => other_site.domain}
-  end
-
-  test "doesn't allow bypassing :website in path with :website or :domain in query param", %{
+  test "doesn't allow bypassing :domain in path with :domain in query param", %{
     conn: conn,
     site: site
   } do
@@ -64,14 +44,13 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
       conn
       |> bypass_through(PlausibleWeb.Router)
       |> get("/sites/#{other_site.domain}/change-domain", %{
-        "domain" => site.domain,
-        "website" => site.domain
+        "domain" => site.domain
       })
       |> AuthorizeSiteAccess.call(_allowed_roles = [:admin, :owner])
 
     assert conn.halted
     assert conn.status == 404
-    assert conn.path_params == %{"website" => other_site.domain}
+    assert conn.path_params == %{"domain" => other_site.domain}
   end
 
   test "returns 404 with custom error message for failed API routes", %{conn: conn, user: user} do


### PR DESCRIPTION
### Changes

While addressing `AuthorizeSiteAccess` plug refactor, it occurred to us that `:website` and `:domain` path params in routes are basically redundant. This PR replaces all the occurrences of `:website` with `:domain`. We make an exception with `dogfood_page_path` where we leave it intact. This way we avoid duplicate entries in demo dashboard.

### Tests
- [x] Automated tests have been added

