### PR TITLE
Stop suggesting pageleave as a custom event goal name

### DIFF
--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Stats.GoalSuggestions do
     native_q =
       from(e in base_event_query(site, query),
         where: fragment("? ilike ?", e.name, ^matches),
-        where: e.name != "pageview",
+        where: e.name not in ["pageview", "pageleave"],
         where: fragment("trim(?)", e.name) != "",
         where: e.name == fragment("trim(?)", e.name),
         where: e.name not in ^excluded,

--- a/test/plausible/stats/goal_suggestions_test.exs
+++ b/test/plausible/stats/goal_suggestions_test.exs
@@ -56,10 +56,14 @@ defmodule Plausible.Stats.GoalSuggestionsTest do
              ]
     end
 
-    test "ignores the 'pageview' event name", %{site: site} do
+    test "ignores 'pageview' and 'pageleave' event names", %{site: site} do
       populate_stats(site, [
         build(:event, name: "Signup"),
-        build(:pageview)
+        build(:pageview,
+          user_id: 1,
+          timestamp: NaiveDateTime.utc_now() |> NaiveDateTime.add(-1, :minute)
+        ),
+        build(:event, name: "pageleave", user_id: 1, timestamp: NaiveDateTime.utc_now())
       ])
 
       assert GoalSuggestions.suggest_event_names(site, "") == ["Signup"]

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -50,9 +50,26 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
     end
 
     test "returns suggestions for goals", %{conn: conn, site: site} do
-      conn = get(conn, "/api/stats/#{site.domain}/suggestions/goal?period=month&date=2019-01-01")
+      conn =
+        get(conn, "/api/stats/#{site.domain}/suggestions/goal?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == []
+    end
+
+    test "returns suggestions for configured site goals but not all event names", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event, name: "Signup", timestamp: ~N[2019-01-01 00:00:00]),
+        build(:event, name: "another", timestamp: ~N[2019-01-01 00:00:00])
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/suggestions/goal?period=day&date=2019-01-01&q=")
+
+      assert json_response(conn, 200) == [%{"label" => "Signup", "value" => "Signup"}]
     end
 
     test "returns suggestions for sources", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

A small leftover from when I disabled adding a goal with the name `pageleave`. Also need to make sure they're not suggested.

Also noticed that the filter_suggestions endpoint for the `goal` dimension is missing a real test, so added that too.

### Tests
- [x] Automated tests have been added