### PR TITLE
Fix bounce_rate metric causing 500s with comparisons

### DIFF
--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -115,7 +115,7 @@ defmodule Plausible.Stats.Filters do
   """
   def get_toplevel_filter(query, prefix) do
     Enum.find(query.filters, fn [_op, dimension | _rest] ->
-      String.starts_with?(dimension, prefix)
+      is_binary(dimension) and String.starts_with?(dimension, prefix)
     end)
   end
 


### PR DESCRIPTION
This was broken by comparison filtering changes