### PR TITLE
Check usage for users with active/cancelled/past due subscriptions

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -265,7 +265,13 @@ defmodule Plausible.Billing do
     user =
       User
       |> Repo.get!(subscription.user_id)
-      |> Map.put(:subscription, subscription)
+      |> Plausible.Users.with_subscription()
+
+    if subscription.id != user.subscription.id do
+      Sentry.capture_message("Susbscription ID mismatch",
+        extra: %{subscription: inspect(subscription), user_id: user.id}
+      )
+    end
 
     user
     |> Plausible.Users.update_accept_traffic_until()

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -43,7 +43,12 @@ defmodule Plausible.Workers.CheckUsage do
           on: s.user_id == u.id,
           left_join: ep in Plausible.Billing.EnterprisePlan,
           on: ep.user_id == u.id,
-          where: s.status == ^Subscription.Status.active(),
+          where:
+            s.status in [
+              ^Subscription.Status.active(),
+              ^Subscription.Status.past_due(),
+              ^Subscription.Status.deleted()
+            ],
           where: not is_nil(s.last_bill_date),
           # Accounts for situations like last_bill_date==2021-01-31 AND today==2021-03-01. Since February never reaches the 31st day, the account is checked on 2021-03-01.
           where:

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -36,31 +36,24 @@ defmodule Plausible.Workers.CheckUsage do
   def perform(_job, usage_mod \\ Quota.Usage, today \\ Date.utc_today()) do
     yesterday = today |> Date.shift(day: -1)
 
-    last_subscription_query =
-      from(s in Subscription,
-        order_by: [desc: s.inserted_at],
-        where:
-          s.status in [
-            ^Subscription.Status.active(),
-            ^Subscription.Status.past_due(),
-            ^Subscription.Status.deleted()
-          ],
-        where: not is_nil(s.last_bill_date),
-        # Accounts for situations like last_bill_date==2021-01-31 AND today==2021-03-01. Since February never reaches the 31st day, the account is checked on 2021-03-01.
-        where: s.next_bill_date >= ^today,
-        where:
-          least(day_of_month(s.last_bill_date), day_of_month(last_day_of_month(^yesterday))) ==
-            day_of_month(^yesterday),
-        limit: 1
-      )
-
     active_subscribers =
       Repo.all(
         from(u in User,
-          join: s in subquery(last_subscription_query),
+          join: s in Plausible.Billing.Subscription,
           on: s.user_id == u.id,
           left_join: ep in Plausible.Billing.EnterprisePlan,
           on: ep.user_id == u.id,
+          where:
+            s.status in [
+              ^Subscription.Status.active(),
+              ^Subscription.Status.past_due(),
+              ^Subscription.Status.deleted()
+            ],
+          where: not is_nil(s.last_bill_date),
+          # Accounts for situations like last_bill_date==2021-01-31 AND today==2021-03-01. Since February never reaches the 31st day, the account is checked on 2021-03-01.
+          where:
+            least(day_of_month(s.last_bill_date), day_of_month(last_day_of_month(^yesterday))) ==
+              day_of_month(^yesterday),
           preload: [subscription: s, enterprise_plan: ep]
         )
       )

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -5,9 +5,17 @@ defmodule Plausible.Workers.CheckUsageTest do
 
   alias Plausible.Workers.CheckUsage
 
+  require Plausible.Billing.Subscription.Status
+
   setup [:create_user, :create_site]
   @paddle_id_10k "558018"
   @date_range Date.range(Timex.today(), Timex.today())
+
+  @accepted_status_values [
+    Plausible.Billing.Subscription.Status.active(),
+    Plausible.Billing.Subscription.Status.past_due(),
+    Plausible.Billing.Subscription.Status.deleted()
+  ]
 
   test "ignores user without subscription" do
     CheckUsage.perform(nil)
@@ -15,319 +23,351 @@ defmodule Plausible.Workers.CheckUsageTest do
     assert_no_emails_delivered()
   end
 
-  test "ignores user with subscription but no usage", %{user: user} do
+  test "ignores user with paused subscription", %{user: user} do
     insert(:subscription,
       user: user,
       paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
+      last_bill_date: Timex.shift(Timex.today(), days: -1),
+      status: Plausible.Billing.Subscription.Status.paused()
     )
 
     CheckUsage.perform(nil)
 
     assert_no_emails_delivered()
-    assert Repo.reload(user).grace_period == nil
   end
 
-  test "does not send an email if account has been over the limit for one billing month", %{
-    user: user
-  } do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 9_000},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+  for status <- @accepted_status_values do
+    describe "#{status} subscription, regular customers" do
+      test "ignores user with subscription but no usage", %{user: user} do
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        CheckUsage.perform(nil)
 
-    CheckUsage.perform(nil, usage_stub)
+        assert_no_emails_delivered()
+        assert Repo.reload(user).grace_period == nil
+      end
 
-    assert_no_emails_delivered()
-    assert Repo.reload(user).grace_period == nil
-  end
+      test "does not send an email if account has been over the limit for one billing month", %{
+        user: user
+      } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 9_000},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-  test "does not send an email if account is over the limit by less than 10%", %{
-    user: user
-  } do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 10_999},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        CheckUsage.perform(nil, usage_stub)
 
-    CheckUsage.perform(nil, usage_stub)
+        assert_no_emails_delivered()
+        assert Repo.reload(user).grace_period == nil
+      end
 
-    assert_no_emails_delivered()
-    assert Repo.reload(user).grace_period == nil
-  end
+      test "does not send an email if account is over the limit by less than 10%", %{
+        user: user
+      } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 10_999},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-  test "sends an email when an account is over their limit for two consecutive billing months", %{
-    user: user
-  } do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        CheckUsage.perform(nil, usage_stub)
 
-    CheckUsage.perform(nil, usage_stub)
+        assert_no_emails_delivered()
+        assert Repo.reload(user).grace_period == nil
+      end
 
-    assert_email_delivered_with(
-      to: [user],
-      subject: "[Action required] You have outgrown your Plausible subscription tier"
-    )
+      test "sends an email when an account is over their limit for two consecutive billing months",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-    assert Repo.reload(user).grace_period.end_date == Timex.shift(Timex.today(), days: 7)
-  end
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-  test "sends an email suggesting enterprise plan when usage is greater than 10M ", %{
-    user: user
-  } do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000_000},
-          last_cycle: %{date_range: @date_range, total: 11_000_000}
-        }
-      end)
+        CheckUsage.perform(nil, usage_stub)
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        assert_email_delivered_with(
+          to: [user],
+          subject: "[Action required] You have outgrown your Plausible subscription tier"
+        )
 
-    CheckUsage.perform(nil, usage_stub)
+        assert Repo.reload(user).grace_period.end_date == Timex.shift(Timex.today(), days: 7)
+      end
 
-    assert_delivered_email_matches(%{html_body: html_body})
+      test "sends an email suggesting enterprise plan when usage is greater than 10M ", %{
+        user: user
+      } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000_000},
+              last_cycle: %{date_range: @date_range, total: 11_000_000}
+            }
+          end)
 
-    assert html_body =~
-             "Your usage exceeds our standard plans, so please reply back to this email for a tailored quote"
-  end
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-  test "skips checking users who already have a grace period", %{user: user} do
-    %{grace_period: existing_grace_period} =
-      user
-      |> Plausible.Auth.GracePeriod.start_changeset()
-      |> Repo.update!()
+        CheckUsage.perform(nil, usage_stub)
 
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+        assert_delivered_email_matches(%{html_body: html_body})
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        assert html_body =~
+                 "Your usage exceeds our standard plans, so please reply back to this email for a tailored quote"
+      end
 
-    CheckUsage.perform(nil, usage_stub)
+      test "skips checking users who already have a grace period", %{user: user} do
+        %{grace_period: existing_grace_period} =
+          user
+          |> Plausible.Auth.GracePeriod.start_changeset()
+          |> Repo.update!()
 
-    assert_no_emails_delivered()
-    assert Repo.reload(user).grace_period.id == existing_grace_period.id
-  end
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-  test "recommends a plan to upgrade to", %{
-    user: user
-  } do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        CheckUsage.perform(nil, usage_stub)
 
-    CheckUsage.perform(nil, usage_stub)
+        assert_no_emails_delivered()
+        assert Repo.reload(user).grace_period.id == existing_grace_period.id
+      end
 
-    assert_delivered_email_matches(%{
-      html_body: html_body
-    })
+      test "recommends a plan to upgrade to", %{
+        user: user
+      } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-    assert html_body =~ "We recommend you upgrade to the 100k/mo plan"
-  end
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-  test "clears grace period when plan is applicable again", %{user: user} do
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000},
-          last_cycle: %{date_range: @date_range, total: 11_000}
-        }
-      end)
+        CheckUsage.perform(nil, usage_stub)
 
-    insert(:subscription,
-      user: user,
-      paddle_plan_id: @paddle_id_10k,
-      last_bill_date: Timex.shift(Timex.today(), days: -1)
-    )
+        assert_delivered_email_matches(%{
+          html_body: html_body
+        })
 
-    CheckUsage.perform(nil, usage_stub)
-    assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+        assert html_body =~ "We recommend you upgrade to the 100k/mo plan"
+      end
 
-    usage_stub =
-      Plausible.Billing.Quota.Usage
-      |> stub(:monthly_pageview_usage, fn _user ->
-        %{
-          penultimate_cycle: %{date_range: @date_range, total: 11_000},
-          last_cycle: %{date_range: @date_range, total: 9_000}
-        }
-      end)
+      test "clears grace period when plan is applicable again", %{user: user} do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000},
+              last_cycle: %{date_range: @date_range, total: 11_000}
+            }
+          end)
 
-    CheckUsage.perform(nil, usage_stub)
-    refute user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
-  end
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: @paddle_id_10k,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-  describe "enterprise customers" do
-    test "skips checking enterprise users who already have a grace period", %{user: user} do
-      %{grace_period: existing_grace_period} =
-        user
-        |> Plausible.Auth.GracePeriod.start_manual_lock_changeset()
-        |> Repo.update!()
+        CheckUsage.perform(nil, usage_stub)
+        assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
 
-      usage_stub =
-        Plausible.Billing.Quota.Usage
-        |> stub(:monthly_pageview_usage, fn _user ->
-          %{
-            penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
-            last_cycle: %{date_range: @date_range, total: 1_100_000}
-          }
-        end)
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 11_000},
+              last_cycle: %{date_range: @date_range, total: 9_000}
+            }
+          end)
 
-      enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
-
-      insert(:subscription,
-        user: user,
-        paddle_plan_id: enterprise_plan.paddle_plan_id,
-        last_bill_date: Timex.shift(Timex.today(), days: -1)
-      )
-
-      CheckUsage.perform(nil, usage_stub)
-
-      assert_no_emails_delivered()
-      assert Repo.reload(user).grace_period.id == existing_grace_period.id
+        CheckUsage.perform(nil, usage_stub)
+        refute user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+      end
     end
+  end
 
-    test "checks billable pageview usage for enterprise customer, sends usage information to enterprise@plausible.io",
-         %{
-           user: user
-         } do
-      usage_stub =
-        Plausible.Billing.Quota.Usage
-        |> stub(:monthly_pageview_usage, fn _user ->
-          %{
-            penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
-            last_cycle: %{date_range: @date_range, total: 1_100_000}
-          }
-        end)
+  for status <- @accepted_status_values do
+    describe "#{status} subscription, enterprise customers" do
+      test "skips checking enterprise users who already have a grace period", %{user: user} do
+        %{grace_period: existing_grace_period} =
+          user
+          |> Plausible.Auth.GracePeriod.start_manual_lock_changeset()
+          |> Repo.update!()
 
-      enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
+              last_cycle: %{date_range: @date_range, total: 1_100_000}
+            }
+          end)
 
-      insert(:subscription,
-        user: user,
-        paddle_plan_id: enterprise_plan.paddle_plan_id,
-        last_bill_date: Timex.shift(Timex.today(), days: -1)
-      )
+        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
 
-      CheckUsage.perform(nil, usage_stub)
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: enterprise_plan.paddle_plan_id,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-      assert_email_delivered_with(
-        to: [{nil, "enterprise@plausible.io"}],
-        subject: "#{user.email} has outgrown their enterprise plan"
-      )
-    end
+        CheckUsage.perform(nil, usage_stub)
 
-    test "checks site limit for enterprise customer, sends usage information to enterprise@plausible.io",
-         %{
-           user: user
-         } do
-      usage_stub =
-        Plausible.Billing.Quota.Usage
-        |> stub(:monthly_pageview_usage, fn _user ->
-          %{
-            penultimate_cycle: %{date_range: @date_range, total: 1},
-            last_cycle: %{date_range: @date_range, total: 1}
-          }
-        end)
+        assert_no_emails_delivered()
+        assert Repo.reload(user).grace_period.id == existing_grace_period.id
+      end
 
-      enterprise_plan = insert(:enterprise_plan, user: user, site_limit: 2)
+      test "checks billable pageview usage for enterprise customer, sends usage information to enterprise@plausible.io",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
+              last_cycle: %{date_range: @date_range, total: 1_100_000}
+            }
+          end)
 
-      insert(:site, members: [user])
-      insert(:site, members: [user])
-      insert(:site, members: [user])
+        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
 
-      insert(:subscription,
-        user: user,
-        paddle_plan_id: enterprise_plan.paddle_plan_id,
-        last_bill_date: Timex.shift(Timex.today(), days: -1)
-      )
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: enterprise_plan.paddle_plan_id,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
 
-      CheckUsage.perform(nil, usage_stub)
+        CheckUsage.perform(nil, usage_stub)
 
-      assert_email_delivered_with(
-        to: [{nil, "enterprise@plausible.io"}],
-        subject: "#{user.email} has outgrown their enterprise plan"
-      )
-    end
+        assert_email_delivered_with(
+          to: [{nil, "enterprise@plausible.io"}],
+          subject: "#{user.email} has outgrown their enterprise plan"
+        )
+      end
 
-    test "starts grace period when plan is outgrown", %{user: user} do
-      usage_stub =
-        Plausible.Billing.Quota.Usage
-        |> stub(:monthly_pageview_usage, fn _user ->
-          %{
-            penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
-            last_cycle: %{date_range: @date_range, total: 1_100_000}
-          }
-        end)
+      test "checks site limit for enterprise customer, sends usage information to enterprise@plausible.io",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1},
+              last_cycle: %{date_range: @date_range, total: 1}
+            }
+          end)
 
-      enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
+        enterprise_plan = insert(:enterprise_plan, user: user, site_limit: 2)
 
-      insert(:subscription,
-        user: user,
-        paddle_plan_id: enterprise_plan.paddle_plan_id,
-        last_bill_date: Timex.shift(Timex.today(), days: -1)
-      )
+        insert(:site, members: [user])
+        insert(:site, members: [user])
+        insert(:site, members: [user])
 
-      CheckUsage.perform(nil, usage_stub)
-      assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: enterprise_plan.paddle_plan_id,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
+
+        CheckUsage.perform(nil, usage_stub)
+
+        assert_email_delivered_with(
+          to: [{nil, "enterprise@plausible.io"}],
+          subject: "#{user.email} has outgrown their enterprise plan"
+        )
+      end
+
+      test "starts grace period when plan is outgrown", %{user: user} do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
+              last_cycle: %{date_range: @date_range, total: 1_100_000}
+            }
+          end)
+
+        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
+
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: enterprise_plan.paddle_plan_id,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
+
+        CheckUsage.perform(nil, usage_stub)
+        assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+      end
     end
   end
 

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -38,17 +38,17 @@ defmodule Plausible.Workers.CheckUsageTest do
 
     insert(:subscription,
       user: user,
-      paddle_plan_id: "wont-exist-should-crash",
+      paddle_plan_id: @paddle_id_10k,
       last_bill_date: Timex.shift(Timex.today(), days: -1),
-      inserted_at: DateTime.shift(DateTime.utc_now(), day: -2),
-      status: :deleted
+      status: :active
     )
 
     insert(:subscription,
       user: user,
-      paddle_plan_id: @paddle_id_10k,
+      paddle_plan_id: "wont-exist-should-crash",
       last_bill_date: Timex.shift(Timex.today(), days: -1),
-      status: :active
+      inserted_at: DateTime.shift(DateTime.utc_now(), day: -2),
+      status: :deleted
     )
 
     CheckUsage.perform(nil, usage_stub)


### PR DESCRIPTION
So that over limit e-mails and grace period is handled regardless - they're still subscribers.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
