### PR TITLE
Infer medium from click id if not present

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -119,6 +119,7 @@ defmodule Plausible.Ingestion.Event do
       put_user_agent: &put_user_agent/2,
       put_basic_info: &put_basic_info/2,
       put_source_info: &put_source_info/2,
+      maybe_infer_medium: &maybe_infer_medium/2,
       put_props: &put_props/2,
       put_revenue: &put_revenue/2,
       put_salts: &put_salts/2,
@@ -267,6 +268,18 @@ defmodule Plausible.Ingestion.Event do
       utm_content: query_params["utm_content"],
       utm_term: query_params["utm_term"]
     })
+  end
+
+  defp maybe_infer_medium(%__MODULE__{} = event, _context) do
+    inferred_medium =
+      case event.clickhouse_session_attrs do
+        %{utm_medium: medium} when is_binary(medium) -> medium
+        %{utm_medium: nil, referrer_source: "Google", click_id_param: "gclid"} -> "(gclid)"
+        %{utm_medium: nil, referrer_source: "Bing", click_id_param: "msclkid"} -> "(msclkid)"
+        _ -> nil
+      end
+
+    update_session_attrs(event, %{utm_medium: inferred_medium})
   end
 
   defp put_geolocation(%__MODULE__{} = event, _context) do

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1374,6 +1374,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.acquisition_channel == "Paid Search"
+      assert session.utm_medium == "(gclid)"
       assert session.click_id_param == "gclid"
     end
 
@@ -1397,6 +1398,31 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.acquisition_channel == "Organic Search"
+      assert session.utm_medium == ""
+      assert session.click_id_param == "gclid"
+    end
+
+    test "does not override utm_medium with (gclid) if link is already tagged", %{
+      conn: conn,
+      site: site
+    } do
+      params = %{
+        name: "pageview",
+        url: "http://example.com?gclid=123identifier&utm_medium=paidads",
+        referrer: "https://google.com",
+        domain: site.domain
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert response(conn, 202) == "ok"
+      assert session.acquisition_channel == "Paid Search"
+      assert session.utm_medium == "paidads"
       assert session.click_id_param == "gclid"
     end
 
@@ -1417,6 +1443,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.acquisition_channel == "Paid Search"
+      assert session.utm_medium == "(msclkid)"
       assert session.click_id_param == "msclkid"
     end
 
@@ -1426,8 +1453,8 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     } do
       params = %{
         name: "pageview",
-        url: "http://example.com?msclkid=123identifier",
-        referrer: "https://duckduckgo.com",
+        url: "http://example.com?msclkid=123identifier&utm_medium=cpc",
+        referrer: "https://bing.com",
         domain: site.domain
       }
 
@@ -1439,8 +1466,33 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       session = get_created_session(site)
 
       assert response(conn, 202) == "ok"
-      assert session.acquisition_channel == "Organic Search"
+      assert session.acquisition_channel == "Paid Search"
+      assert session.utm_medium == "cpc"
       assert session.click_id_param == "msclkid"
+    end
+
+    test "does not override utm_medium with (msclkid) if link is already tagged", %{
+      conn: conn,
+      site: site
+    } do
+      params = %{
+        name: "pageview",
+        url: "http://example.com?gclid=123identifier&utm_medium=paidads",
+        referrer: "https://google.com",
+        domain: site.domain
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      session = get_created_session(site)
+
+      assert response(conn, 202) == "ok"
+      assert session.acquisition_channel == "Paid Search"
+      assert session.utm_medium == "paidads"
+      assert session.click_id_param == "gclid"
     end
 
     test "parses paid search channel based on utm_source and medium", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Adds entries for (gclid) and (msclkid) to utm mediums in case when:
* UTM Medium is not present
* Paid Search channel is inferred from click_id_param and referrer_source

### Tests
- [x] Automated tests have been added

### Changelog
Will add changelog when channels are ready to go live

### Documentation
Will add docs when feature is ready to go live

### Dark mode
- [x] This PR does not change the UI
