### PR TITLE
Fix progress header not showing up when adding a new site

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -71,7 +71,7 @@ defmodule PlausibleWeb.Live.Sites do
           You don't have any sites yet.
         </p>
         <div class="mt-4 flex sm:ml-4 sm:mt-0">
-          <a href="/sites/new?flow=#{PlausibleWeb.Flows.provisioning()}" class="button">
+          <a href={"/sites/new?flow=#{PlausibleWeb.Flows.provisioning()}"} class="button">
             + Add Website
           </a>
         </div>


### PR DESCRIPTION
Fixes non-iterpolated `flow` in the query string after clicking "+ Add Website" from the sites dashboard:

<img width="1582" alt="Screenshot 2024-09-23 at 13 34 41" src="https://github.com/user-attachments/assets/345cdfbf-f117-4943-b91f-5cc532b95d53">

Before: https://staging.plausible.io/sites/new?flow=#{PlausibleWeb.Flows.provisioning()}
After: https://pr-4605.review.plausible.io/sites/new?flow=provisioning
