### PR TITLE
Implement user notes in CRM and HelpScout integration

### DIFF
--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -88,6 +88,7 @@ defmodule Plausible.HelpScout do
       {:ok,
        %{
          email: user.email,
+         notes: user.notes,
          status_label: status_label(user),
          status_link:
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id),

--- a/extra/lib/plausible_web/views/help_scout_view.ex
+++ b/extra/lib/plausible_web/views/help_scout_view.ex
@@ -43,6 +43,16 @@ defmodule PlausibleWeb.HelpScoutView do
             Owner of <b><a href={@sites_link} target="_blank"><%= @sites_count %> sites</a></b>
           </p>
         </div>
+
+        <div :if={@notes} class="notes">
+          <p class="label">
+            Notes
+          </p>
+
+          <p class="value">
+            <%= Phoenix.HTML.Format.text_to_html(@notes, escape: true) %>
+          </p>
+        </div>
       <% end %>
     </.layout>
     """

--- a/extra/lib/plausible_web/views/help_scout_view.ex
+++ b/extra/lib/plausible_web/views/help_scout_view.ex
@@ -42,16 +42,17 @@ defmodule PlausibleWeb.HelpScoutView do
           <p class="label">
             Owner of <b><a href={@sites_link} target="_blank"><%= @sites_count %> sites</a></b>
           </p>
+          <p class="value"></p>
         </div>
 
         <div :if={@notes} class="notes">
           <p class="label">
-            Notes
+            <b>Notes</b>
           </p>
 
-          <p class="value">
+          <div class="value">
             <%= Phoenix.HTML.Format.text_to_html(@notes, escape: true) %>
-          </p>
+          </div>
         </div>
       <% end %>
     </.layout>
@@ -149,6 +150,10 @@ defmodule PlausibleWeb.HelpScoutView do
             .value {
               margin-bottom: 1.25em;
               font-weight: bold;
+            }
+
+            .notes .value {
+              font-weight: normal;
             }
           </style>
         </head>

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -35,6 +35,9 @@ defmodule Plausible.Auth.User do
     field :previous_email, :string
     field :accept_traffic_until, :date
 
+    # Field for purely informational purposes in CRM context
+    field :notes, :string
+
     # A field only used as a manual override - allow subscribing
     # to any plan, even when exceeding its pageview limit
     field :allow_next_upgrade_override, :boolean
@@ -113,7 +116,8 @@ defmodule Plausible.Auth.User do
       :theme,
       :trial_expiry_date,
       :allow_next_upgrade_override,
-      :accept_traffic_until
+      :accept_traffic_until,
+      :notes
     ])
     |> validate_required([:email, :name, :email_verified])
     |> maybe_bump_accept_traffic_until()

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -20,7 +20,8 @@ defmodule Plausible.Auth.UserAdmin do
       allow_next_upgrade_override: nil,
       accept_traffic_until: %{
         help_text: "Change will take up to 15 minutes to propagate"
-      }
+      },
+      notes: %{type: :textarea, rows: 6}
     ]
   end
 

--- a/test/plausible_web/controllers/help_scout_controller_test.exs
+++ b/test/plausible_web/controllers/help_scout_controller_test.exs
@@ -104,9 +104,9 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
       end
     end
 
-    describe "shows/2" do
+    describe "show/2" do
       test "returns details on success", %{conn: conn} do
-        user = insert(:user, email: "hs.match@plausible.test")
+        user = insert(:user, email: "hs.match@plausible.test", notes: "Some note\nwith new line")
 
         conn =
           conn
@@ -115,7 +115,9 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
             "/helpscout/show?conversation_id=123&customer_id=500&email=hs.match@plausible.test"
           )
 
-        assert html_response(conn, 200) =~ "/crm/auth/user/#{user.id}"
+        assert html = html_response(conn, 200)
+        assert html =~ "/crm/auth/user/#{user.id}"
+        assert html =~ "Some note<br>\nwith new line"
       end
 
       test "returns error when cookie is missing", %{conn: conn} do


### PR DESCRIPTION
### Changes

Depends on https://github.com/plausible/analytics/pull/4612

Implements ability to leave notes on a particular user in CRM.

The notes are also exposed (read-only) via HS integration.

### Tests
- [x] Automated tests have been added

