### PR TITLE
Average Scroll Depth Metric

### DIFF
--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -135,7 +135,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
       {
         label: reportInfo.dimensionLabel,
         key: 'name',
-        width: 'w-48 md:w-80 flex items-center break-all',
+        width: 'w-48 md:w-full flex items-center break-all',
         align: 'left',
         renderItem: (item) => (
           <NameCell

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -51,7 +51,8 @@ function PagesModal() {
       metrics.createVisitors({renderLabel: (_query) => "Visitors" }),
       metrics.createPageviews(),
       metrics.createBounceRate(),
-      metrics.createTimeOnPage()
+      metrics.createTimeOnPage(),
+      metrics.createScrollDepth()
     ]
   }
 

--- a/assets/js/dashboard/stats/reports/metric-formatter.ts
+++ b/assets/js/dashboard/stats/reports/metric-formatter.ts
@@ -38,6 +38,7 @@ export const MetricFormatterShort: Record<
 
   bounce_rate: percentageFormatter,
   conversion_rate: percentageFormatter,
+  scroll_depth: percentageFormatter,
   exit_rate: percentageFormatter,
   group_conversion_rate: percentageFormatter,
   percentage: percentageFormatter,
@@ -65,6 +66,7 @@ export const MetricFormatterLong: Record<
 
   bounce_rate: percentageFormatter,
   conversion_rate: percentageFormatter,
+  scroll_depth: percentageFormatter,
   exit_rate: percentageFormatter,
   group_conversion_rate: percentageFormatter,
   percentage: percentageFormatter,

--- a/assets/js/dashboard/stats/reports/metrics.js
+++ b/assets/js/dashboard/stats/reports/metrics.js
@@ -172,7 +172,7 @@ export const createVisitDuration = (props) => {
 export const createBounceRate = (props) => {
   const renderLabel = (_query) => 'Bounce Rate'
   return new Metric({
-    width: 'w-32',
+    width: 'w-28',
     ...props,
     key: 'bounce_rate',
     renderLabel,
@@ -194,7 +194,7 @@ export const createPageviews = (props) => {
 export const createTimeOnPage = (props) => {
   const renderLabel = (_query) => 'Time on Page'
   return new Metric({
-    width: 'w-32',
+    width: 'w-28',
     ...props,
     key: 'time_on_page',
     renderLabel,
@@ -208,6 +208,17 @@ export const createExitRate = (props) => {
     width: 'w-28',
     ...props,
     key: 'exit_rate',
+    renderLabel,
+    sortable: false
+  })
+}
+
+export const createScrollDepth = (props) => {
+  const renderLabel = (_query) => "Scroll Depth"
+  return new Metric({
+    width: 'w-28', 
+    ...props,
+    key: "scroll_depth",
     renderLabel,
     sortable: false
   })

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -15,6 +15,7 @@ export type Metric =
   | "events"
   | "percentage"
   | "conversion_rate"
+  | "scroll_depth"
   | "group_conversion_rate"
   | "time_on_page"
   | "total_revenue"

--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -17,6 +17,7 @@ defmodule Plausible.ClickhouseEventV2 do
 
     field :"meta.key", {:array, :string}
     field :"meta.value", {:array, :string}
+    field :scroll_depth, Ch, type: "UInt8"
 
     field :revenue_source_amount, Ch, type: "Nullable(Decimal64(3))"
     field :revenue_source_currency, Ch, type: "FixedString(3)"
@@ -59,6 +60,7 @@ defmodule Plausible.ClickhouseEventV2 do
         :timestamp,
         :"meta.key",
         :"meta.value",
+        :scroll_depth,
         :revenue_source_amount,
         :revenue_source_currency,
         :revenue_reporting_amount,

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -246,7 +246,8 @@ defmodule Plausible.Ingestion.Event do
       timestamp: event.request.timestamp,
       name: event.request.event_name,
       hostname: event.request.hostname,
-      pathname: event.request.pathname
+      pathname: event.request.pathname,
+      scroll_depth: event.request.scroll_depth
     })
   end
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -541,6 +541,17 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
+  defp validate_metric(:scroll_depth = metric, query) do
+    page_dimension? = Enum.member?(query.dimensions, "event:page")
+    toplevel_page_filter? = not is_nil(Filters.get_toplevel_filter(query, "event:page"))
+
+    if page_dimension? or toplevel_page_filter? do
+      :ok
+    else
+      {:error, "Metric `#{metric}` can only be queried with event:page filters or dimensions."}
+    end
+  end
+
   defp validate_metric(:views_per_visit = metric, query) do
     cond do
       Filters.filtering_on_dimension?(query, "event:page") ->

--- a/lib/plausible/stats/metrics.ex
+++ b/lib/plausible/stats/metrics.ex
@@ -18,7 +18,8 @@ defmodule Plausible.Stats.Metrics do
                  :conversion_rate,
                  :group_conversion_rate,
                  :time_on_page,
-                 :percentage
+                 :percentage,
+                 :scroll_depth
                ] ++ on_ee(do: Plausible.Stats.Goal.Revenue.revenue_metrics(), else: [])
 
   @metric_mappings Enum.into(@all_metrics, %{}, fn metric -> {to_string(metric), metric} end)

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -245,6 +245,7 @@ defmodule Plausible.Stats.SQL.Expression do
 
   def event_metric(:percentage), do: %{}
   def event_metric(:conversion_rate), do: %{}
+  def event_metric(:scroll_depth), do: %{}
   def event_metric(:group_conversion_rate), do: %{}
   def event_metric(:total_visitors), do: %{}
 

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -126,7 +126,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     |> Enum.reduce(%{}, &Map.merge/2)
   end
 
-  defp build_group_by(q, table, query) do
+  def build_group_by(q, table, query) do
     Enum.reduce(query.dimensions, q, &dimension_group_by(&2, table, query, &1))
   end
 

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -16,6 +16,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
     |> maybe_add_percentage_metric(site, query)
     |> maybe_add_global_conversion_rate(site, query)
     |> maybe_add_group_conversion_rate(site, query)
+    |> maybe_add_scroll_depth(site, query)
   end
 
   defp maybe_add_percentage_metric(q, site, query) do
@@ -119,6 +120,71 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
     else
       q
     end
+  end
+
+  def maybe_add_scroll_depth(q, site, query) do
+    cond do
+      :scroll_depth not in query.metrics -> q
+      query.dimensions == [] -> add_aggregate_scroll_depth(q, site, query)
+      true -> add_group_scroll_depth(q, site, query)
+    end
+  end
+
+  defp add_aggregate_scroll_depth(q, site, query) do
+    max_per_visitor_q =
+      Base.base_event_query(site, query)
+      |> where([e], e.name == "pageleave")
+      |> select([e], %{
+        user_id: e.user_id,
+        max_scroll_depth: max(e.scroll_depth)
+      })
+      |> group_by([e], e.user_id)
+
+    scroll_depth_q =
+      subquery(max_per_visitor_q)
+      |> select([p], fragment("toUInt8(round(ifNotFinite(avg(?), 0)))", p.max_scroll_depth))
+
+    select_merge_as(q, [e], %{scroll_depth: subquery(scroll_depth_q)})
+  end
+
+  defp add_group_scroll_depth(q, site, query) do
+    max_per_visitor_q =
+      Base.base_event_query(site, query)
+      |> where([e], e.name == "pageleave")
+      |> select([e], %{
+        user_id: e.user_id,
+        max_scroll_depth: max(e.scroll_depth)
+      })
+      |> SQL.QueryBuilder.build_group_by(:events, query)
+      |> group_by([e], e.user_id)
+
+    dim_shortnames = Enum.map(query.dimensions, fn dim -> shortname(query, dim) end)
+
+    dim_select =
+      dim_shortnames
+      |> Enum.map(fn dim -> {dim, dynamic([p], field(p, ^dim))} end)
+      |> Map.new()
+
+    dim_group_by =
+      dim_shortnames
+      |> Enum.map(fn dim -> dynamic([p], field(p, ^dim)) end)
+
+    scroll_depth_q =
+      subquery(max_per_visitor_q)
+      |> select([p], %{
+        scroll_depth: fragment("toUInt8(round(ifNotFinite(avg(?), 0)))", p.max_scroll_depth)
+      })
+      |> select_merge(^dim_select)
+      |> group_by(^dim_group_by)
+
+    join_on_dim_condition =
+      dim_shortnames
+      |> Enum.map(fn dim -> dynamic([_e, ..., s], selected_as(^dim) == field(s, ^dim)) end)
+      |> Enum.reduce(fn condition, acc -> dynamic([], ^acc and ^condition) end)
+
+    q
+    |> join(:left, [e], s in subquery(scroll_depth_q), on: ^join_on_dim_condition)
+    |> select_merge_as([_e, ..., s], %{scroll_depth: fragment("any(?)", s.scroll_depth)})
   end
 
   # `total_visitors_subquery` returns a subquery which selects `total_visitors` -

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -74,6 +74,7 @@ defmodule Plausible.Stats.TableDecider do
 
   defp metric_partitioner(_, :average_revenue), do: :event
   defp metric_partitioner(_, :total_revenue), do: :event
+  defp metric_partitioner(_, :scroll_depth), do: :event
   defp metric_partitioner(_, :pageviews), do: :event
   defp metric_partitioner(_, :events), do: :event
   defp metric_partitioner(_, :bounce_rate), do: :session

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -87,6 +87,7 @@ defmodule Plausible.Stats.Timeseries do
         :views_per_visit -> Map.merge(row, %{views_per_visit: 0.0})
         :conversion_rate -> Map.merge(row, %{conversion_rate: 0.0})
         :group_conversion_rate -> Map.merge(row, %{group_conversion_rate: 0.0})
+        :scroll_depth -> Map.merge(row, %{scroll_depth: 0})
         :bounce_rate -> Map.merge(row, %{bounce_rate: 0.0})
         :visit_duration -> Map.merge(row, %{visit_duration: nil})
         :average_revenue -> Map.merge(row, %{average_revenue: nil})

--- a/lib/plausible_web/controllers/api/external_query_api_controller.ex
+++ b/lib/plausible_web/controllers/api/external_query_api_controller.ex
@@ -7,21 +7,47 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
   alias Plausible.Stats.Query
 
   def query(conn, params) do
-    site = Repo.preload(conn.assigns.site, :owner)
+    # Temporary - instead of passing the user down to QueryParser, check the
+    # scroll depth feature flag here.
+    if passes_scroll_depth_feature_gate?(params, conn.assigns) do
+      site = Repo.preload(conn.assigns.site, :owner)
 
-    case Query.build(site, conn.assigns.schema_type, params, debug_metadata(conn)) do
-      {:ok, query} ->
-        results = Plausible.Stats.query(site, query)
-        json(conn, results)
+      case Query.build(site, conn.assigns.schema_type, params, debug_metadata(conn)) do
+        {:ok, query} ->
+          results = Plausible.Stats.query(site, query)
+          json(conn, results)
 
-      {:error, message} ->
-        conn
-        |> put_status(400)
-        |> json(%{error: message})
+        {:error, message} ->
+          conn
+          |> put_status(400)
+          |> json(%{error: message})
+      end
+    else
+      conn
+      |> put_status(400)
+      |> json(%{error: "Invalid metric \"scroll depth\""})
     end
   end
 
+  # Also temporary - Since the scroll_depth metric is private, there's no need
+  # to expose it in the public schema.
+  @schema_without_scroll_depth Plausible.Stats.JSONSchema.raw_public_schema()
+                               |> Plausible.Stats.JSONSchema.Utils.traverse(fn
+                                 %{"const" => "scroll_depth"} -> :remove
+                                 value -> value
+                               end)
+
   def schema(conn, _params) do
-    json(conn, Plausible.Stats.JSONSchema.raw_public_schema())
+    json(conn, @schema_without_scroll_depth)
+  end
+
+  defp passes_scroll_depth_feature_gate?(params, assigns) do
+    metrics = params["metrics"]
+    user = assigns[:current_user]
+
+    scroll_depth_queried? = is_list(metrics) and "scroll_depth" in metrics
+    scroll_depth_enabled? = user && FunWithFlags.enabled?(:scroll_depth, for: user)
+
+    if scroll_depth_queried?, do: scroll_depth_enabled?, else: true
   end
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -814,9 +814,16 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site, params, debug_metadata(conn))
 
     extra_metrics =
-      if params["detailed"],
-        do: [:pageviews, :bounce_rate, :time_on_page],
-        else: []
+      cond do
+        params["detailed"] && !query.include_imported ->
+          [:pageviews, :bounce_rate, :time_on_page, :scroll_depth]
+
+        params["detailed"] ->
+          [:pageviews, :bounce_rate, :time_on_page]
+
+        true ->
+          []
+      end
 
     metrics = breakdown_metrics(query, extra_metrics)
     pagination = parse_pagination(params)

--- a/priv/ingest_repo/migrations/20241028142653_add_scroll_depth_to_events.exs
+++ b/priv/ingest_repo/migrations/20241028142653_add_scroll_depth_to_events.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events_v2) do
+      add :scroll_depth, :UInt8
+    end
+  end
+end

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -269,6 +269,10 @@
         {
           "const": "average_revenue",
           "$comment": "only :internal"
+        },
+        {
+          "const": "scroll_depth",
+          "markdownDescription": "The percentage of page content (y-axis) that was visible to an average visitor. Requires: an `event:page` filter or dimension"
         }
       ]
     },

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -334,6 +334,40 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :no_session_for_pageleave
   end
 
+  test "saves scroll depth for a pageleave event" do
+    site = insert(:site)
+
+    pageview_payload = %{
+      name: "pageview",
+      url: "http://#{site.domain}",
+      domain: site.domain
+    }
+
+    build_conn(:post, "/api/events", pageview_payload)
+    |> Request.build()
+    |> then(fn {:ok, pageview_request} ->
+      Event.build_and_buffer(pageview_request)
+    end)
+
+    assert_ingested_scroll_depth = fn input, expected ->
+      payload = %{name: "pageleave", url: "http://#{site.domain}", domain: site.domain, sd: input}
+      conn = build_conn(:post, "/api/events", payload)
+
+      assert {:ok, request} = Request.build(conn)
+      assert {:ok, %{buffered: [event], dropped: []}} = Event.build_and_buffer(request)
+
+      assert event.clickhouse_event.scroll_depth == expected
+    end
+
+    assert_ingested_scroll_depth.(100, 100)
+    assert_ingested_scroll_depth.(50, 50)
+    assert_ingested_scroll_depth.(0, 0)
+    assert_ingested_scroll_depth.(101, 100)
+    assert_ingested_scroll_depth.(-1, 0)
+    assert_ingested_scroll_depth.("1", 0)
+    assert_ingested_scroll_depth.("invalid", 0)
+  end
+
   @tag :ee_only
   test "saves revenue amount" do
     site = insert(:site)

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -464,7 +464,8 @@ defmodule Plausible.Ingestion.RequestTest do
              "revenue_source" => %{"amount" => "12.3", "currency" => "USD"},
              "uri" => "https://dummy.site/pictures/index.html?foo=bar&baz=bam",
              "user_agent" => "Mozilla",
-             "ip_classification" => nil
+             "ip_classification" => nil,
+             "scroll_depth" => nil
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1421,6 +1421,64 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
   end
 
+  describe "scroll_depth metric" do
+    test "fails validation on its own", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["scroll_depth"],
+        "date_range" => "all"
+      }
+      |> check_error(
+        site,
+        "Metric `scroll_depth` can only be queried with event:page filters or dimensions."
+      )
+    end
+
+    test "succeeds with event:page filter", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["scroll_depth"],
+        "date_range" => "all",
+        "filters" => [["is", "event:page", ["/"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:scroll_depth],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:page", ["/"]]],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+    end
+
+    test "succeeds with event:page dimension", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["scroll_depth"],
+        "date_range" => "all",
+        "dimensions" => ["event:page"]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:scroll_depth],
+          utc_time_range: @date_range_day,
+          filters: [],
+          dimensions: ["event:page"],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+    end
+  end
+
   describe "views_per_visit metric" do
     test "succeeds with normal filters", %{site: site} do
       insert(:goal, %{site: site, event_name: "Signup"})

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -127,6 +127,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
              }
     end
 
+    test "scroll depth metric is not recognized in the legacy API v1", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/aggregate", %{
+          "site_id" => site.domain,
+          "period" => "30d",
+          "metrics" => "scroll_depth"
+        })
+
+      assert json_response(conn, 400) == %{
+               "error" =>
+                 "The metric `scroll_depth` is not recognized. Find valid metrics from the documentation: https://plausible.io/docs/stats-api#metrics"
+             }
+    end
+
     for property <- ["event:name", "event:goal", "event:props:custom_prop"] do
       test "validates that session metrics cannot be used with #{property} filter", %{
         conn: conn,

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -101,6 +101,61 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
+    test "can query scroll_depth metric with a page filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
+        build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:10]),
+        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
+        build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageleave, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "filters" => [["is", "event:page", ["/"]]],
+          "date_range" => "all",
+          "metrics" => ["visitors", "scroll_depth"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"metrics" => [2, 70], "dimensions" => []}
+             ]
+    end
+
+    test "scroll depth is 0 when no pageleave data in range", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "filters" => [["is", "event:page", ["/"]]],
+          "date_range" => "all",
+          "metrics" => ["visitors", "scroll_depth"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"metrics" => [1, 0], "dimensions" => []}
+             ]
+    end
+
+    test "scroll depth is 0 when no data at all in range", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "filters" => [["is", "event:page", ["/"]]],
+          "date_range" => "all",
+          "metrics" => ["visitors", "scroll_depth"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"metrics" => [0, 0], "dimensions" => []}
+             ]
+    end
+
     test "does not count pageleave events towards the events metric in a simple aggregate query",
          %{conn: conn, site: site} do
       populate_stats(site, [
@@ -1127,6 +1182,40 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   end
 
   describe "timeseries" do
+    test "scroll_depth metric in a time:day breakdown", %{conn: conn, site: site} do
+      t0 = ~N[2020-01-01 00:00:00]
+      [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+      populate_stats(site, [
+        build(:pageview, user_id: 12, timestamp: t0),
+        build(:pageleave, user_id: 12, timestamp: t1, scroll_depth: 20),
+        build(:pageview, user_id: 34, timestamp: t0),
+        build(:pageleave, user_id: 34, timestamp: t1, scroll_depth: 17),
+        build(:pageview, user_id: 34, timestamp: t2),
+        build(:pageleave, user_id: 34, timestamp: t3, scroll_depth: 60),
+        build(:pageview, user_id: 56, timestamp: NaiveDateTime.add(t0, 1, :day)),
+        build(:pageleave,
+          user_id: 56,
+          timestamp: NaiveDateTime.add(t1, 1, :day),
+          scroll_depth: 20
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["scroll_depth"],
+          "date_range" => "all",
+          "dimensions" => ["time:day"],
+          "filters" => [["is", "event:page", ["/"]]]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["2020-01-01"], "metrics" => [40]},
+               %{"dimensions" => ["2020-01-02"], "metrics" => [20]}
+             ]
+    end
+
     test "shows hourly data for a certain date with time_labels", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),
@@ -1713,6 +1802,187 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
     assert json_response(conn, 200)["results"] == [
              %{"dimensions" => ["/"], "metrics" => [2]},
              %{"dimensions" => ["/plausible.io"], "metrics" => [1]}
+           ]
+  end
+
+  test "breakdown by event:page with scroll_depth metric", %{conn: conn, site: site} do
+    t0 = ~N[2020-01-01 00:00:00]
+    [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+    populate_stats(site, [
+      build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
+      build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+      build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
+      build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+      build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
+      build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+      build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
+      build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+      build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
+      build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+      build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
+      build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+    ])
+
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "pageviews", "scroll_depth"],
+        "date_range" => "all",
+        "dimensions" => ["event:page"]
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["/blog"], "metrics" => [3, 4, 60]},
+             %{"dimensions" => ["/another"], "metrics" => [2, 2, 25]}
+           ]
+  end
+
+  test "breakdown by event:page + visit:source with scroll_depth metric", %{
+    conn: conn,
+    site: site
+  } do
+    t0 = ~N[2020-01-01 00:00:00]
+    [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+    populate_stats(site, [
+      build(:pageview, referrer_source: "Google", user_id: 12, pathname: "/blog", timestamp: t0),
+      build(:pageleave,
+        referrer_source: "Google",
+        user_id: 12,
+        pathname: "/blog",
+        timestamp: t1,
+        scroll_depth: 20
+      ),
+      build(:pageview,
+        referrer_source: "Google",
+        user_id: 12,
+        pathname: "/another",
+        timestamp: t1
+      ),
+      build(:pageleave,
+        referrer_source: "Google",
+        user_id: 12,
+        pathname: "/another",
+        timestamp: t2,
+        scroll_depth: 24
+      ),
+      build(:pageview, referrer_source: "Google", user_id: 34, pathname: "/blog", timestamp: t0),
+      build(:pageleave,
+        referrer_source: "Google",
+        user_id: 34,
+        pathname: "/blog",
+        timestamp: t1,
+        scroll_depth: 17
+      ),
+      build(:pageview,
+        referrer_source: "Google",
+        user_id: 34,
+        pathname: "/another",
+        timestamp: t1
+      ),
+      build(:pageleave,
+        referrer_source: "Google",
+        user_id: 34,
+        pathname: "/another",
+        timestamp: t2,
+        scroll_depth: 26
+      ),
+      build(:pageview, referrer_source: "Google", user_id: 34, pathname: "/blog", timestamp: t2),
+      build(:pageleave,
+        referrer_source: "Google",
+        user_id: 34,
+        pathname: "/blog",
+        timestamp: t3,
+        scroll_depth: 60
+      ),
+      build(:pageview, referrer_source: "Twitter", user_id: 56, pathname: "/blog", timestamp: t0),
+      build(:pageleave,
+        referrer_source: "Twitter",
+        user_id: 56,
+        pathname: "/blog",
+        timestamp: t1,
+        scroll_depth: 20
+      ),
+      build(:pageview,
+        referrer_source: "Twitter",
+        user_id: 56,
+        pathname: "/another",
+        timestamp: t1
+      ),
+      build(:pageleave,
+        referrer_source: "Twitter",
+        user_id: 56,
+        pathname: "/another",
+        timestamp: t2,
+        scroll_depth: 24
+      )
+    ])
+
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "pageviews", "scroll_depth"],
+        "date_range" => "all",
+        "dimensions" => ["event:page", "visit:source"]
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["/blog", "Google"], "metrics" => [2, 3, 40]},
+             %{"dimensions" => ["/another", "Google"], "metrics" => [2, 2, 25]},
+             %{"dimensions" => ["/blog", "Twitter"], "metrics" => [1, 1, 20]},
+             %{"dimensions" => ["/another", "Twitter"], "metrics" => [1, 1, 24]}
+           ]
+  end
+
+  test "breakdown by event:page + time:day with scroll_depth metric", %{conn: conn, site: site} do
+    t0 = ~N[2020-01-01 00:00:00]
+    [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+    populate_stats(site, [
+      build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
+      build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+      build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
+      build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+      build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
+      build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+      build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
+      build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+      build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
+      build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+      build(:pageview, user_id: 56, pathname: "/blog", timestamp: NaiveDateTime.add(t0, 1, :day)),
+      build(:pageleave,
+        user_id: 56,
+        pathname: "/blog",
+        timestamp: NaiveDateTime.add(t1, 1, :day),
+        scroll_depth: 20
+      ),
+      build(:pageview,
+        user_id: 56,
+        pathname: "/another",
+        timestamp: NaiveDateTime.add(t1, 1, :day)
+      ),
+      build(:pageleave,
+        user_id: 56,
+        pathname: "/another",
+        timestamp: NaiveDateTime.add(t2, 1, :day),
+        scroll_depth: 24
+      )
+    ])
+
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => site.domain,
+        "metrics" => ["scroll_depth"],
+        "date_range" => "all",
+        "dimensions" => ["event:page", "time:day"]
+      })
+
+    assert json_response(conn, 200)["results"] == [
+             %{"dimensions" => ["/blog", "2020-01-01"], "metrics" => [40]},
+             %{"dimensions" => ["/another", "2020-01-01"], "metrics" => [25]},
+             %{"dimensions" => ["/another", "2020-01-02"], "metrics" => [24]},
+             %{"dimensions" => ["/blog", "2020-01-02"], "metrics" => [20]}
            ]
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -584,6 +584,56 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
     end
   end
 
+  describe "GET /api/stats/main-graph - scroll_depth plot" do
+    setup [:create_user, :log_in, :create_new_site]
+
+    test "returns 400 when scroll_depth is queried without a page filter", %{
+      conn: conn,
+      site: site
+    } do
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=month&date=2021-01-01&metric=scroll_depth"
+        )
+
+      assert %{"error" => error} = json_response(conn, 400)
+      assert error =~ "can only be queried with a page filter"
+    end
+
+    test "returns scroll depth per day", %{conn: conn, site: site} do
+      t0 = ~N[2020-01-01 00:00:00]
+      [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+      populate_stats(site, [
+        build(:pageview, user_id: 12, timestamp: t0),
+        build(:pageleave, user_id: 12, timestamp: t1, scroll_depth: 20),
+        build(:pageview, user_id: 34, timestamp: t0),
+        build(:pageleave, user_id: 34, timestamp: t1, scroll_depth: 17),
+        build(:pageview, user_id: 34, timestamp: t2),
+        build(:pageleave, user_id: 34, timestamp: t3, scroll_depth: 60),
+        build(:pageview, user_id: 56, timestamp: NaiveDateTime.add(t0, 1, :day)),
+        build(:pageleave,
+          user_id: 56,
+          timestamp: NaiveDateTime.add(t1, 1, :day),
+          scroll_depth: 20
+        )
+      ])
+
+      filters = Jason.encode!(%{page: "/"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/main-graph?period=7d&date=2020-01-07&metric=scroll_depth&filters=#{filters}"
+        )
+
+      assert %{"plot" => plot} = json_response(conn, 200)
+
+      assert plot == [40, 20, 0, 0, 0, 0, 0]
+    end
+  end
+
   describe "GET /api/stats/main-graph - conversion_rate plot" do
     setup [:create_user, :log_in, :create_new_site]
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -272,14 +272,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 0,
-                 "time_on_page" => 600
+                 "time_on_page" => 600,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/john-1",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -334,14 +336,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 0,
-                 "time_on_page" => 120.0
+                 "time_on_page" => 120.0,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -386,14 +390,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -442,14 +448,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/john-1",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -584,8 +592,50 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                }
+             ]
+    end
+
+    test "calculates scroll_depth", %{conn: conn, site: site} do
+      t0 = ~N[2020-01-01 00:00:00]
+      [t1, t2, t3] = for i <- 1..3, do: NaiveDateTime.add(t0, i, :minute)
+
+      populate_stats(site, [
+        build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
+        build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
+        build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
+        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
+        build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
+        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
+        build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&date=2020-01-01&detailed=true")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "/blog",
+                 "visitors" => 3,
+                 "pageviews" => 4,
+                 "bounce_rate" => 33,
+                 "time_on_page" => 60,
+                 "scroll_depth" => 60
+               },
+               %{
+                "name" => "/another",
+                "visitors" => 2,
+                "pageviews" => 2,
+                "bounce_rate" => 0,
+                "time_on_page" => 60,
+                "scroll_depth" => 25
+              }
              ]
     end
 
@@ -631,14 +681,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/about",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -685,7 +737,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -731,21 +784,24 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/post-1",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/post-2",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -783,14 +839,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => 60
+                 "time_on_page" => 60,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/(/post-2",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -836,14 +894,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 50,
-                 "time_on_page" => 600
+                 "time_on_page" => 600,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/about",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil
+                 "time_on_page" => nil,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -937,14 +997,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "time_on_page" => 900.0,
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "name" => "/"
+                 "name" => "/",
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 0,
                  "time_on_page" => nil,
                  "visitors" => 1,
                  "pageviews" => 1,
-                 "name" => "/some-other-page"
+                 "name" => "/some-other-page",
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -984,7 +1046,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/about",
                  "pageviews" => 2,
                  "time_on_page" => nil,
-                 "visitors" => 2
+                 "visitors" => 2,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1063,14 +1126,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "name" => "/about-blog",
                  "pageviews" => 3,
                  "time_on_page" => 1140.0,
-                 "visitors" => 2
+                 "visitors" => 2,
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 0,
                  "name" => "/exit-blog",
                  "pageviews" => 1,
                  "time_on_page" => nil,
-                 "visitors" => 1
+                 "visitors" => 1,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1418,17 +1483,20 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                    "pageviews" => 0,
                    "time_on_page" => 0,
                    "visitors" => 0,
+                   "scroll_depth" => 0,
                    "change" => %{
                      "bounce_rate" => nil,
                      "pageviews" => 100,
                      "time_on_page" => nil,
-                     "visitors" => 100
+                     "visitors" => 100,
+                     "scroll_depth" => 0
                    }
                  },
                  "name" => "/page2",
                  "pageviews" => 2,
                  "time_on_page" => nil,
-                 "visitors" => 2
+                 "visitors" => 2,
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 100,
@@ -1436,16 +1504,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 1,
                  "time_on_page" => nil,
                  "visitors" => 1,
+                 "scroll_depth" => 0,
                  "comparison" => %{
                    "bounce_rate" => 100,
                    "pageviews" => 1,
                    "time_on_page" => nil,
                    "visitors" => 1,
+                   "scroll_depth" => 0,
                    "change" => %{
                      "bounce_rate" => 0,
                      "pageviews" => 0,
                      "time_on_page" => nil,
-                     "visitors" => 0
+                     "visitors" => 0,
+                     "scroll_depth" => 0
                    }
                  }
                }

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -891,7 +891,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
     } do
       filters = Jason.encode!(%{page: "/A"})
 
-      [visitors, visits, pageviews, bounce_rate, time_on_page] =
+      [visitors, visits, pageviews, bounce_rate, time_on_page, scroll_depth] =
         conn
         |> get("/api/stats/#{site.domain}/top-stats?filters=#{filters}")
         |> json_response(200)
@@ -902,6 +902,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       assert %{"graph_metric" => "pageviews"} = pageviews
       assert %{"graph_metric" => "bounce_rate"} = bounce_rate
       assert %{"graph_metric" => "time_on_page"} = time_on_page
+      assert %{"graph_metric" => "scroll_depth"} = scroll_depth
     end
 
     test "returns graph_metric key for top stats with a goal filter", %{
@@ -955,6 +956,46 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert %{"name" => "Unique visitors", "value" => 2, "graph_metric" => "visitors"} in res[
+               "top_stats"
+             ]
+    end
+
+    test "returns scroll_depth with a page filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event,
+          user_id: 123,
+          name: "pageleave",
+          timestamp: ~N[2021-01-01 00:00:10],
+          scroll_depth: 40
+        ),
+        build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:10]),
+        build(:event,
+          user_id: 123,
+          name: "pageleave",
+          timestamp: ~N[2021-01-01 00:00:20],
+          scroll_depth: 60
+        ),
+        build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event,
+          user_id: 456,
+          name: "pageleave",
+          timestamp: ~N[2021-01-01 00:00:10],
+          scroll_depth: 80
+        )
+      ])
+
+      filters = Jason.encode!(%{page: "/"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      res = json_response(conn, 200)
+
+      assert %{"name" => "Scroll depth", "value" => 70, "graph_metric" => "scroll_depth"} in res[
                "top_stats"
              ]
     end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -139,6 +139,10 @@ defmodule Plausible.Factory do
     Map.put(event_factory(), :name, "pageview")
   end
 
+  def pageleave_factory do
+    Map.put(event_factory(), :name, "pageleave")
+  end
+
   def event_factory do
     hostname = sequence(:domain, &"example-#{&1}.com")
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,6 +13,8 @@ else
   FunWithFlags.disable(:read_team_schemas)
 end
 
+FunWithFlags.enable(:scroll_depth)
+
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 
 # warn about minio if it's included in tests but not running

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -48,6 +48,38 @@
   // flag prevents sending multiple pageleaves in those cases.
   var pageLeaveSending = false
 
+  var bodyEl = document.body
+  var docEl = document.documentElement
+
+  function getDocumentHeight() {
+    return Math.max(
+      bodyEl.scrollHeight || 0,
+      bodyEl.offsetHeight || 0,
+      bodyEl.clientHeight || 0,
+      docEl.scrollHeight || 0,
+      docEl.offsetHeight || 0,
+      docEl.clientHeight || 0
+    )
+  }
+
+  function getCurrentScrollDepthPx() {
+    var viewportHeight = window.innerHeight || docEl.clientHeight || 0
+    var scrollTop = window.scrollY || docEl.scrollTop || bodyEl.scrollTop || 0
+
+    return currentDocumentHeight <= viewportHeight ? currentDocumentHeight : scrollTop + viewportHeight
+  }
+
+  var currentDocumentHeight = getDocumentHeight()
+  var maxScrollDepthPx = getCurrentScrollDepthPx()
+
+  document.addEventListener('scroll', function() {
+    var currentScrollDepthPx = getCurrentScrollDepthPx()
+
+    if (currentScrollDepthPx > maxScrollDepthPx) {
+      maxScrollDepthPx = currentScrollDepthPx
+    }
+  })
+
   function triggerPageLeave() {
     if (pageLeaveSending) {return}
     pageLeaveSending = true
@@ -55,6 +87,7 @@
 
     var payload = {
       n: 'pageleave',
+      sd: Math.round((maxScrollDepthPx / currentDocumentHeight) * 100),
       d: dataDomain,
       u: currentPageLeaveURL,
     }
@@ -202,6 +235,8 @@
       if (isSPANavigation && listeningPageLeave) {
         triggerPageLeave();
         currentPageLeaveURL = location.href;
+        currentDocumentHeight = getDocumentHeight()
+        maxScrollDepthPx = getCurrentScrollDepthPx()
       }
       {{/if}}
 


### PR DESCRIPTION
### Changes

- [x] Modify the `pageleave` script variant to start tracking scroll depth
- [x] Start ingesting pageleaves with a `scroll_depth` value from 0 to 100
- [x] Add querying logic for `scroll_depth` (also expose it in Query API v2 under a user-based feature flag)
- [x] Show scroll depth on the dashboard - Top Pages > Details (always); Top Stats / Main Graph (only when page filter applied)
- [ ] TODO: Configure feature flag access to scroll depth on the dashboard
- [ ] TODO: Extract migration

There are still other things missing (e.g. making scroll depth sortable, Dashboard CSV export, Full CSV import/export, dealing with scroll depth when imported data is included, etc...), but since it's feature flagged anyway, we could already merge the bigger chunk of this and iron out the smaller details later. Then we'll already have some real scroll depth data to work with.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
