### PR TITLE
Try to make ingest lock timeout tests less flaky

### DIFF
--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -312,7 +312,7 @@ defmodule Plausible.Ingestion.EventTest do
                )
     end)
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(second_request)
     assert dropped.drop_reason == :lock_timeout


### PR DESCRIPTION
### Changes

Can't tell for sure as this test fail is hard to reproduce, but I suspect there might be situations where reaching session processing step in the first ingest takes longer than the sleep before spinning up the second ingest.

