### PR TITLE
Set default for `teams.allow_next_upgrade_override` schema column

### DIFF
--- a/priv/repo/migrations/20241111094545_set_teams_allow_next_upgrade_override_default.exs
+++ b/priv/repo/migrations/20241111094545_set_teams_allow_next_upgrade_override_default.exs
@@ -1,0 +1,15 @@
+defmodule Plausible.Repo.Migrations.SetTeamsAllowNextUpgradeOverrideDefault do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute """
+              ALTER TABLE teams ALTER COLUMN allow_next_upgrade_override SET DEFAULT false;
+            """,
+            """
+              ALTER TABLE teams ALTER COLUMN allow_next_upgrade_override DROP DEFAULT
+            """
+  end
+end


### PR DESCRIPTION
### Changes

There will be a follow-up migration setting NOT NULL constraint on that column as well (released separately after this migration is run and all out-of-sync teams entries are fixed by backfill).

