### PR TITLE
Solve noisy warnings about `a negative range was inferred for Date.range/2`

### DIFF
--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Stats.Query do
             pagination: nil
 
   require OpenTelemetry.Tracer, as: Tracer
-  alias Plausible.Stats.{Filters, Imported, Legacy}
+  alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy}
 
   @type t :: %__MODULE__{}
 
@@ -50,7 +50,7 @@ defmodule Plausible.Stats.Query do
   end
 
   def date_range(query, options \\ []) do
-    date_range = Plausible.Stats.DateTimeRange.to_date_range(query.utc_time_range, query.timezone)
+    date_range = DateTimeRange.to_date_range(query.utc_time_range, query.timezone)
 
     if Keyword.get(options, :trim_trailing) do
       today = query.now |> DateTime.shift_zone!(query.timezone) |> DateTime.to_date()

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -53,9 +53,11 @@ defmodule Plausible.Stats.Query do
     date_range = Plausible.Stats.DateTimeRange.to_date_range(query.utc_time_range, query.timezone)
 
     if Keyword.get(options, :trim_trailing) do
+      today = query.now |> DateTime.shift_zone!(query.timezone) |> DateTime.to_date()
+
       Date.range(
         date_range.first,
-        earliest(date_range.last, query.now)
+        earliest(date_range.last, today)
       )
     else
       date_range

--- a/test/plausible/stats/comparisons_test.exs
+++ b/test/plausible/stats/comparisons_test.exs
@@ -14,7 +14,11 @@ defmodule Plausible.Stats.ComparisonsTest do
   describe "with period set to this month" do
     test "shifts back this month period when mode is previous_period", %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-03-02"}, ~N[2023-03-02 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-03-02"},
+          ~U[2023-03-02 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
 
@@ -25,7 +29,11 @@ defmodule Plausible.Stats.ComparisonsTest do
     test "shifts back this month period when it's the first day of the month and mode is previous_period",
          %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-03-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
 
@@ -36,7 +44,11 @@ defmodule Plausible.Stats.ComparisonsTest do
     test "matches the day of the week when nearest day is original query start date and mode is previous_period",
          %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-03-02"}, ~N[2023-03-02 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-03-02"},
+          ~U[2023-03-02 14:00:00Z]
+        )
 
       comparison_query =
         Comparisons.get_comparison_query(query, %{
@@ -52,7 +64,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       site = insert(:site, timezone: "US/Eastern")
 
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-03-02"}, ~N[2023-03-02 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-03-02"},
+          ~U[2023-03-02 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
 
@@ -64,7 +80,11 @@ defmodule Plausible.Stats.ComparisonsTest do
   describe "with period set to previous month" do
     test "shifts back using the same number of days when mode is previous_period", %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-02-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
 
@@ -74,7 +94,11 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "shifts back the full month when mode is year_over_year", %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-02-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
 
@@ -86,7 +110,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       site: site
     } do
       query =
-        build_query(site, %{"period" => "month", "date" => "2020-02-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2020-02-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
 
@@ -98,7 +126,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       site: site
     } do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-02-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-02-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query =
         Comparisons.get_comparison_query(query, %{
@@ -112,7 +144,11 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "matches the day of the week when mode is previous_period", %{site: site} do
       query =
-        build_query(site, %{"period" => "month", "date" => "2023-01-01"}, ~N[2023-03-01 14:00:00])
+        build_query(
+          site,
+          %{"period" => "month", "date" => "2023-01-01"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
       comparison_query =
         Comparisons.get_comparison_query(query, %{
@@ -128,7 +164,7 @@ defmodule Plausible.Stats.ComparisonsTest do
   describe "with period set to year to date" do
     test "shifts back by the same number of days when mode is previous_period", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
+        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
 
@@ -138,7 +174,7 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "shifts back by the same number of days when mode is year_over_year", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
+        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
 
       comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
 
@@ -148,7 +184,7 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "matches the day of the week when mode is year_over_year", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~N[2023-03-01 14:00:00])
+        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
 
       comparison_query =
         Comparisons.get_comparison_query(query, %{mode: "year_over_year", match_day_of_week: true})

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -2,6 +2,7 @@ defmodule Plausible.Stats.QueryTest do
   use Plausible.DataCase, async: true
   alias Plausible.Stats.Query
   alias Plausible.Stats.Legacy.QueryBuilder
+  alias Plausible.Stats.DateTimeRange
 
   doctest Plausible.Stats.Legacy.QueryBuilder
 
@@ -206,6 +207,65 @@ defmodule Plausible.Stats.QueryTest do
       q = Query.from(site, %{"period" => "6mo", "filters" => filters})
 
       assert q.filters == [[:is, "visit:source", ["Twitter"]]]
+    end
+  end
+
+  describe "&date_range/2" do
+    defp date_range({first, last}, timezone, now \\ nil, opts \\ []) do
+      %Query{
+        utc_time_range: DateTimeRange.new!(first, last),
+        timezone: timezone,
+        now: now || last
+      }
+      |> Query.date_range(opts)
+    end
+
+    test "with no options" do
+      assert date_range({~U[2024-05-05 00:00:00Z], ~U[2024-05-07 23:59:59Z]}, "Etc/UTC") ==
+               Date.range(~D[2024-05-05], ~D[2024-05-07])
+
+      assert date_range({~U[2024-05-05 12:00:00Z], ~U[2024-05-08 11:59:59Z]}, "Etc/GMT+12") ==
+               Date.range(~D[2024-05-05], ~D[2024-05-07])
+
+      assert date_range({~U[2024-05-04 12:00:00Z], ~U[2024-05-07 11:59:59Z]}, "Etc/GMT-12") ==
+               Date.range(~D[2024-05-05], ~D[2024-05-07])
+    end
+
+    test "trim_trailing: true" do
+      assert date_range(
+               {~U[2024-05-05 00:00:00Z], ~U[2024-05-07 23:59:59Z]},
+               "Etc/UTC",
+               ~U[2024-05-08 12:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-07])
+
+      assert date_range(
+               {~U[2024-05-05 00:00:00Z], ~U[2024-05-07 23:59:59Z]},
+               "Etc/UTC",
+               ~U[2024-05-07 12:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-07])
+
+      assert date_range(
+               {~U[2024-05-05 00:00:00Z], ~U[2024-05-07 23:59:59Z]},
+               "Etc/UTC",
+               ~U[2024-05-06 12:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-06])
+
+      assert date_range(
+               {~U[2024-05-05 12:00:00Z], ~U[2024-05-08 11:59:59Z]},
+               "Etc/GMT+12",
+               ~U[2024-05-09 00:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-07])
+
+      assert date_range(
+               {~U[2024-05-05 12:00:00Z], ~U[2024-05-08 11:59:59Z]},
+               "Etc/GMT+12",
+               ~U[2024-05-07 07:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-06])
     end
   end
 


### PR DESCRIPTION
`query.now` is in utc but the date range was in the querys timezone

This is visible in the pattern on the graph, with peaks around UTC midnight:

![image](https://github.com/user-attachments/assets/f3f7b24e-0428-4bee-9ec5-56a86d0fdf1f)

Ref: https://3.basecamp.com/5308029/buckets/39750953/card_tables/cards/7999429743