### PR TITLE
Log Oban errors (and still report them to Sentry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Add ability to review and revoke particular logged in user sessions
 - Add ability to change password from user settings screen
+- Add error logs for background jobs plausible/analytics#4657
 
 ### Removed
 

--- a/lib/oban_error_reporter.ex
+++ b/lib/oban_error_reporter.ex
@@ -67,8 +67,10 @@ defmodule ObanErrorReporter do
   # Logs the error and sends it to Sentry
   defp capture_error(meta, extra) do
     Logger.error(
+      # this message is ignored by Sentry
       "Background job (#{inspect(extra)}) failed:\n\n  " <>
         Exception.format(:error, meta.reason, meta.stacktrace),
+      # Sentry report is built entirely from crash_reason
       crash_reason: {meta.reason, meta.stacktrace},
       sentry: %{extra: extra}
     )


### PR DESCRIPTION
This PR adds logging for Oban errors. The reasoning is that most self-hosters don't have Sentry configured which makes these errors invisible.

Here's how it'd look after this PR:

<img width="1102" alt="Screenshot 2024-10-08 at 16 23 14" src="https://github.com/user-attachments/assets/68e04e7b-a14b-4bee-8c81-d46c0f2413c5">