### PR TITLE
Switch sites creation to read teams schemas

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -84,7 +84,7 @@ defmodule Plausible.Sites do
   end
 
   def create(user, params) do
-    with :ok <- Quota.ensure_can_add_new_site(user) do
+    with :ok <- Plausible.Teams.Adapter.Read.Billing.ensure_can_add_new_site(user) do
       Ecto.Multi.new()
       |> Ecto.Multi.put(:site_changeset, Site.new(params))
       |> Ecto.Multi.run(:create_team, fn _repo, _context ->

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -6,7 +6,6 @@ defmodule Plausible.Sites do
   import Ecto.Query
 
   alias Plausible.Auth
-  alias Plausible.Billing.Quota
   alias Plausible.Repo
   alias Plausible.Site
   alias Plausible.Site.SharedLink

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -138,7 +138,7 @@ defmodule Plausible.Teams do
 
   defp last_subscription_query() do
     from(subscription in Plausible.Billing.Subscription,
-      order_by: [desc: subscription.inserted_at],
+      order_by: [desc: subscription.inserted_at, desc: subscription.id],
       limit: 1
     )
   end

--- a/lib/plausible/teams/adapter.ex
+++ b/lib/plausible/teams/adapter.ex
@@ -1,0 +1,38 @@
+defmodule Plausible.Teams.Adapter do
+  @moduledoc """
+  Commonly used teams-transition functions
+  """
+  alias Plausible.Teams
+
+  defmacro __using__(_) do
+    quote do
+      alias Plausible.Teams
+      import Teams.Adapter
+    end
+  end
+
+  def team_or_user(user) do
+    switch(
+      user,
+      team_fn: &Function.identity/1,
+      user_fn: &Function.identity/1
+    )
+  end
+
+  def switch(user, opts \\ []) do
+    team_fn = Keyword.fetch!(opts, :team_fn)
+    user_fn = Keyword.fetch!(opts, :user_fn)
+
+    if Teams.read_team_schemas?(user) do
+      team =
+        case Teams.get_by_owner(user) do
+          {:ok, team} -> team
+          {:error, _} -> nil
+        end
+
+      team_fn.(team)
+    else
+      user_fn.(user)
+    end
+  end
+end

--- a/lib/plausible/teams/adapter/read/billing.ex
+++ b/lib/plausible/teams/adapter/read/billing.ex
@@ -17,4 +17,46 @@ defmodule Plausible.Teams.Adapter.Read.Billing do
       Plausible.Billing.check_needs_to_upgrade(user)
     end
   end
+
+  def site_limit(user) do
+    if Teams.read_team_schemas?(user) do
+      team =
+        case Teams.get_by_owner(user) do
+          {:ok, team} -> team
+          {:error, _} -> nil
+        end
+
+      Teams.Billing.site_limit(team)
+    else
+      Plausible.Billing.Quota.Limits.site_limit(user)
+    end
+  end
+
+  def ensure_can_add_new_site(user) do
+    if Teams.read_team_schemas?(user) do
+      team =
+        case Teams.get_by_owner(user) do
+          {:ok, team} -> team
+          {:error, _} -> nil
+        end
+
+      Teams.Billing.ensure_can_add_new_site(team)
+    else
+      Plausible.Billing.Quota.ensure_can_add_new_site(user)
+    end
+  end
+
+  def site_usage(user) do
+    if Teams.read_team_schemas?(user) do
+      team =
+        case Teams.get_by_owner(user) do
+          {:ok, team} -> team
+          {:error, _} -> nil
+        end
+
+      Teams.Billing.site_usage(team)
+    else
+      Plausible.Billing.Quota.Usage.site_usage(user)
+    end
+  end
 end

--- a/lib/plausible/teams/adapter/read/billing.ex
+++ b/lib/plausible/teams/adapter/read/billing.ex
@@ -2,61 +2,36 @@ defmodule Plausible.Teams.Adapter.Read.Billing do
   @moduledoc """
   Transition adapter for new schema reads 
   """
-  alias Plausible.Teams
+  use Plausible.Teams.Adapter
 
   def check_needs_to_upgrade(user) do
-    if Teams.read_team_schemas?(user) do
-      team =
-        case Teams.get_by_owner(user) do
-          {:ok, team} -> team
-          {:error, _} -> nil
-        end
-
-      Teams.Billing.check_needs_to_upgrade(team)
-    else
-      Plausible.Billing.check_needs_to_upgrade(user)
-    end
+    switch(
+      user,
+      team_fn: &Teams.Billing.check_needs_to_upgrade/1,
+      user_fn: &Plausible.Billing.check_needs_to_upgrade/1
+    )
   end
 
   def site_limit(user) do
-    if Teams.read_team_schemas?(user) do
-      team =
-        case Teams.get_by_owner(user) do
-          {:ok, team} -> team
-          {:error, _} -> nil
-        end
-
-      Teams.Billing.site_limit(team)
-    else
-      Plausible.Billing.Quota.Limits.site_limit(user)
-    end
+    switch(
+      user,
+      team_fn: &Teams.Billing.site_limit/1,
+      user_fn: &Plausible.Billing.Quota.Limits.site_limit/1
+    )
   end
 
   def ensure_can_add_new_site(user) do
-    if Teams.read_team_schemas?(user) do
-      team =
-        case Teams.get_by_owner(user) do
-          {:ok, team} -> team
-          {:error, _} -> nil
-        end
-
-      Teams.Billing.ensure_can_add_new_site(team)
-    else
-      Plausible.Billing.Quota.ensure_can_add_new_site(user)
-    end
+    switch(
+      user,
+      team_fn: &Teams.Billing.ensure_can_add_new_site/1,
+      user_fn: &Plausible.Billing.Quota.ensure_can_add_new_site/1
+    )
   end
 
   def site_usage(user) do
-    if Teams.read_team_schemas?(user) do
-      team =
-        case Teams.get_by_owner(user) do
-          {:ok, team} -> team
-          {:error, _} -> nil
-        end
-
-      Teams.Billing.site_usage(team)
-    else
-      Plausible.Billing.Quota.Usage.site_usage(user)
-    end
+    switch(user,
+      team_fn: &Teams.Billing.site_usage/1,
+      user_fn: &Plausible.Billing.Quota.Usage.site_usage/1
+    )
   end
 end

--- a/lib/plausible/teams/adapter/read/ownership.ex
+++ b/lib/plausible/teams/adapter/read/ownership.ex
@@ -3,59 +3,47 @@ defmodule Plausible.Teams.Adapter.Read.Ownership do
   Transition adapter for new schema reads 
   """
   use Plausible
+  use Plausible.Teams.Adapter
   alias Plausible.Site
   alias Plausible.Auth
-  alias Plausible.Teams
   alias Plausible.Site.Memberships.Invitations
 
   def ensure_can_take_ownership(site, user) do
-    if Teams.read_team_schemas?(user) do
-      team =
-        case Teams.get_by_owner(user) do
-          {:ok, team} -> team
-          {:error, _} -> nil
-        end
-
-      Teams.Invitations.ensure_can_take_ownership(site, team)
-    else
-      Invitations.ensure_can_take_ownership(site, user)
-    end
+    switch(
+      user,
+      team_fn: &Teams.Invitations.ensure_can_take_ownership(site, &1),
+      user_fn: &Invitations.ensure_can_take_ownership(site, &1)
+    )
   end
 
   def has_sites?(user) do
-    if Teams.read_team_schemas?(user) do
-      Teams.Users.has_sites?(user, include_pending?: true)
-    else
-      Site.Memberships.any_or_pending?(user)
-    end
+    switch(
+      user,
+      team_fn: fn _ -> Teams.Users.has_sites?(user, include_pending?: true) end,
+      user_fn: &Site.Memberships.any_or_pending?/1
+    )
   end
 
   def owns_sites?(user, sites) do
-    if Teams.read_team_schemas?(user) do
-      Teams.Users.owns_sites?(user, include_pending?: true)
-    else
-      Enum.any?(sites.entries, fn site ->
-        length(site.invitations) > 0 && List.first(site.invitations).role == :owner
-      end) ||
-        Auth.user_owns_sites?(user)
-    end
+    switch(
+      user,
+      team_fn: fn _ -> Teams.Users.owns_sites?(user, include_pending?: true) end,
+      user_fn: fn user ->
+        Enum.any?(sites.entries, fn site ->
+          length(site.invitations) > 0 && List.first(site.invitations).role == :owner
+        end) ||
+          Auth.user_owns_sites?(user)
+      end
+    )
   end
 
   on_ee do
     def check_feature_access(site, new_owner) do
-      user_or_team =
-        if Teams.read_team_schemas?(new_owner) do
-          case Teams.get_by_owner(new_owner) do
-            {:ok, team} -> team
-            {:error, _} -> nil
-          end
-        else
-          new_owner
-        end
+      team_or_user = team_or_user(new_owner)
 
       missing_features =
         Plausible.Billing.Quota.Usage.features_usage(nil, [site.id])
-        |> Enum.filter(&(&1.check_availability(user_or_team) != :ok))
+        |> Enum.filter(&(&1.check_availability(team_or_user) != :ok))
 
       if missing_features == [] do
         :ok

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -42,6 +42,10 @@ defmodule Plausible.Teams.Billing do
     end
   end
 
+  def ensure_can_add_new_site(nil) do
+    :ok
+  end
+
   def ensure_can_add_new_site(team) do
     team = Teams.with_subscription(team)
 
@@ -61,6 +65,10 @@ defmodule Plausible.Teams.Billing do
     end
   end
 
+  def site_limit(nil) do
+    @site_limit_for_trials
+  end
+
   def site_limit(team) do
     if Timex.before?(team.inserted_at, @limit_sites_since) do
       :unlimited
@@ -69,6 +77,8 @@ defmodule Plausible.Teams.Billing do
     end
   end
 
+  def site_usage(nil), do: 0
+
   def site_usage(team) do
     team
     |> Teams.owned_sites()
@@ -76,7 +86,8 @@ defmodule Plausible.Teams.Billing do
   end
 
   defp get_site_limit_from_plan(team) do
-    team = Teams.with_subscription(team)
+    team =
+      Teams.with_subscription(team)
 
     case Plans.get_subscription_plan(team.subscription) do
       %{site_limit: site_limit} -> site_limit

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -2,6 +2,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
   use Plausible
   use PlausibleWeb.ConnCase, async: false
   use Plausible.Repo
+  use Plausible.Teams.Test
 
   on_ee do
     setup :create_user
@@ -77,7 +78,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
       end
 
       test "does not allow creating more sites than the limit", %{conn: conn, user: user} do
-        insert_list(50, :site, members: [user])
+        for _ <- 1..10, do: new_site(owner: user)
 
         conn =
           post(conn, "/api/v1/sites", %{

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -301,7 +301,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn,
       user: user
     } do
-      insert_list(10, :site, members: [user])
+      for _ <- 1..10, do: new_site(owner: user)
 
       conn =
         post(conn, "/sites", %{

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -284,7 +284,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn,
       user: user
     } do
-      insert(:site, members: [user])
+      new_site(owner: user)
 
       post(conn, "/sites", %{
         "site" => %{

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -139,6 +139,32 @@ defmodule Plausible.Teams.Test do
     {:ok, team} = Teams.get_or_create(user)
 
     insert(:growth_subscription, user: user, team: team)
+    user
+  end
+
+  def subscribe_to_plan(user, paddle_plan_id) do
+    {:ok, team} = Teams.get_or_create(user)
+
+    insert(:subscription, user: user, team: team, paddle_plan_id: paddle_plan_id)
+    user
+  end
+
+  def subscribe_to_enterprise_plan(user, attrs) do
+    {:ok, team} = Teams.get_or_create(user)
+
+    {subscription?, attrs} = Keyword.pop(attrs, :subscription?, true)
+
+    enterprise_plan = insert(:enterprise_plan, Keyword.merge([user: user, team: team], attrs))
+
+    if subscription? do
+      insert(:subscription,
+        team: team,
+        user: user,
+        paddle_plan_id: enterprise_plan.paddle_plan_id
+      )
+    end
+
+    user
   end
 
   def assert_team_exists(user, team_id \\ nil) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,6 +9,7 @@ Application.ensure_all_started(:double)
 FunWithFlags.enable(:channels)
 # Temporary flag to test `read_team_schemas` flag on all tests.
 if System.get_env("TEST_READ_TEAM_SCHEMAS") == "1" do
+  IO.puts("READS TEAM SCHEMAS")
   FunWithFlags.enable(:read_team_schemas)
 else
   FunWithFlags.disable(:read_team_schemas)


### PR DESCRIPTION
### Changes

Read team schemas, on creating a new sites, if feature flag is enabled.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
