### PR TITLE
Experimental pageleave events

### DIFF
--- a/extra/lib/plausible_web/dogfood.ex
+++ b/extra/lib/plausible_web/dogfood.ex
@@ -15,9 +15,9 @@ defmodule PlausibleWeb.Dogfood do
 
   def script_url() do
     if Application.get_env(:plausible, :environment) in ["prod", "staging"] do
-      "#{PlausibleWeb.Endpoint.url()}/js/script.manual.pageview-props.tagged-events.js"
+      "#{PlausibleWeb.Endpoint.url()}/js/script.manual.pageview-props.tagged-events.pageleave.js"
     else
-      "#{PlausibleWeb.Endpoint.url()}/js/script.local.manual.pageview-props.tagged-events.js"
+      "#{PlausibleWeb.Endpoint.url()}/js/script.local.manual.pageview-props.tagged-events.pageleave.js"
     end
   end
 

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -34,6 +34,8 @@ defmodule Plausible.Ingestion.Event do
           | :site_page_blocklist
           | :site_hostname_allowlist
           | :verification_agent
+          | :lock_timeout
+          | :no_session_for_pageleave
 
   @type t() :: %__MODULE__{
           domain: String.t() | nil,
@@ -375,6 +377,9 @@ defmodule Plausible.Ingestion.Event do
           event
           | clickhouse_event: ClickhouseEventV2.merge_session(event.clickhouse_event, session)
         }
+
+      {:error, :no_session_for_pageleave} ->
+        drop(event, :no_session_for_pageleave)
 
       {:error, :timeout} ->
         drop(event, :lock_timeout)

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -50,6 +50,7 @@ defmodule Plausible.Stats.Aggregate do
   defp aggregate_time_on_page(site, query) do
     windowed_pages_q =
       from e in base_event_query(site, Query.remove_top_level_filters(query, ["event:page"])),
+        where: e.name != "pageleave",
         select: %{
           next_timestamp: over(fragment("leadInFrame(?)", e.timestamp), :event_horizon),
           next_pathname: over(fragment("leadInFrame(?)", e.pathname), :event_horizon),

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -93,6 +93,7 @@ defmodule Plausible.Stats.Breakdown do
              site,
              Query.remove_top_level_filters(query, ["event:page", "event:props"])
            ),
+           where: e.name != "pageleave",
            select: %{
              next_timestamp: over(fragment("leadInFrame(?)", e.timestamp), :event_horizon),
              next_pathname: over(fragment("leadInFrame(?)", e.pathname), :event_horizon),

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -56,6 +56,7 @@ defmodule Plausible.Stats.Clickhouse do
         ClickhouseRepo.one(
           from(e in "events_v2",
             where: e.site_id in ^site_ids,
+            where: e.name != "pageleave",
             where: fragment("toDate(?)", e.timestamp) >= ^date_range.first,
             where: fragment("toDate(?)", e.timestamp) <= ^date_range.last,
             select: {

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -197,8 +197,8 @@ defmodule Plausible.Stats.SQL.Expression do
   end
 
   def event_metric(:events) do
-    wrap_alias([], %{
-      events: fragment("toUInt64(round(count(*) * any(_sample_factor)))")
+    wrap_alias([e], %{
+      events: fragment("toUInt64(round(countIf(? != 'pageleave') * any(_sample_factor)))", e.name)
     })
   end
 

--- a/lib/plausible_web/plugs/tracker.ex
+++ b/lib/plausible_web/plugs/tracker.ex
@@ -12,7 +12,8 @@ defmodule PlausibleWeb.Tracker do
     "file-downloads",
     "pageview-props",
     "tagged-events",
-    "revenue"
+    "revenue",
+    "pageleave"
   ]
 
   # Generates Power Set of all variants

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -55,6 +55,14 @@ defmodule Plausible.GoalsTest do
     assert {"has already been taken", _} = changeset.errors[:event_name]
   end
 
+  test "create/2 fails to create a goal with 'pageleave' as event_name (reserved)" do
+    site = insert(:site)
+    assert {:error, changeset} = Goals.create(site, %{"event_name" => "pageleave"})
+
+    assert {"The event name 'pageleave' is reserved and cannot be used as a goal", _} =
+             changeset.errors[:event_name]
+  end
+
   @tag :ee_only
   test "create/2 sets site.updated_at for revenue goal" do
     site_1 = insert(:site, updated_at: DateTime.add(DateTime.utc_now(), -3600))

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -318,6 +318,22 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :lock_timeout
   end
 
+  test "drops pageleave event when no session found from cache" do
+    site = insert(:site)
+
+    payload = %{
+      name: "pageleave",
+      url: "https://#{site.domain}/123",
+      d: "#{site.domain}"
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+
+    assert {:ok, request} = Request.build(conn)
+    assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(request)
+    assert dropped.drop_reason == :no_session_for_pageleave
+  end
+
   @tag :ee_only
   test "saves revenue amount" do
     site = insert(:site)

--- a/test/plausible/session/cache_store_test.exs
+++ b/test/plausible/session/cache_store_test.exs
@@ -3,6 +3,22 @@ defmodule Plausible.Session.CacheStoreTest do
 
   alias Plausible.Session.CacheStore
 
+  @session_params %{
+    referrer: "ref",
+    referrer_source: "refsource",
+    utm_medium: "medium",
+    utm_source: "source",
+    utm_campaign: "campaign",
+    utm_content: "content",
+    utm_term: "term",
+    browser: "browser",
+    browser_version: "55",
+    country_code: "EE",
+    screen_size: "Desktop",
+    operating_system: "Mac",
+    operating_system_version: "11"
+  }
+
   setup do
     current_pid = self()
 
@@ -40,23 +56,7 @@ defmodule Plausible.Session.CacheStoreTest do
     event2 = build(:event, name: "pageview", user_id: event1.user_id, site_id: event1.site_id)
     event3 = build(:event, name: "pageview", user_id: event1.user_id, site_id: event1.site_id)
 
-    session_params = %{
-      referrer: "ref",
-      referrer_source: "refsource",
-      utm_medium: "medium",
-      utm_source: "source",
-      utm_campaign: "campaign",
-      utm_content: "content",
-      utm_term: "term",
-      browser: "browser",
-      browser_version: "55",
-      country_code: "EE",
-      screen_size: "Desktop",
-      operating_system: "Mac",
-      operating_system_version: "11"
-    }
-
-    CacheStore.on_event(event1, session_params, nil, buffer)
+    CacheStore.on_event(event1, @session_params, nil, buffer)
 
     assert_receive({:buffer, :insert, [[session1]]})
     assert_receive({:telemetry_handled, duration})
@@ -65,7 +65,7 @@ defmodule Plausible.Session.CacheStoreTest do
     [event2, event3]
     |> Enum.map(fn e ->
       Task.async(fn ->
-        CacheStore.on_event(e, session_params, nil, slow_buffer)
+        CacheStore.on_event(e, @session_params, nil, slow_buffer)
       end)
     end)
     |> Task.await_many()
@@ -120,25 +120,9 @@ defmodule Plausible.Session.CacheStoreTest do
     event2 = build(:event, name: "pageview", user_id: event1.user_id, site_id: event1.site_id)
     event3 = build(:event, name: "pageview", user_id: event1.user_id, site_id: event1.site_id)
 
-    session_params = %{
-      referrer: "ref",
-      referrer_source: "refsource",
-      utm_medium: "medium",
-      utm_source: "source",
-      utm_campaign: "campaign",
-      utm_content: "content",
-      utm_term: "term",
-      browser: "browser",
-      browser_version: "55",
-      country_code: "EE",
-      screen_size: "Desktop",
-      operating_system: "Mac",
-      operating_system_version: "11"
-    }
-
     async1 =
       Task.async(fn ->
-        CacheStore.on_event(event1, session_params, nil, very_slow_buffer)
+        CacheStore.on_event(event1, @session_params, nil, very_slow_buffer)
       end)
 
     # Ensure next events are executed after processing event1 starts
@@ -146,12 +130,12 @@ defmodule Plausible.Session.CacheStoreTest do
 
     async2 =
       Task.async(fn ->
-        CacheStore.on_event(event2, session_params, nil, buffer)
+        CacheStore.on_event(event2, @session_params, nil, buffer)
       end)
 
     async3 =
       Task.async(fn ->
-        CacheStore.on_event(event3, session_params, nil, buffer)
+        CacheStore.on_event(event3, @session_params, nil, buffer)
       end)
 
     Task.await_many([async1, async2, async3])
@@ -174,25 +158,9 @@ defmodule Plausible.Session.CacheStoreTest do
     event2 = build(:event, name: "pageview")
     event3 = build(:event, name: "pageview", user_id: event2.user_id, site_id: event2.site_id)
 
-    session_params = %{
-      referrer: "ref",
-      referrer_source: "refsource",
-      utm_medium: "medium",
-      utm_source: "source",
-      utm_campaign: "campaign",
-      utm_content: "content",
-      utm_term: "term",
-      browser: "browser",
-      browser_version: "55",
-      country_code: "EE",
-      screen_size: "Desktop",
-      operating_system: "Mac",
-      operating_system_version: "11"
-    }
-
     async1 =
       Task.async(fn ->
-        CacheStore.on_event(event1, session_params, nil, very_slow_buffer)
+        CacheStore.on_event(event1, @session_params, nil, very_slow_buffer)
       end)
 
     # Ensure next events are executed after processing event1 starts
@@ -200,14 +168,14 @@ defmodule Plausible.Session.CacheStoreTest do
 
     async2 =
       Task.async(fn ->
-        CacheStore.on_event(event2, session_params, nil, buffer)
+        CacheStore.on_event(event2, @session_params, nil, buffer)
       end)
 
     Process.sleep(100)
 
     async3 =
       Task.async(fn ->
-        CacheStore.on_event(event3, session_params, nil, buffer)
+        CacheStore.on_event(event3, @session_params, nil, buffer)
       end)
 
     Task.await_many([async1, async2, async3])
@@ -229,24 +197,8 @@ defmodule Plausible.Session.CacheStoreTest do
 
     event = build(:event, name: "pageview")
 
-    session_params = %{
-      referrer: "ref",
-      referrer_source: "refsource",
-      utm_medium: "medium",
-      utm_source: "source",
-      utm_campaign: "campaign",
-      utm_term: "term",
-      utm_content: "content",
-      browser: "browser",
-      browser_version: "55",
-      country_code: "EE",
-      screen_size: "Desktop",
-      operating_system: "Mac",
-      operating_system_version: "11"
-    }
-
     assert_raise RuntimeError, "boom", fn ->
-      CacheStore.on_event(event, session_params, nil, crashing_buffer)
+      CacheStore.on_event(event, @session_params, nil, crashing_buffer)
     end
   end
 
@@ -258,23 +210,7 @@ defmodule Plausible.Session.CacheStoreTest do
         "meta.value": ["true", "false"]
       )
 
-    session_params = %{
-      referrer: "ref",
-      referrer_source: "refsource",
-      utm_medium: "medium",
-      utm_source: "source",
-      utm_campaign: "campaign",
-      utm_content: "content",
-      utm_term: "term",
-      browser: "browser",
-      browser_version: "55",
-      country_code: "EE",
-      screen_size: "Desktop",
-      operating_system: "Mac",
-      operating_system_version: "11"
-    }
-
-    CacheStore.on_event(event, session_params, nil, buffer)
+    CacheStore.on_event(event, @session_params, nil, buffer)
 
     assert_receive({:buffer, :insert, [sessions]})
     assert [session] = sessions
@@ -289,19 +225,19 @@ defmodule Plausible.Session.CacheStoreTest do
     assert session.duration == 0
     assert session.pageviews == 1
     assert session.events == 1
-    assert session.referrer == Map.get(session_params, :referrer)
-    assert session.referrer_source == Map.get(session_params, :referrer_source)
-    assert session.utm_medium == Map.get(session_params, :utm_medium)
-    assert session.utm_source == Map.get(session_params, :utm_source)
-    assert session.utm_campaign == Map.get(session_params, :utm_campaign)
-    assert session.utm_content == Map.get(session_params, :utm_content)
-    assert session.utm_term == Map.get(session_params, :utm_term)
-    assert session.country_code == Map.get(session_params, :country_code)
-    assert session.screen_size == Map.get(session_params, :screen_size)
-    assert session.operating_system == Map.get(session_params, :operating_system)
-    assert session.operating_system_version == Map.get(session_params, :operating_system_version)
-    assert session.browser == Map.get(session_params, :browser)
-    assert session.browser_version == Map.get(session_params, :browser_version)
+    assert session.referrer == Map.get(@session_params, :referrer)
+    assert session.referrer_source == Map.get(@session_params, :referrer_source)
+    assert session.utm_medium == Map.get(@session_params, :utm_medium)
+    assert session.utm_source == Map.get(@session_params, :utm_source)
+    assert session.utm_campaign == Map.get(@session_params, :utm_campaign)
+    assert session.utm_content == Map.get(@session_params, :utm_content)
+    assert session.utm_term == Map.get(@session_params, :utm_term)
+    assert session.country_code == Map.get(@session_params, :country_code)
+    assert session.screen_size == Map.get(@session_params, :screen_size)
+    assert session.operating_system == Map.get(@session_params, :operating_system)
+    assert session.operating_system_version == Map.get(@session_params, :operating_system_version)
+    assert session.browser == Map.get(@session_params, :browser)
+    assert session.browser_version == Map.get(@session_params, :browser_version)
     assert session.timestamp == event.timestamp
     assert session.start === event.timestamp
     # assert Map.get(session, :"entry.meta.key") == ["logged_in", "darkmode"]

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -101,6 +101,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
+    test "does not count pageleave events towards the events metric in a simple aggregate query",
+         %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageleave", timestamp: ~N[2021-01-01 00:00:01])
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["events"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"metrics" => [1], "dimensions" => []}
+             ]
+    end
+
     test "can filter by channel", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,

--- a/tracker/compile.js
+++ b/tracker/compile.js
@@ -26,7 +26,7 @@ function compilefile(input, output, templateVars = {}) {
   }
 }
 
-const base_variants = ["hash", "outbound-links", "exclusions", "compat", "local", "manual", "file-downloads", "pageview-props", "tagged-events", "revenue"]
+const base_variants = ["hash", "outbound-links", "exclusions", "compat", "local", "manual", "file-downloads", "pageview-props", "tagged-events", "revenue", "pageleave"]
 const variants = [...g.clone.powerSet(base_variants)].filter(a => a.length > 0).map(a => a.sort());
 
 compilefile(relPath('src/plausible.js'), relPath('../priv/tracker/js/plausible.js'))

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -36,7 +36,18 @@
   // prevents registering multiple listeners in those cases.
   var listeningPageLeave = false
 
+  // In SPA-s, multiple listeners that trigger the pageleave event
+  // might fire nearly at the same time. E.g. when navigating back
+  // in browser history while using hash-based routing - a popstate
+  // and hashchange will be fired in a very quick succession. This
+  // flag prevents sending multiple pageleaves in those cases.
+  var pageLeaveSending = false
+
   function triggerPageLeave(url) {
+    if (pageLeaveSending) {return}
+    pageLeaveSending = true
+    setTimeout(function () {pageLeaveSending = false}, 500)
+
     var payload = {
       n: 'pageleave',
       d: dataDomain,

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -174,7 +174,7 @@
     {{#if pageleave}}
     var lastUrl = location.href
 
-    function pageLeave() {
+    function pageLeaveSPA() {
       triggerPageLeave(lastUrl);
       lastUrl = location.href;
     }
@@ -186,7 +186,7 @@
       {{/unless}}
       
       {{#if pageleave}}
-      if (isSPANavigation) {pageLeave()}
+      if (isSPANavigation) {pageLeaveSPA()}
       {{/if}}
 
       lastPage = location.pathname


### PR DESCRIPTION
### Changes

With a future goal of implementing the `scroll_depth` metric, this PR introduces an experimental script variant for tracking `pageleave` events. 

Sending analytics data when the page is unloaded is unreliable by nature. Hence the first objective is to find out the percentage of pageleave events that we can expect (100% would mean that the number of pageleaves equals the number of pageviews).

If the percentage is reasonable, the next step would be to track a `scroll_depth` parameter with `pageleave` events, and eventually start reporting the average of that value on the dashboard, per page.

Here's a more technical description of the changes introduced in this PR:

* Implement a `script.pageleave.js` script variant.
  * The script will start triggering `pageleaves` on the `pagehide` browser event. We're only sticking with `pagehide` (and not `beforeunload`) because adding listeners to the `beforeunload` event will prevent placing the page in bfcache, therefore negatively affecting website performance ([reference doc](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)).
  * The script will also trigger `pageleaves` on history and hash-based SPA navigation. This will be tested at plausible.io/docs which uses history-based navigation. 
* Start using the new variant on plausible.io (three repositories):
  * plausible/analytics (this PR)
  * plausible/docs (will open a PR once this gets merged)
  * plausible/website (will open a PR once this gets merged)
* Consider `pageleave` a "special" event in many cases:
  * Prohibit adding goals with this event name
  * Do not count it towards the `events` metric
  * Do not count it towards "billable pageviews"
  * Do not let it affect the current `time_on_page`
  * When ingesting `pageleave` events, make sure it just gets the `session_id`, but **does not update the session** itself. At a later iteration we probably want to update `is_bounce` and `duration` as well.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
