### PR TITLE
Fix money values on graphs and `conversions` graph tooltips

### DIFF
--- a/assets/js/dashboard/stats/reports/metric-formatter.ts
+++ b/assets/js/dashboard/stats/reports/metric-formatter.ts
@@ -14,6 +14,7 @@ export type FormattableMetric =
   | 'total_visitors'
   | 'current_visitors'
   | 'exit_rate'
+  | 'conversions'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ValueType = any
@@ -29,6 +30,8 @@ export const MetricFormatterShort: Record<
   views_per_visit: numberShortFormatter,
   visitors: numberShortFormatter,
   visits: numberShortFormatter,
+
+  conversions: numberShortFormatter,
 
   time_on_page: durationFormatter,
   visit_duration: durationFormatter,
@@ -54,6 +57,8 @@ export const MetricFormatterLong: Record<
   views_per_visit: numberLongFormatter,
   visitors: numberLongFormatter,
   visits: numberLongFormatter,
+
+  conversions: numberLongFormatter,
 
   time_on_page: durationFormatter,
   visit_duration: durationFormatter,

--- a/assets/js/dashboard/util/money.ts
+++ b/assets/js/dashboard/util/money.ts
@@ -1,15 +1,21 @@
+import { numberLongFormatter, numberShortFormatter } from "./number-formatter"
+
 type Money = { long: string, short: string }
 
-export function formatMoneyShort(value: Money | null) {
-  if (value) {
+export function formatMoneyShort(value: Money | number | null) {
+  if (typeof value == 'number') {
+    return numberShortFormatter(value)
+  } else if (value) {
     return value.short
   } else {
     return "-"
   }
 }
 
-export function formatMoneyLong(value: Money | null) {
-  if (value) {
+export function formatMoneyLong(value: Money | number | null) {
+  if (typeof value == 'number') {
+    return numberLongFormatter(value)
+  } else if (value) {
     return value.long
   } else {
     return "-"


### PR DESCRIPTION
Another follow-up to https://github.com/plausible/analytics/pull/4716 and https://github.com/plausible/analytics/pull/4692

This change:
1. Restores `conversions` graph tooltips
2. Displays money values on graph correctly