### PR TITLE
Channels: backfill utm_medium based on click_param_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Dashboard shows comparisons for all reports
+- UTM Medium report and API shows (gclid) and (msclkid) for paid searches when no explicit utm medium present.
 
 ### Removed
 ### Changed

--- a/priv/ingest_repo/migrations/20241118112238_backfill_utm_medium_click_id_param.exs
+++ b/priv/ingest_repo/migrations/20241118112238_backfill_utm_medium_click_id_param.exs
@@ -1,0 +1,27 @@
+defmodule Plausible.IngestRepo.Migrations.BackfillUtmMediumClickIdParam do
+  @moduledoc """
+  Backfills utm_medium based on referrer_source and click_id_param
+  """
+  use Ecto.Migration
+
+  def up do
+    execute(fn -> repo().query!(update_query("events_v2")) end)
+    execute(fn -> repo().query!(update_query("sessions_v2")) end)
+  end
+
+  def down do
+    raise "irreversible"
+  end
+
+  defp update_query(table) do
+    """
+    ALTER TABLE #{table}
+    UPDATE utm_medium = multiIf(
+      referrer_source = 'Google' AND click_id_param = 'gclid', '(gclid)',
+      referrer_source = 'Bing' AND click_id_param = 'msclkid', '(msclkid)',
+      ''
+    )
+    WHERE utm_medium = ''
+    """
+  end
+end

--- a/priv/ingest_repo/migrations/20241118112238_backfill_utm_medium_click_id_param.exs
+++ b/priv/ingest_repo/migrations/20241118112238_backfill_utm_medium_click_id_param.exs
@@ -19,9 +19,9 @@ defmodule Plausible.IngestRepo.Migrations.BackfillUtmMediumClickIdParam do
     UPDATE utm_medium = multiIf(
       referrer_source = 'Google' AND click_id_param = 'gclid', '(gclid)',
       referrer_source = 'Bing' AND click_id_param = 'msclkid', '(msclkid)',
-      ''
+      utm_medium
     )
-    WHERE utm_medium = ''
+    WHERE empty(utm_medium) AND NOT empty(click_id_param)
     """
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/4817

The key idea is to show data in the utm medium report when looking at paid search.

Ref: https://3.basecamp.com/5308029/buckets/39036182/card_tables/cards/8022470793