### PR TITLE
Channels: Backfill click_id_param based on historical data

### DIFF
--- a/priv/ingest_repo/migrations/20241106113750_backfill_click_id_param.exs
+++ b/priv/ingest_repo/migrations/20241106113750_backfill_click_id_param.exs
@@ -1,0 +1,24 @@
+defmodule Plausible.IngestRepo.Migrations.BackfillClickIdParam do
+  use Ecto.Migration
+
+  def up do
+    events_sql = """
+      ALTER TABLE events_v2
+      UPDATE click_id_param = transform(referrer_source, ['Google', 'Bing'], ['gclid', 'msclkid'], '')
+      WHERE channel = 'Paid Search' AND click_id_param = ''
+    """
+
+    sessions_sql = """
+      ALTER TABLE sessions_v2
+      UPDATE click_id_param = transform(referrer_source, ['Google', 'Bing'], ['gclid', 'msclkid'], '')
+      WHERE channel = 'Paid Search' AND click_id_param = ''
+    """
+
+    execute(fn -> repo().query!(events_sql) end)
+    execute(fn -> repo().query!(sessions_sql) end)
+  end
+
+  def down do
+    raise "irreversible"
+  end
+end


### PR DESCRIPTION
This will allow channels calculated in clickhouse to be accurate.

Tested via this query:

```sql
select referrer_source, count() as t, transform(referrer_source, ['Google', 'Bing'], ['gclid', 'msclkid'], '')
from events_v2
where timestamp > now() - toIntervalDay(30) AND channel = 'Paid Search' AND click_id_param = ''
group by referrer_source
order by t desc
limit 5
```