### PR TITLE
Adjust GA4 import timeout and page size to reduce risk of 502s and timeouts

### DIFF
--- a/lib/plausible/google/ga4/api.ex
+++ b/lib/plausible/google/ga4/api.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Google.GA4.API do
           expires_at :: String.t()
         }
 
-  @per_page 250_000
+  @per_page 200_000
   @backoff_factor :timer.seconds(10)
   @max_attempts 5
 

--- a/lib/plausible/google/ga4/http.ex
+++ b/lib/plausible/google/ga4/http.ex
@@ -48,7 +48,7 @@ defmodule Plausible.Google.GA4.HTTP do
         url,
         [{"Authorization", "Bearer #{report_request.access_token}"}],
         params,
-        receive_timeout: 60_000
+        receive_timeout: 80_000
       )
 
     with {:ok, %{body: body}} <- response,


### PR DESCRIPTION
### Changes

Adjustment to the GA4 import in the hopes of improving reliability for more complicated cases.