### PR TITLE
Add explicit `order by` to a flaky test

### DIFF
--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -3099,7 +3099,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
             "visit_duration"
           ],
           "date_range" => "all",
-          "dimensions" => ["event:page"]
+          "dimensions" => ["event:page"],
+          "order_by" => [["event:page", "desc"]]
         })
 
       %{"results" => results} = json_response(conn, 200)


### PR DESCRIPTION
otherwise it falls back to `visitors` descending,
which AFAIU is 2 for both metrics leading to random order effectively.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
