### PR TITLE
Make invitations cleanup worker rely on UTC time

### DIFF
--- a/lib/workers/clean_invitations.ex
+++ b/lib/workers/clean_invitations.ex
@@ -2,11 +2,17 @@ defmodule Plausible.Workers.CleanInvitations do
   use Plausible.Repo
   use Oban.Worker, queue: :clean_invitations
 
+  @cutoff Duration.new!(hour: -48)
+
   @impl Oban.Worker
   def perform(_job) do
+    cutoff_time =
+      NaiveDateTime.utc_now(:second)
+      |> NaiveDateTime.shift(@cutoff)
+
     Repo.delete_all(
       from i in Plausible.Auth.Invitation,
-        where: i.inserted_at < fragment("now() - INTERVAL '48 hours'")
+        where: i.inserted_at < ^cutoff_time
     )
 
     :ok

--- a/test/workers/clean_invitations_test.exs
+++ b/test/workers/clean_invitations_test.exs
@@ -3,8 +3,10 @@ defmodule Plausible.Workers.CleanInvitationsTest do
   alias Plausible.Workers.CleanInvitations
 
   test "cleans invitation that is more than 48h old" do
+    now = NaiveDateTime.utc_now(:second)
+
     insert(:invitation,
-      inserted_at: Timex.shift(Timex.now(), hours: -49),
+      inserted_at: NaiveDateTime.shift(now, hour: -49),
       site: build(:site),
       inviter: build(:user)
     )
@@ -15,8 +17,10 @@ defmodule Plausible.Workers.CleanInvitationsTest do
   end
 
   test "does not clean invitation that is less than 48h old" do
+    now = NaiveDateTime.utc_now(:second)
+
     insert(:invitation,
-      inserted_at: Timex.shift(Timex.now(), hours: -47),
+      inserted_at: NaiveDateTime.shift(now, hour: -47),
       site: build(:site),
       inviter: build(:user)
     )


### PR DESCRIPTION
### Changes

Fixes a problem where tests fail due to timezone shift when run locally against a DB with non-UTC timezone configured. The database of course should be configured properly in the first place but this change has an added benefit of making it more consistent with other time-dependent checks where the timestamp for comparison is usually provided from the app-side and not calculated directly in the database.


