### PR TITLE
Comparisons: Fix exports issue

### DIFF
--- a/assets/js/dashboard/stats/graph/stats-export.js
+++ b/assets/js/dashboard/stats/graph/stats-export.js
@@ -34,7 +34,7 @@ export default function StatsExport() {
 
   function renderExportLink() {
     const interval = getCurrentInterval(site, query)
-    const queryParams = api.serializeQuery(query, [{ interval }])
+    const queryParams = api.serializeQuery(query, [{ interval, comparison: undefined }])
     const endpoint = `/${encodeURIComponent(site.domain)}/export${queryParams}`
 
     return (

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -547,7 +547,8 @@ config :plausible, Plausible.ClickhouseRepo,
   transport_opts: ch_transport_opts,
   settings: [
     readonly: 1,
-    join_algorithm: "direct,parallel_hash,hash"
+    join_algorithm: "direct,parallel_hash,hash",
+    max_parser_depth: 100_000
   ]
 
 config :plausible, Plausible.IngestRepo,


### PR DESCRIPTION
### Changes

This PR:
1. Increases `max_parser_depth` setting. See https://github.com/plausible/analytics/commit/6399cf54318c40434dd3686df253ab09ef4d3c3c for full context
2. Removes comparisons querying from exports endpoint - the data would never be used anyways.