### PR TITLE
Implement basics of Teams

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -83,7 +83,7 @@
           # If you don't want TODO comments to cause `mix credo` to fail, just
           # set this value to 0 (zero).
           #
-          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+          {Credo.Check.Design.TagTODO, [exit_status: 0]},
           {Credo.Check.Design.TagFIXME, []},
 
           #

--- a/lib/mix/tasks/create_free_subscription.ex
+++ b/lib/mix/tasks/create_free_subscription.ex
@@ -15,8 +15,9 @@ defmodule Mix.Tasks.CreateFreeSubscription do
 
   def execute(user_id) do
     user = Repo.get(Plausible.Auth.User, user_id)
+    {:ok, team} = Plausible.Teams.get_or_create(user)
 
-    Subscription.free(%{user_id: user_id})
+    Subscription.free(%{user_id: user_id, team_id: team.id})
     |> Repo.insert!()
 
     IO.puts("Created a free subscription for user: #{user.name}")

--- a/lib/mix/tasks/create_free_subscription.ex
+++ b/lib/mix/tasks/create_free_subscription.ex
@@ -20,6 +20,8 @@ defmodule Mix.Tasks.CreateFreeSubscription do
     Subscription.free(%{user_id: user_id, team_id: team.id})
     |> Repo.insert!()
 
+    Plausible.Teams.sync_team(user)
+
     IO.puts("Created a free subscription for user: #{user.name}")
   end
 end

--- a/lib/mix/tasks/pull_sandbox_subscription.ex
+++ b/lib/mix/tasks/pull_sandbox_subscription.ex
@@ -41,6 +41,7 @@ defmodule Mix.Tasks.PullSandboxSubscription do
           res = body["response"] |> List.first()
           user = Repo.get_by!(User, email: res["user_email"])
           {:ok, team} = Plausible.Teams.get_or_create(user)
+          Plausible.Teams.sync_team(user)
 
           subscription = %{
             paddle_subscription_id: res["subscription_id"] |> to_string(),

--- a/lib/mix/tasks/pull_sandbox_subscription.ex
+++ b/lib/mix/tasks/pull_sandbox_subscription.ex
@@ -40,6 +40,7 @@ defmodule Mix.Tasks.PullSandboxSubscription do
         if body["success"] do
           res = body["response"] |> List.first()
           user = Repo.get_by!(User, email: res["user_email"])
+          {:ok, team} = Plausible.Teams.get_or_create(user)
 
           subscription = %{
             paddle_subscription_id: res["subscription_id"] |> to_string(),
@@ -47,6 +48,7 @@ defmodule Mix.Tasks.PullSandboxSubscription do
             cancel_url: res["cancel_url"],
             update_url: res["update_url"],
             user_id: user.id,
+            team_id: team.id,
             status: res["state"],
             last_bill_date: res["last_payment"]["date"],
             next_bill_date: res["next_payment"]["date"],

--- a/lib/plausible.ex
+++ b/lib/plausible.ex
@@ -4,6 +4,7 @@ defmodule Plausible do
   """
 
   @ce_builds [:ce, :ce_test, :ce_dev]
+  @public_builds [:ce, :prod]
 
   defmacro __using__(_) do
     quote do
@@ -56,6 +57,14 @@ defmodule Plausible do
   else
     def product_name do
       "Plausible Analytics"
+    end
+  end
+
+  defmacro with_teams(do: do_block) do
+    if Mix.env() in @public_builds do
+      quote do
+        unquote(do_block)
+      end
     end
   end
 end

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -17,7 +17,6 @@ defmodule Plausible.Auth.ApiKey do
     field :key_prefix, :string
 
     belongs_to :user, Plausible.Auth.User
-    belongs_to :team, Plausible.Teams.Team
 
     timestamps()
   end

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -17,6 +17,7 @@ defmodule Plausible.Auth.ApiKey do
     field :key_prefix, :string
 
     belongs_to :user, Plausible.Auth.User
+    belongs_to :team, Plausible.Teams.Team
 
     timestamps()
   end

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -53,6 +53,7 @@ defmodule Plausible.Auth.User do
 
     has_many :sessions, Plausible.Auth.UserSession
     has_many :site_memberships, Plausible.Site.Membership
+    has_many :team_memberships, Plausible.Teams.Membership
     has_many :sites, through: [:site_memberships, :site]
     has_many :api_keys, Plausible.Auth.ApiKey
     has_one :google_auth, Plausible.Site.GoogleAuth

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -65,7 +65,7 @@ defmodule Plausible.Auth.UserAdmin do
   defp lock(user) do
     if user.grace_period do
       Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
-      user |> Plausible.Auth.GracePeriod.end_changeset() |> Repo.update()
+      {:ok, Plausible.Users.end_grace_period(user)}
     else
       {:error, user, "No active grace period on this user"}
     end
@@ -73,7 +73,7 @@ defmodule Plausible.Auth.UserAdmin do
 
   defp unlock(user) do
     if user.grace_period do
-      Plausible.Auth.GracePeriod.remove_changeset(user) |> Repo.update()
+      Plausible.Users.remove_grace_period(user)
       Plausible.Billing.SiteLocker.set_lock_status_for(user, false)
       {:ok, user}
     else

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -62,6 +62,12 @@ defmodule Plausible.Auth.UserAdmin do
     ]
   end
 
+  def after_update(_conn, user) do
+    Plausible.Teams.sync_team(user)
+
+    {:ok, user}
+  end
+
   defp lock(user) do
     if user.grace_period do
       Plausible.Billing.SiteLocker.set_lock_status_for(user, true)

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -62,10 +62,12 @@ defmodule Plausible.Auth.UserAdmin do
     ]
   end
 
-  def after_update(_conn, user) do
-    Plausible.Teams.sync_team(user)
+  with_teams do
+    def after_update(_conn, user) do
+      Plausible.Teams.sync_team(user)
 
-    {:ok, user}
+      {:ok, user}
+    end
   end
 
   defp lock(user) do

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -264,12 +264,6 @@ defmodule Plausible.Billing do
   defp present?(nil), do: false
   defp present?(_), do: true
 
-  defp remove_grace_period(%User{} = user) do
-    user
-    |> Plausible.Auth.GracePeriod.remove_changeset()
-    |> Repo.update!()
-  end
-
   @spec format_price(Money.t()) :: String.t()
   def format_price(money) do
     Money.to_string!(money, fractional_digits: 2, no_fraction_if_integer: true)
@@ -303,7 +297,7 @@ defmodule Plausible.Billing do
 
     user
     |> Plausible.Users.update_accept_traffic_until()
-    |> remove_grace_period()
+    |> Plausible.Users.remove_grace_period()
     |> Plausible.Users.maybe_reset_next_upgrade_override()
     |> tap(&Plausible.Billing.SiteLocker.update_sites_for/1)
     |> maybe_adjust_api_key_limits()

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -120,10 +120,32 @@ defmodule Plausible.Billing do
   defp handle_subscription_created(params) do
     params =
       if present?(params["passthrough"]) do
-        params
+        case String.split(to_string(params["passthrough"]), ";") do
+          [user_id] ->
+            user = Repo.get!(User, user_id)
+            {:ok, team} = Plausible.Teams.get_or_create(user)
+            Map.put(params, "team_id", team.id)
+
+          [user_id, ""] ->
+            user = Repo.get!(User, user_id)
+            {:ok, team} = Plausible.Teams.get_or_create(user)
+
+            params
+            |> Map.put("passthrough", user_id)
+            |> Map.put("team_id", team.id)
+
+          [user_id, team_id] ->
+            params
+            |> Map.put("passthrough", user_id)
+            |> Map.put("team_id", team_id)
+        end
       else
-        user = Repo.get_by(User, email: params["email"])
-        Map.put(params, "passthrough", user && user.id)
+        user = Repo.get_by!(User, email: params["email"])
+        {:ok, team} = Plausible.Teams.get_or_create(user)
+
+        params
+        |> Map.put("passthrough", user.id)
+        |> Map.put("team_id", team.id)
       end
 
     subscription_params = format_subscription(params) |> add_last_bill_date(params)
@@ -209,7 +231,7 @@ defmodule Plausible.Billing do
   end
 
   defp format_subscription(params) do
-    %{
+    params = %{
       paddle_subscription_id: params["subscription_id"],
       paddle_plan_id: params["subscription_plan_id"],
       cancel_url: params["cancel_url"],
@@ -220,6 +242,12 @@ defmodule Plausible.Billing do
       next_bill_amount: params["unit_price"] || params["new_unit_price"],
       currency_code: params["currency"]
     }
+
+    if team_id = params["team_id"] do
+      Map.put(params, :team_id, team_id)
+    else
+      params
+    end
   end
 
   defp add_last_bill_date(subscription_params, paddle_params) do

--- a/lib/plausible/billing/enterprise_plan.ex
+++ b/lib/plausible/billing/enterprise_plan.ex
@@ -13,6 +13,10 @@ defmodule Plausible.Billing.EnterprisePlan do
     :team_member_limit
   ]
 
+  @optional_fields [
+    :team_id
+  ]
+
   schema "enterprise_plans" do
     field :paddle_plan_id, :string
     field :billing_interval, Ecto.Enum, values: [:monthly, :yearly]
@@ -30,7 +34,7 @@ defmodule Plausible.Billing.EnterprisePlan do
 
   def changeset(model, attrs \\ %{}) do
     model
-    |> cast(attrs, @required_fields)
+    |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:user_id)
   end

--- a/lib/plausible/billing/enterprise_plan.ex
+++ b/lib/plausible/billing/enterprise_plan.ex
@@ -23,6 +23,7 @@ defmodule Plausible.Billing.EnterprisePlan do
     field :hourly_api_request_limit, :integer
 
     belongs_to :user, Plausible.Auth.User
+    belongs_to :team, Plausible.Teams.Team
 
     timestamps()
   end

--- a/lib/plausible/billing/enterprise_plan_admin.ex
+++ b/lib/plausible/billing/enterprise_plan_admin.ex
@@ -51,6 +51,16 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
 
   def create_changeset(schema, attrs) do
     attrs = sanitize_attrs(attrs)
+
+    team_id =
+      if user_id = attrs["user_id"] do
+        user = Repo.get!(Plausible.Auth.User, user_id)
+        {:ok, team} = Plausible.Teams.get_or_create(user)
+        team.id
+      end
+
+    attrs = Map.put(attrs, "team_id", team_id)
+
     Plausible.Billing.EnterprisePlan.changeset(schema, attrs)
   end
 

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -21,9 +21,7 @@ defmodule Plausible.Billing.SiteLocker do
         set_lock_status_for(user, true)
 
         if user.grace_period.is_over != true do
-          user
-          |> Plausible.Auth.GracePeriod.end_changeset()
-          |> Repo.update!()
+          Plausible.Users.end_grace_period(user)
 
           if send_email? do
             send_grace_period_end_email(user)

--- a/lib/plausible/billing/subscription.ex
+++ b/lib/plausible/billing/subscription.ex
@@ -20,7 +20,7 @@ defmodule Plausible.Billing.Subscription do
     :currency_code
   ]
 
-  @optional_fields [:last_bill_date]
+  @optional_fields [:last_bill_date, :team_id]
 
   schema "subscriptions" do
     field :paddle_subscription_id, :string
@@ -53,7 +53,7 @@ defmodule Plausible.Billing.Subscription do
       next_bill_amount: "0",
       currency_code: "EUR"
     }
-    |> cast(attrs, @required_fields)
+    |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required([:user_id])
     |> unique_constraint(:paddle_subscription_id)
   end

--- a/lib/plausible/billing/subscription.ex
+++ b/lib/plausible/billing/subscription.ex
@@ -34,6 +34,7 @@ defmodule Plausible.Billing.Subscription do
     field :currency_code, :string
 
     belongs_to :user, Plausible.Auth.User
+    belongs_to :team, Plausible.Teams.Team
 
     timestamps()
   end

--- a/lib/plausible/data_migration.ex
+++ b/lib/plausible/data_migration.ex
@@ -6,7 +6,7 @@ defmodule Plausible.DataMigration do
 
   defmacro __using__(opts) do
     dir = Keyword.fetch!(opts, :dir)
-    repo = Keyword.get(opts, :repo, Plausible.DataMigration.Repo)
+    repo = Keyword.get(opts, :repo, Plausible.DataMigration.ClickhouseRepo)
 
     quote bind_quoted: [dir: dir, repo: repo] do
       @dir dir

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -24,7 +24,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
         Application.get_env(:plausible, Plausible.Repo)[:url]
       )
 
-    @repo.start(db_url, 16)
+    @repo.start(db_url,
+      pool_size: System.schedulers_online() * 2,
+      ssl: true,
+      ssl_opts: [verify: :verify_none]
+    )
 
     backfill()
   end

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -45,11 +45,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(sites_without_teams)} sites without teams...")
+    log("Found #{length(sites_without_teams)} sites without teams...")
 
     teams_count = backfill_teams(sites_without_teams)
 
-    IO.puts("Backfilled #{teams_count} teams.")
+    log("Backfilled #{teams_count} teams.")
 
     owner_site_memberships_query =
       from(
@@ -70,13 +70,13 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts(
+    log(
       "Found #{length(users_with_subscriptions_without_sites)} users with subscriptions without sites..."
     )
 
     teams_count = backfill_teams_for_users(users_with_subscriptions_without_sites)
 
-    IO.puts("Backfilled #{teams_count} teams from users with subscriptions without sites.")
+    log("Backfilled #{teams_count} teams from users with subscriptions without sites.")
 
     # Stale teams sync
 
@@ -98,13 +98,13 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(stale_teams)} teams which have fields out of sync...")
+    log("Found #{length(stale_teams)} teams which have fields out of sync...")
 
     sync_teams(stale_teams)
 
     # Subsciprtions backfill
 
-    IO.puts("Brought out of sync teams up to date.")
+    log("Brought out of sync teams up to date.")
 
     subscriptions_without_teams =
       from(
@@ -118,11 +118,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(subscriptions_without_teams)} subscriptions without team...")
+    log("Found #{length(subscriptions_without_teams)} subscriptions without team...")
 
     backfill_subscriptions(subscriptions_without_teams)
 
-    IO.puts("All subscriptions are linked to a team now.")
+    log("All subscriptions are linked to a team now.")
 
     # Enterprise plans backfill
 
@@ -138,11 +138,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(enterprise_plans_without_teams)} enterprise plans without team...")
+    log("Found #{length(enterprise_plans_without_teams)} enterprise plans without team...")
 
     backfill_enterprise_plans(enterprise_plans_without_teams)
 
-    IO.puts("All enterprise plans are linked to a team now.")
+    log("All enterprise plans are linked to a team now.")
 
     # Guest Memberships cleanup
 
@@ -165,11 +165,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(guest_memberships_to_remove)} guest memberships to remove...")
+    log("Found #{length(guest_memberships_to_remove)} guest memberships to remove...")
 
     team_ids_to_prune = remove_guest_memberships(guest_memberships_to_remove)
 
-    IO.puts("Pruning guest team memberships for #{length(team_ids_to_prune)} teams...")
+    log("Pruning guest team memberships for #{length(team_ids_to_prune)} teams...")
 
     from(t in Teams.Team, where: t.id in ^team_ids_to_prune)
     |> @repo.all(timeout: :infinity)
@@ -177,7 +177,7 @@ defmodule Plausible.DataMigration.BackfillTeams do
       Plausible.Teams.Memberships.prune_guests(team)
     end)
 
-    IO.puts("Guest memberships cleared.")
+    log("Guest memberships cleared.")
 
     # Guest Memberships backfill
 
@@ -203,13 +203,13 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts(
+    log(
       "Found #{length(site_memberships_to_backfill)} site memberships without guest membership..."
     )
 
     backfill_guest_memberships(site_memberships_to_backfill)
 
-    IO.puts("Backfilled missing guest memberships.")
+    log("Backfilled missing guest memberships.")
 
     # Stale guest memberships sync
 
@@ -228,11 +228,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(stale_guest_memberships)} guest memberships with role out of sync...")
+    log("Found #{length(stale_guest_memberships)} guest memberships with role out of sync...")
 
     sync_guest_memberships(stale_guest_memberships)
 
-    IO.puts("All guest memberships are up to date now.")
+    log("All guest memberships are up to date now.")
 
     # Guest invitations cleanup
 
@@ -256,11 +256,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(guest_invitations_to_remove)} guest invitations to remove...")
+    log("Found #{length(guest_invitations_to_remove)} guest invitations to remove...")
 
     team_ids_to_prune = remove_guest_invitations(guest_invitations_to_remove)
 
-    IO.puts("Pruning guest team invitations for #{length(team_ids_to_prune)} teams...")
+    log("Pruning guest team invitations for #{length(team_ids_to_prune)} teams...")
 
     from(t in Teams.Team, where: t.id in ^team_ids_to_prune)
     |> @repo.all(timeout: :infinity)
@@ -268,7 +268,7 @@ defmodule Plausible.DataMigration.BackfillTeams do
       Plausible.Teams.Invitations.prune_guest_invitations(team)
     end)
 
-    IO.puts("Guest invitations cleared.")
+    log("Guest invitations cleared.")
 
     # Guest invitations backfill
 
@@ -294,13 +294,13 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts(
+    log(
       "Found #{length(site_invitations_to_backfill)} site invitations without guest invitation..."
     )
 
     backfill_guest_invitations(site_invitations_to_backfill)
 
-    IO.puts("Backfilled missing guest invitations.")
+    log("Backfilled missing guest invitations.")
 
     # Stale guest invitations sync
 
@@ -319,11 +319,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(stale_guest_invitations)} guest invitations with role out of sync...")
+    log("Found #{length(stale_guest_invitations)} guest invitations with role out of sync...")
 
     sync_guest_invitations(stale_guest_invitations)
 
-    IO.puts("All guest invitations are up to date now.")
+    log("All guest invitations are up to date now.")
 
     # Site transfers cleanup
 
@@ -343,11 +343,11 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts("Found #{length(site_transfers_to_remove)} site transfers to remove...")
+    log("Found #{length(site_transfers_to_remove)} site transfers to remove...")
 
     remove_site_transfers(site_transfers_to_remove)
 
-    IO.puts("Site transfers cleared.")
+    log("Site transfers cleared.")
 
     # Site transfers backfill
 
@@ -371,15 +371,15 @@ defmodule Plausible.DataMigration.BackfillTeams do
       )
       |> @repo.all(timeout: :infinity)
 
-    IO.puts(
+    log(
       "Found #{length(site_invitations_to_backfill)} ownership transfers without site transfer..."
     )
 
     backfill_site_transfers(site_invitations_to_backfill)
 
-    IO.puts("Backfilled missing site transfers.")
+    log("Backfilled missing site transfers.")
 
-    IO.puts("All data are up to date now!")
+    log("All data are up to date now!")
   end
 
   defp backfill_teams(sites) do
@@ -390,9 +390,9 @@ defmodule Plausible.DataMigration.BackfillTeams do
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
     |> tap(fn grouped ->
       if grouped != %{} do
-        IO.puts("Teams about to be created: #{map_size(grouped)}")
+        log("Teams about to be created: #{map_size(grouped)}")
 
-        IO.puts(
+        log(
           "Max sites: #{Enum.max_by(grouped, fn {_, sites} -> length(sites) end) |> elem(1) |> length()}"
         )
       end
@@ -551,9 +551,9 @@ defmodule Plausible.DataMigration.BackfillTeams do
     |> Enum.group_by(&{&1.site.team, &1.user}, &{&1.site, &1.role})
     |> tap(fn grouped ->
       if grouped != %{} do
-        IO.puts("Team memberships to be created: #{map_size(grouped)}")
+        log("Team memberships to be created: #{map_size(grouped)}")
 
-        IO.puts(
+        log(
           "Max guest memberships: #{Enum.max_by(grouped, fn {_, gms} -> length(gms) end) |> elem(1) |> length()}"
         )
       end
@@ -683,6 +683,10 @@ defmodule Plausible.DataMigration.BackfillTeams do
     end)
   end
 
-  def translate_role(:admin), do: :editor
-  def translate_role(:viewer), do: :viewer
+  defp translate_role(:admin), do: :editor
+  defp translate_role(:viewer), do: :viewer
+
+  defp log(msg) do
+    IO.puts("[#{NaiveDateTime.utc_now(:second)}] #{msg}")
+  end
 end

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -389,14 +389,16 @@ defmodule Plausible.DataMigration.BackfillTeams do
       {owner, site_id}
     end)
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
-    |> tap(fn grouped ->
-      if grouped != %{} do
+    |> tap(fn
+      grouped when grouped != %{} ->
         log("Teams about to be created: #{map_size(grouped)}")
 
         log(
           "Max sites: #{Enum.max_by(grouped, fn {_, sites} -> length(sites) end) |> elem(1) |> length()}"
         )
-      end
+
+      _ ->
+        :pass
     end)
     |> Enum.with_index()
     |> Task.async_stream(
@@ -558,14 +560,16 @@ defmodule Plausible.DataMigration.BackfillTeams do
   defp backfill_guest_memberships(site_memberships) do
     site_memberships
     |> Enum.group_by(&{&1.site.team, &1.user}, & &1)
-    |> tap(fn grouped ->
-      if grouped != %{} do
+    |> tap(fn
+      grouped when grouped != %{} ->
         log("Team memberships to be created: #{map_size(grouped)}")
 
         log(
           "Max guest memberships: #{Enum.max_by(grouped, fn {_, gms} -> length(gms) end) |> elem(1) |> length()}"
         )
-      end
+
+      _ ->
+        :pass
     end)
     |> Enum.with_index()
     |> Task.async_stream(

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -8,7 +8,7 @@ defmodule Plausible.DataMigration.BackfillTeams do
   alias Plausible.Auth
   alias Plausible.Teams
 
-  use Plausible.DataMigration, repo: Plausible.DataMigration.PostgresRepo, dir: false
+  @repo Plausible.DataMigration.PostgresRepo
 
   defmacrop is_distinct(f1, f2) do
     quote do

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -24,11 +24,7 @@ defmodule Plausible.DataMigration.BackfillTeams do
         Application.get_env(:plausible, Plausible.Repo)[:url]
       )
 
-    @repo.start(db_url,
-      pool_size: System.schedulers_online() * 2,
-      ssl: true,
-      ssl_opts: [verify: :verify_none]
-    )
+    @repo.start(db_url, pool_size: System.schedulers_online() * 2)
 
     backfill()
   end

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -1,0 +1,514 @@
+defmodule Plausible.DataMigration.BackfillTeams do
+  @moduledoc """
+  Backfill and sync all teams related entities.
+  """
+
+  import Ecto.Query
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+  alias Plausible.Teams
+
+  def run() do
+    # Teams backfill
+
+    sites_without_teams =
+      from(
+        s in Plausible.Site,
+        inner_join: m in assoc(s, :memberships),
+        inner_join: o in assoc(m, :user),
+        where: m.role == :owner,
+        where: is_nil(s.team_id),
+        preload: [memberships: {m, user: o}]
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(sites_without_teams)} sites without teams...")
+
+    teams_count = backfill_teams(sites_without_teams)
+
+    IO.puts("Backfilled #{teams_count} teams.")
+
+    # Stale teams sync
+
+    stale_teams =
+      from(
+        t in Teams.Team,
+        inner_join: tm in assoc(t, :team_memberships),
+        inner_join: o in assoc(tm, :user),
+        where: tm.role == :owner,
+        where:
+          o.trial_expiry_date != t.trial_expiry_date or
+            o.accept_traffic_until != t.accept_traffic_until or
+            o.allow_next_upgrade_override != t.allow_next_upgrade_override or
+            o.grace_period != t.grace_period,
+        preload: [team_memberships: {tm, user: o}]
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(stale_teams)} teams which have fields out of sync...")
+
+    sync_teams(stale_teams)
+
+    # Subsciprtions backfill
+
+    IO.puts("Brought out of sync teams up to date.")
+
+    subscriptions_without_teams =
+      from(
+        s in Plausible.Billing.Subscription,
+        inner_join: u in assoc(s, :user),
+        inner_join: tm in assoc(u, :team_memberships),
+        inner_join: t in assoc(tm, :team),
+        where: tm.role == :owner,
+        where: is_nil(s.team_id),
+        preload: [user: {u, team_memberships: {tm, team: t}}]
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(subscriptions_without_teams)} subscriptions without team...")
+
+    backfill_subscriptions(subscriptions_without_teams)
+
+    IO.puts("All subscriptions are linked to a team now.")
+
+    # Enterprise plans backfill
+
+    enterprise_plans_without_teams =
+      from(
+        ep in Plausible.Billing.EnterprisePlan,
+        inner_join: u in assoc(ep, :user),
+        inner_join: tm in assoc(u, :team_memberships),
+        inner_join: t in assoc(tm, :team),
+        where: tm.role == :owner,
+        where: is_nil(ep.team_id),
+        preload: [user: {u, team_memberships: {tm, team: t}}]
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(enterprise_plans_without_teams)} enterprise plans without team...")
+
+    backfill_enterprise_plans(enterprise_plans_without_teams)
+
+    IO.puts("All enterprise plans are linked to a team now.")
+
+    # Guest Memberships cleanup
+
+    site_memberships_query =
+      from(
+        sm in Plausible.Site.Membership,
+        where: sm.site_id == parent_as(:guest_membership).site_id,
+        where: sm.user_id == parent_as(:team_membership).user_id,
+        where: sm.role != :owner,
+        select: 1
+      )
+
+    guest_memberships_to_remove =
+      from(
+        gm in Teams.GuestMembership,
+        as: :guest_membership,
+        inner_join: tm in assoc(gm, :team_membership),
+        as: :team_membership,
+        where: not exists(site_memberships_query)
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(guest_memberships_to_remove)} guest memberships to remove...")
+
+    team_ids_to_prune = remove_guest_memberships(guest_memberships_to_remove)
+
+    IO.puts("Pruning guest team memberships for #{length(team_ids_to_prune)} teams...")
+
+    from(t in Teams.Team, where: t.id in ^team_ids_to_prune)
+    |> Repo.all()
+    |> Enum.each(fn team ->
+      Plausible.Teams.Memberships.prune_guests(team)
+    end)
+
+    IO.puts("Guest memberships cleared.")
+
+    # Guest Memberships backfill
+
+    guest_memberships_query =
+      from(
+        gm in Teams.GuestMembership,
+        inner_join: tm in assoc(gm, :team_membership),
+        where: gm.site_id == parent_as(:site_membership).site_id,
+        where: tm.user_id == parent_as(:site_membership).user_id,
+        select: 1
+      )
+
+    site_memberships_to_backfill =
+      from(
+        sm in Plausible.Site.Membership,
+        as: :site_membership,
+        inner_join: s in assoc(sm, :site),
+        inner_join: t in assoc(s, :team),
+        inner_join: u in assoc(sm, :user),
+        where: sm.role != :owner,
+        where: not exists(guest_memberships_query),
+        preload: [user: u, site: {s, team: t}]
+      )
+      |> Repo.all()
+
+    IO.puts(
+      "Found #{length(site_memberships_to_backfill)} site memberships without guest membership..."
+    )
+
+    backfill_guest_memberships(site_memberships_to_backfill)
+
+    IO.puts("Backfilled missing guest memberships.")
+
+    # Stale guest memberships sync
+
+    stale_guest_memberships =
+      from(
+        sm in Plausible.Site.Membership,
+        inner_join: tm in Teams.Membership,
+        on: tm.user_id == sm.user_id,
+        inner_join: gm in assoc(tm, :guest_memberships),
+        on: gm.site_id == sm.site_id,
+        where: tm.role == :guest,
+        where:
+          (gm.role == :viewer and sm.role == :admin) or
+            (gm.role == :editor and sm.role == :viewer),
+        select: {gm, sm.role}
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(stale_guest_memberships)} guest memberships with role out of sync...")
+
+    sync_guest_memberships(stale_guest_memberships)
+
+    IO.puts("All guest memberships are up to date now.")
+
+    # Guest invitations cleanup
+
+    site_invitations_query =
+      from(
+        i in Auth.Invitation,
+        where: i.site_id == parent_as(:guest_invitation).site_id,
+        where: i.email == parent_as(:team_invitation).email,
+        where:
+          (i.role == :viewer and parent_as(:guest_invitation).role == :viewer) or
+            (i.role == :admin and parent_as(:guest_invitation).role == :editor)
+      )
+
+    guest_invitations_to_remove =
+      from(
+        gi in Teams.GuestInvitation,
+        as: :guest_invitation,
+        inner_join: ti in assoc(gi, :team_invitation),
+        as: :team_invitation,
+        where: not exists(site_invitations_query)
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(guest_invitations_to_remove)} guest invitations to remove...")
+
+    team_ids_to_prune = remove_guest_invitations(guest_invitations_to_remove)
+
+    IO.puts("Pruning guest team invitations for #{length(team_ids_to_prune)} teams...")
+
+    from(t in Teams.Team, where: t.id in ^team_ids_to_prune)
+    |> Repo.all()
+    |> Enum.each(fn team ->
+      Plausible.Teams.Invitations.prune_guest_invitations(team)
+    end)
+
+    IO.puts("Guest invitations cleared.")
+
+    # Guest invitations backfill
+
+    guest_invitations_query =
+      from(
+        gi in Teams.GuestInvitation,
+        inner_join: ti in assoc(gi, :team_invitation),
+        where: gi.site_id == parent_as(:site_invitation).site_id,
+        where: ti.email == parent_as(:site_invitation).email,
+        select: 1
+      )
+
+    site_invitations_to_backfill =
+      from(
+        si in Auth.Invitation,
+        as: :site_invitation,
+        inner_join: s in assoc(si, :site),
+        inner_join: t in assoc(s, :team),
+        inner_join: inv in assoc(si, :inviter),
+        where: si.role != :owner,
+        where: not exists(guest_invitations_query),
+        preload: [site: {s, team: t}, inviter: inv]
+      )
+      |> Repo.all()
+
+    IO.puts(
+      "Found #{length(site_invitations_to_backfill)} site invitations without guest invitation..."
+    )
+
+    backfill_guest_invitations(site_invitations_to_backfill)
+
+    IO.puts("Backfilled missing guest invitations.")
+
+    # Stale guest invitations sync
+
+    stale_guest_invitations =
+      from(
+        si in Auth.Invitation,
+        inner_join: ti in Teams.Invitation,
+        on: ti.email == si.email,
+        inner_join: gi in assoc(ti, :guest_invitations),
+        on: gi.site_id == si.site_id,
+        where: ti.role == :guest,
+        where:
+          (gi.role == :viewer and si.role == :admin) or
+            (gi.role == :editor and si.role == :viewer),
+        select: {gi, si.role}
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(stale_guest_invitations)} guest invitations with role out of sync...")
+
+    sync_guest_invitations(stale_guest_invitations)
+
+    IO.puts("All guest invitations are up to date now.")
+
+    # Site transfers cleanup
+
+    site_invitations_query =
+      from(
+        i in Auth.Invitation,
+        where: i.site_id == parent_as(:site_transfer).site_id,
+        where: i.email == parent_as(:site_transfer).email,
+        where: i.role == :owner
+      )
+
+    site_transfers_to_remove =
+      from(
+        st in Teams.SiteTransfer,
+        as: :site_transfer,
+        where: not exists(site_invitations_query)
+      )
+      |> Repo.all()
+
+    IO.puts("Found #{length(site_transfers_to_remove)} site transfers to remove...")
+
+    remove_site_transfers(site_transfers_to_remove)
+
+    IO.puts("Site transfers cleared.")
+
+    # Site transfers backfill
+
+    site_transfers_query =
+      from(
+        st in Teams.SiteTransfer,
+        where: st.site_id == parent_as(:site_invitation).site_id,
+        where: st.email == parent_as(:site_invitation).email,
+        select: 1
+      )
+
+    site_invitations_to_backfill =
+      from(
+        si in Auth.Invitation,
+        as: :site_invitation,
+        inner_join: s in assoc(si, :site),
+        inner_join: inv in assoc(si, :inviter),
+        where: si.role == :owner,
+        where: not exists(site_transfers_query),
+        preload: [inviter: inv, site: s]
+      )
+      |> Repo.all()
+
+    IO.puts(
+      "Found #{length(site_invitations_to_backfill)} ownership transfers without site transfer..."
+    )
+
+    backfill_site_transfers(site_invitations_to_backfill)
+
+    IO.puts("Backfilled missing site transfers.")
+
+    IO.puts("All data are up to date now!")
+  end
+
+  defp backfill_teams(sites) do
+    sites
+    |> Enum.map(fn %{id: site_id, memberships: [%{user: owner, role: :owner}]} ->
+      {owner, site_id}
+    end)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.map(fn {owner, site_ids} ->
+      team =
+        "My Team"
+        |> Teams.Team.changeset()
+        |> Ecto.Changeset.put_change(:trial_expiry_date, owner.trial_expiry_date)
+        |> Ecto.Changeset.put_change(:accept_traffic_until, owner.accept_traffic_until)
+        |> Ecto.Changeset.put_change(
+          :allow_next_upgrade_override,
+          owner.allow_next_upgrade_override
+        )
+        |> Ecto.Changeset.put_embed(:grace_period, owner.grace_period)
+        |> Repo.insert!()
+
+      team
+      |> Teams.Membership.changeset(owner, :owner)
+      |> Repo.insert!()
+
+      Repo.update_all(from(s in Plausible.Site, where: s.id in ^site_ids),
+        set: [team_id: team.id]
+      )
+    end)
+    |> length()
+  end
+
+  defp sync_teams(stale_teams) do
+    Enum.each(stale_teams, fn team ->
+      [%{user: owner}] = team.team_memberships
+
+      team
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_change(:trial_expiry_date, owner.trial_expiry_date)
+      |> Ecto.Changeset.put_change(:accept_traffic_until, owner.accept_traffic_until)
+      |> Ecto.Changeset.put_change(
+        :allow_next_upgrade_override,
+        owner.allow_next_upgrade_override
+      )
+      |> Ecto.Changeset.put_embed(:grace_period, owner.grace_period)
+      |> Repo.update!()
+    end)
+  end
+
+  defp backfill_subscriptions(subscriptions) do
+    Enum.each(subscriptions, fn subscription ->
+      [%{team: team, role: :owner}] = subscription.user.team_memberships
+
+      subscription
+      |> Ecto.Changeset.change(team_id: team.id)
+      |> Repo.update!()
+    end)
+  end
+
+  defp backfill_enterprise_plans(enterprise_plans) do
+    Enum.each(enterprise_plans, fn enterprise_plan ->
+      [%{team: team, role: :owner}] = enterprise_plan.user.team_memberships
+
+      enterprise_plan
+      |> Ecto.Changeset.change(team_id: team.id)
+      |> Repo.update!()
+    end)
+  end
+
+  defp remove_guest_memberships(guest_memberships) do
+    ids = Enum.map(guest_memberships, & &1.id)
+
+    {_, team_ids} =
+      Repo.delete_all(
+        from(
+          gm in Teams.GuestMembership,
+          inner_join: tm in assoc(gm, :team_membership),
+          where: gm.id in ^ids,
+          select: tm.team_id
+        )
+      )
+
+    Enum.uniq(team_ids)
+  end
+
+  defp backfill_guest_memberships(site_memberships) do
+    now = NaiveDateTime.utc_now(:second)
+
+    site_memberships
+    |> Enum.group_by(&{&1.site.team, &1.user}, &{&1.site, &1.role})
+    |> Enum.each(fn {{team, user}, sites_and_roles} ->
+      team_membership =
+        team
+        |> Teams.Membership.changeset(user, :guest)
+        |> Repo.insert!(
+          on_conflict: [set: [updated_at: now]],
+          conflict_target: [:team_id, :user_id]
+        )
+
+      Enum.each(sites_and_roles, fn {site, role} ->
+        team_membership
+        |> Teams.GuestMembership.changeset(site, translate_role(role))
+        |> Repo.insert!()
+      end)
+    end)
+  end
+
+  defp sync_guest_memberships(guest_memberships_and_roles) do
+    Enum.each(guest_memberships_and_roles, fn {guest_membership, role} ->
+      guest_membership
+      |> Ecto.Changeset.change(role: translate_role(role))
+      |> Repo.update!()
+    end)
+  end
+
+  defp remove_guest_invitations(guest_invitations) do
+    ids = Enum.map(guest_invitations, & &1.id)
+
+    {_, team_ids} =
+      Repo.delete_all(
+        from(
+          gi in Teams.GuestInvitation,
+          inner_join: ti in assoc(gi, :team_invitation),
+          where: gi.id in ^ids,
+          select: ti.team_id
+        )
+      )
+
+    Enum.uniq(team_ids)
+  end
+
+  defp backfill_guest_invitations(site_invitations) do
+    site_invitations
+    |> Enum.group_by(&{&1.site.team, &1.email}, &{&1.site, &1.role, &1.inviter})
+    |> Enum.each(fn {{team, email}, sites_and_roles} ->
+      now = NaiveDateTime.utc_now(:second)
+
+      {_, _, inviter} = List.first(sites_and_roles)
+
+      team_invitation =
+        team
+        # NOTE: we put first inviter matching team/email combination
+        |> Teams.Invitation.changeset(email: email, role: :guest, inviter: inviter)
+        |> Repo.insert!(
+          on_conflict: [set: [updated_at: now]],
+          conflict_target: [:team_id, :email]
+        )
+
+      Enum.each(sites_and_roles, fn {site, role, _} ->
+        team_invitation
+        |> Teams.GuestInvitation.changeset(site, translate_role(role))
+        |> Repo.insert!()
+      end)
+    end)
+  end
+
+  defp sync_guest_invitations(guest_invitations_and_roles) do
+    Enum.each(guest_invitations_and_roles, fn {guest_invitation, role} ->
+      guest_invitation
+      |> Ecto.Changeset.change(role: translate_role(role))
+      |> Repo.update!()
+    end)
+  end
+
+  defp remove_site_transfers(site_transfers) do
+    ids = Enum.map(site_transfers, & &1.id)
+
+    Repo.delete_all(from(st in Teams.SiteTransfer, where: st.id in ^ids))
+  end
+
+  defp backfill_site_transfers(site_invitations) do
+    Enum.each(site_invitations, fn site_invitation ->
+      site_invitation.site
+      |> Teams.SiteTransfer.changeset(
+        initiator: site_invitation.inviter,
+        email: site_invitation.email
+      )
+      |> Repo.insert!()
+    end)
+  end
+
+  def translate_role(:admin), do: :editor
+  def translate_role(:viewer), do: :viewer
+end

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -20,6 +20,18 @@ defmodule Plausible.DataMigration.BackfillTeams do
 
     @repo.start(db_url)
 
+    @repo.transaction(
+      fn ->
+        backfill()
+
+        IO.puts("Rolling back")
+        @repo.rollback("Rolled back")
+      end,
+      timeout: :infinity
+    )
+  end
+
+  defp backfill() do
     sites_without_teams =
       from(
         s in Plausible.Site,

--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -363,11 +363,13 @@ defmodule Plausible.DataMigration.BackfillTeams do
     end)
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
     |> tap(fn grouped ->
-      IO.puts("Teams about to be created: #{map_size(grouped)}")
+      if grouped != %{} do
+        IO.puts("Teams about to be created: #{map_size(grouped)}")
 
-      IO.puts(
-        "Max sites: #{Enum.max_by(grouped, fn {_, sites} -> length(sites) end) |> elem(1) |> length()}"
-      )
+        IO.puts(
+          "Max sites: #{Enum.max_by(grouped, fn {_, sites} -> length(sites) end) |> elem(1) |> length()}"
+        )
+      end
     end)
     |> Enum.with_index()
     |> Task.async_stream(fn {{owner, site_ids}, idx} ->

--- a/lib/plausible/data_migration/clickhouse_repo.ex
+++ b/lib/plausible/data_migration/clickhouse_repo.ex
@@ -1,4 +1,4 @@
-defmodule Plausible.DataMigration.Repo do
+defmodule Plausible.DataMigration.ClickhouseRepo do
   @moduledoc """
   Ecto.Repo for Clickhouse data migrations, to be started manually,
   outside of the main application supervision tree.

--- a/lib/plausible/data_migration/postgres_repo.ex
+++ b/lib/plausible/data_migration/postgres_repo.ex
@@ -7,16 +7,16 @@ defmodule Plausible.DataMigration.PostgresRepo do
     otp_app: :plausible,
     adapter: Ecto.Adapters.Postgres
 
-  def start(url, pool_size \\ 1) when is_binary(url) do
+  def start(url, opts \\ []) when is_binary(url) do
     default_config = Plausible.Repo.config()
 
     start_link(
       url: url,
       queue_target: 500,
       queue_interval: 2000,
-      pool_size: pool_size,
-      ssl: default_config[:ssl],
-      ssl_opts: default_config[:ssl_opts]
+      pool_size: opts[:pool_size] || 1,
+      ssl: opts[:ssl] || default_config[:ssl],
+      ssl_opts: opts[:ssl_opts] || default_config[:ssl_opts]
     )
   end
 end

--- a/lib/plausible/data_migration/postgres_repo.ex
+++ b/lib/plausible/data_migration/postgres_repo.ex
@@ -7,12 +7,16 @@ defmodule Plausible.DataMigration.PostgresRepo do
     otp_app: :plausible,
     adapter: Ecto.Adapters.Postgres
 
-  def start(url) when is_binary(url) do
+  def start(url, pool_size \\ 1) when is_binary(url) do
+    default_config = Plausible.Repo.config()
+
     start_link(
       url: url,
       queue_target: 500,
       queue_interval: 2000,
-      pool_size: 1
+      pool_size: pool_size,
+      ssl: default_config[:ssl],
+      ssl_opts: default_config[:ssl_opts]
     )
   end
 end

--- a/lib/plausible/data_migration/postgres_repo.ex
+++ b/lib/plausible/data_migration/postgres_repo.ex
@@ -1,0 +1,18 @@
+defmodule Plausible.DataMigration.PostgresRepo do
+  @moduledoc """
+  Ecto.Repo for Posrtgres data migrations, to be started manually,
+  outside of the main application supervision tree.
+  """
+  use Ecto.Repo,
+    otp_app: :plausible,
+    adapter: Ecto.Adapters.Postgres
+
+  def start(url) when is_binary(url) do
+    start_link(
+      url: url,
+      queue_target: 500,
+      queue_interval: 2000,
+      pool_size: 1
+    )
+  end
+end

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -74,6 +74,12 @@ defmodule Plausible.Site do
     timestamps()
   end
 
+  def new_for_team(team, params) do
+    params
+    |> new()
+    |> put_assoc(:team, team)
+  end
+
   def new(params), do: changeset(%__MODULE__{}, params)
 
   @domain_unique_error """

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -32,6 +32,11 @@ defmodule Plausible.Site do
     # NOTE: needed by `SiteImports` data migration script
     embeds_one :imported_data, Plausible.Site.ImportedData, on_replace: :update
 
+    # NOTE: new teams relations
+    belongs_to :team, Plausible.Teams.Team
+    has_many :guest_memberships, Plausible.Teams.GuestMembership
+    has_many :guest_invitations, Plausible.Teams.GuestInvitation
+
     embeds_one :installation_meta, Plausible.Site.InstallationMeta,
       on_replace: :update,
       defaults_to_struct: true

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -187,7 +187,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   end
 
   defp notify_invitation_accepted(invitation) do
-    PlausibleWeb.Email.invitation_accepted(invitation)
+    invitation.inviter.email
+    |> PlausibleWeb.Email.invitation_accepted(invitation.email, invitation.site)
     |> Plausible.Mailer.send()
   end
 end

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -182,7 +182,11 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   end
 
   defp notify_invitation_accepted(%Auth.Invitation{role: :owner} = invitation) do
-    PlausibleWeb.Email.ownership_transfer_accepted(invitation)
+    PlausibleWeb.Email.ownership_transfer_accepted(
+      invitation.email,
+      invitation.inviter.email,
+      invitation.site
+    )
     |> Plausible.Mailer.send()
   end
 

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -108,9 +108,23 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
 
     email =
       case {invitee, invitation.role} do
-        {invitee, :owner} -> PlausibleWeb.Email.ownership_transfer_request(invitation, invitee)
-        {nil, _role} -> PlausibleWeb.Email.new_user_invitation(invitation)
-        {%User{}, _role} -> PlausibleWeb.Email.existing_user_invitation(invitation)
+        {invitee, :owner} ->
+          PlausibleWeb.Email.ownership_transfer_request(invitation, invitee)
+
+        {nil, _role} ->
+          PlausibleWeb.Email.new_user_invitation(
+            invitation.email,
+            invitation.invitation_id,
+            invitation.site,
+            invitation.inviter
+          )
+
+        {%User{}, _role} ->
+          PlausibleWeb.Email.existing_user_invitation(
+            invitation.email,
+            invitation.site,
+            invitation.inviter
+          )
       end
 
     Plausible.Mailer.send(email)

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -109,7 +109,13 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
     email =
       case {invitee, invitation.role} do
         {invitee, :owner} ->
-          PlausibleWeb.Email.ownership_transfer_request(invitation, invitee)
+          PlausibleWeb.Email.ownership_transfer_request(
+            invitation.email,
+            invitation.invitation_id,
+            invitation.site,
+            invitation.inviter,
+            invitee
+          )
 
         {nil, _role} ->
           PlausibleWeb.Email.new_user_invitation(

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -80,6 +80,9 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
          %Ecto.Changeset{} = changeset <- Invitation.new(attrs),
          {:ok, invitation} <- Plausible.Repo.insert(changeset) do
       send_invitation_email(invitation, invitee)
+
+      Plausible.Teams.Invitations.invite_sync(site, invitation)
+
       invitation
     else
       {:error, cause} -> Plausible.Repo.rollback(cause)

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -9,6 +9,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   alias Plausible.Site.Memberships.Invitations
   alias Plausible.Billing.Quota
   import Ecto.Query
+  use Plausible
 
   @type invite_error() ::
           Ecto.Changeset.t()
@@ -81,7 +82,9 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
          {:ok, invitation} <- Plausible.Repo.insert(changeset) do
       send_invitation_email(invitation, invitee)
 
-      Plausible.Teams.Invitations.invite_sync(site, invitation)
+      with_teams do
+        Plausible.Teams.Invitations.invite_sync(site, invitation)
+      end
 
       invitation
     else

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -208,8 +208,9 @@ defmodule Plausible.Sites do
   defp maybe_start_trial(multi, user) do
     case user.trial_expiry_date do
       nil ->
-        changeset = Auth.User.start_trial(user)
-        Ecto.Multi.update(multi, :user, changeset)
+        Ecto.Multi.run(multi, :user, fn _, _ ->
+          {:ok, Plausible.Users.start_trial(user)}
+        end)
 
       _ ->
         multi

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -5,155 +5,20 @@ defmodule Plausible.Teams do
 
   import Ecto.Query
 
-  alias __MODULE__
   alias Plausible.Repo
 
-  defmodule Sites do
-    @moduledoc false
+  def with_subscription(team) do
+    Repo.preload(team, subscription: last_subscription_query())
+  end
 
-    alias Plausible.Auth
-    alias Plausible.Site
+  def owned_sites(team) do
+    Repo.preload(team, :sites).sites
+  end
 
-    @type list_opt() :: {:filter_by_domain, String.t()}
-
-    @spec list(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
-    def list(user, pagination_params, opts \\ []) do
-      domain_filter = Keyword.get(opts, :filter_by_domain)
-
-      team_membership_query =
-        from tm in Teams.Membership,
-          inner_join: t in assoc(tm, :team),
-          inner_join: s in assoc(t, :sites),
-          where: tm.user_id == ^user.id and tm.role != :guest,
-          select: %{site_id: s.id, entry_type: "site"}
-
-      guest_membership_query =
-        from tm in Teams.Membership,
-          inner_join: gm in assoc(tm, :guest_memberships),
-          inner_join: s in assoc(gm, :site),
-          where: tm.user_id == ^user.id and tm.role == :guest,
-          select: %{site_id: s.id, entry_type: "site"}
-
-      union_query =
-        from s in team_membership_query,
-          union_all: ^guest_membership_query
-
-      from(u in subquery(union_query),
-        inner_join: s in Plausible.Site,
-        on: u.site_id == s.id,
-        left_join: up in Site.UserPreference,
-        on: up.site_id == s.id,
-        select: %{
-          s
-          | entry_type:
-              selected_as(
-                fragment(
-                  """
-                  CASE
-                    WHEN ? IS NOT NULL THEN 'pinned_site'
-                    ELSE ?
-                  END
-                  """,
-                  up.pinned_at,
-                  u.entry_type
-                ),
-                :entry_type
-              ),
-            pinned_at: selected_as(up.pinned_at, :pinned_at)
-        },
-        order_by: [
-          asc: selected_as(:entry_type),
-          desc: selected_as(:pinned_at),
-          asc: s.domain
-        ]
-      )
-      |> maybe_filter_by_domain(domain_filter)
-      |> Repo.paginate(pagination_params)
-    end
-
-    @spec list_with_invitations(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
-    def list_with_invitations(user, pagination_params, opts \\ []) do
-      domain_filter = Keyword.get(opts, :filter_by_domain)
-
-      team_membership_query =
-        from tm in Teams.Membership,
-          inner_join: t in assoc(tm, :team),
-          inner_join: s in assoc(t, :sites),
-          where: tm.user_id == ^user.id and tm.role != :guest,
-          select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
-
-      guest_membership_query =
-        from(tm in Teams.Membership,
-          inner_join: gm in assoc(tm, :guest_memberships),
-          inner_join: s in assoc(gm, :site),
-          where: tm.user_id == ^user.id and tm.role == :guest,
-          select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
-        )
-
-      guest_invitation_query =
-        from ti in Teams.Invitation,
-          inner_join: gi in assoc(ti, :guest_invitations),
-          inner_join: s in assoc(gi, :site),
-          where: ti.email == ^user.email and ti.role == :guest,
-          select: %{
-            site_id: s.id,
-            entry_type: "invitation",
-            invitation_id: ti.id,
-            invitation_role: gi.role
-          }
-
-      union_query =
-        from s in team_membership_query,
-          union_all: ^guest_membership_query,
-          union_all: ^guest_invitation_query
-
-      from(u in subquery(union_query),
-        inner_join: s in Plausible.Site,
-        on: u.site_id == s.id,
-        left_join: up in Site.UserPreference,
-        on: up.site_id == s.id,
-        left_join: ti in Teams.Invitation,
-        on: ti.id == u.invitation_id,
-        select: %{
-          s
-          | entry_type:
-              selected_as(
-                fragment(
-                  """
-                  CASE
-                    WHEN ? IS NOT NULL THEN 'pinned_site'
-                    ELSE ?
-                  END
-                  """,
-                  up.pinned_at,
-                  u.entry_type
-                ),
-                :entry_type
-              ),
-            pinned_at: selected_as(up.pinned_at, :pinned_at),
-            invitations: [
-              %Plausible.Auth.Invitation{
-                invitation_id: ti.invitation_id,
-                email: ti.email,
-                role: u.invitation_role
-              }
-            ]
-        },
-        order_by: [
-          asc: selected_as(:entry_type),
-          desc: selected_as(:pinned_at),
-          asc: s.domain
-        ]
-      )
-      |> maybe_filter_by_domain(domain_filter)
-      |> Repo.paginate(pagination_params)
-    end
-
-    defp maybe_filter_by_domain(query, domain)
-         when byte_size(domain) >= 1 and byte_size(domain) <= 64 do
-      where(query, [s], ilike(s.domain, ^"%#{domain}%"))
-    end
-
-    defp maybe_filter_by_domain(query, _), do: query
+  defp last_subscription_query() do
+    from(subscription in Plausible.Billing.Subscription,
+      order_by: [desc: subscription.inserted_at],
+      limit: 1
+    )
   end
 end

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -55,11 +55,15 @@ defmodule Plausible.Teams do
     team =
       "My Team"
       |> Teams.Team.changeset()
+      |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
+      |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()
 
     team_membership =
       team
       |> Teams.Membership.changeset(user, :owner)
+      |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
+      |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!(
         on_conflict: :nothing,
         conflict_target: {:unsafe_fragment, "(user_id) WHERE role != 'guest'"}

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -17,14 +17,16 @@ defmodule Plausible.Teams do
   end
 
   @doc """
-  Get or create implicit user's team.
+  Get or create user's team.
 
   If the user has no non-guest membership yet, an implicit "My Team" team is
   created with them as an owner.
 
-  If the user already has an owner membership in an existing team, that team is returned.
+  If the user already has an owner membership in an existing team,
+  that team is returned.
 
-  If the user has any other non-guest membership, `no_team` error is returned.
+  If the user has a non-guest membership other than owner, `:no_team` error
+  is returned.
   """
   def get_or_create(user) do
     result =

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -2,4 +2,158 @@ defmodule Plausible.Teams do
   @moduledoc """
   Core context of teams.
   """
+
+  import Ecto.Query
+
+  alias __MODULE__
+  alias Plausible.Repo
+
+  defmodule Sites do
+    @moduledoc false
+
+    alias Plausible.Auth
+    alias Plausible.Site
+
+    @type list_opt() :: {:filter_by_domain, String.t()}
+
+    @spec list(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
+    def list(user, pagination_params, opts \\ []) do
+      domain_filter = Keyword.get(opts, :filter_by_domain)
+
+      team_membership_query =
+        from tm in Teams.Membership,
+          inner_join: t in assoc(tm, :team),
+          inner_join: s in assoc(t, :sites),
+          where: tm.user_id == ^user.id and tm.role != :guest,
+          select: %{site_id: s.id, entry_type: "site"}
+
+      guest_membership_query =
+        from tm in Teams.Membership,
+          inner_join: gm in assoc(tm, :guest_memberships),
+          inner_join: s in assoc(gm, :site),
+          where: tm.user_id == ^user.id and tm.role == :guest,
+          select: %{site_id: s.id, entry_type: "site"}
+
+      union_query =
+        from s in team_membership_query,
+          union_all: ^guest_membership_query
+
+      from(u in subquery(union_query),
+        inner_join: s in Plausible.Site,
+        on: u.site_id == s.id,
+        left_join: up in Site.UserPreference,
+        on: up.site_id == s.id,
+        select: %{
+          s
+          | entry_type:
+              selected_as(
+                fragment(
+                  """
+                  CASE
+                    WHEN ? IS NOT NULL THEN 'pinned_site'
+                    ELSE ?
+                  END
+                  """,
+                  up.pinned_at,
+                  u.entry_type
+                ),
+                :entry_type
+              ),
+            pinned_at: selected_as(up.pinned_at, :pinned_at)
+        },
+        order_by: [
+          asc: selected_as(:entry_type),
+          desc: selected_as(:pinned_at),
+          asc: s.domain
+        ]
+      )
+      |> maybe_filter_by_domain(domain_filter)
+      |> Repo.paginate(pagination_params)
+    end
+
+    @spec list_with_invitations(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
+    def list_with_invitations(user, pagination_params, opts \\ []) do
+      domain_filter = Keyword.get(opts, :filter_by_domain)
+
+      team_membership_query =
+        from tm in Teams.Membership,
+          inner_join: t in assoc(tm, :team),
+          inner_join: s in assoc(t, :sites),
+          where: tm.user_id == ^user.id and tm.role != :guest,
+          select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
+
+      guest_membership_query =
+        from(tm in Teams.Membership,
+          inner_join: gm in assoc(tm, :guest_memberships),
+          inner_join: s in assoc(gm, :site),
+          where: tm.user_id == ^user.id and tm.role == :guest,
+          select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
+        )
+
+      guest_invitation_query =
+        from ti in Teams.Invitation,
+          inner_join: gi in assoc(ti, :guest_invitations),
+          inner_join: s in assoc(gi, :site),
+          where: ti.email == ^user.email and ti.role == :guest,
+          select: %{
+            site_id: s.id,
+            entry_type: "invitation",
+            invitation_id: ti.id,
+            invitation_role: gi.role
+          }
+
+      union_query =
+        from s in team_membership_query,
+          union_all: ^guest_membership_query,
+          union_all: ^guest_invitation_query
+
+      from(u in subquery(union_query),
+        inner_join: s in Plausible.Site,
+        on: u.site_id == s.id,
+        left_join: up in Site.UserPreference,
+        on: up.site_id == s.id,
+        left_join: ti in Teams.Invitation,
+        on: ti.id == u.invitation_id,
+        select: %{
+          s
+          | entry_type:
+              selected_as(
+                fragment(
+                  """
+                  CASE
+                    WHEN ? IS NOT NULL THEN 'pinned_site'
+                    ELSE ?
+                  END
+                  """,
+                  up.pinned_at,
+                  u.entry_type
+                ),
+                :entry_type
+              ),
+            pinned_at: selected_as(up.pinned_at, :pinned_at),
+            invitations: [
+              %Plausible.Auth.Invitation{
+                invitation_id: ti.invitation_id,
+                email: ti.email,
+                role: u.invitation_role
+              }
+            ]
+        },
+        order_by: [
+          asc: selected_as(:entry_type),
+          desc: selected_as(:pinned_at),
+          asc: s.domain
+        ]
+      )
+      |> maybe_filter_by_domain(domain_filter)
+      |> Repo.paginate(pagination_params)
+    end
+
+    defp maybe_filter_by_domain(query, domain)
+         when byte_size(domain) >= 1 and byte_size(domain) <= 64 do
+      where(query, [s], ilike(s.domain, ^"%#{domain}%"))
+    end
+
+    defp maybe_filter_by_domain(query, _), do: query
+  end
 end

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -1,0 +1,5 @@
+defmodule Plausible.Teams do
+  @moduledoc """
+  Core context of teams.
+  """
+end

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Teams do
 
   import Ecto.Query
 
+  alias __MODULE__
   alias Plausible.Repo
 
   def with_subscription(team) do
@@ -13,6 +14,57 @@ defmodule Plausible.Teams do
 
   def owned_sites(team) do
     Repo.preload(team, :sites).sites
+  end
+
+  @doc """
+  Get or create implicit user's team.
+
+  If the user has no non-guest membership yet, an implicit "My Team" team is
+  created with them as an owner.
+
+  If the user already has an owner membership in an existing team, that team is returned.
+
+  If the user has any other non-guest membership, `no_team` error is returned.
+  """
+  def get_or_create(user) do
+    result =
+      Repo.transaction(fn ->
+        team =
+          "My Team"
+          |> Teams.Team.changeset()
+          |> Repo.insert!()
+
+        team_membership = Teams.Membership.changeset(team, user, :owner)
+
+        case Repo.insert(team_membership) do
+          {:ok, _} ->
+            team
+
+          {:error, %{errors: [user_id: {"has already been taken", _}]}} ->
+            Repo.rollback(:exists_already)
+        end
+      end)
+
+    case result do
+      {:ok, team} -> {:ok, team}
+      {:error, :exists_already} -> get_owned_by_user(user)
+    end
+  end
+
+  defp get_owned_by_user(user) do
+    result =
+      from(tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        where: tm.user_id == ^user.id and tm.role == :owner,
+        select: t,
+        order_by: t.id
+      )
+      |> Repo.one()
+
+    case result do
+      nil -> {:error, :no_team}
+      team -> {:ok, team}
+    end
   end
 
   defp last_subscription_query() do

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -37,6 +37,20 @@ defmodule Plausible.Teams do
     end
   end
 
+  def sync_team(user) do
+    case get_owned_by_user(user) do
+      {:ok, team} ->
+        team
+        |> Teams.Team.sync_changeset(user)
+        |> Repo.update!()
+
+      _ ->
+        :skip
+    end
+
+    :ok
+  end
+
   defp create_my_team(user) do
     team =
       "My Team"

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -3,6 +3,7 @@ defmodule Plausible.Teams.Billing do
 
   import Ecto.Query
 
+  alias Plausible.Billing.Subscriptions
   alias Plausible.Billing.Plans
   alias Plausible.Repo
   alias Plausible.Teams
@@ -19,18 +20,136 @@ defmodule Plausible.Teams.Billing do
     end
   end
 
+  def quota_usage(team, opts) do
+    team = Teams.with_subscription(team)
+    with_features? = Keyword.get(opts, :with_features, false)
+    pending_site_ids = Keyword.get(opts, :pending_ownership_site_ids, [])
+    team_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
+    all_site_ids = pending_site_ids ++ team_site_ids
+
+    monthly_pageviews = monthly_pageview_usage(team, all_site_ids)
+    team_member_usage = team_member_usage(team, pending_ownership_site_ids: pending_site_ids)
+
+    basic_usage = %{
+      monthly_pageviews: monthly_pageviews,
+      team_members: team_member_usage,
+      sites: length(all_site_ids)
+    }
+
+    if with_features? do
+      Map.put(basic_usage, :features, features_usage(team, all_site_ids))
+    else
+      basic_usage
+    end
+  end
+
+  def monthly_pageview_usage(team, site_ids) do
+    team = Teams.with_subscription(team)
+    active_subscription? = Subscriptions.active?(team.subscription)
+
+    if active_subscription? and team.subscription.last_bill_date != nil do
+      [:current_cycle, :last_cycle, :penultimate_cycle]
+      |> Task.async_stream(fn cycle ->
+        {cycle, usage_cycle(team, cycle, site_ids)}
+      end)
+      |> Enum.into(%{}, fn {:ok, cycle_usage} -> cycle_usage end)
+    else
+      %{last_30_days: usage_cycle(team, :last_30_days, site_ids)}
+    end
+  end
+
   def team_member_usage(team, opts) do
     exclude_emails = Keyword.get(opts, :exclude_emails, [])
-
-    site_ids =
-      case Keyword.get(opts, :pending_ownership_site_ids) do
-        [_ | _] = pending_ids -> pending_ids
-        _ -> []
-      end
+    pending_site_ids = Keyword.get(opts, :pending_ownership_site_ids, [])
 
     team
-    |> query_team_member_emails(site_ids, exclude_emails)
+    |> query_team_member_emails(pending_site_ids, exclude_emails)
     |> Repo.aggregate(:count)
+  end
+
+  def usage_cycle(team, cycle, owned_site_ids \\ nil, today \\ Date.utc_today())
+
+  def usage_cycle(team, cycle, nil, today) do
+    owned_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
+    usage_cycle(team, cycle, owned_site_ids, today)
+  end
+
+  def usage_cycle(_team, :last_30_days, owned_site_ids, today) do
+    date_range = Date.range(Date.shift(today, day: -30), today)
+
+    {pageviews, custom_events} =
+      Plausible.Stats.Clickhouse.usage_breakdown(owned_site_ids, date_range)
+
+    %{
+      date_range: date_range,
+      pageviews: pageviews,
+      custom_events: custom_events,
+      total: pageviews + custom_events
+    }
+  end
+
+  def usage_cycle(team, cycle, owned_site_ids, today) do
+    team = Teams.with_subscription(team)
+    last_bill_date = team.subscription.last_bill_date
+
+    normalized_last_bill_date =
+      Date.shift(last_bill_date, month: Timex.diff(today, last_bill_date, :months))
+
+    date_range =
+      case cycle do
+        :current_cycle ->
+          Date.range(
+            normalized_last_bill_date,
+            Date.shift(normalized_last_bill_date, month: 1, day: -1)
+          )
+
+        :last_cycle ->
+          Date.range(
+            Date.shift(normalized_last_bill_date, month: -1),
+            Date.shift(normalized_last_bill_date, day: -1)
+          )
+
+        :penultimate_cycle ->
+          Date.range(
+            Date.shift(normalized_last_bill_date, month: -2),
+            Date.shift(normalized_last_bill_date, day: -1, month: -1)
+          )
+      end
+
+    {pageviews, custom_events} =
+      Plausible.Stats.Clickhouse.usage_breakdown(owned_site_ids, date_range)
+
+    %{
+      date_range: date_range,
+      pageviews: pageviews,
+      custom_events: custom_events,
+      total: pageviews + custom_events
+    }
+  end
+
+  def features_usage(user, site_ids \\ nil)
+
+  def features_usage(%Teams.Team{} = team, nil) do
+    owned_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
+    features_usage(team, owned_site_ids)
+  end
+
+  def features_usage(%Teams.Team{} = team, owned_site_ids) when is_list(owned_site_ids) do
+    site_scoped_feature_usage = features_usage(nil, owned_site_ids)
+
+    stats_api_used? =
+      from(a in Plausible.Auth.ApiKey, where: a.team_id == ^team.id)
+      |> Plausible.Repo.exists?()
+
+    if stats_api_used? do
+      site_scoped_feature_usage ++ [Feature.StatsAPI]
+    else
+      site_scoped_feature_usage
+    end
+  end
+
+  def features_usage(nil, owned_site_ids) when is_list(owned_site_ids) do
+    Plausible.Billing.Quota.Usage.features_usage(nil, owned_site_ids)
   end
 
   defp query_team_member_emails(team, site_ids, exclude_emails) do

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -1,0 +1,70 @@
+defmodule Plausible.Teams.Billing do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Plausible.Billing.Plans
+  alias Plausible.Repo
+  alias Plausible.Teams
+
+  @team_member_limit_for_trials 3
+
+  def team_member_limit(team) do
+    team = Teams.with_subscription(team)
+
+    case Plans.get_subscription_plan(team.subscription) do
+      %{team_member_limit: limit} -> limit
+      :free_10k -> :unlimited
+      nil -> @team_member_limit_for_trials
+    end
+  end
+
+  def team_member_usage(team, opts) do
+    exclude_emails = Keyword.get(opts, :exclude_emails, [])
+
+    site_ids =
+      case Keyword.get(opts, :pending_ownership_site_ids) do
+        [_ | _] = pending_ids -> pending_ids
+        _ -> []
+      end
+
+    team
+    |> query_team_member_emails(site_ids, exclude_emails)
+    |> Repo.aggregate(:count)
+  end
+
+  defp query_team_member_emails(team, site_ids, exclude_emails) do
+    pending_memberships_q =
+      from tm in Teams.Membership,
+        inner_join: u in assoc(tm, :user),
+        inner_join: gm in assoc(tm, :guest_memberships),
+        where: gm.site_id in ^site_ids and tm.role != :owner,
+        where: u.email not in ^exclude_emails,
+        select: %{email: u.email}
+
+    pending_invitations_q =
+      from ti in Teams.Invitation,
+        inner_join: gi in assoc(ti, :guest_invitations),
+        where: gi.site_id in ^site_ids and ti.role != :owner,
+        where: ti.email not in ^exclude_emails,
+        select: %{email: ti.email}
+
+    team_memberships_q =
+      from tm in Teams.Membership,
+        inner_join: u in assoc(tm, :user),
+        where: tm.team_id == ^team.id and tm.role != :owner,
+        where: u.email not in ^exclude_emails,
+        select: %{email: u.email}
+
+    team_invitations_q =
+      from ti in Teams.Invitation,
+        where: ti.team_id == ^team.id and ti.role != :owner,
+        where: ti.email not in ^exclude_emails,
+        select: %{email: ti.email}
+
+    pending_memberships_q
+    |> union(^pending_invitations_q)
+    |> union(^team_memberships_q)
+    |> union(^team_invitations_q)
+  end
+end

--- a/lib/plausible/teams/guest_invitation.ex
+++ b/lib/plausible/teams/guest_invitation.ex
@@ -5,6 +5,8 @@ defmodule Plausible.Teams.GuestInvitation do
 
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   schema "guest_invitations" do
     field :role, Ecto.Enum, values: [:viewer, :editor]
 
@@ -12,5 +14,13 @@ defmodule Plausible.Teams.GuestInvitation do
     belongs_to :team_invitation, Plausible.Teams.Invitation
 
     timestamps()
+  end
+
+  def changeset(team_invitation, site, role) do
+    %__MODULE__{}
+    |> cast(%{role: role}, [:role])
+    |> validate_required(:role)
+    |> put_assoc(:team_invitation, team_invitation)
+    |> put_assoc(:site, site)
   end
 end

--- a/lib/plausible/teams/guest_invitation.ex
+++ b/lib/plausible/teams/guest_invitation.ex
@@ -1,0 +1,16 @@
+defmodule Plausible.Teams.GuestInvitation do
+  @moduledoc """
+  Guest invitation schema
+  """
+
+  use Ecto.Schema
+
+  schema "guest_invitations" do
+    field :role, Ecto.Enum, values: [:viewer, :editor]
+
+    belongs_to :site, Plausible.Site
+    belongs_to :team_invitation, Plausible.Teams.Invitation
+
+    timestamps()
+  end
+end

--- a/lib/plausible/teams/guest_membership.ex
+++ b/lib/plausible/teams/guest_membership.ex
@@ -5,6 +5,8 @@ defmodule Plausible.Teams.GuestMembership do
 
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   schema "guest_memberships" do
     field :role, Ecto.Enum, values: [:viewer, :editor]
 
@@ -12,5 +14,13 @@ defmodule Plausible.Teams.GuestMembership do
     belongs_to :site, Plausible.Site
 
     timestamps()
+  end
+
+  def changeset(team_membership, site, role) do
+    %__MODULE__{}
+    |> change()
+    |> put_change(:role, role)
+    |> put_assoc(:team_membership, team_membership)
+    |> put_assoc(:site, site)
   end
 end

--- a/lib/plausible/teams/guest_membership.ex
+++ b/lib/plausible/teams/guest_membership.ex
@@ -1,0 +1,16 @@
+defmodule Plausible.Teams.GuestMembership do
+  @moduledoc """
+  Guest membership schema
+  """
+
+  use Ecto.Schema
+
+  schema "guest_memberships" do
+    field :role, Ecto.Enum, values: [:viewer, :editor]
+
+    belongs_to :team_membership, Plausible.Teams.Membership
+    belongs_to :site, Plausible.Site
+
+    timestamps()
+  end
+end

--- a/lib/plausible/teams/invitation.ex
+++ b/lib/plausible/teams/invitation.ex
@@ -1,0 +1,20 @@
+defmodule Plausible.Teams.Invitation do
+  @moduledoc """
+  Team invitation schema
+  """
+
+  use Ecto.Schema
+
+  schema "team_invitations" do
+    field :invitation_id, :string
+    field :email, :string
+    field :role, Ecto.Enum, values: [:guest, :viewer, :editor, :admin, :owner]
+
+    belongs_to :inviter, Plausible.Auth.User
+    belongs_to :team, Plausible.Teams.Team
+
+    has_many :guest_invitations, Plausible.Teams.GuestInvitation, foreign_key: :team_invitation_id
+
+    timestamps()
+  end
+end

--- a/lib/plausible/teams/invitation.ex
+++ b/lib/plausible/teams/invitation.ex
@@ -5,6 +5,8 @@ defmodule Plausible.Teams.Invitation do
 
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   schema "team_invitations" do
     field :invitation_id, :string
     field :email, :string
@@ -16,5 +18,17 @@ defmodule Plausible.Teams.Invitation do
     has_many :guest_invitations, Plausible.Teams.GuestInvitation, foreign_key: :team_invitation_id
 
     timestamps()
+  end
+
+  def changeset(team, opts) do
+    email = Keyword.fetch!(opts, :email)
+    role = Keyword.fetch!(opts, :role)
+    inviter = Keyword.fetch!(opts, :inviter)
+
+    %__MODULE__{invitation_id: Nanoid.generate()}
+    |> cast(%{email: email, role: role}, [:email, :role])
+    |> validate_required([:email, :role])
+    |> put_assoc(:team, team)
+    |> put_assoc(:inviter, inviter)
   end
 end

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -1,0 +1,122 @@
+defmodule Plausible.Teams.Invitations do
+  @moduledoc false
+
+  alias Plausible.Auth
+  alias Plausible.Billing
+  alias Plausible.Repo
+  alias Plausible.Teams
+
+  def invite(site, inviter, invitee_email, role, opts \\ [])
+
+  # ownership transfer => site transfer
+  def invite(_site, _inviter, _invitee_email, :owner, _opts) do
+    # TODO
+    {:error, :not_implemented}
+  end
+
+  def invite(site, inviter, invitee_email, role, opts) do
+    check_permissions? = opts[:check_permissions]
+    site = Repo.preload(site, :team)
+    role = translate_role(role)
+
+    with :ok <- check_invitation_permissions(site.team, inviter, check_permissions?),
+         :ok <- check_team_member_limit(site.team, role, invitee_email),
+         invitee = Auth.find_user_by(email: invitee_email),
+         :ok <- ensure_transfer_valid(site.team, invitee, role),
+         :ok <- ensure_new_membership(site, invitee, role),
+         {:ok, guest_invitation} <- create_invitation(site, invitee_email, role, inviter) do
+      send_invitation_email(guest_invitation, invitee)
+      {:ok, guest_invitation}
+    end
+  end
+
+  defp check_invitation_permissions(_team, _inviter, false = _check_permission?) do
+    :ok
+  end
+
+  defp check_invitation_permissions(team, inviter, _) do
+    case Teams.Memberships.team_role(team, inviter) do
+      {:ok, role} when role in [:owner, :admin] -> :ok
+      _ -> {:error, :forbidden}
+    end
+  end
+
+  defp translate_role(:admin), do: :editor
+  defp translate_role(role), do: role
+
+  defp check_team_member_limit(_team, :owner, _invitee_email), do: :ok
+
+  defp check_team_member_limit(team, _role, invitee_email) do
+    limit = Teams.Billing.team_member_limit(team)
+    usage = Teams.Billing.team_member_usage(team, exclude_emails: [invitee_email])
+
+    if Billing.Quota.below_limit?(usage, limit) do
+      :ok
+    else
+      {:error, {:over_limit, limit}}
+    end
+  end
+
+  defp ensure_transfer_valid(_team, nil, _role), do: :ok
+
+  defp ensure_transfer_valid(_site, _new_owner, :owner), do: {:error, :use_site_transfer}
+
+  defp ensure_transfer_valid(_site, _new_owner, _role), do: :ok
+
+  defp ensure_new_membership(_site, nil, _role), do: :ok
+
+  defp ensure_new_membership(site, invitee, _role) do
+    if is_nil(Teams.Memberships.site_role(site, invitee)) do
+      :ok
+    else
+      {:error, :already_a_member}
+    end
+  end
+
+  defp create_invitation(site, invitee_email, role, inviter) do
+    Repo.transaction(fn ->
+      with {:ok, team_invitation} <- create_team_invitation(site.team, invitee_email, inviter),
+           {:ok, guest_invitation} <- create_guest_invitation(team_invitation, site, role) do
+        guest_invitation
+      else
+        {:error, changeset} -> Repo.rollback(changeset)
+      end
+    end)
+  end
+
+  defp create_team_invitation(team, invitee_email, inviter) do
+    now = NaiveDateTime.utc_now(:second)
+
+    team
+    |> Teams.Invitation.changeset(email: invitee_email, role: :guest, inviter: inviter)
+    |> Repo.insert(on_conflict: [set: [updated_at: now]], conflict_target: [:team_id, :email])
+  end
+
+  defp create_guest_invitation(team_invitation, site, role) do
+    team_invitation
+    |> Teams.GuestInvitation.changeset(site, role)
+    |> Repo.insert()
+  end
+
+  defp send_invitation_email(guest_invitation, invitee) do
+    team_invitation = guest_invitation.team_invitation
+
+    email =
+      if invitee do
+        PlausibleWeb.Email.existing_user_invitation(
+          team_invitation.email,
+          guest_invitation.site,
+          team_invitation.inviter
+        )
+      else
+        PlausibleWeb.Email.new_user_invitation(
+          team_invitation.email,
+          team_invitation.invitation_id,
+          guest_invitation.site,
+          team_invitation.inviter
+        )
+      end
+
+    Plausible.Mailer.send(email)
+  end
+end

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -49,7 +49,9 @@ defmodule Plausible.Teams.Invitations do
           :ok = transfer_site_ownership(site, team, now)
         end)
 
-      {:ok, Teams.Memberships.get(team, new_owner)}
+      {:ok, team_membership} = Teams.Memberships.get(team, new_owner)
+
+      {:ok, team_membership}
     end
   end
 
@@ -145,7 +147,9 @@ defmodule Plausible.Teams.Invitations do
 
       send_transfer_accepted_email(site_transfer)
 
-      Teams.Memberships.get(team, new_owner)
+      {:ok, team_membership} = Teams.Memberships.get(team, new_owner)
+
+      {:ok, team_membership}
     end
   end
 
@@ -283,7 +287,7 @@ defmodule Plausible.Teams.Invitations do
   defp ensure_new_membership(_site, nil, _role), do: :ok
 
   defp ensure_new_membership(site, invitee, _role) do
-    if is_nil(Teams.Memberships.site_role(site, invitee)) do
+    if Teams.Memberships.site_role(site, invitee) == {:error, :not_a_member} do
       :ok
     else
       {:error, :already_a_member}

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -24,5 +24,6 @@ defmodule Plausible.Teams.Membership do
     |> put_change(:role, role)
     |> put_assoc(:team, team)
     |> put_assoc(:user, user)
+    |> unique_constraint(:user_id, name: :one_team_per_user)
   end
 end

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -5,6 +5,8 @@ defmodule Plausible.Teams.Membership do
 
   use Ecto.Schema
 
+  import Ecto.Changeset
+
   schema "team_memberships" do
     field :role, Ecto.Enum, values: [:guest, :viewer, :editor, :admin, :owner]
 
@@ -14,5 +16,13 @@ defmodule Plausible.Teams.Membership do
     has_many :guest_memberships, Plausible.Teams.GuestMembership, foreign_key: :team_membership_id
 
     timestamps()
+  end
+
+  def changeset(team, user, role) do
+    %__MODULE__{}
+    |> change()
+    |> put_change(:role, role)
+    |> put_assoc(:team, team)
+    |> put_assoc(:user, user)
   end
 end

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -1,0 +1,18 @@
+defmodule Plausible.Teams.Membership do
+  @moduledoc """
+  Team membership schema
+  """
+
+  use Ecto.Schema
+
+  schema "team_memberships" do
+    field :role, Ecto.Enum, values: [:guest, :viewer, :editor, :admin, :owner]
+
+    belongs_to :user, Plausible.Auth.User
+    belongs_to :team, Plausible.Teams.Team
+
+    has_many :guest_memberships, Plausible.Teams.GuestMembership, foreign_key: :team_membership_id
+
+    timestamps()
+  end
+end

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -1,0 +1,41 @@
+defmodule Plausible.Teams.Memberships do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+
+  def team_role(team, user) do
+    result =
+      from(u in Auth.User,
+        inner_join: tm in assoc(u, :team_memberships),
+        where: tm.team_id == ^team.id and tm.user_id == ^user.id,
+        select: tm.role
+      )
+      |> Repo.one()
+
+    case result do
+      nil -> {:error, :not_a_member}
+      role -> {:ok, role}
+    end
+  end
+
+  def site_role(site, user) do
+    result =
+      from(u in Auth.User,
+        inner_join: tm in assoc(u, :team_memberships),
+        left_join: gm in assoc(tm, :guest_memberships),
+        where: tm.team_id == ^site.team_id and tm.user_id == ^user.id,
+        where: tm.role != :guest or gm.site_id == ^site.id,
+        select: {tm.role, gm.role}
+      )
+      |> Repo.one()
+
+    case result do
+      {:guest, role} -> role
+      {role, _} -> role
+      _ -> nil
+    end
+  end
+end

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -69,6 +69,7 @@ defmodule Plausible.Teams.Memberships do
       {:ok, guest_membership} ->
         guest_membership
         |> Ecto.Changeset.change(role: new_role)
+        |> Ecto.Changeset.put_change(:updated_at, site_membership.updated_at)
         |> Repo.update!()
 
       {:error, _} ->

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -5,6 +5,21 @@ defmodule Plausible.Teams.Memberships do
 
   alias Plausible.Auth
   alias Plausible.Repo
+  alias Plausible.Teams
+
+  def get(team, user) do
+    result =
+      from(tm in Teams.Membership,
+        left_join: gm in assoc(tm, :guest_memberships),
+        where: tm.team_id == ^team.id and tm.user_id == ^user.id
+      )
+      |> Repo.one()
+
+    case result do
+      nil -> {:error, :not_a_member}
+      team_membership -> team_membership
+    end
+  end
 
   def team_role(team, user) do
     result =
@@ -37,5 +52,28 @@ defmodule Plausible.Teams.Memberships do
       {role, _} -> role
       _ -> nil
     end
+  end
+
+  def prune_guests(team, opts \\ []) do
+    ignore_guest_ids = Keyword.get(opts, :ignore_guest_ids, [])
+
+    guest_query =
+      from(
+        gm in Teams.GuestMembership,
+        where: gm.team_membership_id == parent_as(:team_membership).id,
+        where: gm.id not in ^ignore_guest_ids,
+        select: true
+      )
+
+    Repo.delete_all(
+      from(
+        tm in Teams.Membership,
+        as: :team_membership,
+        where: tm.team_id == ^team.id and tm.role == :guest,
+        where: not exists(guest_query)
+      )
+    )
+
+    :ok
   end
 end

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -17,7 +17,7 @@ defmodule Plausible.Teams.Memberships do
 
     case result do
       nil -> {:error, :not_a_member}
-      team_membership -> team_membership
+      team_membership -> {:ok, team_membership}
     end
   end
 
@@ -48,9 +48,9 @@ defmodule Plausible.Teams.Memberships do
       |> Repo.one()
 
     case result do
-      {:guest, role} -> role
-      {role, _} -> role
-      _ -> nil
+      {:guest, role} -> {:ok, role}
+      {role, _} -> {:ok, role}
+      _ -> {:error, :not_a_member}
     end
   end
 

--- a/lib/plausible/teams/site_transfer.ex
+++ b/lib/plausible/teams/site_transfer.ex
@@ -1,0 +1,35 @@
+defmodule Plausible.Teams.SiteTransfer do
+  @moduledoc """
+  Site transfer schema
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "team_site_transfers" do
+    field :transfer_id, :string
+    field :email, :string
+    field :transfer_guests, :boolean, default: true
+
+    belongs_to :site, Plausible.Site
+    belongs_to :initiator, Plausible.Auth.User
+    belongs_to :destination_team, Plausible.Teams.Team
+
+    timestamps()
+  end
+
+  def changeset(site, opts) do
+    initiator = Keyword.fetch!(opts, :initiator)
+    transfer_guests = Keyword.get(opts, :transfer_guests, true)
+    destination_team = Keyword.get(opts, :destination_team)
+    email = Keyword.get(opts, :email)
+
+    %__MODULE__{transfer_id: Nanoid.generate()}
+    |> cast(%{email: email}, [:email])
+    |> put_change(:transfer_guests, transfer_guests)
+    |> put_assoc(:site, site)
+    |> put_assoc(:destination_team, destination_team)
+    |> put_assoc(:initiator, initiator)
+  end
+end

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -10,6 +10,22 @@ defmodule Plausible.Teams.Sites do
 
   @type list_opt() :: {:filter_by_domain, String.t()}
 
+  def get_owner(team) do
+    owner_query =
+      from(
+        tm in Teams.Membership,
+        inner_join: u in assoc(tm, :user),
+        where: tm.team_id == ^team.id and tm.role == :owner,
+        select: u
+      )
+
+    case Repo.all(owner_query) do
+      [owner_user] -> {:ok, owner_user}
+      [] -> {:error, :no_owner}
+      _ -> {:error, :multiple_owners}
+    end
+  end
+
   @spec list(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
   def list(user, pagination_params, opts \\ []) do
     domain_filter = Keyword.get(opts, :filter_by_domain)

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -1,0 +1,152 @@
+defmodule Plausible.Teams.Sites do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Plausible.Auth
+  alias Plausible.Repo
+  alias Plausible.Site
+  alias Plausible.Teams
+
+  @type list_opt() :: {:filter_by_domain, String.t()}
+
+  @spec list(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
+  def list(user, pagination_params, opts \\ []) do
+    domain_filter = Keyword.get(opts, :filter_by_domain)
+
+    team_membership_query =
+      from tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        inner_join: s in assoc(t, :sites),
+        where: tm.user_id == ^user.id and tm.role != :guest,
+        select: %{site_id: s.id, entry_type: "site"}
+
+    guest_membership_query =
+      from tm in Teams.Membership,
+        inner_join: gm in assoc(tm, :guest_memberships),
+        inner_join: s in assoc(gm, :site),
+        where: tm.user_id == ^user.id and tm.role == :guest,
+        select: %{site_id: s.id, entry_type: "site"}
+
+    union_query =
+      from s in team_membership_query,
+        union_all: ^guest_membership_query
+
+    from(u in subquery(union_query),
+      inner_join: s in Plausible.Site,
+      on: u.site_id == s.id,
+      left_join: up in Site.UserPreference,
+      on: up.site_id == s.id,
+      select: %{
+        s
+        | entry_type:
+            selected_as(
+              fragment(
+                """
+                CASE
+                  WHEN ? IS NOT NULL THEN 'pinned_site'
+                  ELSE ?
+                END
+                """,
+                up.pinned_at,
+                u.entry_type
+              ),
+              :entry_type
+            ),
+          pinned_at: selected_as(up.pinned_at, :pinned_at)
+      },
+      order_by: [
+        asc: selected_as(:entry_type),
+        desc: selected_as(:pinned_at),
+        asc: s.domain
+      ]
+    )
+    |> maybe_filter_by_domain(domain_filter)
+    |> Repo.paginate(pagination_params)
+  end
+
+  @spec list_with_invitations(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
+  def list_with_invitations(user, pagination_params, opts \\ []) do
+    domain_filter = Keyword.get(opts, :filter_by_domain)
+
+    team_membership_query =
+      from tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        inner_join: s in assoc(t, :sites),
+        where: tm.user_id == ^user.id and tm.role != :guest,
+        select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
+
+    guest_membership_query =
+      from(tm in Teams.Membership,
+        inner_join: gm in assoc(tm, :guest_memberships),
+        inner_join: s in assoc(gm, :site),
+        where: tm.user_id == ^user.id and tm.role == :guest,
+        select: %{site_id: s.id, entry_type: "site", invitation_id: 0, invitation_role: ""}
+      )
+
+    guest_invitation_query =
+      from ti in Teams.Invitation,
+        inner_join: gi in assoc(ti, :guest_invitations),
+        inner_join: s in assoc(gi, :site),
+        where: ti.email == ^user.email and ti.role == :guest,
+        select: %{
+          site_id: s.id,
+          entry_type: "invitation",
+          invitation_id: ti.id,
+          invitation_role: gi.role
+        }
+
+    union_query =
+      from s in team_membership_query,
+        union_all: ^guest_membership_query,
+        union_all: ^guest_invitation_query
+
+    from(u in subquery(union_query),
+      inner_join: s in Plausible.Site,
+      on: u.site_id == s.id,
+      left_join: up in Site.UserPreference,
+      on: up.site_id == s.id,
+      left_join: ti in Teams.Invitation,
+      on: ti.id == u.invitation_id,
+      select: %{
+        s
+        | entry_type:
+            selected_as(
+              fragment(
+                """
+                CASE
+                  WHEN ? IS NOT NULL THEN 'pinned_site'
+                  ELSE ?
+                END
+                """,
+                up.pinned_at,
+                u.entry_type
+              ),
+              :entry_type
+            ),
+          pinned_at: selected_as(up.pinned_at, :pinned_at),
+          invitations: [
+            %Plausible.Auth.Invitation{
+              invitation_id: ti.invitation_id,
+              email: ti.email,
+              role: u.invitation_role
+            }
+          ]
+      },
+      order_by: [
+        asc: selected_as(:entry_type),
+        desc: selected_as(:pinned_at),
+        asc: s.domain
+      ]
+    )
+    |> maybe_filter_by_domain(domain_filter)
+    |> Repo.paginate(pagination_params)
+  end
+
+  defp maybe_filter_by_domain(query, domain)
+       when byte_size(domain) >= 1 and byte_size(domain) <= 64 do
+    where(query, [s], ilike(s.domain, ^"%#{domain}%"))
+  end
+
+  defp maybe_filter_by_domain(query, _), do: query
+end

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -10,6 +10,44 @@ defmodule Plausible.Teams.Sites do
 
   @type list_opt() :: {:filter_by_domain, String.t()}
 
+  @spec create(Teams.Team.t(), map()) :: {:ok, map()}
+  def create(team, params) do
+    with :ok <- Teams.Billing.ensure_can_add_new_site(team) do
+      Ecto.Multi.new()
+      |> Ecto.Multi.put(:site_changeset, Site.new_for_team(team, params))
+      |> Ecto.Multi.run(:clear_changed_from, fn
+        _repo, %{site_changeset: %{changes: %{domain: domain}}} ->
+          if site_to_clear = Repo.get_by(Site, team_id: team.id, domain_changed_from: domain) do
+            site_to_clear
+            |> Ecto.Changeset.change()
+            |> Ecto.Changeset.put_change(:domain_changed_from, nil)
+            |> Ecto.Changeset.put_change(:domain_changed_at, nil)
+            |> Repo.update()
+          else
+            {:ok, :ignore}
+          end
+
+        _repo, _context ->
+          {:ok, :ignore}
+      end)
+      |> Ecto.Multi.insert(:site, fn %{site_changeset: site} -> site end)
+      |> maybe_start_trial(team)
+      |> Repo.transaction()
+    end
+  end
+
+  defp maybe_start_trial(multi, team) do
+    case team.trial_expiry_date do
+      nil ->
+        changeset = Teams.Team.start_trial(team)
+        Ecto.Multi.update(multi, :team, changeset)
+
+      _ ->
+        multi
+    end
+  end
+
+  @spec get_owner(Teams.Team.t()) :: {:ok, Auth.User.t()} | {:error, :no_owner | :multiple_owners}
   def get_owner(team) do
     owner_query =
       from(

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -29,6 +29,15 @@ defmodule Plausible.Teams.Team do
     timestamps()
   end
 
+  def sync_changeset(team, user) do
+    team
+    |> change()
+    |> put_change(:trial_expiry_date, user.trial_expiry_date)
+    |> put_change(:accept_traffic_until, user.accept_traffic_until)
+    |> put_change(:allow_next_upgrade_override, user.allow_next_upgrade_override)
+    |> put_embed(:grace_period, user.grace_period)
+  end
+
   def changeset(name, today \\ Date.utc_today()) do
     trial_expiry_date =
       if ee?() do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -4,6 +4,9 @@ defmodule Plausible.Teams.Team do
   """
 
   use Ecto.Schema
+  use Plausible
+
+  import Ecto.Changeset
 
   schema "teams" do
     field :name, :string
@@ -20,5 +23,19 @@ defmodule Plausible.Teams.Team do
     has_one :enterprise_plan, Plausible.Billing.EnterprisePlan
 
     timestamps()
+  end
+
+  def changeset(name, today \\ Date.utc_today()) do
+    trial_expiry_date =
+      if ee?() do
+        Date.shift(today, day: 30)
+      else
+        Date.shift(today, year: 100)
+      end
+
+    %__MODULE__{}
+    |> cast(%{name: name}, [:name])
+    |> validate_required(:name)
+    |> put_change(:trial_expiry_date, trial_expiry_date)
   end
 end

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -1,0 +1,24 @@
+defmodule Plausible.Teams.Team do
+  @moduledoc """
+  Team schema
+  """
+
+  use Ecto.Schema
+
+  schema "teams" do
+    field :name, :string
+    field :trial_expiry_date, :date
+    field :accept_traffic_until, :date
+    field :allow_next_upgrade_override, :boolean
+
+    embeds_one :grace_period, Plausible.Auth.GracePeriod, on_replace: :update
+
+    has_many :sites, Plausible.Site
+    has_many :team_memberships, Plausible.Teams.Membership
+    has_many :team_invitations, Plausible.Teams.Invitation
+    has_one :subscription, Plausible.Billing.Subscription
+    has_one :enterprise_plan, Plausible.Billing.EnterprisePlan
+
+    timestamps()
+  end
+end

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -36,6 +36,8 @@ defmodule Plausible.Teams.Team do
     |> put_change(:accept_traffic_until, user.accept_traffic_until)
     |> put_change(:allow_next_upgrade_override, user.allow_next_upgrade_override)
     |> put_embed(:grace_period, user.grace_period)
+    |> put_change(:inserted_at, user.inserted_at)
+    |> put_change(:updated_at, user.updated_at)
   end
 
   def changeset(name, today \\ Date.utc_today()) do

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -8,6 +8,7 @@ defmodule Plausible.Users do
   import Ecto.Query
 
   alias Plausible.Auth
+  alias Plausible.Auth.GracePeriod
   alias Plausible.Billing.Subscription
   alias Plausible.Repo
 
@@ -118,6 +119,30 @@ defmodule Plausible.Users do
     from(subscription in last_subscription_query(),
       where: subscription.user_id == parent_as(:user).id
     )
+  end
+
+  def start_grace_period(user) do
+    user
+    |> GracePeriod.start_changeset()
+    |> Repo.update!()
+  end
+
+  def start_manual_lock_grace_period(user) do
+    user
+    |> GracePeriod.start_manual_lock_changeset()
+    |> Repo.update!()
+  end
+
+  def end_grace_period(user) do
+    user
+    |> GracePeriod.end_changeset()
+    |> Repo.update!()
+  end
+
+  def remove_grace_period(user) do
+    user
+    |> GracePeriod.remove_changeset()
+    |> Repo.update!()
   end
 
   defp last_subscription_query() do

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -36,7 +36,9 @@ defmodule Plausible.Users do
       |> Auth.User.changeset(%{accept_traffic_until: accept_traffic_until(user)})
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -110,7 +112,9 @@ defmodule Plausible.Users do
       |> Auth.User.start_trial()
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -121,7 +125,9 @@ defmodule Plausible.Users do
       |> Auth.User.changeset(%{allow_next_upgrade_override: true})
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -133,7 +139,9 @@ defmodule Plausible.Users do
         |> Auth.User.changeset(%{allow_next_upgrade_override: false})
         |> Repo.update!()
 
-      Plausible.Teams.sync_team(user)
+      with_teams do
+        Plausible.Teams.sync_team(user)
+      end
 
       user
     else
@@ -153,7 +161,9 @@ defmodule Plausible.Users do
       |> GracePeriod.start_changeset()
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -164,7 +174,9 @@ defmodule Plausible.Users do
       |> GracePeriod.start_manual_lock_changeset()
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -175,7 +187,9 @@ defmodule Plausible.Users do
       |> GracePeriod.end_changeset()
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end
@@ -186,7 +200,9 @@ defmodule Plausible.Users do
       |> GracePeriod.remove_changeset()
       |> Repo.update!()
 
-    Plausible.Teams.sync_team(user)
+    with_teams do
+      Plausible.Teams.sync_team(user)
+    end
 
     user
   end

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -31,9 +31,14 @@ defmodule Plausible.Users do
 
   @spec update_accept_traffic_until(Auth.User.t()) :: Auth.User.t()
   def update_accept_traffic_until(user) do
+    user =
+      user
+      |> Auth.User.changeset(%{accept_traffic_until: accept_traffic_until(user)})
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> Auth.User.changeset(%{accept_traffic_until: accept_traffic_until(user)})
-    |> Repo.update!()
   end
 
   @spec bump_last_seen(Auth.User.t() | pos_integer(), NaiveDateTime.t()) :: :ok
@@ -100,22 +105,37 @@ defmodule Plausible.Users do
   end
 
   def start_trial(%Auth.User{} = user) do
+    user =
+      user
+      |> Auth.User.start_trial()
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> Auth.User.start_trial()
-    |> Repo.update!()
   end
 
   def allow_next_upgrade_override(%Auth.User{} = user) do
+    user =
+      user
+      |> Auth.User.changeset(%{allow_next_upgrade_override: true})
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> Auth.User.changeset(%{allow_next_upgrade_override: true})
-    |> Repo.update!()
   end
 
   def maybe_reset_next_upgrade_override(%Auth.User{} = user) do
     if user.allow_next_upgrade_override do
+      user =
+        user
+        |> Auth.User.changeset(%{allow_next_upgrade_override: false})
+        |> Repo.update!()
+
+      Plausible.Teams.sync_team(user)
+
       user
-      |> Auth.User.changeset(%{allow_next_upgrade_override: false})
-      |> Repo.update!()
     else
       user
     end
@@ -128,27 +148,47 @@ defmodule Plausible.Users do
   end
 
   def start_grace_period(user) do
+    user =
+      user
+      |> GracePeriod.start_changeset()
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> GracePeriod.start_changeset()
-    |> Repo.update!()
   end
 
   def start_manual_lock_grace_period(user) do
+    user =
+      user
+      |> GracePeriod.start_manual_lock_changeset()
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> GracePeriod.start_manual_lock_changeset()
-    |> Repo.update!()
   end
 
   def end_grace_period(user) do
+    user =
+      user
+      |> GracePeriod.end_changeset()
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> GracePeriod.end_changeset()
-    |> Repo.update!()
   end
 
   def remove_grace_period(user) do
+    user =
+      user
+      |> GracePeriod.remove_changeset()
+      |> Repo.update!()
+
+    Plausible.Teams.sync_team(user)
+
     user
-    |> GracePeriod.remove_changeset()
-    |> Repo.update!()
   end
 
   defp last_subscription_query() do

--- a/lib/plausible/users.ex
+++ b/lib/plausible/users.ex
@@ -99,6 +99,12 @@ defmodule Plausible.Users do
     Auth.EmailVerification.any?(user)
   end
 
+  def start_trial(%Auth.User{} = user) do
+    user
+    |> Auth.User.start_trial()
+    |> Repo.update!()
+  end
+
   def allow_next_upgrade_override(%Auth.User{} = user) do
     user
     |> Auth.User.changeset(%{allow_next_upgrade_override: true})

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -227,7 +227,11 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_user.subscription) do %>
       <.change_plan_link {assigns} />
     <% else %>
-      <PlausibleWeb.Components.Billing.paddle_button user={@current_user} {assigns}>
+      <PlausibleWeb.Components.Billing.paddle_button
+        user={@current_user}
+        team={@current_team}
+        {assigns}
+      >
         Upgrade
       </PlausibleWeb.Components.Billing.paddle_button>
     <% end %>

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -12,6 +12,7 @@ defmodule PlausibleWeb.Site.MembershipController do
 
   use PlausibleWeb, :controller
   use Plausible.Repo
+  use Plausible
   alias Plausible.Sites
   alias Plausible.Site.{Membership, Memberships}
 
@@ -170,7 +171,9 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> Membership.set_role(new_role)
         |> Repo.update!()
 
+      with_teams do
       Plausible.Teams.Memberships.update_role_sync(membership)
+      end
 
       redirect_target =
         if membership.user.id == current_user.id and new_role == :viewer do
@@ -217,7 +220,9 @@ defmodule PlausibleWeb.Site.MembershipController do
 
     if membership do
       Repo.delete!(membership)
+      with_teams do
       Plausible.Teams.Memberships.remove_sync(membership)
+    end
 
       membership
       |> PlausibleWeb.Email.site_member_removed()

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -172,7 +172,7 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> Repo.update!()
 
       with_teams do
-      Plausible.Teams.Memberships.update_role_sync(membership)
+        Plausible.Teams.Memberships.update_role_sync(membership)
       end
 
       redirect_target =
@@ -220,9 +220,10 @@ defmodule PlausibleWeb.Site.MembershipController do
 
     if membership do
       Repo.delete!(membership)
+
       with_teams do
-      Plausible.Teams.Memberships.remove_sync(membership)
-    end
+        Plausible.Teams.Memberships.remove_sync(membership)
+      end
 
       membership
       |> PlausibleWeb.Email.site_member_removed()

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -170,6 +170,8 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> Membership.set_role(new_role)
         |> Repo.update!()
 
+      Plausible.Teams.Memberships.update_role_sync(membership)
+
       redirect_target =
         if membership.user.id == current_user.id and new_role == :viewer do
           "/#{URI.encode_www_form(site.domain)}"
@@ -215,6 +217,7 @@ defmodule PlausibleWeb.Site.MembershipController do
 
     if membership do
       Repo.delete!(membership)
+      Plausible.Teams.Memberships.remove_sync(membership)
 
       membership
       |> PlausibleWeb.Email.site_member_removed()

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -256,15 +256,15 @@ defmodule PlausibleWeb.Email do
     )
   end
 
-  def ownership_transfer_request(invitation, new_owner_account) do
+  def ownership_transfer_request(email, invitation_id, site, inviter, new_owner_account) do
     priority_email()
-    |> to(invitation.email)
+    |> to(email)
     |> tag("ownership-transfer-request")
-    |> subject(
-      "[#{Plausible.product_name()}] Request to transfer ownership of #{invitation.site.domain}"
-    )
+    |> subject("[#{Plausible.product_name()}] Request to transfer ownership of #{site.domain}")
     |> render("ownership_transfer_request.html",
-      invitation: invitation,
+      invitation_id: invitation_id,
+      inviter: inviter,
+      site: site,
       new_owner_account: new_owner_account
     )
   end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -295,16 +295,16 @@ defmodule PlausibleWeb.Email do
     )
   end
 
-  def ownership_transfer_accepted(invitation) do
+  def ownership_transfer_accepted(new_owner_email, inviter_email, site) do
     priority_email()
-    |> to(invitation.inviter.email)
+    |> to(inviter_email)
     |> tag("ownership-transfer-accepted")
     |> subject(
-      "[#{Plausible.product_name()}] #{invitation.email} accepted the ownership transfer of #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{new_owner_email} accepted the ownership transfer of #{site.domain}"
     )
     |> render("ownership_transfer_accepted.html",
-      user: invitation.inviter,
-      invitation: invitation
+      new_owner_email: new_owner_email,
+      site: site
     )
   end
 

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -269,16 +269,16 @@ defmodule PlausibleWeb.Email do
     )
   end
 
-  def invitation_accepted(invitation) do
+  def invitation_accepted(inviter_email, invitee_email, site) do
     priority_email()
-    |> to(invitation.inviter.email)
+    |> to(inviter_email)
     |> tag("invitation-accepted")
     |> subject(
-      "[#{Plausible.product_name()}] #{invitation.email} accepted your invitation to #{invitation.site.domain}"
+      "[#{Plausible.product_name()}] #{invitee_email} accepted your invitation to #{site.domain}"
     )
     |> render("invitation_accepted.html",
-      user: invitation.inviter,
-      invitation: invitation
+      invitee_email: invitee_email,
+      site: site
     )
   end
 

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -233,23 +233,26 @@ defmodule PlausibleWeb.Email do
     |> render("cancellation_email.html", user: user)
   end
 
-  def new_user_invitation(invitation) do
+  def new_user_invitation(email, invitation_id, site, inviter) do
     priority_email()
-    |> to(invitation.email)
+    |> to(email)
     |> tag("new-user-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to #{invitation.site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to #{site.domain}")
     |> render("new_user_invitation.html",
-      invitation: invitation
+      invitation_id: invitation_id,
+      site: site,
+      inviter: inviter
     )
   end
 
-  def existing_user_invitation(invitation) do
+  def existing_user_invitation(email, site, inviter) do
     priority_email()
-    |> to(invitation.email)
+    |> to(email)
     |> tag("existing-user-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to #{invitation.site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to #{site.domain}")
     |> render("existing_user_invitation.html",
-      invitation: invitation
+      site: site,
+      inviter: inviter
     )
   end
 

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -31,6 +31,13 @@ defmodule PlausibleWeb.Live.AuthContext do
           _ -> nil
         end
       end)
+      |> assign_new(:current_team, fn context ->
+        case context.current_user do
+          nil -> nil
+          %{team_memberships: [%{team: team}]} -> team
+          %{team_memberships: []} -> nil
+        end
+      end)
 
     {:cont, socket}
   end

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -20,12 +20,22 @@ defmodule PlausibleWeb.AuthPlug do
       {:ok, user_session} ->
         user = user_session.user
 
+        team =
+          case user.team_memberships do
+            [%{team: team}] ->
+              team
+
+            [] ->
+              nil
+          end
+
         Plausible.OpenTelemetry.add_user_attributes(user)
         Sentry.Context.set_user_context(%{id: user.id, name: user.name, email: user.email})
 
         conn
         |> assign(:current_user, user)
         |> assign(:current_user_session, user_session)
+        |> assign(:current_team, team)
 
       _ ->
         conn

--- a/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
+++ b/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
@@ -67,6 +67,7 @@
           id="paddle-button"
           paddle_product_id={@latest_enterprise_plan.paddle_plan_id}
           user={@current_user}
+          team={@current_team}
         >
           <svg fill="currentColor" viewBox="0 0 20 20" class="inline w-4 h-4 mr-2">
             <path

--- a/lib/plausible_web/templates/email/existing_user_invitation.html.heex
+++ b/lib/plausible_web/templates/email/existing_user_invitation.html.heex
@@ -1,3 +1,3 @@
-<%= @invitation.inviter.email %> has invited you to the <%= @invitation.site.domain %> site on <%= Plausible.product_name() %>.
+<%= @inviter.email %> has invited you to the <%= @site.domain %> site on <%= Plausible.product_name() %>.
 <a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a> to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent.

--- a/lib/plausible_web/templates/email/invitation_accepted.html.heex
+++ b/lib/plausible_web/templates/email/invitation_accepted.html.heex
@@ -1,2 +1,2 @@
-<%= @invitation.email %> has accepted your invitation to <%= @invitation.site.domain %>.
-<a href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)}>Click here</a> to view site settings.
+<%= @invitee_email %> has accepted your invitation to <%= @site.domain %>.
+<a href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @site.domain)}>Click here</a> to view site settings.

--- a/lib/plausible_web/templates/email/new_user_invitation.html.heex
+++ b/lib/plausible_web/templates/email/new_user_invitation.html.heex
@@ -1,9 +1,9 @@
-<%= @invitation.inviter.email %> has invited you to join the <%= @invitation.site.domain %> site on <%= Plausible.product_name() %>.
+<%= @inviter.email %> has invited you to join the <%= @site.domain %> site on <%= Plausible.product_name() %>.
 <a href={
   Routes.auth_url(
     PlausibleWeb.Endpoint,
     :register_from_invitation_form,
-    @invitation.invitation_id
+    @invitation_id
   )
 }>Click here</a> to create your account. The link is valid for 48 hours after this email is sent.
 <br /><br />

--- a/lib/plausible_web/templates/email/ownership_transfer_accepted.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_accepted.html.heex
@@ -1,3 +1,3 @@
-<%= @invitation.email %> has accepted the ownership transfer of <%= @invitation.site.domain %>. They will be responsible for billing of it going
+<%= @new_owner_email %> has accepted the ownership transfer of <%= @site.domain %>. They will be responsible for billing of it going
 forward and your role has been changed to <b>admin</b>.
-<a href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @invitation.site.domain)}>Click here</a> to view site settings.
+<a href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @site.domain)}>Click here</a> to view site settings.

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
@@ -5,11 +5,7 @@
 <% else %>
   <a
     phx-no-format
-    href={
-      Routes.auth_url(PlausibleWeb.Endpoint, :register_form,
-        invitation: @invitation_id
-      )
-    }
+    href={Routes.auth_url(PlausibleWeb.Endpoint, :register_form, invitation: @invitation_id)}
   >Click here</a> to create your account. <br /><br />
   Plausible is a lightweight and open-source website analytics tool. We hope you like our simple and ethical approach to tracking website visitors.
 <% end %>

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
@@ -1,4 +1,4 @@
-<%= @invitation.inviter.email %> has requested to transfer the ownership of <%= @invitation.site.domain %> site on <%= Plausible.product_name() %> to you.
+<%= @inviter.email %> has requested to transfer the ownership of <%= @site.domain %> site on <%= Plausible.product_name() %> to you.
 <%= if @new_owner_account do %>
   <a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a>
   to view and respond to the invitation.
@@ -7,7 +7,7 @@
     phx-no-format
     href={
       Routes.auth_url(PlausibleWeb.Endpoint, :register_form,
-        invitation: @invitation.invitation_id
+        invitation: @invitation_id
       )
     }
   >Click here</a> to create your account. <br /><br />

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -129,10 +129,13 @@ defmodule PlausibleWeb.UserAuth do
       from(us in Auth.UserSession,
         inner_join: u in assoc(us, :user),
         as: :user,
+        left_join: tm in assoc(u, :team_memberships),
+        on: tm.role != :guest,
+        left_join: t in assoc(tm, :team),
         left_lateral_join: s in subquery(last_subscription_query),
         on: true,
         where: us.token == ^token and us.timeout_at > ^now,
-        preload: [user: {u, subscription: s}]
+        preload: [user: {u, subscription: s, team_memberships: {tm, team: t}}]
       )
 
     case Repo.one(token_query) do

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -103,9 +103,8 @@ defmodule Plausible.Workers.CheckUsage do
   def maybe_remove_grace_period(subscriber, usage_mod) do
     case check_pageview_usage_last_cycle(subscriber, usage_mod) do
       {:below_limit, _} ->
-        subscriber
-        |> Plausible.Auth.GracePeriod.remove_changeset()
-        |> Repo.update()
+        Plausible.Users.remove_grace_period(subscriber)
+        :ok
 
       _ ->
         :skip
@@ -121,9 +120,7 @@ defmodule Plausible.Workers.CheckUsage do
         PlausibleWeb.Email.over_limit_email(subscriber, pageview_usage, suggested_plan)
         |> Plausible.Mailer.send()
 
-        subscriber
-        |> Plausible.Auth.GracePeriod.start_changeset()
-        |> Repo.update()
+        Plausible.Users.start_grace_period(subscriber)
 
       _ ->
         nil
@@ -147,9 +144,7 @@ defmodule Plausible.Workers.CheckUsage do
         )
         |> Plausible.Mailer.send()
 
-        subscriber
-        |> Plausible.Auth.GracePeriod.start_manual_lock_changeset()
-        |> Repo.update()
+        Plausible.Users.start_manual_lock_grace_period(subscriber)
     end
   end
 

--- a/lib/workers/clean_invitations.ex
+++ b/lib/workers/clean_invitations.ex
@@ -15,6 +15,11 @@ defmodule Plausible.Workers.CleanInvitations do
         where: i.inserted_at < ^cutoff_time
     )
 
+    Repo.delete_all(
+      from ti in Plausible.Teams.Invitation,
+        where: ti.inserted_at < ^cutoff_time
+    )
+
     :ok
   end
 end

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -77,7 +77,7 @@ defmodule Plausible.BillingTest do
       user = insert(:user, trial_expiry_date: Timex.shift(Timex.today(), days: -1))
       insert(:subscription, user: user, next_bill_date: Timex.today())
 
-      user = user |> Plausible.Auth.GracePeriod.end_changeset() |> Repo.update!()
+      user = Plausible.Users.end_grace_period(user)
 
       assert Billing.check_needs_to_upgrade(user) == {:needs_to_upgrade, :grace_period_ended}
     end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -216,6 +216,51 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       )
     end
 
+    test "converts an invitation into a membership (TEAMS)" do
+      inviter = insert(:user)
+      invitee = insert(:user)
+      team = insert(:team)
+      site = insert(:site, team: team, members: [inviter])
+      insert(:team_membership, team: team, user: inviter, role: :owner)
+
+      _invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: inviter,
+          email: invitee.email,
+          role: :admin
+        )
+
+      team_invitation =
+        insert(:team_invitation,
+          team: team,
+          inviter: inviter,
+          email: invitee.email,
+          role: :guest
+        )
+
+      insert(:guest_invitation, team_invitation: team_invitation, site: site, role: :editor)
+
+      assert {:ok, team_membership} =
+               Plausible.Teams.Invitations.accept(team_invitation.invitation_id, invitee)
+
+      assert [guest_membership] =
+               Repo.preload(team_membership, :guest_memberships).guest_memberships
+
+      assert guest_membership.site_id == site.id
+      assert team_membership.user_id == invitee.id
+      assert guest_membership.role == :editor
+      assert team_membership.role == :guest
+      assert team_membership.team_id == team.id
+
+      refute Repo.reload(team_invitation)
+
+      assert_email_delivered_with(
+        to: [nil: inviter.email],
+        subject: @subject_prefix <> "#{invitee.email} accepted your invitation to #{site.domain}"
+      )
+    end
+
     test "does not degrade role when trying to invite self as an owner" do
       user = insert(:user)
 

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -13,6 +13,16 @@ defmodule Plausible.SitesTest do
                Sites.create(user, params)
     end
 
+    test "creates a site (TEAM)" do
+      user = insert(:user)
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      params = %{"domain" => "example.com", "timezone" => "Europe/London"}
+
+      assert {:ok, %{site: %{domain: "example.com", timezone: "Europe/London"}}} =
+               Plausible.Teams.Sites.create(team, params)
+    end
+
     test "fails on invalid timezone" do
       user = insert(:user)
 
@@ -20,6 +30,16 @@ defmodule Plausible.SitesTest do
 
       assert {:error, :site, %{errors: [timezone: {"is invalid", []}]}, %{}} =
                Sites.create(user, params)
+    end
+
+    test "fails on invalid timezone (TEAM)" do
+      user = insert(:user)
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      params = %{"domain" => "example.com", "timezone" => "blah"}
+
+      assert {:error, :site, %{errors: [timezone: {"is invalid", []}]}, %{}} =
+               Plausible.Teams.Sites.create(team, params)
     end
   end
 

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -148,82 +148,194 @@ defmodule Plausible.SitesTest do
                page_number: 1,
                total_entries: 0,
                total_pages: 1
+             } = Plausible.Teams.Sites.list(user, %{})
+
+      assert %{
+               entries: [],
+               page_size: 24,
+               page_number: 1,
+               total_entries: 0,
+               total_pages: 1
              } = Sites.list_with_invitations(user, %{})
+
+      assert %{
+               entries: [],
+               page_size: 24,
+               page_number: 1,
+               total_entries: 0,
+               total_pages: 1
+             } = Plausible.Teams.Sites.list_with_invitations(user, %{})
     end
 
     test "pinned site doesn't matter with membership revoked (no active invitations)" do
       user1 = insert(:user, email: "user1@example.com")
       user2 = insert(:user, email: "user2@example.com")
 
-      insert(:site, members: [user1], domain: "one.example.com")
+      team1 = insert(:team)
+      insert(:site, team: team1, members: [user1], domain: "one.example.com")
+      insert(:team_membership, team: team1, user: user1, role: :owner)
+
+      team2 = insert(:team)
 
       site2 =
         insert(:site,
+          team: team2,
           members: [user2],
           domain: "two.example.com"
         )
 
+      insert(:team_membership, team: team2, user: user2, role: :owner)
+
       membership = insert(:site_membership, user: user1, role: :viewer, site: site2)
+      team_membership = insert(:team_membership, team: team2, user: user1, role: :guest)
+      insert(:guest_membership, team_membership: team_membership, site: site2, role: :viewer)
 
       {:ok, _} = Sites.toggle_pin(user1, site2)
 
       Repo.delete!(membership)
+      Repo.delete!(team_membership)
 
       assert %{entries: [%{domain: "one.example.com"}]} = Sites.list(user1, %{})
       assert %{entries: [%{domain: "one.example.com"}]} = Sites.list_with_invitations(user1, %{})
+
+      assert %{entries: [%{domain: "one.example.com"}]} = Plausible.Teams.Sites.list(user1, %{})
+
+      assert %{entries: [%{domain: "one.example.com"}]} =
+               Plausible.Teams.Sites.list_with_invitations(user1, %{})
     end
 
     test "pinned site doesn't matter with membership revoked (with active invitation)" do
       user1 = insert(:user, email: "user1@example.com")
       user2 = insert(:user, email: "user2@example.com")
 
-      insert(:site, members: [user1], domain: "one.example.com")
+      team1 = insert(:team)
+      insert(:site, team: team1, members: [user1], domain: "one.example.com")
+      insert(:team_membership, team: team1, user: user1, role: :owner)
+
+      team2 = insert(:team)
 
       site2 =
         insert(:site,
+          team: team2,
           members: [user2],
           domain: "two.example.com"
         )
 
+      insert(:team_membership, team: team2, user: user2, role: :owner)
+
       membership = insert(:site_membership, user: user1, role: :viewer, site: site2)
+      team_membership = insert(:team_membership, team: team2, user: user1, role: :guest)
+      insert(:guest_membership, team_membership: team_membership, site: site2, role: :viewer)
+
       insert(:invitation, email: user1.email, inviter: user2, role: :owner, site: site2)
+
+      team_invitation =
+        insert(:team_invitation, team: team2, email: user1.email, inviter: user2, role: :guest)
+
+      insert(:guest_invitation, team_invitation: team_invitation, site: site2, role: :editor)
 
       {:ok, _} = Sites.toggle_pin(user1, site2)
 
       Repo.delete!(membership)
+      Repo.delete!(team_membership)
 
       assert %{entries: [%{domain: "one.example.com"}]} = Sites.list(user1, %{})
 
       assert %{entries: [%{domain: "two.example.com"}, %{domain: "one.example.com"}]} =
                Sites.list_with_invitations(user1, %{})
+
+      assert %{entries: [%{domain: "one.example.com"}]} = Plausible.Teams.Sites.list(user1, %{})
+
+      assert %{entries: [%{domain: "two.example.com"}, %{domain: "one.example.com"}]} =
+               Plausible.Teams.Sites.list_with_invitations(user1, %{})
     end
 
     test "puts invitations first, pinned sites second, sites last" do
       user = insert(:user, email: "hello@example.com")
 
-      site1 = %{id: site_id1} = insert(:site, members: [user], domain: "one.example.com")
-      site2 = %{id: site_id2} = insert(:site, members: [user], domain: "two.example.com")
-      %{id: site_id4} = insert(:site, members: [user], domain: "four.example.com")
+      team1 = insert(:team)
 
-      _rogue_site = insert(:site, domain: "rogue.example.com")
+      site1 =
+        %{id: site_id1} = insert(:site, team: team1, members: [user], domain: "one.example.com")
 
-      insert(:invitation, email: user.email, inviter: build(:user), role: :owner, site: site1)
+      insert(:team_membership, team: team1, user: user, role: :owner)
+      team2 = insert(:team)
 
-      %{id: site_id3} =
-        insert(:site,
-          domain: "three.example.com",
-          invitations: [
-            build(:invitation, email: user.email, inviter: build(:user), role: :viewer)
-          ]
+      site2 =
+        %{id: site_id2} = insert(:site, team: team2, members: [user], domain: "two.example.com")
+
+      insert(:team_membership, team: team2, user: build(:user), role: :owner)
+      team_membership2 = insert(:team_membership, team: team2, user: user, role: :guest)
+      insert(:guest_membership, team_membership: team_membership2, site: site2, role: :editor)
+
+      team4 = insert(:team)
+
+      site4 =
+        %{id: site_id4} = insert(:site, team: team4, members: [user], domain: "four.example.com")
+
+      insert(:team_membership, team: team4, user: build(:user), role: :owner)
+      team_membership4 = insert(:team_membership, team: team4, user: user, role: :guest)
+      insert(:guest_membership, team_membership: team_membership4, site: site4, role: :viewer)
+
+      _rogue_site = insert(:site, team: build(:team), domain: "rogue.example.com")
+
+      ## Having owner invite on owned site does not make much sense?
+      ## Maybe that was a repro of real-life example?
+      # insert(:invitation, email: user.email, inviter: build(:user), role: :owner, site: site1)
+
+      # team_invitation1 =
+      #   insert(:team_invitation,
+      #     team: team1,
+      #     email: user.email,
+      #     inviter: build(:user),
+      #     role: :guest
+      #   )
+
+      # insert(:guest_invitation, team_invitation: team_invitation1, site: site1, role: :editor)
+
+      team3 = insert(:team)
+
+      site3 = %{id: site_id3} = insert(:site, team: team3, domain: "three.example.com")
+
+      insert(:invitation, email: user.email, inviter: build(:user), role: :viewer, site: site3)
+
+      team_invitation2 =
+        insert(:team_invitation,
+          team: team3,
+          email: user.email,
+          inviter: build(:user),
+          role: :guest
         )
 
+      insert(:guest_invitation, team_invitation: team_invitation2, site: site3, role: :viewer)
+
       insert(:invitation, email: "friend@example.com", inviter: user, role: :viewer, site: site1)
+
+      team_invitation3 =
+        insert(:team_invitation,
+          team: team1,
+          email: "friend@example.com",
+          inviter: user,
+          role: :guest
+        )
+
+      insert(:guest_invitation, team_invitation: team_invitation3, site: site1, role: :viewer)
 
       insert(:invitation,
         site: site1,
         inviter: user,
         email: "another@example.com"
       )
+
+      team_invitation4 =
+        insert(:team_invitation,
+          team: team1,
+          email: "another@example.com",
+          inviter: user,
+          role: :guest
+        )
+
+      insert(:guest_invitation, team_invitation: team_invitation4, site: site1, role: :editor)
 
       {:ok, _} = Sites.toggle_pin(user, site2)
 
@@ -237,12 +349,29 @@ defmodule Plausible.SitesTest do
 
       assert %{
                entries: [
-                 %{id: ^site_id1, entry_type: "invitation"},
                  %{id: ^site_id3, entry_type: "invitation"},
                  %{id: ^site_id2, entry_type: "pinned_site"},
-                 %{id: ^site_id4, entry_type: "site"}
+                 %{id: ^site_id4, entry_type: "site"},
+                 %{id: ^site_id1, entry_type: "site"}
                ]
              } = Sites.list_with_invitations(user, %{})
+
+      assert %{
+               entries: [
+                 %{id: ^site_id2, entry_type: "pinned_site"},
+                 %{id: ^site_id4, entry_type: "site"},
+                 %{id: ^site_id1, entry_type: "site"}
+               ]
+             } = Plausible.Teams.Sites.list(user, %{})
+
+      assert %{
+               entries: [
+                 %{id: ^site_id3, entry_type: "invitation"},
+                 %{id: ^site_id2, entry_type: "pinned_site"},
+                 %{id: ^site_id4, entry_type: "site"},
+                 %{id: ^site_id1, entry_type: "site"}
+               ]
+             } = Plausible.Teams.Sites.list_with_invitations(user, %{})
     end
 
     test "pinned sites are ordered according to the time they were pinned at" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -78,6 +78,7 @@ defmodule Plausible.Factory do
     attrs = if defined_memberships?, do: attrs, else: Map.put_new(attrs, :members, [build(:user)])
 
     site = %Plausible.Site{
+      team: build(:team),
       native_stats_start_at: ~N[2000-01-01 00:00:00],
       domain: domain,
       timezone: "UTC"

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,41 @@ defmodule Plausible.Factory do
   require Plausible.Billing.Subscription.Status
   alias Plausible.Billing.Subscription
 
+  def team_factory do
+    %Plausible.Teams.Team{
+      name: "My Team",
+      trial_expiry_date: Timex.today() |> Timex.shift(days: 30)
+    }
+  end
+
+  def team_membership_factory do
+    %Plausible.Teams.Membership{
+      user: build(:user),
+      role: :viewer
+    }
+  end
+
+  def guest_membership_factory do
+    %Plausible.Teams.GuestMembership{
+      team_membership: build(:team_membership, role: :guest)
+    }
+  end
+
+  def team_invitation_factory do
+    %Plausible.Teams.Invitation{
+      invitation_id: Nanoid.generate(),
+      email: sequence(:email, &"email-#{&1}@example.com"),
+      role: :admin
+    }
+  end
+
+  def guest_invitation_factory do
+    %Plausible.Teams.GuestInvitation{
+      role: :editor,
+      team_invitation: build(:team_invitation, role: :guest)
+    }
+  end
+
   def user_factory(attrs) do
     pw = Map.get(attrs, :password, "password")
 

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -232,10 +232,7 @@ defmodule Plausible.Workers.CheckUsageTest do
       end
 
       test "skips checking users who already have a grace period", %{user: user} do
-        %{grace_period: existing_grace_period} =
-          user
-          |> Plausible.Auth.GracePeriod.start_changeset()
-          |> Repo.update!()
+        %{grace_period: existing_grace_period} = Plausible.Users.start_grace_period(user)
 
         usage_stub =
           Plausible.Billing.Quota.Usage
@@ -326,9 +323,7 @@ defmodule Plausible.Workers.CheckUsageTest do
     describe "#{status} subscription, enterprise customers" do
       test "skips checking enterprise users who already have a grace period", %{user: user} do
         %{grace_period: existing_grace_period} =
-          user
-          |> Plausible.Auth.GracePeriod.start_manual_lock_changeset()
-          |> Repo.update!()
+          Plausible.Users.start_manual_lock_grace_period(user)
 
         usage_stub =
           Plausible.Billing.Quota.Usage


### PR DESCRIPTION
### Changes

This PR is the first step towards implementing support for team accounts in Plausible. A new schema is implemented along with the logic replicating existing site-centric approach. After we fully switch to using the new schemas, we will start implementing new logic and UI on top of those schemas.
