### PR TITLE
Channels: Read from new column, don't write

### DIFF
--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -27,7 +27,6 @@ defmodule Plausible.ClickhouseEventV2 do
     field :referrer, :string
     field :referrer_source, :string
     field :click_id_param, Ch, type: "LowCardinality(String)"
-    field :channel, Ch, type: "LowCardinality(String)"
     field :utm_medium, :string
     field :utm_source, :string
     field :utm_campaign, :string
@@ -44,6 +43,8 @@ defmodule Plausible.ClickhouseEventV2 do
     field :operating_system_version, Ch, type: "LowCardinality(String)"
     field :browser, Ch, type: "LowCardinality(String)"
     field :browser_version, Ch, type: "LowCardinality(String)"
+
+    field :acquisition_channel, Ch, type: "LowCardinality(String)", writable: :never
   end
 
   def new(attrs) do
@@ -72,7 +73,6 @@ defmodule Plausible.ClickhouseEventV2 do
     :session_id,
     :referrer,
     :referrer_source,
-    :channel,
     :click_id_param,
     :utm_medium,
     :utm_source,

--- a/lib/plausible/clickhouse_session_v2.ex
+++ b/lib/plausible/clickhouse_session_v2.ex
@@ -58,7 +58,6 @@ defmodule Plausible.ClickhouseSessionV2 do
     field :utm_term, :string
     field :referrer, :string
     field :referrer_source, :string
-    field :channel, Ch, type: "LowCardinality(String)"
     field :click_id_param, Ch, type: "LowCardinality(String)"
 
     field :country_code, Ch, type: "LowCardinality(FixedString(2))"
@@ -74,6 +73,8 @@ defmodule Plausible.ClickhouseSessionV2 do
     field :timestamp, :naive_datetime
 
     field :transferred_from, :string
+
+    field :acquisition_channel, Ch, type: "LowCardinality(String)", writable: :never
   end
 
   def random_uint64() do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -119,7 +119,6 @@ defmodule Plausible.Ingestion.Event do
       put_user_agent: &put_user_agent/2,
       put_basic_info: &put_basic_info/2,
       put_source_info: &put_source_info/2,
-      put_channel: &put_channel/2,
       put_props: &put_props/2,
       put_revenue: &put_revenue/2,
       put_salts: &put_salts/2,
@@ -268,21 +267,6 @@ defmodule Plausible.Ingestion.Event do
       utm_content: query_params["utm_content"],
       utm_term: query_params["utm_term"]
     })
-  end
-
-  defp put_channel(%__MODULE__{} = event, _context) do
-    session = event.clickhouse_session_attrs
-
-    channel =
-      Plausible.Ingestion.Acquisition.get_channel(
-        session[:referrer_source],
-        session[:utm_medium],
-        session[:utm_campaign],
-        session[:utm_source],
-        session[:click_id_param]
-      )
-
-    update_session_attrs(event, %{channel: channel})
   end
 
   defp put_geolocation(%__MODULE__{} = event, _context) do

--- a/lib/plausible/ingestion/write_buffer.ex
+++ b/lib/plausible/ingestion/write_buffer.ex
@@ -111,7 +111,9 @@ defmodule Plausible.Ingestion.WriteBuffer do
 
   @doc false
   def compile_time_prepare(schema) do
-    fields = schema.__schema__(:fields)
+    fields =
+      schema.__schema__(:fields)
+      |> Enum.reject(&(&1 in fields_to_ignore()))
 
     types =
       Enum.map(fields, fn field ->
@@ -147,4 +149,6 @@ defmodule Plausible.Ingestion.WriteBuffer do
       ]
     }
   end
+
+  defp fields_to_ignore(), do: [:acquisition_channel]
 end

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -115,7 +115,6 @@ defmodule Plausible.Session.CacheStore do
       pageviews: if(event.name == "pageview", do: 1, else: 0),
       events: 1,
       referrer: Map.get(session_attributes, :referrer),
-      channel: Map.get(session_attributes, :channel),
       click_id_param: Map.get(session_attributes, :click_id_param),
       referrer_source: Map.get(session_attributes, :referrer_source),
       utm_medium: Map.get(session_attributes, :utm_medium),

--- a/lib/plausible/stats/filter_suggestions.ex
+++ b/lib/plausible/stats/filter_suggestions.ex
@@ -192,7 +192,7 @@ defmodule Plausible.Stats.FilterSuggestions do
         "page" -> :pathname
         "entry_page" -> :entry_page
         "source" -> :referrer_source
-        "channel" -> :channel
+        "channel" -> :acquisition_channel
         "os" -> :operating_system
         "os_version" -> :operating_system_version
         "screen" -> :screen_size

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -151,7 +151,7 @@ defmodule Plausible.Stats.SQL.Expression do
     do: field_or_blank_value(q, key, t.source, @no_ref)
 
   def select_dimension(q, key, "visit:channel", _table, _query),
-    do: field_or_blank_value(q, key, t.channel, @no_channel)
+    do: field_or_blank_value(q, key, t.acquisition_channel, @no_channel)
 
   def select_dimension(q, key, "visit:referrer", _table, _query),
     do: field_or_blank_value(q, key, t.referrer, @no_ref)

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -123,7 +123,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
          [_, "visit:" <> key | _rest] = filter
        ) do
     # Filter events query with visit dimension if possible
-    field_name = String.to_existing_atom(key)
+    field_name = db_field_name(key)
 
     if Enum.member?(@sessions_only_visit_fields, field_name) do
       true
@@ -137,7 +137,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
   end
 
   defp add_filter(:sessions, _query, [_, "visit:" <> key | _rest] = filter) do
-    filter_field(String.to_existing_atom(key), filter)
+    filter_field(db_field_name(key), filter)
   end
 
   defp add_filter(:sessions, _query, [_, "event:" <> _ | _rest]) do
@@ -281,6 +281,9 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
   @no_ref "Direct / None"
   @not_set "(not set)"
+
+  defp db_field_name("channel"), do: :acquisition_channel
+  defp db_field_name(name), do: String.to_existing_atom(name)
 
   defp db_field_val(:source, @no_ref), do: ""
   defp db_field_val(:referrer, @no_ref), do: ""

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/channels.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/channels.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-Direct,1,50.0
+Direct,1,33.3

--- a/test/plausible_web/controllers/CSVs/30d/channels.csv
+++ b/test/plausible_web/controllers/CSVs/30d/channels.csv
@@ -1,4 +1,3 @@
 name,visitors,bounce_rate,visit_duration
-Direct,2,50,30
+Direct,3,67,20
 Organic Search,1,0,60
-Paid Search,1,100,0

--- a/test/plausible_web/controllers/CSVs/6m/channels.csv
+++ b/test/plausible_web/controllers/CSVs/6m/channels.csv
@@ -1,4 +1,4 @@
 name,visitors,bounce_rate,visit_duration
-Direct,2,50,30
-Paid Search,2,100,0
+Direct,3,67,20
 Organic Search,1,0,60
+Paid Search,1,100,0

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1274,7 +1274,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Cross-network"
+      assert session.acquisition_channel == "Cross-network"
     end
 
     test "parses paid shopping channel based on campaign/medium", %{conn: conn, site: site} do
@@ -1292,7 +1292,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Shopping"
+      assert session.acquisition_channel == "Paid Shopping"
     end
 
     test "parses paid shopping channel based on referrer source and medium", %{
@@ -1314,7 +1314,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Shopping"
+      assert session.acquisition_channel == "Paid Shopping"
     end
 
     test "parses paid shopping channel based on referrer utm_source and medium", %{
@@ -1335,7 +1335,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Shopping"
+      assert session.acquisition_channel == "Paid Shopping"
     end
 
     test "parses paid search channel based on referrer and medium", %{conn: conn, site: site} do
@@ -1354,7 +1354,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
     end
 
     test "parses paid search channel based on gclid", %{conn: conn, site: site} do
@@ -1373,7 +1373,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
       assert session.click_id_param == "gclid"
     end
 
@@ -1396,7 +1396,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
       assert session.click_id_param == "gclid"
     end
 
@@ -1416,7 +1416,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
       assert session.click_id_param == "msclkid"
     end
 
@@ -1439,7 +1439,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
       assert session.click_id_param == "msclkid"
     end
 
@@ -1458,7 +1458,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
       assert session.click_id_param == ""
     end
 
@@ -1478,7 +1478,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "parses paid social channel based on utm_source and medium", %{conn: conn, site: site} do
@@ -1496,7 +1496,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "parses paid video channel based on referrer and medium", %{conn: conn, site: site} do
@@ -1515,7 +1515,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Video"
+      assert session.acquisition_channel == "Paid Video"
     end
 
     test "parses paid video channel based on utm_source and medium", %{conn: conn, site: site} do
@@ -1533,7 +1533,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Video"
+      assert session.acquisition_channel == "Paid Video"
     end
 
     test "parses display channel", %{conn: conn, site: site} do
@@ -1551,7 +1551,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Display"
+      assert session.acquisition_channel == "Display"
     end
 
     test "parses paid other channel", %{conn: conn, site: site} do
@@ -1569,7 +1569,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Paid Other"
+      assert session.acquisition_channel == "Paid Other"
     end
 
     test "parses organic shopping channel from referrer", %{conn: conn, site: site} do
@@ -1588,7 +1588,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Shopping"
+      assert session.acquisition_channel == "Organic Shopping"
     end
 
     test "parses organic shopping channel from utm_source", %{conn: conn, site: site} do
@@ -1606,7 +1606,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Shopping"
+      assert session.acquisition_channel == "Organic Shopping"
     end
 
     test "parses organic shopping channel from utm_campaign", %{conn: conn, site: site} do
@@ -1624,7 +1624,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Shopping"
+      assert session.acquisition_channel == "Organic Shopping"
     end
 
     test "parses organic social channel from referrer", %{conn: conn, site: site} do
@@ -1643,7 +1643,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "parses organic social channel from utm_source", %{conn: conn, site: site} do
@@ -1661,7 +1661,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "parses organic social channel from utm_medium", %{conn: conn, site: site} do
@@ -1679,7 +1679,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "parses organic video channel from referrer", %{conn: conn, site: site} do
@@ -1698,7 +1698,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Video"
+      assert session.acquisition_channel == "Organic Video"
     end
 
     test "parses organic video channel from utm_source", %{conn: conn, site: site} do
@@ -1716,7 +1716,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Video"
+      assert session.acquisition_channel == "Organic Video"
     end
 
     test "parses organic video channel from utm_medium", %{conn: conn, site: site} do
@@ -1734,7 +1734,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Video"
+      assert session.acquisition_channel == "Organic Video"
     end
 
     test "parses organic search channel from referrer", %{conn: conn, site: site} do
@@ -1753,7 +1753,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "parses organic search channel from utm_source", %{conn: conn, site: site} do
@@ -1771,7 +1771,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "parses referral channel from utm_medium", %{conn: conn, site: site} do
@@ -1789,7 +1789,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Referral"
+      assert session.acquisition_channel == "Referral"
     end
 
     test "parses email channel from utm_source", %{conn: conn, site: site} do
@@ -1807,7 +1807,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Email"
+      assert session.acquisition_channel == "Email"
     end
 
     test "parses email channel from utm_medium", %{conn: conn, site: site} do
@@ -1825,7 +1825,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Email"
+      assert session.acquisition_channel == "Email"
     end
 
     test "parses affiliates channel from utm_medium", %{conn: conn, site: site} do
@@ -1843,7 +1843,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Affiliates"
+      assert session.acquisition_channel == "Affiliates"
     end
 
     test "parses audio channel from utm_medium", %{conn: conn, site: site} do
@@ -1861,7 +1861,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Audio"
+      assert session.acquisition_channel == "Audio"
     end
 
     test "parses sms channel from utm_source", %{conn: conn, site: site} do
@@ -1879,7 +1879,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "SMS"
+      assert session.acquisition_channel == "SMS"
     end
 
     test "parses sms channel from utm_medium", %{conn: conn, site: site} do
@@ -1897,7 +1897,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "SMS"
+      assert session.acquisition_channel == "SMS"
     end
 
     test "parses mobile push notifications channel from utm_medium with push", %{
@@ -1918,7 +1918,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Mobile Push Notifications"
+      assert session.acquisition_channel == "Mobile Push Notifications"
     end
 
     test "parses mobile push notifications channel from utm_medium", %{conn: conn, site: site} do
@@ -1936,7 +1936,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Mobile Push Notifications"
+      assert session.acquisition_channel == "Mobile Push Notifications"
     end
 
     test "parses referral channel if session starts with a simple referral", %{
@@ -1958,7 +1958,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Referral"
+      assert session.acquisition_channel == "Referral"
     end
 
     test "parses direct channel if session starts without referrer or utm tags", %{
@@ -1979,7 +1979,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.channel == "Direct"
+      assert session.acquisition_channel == "Direct"
     end
   end
 
@@ -2009,7 +2009,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Threads"
       assert session.utm_source == "threads"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "ig is Instagram", %{
@@ -2032,7 +2032,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Instagram"
       assert session.utm_source == "ig"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "yt is Youtube", %{
@@ -2055,7 +2055,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Youtube"
       assert session.utm_source == "yt"
-      assert session.channel == "Organic Video"
+      assert session.acquisition_channel == "Organic Video"
     end
 
     test "yt-ads is Youtube paid", %{
@@ -2078,7 +2078,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Youtube"
       assert session.utm_source == "yt-ads"
-      assert session.channel == "Paid Video"
+      assert session.acquisition_channel == "Paid Video"
     end
 
     test "fb is Facebook", %{
@@ -2101,7 +2101,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Facebook"
       assert session.utm_source == "fb"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "fb-ads is Facebook", %{
@@ -2124,7 +2124,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Facebook"
       assert session.utm_source == "fb-ads"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "fbad is Facebook", %{
@@ -2147,7 +2147,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Facebook"
       assert session.utm_source == "fbad"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "facebook-ads is Facebook", %{
@@ -2170,7 +2170,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Facebook"
       assert session.utm_source == "facebook-ads"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "Reddit-ads is Reddit", %{
@@ -2193,7 +2193,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Reddit"
       assert session.utm_source == "Reddit-ads"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "google_ads is Google", %{
@@ -2216,7 +2216,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Google"
       assert session.utm_source == "google_ads"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
     end
 
     test "Google-ads is Google", %{
@@ -2239,7 +2239,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Google"
       assert session.utm_source == "Google-ads"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
     end
 
     test "utm_source=Adwords is Google paid search", %{
@@ -2262,7 +2262,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Google"
       assert session.utm_source == "Adwords"
-      assert session.channel == "Paid Search"
+      assert session.acquisition_channel == "Paid Search"
     end
 
     test "twitter-ads is Twitter", %{
@@ -2285,7 +2285,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Twitter"
       assert session.utm_source == "twitter-ads"
-      assert session.channel == "Paid Social"
+      assert session.acquisition_channel == "Paid Social"
     end
 
     test "android-app://com.reddit.frontpage is Reddit", %{
@@ -2308,7 +2308,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Reddit"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "perplexity.ai is Perplexity", %{
@@ -2331,7 +2331,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Perplexity"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "utm_source=perplexity is Perplexity", %{
@@ -2353,7 +2353,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Perplexity"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "statics.teams.cdn.office.net is Microsoft Teams", %{
@@ -2376,7 +2376,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Microsoft Teams"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "wikipedia domain is resolved as Wikipedia", %{
@@ -2399,7 +2399,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Wikipedia"
-      assert session.channel == "Referral"
+      assert session.acquisition_channel == "Referral"
     end
 
     test "ntp.msn.com is Bing", %{
@@ -2422,7 +2422,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Bing"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "search.brave.com is Brave", %{
@@ -2445,7 +2445,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Brave"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.com.tr is Yandex", %{
@@ -2468,7 +2468,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.kz is Yandex", %{
@@ -2491,7 +2491,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "ya.ru is Yandex", %{
@@ -2514,7 +2514,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.uz is Yandex", %{
@@ -2537,7 +2537,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.fr is Yandex", %{
@@ -2560,7 +2560,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.eu is Yandex", %{
@@ -2583,7 +2583,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "yandex.tm is Yandex", %{
@@ -2606,7 +2606,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yandex"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "discord.com is Discord", %{
@@ -2629,7 +2629,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Discord"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "discordapp.com is Discord", %{
@@ -2652,7 +2652,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Discord"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "canary.discord.com is Discord", %{
@@ -2675,7 +2675,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Discord"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "ptb.discord.com is Discord", %{
@@ -2698,7 +2698,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Discord"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "www.baidu.com is Baidu", %{conn: conn, site: site} do
@@ -2718,7 +2718,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Baidu"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "t.me is Telegram", %{conn: conn, site: site} do
@@ -2738,7 +2738,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Telegram"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "webk.telegram.org is Telegram", %{conn: conn, site: site} do
@@ -2758,7 +2758,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Telegram"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "sogou.com is Sogou", %{conn: conn, site: site} do
@@ -2778,7 +2778,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Sogou"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "m.sogou.com is Sogou", %{conn: conn, site: site} do
@@ -2798,7 +2798,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Sogou"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "wap.sogou.com is Sogou", %{conn: conn, site: site} do
@@ -2818,7 +2818,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Sogou"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "linktr.ee is Linktree", %{conn: conn, site: site} do
@@ -2838,7 +2838,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Linktree"
-      assert session.channel == "Referral"
+      assert session.acquisition_channel == "Referral"
     end
 
     test "linktree is Linktree", %{conn: conn, site: site} do
@@ -2857,7 +2857,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Linktree"
-      assert session.channel == "Referral"
+      assert session.acquisition_channel == "Referral"
     end
   end
 
@@ -2887,7 +2887,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Hacker News"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "yahoo is organic search", %{
@@ -2910,7 +2910,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Yahoo!"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "gmail is email channel", %{
@@ -2933,7 +2933,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Gmail"
-      assert session.channel == "Email"
+      assert session.acquisition_channel == "Email"
     end
 
     test "utm_source=newsletter is email channel", %{
@@ -2955,7 +2955,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Newsletter-UK"
-      assert session.channel == "Email"
+      assert session.acquisition_channel == "Email"
     end
 
     test "temu.com is shopping channel", %{
@@ -2978,7 +2978,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "temu.com"
-      assert session.channel == "Organic Shopping"
+      assert session.acquisition_channel == "Organic Shopping"
     end
 
     test "utm_source=Telegram is social channel", %{
@@ -3000,7 +3000,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Telegram"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "chatgpt.com is search channel", %{
@@ -3023,7 +3023,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "chatgpt.com"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
 
     test "Slack is social channel", %{
@@ -3046,7 +3046,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Slack"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "producthunt is social", %{
@@ -3068,7 +3068,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "producthunt"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "github is social", %{
@@ -3091,7 +3091,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "GitHub"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "steamcommunity.com is social", %{
@@ -3114,7 +3114,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "steamcommunity.com"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "Vkontakte is social", %{
@@ -3137,7 +3137,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Vkontakte"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "Threads is social", %{
@@ -3160,7 +3160,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Threads"
-      assert session.channel == "Organic Social"
+      assert session.acquisition_channel == "Organic Social"
     end
 
     test "Ecosia is search", %{
@@ -3183,7 +3183,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == "Ecosia"
-      assert session.channel == "Organic Search"
+      assert session.acquisition_channel == "Organic Search"
     end
   end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -277,15 +277,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
   test "breakdown by visit:channel", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        channel: "Organic Search",
+        referrer_source: "Bing",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        channel: "Organic Search",
+        referrer_source: "Bing",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        channel: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -145,7 +145,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       populate_stats(site, [
         build(:pageview,
           referrer_source: "Google",
-          channel: "Organic Search",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
@@ -1445,15 +1444,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   test "breakdown by visit:channel", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview,
-        channel: "Organic Search",
+        referrer_source: "Google",
         timestamp: ~N[2021-01-01 00:00:00]
       ),
       build(:pageview,
-        channel: "Organic Search",
+        referrer_source: "Google",
         timestamp: ~N[2021-01-01 00:25:00]
       ),
       build(:pageview,
-        channel: "",
         timestamp: ~N[2021-01-01 00:00:00]
       )
     ])

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -728,7 +728,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
     test "can filter by channel", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          channel: "Organic Search",
+          referrer_source: "Bing",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -727,21 +727,23 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
     test "returns top channels by unique user ids", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,
-          channel: "Organic Search",
+          referrer_source: "Bing",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          channel: "Organic Search",
+          referrer_source: "Bing",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
         build(:pageview,
-          channel: "Paid Social",
+          referrer_source: "Facebook",
+          utm_source: "fb-ads",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
         build(:pageview,
-          channel: "Paid Social",
+          referrer_source: "Facebook",
+          utm_source: "fb-ads",
           timestamp: ~N[2021-01-01 00:00:00]
         )
       ])

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -76,11 +76,11 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
     test "returns suggestions for channels", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], channel: "Organic Search"),
-        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], channel: "Organic Search"),
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
+        build(:pageview, timestamp: ~N[2019-01-01 23:00:00], referrer_source: "Bing"),
         build(:pageview,
           timestamp: ~N[2019-01-01 23:00:00],
-          channel: "Video"
+          referrer_source: "Youtube"
         )
       ])
 
@@ -89,7 +89,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
 
       assert json_response(conn, 200) == [
                %{"label" => "Organic Search", "value" => "Organic Search"},
-               %{"label" => "Video", "value" => "Video"}
+               %{"label" => "Organic Video", "value" => "Organic Video"}
              ]
     end
 

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -694,8 +694,7 @@ defmodule PlausibleWeb.StatsControllerTest do
         country_code: "EE",
         subdivision1_code: "EE-37",
         city_geoname_id: 588_409,
-        referrer_source: "Google",
-        channel: "Organic Search"
+        referrer_source: "Google"
       ),
       build(:pageview,
         user_id: 123,
@@ -705,8 +704,7 @@ defmodule PlausibleWeb.StatsControllerTest do
         country_code: "EE",
         subdivision1_code: "EE-37",
         city_geoname_id: 588_409,
-        referrer_source: "Google",
-        channel: "Organic Search"
+        referrer_source: "Google"
       ),
       build(:pageview,
         pathname: "/",
@@ -717,7 +715,6 @@ defmodule PlausibleWeb.StatsControllerTest do
         utm_source: "google",
         utm_content: "content",
         utm_term: "term",
-        channel: "Paid Search",
         browser: "Firefox",
         browser_version: "120",
         operating_system: "Mac",
@@ -738,7 +735,7 @@ defmodule PlausibleWeb.StatsControllerTest do
         utm_campaign: "ads",
         country_code: "EE",
         referrer_source: "Google",
-        channel: "Paid Search",
+        click_id_param: "gclid",
         browser: "FirefoxNoVersion",
         operating_system: "MacNoVersion"
       ),

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -91,7 +91,7 @@ defmodule Plausible.TestUtils do
 
         Factory.build(:pageview, pageview)
         |> Map.from_struct()
-        |> Map.delete(:__meta__)
+        |> Map.drop([:__meta__, :acquisition_channel])
         |> update_in([:timestamp], &to_naive_truncate/1)
       end)
 


### PR DESCRIPTION
### Changes

Follow-up to https://github.com/plausible/analytics/pull/4798

Once this change is in, we'll read from the new `acquisition_channel` column.