### PR TITLE
Handle cross-device file move

### DIFF
--- a/lib/plausible/file.ex
+++ b/lib/plausible/file.ex
@@ -21,7 +21,7 @@ defmodule Plausible.File do
           _ -> reraise(e, __STACKTRACE__)
         end
       after
-        File.rm!(source)
+        File.rm(source)
       end
   end
 end

--- a/lib/plausible/file.ex
+++ b/lib/plausible/file.ex
@@ -16,12 +16,10 @@ defmodule Plausible.File do
       case e.reason do
         # fallback to cp/rm for cross-device moves
         # https://github.com/plausible/analytics/issues/4638
-        :exdev ->
-          File.cp!(source, destination)
-          File.rm!(source)
-
-        _ ->
-          reraise(e, __STACKTRACE__)
+        :exdev -> File.cp!(source, destination)
+        _ -> reraise(e, __STACKTRACE__)
       end
+  after
+    File.rm(source)
   end
 end

--- a/lib/plausible/file.ex
+++ b/lib/plausible/file.ex
@@ -1,0 +1,27 @@
+defmodule Plausible.File do
+  @moduledoc """
+  File helpers for Plausible.
+  """
+
+  @doc """
+  Moves a file from one location to another.
+
+  Tries renaming first, and falls back to copying and deleting the original.
+  """
+  @spec mv!(Path.t(), Path.t()) :: :ok
+  def mv!(source, destination) do
+    File.rename!(source, destination)
+  rescue
+    e in File.RenameError ->
+      case e.reason do
+        # fallback to cp/rm for cross-device moves
+        # https://github.com/plausible/analytics/issues/4638
+        :exdev ->
+          File.cp!(source, destination)
+          File.rm!(source)
+
+        _ ->
+          reraise(e, __STACKTRACE__)
+      end
+  end
+end

--- a/lib/plausible/file.ex
+++ b/lib/plausible/file.ex
@@ -13,13 +13,15 @@ defmodule Plausible.File do
     File.rename!(source, destination)
   rescue
     e in File.RenameError ->
-      case e.reason do
-        # fallback to cp/rm for cross-device moves
-        # https://github.com/plausible/analytics/issues/4638
-        :exdev -> File.cp!(source, destination)
-        _ -> reraise(e, __STACKTRACE__)
+      try do
+        case e.reason do
+          # fallback to cp/rm for cross-device moves
+          # https://github.com/plausible/analytics/issues/4638
+          :exdev -> File.cp!(source, destination)
+          _ -> reraise(e, __STACKTRACE__)
+        end
+      after
+        File.rm!(source)
       end
-  after
-    File.rm(source)
   end
 end

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.Live.CSVImport do
 
           fn meta, entry ->
             local_path = Path.join(local_dir, Path.basename(meta.path))
-            File.rename!(meta.path, local_path)
+            Plausible.File.mv!(meta.path, local_path)
             {:ok, %{"local_path" => local_path, "filename" => entry.client_name}}
           end
       end

--- a/lib/workers/export_analytics.ex
+++ b/lib/workers/export_analytics.ex
@@ -101,7 +101,7 @@ defmodule Plausible.Workers.ExportAnalytics do
 
     File.mkdir_p!(Path.dirname(local_path))
     if File.exists?(local_path), do: File.rm!(local_path)
-    File.rename!(tmp_path, local_path)
+    Plausible.File.mv!(tmp_path, local_path)
   end
 
   defp email_failure(args) do

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -551,7 +551,7 @@ defmodule Plausible.Imported.CSVImporterTest do
           )
         )
       else
-        File.rename!(local_path, Path.join(tmp_dir, "plausible-export.zip"))
+        Plausible.File.mv!(local_path, Path.join(tmp_dir, "plausible-export.zip"))
       end
 
       # unzip archive

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -551,7 +551,7 @@ defmodule Plausible.Imported.CSVImporterTest do
           )
         )
       else
-        Plausible.File.mv!(local_path, Path.join(tmp_dir, "plausible-export.zip"))
+        File.rename!(local_path, Path.join(tmp_dir, "plausible-export.zip"))
       end
 
       # unzip archive


### PR DESCRIPTION
This PR replaces `File.rename!` with a custom `Plausible.File.mv!` functions that tries `File.rename!` first and falls back to `File.cp!` and `File.rm` in case of EXDEV error:

> EXDEV oldpath and newpath are not on the same mounted filesystem. (Linux permits a filesystem to be mounted at multiple points, but rename() does not work across different mount points, even if the same filesystem is mounted on both.)

Closes https://github.com/plausible/analytics/issues/4638

---

Since EE uses S3 instead of local disk for exports/imports, this PR only affects CE.