### PR TITLE
Set `default: false` on `allow_next_upgrade_override` in Team and Use…

### DIFF
--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -41,7 +41,7 @@ defmodule Plausible.Auth.User do
 
     # A field only used as a manual override - allow subscribing
     # to any plan, even when exceeding its pageview limit
-    field :allow_next_upgrade_override, :boolean
+    field :allow_next_upgrade_override, :boolean, default: false
 
     # Fields for TOTP authentication. See `Plausible.Auth.TOTP`.
     field :totp_enabled, :boolean, default: false

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Teams.Team do
     field :name, :string
     field :trial_expiry_date, :date
     field :accept_traffic_until, :date
-    field :allow_next_upgrade_override, :boolean
+    field :allow_next_upgrade_override, :boolean, default: false
 
     embeds_one :grace_period, Plausible.Auth.GracePeriod, on_replace: :update
 


### PR DESCRIPTION
Extracted from https://github.com/plausible/analytics/pull/4807