### PR TITLE
Make time-on-page ungraphable

### DIFF
--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -15,7 +15,7 @@ export function getGraphableMetrics(query, site) {
   } else if (isGoalFilter) {
     return ["visitors", "events", "conversion_rate"]
   } else if (isPageFilter) {
-    return ["visitors", "visits", "pageviews", "bounce_rate", "time_on_page"]
+    return ["visitors", "visits", "pageviews", "bounce_rate"]
   } else {
     return ["visitors", "visits", "pageviews", "views_per_visit", "bounce_rate", "visit_duration"]
   }


### PR DESCRIPTION
This was marked as graphable in FE but not in BE previously. After removing the BE check, this started throwing errors:

https://sentry.plausible.io/organizations/plausible/issues/626/?project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0