### PR TITLE
Add size reporter GH action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,3 +32,4 @@ jobs:
     - run: npm run check-format --prefix ./assets
     - run: npm run test --prefix ./assets
     - run: npm run deploy --prefix ./tracker
+    - run: npm run report-sizes --prefix ./tracker

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "deploy": "node compile.js",
     "test": "npm run deploy && npx playwright test --config=./test/support/playwright.config.js",
+    "report-sizes": "node report-sizes.js",
     "start": "node test/support/server.js"
   },
   "license": "MIT",

--- a/tracker/report-sizes.js
+++ b/tracker/report-sizes.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PrivTrackerDir = '../priv/tracker/js/';
+
+const toReport = [
+  'plausible.js',
+  'plausible.pageleave.js',
+  'plausible.manual.pageleave.js',
+  'plausible.hash.pageleave.js'
+];
+
+const results = [];
+
+toReport.forEach((filename) => {
+  const filePath = path.join(PrivTrackerDir, filename);
+  if (fs.statSync(filePath).isFile()) {
+    results.push({
+      'Filename': filename,
+      'Real Size (Bytes)': fs.statSync(filePath).size,
+      'Gzipped Size (Bytes)': execSync(`gzip -c -9 "${filePath}"`).length,
+      'Brotli Size (Bytes)': execSync(`brotli -c -q 11 "${filePath}"`).length
+    });
+  }
+});
+
+console.table(results)


### PR DESCRIPTION
### Changes

Currently opted for a selection of filenames that are "interesting to know". Printing out file sizes for every file is pretty noisy (> 2000 lines) and irrelevant, I think. The default `plausible.js` script size is the one that matters.