### PR TITLE
Fix dashboard crash

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -19,7 +19,7 @@ import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
 function fetchTopStats(site, query) {
   const q = { ...query }
 
-  if (!isComparisonEnabled(q.comparison)) {
+  if (!isComparisonEnabled(q.comparison) && query.period !== 'realtime') {
     q.comparison = 'previous_period'
   }
 


### PR DESCRIPTION
### Changes

Fixes dashboard crashing when comparisons are enabled in the query and changing from realtime period to a historical period.

The [previous attempt](https://github.com/plausible/analytics/pull/4732) to fix this did half of the work, but since the `comparing_from` and `comparing_to` fields were returned from the backend even for realtime queries, the bug is still there.

Reproduction:

1. Comparison disabled, choose a non-realtime period (e.g. press T for "Last 30 days")
2. Enable comparison mode (press X)
3. Choose the realtime period (press R)
4. Choose a non-realtime period again (press T)