### PR TITLE
Fix experimental pageleaves script (SPAs)

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -190,7 +190,7 @@
       {{/unless}}
       
       {{#if pageleave}}
-      if (isSPANavigation) {
+      if (isSPANavigation && listeningPageLeave) {
         triggerPageLeave();
         currentURL = location.href;
       }

--- a/tracker/test/fixtures/manual.html
+++ b/tracker/test/fixtures/manual.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Plausible Playwright tests</title>
+  <script defer src="/tracker/js/plausible.local.manual.js"></script>
+</head>
+
+<body>
+  <button id="pageview-trigger">
+    Triggers a pageview with default URL (location.href)
+  </button>
+  <button id="pageview-trigger-custom-url">
+    Triggers a pageview with custom URL
+  </button>
+  <button id="custom-event-trigger">
+    Triggers a custom event with default URL (location.href)
+  </button>
+  <button id="custom-event-trigger-custom-url">
+    Triggers a custom event with custom URL
+  </button>
+
+  <script>
+    document.addEventListener('click', (e) => {
+      if (e.target.id === 'pageview-trigger') {
+        window.plausible('pageview') 
+      }
+      if (e.target.id === 'pageview-trigger-custom-url') {
+        window.plausible('pageview', {u: 'https://example.com/custom/location'})
+      }
+      if (e.target.id === 'custom-event-trigger') {
+        window.plausible('CustomEvent') 
+      }
+      if (e.target.id === 'custom-event-trigger-custom-url') {
+        window.plausible('CustomEvent', {u: 'https://example.com/custom/location'}) 
+      }
+    })
+  </script>
+</body>
+
+</html>

--- a/tracker/test/manual.spec.js
+++ b/tracker/test/manual.spec.js
@@ -1,0 +1,35 @@
+const { mockRequest } = require('./support/test-utils')
+const { expect, test } = require('@playwright/test');
+const { LOCAL_SERVER_ADDR } = require('./support/server');
+
+async function clickPageElementAndExpectEventRequest(page, buttonId, expectedBodyParams) {
+  const plausibleRequestMock = mockRequest(page, '/api/event')
+  await page.click(buttonId)
+  const plausibleRequest = await plausibleRequestMock;
+
+  expect(plausibleRequest.url()).toContain('/api/event')
+
+  const body = plausibleRequest.postDataJSON()
+
+  Object.keys(expectedBodyParams).forEach((key) => {
+    expect(body[key]).toEqual(expectedBodyParams[key])
+  })
+}
+
+test.describe('manual extension', () => {
+  test('can trigger custom events with and without a custom URL if pageview was sent with the default URL', async ({ page }) => {
+    await page.goto('/manual.html');
+
+    await clickPageElementAndExpectEventRequest(page, '#pageview-trigger', {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/manual.html`})
+    await clickPageElementAndExpectEventRequest(page, '#custom-event-trigger', {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`})
+    await clickPageElementAndExpectEventRequest(page, '#custom-event-trigger-custom-url', {n: 'CustomEvent', u: `https://example.com/custom/location`})
+  });
+
+  test('can trigger custom events with and without a custom URL if pageview was sent with a custom URL', async ({ page }) => {
+    await page.goto('/manual.html');
+
+    await clickPageElementAndExpectEventRequest(page, '#pageview-trigger-custom-url', {n: 'pageview', u: `https://example.com/custom/location`})
+    await clickPageElementAndExpectEventRequest(page, '#custom-event-trigger', {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`})
+    await clickPageElementAndExpectEventRequest(page, '#custom-event-trigger-custom-url', {n: 'CustomEvent', u: `https://example.com/custom/location`})
+  });
+});


### PR DESCRIPTION
### Changes

Fixes two bugs with the experimental script:

1. After the initial pageview is triggered, the current script sets an eventListener to trigger pageleave with the **URL of the initial page**, when `pagehide` occurs. That doesn't make sense in Single Page Apps. Instead, every time SPA navigation takes place, that URL should change to that of the last pageview.

2. Currently, pageleave events in SPAs are being fired regardless of exclusion rules (incl localhost and bot traffic). The second commit of this PR fixes that by adding an additional condition: only fire pageleaves on SPA navigation if `listeningPageLeave` is `true`. That value will never become true until a pageview has been sent.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
