### PR TITLE
Fixes for `?source` and `?ref` params

### DIFF
--- a/lib/plausible/ingestion/acquisition.ex
+++ b/lib/plausible/ingestion/acquisition.ex
@@ -166,31 +166,21 @@ defmodule Plausible.Ingestion.Acquisition do
       source == "firebase"
   end
 
-  defp shopping_source?(nil), do: false
-
   defp shopping_source?(source) do
     @source_categories[source] == "SOURCE_CATEGORY_SHOPPING"
   end
-
-  defp search_source?(nil), do: false
 
   defp search_source?(source) do
     @source_categories[source] == "SOURCE_CATEGORY_SEARCH"
   end
 
-  defp social_source?(nil), do: false
-
   defp social_source?(source) do
     @source_categories[source] == "SOURCE_CATEGORY_SOCIAL"
   end
 
-  defp video_source?(nil), do: false
-
   defp video_source?(source) do
     @source_categories[source] == "SOURCE_CATEGORY_VIDEO"
   end
-
-  defp email_source?(nil), do: false
 
   defp email_source?(source) do
     @source_categories[source] == "SOURCE_CATEGORY_EMAIL"

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -406,6 +406,39 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert session.referrer_source == "betalist"
+      assert session.utm_source == "betalist"
+    end
+
+    test "?ref param behaves like ?utm_source", %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?ref=betalist",
+        domain: site.domain
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert session.referrer_source == "betalist"
+      assert session.utm_source == "betalist"
+    end
+
+    test "?source param behaves like ?utm_source", %{conn: conn, site: site} do
+      params = %{
+        name: "pageview",
+        url: "http://www.example.com/?source=betalist",
+        domain: site.domain
+      }
+
+      conn
+      |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert session.referrer_source == "betalist"
+      assert session.utm_source == "betalist"
     end
 
     test "if utm_source matches a capitalized form from ref_inspector, the capitalized form is recorded",
@@ -2192,7 +2225,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     } do
       params = %{
         name: "pageview",
-        url: "http://example.com?utm_source=Google-ads",
+        url: "http://example.com?source=Google-ads",
         domain: site.domain
       }
 


### PR DESCRIPTION
### Changes

I messed up with channels & source merging. The way we've been collecting data, some information gets lost. Specifically, when someone uses `?ref=googleads`, for example, it will be stored as `source=Google` and `channel=Organic Search` with no ability for the user to filter or split that traffic after the fact.

Previously `googleads` would show up separately in the Sources report but after https://github.com/plausible/analytics/pull/4751 it's merged with `Google`. This means customers who rely on manually tagged `?ref` and `?source` params lost some data.

This PR intends to fix this going forward with 2 functional changes:
* Makes `?ref` and `?source` query params a true alias for `?utm_source` so they are handled identically and stored in the `utm_source` column.
* For channel data, previously only the `?utm_source` query param was inspected to determine paid source but not `?ref` or `?source`. 

The effect for the `?ref=googleads` example above is as follows:
* Source will still be determined as **Google**
* The channel for that session will be **Paid Search** as opposed to Organic Search
* The UTM Sources report will contain a **googleads** entry that user can filter for instead of being empty

Unfortunately for a case like this the historical data was lost. It may be possible with some effort to dig into backups and restore most of it. Doesn't look like the impact is big enough to warrant that at the moment, though.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
