### PR TITLE
Remove unnecessary Enum.reject/2 call

### DIFF
--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -63,14 +63,12 @@ defmodule PlausibleWeb.LayoutView do
       %{
         key: "Shields",
         icon: :shield_exclamation,
-        value:
-          [
-            %{key: "IP Addresses", value: "shields/ip_addresses"},
-            %{key: "Countries", value: "shields/countries"},
-            %{key: "Pages", value: "shields/pages"},
-            %{key: "Hostnames", value: "shields/hostnames"}
-          ]
-          |> Enum.reject(&is_nil/1)
+        value: [
+          %{key: "IP Addresses", value: "shields/ip_addresses"},
+          %{key: "Countries", value: "shields/countries"},
+          %{key: "Pages", value: "shields/pages"},
+          %{key: "Hostnames", value: "shields/hostnames"}
+        ]
       },
       %{key: "Email Reports", value: "email-reports", icon: :envelope},
       if conn.assigns[:current_user_role] == :owner do


### PR DESCRIPTION
This PR removes unnecessary `Enum.reject(..., &is_nil/1)` call since the list is static and all values are non-nil.