### PR TITLE
Fix team sync on ownership transfer removal

### DIFF
--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -78,7 +78,7 @@ defmodule Plausible.Teams.Invitations do
         from(
           st in Teams.SiteTransfer,
           where: st.email == ^site_invitation.email,
-          where: st.team_id == ^site.team.id
+          where: st.site_id == ^site.id
         )
       )
     else

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -229,6 +229,32 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       refute Repo.reload(invitation)
     end
 
+    test "removes the invitation for ownership transfer", %{conn: conn, user: user} do
+      site =
+        insert(:site,
+          members: [build(:user)],
+          memberships: [build(:site_membership, user: user, role: :admin)]
+        )
+
+      invitation =
+        insert(:invitation,
+          site_id: site.id,
+          inviter: build(:user),
+          email: "jane@example.com",
+          role: :owner
+        )
+
+      conn =
+        delete(
+          conn,
+          Routes.invitation_path(conn, :remove_invitation, site.domain, invitation.invitation_id)
+        )
+
+      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/settings/people"
+
+      refute Repo.reload(invitation)
+    end
+
     test "fails to remove an invitation with insufficient permission", %{conn: conn, user: user} do
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
 


### PR DESCRIPTION
### Changes

Addresses faulty sync logic for transfer ownership removal.

### Tests
- [x] Automated tests have been added

