### PR TITLE
Comparisons: Fix filter transformations

### DIFF
--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -99,8 +99,8 @@ defmodule Plausible.Stats.Filters do
 
     filters
     |> traverse()
-    |> Enum.filter(fn {_filter, _root, depth} -> depth >= min_depth end)
-    |> Enum.map(fn {[_operator, dimension | _rest], _root, _depth} -> dimension end)
+    |> Enum.filter(fn {_filter, depth} -> depth >= min_depth end)
+    |> Enum.map(fn {[_operator, dimension | _rest], _depth} -> dimension end)
   end
 
   def filtering_on_dimension?(query, dimension) do
@@ -145,7 +145,8 @@ defmodule Plausible.Stats.Filters do
     case {transformer.(filter), filter} do
       # Transformer did not return that value - transform that subtree
       {nil, [operation, child_filter]} when operation in [:not, :ignore_in_totals_query] ->
-        [[:not, transform_tree(child_filter, transformer)]]
+        [transformed_child] = transform_tree(child_filter, transformer)
+        [[operation, transformed_child]]
 
       {nil, [operation, filters]} when operation in [:and, :or] ->
         [[operation, transform_filters(filters, transformer)]]
@@ -160,22 +161,22 @@ defmodule Plausible.Stats.Filters do
     end
   end
 
-  defp traverse(filters, root \\ nil, depth \\ -1) do
+  defp traverse(filters, depth \\ -1) do
     filters
-    |> Enum.flat_map(&traverse_tree(&1, root || &1, depth + 1))
+    |> Enum.flat_map(&traverse_tree(&1, depth + 1))
   end
 
-  defp traverse_tree(filter, root, depth) do
+  defp traverse_tree(filter, depth) do
     case filter do
       [operation, child_filter] when operation in [:not, :ignore_in_totals_query] ->
-        traverse_tree(child_filter, root, depth + 1)
+        traverse_tree(child_filter, depth + 1)
 
       [operation, filters] when operation in [:and, :or] ->
-        traverse(filters, root || filter, depth + 1)
+        traverse(filters, depth + 1)
 
       # Leaf node
       _ ->
-        [{filter, root, depth}]
+        [{filter, depth}]
     end
   end
 end


### PR DESCRIPTION
Previously the code would use the incorrect operator and lead to nesting. This broke pages report in hard-to-reproduce ways.