### PR TITLE
Properly interpolate site name in site setup success email

### DIFF
--- a/lib/plausible_web/templates/email/site_setup_success_email.html.heex
+++ b/lib/plausible_web/templates/email/site_setup_success_email.html.heex
@@ -1,5 +1,5 @@
 Congrats! We've recorded the first visitor on
-<.unstyled_link href={"https://#{@site.domain}"}>@site.domain</.unstyled_link>. Your traffic is now being counted without compromising the user experience and privacy of your visitors.
+<.unstyled_link href={"https://#{@site.domain}"}><%= @site.domain %></.unstyled_link>. Your traffic is now being counted without compromising the user experience and privacy of your visitors.
 <br /><br /> Do check out your
 <.unstyled_link href={"#{plausible_url()}/#{URI.encode_www_form(@site.domain)}"}>
   easy to use, fast-loading and privacy-friendly dashboard


### PR DESCRIPTION
### Changes

Addresses an issue where site domain name is not properly interpolated in email sent to the user.

