### PR TITLE
Get rid of memberships prosthetic for `Teams.Sites.list_with_invitations`

### DIFF
--- a/lib/plausible/data_migration/backfill_teams.ex
+++ b/lib/plausible/data_migration/backfill_teams.ex
@@ -188,7 +188,7 @@ defmodule Plausible.DataMigration.BackfillTeams do
         gm in Teams.GuestMembership,
         inner_join: tm in assoc(gm, :team_membership),
         inner_join: s in assoc(gm, :site),
-        where: tm.team_id != s.id
+        where: tm.team_id != s.team_id
       )
       |> @repo.all()
 


### PR DESCRIPTION

### Changes

This PR:

- removes "prosthetic" relying on the old schema in new sites list query logic
- fixes a bug in recent update to the backfill script


