### PR TITLE
Set root domain `(none)` for ingests without hostname

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -541,6 +541,7 @@ defmodule Plausible.Ingestion.Event do
     end
   end
 
+  defp get_root_domain("(none)"), do: "(none)"
   defp get_root_domain(nil), do: "(none)"
 
   defp get_root_domain(hostname) do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -542,7 +542,6 @@ defmodule Plausible.Ingestion.Event do
   end
 
   defp get_root_domain("(none)"), do: "(none)"
-  defp get_root_domain(nil), do: "(none)"
 
   defp get_root_domain(hostname) do
     case :inet.parse_ipv4_address(String.to_charlist(hostname)) do

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -194,11 +194,11 @@ defmodule Plausible.Ingestion.Request do
   defp put_hostname(changeset) do
     host =
       case Changeset.get_field(changeset, :uri) do
-        %{host: host} when is_binary(host) and host != "" -> host
+        %{host: host} when is_binary(host) and host != "" -> sanitize_hostname(host)
         _ -> "(none)"
       end
 
-    Changeset.put_change(changeset, :hostname, sanitize_hostname(host))
+    Changeset.put_change(changeset, :hostname, host)
   end
 
   @max_props 30
@@ -294,8 +294,6 @@ defmodule Plausible.Ingestion.Request do
   def sanitize_hostname(%URI{host: hostname}) do
     sanitize_hostname(hostname)
   end
-
-  def sanitize_hostname("(none)"), do: "(none)"
 
   def sanitize_hostname(hostname) when is_binary(hostname) do
     hostname

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -295,6 +295,8 @@ defmodule Plausible.Ingestion.Request do
     sanitize_hostname(hostname)
   end
 
+  def sanitize_hostname("(none)"), do: "(none)"
+
   def sanitize_hostname(hostname) when is_binary(hostname) do
     hostname
     |> String.trim()

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -397,4 +397,20 @@ defmodule Plausible.Ingestion.EventTest do
     assert {:ok, %{buffered: [event]}} = Event.build_and_buffer(request)
     assert event.clickhouse_event.hostname == "foo.netlify.app"
   end
+
+  test "hostname is (none) when no hostname can be derived from the url" do
+    site = insert(:site, domain: "foo.example.com")
+
+    payload = %{
+      domain: site.domain,
+      name: "pageview",
+      url: "/no/hostname"
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+    assert {:ok, request} = Request.build(conn)
+
+    assert {:ok, %{buffered: [event]}} = Event.build_and_buffer(request)
+    assert event.clickhouse_event.hostname == "(none)"
+  end
 end


### PR DESCRIPTION
### Changes

This is not a bug, but more of a micro-optimization. If the hostname is known to be `(none)`, there's no need try and compute root domain. 

:eyes: At the same, it looks like ingestion had a dead clause trying to match `nil` hostname. `Plausible.Ingestion.Request` should reject such cases before they reach `Plausible.Ingestion.Event` processing. 

Ref https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/7916301991

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
