### PR TITLE
Comparisons pagination fixes

### DIFF
--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -58,7 +58,7 @@ defmodule Plausible.Stats.Comparisons do
   end
 
   @doc """
-  Builds comparison query after executing `main` query.
+  Builds comparison query that specifically filters for values appearing in the main query results.
 
   When querying for comparisons with dimensions and pagination, extra
   filters are added to ensure comparison query returns same set of results

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -8,7 +8,7 @@ defmodule Plausible.Stats.Comparisons do
   """
 
   alias Plausible.Stats
-  alias Plausible.Stats.{Query, DateTimeRange}
+  alias Plausible.Stats.{Query, DateTimeRange, Time}
 
   @spec get_comparison_query(Stats.Query.t(), map()) :: Stats.Query.t()
   @doc """
@@ -86,7 +86,7 @@ defmodule Plausible.Stats.Comparisons do
     query_filters =
       query.dimensions
       |> Enum.zip(dimension_labels)
-      |> Enum.reject(fn {dimension, _label} -> String.starts_with?(dimension, "time") end)
+      |> Enum.reject(fn {dimension, _label} -> Time.time_dimension?(dimension) end)
       |> Enum.map(fn {dimension, label} -> [:is, dimension, [label]] end)
 
     case query_filters do

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -167,7 +167,7 @@ defmodule Plausible.Stats.Filters do
 
   defp traverse_tree(filter, root, depth) do
     case filter do
-      [:not, child_filter] ->
+      [operation, child_filter] when operation in [:not, :ignore_in_totals_query] ->
         traverse_tree(child_filter, root, depth + 1)
 
       [operation, filters] when operation in [:and, :or] ->

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -144,7 +144,7 @@ defmodule Plausible.Stats.Filters do
   defp transform_tree(filter, transformer) do
     case {transformer.(filter), filter} do
       # Transformer did not return that value - transform that subtree
-      {nil, [:not, child_filter]} ->
+      {nil, [operation, child_filter]} when operation in [:not, :ignore_in_totals_query] ->
         [[:not, transform_tree(child_filter, transformer)]]
 
       {nil, [operation, filters]} when operation in [:and, :or] ->

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -3,7 +3,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   use Plausible
 
-  alias Plausible.Stats.{TableDecider, Filters, Metrics, DateTimeRange, JSONSchema}
+  alias Plausible.Stats.{TableDecider, Filters, Metrics, DateTimeRange, JSONSchema, Time}
 
   @default_include %{
     imports: false,
@@ -578,7 +578,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp validate_include(query) do
-    time_dimension? = Enum.any?(query.dimensions, &String.starts_with?(&1, "time"))
+    time_dimension? = Enum.any?(query.dimensions, &Time.time_dimension?/1)
 
     if query.include.time_labels and not time_dimension? do
       {:error, "Invalid include.time_labels: requires a time dimension."}

--- a/lib/plausible/stats/imported/sql/where_builder.ex
+++ b/lib/plausible/stats/imported/sql/where_builder.ex
@@ -29,6 +29,10 @@ defmodule Plausible.Stats.Imported.SQL.WhereBuilder do
     |> Enum.reduce(fn condition, acc -> dynamic([], ^acc and ^condition) end)
   end
 
+  defp add_filter(query, [:ignore_in_totals_query, filter]) do
+    add_filter(query, filter)
+  end
+
   defp add_filter(query, [:not, filter]) do
     dynamic([i], not (^add_filter(query, filter)))
   end

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -93,7 +93,7 @@ defmodule Plausible.Stats.Query do
   def remove_top_level_filters(query, prefixes) do
     new_filters =
       Enum.reject(query.filters, fn [_, filter_key | _rest] ->
-        Enum.any?(prefixes, &String.starts_with?(filter_key, &1))
+        is_binary(filter_key) and Enum.any?(prefixes, &String.starts_with?(filter_key, &1))
       end)
 
     query

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Stats.QueryOptimizer do
   """
 
   use Plausible
-  alias Plausible.Stats.{DateTimeRange, Filters, Query, TableDecider, Util}
+  alias Plausible.Stats.{DateTimeRange, Filters, Query, TableDecider, Util, Time}
 
   @doc """
     This module manipulates an existing query, updating it according to business logic.
@@ -147,7 +147,7 @@ defmodule Plausible.Stats.QueryOptimizer do
   end
 
   defp time_dimension(query) do
-    Enum.find(query.dimensions, &String.starts_with?(&1, "time"))
+    Enum.find(query.dimensions, &Time.time_dimension?/1)
   end
 
   defp split_sessions_query(query, session_metrics) do

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -97,7 +97,7 @@ defmodule Plausible.Stats.QueryRunner do
       |> Enum.map(fn {dimension, label} -> [:is, dimension, [label]] end)
 
     if length(query_filters) > 0 do
-      [[:and, query_filters]]
+      [[:ignore_in_totals_query, [:and, query_filters]]]
     else
       []
     end

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -21,7 +21,9 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
   defp maybe_add_percentage_metric(q, site, query) do
     if :percentage in query.metrics do
       total_query =
-        Query.set(query,
+        query
+        |> remove_filters_ignored_in_totals_query()
+        |> Query.set(
           dimensions: [],
           include_imported: query.include_imported
         )

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -75,6 +75,10 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
     )
   end
 
+  defp add_filter(table, query, [:ignore_in_totals_query, filter]) do
+    add_filter(table, query, filter)
+  end
+
   defp add_filter(table, query, [:not, filter]) do
     dynamic([e], not (^add_filter(table, query, filter)))
   end

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Stats.Time do
   def format_datetime(other), do: other
 
   def time_dimension(query) do
-    Enum.find(query.dimensions, &time_dimension/1)
+    Enum.find(query.dimensions, &time_dimension?/1)
   end
 
   def time_dimension?("time" <> _rest), do: true

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -33,8 +33,11 @@ defmodule Plausible.Stats.Time do
   def format_datetime(other), do: other
 
   def time_dimension(query) do
-    Enum.find(query.dimensions, &String.starts_with?(&1, "time"))
+    Enum.find(query.dimensions, &time_dimension/1)
   end
+
+  def time_dimension?("time" <> _rest), do: true
+  def time_dimension?(_dimension), do: false
 
   @doc """
   Returns list of time bucket labels for the given query.

--- a/lib/plausible_web/controllers/api/external_query_api_controller.ex
+++ b/lib/plausible_web/controllers/api/external_query_api_controller.ex
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
   def query(conn, params) do
     site = Repo.preload(conn.assigns.site, :owner)
 
-    case Query.build(site, :public, params, debug_metadata(conn)) do
+    case Query.build(site, conn.assigns.schema_type, params, debug_metadata(conn)) do
       {:ok, query} ->
         results = Plausible.Stats.query(site, query)
         json(conn, results)

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -215,7 +215,7 @@ defmodule PlausibleWeb.Router do
 
     if Mix.env() in [:test, :ce_test] do
       scope assigns: %{schema_type: :internal} do
-        post "/query-internal", ExternalQueryApiController, :query
+        post "/query-internal-test", ExternalQueryApiController, :query
       end
     end
   end

--- a/test/plausible/stats/comparisons_test.exs
+++ b/test/plausible/stats/comparisons_test.exs
@@ -3,6 +3,8 @@ defmodule Plausible.Stats.ComparisonsTest do
   alias Plausible.Stats.{DateTimeRange, Query, Comparisons}
   import Plausible.TestUtils
 
+  setup [:create_user, :create_new_site]
+
   def build_query(site, params, now) do
     query = Query.from(site, params)
 
@@ -10,9 +12,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with period set to this month" do
-    test "shifts back this month period when mode is previous_period" do
-      site = insert(:site)
-
+    test "shifts back this month period when mode is previous_period", %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-03-02"}, ~N[2023-03-02 14:00:00])
 
@@ -22,9 +22,8 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2023-02-28 23:59:59Z]
     end
 
-    test "shifts back this month period when it's the first day of the month and mode is previous_period" do
-      site = insert(:site)
-
+    test "shifts back this month period when it's the first day of the month and mode is previous_period",
+         %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
 
@@ -34,9 +33,8 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2023-02-28 23:59:59Z]
     end
 
-    test "matches the day of the week when nearest day is original query start date and mode is previous_period" do
-      site = insert(:site)
-
+    test "matches the day of the week when nearest day is original query start date and mode is previous_period",
+         %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-03-02"}, ~N[2023-03-02 14:00:00])
 
@@ -64,9 +62,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with period set to previous month" do
-    test "shifts back using the same number of days when mode is previous_period" do
-      site = insert(:site)
-
+    test "shifts back using the same number of days when mode is previous_period", %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
 
@@ -76,9 +72,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2023-01-31 23:59:59Z]
     end
 
-    test "shifts back the full month when mode is year_over_year" do
-      site = insert(:site)
-
+    test "shifts back the full month when mode is year_over_year", %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
 
@@ -88,9 +82,9 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2022-02-28 23:59:59Z]
     end
 
-    test "shifts back whole month plus one day when mode is year_over_year and a leap year" do
-      site = insert(:site)
-
+    test "shifts back whole month plus one day when mode is year_over_year and a leap year", %{
+      site: site
+    } do
       query =
         build_query(site, %{"period" => "month", "date" => "2020-02-01"}, ~N[2023-03-01 14:00:00])
 
@@ -100,9 +94,9 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2019-03-01 23:59:59Z]
     end
 
-    test "matches the day of the week when mode is previous_period keeping the same day" do
-      site = insert(:site)
-
+    test "matches the day of the week when mode is previous_period keeping the same day", %{
+      site: site
+    } do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
 
@@ -116,9 +110,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2023-01-31 23:59:59Z]
     end
 
-    test "matches the day of the week when mode is previous_period" do
-      site = insert(:site)
-
+    test "matches the day of the week when mode is previous_period", %{site: site} do
       query =
         build_query(site, %{"period" => "month", "date" => "2023-01-01"}, ~N[2023-03-01 14:00:00])
 
@@ -134,9 +126,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with period set to year to date" do
-    test "shifts back by the same number of days when mode is previous_period" do
-      site = insert(:site)
-
+    test "shifts back by the same number of days when mode is previous_period", %{site: site} do
       query =
         build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
 
@@ -146,9 +136,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2022-12-31 23:59:59Z]
     end
 
-    test "shifts back by the same number of days when mode is year_over_year" do
-      site = insert(:site)
-
+    test "shifts back by the same number of days when mode is year_over_year", %{site: site} do
       query =
         build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
 
@@ -158,9 +146,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2022-03-01 23:59:59Z]
     end
 
-    test "matches the day of the week when mode is year_over_year" do
-      site = insert(:site)
-
+    test "matches the day of the week when mode is year_over_year", %{site: site} do
       query =
         build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
 
@@ -173,8 +159,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with period set to previous year" do
-    test "shifts back a whole year when mode is year_over_year" do
-      site = insert(:site)
+    test "shifts back a whole year when mode is year_over_year", %{site: site} do
       query = Query.from(site, %{"period" => "year", "date" => "2022-03-02"})
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
@@ -183,8 +168,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2021-12-31 23:59:59Z]
     end
 
-    test "shifts back a whole year when mode is previous_period" do
-      site = insert(:site)
+    test "shifts back a whole year when mode is previous_period", %{site: site} do
       query = Query.from(site, %{"period" => "year", "date" => "2022-03-02"})
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
@@ -195,8 +179,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with period set to custom" do
-    test "shifts back by the same number of days when mode is previous_period" do
-      site = insert(:site)
+    test "shifts back by the same number of days when mode is previous_period", %{site: site} do
       query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
@@ -205,8 +188,7 @@ defmodule Plausible.Stats.ComparisonsTest do
       assert comparison_query.utc_time_range.last == ~U[2022-12-31 23:59:59Z]
     end
 
-    test "shifts back to last year when mode is year_over_year" do
-      site = insert(:site)
+    test "shifts back to last year when mode is year_over_year", %{site: site} do
       query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
@@ -217,8 +199,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "with mode set to custom" do
-    test "sets first and last dates" do
-      site = insert(:site)
+    test "sets first and last dates", %{site: site} do
       query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
 
       comparison_query =
@@ -233,7 +214,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   end
 
   describe "include_imported" do
-    setup [:create_user, :create_new_site, :create_site_import]
+    setup [:create_site_import]
 
     test "defaults to source_query.include_imported", %{site: site} do
       query = Query.from(site, %{"period" => "day", "date" => "2023-01-01"})

--- a/test/plausible/stats/comparisons_test.exs
+++ b/test/plausible/stats/comparisons_test.exs
@@ -273,17 +273,18 @@ defmodule Plausible.Stats.ComparisonsTest do
           "filters" => [["is", "visit:country_name", ["Estonia"]]]
         })
 
-      result_query =
-        Comparisons.add_comparison_filters(query, [
-          %{
-            dimensions: ["Chrome", "99.9", "2024-01-01"],
-            metrics: [123]
-          },
-          %{
-            dimensions: ["Firefox", "12.0", "2024-01-01"],
-            metrics: [123]
-          }
-        ])
+      main_query_results = [
+        %{
+          dimensions: ["Chrome", "99.9", "2024-01-01"],
+          metrics: [123]
+        },
+        %{
+          dimensions: ["Firefox", "12.0", "2024-01-01"],
+          metrics: [123]
+        }
+      ]
+
+      result_query = Comparisons.add_comparison_filters(query, main_query_results)
 
       assert result_query.filters == [
                [:is, "visit:country_name", ["Estonia"]],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal", %{
+      post(conn, "/api/v2/query-internal-test", %{
         "site_id" => site.domain,
         "metrics" => ["pageviews"],
         "date_range" => ["2021-01-07", "2021-01-13"],
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal", %{
+      post(conn, "/api/v2/query-internal-test", %{
         "site_id" => site.domain,
         "metrics" => ["pageviews"],
         "date_range" => ["2021-01-07", "2021-01-13"],
@@ -129,7 +129,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal", %{
+      post(conn, "/api/v2/query-internal-test", %{
         "site_id" => site.domain,
         "metrics" => ["visitors", "percentage"],
         "date_range" => ["2021-01-07", "2021-01-13"],
@@ -194,7 +194,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal", %{
+      post(conn, "/api/v2/query-internal-test", %{
         "site_id" => site.domain,
         "metrics" => ["visitors", "percentage"],
         "date_range" => ["2021-01-07", "2021-01-13"],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -1,0 +1,230 @@
+defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
+  use PlausibleWeb.ConnCase
+
+  setup [:create_user, :create_new_site, :create_api_key, :use_api_key, :create_site_import]
+
+  test "aggregates a single metric", %{conn: conn, site: site} do
+    populate_stats(site, [
+      build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, timestamp: ~N[2021-01-02 00:00:00]),
+      build(:pageview, timestamp: ~N[2021-01-07 00:00:00])
+    ])
+
+    conn =
+      post(conn, "/api/v2/query-internal", %{
+        "site_id" => site.domain,
+        "metrics" => ["pageviews"],
+        "date_range" => ["2021-01-07", "2021-01-13"],
+        "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{
+               "dimensions" => [],
+               "metrics" => [1],
+               "comparison" => %{"change" => [-67], "dimensions" => [], "metrics" => [3]}
+             }
+           ]
+  end
+
+  test "timeseries comparison", %{conn: conn, site: site} do
+    populate_stats(site, [
+      build(:pageview, timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, timestamp: ~N[2021-01-01 00:25:00]),
+      build(:pageview, timestamp: ~N[2021-01-06 00:00:00]),
+      build(:pageview, timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, timestamp: ~N[2021-01-08 00:00:00])
+    ])
+
+    conn =
+      post(conn, "/api/v2/query-internal", %{
+        "site_id" => site.domain,
+        "metrics" => ["pageviews"],
+        "date_range" => ["2021-01-07", "2021-01-13"],
+        "dimensions" => ["time:day"],
+        "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{
+               "dimensions" => ["2021-01-07"],
+               "metrics" => [1],
+               "comparison" => %{
+                 "dimensions" => ["2020-12-31"],
+                 "metrics" => [0],
+                 "change" => [100]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-08"],
+               "metrics" => [1],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-01"],
+                 "metrics" => [2],
+                 "change" => [-50]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-09"],
+               "metrics" => [0],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-02"],
+                 "metrics" => [0],
+                 "change" => [0]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-10"],
+               "metrics" => [0],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-03"],
+                 "metrics" => [0],
+                 "change" => [0]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-11"],
+               "metrics" => [0],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-04"],
+                 "metrics" => [0],
+                 "change" => [0]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-12"],
+               "metrics" => [0],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-05"],
+                 "metrics" => [0],
+                 "change" => [0]
+               }
+             },
+             %{
+               "dimensions" => ["2021-01-13"],
+               "metrics" => [0],
+               "comparison" => %{
+                 "dimensions" => ["2021-01-06"],
+                 "metrics" => [1],
+                 "change" => [-100]
+               }
+             }
+           ]
+  end
+
+  test "dimensional comparison with low limit", %{conn: conn, site: site} do
+    populate_stats(site, [
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
+    ])
+
+    conn =
+      post(conn, "/api/v2/query-internal", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "percentage"],
+        "date_range" => ["2021-01-07", "2021-01-13"],
+        "dimensions" => ["visit:browser"],
+        "include" => %{
+          "comparisons" => %{"mode" => "previous_period"}
+        },
+        "pagination" => %{"limit" => 2}
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{
+               "dimensions" => ["Chrome"],
+               "metrics" => [2, 66.7],
+               "comparison" => %{
+                 "dimensions" => ["Chrome"],
+                 "metrics" => [1, 12.5],
+                 "change" => [100, 434]
+               }
+             },
+             %{
+               "dimensions" => ["Firefox"],
+               "metrics" => [1, 33.3],
+               "comparison" => %{
+                 "dimensions" => ["Firefox"],
+                 "metrics" => [4, 50.0],
+                 "change" => [-75, -33]
+               }
+             }
+           ]
+  end
+
+  test "dimensional comparison with imported data", %{
+    conn: conn,
+    site: site,
+    site_import: site_import
+  } do
+    populate_stats(site, site_import.id, [
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:00:00]),
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:imported_browsers,
+        date: ~D[2021-01-01],
+        browser: "Firefox",
+        browser_version: "121",
+        visitors: 50
+      ),
+      build(:imported_browsers,
+        date: ~D[2021-01-01],
+        browser: "Chrome",
+        browser_version: "99",
+        visitors: 39
+      ),
+      build(:imported_browsers,
+        date: ~D[2021-01-01],
+        browser: "Safari",
+        browser_version: "99",
+        visitors: 10
+      ),
+      build(:imported_visitors, date: ~D[2021-01-01], visitors: 99)
+    ])
+
+    conn =
+      post(conn, "/api/v2/query-internal", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "percentage"],
+        "date_range" => ["2021-01-07", "2021-01-13"],
+        "dimensions" => ["visit:browser"],
+        "include" => %{
+          "imports" => true,
+          "comparisons" => %{"mode" => "previous_period"}
+        },
+        "pagination" => %{"limit" => 2}
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{
+               "dimensions" => ["Chrome"],
+               "metrics" => [2, 66.7],
+               "comparison" => %{
+                 "dimensions" => ["Chrome"],
+                 "metrics" => [40, 40.0],
+                 "change" => [-95, 67]
+               }
+             },
+             %{
+               "dimensions" => ["Firefox"],
+               "metrics" => [1, 33.3],
+               "comparison" => %{
+                 "dimensions" => ["Firefox"],
+                 "metrics" => [50, 50.0],
+                 "change" => [-98, -33]
+               }
+             }
+           ]
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -224,8 +224,8 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
                  "percentage" => 33.3,
                  "comparison" => %{
                    "visitors" => 1,
-                   "percentage" => 100.0,
-                   "change" => %{"percentage" => -67, "visitors" => 0}
+                   "percentage" => 50.0,
+                   "change" => %{"percentage" => -33, "visitors" => 0}
                  }
                }
              ]
@@ -255,8 +255,8 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
                  "percentage" => 66.7,
                  "comparison" => %{
                    "visitors" => 1,
-                   "percentage" => 100.0,
-                   "change" => %{"percentage" => -33, "visitors" => 100}
+                   "percentage" => 25.0,
+                   "change" => %{"percentage" => 167, "visitors" => 100}
                  }
                }
              ]


### PR DESCRIPTION
### Changes

Depends on https://github.com/plausible/analytics/pull/4692

Currently, when doing comparisons when breaking down by e.g. `visit:browser` dimension, zeroes would be incorrectly applied when small limits are in place. This is because the top 10 browsers today might not be the same as in previous period.

This PR fixes that by OR-ing together all dimension values from main result in comparison filter. Additionally, this filter is ignored when calculating totals as is needed for percentage/conversion rate calculations.

Rather than test every old endpoint separately, this PR adds a test-only endpoint for testing query logic as well.