### PR TITLE
Delay "Add Goal" button activation till wss connects

### DIFF
--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -27,7 +27,7 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
         >
           Add Goal
         </.button>
-        <.button :if={connected?(@socket)} id="add-goal-button" mt?={false}>
+        <.button :if={not connected?(@socket)} id="add-goal-button" mt?={false}>
           Add Goal
         </.button>
       </.filter_bar>

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -27,7 +27,7 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
         >
           Add Goal
         </.button>
-        <.button :if={not connected?(@socket)} id="add-goal-button" mt?={false}>
+        <.button :if={connected?(@socket)} id="add-goal-button" mt?={false}>
           Add Goal
         </.button>
       </.filter_bar>

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -18,12 +18,16 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
     <div>
       <.filter_bar filter_text={@filter_text} placeholder="Search Goals">
         <.button
+          :if={connected?(@socket)}
           id="add-goal-button"
           phx-click="add-goal"
           mt?={false}
           x-data
           x-on:click={Modal.JS.preopen("goals-form-modal")}
         >
+          Add Goal
+        </.button>
+        <.button :if={not connected?(@socket)} id="add-goal-button" mt?={false}>
           Add Goal
         </.button>
       </.filter_bar>

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -85,7 +85,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
     test "add goal button is rendered", %{conn: conn, site: site} do
       conn = get(conn, "/#{site.domain}/settings/goals")
       resp = html_response(conn, 200)
-      assert element_exists?(resp, ~s/button#add-goal-button[phx-click="add-goal"]/)
+      assert element_exists?(resp, ~s/button#add-goal-button/)
     end
 
     test "search goals input is rendered", %{conn: conn, site: site} do


### PR DESCRIPTION
Perhaps still better than indefinite spinner in high latency conditions...

reading material: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7954549712