### PR TITLE
Trigger pageviews on pages loaded from bfcache

### DIFF
--- a/lib/plausible_web/templates/layout/_tracking.html.heex
+++ b/lib/plausible_web/templates/layout/_tracking.html.heex
@@ -32,6 +32,13 @@
       }
 
       plausible('pageview', defaultEventOptions)
+
+      window.addEventListener('pageshow', function(event) {
+        if (event.persisted) {
+          // Page was restored from bfcache - trigger a pageview
+          plausible('pageview', defaultEventOptions);
+        }
+      })
     </script>
   <% end %>
 <% end %>

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -231,6 +231,15 @@
     } else {
       page()
     }
+
+    {{#if pageleave}}
+    window.addEventListener('pageshow', function(event) {
+      if (event.persisted) {
+        // Page was restored from bfcache - trigger a pageview
+        page();
+      }
+    })
+    {{/if}}
   {{/unless}}
 
   {{#if (any outbound_links file_downloads tagged_events)}}


### PR DESCRIPTION
### Changes

While experimenting with pageleave events we've discovered that pageviews are not being fired when a page is loaded from bfcache.

This PR fixes that, for now, only in the context of the pageleave script variant. I'm leaving the default script untouched for now as the pageleave variant will also be merged into the default script at some point.

The fix itself is to listen for the `pageshow` event and fire a pageview if the `event.persisted` property is `true`.

Note that we only add the 'pageshow' listener if the script is **not in manual mode**. If it's manual, the listener needs to be added manually as well.

Since we're using the manual variant ourselves (in both this repo, and in plausible/website):

1. the PR at hand updates `_tracking.html` to add the 'pageshow' listener
2. [this PR](https://github.com/plausible/website/pull/662) updates the tracking in the plausible/website repo

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI