### PR TITLE
Run full test suite against `read_team_schemas` FF on CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,25 +16,25 @@ env:
 
 jobs:
   build:
-    name: "Build and test (${{ matrix.mix_env }}, ${{ matrix.postgres_image }}${{ matrix.test_read_team_schemas == '1' && ', read_team_schemas' || '' }})"
+    name: "Build and test (${{ matrix.mix_env }}, ${{ matrix.postgres_image }}${{ matrix.test_read_team_schemas_and_experimental_reduced_joins == '1' && ', read_team_schemas_and_experimental_reduced_joins' || '' }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         mix_env: ["test", "ce_test"]
         postgres_image: ["postgres:16"]
-        test_read_team_schemas: ["0"]
+        test_read_team_schemas_and_experimental_reduced_joins: ["0"]
 
         include:
           - mix_env: "test"
             postgres_image: "postgres:15"
-            test_read_team_schemas: "0"
+            test_read_team_schemas_and_experimental_reduced_joins: "0"
           - mix_env: "test"
             postgres_image: "postgres:16"
-            test_read_team_schemas: "1"
+            test_read_team_schemas_and_experimental_reduced_joins: "1"
 
     env:
       MIX_ENV: ${{ matrix.mix_env }}
-      TEST_READ_TEAM_SCHEMAS: ${{ matrix.test_read_team_schemas }}
+      TEST_READ_TEAM_SCHEMAS_AND_EXPERIMENTAL_REDUCED_JOINS: ${{ matrix.test_read_team_schemas_and_experimental_reduced_joins }}
     services:
       postgres:
         image: ${{ matrix.postgres_image }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,25 +16,25 @@ env:
 
 jobs:
   build:
-    name: "Build and test (${{ matrix.mix_env }}, ${{ matrix.postgres_image }}${{ matrix.test_experimental_reduced_joins == '1' && ', experimental_reduced_joins' || '' }})"
+    name: "Build and test (${{ matrix.mix_env }}, ${{ matrix.postgres_image }}${{ matrix.test_read_team_schemas == '1' && ', read_team_schemas' || '' }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         mix_env: ["test", "ce_test"]
         postgres_image: ["postgres:16"]
-        test_experimental_reduced_joins: ["0"]
+        test_read_team_schemas: ["0"]
 
         include:
           - mix_env: "test"
             postgres_image: "postgres:15"
-            test_experimental_reduced_joins: "0"
+            test_read_team_schemas: "0"
           - mix_env: "test"
             postgres_image: "postgres:16"
-            test_experimental_reduced_joins: "1"
+            test_read_team_schemas: "1"
 
     env:
       MIX_ENV: ${{ matrix.mix_env }}
-      TEST_EXPERIMENTAL_REDUCED_JOINS: ${{ matrix.test_experimental_reduced_joins }}
+      TEST_READ_TEAM_SCHEMAS: ${{ matrix.test_read_team_schemas }}
     services:
       postgres:
         image: ${{ matrix.postgres_image }}

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -35,7 +35,8 @@ defmodule PlausibleWeb.Live.Sites do
       |> assign_new(:needs_to_upgrade, fn %{current_user: current_user, sites: sites} ->
         user_owns_sites =
           Enum.any?(sites.entries, fn site ->
-            length(site.invitations) > 0 && List.first(site.invitations).role == :owner
+            # length(site.invitations) > 0 && List.first(site.invitations).role == :owner
+            List.first(site.invitations).role == :owner
           end) ||
             Auth.user_owns_sites?(current_user)
 

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -35,8 +35,7 @@ defmodule PlausibleWeb.Live.Sites do
       |> assign_new(:needs_to_upgrade, fn %{current_user: current_user, sites: sites} ->
         user_owns_sites =
           Enum.any?(sites.entries, fn site ->
-            # length(site.invitations) > 0 && List.first(site.invitations).role == :owner
-            List.first(site.invitations).role == :owner
+            length(site.invitations) > 0 && List.first(site.invitations).role == :owner
           end) ||
             Auth.user_owns_sites?(current_user)
 

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -16,6 +16,22 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert text(html) =~ "You don't have any sites yet"
     end
 
+    test "renders metadata for invitation", %{
+      conn: conn,
+      user: user
+    } do
+      inviter = new_user()
+      site = new_site(owner: inviter)
+
+      invitation = invite_guest(site, user, inviter: inviter, role: :viewer)
+
+      {:ok, _lv, html} = live(conn, "/sites")
+
+      invitation_data = get_invitation_data(html)
+
+      assert get_in(invitation_data, ["invitations", invitation.invitation_id, "invitation"])
+    end
+
     @tag :ee_only
     test "renders ownership transfer invitation for a case with no plan", %{
       conn: conn,

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -78,7 +78,13 @@ defmodule Plausible.Teams.Test do
       )
 
     team_invitation =
-      insert(:team_invitation, team: team, email: email, inviter: inviter, role: :guest)
+      insert(:team_invitation,
+        invitation_id: old_model_invitation.invitation_id,
+        team: team,
+        email: email,
+        inviter: inviter,
+        role: :guest
+      )
 
     insert(:guest_invitation, team_invitation: team_invitation, site: site, role: role)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,14 +6,12 @@ end
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 Application.ensure_all_started(:double)
 
-# Temporary flag to test `experimental_reduced_joins` flag on all tests.
-if System.get_env("TEST_EXPERIMENTAL_REDUCED_JOINS") == "1" do
-  FunWithFlags.enable(:experimental_reduced_joins)
+# Temporary flag to test `read_team_schemas` flag on all tests.
+if System.get_env("TEST_READ_TEAM_SCHEMAS") == "1" do
+  FunWithFlags.enable(:read_team_schemas)
 else
-  FunWithFlags.disable(:experimental_reduced_joins)
+  FunWithFlags.disable(:read_team_schemas)
 end
-
-FunWithFlags.enable(:read_team_schemas)
 
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,11 +6,14 @@ end
 Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)
 Application.ensure_all_started(:double)
 
-# Temporary flag to test `read_team_schemas` flag on all tests.
-if System.get_env("TEST_READ_TEAM_SCHEMAS") == "1" do
+# Temporary flag to test `read_team_schemas` and `experimental_reduced_joins`
+# flags on all tests.
+if System.get_env("TEST_READ_TEAM_SCHEMAS_AND_EXPERIMENTAL_REDUCED_JOINS") == "1" do
   FunWithFlags.enable(:read_team_schemas)
+  FunWithFlags.enable(:experimental_reduced_joins)
 else
   FunWithFlags.disable(:read_team_schemas)
+  FunWithFlags.disable(:experimental_reduced_joins)
 end
 
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)


### PR DESCRIPTION
### Changes

This PR introduces full test suite runs with `read_team_schemas` feature flag up and down on CI. It's meant to reduce the risk of regressions during future further changes.

We are replacing the existing setup for `experimental_reduced_joins` which wasn't actively used and will be removed some time in the future. This way we don't make CI run longer than necessary.



### Tests
- [x] Automated tests have been added

