### PR TITLE
Sync team consistently on site creation

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -206,13 +206,9 @@ defmodule Plausible.Sites do
         Site.Membership.new(site, user)
       end)
       |> maybe_start_trial(user)
-      |> Ecto.Multi.run(:sync_team, fn
-        _repo, %{user: user} ->
-          Plausible.Teams.sync_team(user)
-          {:ok, nil}
-
-        _repo, _context ->
-          {:ok, nil}
+      |> Ecto.Multi.run(:sync_team, fn _repo, %{user: user} ->
+        Plausible.Teams.sync_team(user)
+        {:ok, nil}
       end)
       |> Repo.transaction()
     end
@@ -226,7 +222,7 @@ defmodule Plausible.Sites do
         end)
 
       _ ->
-        multi
+        Ecto.Multi.put(multi, :user, user)
     end
   end
 


### PR DESCRIPTION
### Changes

Follow-up fix for syncing team consistently each time site is created, regardless if user's trial is initiated or not yet.