### PR TITLE
fractional_sample_rate: Vary sample rate according to traffic estimation

### DIFF
--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -3,13 +3,22 @@ defmodule Plausible.Stats.Sampling do
   Sampling related functions
   """
   @default_sample_threshold 20_000_000
+  # 1 percent
+  @min_sample_rate 0.01
 
   import Ecto.Query
+
+  alias Plausible.Stats.{Query, SamplingCache}
+
+  def default_sample_threshold(), do: @default_sample_threshold
 
   @spec add_query_hint(Ecto.Query.t(), Plausible.Stats.Query.t()) :: Ecto.Query.t()
   def add_query_hint(%Ecto.Query{} = db_query, %Plausible.Stats.Query{} = query) do
     case query.sample_threshold do
-      :infinite ->
+      :no_sampling ->
+        db_query
+
+      nil ->
         db_query
 
       threshold ->
@@ -33,10 +42,10 @@ defmodule Plausible.Stats.Sampling do
     sample_threshold =
       case params["sample_threshold"] do
         nil ->
-          site_default_threshold(site)
+          decide_sample_rate(site, query)
 
         "infinite" ->
-          :infinite
+          :no_sampling
 
         value_string ->
           {value, _} = Float.parse(value_string)
@@ -46,13 +55,41 @@ defmodule Plausible.Stats.Sampling do
     Map.put(query, :sample_threshold, sample_threshold)
   end
 
-  defp site_default_threshold(site) do
-    if FunWithFlags.enabled?(:fractional_hardcoded_sample_rate, for: site) do
-      # Hard-coded sample rate to temporarily fix an issue for a client.
-      # To be solved as part of https://3.basecamp.com/5308029/buckets/39750953/messages/7978775089
-      0.1
-    else
-      @default_sample_threshold
+  defp decide_sample_rate(site, query) do
+    cond do
+      FunWithFlags.enabled?(:fractional_hardcoded_sample_rate, for: site) ->
+        # Hard-coded sample rate to temporarily fix an issue for a client.
+        # To be solved as part of https://3.basecamp.com/5308029/buckets/39750953/messages/7978775089
+        0.1
+
+      FunWithFlags.enabled?(:fractional_sample_rate, for: site) ->
+        traffic_30_day = SamplingCache.get(site.id)
+        fractional_sample_rate(traffic_30_day, query)
+
+      true ->
+        @default_sample_threshold
+    end
+  end
+
+  def fractional_sample_rate(nil = _traffic_30_day, _query), do: :no_sampling
+
+  def fractional_sample_rate(traffic_30_day, query) do
+    date_range = Query.date_range(query)
+    duration = Date.diff(date_range.last, date_range.first)
+    estimated_traffic = traffic_30_day / 30.0 * duration
+
+    fraction =
+      if(estimated_traffic > 0,
+        do: Float.round(@default_sample_threshold / estimated_traffic, 2),
+        else: 1.0
+      )
+
+    cond do
+      # Don't sample small time ranges
+      duration < 1 -> :no_sampling
+      # If sampling doesn't have a significant effect, don't sample
+      fraction > 0.4 -> :no_sampling
+      true -> max(fraction, @min_sample_rate)
     end
   end
 end

--- a/extra/lib/plausible/stats/sampling_cache.ex
+++ b/extra/lib/plausible/stats/sampling_cache.ex
@@ -50,7 +50,6 @@ defmodule Plausible.Stats.SamplingCache do
   end
 
   def thirty_days_ago() do
-    Date.utc_today()
-    |> Date.add(-30)
+    Date.shift(Date.utc_today(), day: -30)
   end
 end

--- a/extra/lib/plausible/stats/sampling_cache.ex
+++ b/extra/lib/plausible/stats/sampling_cache.ex
@@ -1,0 +1,56 @@
+defmodule Plausible.Stats.SamplingCache do
+  @moduledoc """
+  Cache storing estimation for events ingested by a team in the past month.
+
+  Used for sampling rate calculations in Plausible.Stats.Sampling.
+  """
+  alias Plausible.Ingestion
+  alias Plausible.Stats.Sampling
+
+  import Ecto.Query
+  use Plausible.Cache
+
+  @cache_name :stats_sampling_cache
+
+  @impl true
+  def name(), do: @cache_name
+
+  @impl true
+  def child_id(), do: :cache_stats_sampling
+
+  @impl true
+  def repo(), do: Plausible.ClickhouseRepo
+
+  @impl true
+  def count_all() do
+    base_db_query()
+    |> repo().all()
+    |> length()
+  end
+
+  @impl true
+  def base_db_query() do
+    from(r in Ingestion.Counters.Record,
+      select: {
+        r.site_id,
+        selected_as(fragment("sumIf(value, metric = 'buffered')"), :events_ingested)
+      },
+      where: fragment("toDate(event_timebucket) >= ?", ^thirty_days_ago()),
+      group_by: r.site_id,
+      having: selected_as(:events_ingested) > ^Sampling.default_sample_threshold()
+    )
+  end
+
+  @impl true
+  def get_from_source(site_id) do
+    base_db_query()
+    |> repo().all()
+    |> Map.new()
+    |> Map.get(site_id)
+  end
+
+  def thirty_days_ago() do
+    Date.utc_today()
+    |> Date.add(-30)
+  end
+end

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -13,92 +13,103 @@ defmodule Plausible.Application do
     # in CE we start the endpoint under site_encrypt for automatic https
     endpoint = on_ee(do: PlausibleWeb.Endpoint, else: maybe_https_endpoint())
 
-    children = [
-      Plausible.Cache.Stats,
-      Plausible.Repo,
-      Plausible.ClickhouseRepo,
-      Plausible.IngestRepo,
-      Plausible.AsyncInsertRepo,
-      Plausible.ImportDeletionRepo,
-      {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
-      {Plausible.RateLimit, clean_period: :timer.minutes(10)},
-      Plausible.Ingestion.Counters,
-      {Finch, name: Plausible.Finch, pools: finch_pool_config()},
-      {Phoenix.PubSub, name: Plausible.PubSub},
-      Plausible.Session.Salts,
-      Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
-      Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
-      ReferrerBlocklist,
-      Plausible.Cache.Adapter.child_spec(:customer_currency, :cache_customer_currency,
-        ttl_check_interval: :timer.minutes(5),
-        global_ttl: :timer.minutes(60)
-      ),
-      Plausible.Cache.Adapter.child_spec(:user_agents, :cache_user_agents,
-        ttl_check_interval: :timer.seconds(5),
-        global_ttl: :timer.minutes(60)
-      ),
-      Plausible.Cache.Adapter.child_spec(:sessions, :cache_sessions,
-        ttl_check_interval: :timer.seconds(1),
-        global_ttl: :timer.minutes(30)
-      ),
-      warmed_cache(Plausible.Site.Cache,
-        adapter_opts: [ttl_check_interval: false],
-        warmers: [
-          refresh_all:
-            {Plausible.Site.Cache.All,
-             interval: :timer.minutes(15) + Enum.random(1..:timer.seconds(10))},
-          refresh_updated_recently:
-            {Plausible.Site.Cache.RecentlyUpdated, interval: :timer.seconds(30)}
-        ]
-      ),
-      warmed_cache(Plausible.Shield.IPRuleCache,
-        adapter_opts: [ttl_check_interval: false],
-        warmers: [
-          refresh_all:
-            {Plausible.Shield.IPRuleCache.All,
-             interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
-          refresh_updated_recently:
-            {Plausible.Shield.IPRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
-        ]
-      ),
-      warmed_cache(Plausible.Shield.CountryRuleCache,
-        adapter_opts: [ttl_check_interval: false],
-        warmers: [
-          refresh_all:
-            {Plausible.Shield.CountryRuleCache.All,
-             interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
-          refresh_updated_recently:
-            {Plausible.Shield.CountryRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
-        ]
-      ),
-      warmed_cache(Plausible.Shield.PageRuleCache,
-        adapter_opts: [ttl_check_interval: false, ets_options: [:bag]],
-        warmers: [
-          refresh_all:
-            {Plausible.Shield.PageRuleCache.All,
-             interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
-          refresh_updated_recently:
-            {Plausible.Shield.PageRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
-        ]
-      ),
-      warmed_cache(Plausible.Shield.HostnameRuleCache,
-        adapter_opts: [ttl_check_interval: false, ets_options: [:bag]],
-        warmers: [
-          refresh_all:
-            {Plausible.Shield.HostnameRuleCache.All,
-             interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
-          refresh_updated_recently:
-            {Plausible.Shield.HostnameRuleCache.RecentlyUpdated, interval: :timer.seconds(25)}
-        ]
-      ),
-      endpoint,
-      {Oban, Application.get_env(:plausible, Oban)},
-      Plausible.PromEx
-    ]
-
-    on_ee do
-      children = children ++ help_scout_vault()
-    end
+    children =
+      [
+        Plausible.Cache.Stats,
+        Plausible.Repo,
+        Plausible.ClickhouseRepo,
+        Plausible.IngestRepo,
+        Plausible.AsyncInsertRepo,
+        Plausible.ImportDeletionRepo,
+        {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
+        {Plausible.RateLimit, clean_period: :timer.minutes(10)},
+        Plausible.Ingestion.Counters,
+        {Finch, name: Plausible.Finch, pools: finch_pool_config()},
+        {Phoenix.PubSub, name: Plausible.PubSub},
+        Plausible.Session.Salts,
+        Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
+        Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
+        ReferrerBlocklist,
+        Plausible.Cache.Adapter.child_spec(:customer_currency, :cache_customer_currency,
+          ttl_check_interval: :timer.minutes(5),
+          global_ttl: :timer.minutes(60)
+        ),
+        Plausible.Cache.Adapter.child_spec(:user_agents, :cache_user_agents,
+          ttl_check_interval: :timer.seconds(5),
+          global_ttl: :timer.minutes(60)
+        ),
+        Plausible.Cache.Adapter.child_spec(:sessions, :cache_sessions,
+          ttl_check_interval: :timer.seconds(1),
+          global_ttl: :timer.minutes(30)
+        ),
+        warmed_cache(Plausible.Site.Cache,
+          adapter_opts: [ttl_check_interval: false],
+          warmers: [
+            refresh_all:
+              {Plausible.Site.Cache.All,
+               interval: :timer.minutes(15) + Enum.random(1..:timer.seconds(10))},
+            refresh_updated_recently:
+              {Plausible.Site.Cache.RecentlyUpdated, interval: :timer.seconds(30)}
+          ]
+        ),
+        warmed_cache(Plausible.Shield.IPRuleCache,
+          adapter_opts: [ttl_check_interval: false],
+          warmers: [
+            refresh_all:
+              {Plausible.Shield.IPRuleCache.All,
+               interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
+            refresh_updated_recently:
+              {Plausible.Shield.IPRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
+          ]
+        ),
+        warmed_cache(Plausible.Shield.CountryRuleCache,
+          adapter_opts: [ttl_check_interval: false],
+          warmers: [
+            refresh_all:
+              {Plausible.Shield.CountryRuleCache.All,
+               interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
+            refresh_updated_recently:
+              {Plausible.Shield.CountryRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
+          ]
+        ),
+        warmed_cache(Plausible.Shield.PageRuleCache,
+          adapter_opts: [ttl_check_interval: false, ets_options: [:bag]],
+          warmers: [
+            refresh_all:
+              {Plausible.Shield.PageRuleCache.All,
+               interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
+            refresh_updated_recently:
+              {Plausible.Shield.PageRuleCache.RecentlyUpdated, interval: :timer.seconds(35)}
+          ]
+        ),
+        warmed_cache(Plausible.Shield.HostnameRuleCache,
+          adapter_opts: [ttl_check_interval: false, ets_options: [:bag]],
+          warmers: [
+            refresh_all:
+              {Plausible.Shield.HostnameRuleCache.All,
+               interval: :timer.minutes(3) + Enum.random(1..:timer.seconds(10))},
+            refresh_updated_recently:
+              {Plausible.Shield.HostnameRuleCache.RecentlyUpdated, interval: :timer.seconds(25)}
+          ]
+        ),
+        on_ee do
+          warmed_cache(Plausible.Stats.SamplingCache,
+            adapter_opts: [ttl_check_interval: false],
+            warmers: [
+              refresh_all:
+                {Plausible.Stats.SamplingCache.All,
+                 interval: :timer.hours(24) + Enum.random(1..:timer.minutes(60))}
+            ]
+          )
+        end,
+        endpoint,
+        {Oban, Application.get_env(:plausible, Oban)},
+        Plausible.PromEx,
+        on_ee do
+          help_scout_vault()
+        end
+      ]
+      |> Enum.reject(&is_nil/1)
 
     opts = [strategy: :one_for_one, name: Plausible.Supervisor]
 

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -183,9 +183,9 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   @tag :ee_only
-  test "adds sample_threshold :infinite to query struct", %{site: site} do
+  test "adds sample_threshold :no_sampling to query struct", %{site: site} do
     q = Query.from(site, %{"period" => "30d", "sample_threshold" => "infinite"})
-    assert q.sample_threshold == :infinite
+    assert q.sample_threshold == :no_sampling
   end
 
   @tag :ee_only

--- a/test/plausible/stats/sampling_cache_test.exs
+++ b/test/plausible/stats/sampling_cache_test.exs
@@ -45,10 +45,10 @@ defmodule Plausible.Stats.SamplingCacheTest do
 
         {:ok, _} = start_test_cache(test)
 
-        assert SamplingCache.get(1) == nil
-        assert SamplingCache.get(2) == 22_000_000
-        assert SamplingCache.get(3) == nil
-        assert SamplingCache.get(4) == nil
+        assert SamplingCache.get(1, force?: true, cache_name: test) == nil
+        assert SamplingCache.get(2, force?: true, cache_name: test) == 22_000_000
+        assert SamplingCache.get(3, force?: true, cache_name: test) == nil
+        assert SamplingCache.get(4, force?: true, cache_name: test) == nil
       end
     end
 

--- a/test/plausible/stats/sampling_cache_test.exs
+++ b/test/plausible/stats/sampling_cache_test.exs
@@ -57,6 +57,7 @@ defmodule Plausible.Stats.SamplingCacheTest do
 
         start_test_cache(test)
 
+        assert SamplingCache.count_all() == 1
         assert SamplingCache.get(1, force?: true, cache_name: test) == nil
         assert SamplingCache.get(2, force?: true, cache_name: test) == 22_000_000
         assert SamplingCache.get(3, force?: true, cache_name: test) == nil
@@ -72,6 +73,8 @@ defmodule Plausible.Stats.SamplingCacheTest do
         ])
 
         :ok = SamplingCache.refresh_all(cache_name: test)
+
+        assert SamplingCache.count_all() == 2
         assert SamplingCache.get(1, force?: true, cache_name: test) == 22_000_000
         assert SamplingCache.get(2, force?: true, cache_name: test) == 22_000_000
       end

--- a/test/plausible/stats/sampling_cache_test.exs
+++ b/test/plausible/stats/sampling_cache_test.exs
@@ -1,0 +1,32 @@
+defmodule Plausible.Stats.SamplingCacheTest do
+  use Plausible.DataCase, async: true
+  alias Plausible.Stats.SamplingCache
+
+  test "returns cached values for traffic in past 30 days", %{test: test} do
+    now = DateTime.utc_now()
+
+    Plausible.IngestRepo.insert_all(Plausible.Ingestion.Counters.Record, [
+      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -1, :day), metric: "buffered"},
+      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -5, :day), metric: "buffered"},
+      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"},
+      %{site_id: 3, value: 44_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"},
+      %{site_id: 4, value: 11_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"}
+    ])
+
+    {:ok, _} = start_test_cache(test)
+
+    assert SamplingCache.get(1) == nil
+    assert SamplingCache.get(2) == 22_000_000
+    assert SamplingCache.get(3) == nil
+    assert SamplingCache.get(4) == nil
+  end
+
+  def add(datetime, n, unit) do
+    DateTime.add(datetime, n, unit) |> DateTime.truncate(:second)
+  end
+
+  defp start_test_cache(cache_name) do
+    %{start: {m, f, a}} = SamplingCache.child_spec(cache_name: cache_name)
+    apply(m, f, a)
+  end
+end

--- a/test/plausible/stats/sampling_cache_test.exs
+++ b/test/plausible/stats/sampling_cache_test.exs
@@ -1,32 +1,64 @@
 defmodule Plausible.Stats.SamplingCacheTest do
   use Plausible.DataCase, async: true
-  alias Plausible.Stats.SamplingCache
 
-  test "returns cached values for traffic in past 30 days", %{test: test} do
-    now = DateTime.utc_now()
+  use Plausible
 
-    Plausible.IngestRepo.insert_all(Plausible.Ingestion.Counters.Record, [
-      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -1, :day), metric: "buffered"},
-      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -5, :day), metric: "buffered"},
-      %{site_id: 2, value: 11_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"},
-      %{site_id: 3, value: 44_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"},
-      %{site_id: 4, value: 11_000_000, event_timebucket: add(now, -35, :day), metric: "buffered"}
-    ])
+  on_ee do
+    alias Plausible.Stats.SamplingCache
 
-    {:ok, _} = start_test_cache(test)
+    describe "getter" do
+      test "returns cached values for traffic in past 30 days", %{test: test} do
+        now = DateTime.utc_now()
 
-    assert SamplingCache.get(1) == nil
-    assert SamplingCache.get(2) == 22_000_000
-    assert SamplingCache.get(3) == nil
-    assert SamplingCache.get(4) == nil
-  end
+        Plausible.IngestRepo.insert_all(Plausible.Ingestion.Counters.Record, [
+          %{
+            site_id: 2,
+            value: 11_000_000,
+            event_timebucket: add(now, -1, :day),
+            metric: "buffered"
+          },
+          %{
+            site_id: 2,
+            value: 11_000_000,
+            event_timebucket: add(now, -5, :day),
+            metric: "buffered"
+          },
+          %{
+            site_id: 2,
+            value: 11_000_000,
+            event_timebucket: add(now, -35, :day),
+            metric: "buffered"
+          },
+          %{
+            site_id: 3,
+            value: 44_000_000,
+            event_timebucket: add(now, -35, :day),
+            metric: "buffered"
+          },
+          %{
+            site_id: 4,
+            value: 11_000_000,
+            event_timebucket: add(now, -35, :day),
+            metric: "buffered"
+          }
+        ])
 
-  def add(datetime, n, unit) do
-    DateTime.add(datetime, n, unit) |> DateTime.truncate(:second)
-  end
+        {:ok, _} = start_test_cache(test)
 
-  defp start_test_cache(cache_name) do
-    %{start: {m, f, a}} = SamplingCache.child_spec(cache_name: cache_name)
-    apply(m, f, a)
+        assert SamplingCache.get(1) == nil
+        assert SamplingCache.get(2) == 22_000_000
+        assert SamplingCache.get(3) == nil
+        assert SamplingCache.get(4) == nil
+      end
+    end
+
+    def add(datetime, n, unit) do
+      DateTime.add(datetime, n, unit) |> DateTime.truncate(:second)
+    end
+
+    defp start_test_cache(cache_name) do
+      %{start: {m, f, a}} = SamplingCache.child_spec(cache_name: cache_name)
+      apply(m, f, a)
+    end
   end
 end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -1,0 +1,49 @@
+defmodule Plausible.Stats.SamplingTest do
+  use Plausible.DataCase, async: true
+
+  import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
+
+  alias Plausible.Stats.{Query, DateTimeRange}
+
+  describe "&fractional_sample_rate/2" do
+    test "no traffic estimate" do
+      assert fractional_sample_rate(nil, query(30)) == :no_sampling
+    end
+
+    test "scales sampling rate according to query duration" do
+      assert fractional_sample_rate(40_000_000, query(30)) == :no_sampling
+      assert fractional_sample_rate(40_000_000, query(60)) == 0.25
+      assert fractional_sample_rate(40_000_000, query(100)) == 0.15
+
+      assert fractional_sample_rate(100_000_000, query(1)) == :no_sampling
+      assert fractional_sample_rate(100_000_000, query(5)) == :no_sampling
+      assert fractional_sample_rate(100_000_000, query(10)) == :no_sampling
+      assert fractional_sample_rate(100_000_000, query(15)) == 0.40
+      assert fractional_sample_rate(100_000_000, query(30)) == 0.20
+      assert fractional_sample_rate(100_000_000, query(60)) == 0.10
+      assert fractional_sample_rate(100_000_000, query(100)) == 0.06
+
+      assert fractional_sample_rate(300_000_000, query(2)) == :no_sampling
+      assert fractional_sample_rate(300_000_000, query(5)) == 0.40
+      assert fractional_sample_rate(300_000_000, query(10)) == 0.20
+    end
+
+    test "short durations" do
+      assert fractional_sample_rate(30_000_000, query(1, :hour)) == :no_sampling
+    end
+
+    test "very low sampling rate" do
+      assert fractional_sample_rate(300_000_000_000, query(30)) == 0.01
+    end
+  end
+
+  def query(duration, unit \\ :day) do
+    first = DateTime.utc_now()
+    last = DateTime.add(first, duration, unit)
+
+    %Query{
+      utc_time_range: DateTimeRange.new!(first, last),
+      timezone: "UTC"
+    }
+  end
+end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -31,7 +31,7 @@ defmodule Plausible.Stats.SamplingTest do
       end
 
       test "short durations" do
-        assert fractional_sample_rate(30_000_000, query(1, :hour)) == :no_sampling
+        assert fractional_sample_rate(300_000_000_000, query(1, :hour)) == :no_sampling
       end
 
       test "very low sampling rate" do

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -1,49 +1,52 @@
 defmodule Plausible.Stats.SamplingTest do
   use Plausible.DataCase, async: true
 
-  import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
+  use Plausible
 
-  alias Plausible.Stats.{Query, DateTimeRange}
+  on_ee do
+    import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
+    alias Plausible.Stats.{Query, DateTimeRange}
 
-  describe "&fractional_sample_rate/2" do
-    test "no traffic estimate" do
-      assert fractional_sample_rate(nil, query(30)) == :no_sampling
+    describe "&fractional_sample_rate/2" do
+      test "no traffic estimate" do
+        assert fractional_sample_rate(nil, query(30)) == :no_sampling
+      end
+
+      test "scales sampling rate according to query duration" do
+        assert fractional_sample_rate(40_000_000, query(30)) == :no_sampling
+        assert fractional_sample_rate(40_000_000, query(60)) == 0.25
+        assert fractional_sample_rate(40_000_000, query(100)) == 0.15
+
+        assert fractional_sample_rate(100_000_000, query(1)) == :no_sampling
+        assert fractional_sample_rate(100_000_000, query(5)) == :no_sampling
+        assert fractional_sample_rate(100_000_000, query(10)) == :no_sampling
+        assert fractional_sample_rate(100_000_000, query(15)) == 0.40
+        assert fractional_sample_rate(100_000_000, query(30)) == 0.20
+        assert fractional_sample_rate(100_000_000, query(60)) == 0.10
+        assert fractional_sample_rate(100_000_000, query(100)) == 0.06
+
+        assert fractional_sample_rate(300_000_000, query(2)) == :no_sampling
+        assert fractional_sample_rate(300_000_000, query(5)) == 0.40
+        assert fractional_sample_rate(300_000_000, query(10)) == 0.20
+      end
+
+      test "short durations" do
+        assert fractional_sample_rate(30_000_000, query(1, :hour)) == :no_sampling
+      end
+
+      test "very low sampling rate" do
+        assert fractional_sample_rate(300_000_000_000, query(30)) == 0.01
+      end
     end
 
-    test "scales sampling rate according to query duration" do
-      assert fractional_sample_rate(40_000_000, query(30)) == :no_sampling
-      assert fractional_sample_rate(40_000_000, query(60)) == 0.25
-      assert fractional_sample_rate(40_000_000, query(100)) == 0.15
+    def query(duration, unit \\ :day) do
+      first = DateTime.utc_now()
+      last = DateTime.add(first, duration, unit)
 
-      assert fractional_sample_rate(100_000_000, query(1)) == :no_sampling
-      assert fractional_sample_rate(100_000_000, query(5)) == :no_sampling
-      assert fractional_sample_rate(100_000_000, query(10)) == :no_sampling
-      assert fractional_sample_rate(100_000_000, query(15)) == 0.40
-      assert fractional_sample_rate(100_000_000, query(30)) == 0.20
-      assert fractional_sample_rate(100_000_000, query(60)) == 0.10
-      assert fractional_sample_rate(100_000_000, query(100)) == 0.06
-
-      assert fractional_sample_rate(300_000_000, query(2)) == :no_sampling
-      assert fractional_sample_rate(300_000_000, query(5)) == 0.40
-      assert fractional_sample_rate(300_000_000, query(10)) == 0.20
+      %Query{
+        utc_time_range: DateTimeRange.new!(first, last),
+        timezone: "UTC"
+      }
     end
-
-    test "short durations" do
-      assert fractional_sample_rate(30_000_000, query(1, :hour)) == :no_sampling
-    end
-
-    test "very low sampling rate" do
-      assert fractional_sample_rate(300_000_000_000, query(30)) == 0.01
-    end
-  end
-
-  def query(duration, unit \\ :day) do
-    first = DateTime.utc_now()
-    last = DateTime.add(first, duration, unit)
-
-    %Query{
-      utc_time_range: DateTimeRange.new!(first, last),
-      timezone: "UTC"
-    }
   end
 end


### PR DESCRIPTION
Our old sampling mechanism used SAMPLE 20000000 syntax. This was wonderful since it allowed essentially dynamic sampling based on the data being queried. However this ran into many issues relating to JOINs and sample rate being different for different tables.

Instead, we now start to dynamically vary sample rates fractionally.

At query time we check the time window being queried and estimate how many rows this query might reach. For large queries, we then dynamically decide the sample rate.

For getting the traffic estimate for a site, we have a new SampingCache class which queries `ingest_counters`.

Future work:
- The query being cached is slightly expensive and can be sped up with a ClickHouse projection. This will be added in a follow-up PR.
- Reducing sample rate if `query.filters` is set.