### PR TITLE
Mua: support 465 port connections

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -641,8 +641,18 @@ case mailer_adapter do
     config :plausible, Plausible.Mailer, ssl: [middlebox_comp_mode: middlebox_comp_mode]
 
     if relay = get_var_from_path_or_env(config_dir, "SMTP_HOST_ADDR") do
-      port = get_int_from_path_or_env(config_dir, "SMTP_HOST_PORT", 25)
-      config :plausible, Plausible.Mailer, relay: relay, port: port
+      port = get_int_from_path_or_env(config_dir, "SMTP_HOST_PORT", 587)
+      ssl_enabled = get_var_from_path_or_env(config_dir, "SMTP_HOST_SSL_ENABLED", "false")
+      ssl_enabled = String.to_existing_atom(ssl_enabled)
+
+      protocol =
+        if ssl_enabled || port == 465 do
+          :ssl
+        else
+          :tcp
+        end
+
+      config :plausible, Plausible.Mailer, protocol: protocol, relay: relay, port: port
     end
 
     username = get_var_from_path_or_env(config_dir, "SMTP_USER_NAME")

--- a/test/plausible/config_test.exs
+++ b/test/plausible/config_test.exs
@@ -168,8 +168,48 @@ defmodule Plausible.ConfigTest do
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
                {:adapter, Bamboo.Mua},
                {:ssl, [middlebox_comp_mode: false]},
+               {:protocol, :tcp},
                {:relay, "localhost"},
                {:port, 2525},
+               {:auth, [username: "neo", password: "one"]}
+             ]
+    end
+
+    test "Bamboo.Mua (ssl relay config)" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.Mua"},
+        {"SMTP_HOST_ADDR", "localhost"},
+        {"SMTP_HOST_PORT", "2525"},
+        {"SMTP_HOST_SSL_ENABLED", "true"},
+        {"SMTP_USER_NAME", "neo"},
+        {"SMTP_USER_PWD", "one"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               {:adapter, Bamboo.Mua},
+               {:ssl, [middlebox_comp_mode: false]},
+               {:protocol, :ssl},
+               {:relay, "localhost"},
+               {:port, 2525},
+               {:auth, [username: "neo", password: "one"]}
+             ]
+    end
+
+    test "Bamboo.Mua (port=465 relay config)" do
+      env = [
+        {"MAILER_ADAPTER", "Bamboo.Mua"},
+        {"SMTP_HOST_ADDR", "localhost"},
+        {"SMTP_HOST_PORT", "465"},
+        {"SMTP_USER_NAME", "neo"},
+        {"SMTP_USER_PWD", "one"}
+      ]
+
+      assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
+               {:adapter, Bamboo.Mua},
+               {:ssl, [middlebox_comp_mode: false]},
+               {:protocol, :ssl},
+               {:relay, "localhost"},
+               {:port, 465},
                {:auth, [username: "neo", password: "one"]}
              ]
     end
@@ -186,6 +226,7 @@ defmodule Plausible.ConfigTest do
       assert get_in(runtime_config(env), [:plausible, Plausible.Mailer]) == [
                adapter: Bamboo.Mua,
                ssl: [middlebox_comp_mode: false],
+               protocol: :tcp,
                relay: "localhost",
                port: 2525
              ]


### PR DESCRIPTION
This PR adds support for SMTPS connections and also makes Mua use SMTPS when relay port is 465.

Related: https://github.com/plausible/analytics/discussions/4584