### PR TITLE
Tiny source data update

### DIFF
--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -37,7 +37,8 @@ defmodule PlausibleWeb.Favicon do
     "Wikipedia" => "en.wikipedia.org",
     "Discord" => "discord.com",
     "Perplexity" => "perplexity.ai",
-    "Microsoft Teams" => "microsoft.com"
+    "Microsoft Teams" => "microsoft.com",
+    "LinkedIn" => "linkedin.com"
   }
 
   def init(_) do

--- a/priv/custom_sources.json
+++ b/priv/custom_sources.json
@@ -11,6 +11,7 @@
   "search.brave.com":"Brave",
   "sogou.com":"Sogou",
   "statics.teams.cdn.office.net":"Microsoft Teams",
+  "teams.microsoft.com":"Microsoft Teams",
   "t.me":"Telegram",
   "wap.sogou.com":"Sogou",
   "ya.ru":"Yandex",


### PR DESCRIPTION
Very small update from browsing the live demo:
* Merge teams.microsoft.com -> Microsoft Teams (not important enough to backfill this IMO)
* Display favicon for Linkedin source