### PR TITLE
Address team syncing discrepancies

### DIFF
--- a/lib/workers/clean_invitations.ex
+++ b/lib/workers/clean_invitations.ex
@@ -20,6 +20,11 @@ defmodule Plausible.Workers.CleanInvitations do
         where: ti.inserted_at < ^cutoff_time
     )
 
+    Repo.delete_all(
+      from ti in Plausible.Teams.SiteTransfer,
+        where: ti.inserted_at < ^cutoff_time
+    )
+
     :ok
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -38,6 +38,13 @@ defmodule Plausible.Factory do
     }
   end
 
+  def site_transfer_factory do
+    %Plausible.Teams.SiteTransfer{
+      transfer_id: Nanoid.generate(),
+      email: sequence(:email, &"email-#{&1}@example.com")
+    }
+  end
+
   def user_factory(attrs) do
     pw = Map.get(attrs, :password, "password")
 

--- a/test/workers/clean_invitations_test.exs
+++ b/test/workers/clean_invitations_test.exs
@@ -2,7 +2,7 @@ defmodule Plausible.Workers.CleanInvitationsTest do
   use Plausible.DataCase
   alias Plausible.Workers.CleanInvitations
 
-  test "cleans invitation that is more than 48h old" do
+  test "cleans invitations and transfers that are more than 48h old" do
     now = NaiveDateTime.utc_now(:second)
 
     insert(:invitation,
@@ -11,18 +11,67 @@ defmodule Plausible.Workers.CleanInvitationsTest do
       inviter: build(:user)
     )
 
+    site = insert(:site, team: build(:team))
+
+    team_invitation =
+      insert(:team_invitation,
+        inserted_at: NaiveDateTime.shift(now, hour: -49),
+        team: site.team,
+        inviter: build(:user),
+        role: :guest
+      )
+
+    insert(:guest_invitation,
+      inserted_at: NaiveDateTime.shift(now, hour: -49),
+      team_invitation: team_invitation,
+      site: site,
+      role: :viewer
+    )
+
+    insert(:site_transfer,
+      inserted_at: NaiveDateTime.shift(now, hour: -49),
+      site: site,
+      initiator: build(:user)
+    )
+
     CleanInvitations.perform(nil)
 
     refute Repo.exists?(Plausible.Auth.Invitation)
+    refute Repo.exists?(Plausible.Teams.Invitation)
+    refute Repo.exists?(Plausible.Teams.GuestInvitation)
+    refute Repo.exists?(Plausible.Teams.SiteTransfer)
   end
 
-  test "does not clean invitation that is less than 48h old" do
+  test "does not clean invitations and transfers that are less than 48h old" do
     now = NaiveDateTime.utc_now(:second)
 
     insert(:invitation,
       inserted_at: NaiveDateTime.shift(now, hour: -47),
       site: build(:site),
       inviter: build(:user)
+    )
+
+    site = insert(:site, team: build(:team))
+
+    team_invitation =
+      insert(:team_invitation,
+        inserted_at: NaiveDateTime.shift(now, hour: -47),
+        team: site.team,
+        inviter: build(:user),
+        role: :guest
+      )
+
+    insert(:guest_invitation,
+      inserted_at: NaiveDateTime.shift(now, hour: -47),
+      team_invitation: team_invitation,
+      site: site,
+      role: :viewer
+    )
+
+    insert(:site_transfer,
+      inserted_at: NaiveDateTime.shift(now, hour: -47),
+      site: site,
+      initiator: build(:user)
     )
 
     CleanInvitations.perform(nil)


### PR DESCRIPTION
### Changes

- always run invitations and site transfers accept sync inside transaction along with the current logic
- clean expired site transfers
- add dry run mode to teams backfill

### Tests
- [x] Automated tests have been added

