### PR TITLE
Speed up counting past 30 day traffic via ingest_counters

### DIFF
--- a/priv/ingest_repo/migrations/20241120064325_create_ingest_counters_site_traffic_projection.exs
+++ b/priv/ingest_repo/migrations/20241120064325_create_ingest_counters_site_traffic_projection.exs
@@ -1,0 +1,22 @@
+defmodule Plausible.IngestRepo.Migrations.CreateIngestCountersSiteTrafficProjection do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      ALTER TABLE ingest_counters
+      #{Plausible.MigrationUtils.on_cluster_statement("ingest_counters")}
+      ADD PROJECTION ingest_counters_site_traffic_projection (
+        SELECT site_id, toDate(event_timebucket), sumIf(value, metric = 'buffered')
+        GROUP BY site_id, toDate(event_timebucket)
+      )
+    """
+  end
+
+  def down do
+    execute """
+      ALTER TABLE ingest_counters
+      #{Plausible.MigrationUtils.on_cluster_statement("ingest_counters")}
+      DROP PROJECTION ingest_counters_site_traffic_projection
+    """
+  end
+end

--- a/priv/ingest_repo/migrations/20241120064325_create_ingest_counters_site_traffic_projection.exs
+++ b/priv/ingest_repo/migrations/20241120064325_create_ingest_counters_site_traffic_projection.exs
@@ -24,6 +24,12 @@ defmodule Plausible.IngestRepo.Migrations.CreateIngestCountersSiteTrafficProject
         GROUP BY site_id, toDate(event_timebucket)
       )
     """
+
+    execute """
+      ALTER TABLE ingest_counters
+      #{Plausible.MigrationUtils.on_cluster_statement("ingest_counters")}
+      MATERIALIZE PROJECTION ingest_counters_site_traffic_projection
+    """
   end
 
   def down do


### PR DESCRIPTION
Companion to https://github.com/plausible/analytics/pull/4839

A projection speeds up ClickHouse queries by storing data in a different order in each part. In this case, it pre-aggregates results by site, speeding up the query and requiring less resources at query-time.

Query stats before:
```
-- 10 rows in set. Elapsed: 1.134 sec. Processed 1.45 billion rows, 21.65 GB (1.28 billion rows/s., 19.09 GB/s.)
-- Peak memory usage: 53.41 MiB.
```

After:
```
-- 10 rows in set. Elapsed: 0.321 sec. Processed 39.70 million rows, 1.07 GB (123.51 million rows/s., 3.33 GB/s.)
-- Peak memory usage: 97.43 MiB.
```