### PR TITLE
Follow-up to Solve noisy warnings about a negative range was inferred for Date.range/2

### DIFF
--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -57,18 +57,18 @@ defmodule Plausible.Stats.Query do
 
       Date.range(
         date_range.first,
-        clamp(today, date_range.first, date_range.last)
+        clamp(today, date_range)
       )
     else
       date_range
     end
   end
 
-  defp clamp(date, lower_bound, upper_bound) do
+  defp clamp(date, date_range) do
     cond do
-      Date.compare(date, lower_bound) == :lt -> lower_bound
-      Date.compare(date, upper_bound) == :gt -> upper_bound
-      true -> date
+      date in date_range -> date
+      Date.before?(date, date_range.first) -> date_range.first
+      Date.after?(date, date_range.last) -> date_range.last
     end
   end
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -57,15 +57,19 @@ defmodule Plausible.Stats.Query do
 
       Date.range(
         date_range.first,
-        earliest(date_range.last, today)
+        clamp(today, date_range.first, date_range.last)
       )
     else
       date_range
     end
   end
 
-  defp earliest(a, b) do
-    if Date.compare(a, b) in [:eq, :lt], do: a, else: b
+  defp clamp(date, lower_bound, upper_bound) do
+    cond do
+      Date.compare(date, lower_bound) == :lt -> lower_bound
+      Date.compare(date, upper_bound) == :gt -> upper_bound
+      true -> date
+    end
   end
 
   def set(query, keywords) do

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -266,6 +266,13 @@ defmodule Plausible.Stats.QueryTest do
                ~U[2024-05-07 07:00:00Z],
                trim_trailing: true
              ) == Date.range(~D[2024-05-05], ~D[2024-05-06])
+
+      assert date_range(
+               {~U[2024-05-05 12:00:00Z], ~U[2024-05-08 11:59:59Z]},
+               "Etc/GMT+12",
+               ~U[2024-05-03 07:00:00Z],
+               trim_trailing: true
+             ) == Date.range(~D[2024-05-05], ~D[2024-05-05])
     end
   end
 


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/4803

We could still get warnings about negative date ranges when the date being queried is in the future.

This could happen if the users local time is in the future for some reason or they manually edit the url.

Ref: https://3.basecamp.com/5308029/buckets/39750953/card_tables/cards/7999429743