### PR TITLE
Saved segments/create table

### DIFF
--- a/priv/repo/migrations/20241107120000_create_segments.exs
+++ b/priv/repo/migrations/20241107120000_create_segments.exs
@@ -2,14 +2,16 @@ defmodule Plausible.Repo.Migrations.CreateSegments do
   use Ecto.Migration
 
   def change do
+    execute(
+      "CREATE TYPE segment_type AS ENUM ('personal', 'site')",
+      "DROP TYPE segment_type"
+    )
+
     create table(:segments) do
       add :name, :string, null: false
-      add :personal, :boolean, default: true, null: false
+      add :type, :segment_type, null: false, default: "personal"
       add :segment_data, :map, null: false
       add :site_id, references(:sites, on_delete: :delete_all), null: false
-
-      # owner_id is null (aka segment is dangling) when the original owner is deassociated from the site
-      # the segment is dangling until another user edits it: the editor becomes the new owner
       add :owner_id, references(:users, on_delete: :nothing), null: true
 
       timestamps()

--- a/priv/repo/migrations/20241107120000_create_segments.exs
+++ b/priv/repo/migrations/20241107120000_create_segments.exs
@@ -1,0 +1,20 @@
+defmodule Plausible.Repo.Migrations.CreateSegments do
+  use Ecto.Migration
+
+  def change do
+    create table(:segments) do
+      add :name, :string, null: false
+      add :personal, :boolean, default: true, null: false
+      add :segment_data, :map, null: false
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+      # owner_id is null (aka segment is dangling) when the original owner is deassociated from the site
+      # the segment is dangling until another user edits it: the editor becomes the new owner
+      add :owner_id, references(:users, on_delete: :nothing), null: true
+
+      timestamps()
+    end
+
+    create index(:segments, [:segment_data], using: :gin)
+    create index(:segments, [:site_id])
+  end
+end

--- a/priv/repo/migrations/20241107120000_create_segments.exs
+++ b/priv/repo/migrations/20241107120000_create_segments.exs
@@ -7,6 +7,7 @@ defmodule Plausible.Repo.Migrations.CreateSegments do
       add :personal, :boolean, default: true, null: false
       add :segment_data, :map, null: false
       add :site_id, references(:sites, on_delete: :delete_all), null: false
+
       # owner_id is null (aka segment is dangling) when the original owner is deassociated from the site
       # the segment is dangling until another user edits it: the editor becomes the new owner
       add :owner_id, references(:users, on_delete: :nothing), null: true

--- a/priv/repo/migrations/20241107120000_create_segments.exs
+++ b/priv/repo/migrations/20241107120000_create_segments.exs
@@ -14,7 +14,6 @@ defmodule Plausible.Repo.Migrations.CreateSegments do
       timestamps()
     end
 
-    create index(:segments, [:segment_data], using: :gin)
     create index(:segments, [:site_id])
   end
 end


### PR DESCRIPTION
### Changes

Creates the saved segments table.
```
         List of data types
 Schema |     Name     | Description 
--------+--------------+-------------
 public | segment_type | 

                                           Table "public.segments"
    Column    |              Type              | Collation | Nullable |               Default                
--------------+--------------------------------+-----------+----------+--------------------------------------
 id           | bigint                         |           | not null | nextval('segments_id_seq'::regclass)
 name         | character varying(255)         |           | not null | 
 type         | segment_type                   |           | not null | 'personal'::segment_type
 segment_data | jsonb                          |           | not null | 
 site_id      | bigint                         |           | not null | 
 owner_id     | bigint                         |           |          | 
 inserted_at  | timestamp(0) without time zone |           | not null | 
 updated_at   | timestamp(0) without time zone |           | not null | 
Indexes:
    "segments_pkey" PRIMARY KEY, btree (id)
    "segments_site_id_index" btree (site_id)
Foreign-key constraints:
    "segments_owner_id_fkey" FOREIGN KEY (owner_id) REFERENCES users(id)
    "segments_site_id_fkey" FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE CASCADE
```

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
