### PR TITLE
Settings password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add ability to review and revoke particular logged in user sessions
+- Add ability to change password from user settings screen
 
 ### Removed
 

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -23,6 +23,11 @@ defmodule Plausible.Auth do
       prefix: "email-change:user",
       limit: 2,
       interval: :timer.hours(1)
+    },
+    password_change_user: %{
+      prefix: "password-change:user",
+      limit: 5,
+      interval: :timer.minutes(20)
     }
   }
 

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -25,6 +25,7 @@ defmodule Plausible.Auth.User do
   schema "users" do
     field :email, :string
     field :password_hash
+    field :old_password, :string, virtual: true
     field :password, :string, virtual: true
     field :password_confirmation, :string, virtual: true
     field :name, :string
@@ -65,8 +66,7 @@ defmodule Plausible.Auth.User do
     %Plausible.Auth.User{}
     |> cast(attrs, @required)
     |> validate_required(@required)
-    |> validate_length(:password, min: 12, message: "has to be at least 12 characters")
-    |> validate_length(:password, max: 128, message: "cannot be longer than 128 characters")
+    |> validate_password_length()
     |> validate_confirmation(:password, required: true)
     |> validate_password_strength()
     |> hash_password()
@@ -142,9 +142,20 @@ defmodule Plausible.Auth.User do
     user
     |> cast(%{password: password}, [:password])
     |> validate_required([:password])
-    |> validate_length(:password, min: 12, message: "has to be at least 12 characters")
-    |> validate_length(:password, max: 128, message: "cannot be longer than 128 characters")
+    |> validate_password_length()
     |> validate_password_strength()
+    |> hash_password()
+  end
+
+  def password_changeset(user, params \\ %{}) do
+    user
+    |> cast(params, [:old_password, :password])
+    |> check_password(:old_password)
+    |> validate_required([:old_password, :password])
+    |> validate_password_length()
+    |> validate_confirmation(:password, required: true)
+    |> validate_password_strength()
+    |> validate_password_changed()
     |> hash_password()
   end
 
@@ -226,16 +237,33 @@ defmodule Plausible.Auth.User do
     end
   end
 
-  defp check_password(changeset) do
-    if password = get_change(changeset, :password) do
+  defp validate_password_changed(changeset) do
+    old_password = get_change(changeset, :old_password)
+    new_password = get_change(changeset, :password)
+
+    if old_password == new_password do
+      add_error(changeset, :password, "is too weak", validation: :different_password)
+    else
+      changeset
+    end
+  end
+
+  defp check_password(changeset, field \\ :password) do
+    if password = get_change(changeset, field) do
       if Plausible.Auth.Password.match?(password, changeset.data.password_hash) do
         changeset
       else
-        add_error(changeset, :password, "is invalid", validation: :check_password)
+        add_error(changeset, field, "is invalid", validation: :check_password)
       end
     else
       changeset
     end
+  end
+
+  defp validate_password_length(changeset) do
+    changeset
+    |> validate_length(:password, min: 12, message: "has to be at least 12 characters")
+    |> validate_length(:password, max: 128, message: "cannot be longer than 128 characters")
   end
 
   defp validate_password_strength(changeset) do

--- a/lib/plausible_web/components/two_factor.ex
+++ b/lib/plausible_web/components/two_factor.ex
@@ -24,14 +24,26 @@ defmodule PlausibleWeb.Components.TwoFactor do
   attr :form, :any, required: true
   attr :field, :any, required: true
   attr :class, :string, default: ""
+  attr :show_button?, :boolean, default: true
 
   def verify_2fa_input(assigns) do
+    input_class =
+      "font-mono tracking-[0.5em] w-36 pl-5 font-medium shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-500 dark:text-gray-200 dark:bg-gray-900 rounded-l-md"
+
+    input_class =
+      if assigns.show_button? do
+        input_class
+      else
+        [input_class, "rounded-r-md"]
+      end
+
+    assigns = assign(assigns, :input_class, input_class)
+
     ~H"""
     <div class={[@class, "flex items-center"]}>
       <%= Phoenix.HTML.Form.text_input(@form, @field,
         autocomplete: "off",
-        class:
-          "font-mono tracking-[0.5em] w-36 pl-5 font-medium shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-500 dark:text-gray-200 dark:bg-gray-900 rounded-l-md",
+        class: @input_class,
         oninput:
           "this.value=this.value.replace(/[^0-9]/g, ''); if (this.value.length >= 6) document.getElementById('verify-button').focus()",
         onclick: "this.select();",
@@ -42,6 +54,7 @@ defmodule PlausibleWeb.Components.TwoFactor do
         required: "required"
       ) %>
       <PlausibleWeb.Components.Generic.button
+        :if={@show_button?}
         type="submit"
         id={@id}
         mt?={false}

--- a/lib/plausible_web/components/two_factor.ex
+++ b/lib/plausible_web/components/two_factor.ex
@@ -2,7 +2,8 @@ defmodule PlausibleWeb.Components.TwoFactor do
   @moduledoc """
   Reusable components specific to 2FA
   """
-  use Phoenix.Component
+  use Phoenix.Component, global_prefixes: ~w(x-)
+  import PlausibleWeb.Components.Generic
 
   attr :text, :string, required: true
   attr :scale, :integer, default: 4
@@ -152,13 +153,14 @@ defmodule PlausibleWeb.Components.TwoFactor do
             </div>
             <div class="bg-gray-50 dark:bg-gray-850 px-4 py-3 sm:px-9 sm:flex sm:flex-row-reverse">
               <%= render_slot(@buttons) %>
-              <button
+              <.button
                 type="button"
-                class="sm:mr-2 mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-850 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
                 x-on:click={"#{@state_param} = false"}
+                class="mr-2"
+                theme="bright"
               >
                 Cancel
-              </button>
+              </.button>
             </div>
           <% end %>
         </div>

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -559,6 +559,7 @@ defmodule PlausibleWeb.AuthController do
               {:error, _} ->
                 changes
                 |> Ecto.Changeset.add_error(:password, "invalid 2FA code")
+                |> Map.put(:action, :validate)
                 |> Repo.rollback()
             end
           else

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -329,6 +329,7 @@ defmodule PlausibleWeb.Router do
     get "/settings", AuthController, :user_settings
     put "/settings", AuthController, :save_settings
     put "/settings/email", AuthController, :update_email
+    put "/settings/password", AuthController, :update_password
     post "/settings/email/cancel", AuthController, :cancel_update_email
     delete "/me", AuthController, :delete_me
     get "/settings/api-keys/new", AuthController, :new_api_key

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -250,17 +250,20 @@
         </div>
       </div>
 
-      <div class="my-4" :if={Plausible.Auth.TOTP.enabled?(@current_user)}>
+      <div :if={Plausible.Auth.TOTP.enabled?(@current_user)} class="my-4">
         <%= label(f, :two_factor_code, "Verify with 2FA",
           class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
         ) %>
         <div class="mt-1">
-          <PlausibleWeb.Components.TwoFactor.verify_2fa_input form={f} show_button?={false} field={:two_factor_code} />
+          <PlausibleWeb.Components.TwoFactor.verify_2fa_input
+            form={f}
+            show_button?={false}
+            field={:two_factor_code}
+          />
 
           <%= error_tag(f, :two_factor_code) %>
         </div>
       </div>
-
 
       <%= submit("Change my password",
         class:

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -220,7 +220,7 @@
             class:
               "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
           ) %>
-          <%= error_tag(f, :old_password) %>
+          <%= error_tag(f, :old_password, only_first?: true) %>
         </div>
       </div>
       <div class="my-4">
@@ -233,7 +233,7 @@
             class:
               "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
           ) %>
-          <%= error_tag(f, :password) %>
+          <%= error_tag(f, :password, only_first?: true) %>
         </div>
       </div>
       <div class="my-4">
@@ -246,7 +246,7 @@
             class:
               "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
           ) %>
-          <%= error_tag(f, :password_confirmation) %>
+          <%= error_tag(f, :password_confirmation, only_first?: true) %>
         </div>
       </div>
 
@@ -260,8 +260,6 @@
             show_button?={false}
             field={:two_factor_code}
           />
-
-          <%= error_tag(f, :two_factor_code) %>
         </div>
       </div>
 

--- a/lib/plausible_web/templates/auth/user_settings.html.heex
+++ b/lib/plausible_web/templates/auth/user_settings.html.heex
@@ -203,6 +203,72 @@
     <% end %>
   </div>
 
+  <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-red-600 rounded rounded-t-none shadow-md dark:bg-gray-800">
+    <h2 id="change-password" class="text-xl font-black dark:text-gray-100">
+      Change password
+    </h2>
+
+    <div class="my-4 border-b border-gray-300 dark:border-gray-500"></div>
+
+    <%= form_for @password_changeset, "/settings/password#change-password", [class: "max-w-sm"], fn f -> %>
+      <div class="my-4">
+        <%= label(f, :old_password, "Current password",
+          class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+        ) %>
+        <div class="mt-1">
+          <%= password_input(f, :old_password,
+            class:
+              "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
+          ) %>
+          <%= error_tag(f, :old_password) %>
+        </div>
+      </div>
+      <div class="my-4">
+        <%= label(f, :password, "New password",
+          class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+        ) %>
+        <div class="mt-1">
+          <%= password_input(f, :password,
+            autocomplete: "new-password",
+            class:
+              "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
+          ) %>
+          <%= error_tag(f, :password) %>
+        </div>
+      </div>
+      <div class="my-4">
+        <%= label(f, :password_confirmation, "Confirm new password",
+          class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+        ) %>
+        <div class="mt-1">
+          <%= password_input(f, :password_confirmation,
+            autocomplete: "new-password",
+            class:
+              "shadow-sm dark:bg-gray-900 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 dark:border-gray-500 rounded-md dark:bg-gray-800"
+          ) %>
+          <%= error_tag(f, :password_confirmation) %>
+        </div>
+      </div>
+
+      <div class="my-4" :if={Plausible.Auth.TOTP.enabled?(@current_user)}>
+        <%= label(f, :two_factor_code, "Verify with 2FA",
+          class: "block text-sm font-medium text-gray-700 dark:text-gray-300"
+        ) %>
+        <div class="mt-1">
+          <PlausibleWeb.Components.TwoFactor.verify_2fa_input form={f} show_button?={false} field={:two_factor_code} />
+
+          <%= error_tag(f, :two_factor_code) %>
+        </div>
+      </div>
+
+
+      <%= submit("Change my password",
+        class:
+          "inline-block mt-4 px-4 py-2 border border-gray-300 dark:border-gray-500 text-sm leading-5 font-medium rounded-md text-red-600 dark:text-red-500 bg-white dark:bg-gray-800 hover:text-red-400 focus:outline-none focus:border-blue-300 focus:ring active:text-red-800 active:bg-gray-50 transition ease-in-out duration-150"
+      ) %>
+    <% end %>
+  </div>
+
   <div class="max-w-2xl px-8 pt-6 pb-8 mx-auto mt-16 bg-white border-t-2 border-green-500 rounded rounded-t-none shadow-md dark:bg-gray-800">
     <h2 id="setup-2fa" class="text-xl font-black dark:text-gray-100">
       Two-Factor Authentication (2FA)

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.UserAuth do
   Functions for user session management.
   """
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query
 
   alias Plausible.Auth
   alias Plausible.Repo
@@ -85,12 +85,19 @@ defmodule PlausibleWeb.UserAuth do
     :ok
   end
 
-  @spec revoke_all_user_sessions(Auth.User.t()) :: :ok
-  def revoke_all_user_sessions(user) do
-    {_count, tokens} =
-      Repo.delete_all(
-        from us in Auth.UserSession, where: us.user_id == ^user.id, select: us.token
-      )
+  @spec revoke_all_user_sessions(Auth.User.t(), Keyword.t()) :: :ok
+  def revoke_all_user_sessions(user, opts \\ []) do
+    except = Keyword.get(opts, :except)
+
+    delete_query = from us in Auth.UserSession, where: us.user_id == ^user.id, select: us.token
+
+    delete_query = if except do
+      where(delete_query, [us], us.id != ^except.id)
+    else
+      delete_query
+    end
+
+    {_count, tokens} = Repo.delete_all(delete_query)
 
     Enum.each(tokens, fn token ->
       PlausibleWeb.Endpoint.broadcast(live_socket_id(token), "disconnect", %{})

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -91,11 +91,12 @@ defmodule PlausibleWeb.UserAuth do
 
     delete_query = from us in Auth.UserSession, where: us.user_id == ^user.id, select: us.token
 
-    delete_query = if except do
-      where(delete_query, [us], us.id != ^except.id)
-    else
-      delete_query
-    end
+    delete_query =
+      if except do
+        where(delete_query, [us], us.id != ^except.id)
+      else
+        delete_query
+      end
 
     {_count, tokens} = Repo.delete_all(delete_query)
 

--- a/lib/plausible_web/views/error_helpers.ex
+++ b/lib/plausible_web/views/error_helpers.ex
@@ -1,13 +1,24 @@
 defmodule PlausibleWeb.ErrorHelpers do
   use Phoenix.HTML
 
-  def error_tag(%{errors: errors}, field) do
-    Enum.map(Keyword.get_values(errors, field), fn error ->
+  def error_tag(map_or_form, field, opts \\ [])
+
+  def error_tag(%{errors: errors}, field, opts) do
+    error_messages = Keyword.get_values(errors, field)
+
+    error_messages =
+      if Keyword.get(opts, :only_first?) do
+        Enum.take(error_messages, 1)
+      else
+        error_messages
+      end
+
+    Enum.map(error_messages, fn error ->
       content_tag(:div, translate_error(error), class: "mt-2 text-sm text-red-500")
     end)
   end
 
-  def error_tag(assigns, field) when is_map(assigns) do
+  def error_tag(assigns, field, _opts) when is_map(assigns) do
     error = assigns[field]
 
     if error do


### PR DESCRIPTION
### Changes

This PR adds a password change capability to account settings.

![image](https://github.com/user-attachments/assets/5fd54f01-4e46-4a65-93bf-b0d8d12cb199)

![image](https://github.com/user-attachments/assets/2d755164-abb0-4804-8993-576854667129)

UI-wise it will receive more love in a follow-up iteration - we're planning to rewrite the account settings completely (as part of Team Accounts project).


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
