### PR TITLE
Remove bracket from welcome email

### DIFF
--- a/lib/plausible_web/templates/email/welcome_email.html.heex
+++ b/lib/plausible_web/templates/email/welcome_email.html.heex
@@ -35,5 +35,5 @@ and
 </.unstyled_link>
 <br />
 <br /><br /> Then you're ready to start exploring your fast loading, ethical and actionable
-<.unstyled_link href="https://plausible.io/sites">Plausible dashboard</.unstyled_link>).
+<.unstyled_link href="https://plausible.io/sites">Plausible dashboard</.unstyled_link>.
 <br /><br /> Have a question, feedback or need some guidance? Do reply back to this email.

--- a/lib/plausible_web/templates/email/welcome_email.html.heex
+++ b/lib/plausible_web/templates/email/welcome_email.html.heex
@@ -17,7 +17,7 @@ to get keyword phrases people find your site with<br /> *
 <br /> * Set up easy goals including
 <.unstyled_link href="https://plausible.io/docs/error-pages-tracking-404">
   404 error pages
-</.unstyled_link>),
+</.unstyled_link>,
 <.unstyled_link href="https://plausible.io/docs/file-downloads-tracking">
   file downloads
 </.unstyled_link>


### PR DESCRIPTION
This PR removes a bracket after "404 error pages" in the Welcome email:

<img width="944" alt="Screenshot 2024-10-16 at 14 47 07" src="https://github.com/user-attachments/assets/a708d575-daa4-4f8b-8452-69f1e2cb40e6">
