### PR TITLE
Fix custom property value filter suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-- Fix returning filter suggestions for custom property values in the dashbaord Filter modal
+- Fix returning filter suggestions for multiple custom property values in the dashboard Filter modal
 
 ## v2.1.4 - 2024-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+- Fix returning filter suggestions for custom property values in the dashbaord Filter modal
+
 ## v2.1.4 - 2024-10-08
 
 ### Added

--- a/assets/js/dashboard/stats/modals/filter-modal-props-row.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-props-row.js
@@ -56,7 +56,10 @@ export default function FilterModalPropsRow({
       return Promise.resolve([])
     }
     return fetchSuggestions(
-      apiPath(site, `/suggestions/custom-prop-values/${encodeURIComponent(propKey)}`),
+      apiPath(
+        site,
+        `/suggestions/custom-prop-values/${encodeURIComponent(propKey)}`
+      ),
       query,
       input,
       [FILTER_OPERATIONS.isNot, filterKey, ['(none)']]

--- a/assets/js/dashboard/stats/modals/filter-modal-props-row.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-props-row.js
@@ -56,7 +56,7 @@ export default function FilterModalPropsRow({
       return Promise.resolve([])
     }
     return fetchSuggestions(
-      apiPath(site, `/suggestions/prop_value`),
+      apiPath(site, `/suggestions/custom-prop-values/${encodeURIComponent(propKey)}`),
       query,
       input,
       [FILTER_OPERATIONS.isNot, filterKey, ['(none)']]

--- a/lib/plausible/stats.ex
+++ b/lib/plausible/stats.ex
@@ -50,4 +50,9 @@ defmodule Plausible.Stats do
     include_sentry_replay_info()
     FilterSuggestions.filter_suggestions(site, query, filter_name, filter_search)
   end
+
+  def custom_prop_value_filter_suggestions(site, query, prop_key, filter_search) do
+    include_sentry_replay_info()
+    FilterSuggestions.custom_prop_value_filter_suggestions(site, query, prop_key, filter_search)
+  end
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1361,6 +1361,17 @@ defmodule PlausibleWeb.Api.StatsController do
     )
   end
 
+  def custom_prop_value_filter_suggestions(conn, %{"prop_key" => prop_key} = params) do
+    site = conn.assigns[:site]
+
+    query = Query.from(site, params, debug_metadata(conn))
+
+    json(
+      conn,
+      Stats.custom_prop_value_filter_suggestions(site, query, prop_key, params["q"])
+    )
+  end
+
   defp transform_keys(result, keys_to_replace) when is_map(result) do
     for {key, val} <- result, do: {Map.get(keys_to_replace, key, key), val}, into: %{}
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -197,6 +197,10 @@ defmodule PlausibleWeb.Router do
     get "/:domain/conversions", StatsController, :conversions
     get "/:domain/custom-prop-values/:prop_key", StatsController, :custom_prop_values
     get "/:domain/suggestions/:filter_name", StatsController, :filter_suggestions
+
+    get "/:domain/suggestions/custom-prop-values/:prop_key",
+        StatsController,
+        :custom_prop_value_filter_suggestions
   end
 
   scope "/api/v1/stats", PlausibleWeb.Api, assigns: %{api_scope: "stats:read:*"} do

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -573,7 +573,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_value?period=day&date=2022-01-01&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/custom-prop-values/author?period=day&date=2022-01-01&filters=#{filters}"
         )
 
       assert json_response(conn, 200) == [
@@ -610,12 +610,48 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_value?period=day&date=2022-01-01&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/custom-prop-values/author?period=day&date=2022-01-01&filters=#{filters}"
         )
 
       assert json_response(conn, 200) == [
                %{"label" => "Uku Taht", "value" => "Uku Taht"},
                %{"label" => "Marko Saric", "value" => "Marko Saric"}
+             ]
+    end
+
+    test "returns prop value suggestions with multiple custom property filters in query", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          "meta.key": ["author", "browser_language"],
+          "meta.value": ["Uku Taht", "en-US"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author", "browser_language"],
+          "meta.value": ["Uku Taht", "en-US"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author", "browser_language"],
+          "meta.value": ["Marko Saric", "de-DE"],
+          timestamp: ~N[2022-01-01 00:00:00]
+        ),
+        build(:pageview, timestamp: ~N[2022-01-01 00:00:00])
+      ])
+
+      filters = Jason.encode!(%{props: %{browser_language: "!(none)", author: "Uku Taht"}})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/suggestions/custom-prop-values/browser_language?period=day&date=2022-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200) == [
+               %{"label" => "en-US", "value" => "en-US"}
              ]
     end
 
@@ -644,7 +680,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_value?period=all&date=CLEVER_SECURITY_RESEARCH&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/custom-prop-values/author?period=all&date=CLEVER_SECURITY_RESEARCH&filters=#{filters}"
         )
 
       assert json_response(conn, 400) == %{
@@ -1008,7 +1044,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       value_conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_value?period=day&date=2022-01-01&with_imported=true&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/custom-prop-values/url?period=day&date=2022-01-01&with_imported=true&filters=#{filters}"
         )
 
       assert json_response(value_conn, 200) == [


### PR DESCRIPTION
### Changes

This has been broken since filtering by multiple custom props became possible. 

To reproduce the bug:

1. Go to the live demo
2. Open the filter modal and apply a filter like "browser_language is en-US"
3. Click on the filter card above the dashboard to edit the filter (the filter modal will open again)
4. Click "+ Add another"
5. Select a property other than `browser_language`, e.g. `logged_in`
6. Click on the prop value field to fetch suggestions
7. BUG: suggestions are fetched for `browser_language` rather than `logged_in`

![image](https://github.com/user-attachments/assets/f7dd0aae-c67b-466f-9d85-3302bb590536)


The current logic in the `/:domain/suggestions` endpoint for custom prop values is not accounting for the fact that there might be multiple filters with the `event:props` prefix.

This PR fixes that, introducing a new endpoint with a `prop_key` path parameter which indicates for what `prop_key` we actually want the value suggestions returned.

The old endpoint will be removed in a follow-up PR.

This PR also adds test coverage to the searching functionality for both `prop_key` and `prop_value` suggestions.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
