### PR TITLE
Make "Details" search case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Dashboard shows comparisons for all reports
+- Support for `icontains` and `icontains_not` operators in Stats API filters
 
 ### Removed
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Dashboard shows comparisons for all reports
-- Support for `icontains` and `icontains_not` operators in Stats API filters
+- Support for `icontains` and `icontains_not` operators in Stats API filters for case-insensitive searches.
+  Those are enabled by default in "Details" search inputs on the dashboard.
 
 ### Removed
 ### Changed

--- a/assets/js/dashboard/stats/modals/conversions.js
+++ b/assets/js/dashboard/stats/modals/conversions.js
@@ -28,7 +28,7 @@ function ConversionsModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/devices/browsers-modal.js
+++ b/assets/js/dashboard/stats/modals/devices/browsers-modal.js
@@ -29,7 +29,7 @@ function BrowsersModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   const renderIcon = useCallback((listItem) => browserIconFor(listItem.name), [])

--- a/assets/js/dashboard/stats/modals/devices/operating-systems-modal.js
+++ b/assets/js/dashboard/stats/modals/devices/operating-systems-modal.js
@@ -29,7 +29,7 @@ function OperatingSystemsModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   const renderIcon = useCallback((listItem) => osIconFor(listItem.name), [])

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -29,7 +29,7 @@ function EntryPagesModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -29,7 +29,7 @@ function ExitPagesModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/locations-modal.js
+++ b/assets/js/dashboard/stats/modals/locations-modal.js
@@ -32,7 +32,7 @@ function LocationsModal({ currentView }) {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', `${reportInfo.dimension}_name`, [searchString]])
+    return addFilter(query, ['icontains', `${reportInfo.dimension}_name`, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -29,7 +29,7 @@ function PagesModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/props.js
+++ b/assets/js/dashboard/stats/modals/props.js
@@ -36,7 +36,7 @@ function PropsModal() {
   }, [propKey])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', `${EVENT_PROPS_PREFIX}${propKey}`, [searchString]])
+    return addFilter(query, ['icontains', `${EVENT_PROPS_PREFIX}${propKey}`, [searchString]])
   }, [propKey])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -32,7 +32,7 @@ function ReferrerDrilldownModal() {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -57,7 +57,7 @@ function SourcesModal({ currentView }) {
   }, [reportInfo.dimension])
 
   const addSearchFilter = useCallback((query, searchString) => {
-    return addFilter(query, ['contains', reportInfo.dimension, [searchString]])
+    return addFilter(query, ['icontains', reportInfo.dimension, [searchString]])
   }, [reportInfo.dimension])
 
   function chooseMetrics() {

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -76,7 +76,7 @@ export type FilterWithoutGoals = [
 /**
  * filter operation
  */
-export type FilterOperationWithoutGoals = "is_not" | "contains_not" | "matches" | "matches_not";
+export type FilterOperationWithoutGoals = "is_not" | "contains_not" | "icontains_not" | "matches" | "matches_not";
 export type Clauses = (string | number)[];
 /**
  * @minItems 3
@@ -90,7 +90,7 @@ export type FilterWithGoals = [
 /**
  * filter operation
  */
-export type FilterOperationWithGoals = "is" | "contains";
+export type FilterOperationWithGoals = "is" | "contains" | "icontains";
 /**
  * @minItems 2
  * @maxItems 2

--- a/lib/plausible/goals/filters.ex
+++ b/lib/plausible/goals/filters.ex
@@ -21,7 +21,7 @@ defmodule Plausible.Goals.Filters do
     `pathname`, and also skips the `e.name == "pageview"` check.
   """
   def add_filter(query, [operation, "event:goal", clauses], opts \\ [])
-      when operation in [:is, :contains] do
+      when operation in [:is, :contains, :icontains] do
     imported? = Keyword.get(opts, :imported?, false)
 
     Enum.reduce(clauses, false, fn clause, dynamic_statement ->
@@ -46,7 +46,8 @@ defmodule Plausible.Goals.Filters do
     end)
   end
 
-  def filter_preloaded(preloaded_goals, operation, clause) when operation in [:is, :contains] do
+  def filter_preloaded(preloaded_goals, operation, clause)
+      when operation in [:is, :contains, :icontains] do
     Enum.filter(preloaded_goals, fn goal -> matches?(goal, operation, clause) end)
   end
 
@@ -64,6 +65,12 @@ defmodule Plausible.Goals.Filters do
 
       :contains ->
         String.contains?(Plausible.Goal.display_name(goal), clause)
+
+      :icontains ->
+        goal
+        |> Plausible.Goal.display_name()
+        |> String.downcase()
+        |> String.contains?(String.downcase(clause))
     end
   end
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -105,6 +105,8 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_operator(["matches_wildcard_not" | _rest]), do: {:ok, :matches_wildcard_not}
   defp parse_operator(["contains" | _rest]), do: {:ok, :contains}
   defp parse_operator(["contains_not" | _rest]), do: {:ok, :contains_not}
+  defp parse_operator(["icontains" | _rest]), do: {:ok, :icontains}
+  defp parse_operator(["icontains_not" | _rest]), do: {:ok, :icontains_not}
   defp parse_operator(["not" | _rest]), do: {:ok, :not}
   defp parse_operator(["and" | _rest]), do: {:ok, :and}
   defp parse_operator(["or" | _rest]), do: {:ok, :or}
@@ -132,7 +134,9 @@ defmodule Plausible.Stats.Filters.QueryParser do
               :matches_wildcard,
               :matches_wildcard_not,
               :contains,
-              :contains_not
+              :contains_not,
+              :icontains,
+              :icontains_not
             ],
        do: parse_clauses_list(filter)
 

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -339,12 +339,12 @@
     },
     "filter_operation_without_goals": {
       "type": "string",
-      "enum": ["is_not", "contains_not", "matches", "matches_not"],
+      "enum": ["is_not", "contains_not", "icontains_not", "matches", "matches_not"],
       "description": "filter operation"
     },
     "filter_operation_with_goals": {
       "type": "string",
-      "enum": ["is", "contains"],
+      "enum": ["is", "contains", "icontains"],
       "description": "filter operation"
     },
     "filter_without_goals": {


### PR DESCRIPTION
This is done by introducing `icontains` and `icontains_not` filter operator variants, so that no unexpected behaviour is accidentally triggered.

Dashboard searches for:

  - top/entry/exit pages
  - cities
  - conversions
  - sources (including UTM)
  - props
  - browsers/OS

use `icontains` explicitly.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated: https://github.com/plausible/docs/pull/562
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
