### PR TITLE
Change cookie key in CE

### DIFF
--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -9,8 +9,8 @@ defmodule PlausibleWeb.Endpoint do
   end
 
   @session_options [
-    # key to be patched
-    key: "",
+    # in EE key is replaced, dynamically via RuntimeSessionAdapter, see below
+    key: "_plausible_key",
     store: :cookie,
     signing_salt: "I45i0SKHEku2f3tJh6y4v8gztrb/eG5KGCOe/o/AwFb7VHeuvDOn7AAq6KsdmOFM",
     # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
@@ -115,13 +115,13 @@ defmodule PlausibleWeb.Endpoint do
         # websocket requests within single root domain, in case websocket_url()
         # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
         Keyword.put(@session_options, :domain, host())
+        |> Keyword.put(:key, "_plausible_#{Application.fetch_env!(:plausible, :environment)}")
       else
         # CE setup is simpler and we don't need to worry about WS domain being different
         @session_options
       end
 
     session_options
-    |> Keyword.put(:key, "_plausible_#{Application.fetch_env!(:plausible, :environment)}")
     |> Keyword.put(:secure, secure_cookie?())
   end
 

--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -9,14 +9,14 @@ defmodule PlausibleWeb.Endpoint do
   end
 
   @session_options [
-    # in EE key is replaced, dynamically via RuntimeSessionAdapter, see below
+    # in EE key is replaced dynamically via runtime_session_opts, see below
     key: "_plausible_key",
     store: :cookie,
     signing_salt: "I45i0SKHEku2f3tJh6y4v8gztrb/eG5KGCOe/o/AwFb7VHeuvDOn7AAq6KsdmOFM",
     # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
     max_age: 60 * 60 * 24 * 365 * 5,
     extra: "SameSite=Lax"
-    # in EE domain is added dynamically via RuntimeSessionAdapter, see below
+    # in EE domain is added dynamically via runtime_session_opts, see below
   ]
 
   socket("/live", Phoenix.LiveView.Socket,


### PR DESCRIPTION
Fix for https://github.com/plausible/analytics/discussions/4618#discussioncomment-10751271

What is happening (probably):
- after POST /login browsers store two cookies, legacy-session one for .\<domain\> and new-session one for \<domain\> for the same key
- (some?) browsers put legacy-session cookie first in the cookie header
- Plug uses maps, so only one _plausible_prod cookie gets in, and in the current implementation, it's the first one that appears in the cookie header
- if legacy-session cookie ends up in the session map, auth plugs fail and redirect back to /login

This PR just changes the cookie key to `_plausible_key` so that there wouldn't be any conflicts.