### PR TITLE
Fix revenue metrics if custom display name is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Revenue metrics are displayed correctly after goal has been renamed
 
 ## v2.1.3 - 2024-09-26
 

--- a/extra/lib/plausible/stats/goal/revenue.ex
+++ b/extra/lib/plausible/stats/goal/revenue.ex
@@ -42,7 +42,7 @@ defmodule Plausible.Stats.Goal.Revenue do
       revenue_goals_currencies =
         Plausible.Repo.all(
           from rg in Ecto.assoc(site, :revenue_goals),
-            where: rg.event_name in ^goal_filters,
+            where: rg.display_name in ^goal_filters,
             select: rg.currency,
             distinct: true
         )
@@ -58,7 +58,7 @@ defmodule Plausible.Stats.Goal.Revenue do
   def cast_revenue_metrics_to_money([%{goal: _goal} | _rest] = results, revenue_goals)
       when is_list(revenue_goals) do
     for result <- results do
-      if matching_goal = Enum.find(revenue_goals, &(&1.event_name == result.goal)) do
+      if matching_goal = Enum.find(revenue_goals, &(&1.display_name == result.goal)) do
         cast_revenue_metrics_to_money(result, matching_goal.currency)
       else
         result

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -775,9 +775,14 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
         )
       ])
 
-      insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
+      insert(:goal, %{
+        site: site,
+        event_name: "Payment",
+        currency: :EUR,
+        display_name: "PaymentEUR"
+      })
 
-      filters = Jason.encode!(%{goal: "Payment"})
+      filters = Jason.encode!(%{goal: "PaymentEUR"})
 
       conn =
         get(

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1338,8 +1338,19 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
     @tag :ee_only
     test "returns average and total when filtering by a revenue goal", %{conn: conn, site: site} do
-      insert(:goal, site: site, event_name: "Payment", currency: "USD")
-      insert(:goal, site: site, event_name: "AddToCart", currency: "EUR")
+      insert(:goal,
+        site: site,
+        event_name: "Payment",
+        currency: "USD",
+        display_name: "PaymentUSD"
+      )
+
+      insert(:goal,
+        site: site,
+        event_name: "AddToCart",
+        currency: "EUR",
+        display_name: "AddToCartEUR"
+      )
 
       populate_stats(site, [
         build(:event,
@@ -1364,7 +1375,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         )
       ])
 
-      filters = Jason.encode!(%{goal: "Payment"})
+      filters = Jason.encode!(%{goal: "PaymentUSD"})
       conn = get(conn, "/api/stats/#{site.domain}/top-stats?period=all&filters=#{filters}")
       assert %{"top_stats" => top_stats} = json_response(conn, 200)
 


### PR DESCRIPTION
Seems since https://github.com/plausible/analytics/pull/4415 or https://github.com/plausible/analytics/pull/4391, revenue metrics have not been correctly displayed on the dashboard if the goal display name has been changed from the default.

Discovered while refactoring this code, wanted to PR the fix separately.