### PR TITLE
Restore average/total revenue to top stats

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -16,30 +16,14 @@ import {
   MetricFormatterLong
 } from '../reports/metric-formatter'
 
-function Maybe({ condition, children }) {
-  if (condition) {
-    return children
-  } else {
-    return null
-  }
-}
-
 function topStatNumberShort(metric, value) {
-  if (typeof value == 'number') {
-    const formatter = MetricFormatterShort[metric]
-    return formatter(value)
-  } else {
-    return null
-  }
+  const formatter = MetricFormatterShort[metric]
+  return formatter(value)
 }
 
 function topStatNumberLong(metric, value) {
-  if (typeof value == 'number') {
-    const formatter = MetricFormatterLong[metric]
-    return formatter(value)
-  } else {
-    return null
-  }
+  const formatter = MetricFormatterLong[metric]
+  return formatter(value)
 }
 
 export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
@@ -163,22 +147,22 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
               >
                 {topStatNumberShort(stat.graph_metric, stat.value)}
               </p>
-              <Maybe condition={!query.comparison && stat.change != null}>
+              {query.comparison && stat.change != null && (
                 <ChangeArrow
                   metric={stat.graph_metric}
                   change={stat.change}
                   className="pl-2 text-xs dark:text-gray-100"
                 />
-              </Maybe>
+              )}
             </span>
-            <Maybe condition={query.comparison}>
+            {query.comparison && (
               <p className="text-xs dark:text-gray-100">
                 {formatDateRange(site, data.from, data.to)}
               </p>
-            </Maybe>
+            )}
           </div>
 
-          <Maybe condition={query.comparison}>
+          {query.comparison && (
             <div>
               <p className="font-bold text-xl text-gray-500 dark:text-gray-400">
                 {topStatNumberShort(stat.graph_metric, stat.comparison_value)}
@@ -187,7 +171,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
                 {formatDateRange(site, data.comparing_from, data.comparing_to)}
               </p>
             </div>
-          </Maybe>
+          )}
         </div>
       </Tooltip>
     )

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -147,22 +147,22 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
               >
                 {topStatNumberShort(stat.graph_metric, stat.value)}
               </p>
-              {query.comparison && stat.change != null && (
+              {query.comparison && stat.change != null ? (
                 <ChangeArrow
                   metric={stat.graph_metric}
                   change={stat.change}
                   className="pl-2 text-xs dark:text-gray-100"
                 />
-              )}
+              ) : null}
             </span>
-            {query.comparison && (
+            {query.comparison ? (
               <p className="text-xs dark:text-gray-100">
                 {formatDateRange(site, data.from, data.to)}
               </p>
-            )}
+            ) : null}
           </div>
 
-          {query.comparison && (
+          {query.comparison ? (
             <div>
               <p className="font-bold text-xl text-gray-500 dark:text-gray-400">
                 {topStatNumberShort(stat.graph_metric, stat.comparison_value)}
@@ -171,7 +171,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
                 {formatDateRange(site, data.comparing_from, data.comparing_to)}
               </p>
             </div>
-          )}
+          ) : null}
         </div>
       </Tooltip>
     )


### PR DESCRIPTION
These werent being graphed due to incorrect conditional. The root cause of the error Artur flagged was the <Maybe /> children being eagerly evaluated, causing incorrect values to be passed to formatters.

Missed this since my trial had run out locally :sweat_smile: 

Ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7945586401