### PR TITLE
Bring back premium feature notices (+no "email us" notice for trials)

### DIFF
--- a/lib/plausible/billing/enterprise_plan.ex
+++ b/lib/plausible/billing/enterprise_plan.ex
@@ -2,6 +2,8 @@ defmodule Plausible.Billing.EnterprisePlan do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t() :: %__MODULE__{}
+
   @required_fields [
     :user_id,
     :paddle_plan_id,

--- a/lib/plausible/billing/plan.ex
+++ b/lib/plausible/billing/plan.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Billing.Plan do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @type t() :: %__MODULE__{} | :enterprise
+  @type t() :: %__MODULE__{}
 
   embedded_schema do
     # Due to grandfathering, we sometimes need to check the "generation" (e.g.

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -106,7 +106,7 @@ defmodule Plausible.Billing.Plans do
   end
 
   @spec get_subscription_plan(nil | Subscription.t()) ::
-          nil | :free_10k | %Plan{} | %EnterprisePlan{}
+          nil | :free_10k | Plan.t() | EnterprisePlan.t()
   def get_subscription_plan(nil), do: nil
 
   def get_subscription_plan(subscription) do

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -105,6 +105,8 @@ defmodule Plausible.Billing.Plans do
     end)
   end
 
+  @spec get_subscription_plan(nil | Subscription.t()) ::
+          nil | :free_10k | %Plan{} | %EnterprisePlan{}
   def get_subscription_plan(nil), do: nil
 
   def get_subscription_plan(subscription) do

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -302,11 +302,12 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   defp upgrade_call_to_action(assigns) do
     billable_user = Plausible.Users.with_subscription(assigns.billable_user)
 
-    upgrade_assistance_required? = case Plans.get_subscription_plan(billable_user.subscription) do
-      %Plausible.Billing.Plan{kind: :business} -> true
-      %Plausible.Billing.EnterprisePlan{} -> true
-      _ -> false
-    end
+    upgrade_assistance_required? =
+      case Plans.get_subscription_plan(billable_user.subscription) do
+        %Plausible.Billing.Plan{kind: :business} -> true
+        %Plausible.Billing.EnterprisePlan{} -> true
+        _ -> false
+      end
 
     cond do
       assigns.billable_user.id !== assigns.current_user.id ->

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -12,12 +12,13 @@
       Compose Goals into Funnels
     </:subtitle>
 
+    <PlausibleWeb.Components.Billing.Notice.premium_feature
+      billable_user={@site.owner}
+      current_user={@current_user}
+      feature_mod={Plausible.Billing.Feature.Funnels}
+    />
+
     <div :if={Plausible.Billing.Feature.Funnels.enabled?(@site)}>
-      <PlausibleWeb.Components.Billing.Notice.premium_feature
-        billable_user={@site.owner}
-        current_user={@current_user}
-        feature_mod={Plausible.Billing.Feature.Funnels}
-      />
       <%= live_render(@conn, PlausibleWeb.Live.FunnelSettings,
         session: %{"site_id" => @site.id, "domain" => @site.domain}
       ) %>

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -13,13 +13,14 @@
       create custom metrics.
     </:subtitle>
 
+    <PlausibleWeb.Components.Billing.Notice.premium_feature
+      billable_user={@site.owner}
+      current_user={@current_user}
+      feature_mod={Plausible.Billing.Feature.Props}
+      grandfathered?
+    />
+
     <div :if={Plausible.Billing.Feature.Props.enabled?(@site)}>
-      <PlausibleWeb.Components.Billing.Notice.premium_feature
-        billable_user={@site.owner}
-        current_user={@current_user}
-        feature_mod={Plausible.Billing.Feature.Props}
-        grandfathered?
-      />
       <%= live_render(@conn, PlausibleWeb.Live.PropsSettings,
         id: "props-form",
         session: %{"site_id" => @site.id, "domain" => @site.domain}

--- a/test/plausible_web/live/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings_test.exs
@@ -10,6 +10,19 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
     describe "GET /:domain/settings/funnels" do
       setup [:create_user, :log_in, :create_site]
 
+      @tag :ee_only
+      test "upgrade notice renders", %{conn: conn, site: site, user: user} do
+        user
+        |> Plausible.Auth.User.end_trial()
+        |> Plausible.Repo.update!()
+
+        conn = get(conn, "/#{site.domain}/settings/funnels")
+        resp = conn |> html_response(200) |> text()
+
+        assert resp =~
+                 "Your account does not have access to Funnels. To get access to this feature, please contact hello@plausible.io"
+      end
+
       test "lists funnels for the site and renders help link", %{conn: conn, site: site} do
         {:ok, _} = setup_funnels(site)
         conn = get(conn, "/#{site.domain}/settings/funnels")
@@ -18,6 +31,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
         assert resp =~ "Compose Goals into Funnels"
         assert resp =~ "From blog to signup"
         assert resp =~ "From signup to blog"
+        refute resp =~ "Your account does not have access"
         assert element_exists?(resp, "a[href=\"https://plausible.io/docs/funnel-analysis\"]")
       end
 

--- a/test/plausible_web/live/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings_test.exs
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
       setup [:create_user, :log_in, :create_site]
 
       @tag :ee_only
-      test "upgrade notice renders", %{conn: conn, site: site, user: user} do
+      test "premium feature notice renders", %{conn: conn, site: site, user: user} do
         user
         |> Plausible.Auth.User.end_trial()
         |> Plausible.Repo.update!()
@@ -19,8 +19,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
         conn = get(conn, "/#{site.domain}/settings/funnels")
         resp = conn |> html_response(200) |> text()
 
-        assert resp =~
-                 "Your account does not have access to Funnels. To get access to this feature, please contact hello@plausible.io"
+        assert resp =~ "please upgrade your subscription"
       end
 
       test "lists funnels for the site and renders help link", %{conn: conn, site: site} do
@@ -32,6 +31,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
         assert resp =~ "From blog to signup"
         assert resp =~ "From signup to blog"
         refute resp =~ "Your account does not have access"
+        refute resp =~ "please upgrade your subscription"
         assert element_exists?(resp, "a[href=\"https://plausible.io/docs/funnel-analysis\"]")
       end
 

--- a/test/plausible_web/live/props_settings_test.exs
+++ b/test/plausible_web/live/props_settings_test.exs
@@ -6,6 +6,19 @@ defmodule PlausibleWeb.Live.PropsSettingsTest do
   describe "GET /:domain/settings/properties" do
     setup [:create_user, :log_in, :create_site]
 
+    @tag :ee_only
+    test "premium feature notice renders", %{conn: conn, site: site, user: user} do
+      user
+      |> Plausible.Auth.User.end_trial()
+      |> Plausible.Repo.update!()
+
+      conn = get(conn, "/#{site.domain}/settings/properties")
+      resp = conn |> html_response(200) |> text()
+
+      assert resp =~
+               "Your account does not have access to Custom Properties. To get access to this feature, please contact hello@plausible.io"
+    end
+
     test "lists props for the site and renders links", %{conn: conn, site: site} do
       {:ok, site} = Plausible.Props.allow(site, ["amount", "logged_in", "is_customer"])
       conn = get(conn, "/#{site.domain}/settings/properties")

--- a/test/plausible_web/live/props_settings_test.exs
+++ b/test/plausible_web/live/props_settings_test.exs
@@ -15,8 +15,7 @@ defmodule PlausibleWeb.Live.PropsSettingsTest do
       conn = get(conn, "/#{site.domain}/settings/properties")
       resp = conn |> html_response(200) |> text()
 
-      assert resp =~
-               "Your account does not have access to Custom Properties. To get access to this feature, please contact hello@plausible.io"
+      assert resp =~ "please upgrade your subscription"
     end
 
     test "lists props for the site and renders links", %{conn: conn, site: site} do
@@ -34,6 +33,7 @@ defmodule PlausibleWeb.Live.PropsSettingsTest do
       assert resp =~ "amount"
       assert resp =~ "logged_in"
       assert resp =~ "is_customer"
+      refute resp =~ "please upgrade your subscription"
     end
 
     test "lists props with disallow actions", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7959193799

This change brings back premium feature notices to funnels and custom props, such as:

![image](https://github.com/user-attachments/assets/9b96d836-5938-4134-9dde-a2ba54842f89)

it also adds relevant tests, so it's not accidentally removed in the future.

We also stop asking users to e-mail us, upgrade should be a viable option for everyone.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
