### PR TITLE
Improve report performance with high-cardinality import joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Details modal search inputs are now case-insensitive.
+- Improved report performance in cases where site has a lot of unique pathnames
 
 ### Fixed
 

--- a/lib/plausible/stats/imported/sql/expression.ex
+++ b/lib/plausible/stats/imported/sql/expression.ex
@@ -19,7 +19,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
 
   def select_imported_metrics(q, [:visitors | rest]) do
     q
-    |> select_merge([i], %{visitors: sum(i.visitors)})
+    |> select_merge_as([i], %{visitors: sum(i.visitors)})
     |> select_imported_metrics(rest)
   end
 
@@ -28,13 +28,13 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:events | rest]
       ) do
     q
-    |> select_merge([i], %{events: sum(i.events)})
+    |> select_merge_as([i], %{events: sum(i.events)})
     |> select_imported_metrics(rest)
   end
 
   def select_imported_metrics(q, [:events | rest]) do
     q
-    |> select_merge([i], %{events: sum(i.pageviews)})
+    |> select_merge_as([i], %{events: sum(i.pageviews)})
     |> select_imported_metrics(rest)
   end
 
@@ -43,7 +43,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:visits | rest]
       ) do
     q
-    |> select_merge([i], %{visits: sum(i.exits)})
+    |> select_merge_as([i], %{visits: sum(i.exits)})
     |> select_imported_metrics(rest)
   end
 
@@ -52,13 +52,13 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:visits | rest]
       ) do
     q
-    |> select_merge([i], %{visits: sum(i.entrances)})
+    |> select_merge_as([i], %{visits: sum(i.entrances)})
     |> select_imported_metrics(rest)
   end
 
   def select_imported_metrics(q, [:visits | rest]) do
     q
-    |> select_merge([i], %{visits: sum(i.visits)})
+    |> select_merge_as([i], %{visits: sum(i.visits)})
     |> select_imported_metrics(rest)
   end
 
@@ -67,14 +67,14 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:pageviews | rest]
       ) do
     q
-    |> select_merge([i], %{pageviews: 0})
+    |> select_merge_as([i], %{pageviews: 0})
     |> select_imported_metrics(rest)
   end
 
   def select_imported_metrics(q, [:pageviews | rest]) do
     q
     |> where([i], i.pageviews > 0)
-    |> select_merge([i], %{pageviews: sum(i.pageviews)})
+    |> select_merge_as([i], %{pageviews: sum(i.pageviews)})
     |> select_imported_metrics(rest)
   end
 
@@ -83,7 +83,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:bounce_rate | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       bounces: 0,
       __internal_visits: 0
     })
@@ -95,7 +95,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:bounce_rate | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       bounces: sum(i.bounces),
       __internal_visits: sum(i.entrances)
     })
@@ -107,7 +107,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:bounce_rate | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       bounces: sum(i.bounces),
       __internal_visits: sum(i.exits)
     })
@@ -116,7 +116,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
 
   def select_imported_metrics(q, [:bounce_rate | rest]) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       bounces: sum(i.bounces),
       __internal_visits: sum(i.visits)
     })
@@ -128,7 +128,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:visit_duration | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       visit_duration: 0,
       __internal_visits: 0
     })
@@ -140,7 +140,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:visit_duration | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       visit_duration: sum(i.visit_duration),
       __internal_visits: sum(i.entrances)
     })
@@ -152,7 +152,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
         [:visit_duration | rest]
       ) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       visit_duration: sum(i.visit_duration),
       __internal_visits: sum(i.exits)
     })
@@ -161,7 +161,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
 
   def select_imported_metrics(q, [:visit_duration | rest]) do
     q
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       visit_duration: sum(i.visit_duration),
       __internal_visits: sum(i.visits)
     })
@@ -174,7 +174,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
       ) do
     q
     |> where([i], i.pageviews > 0)
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       pageviews: sum(i.pageviews),
       __internal_visits: sum(i.entrances)
     })
@@ -187,7 +187,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
       ) do
     q
     |> where([i], i.pageviews > 0)
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       pageviews: sum(i.pageviews),
       __internal_visits: sum(i.exits)
     })
@@ -197,7 +197,7 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
   def select_imported_metrics(q, [:views_per_visit | rest]) do
     q
     |> where([i], i.pageviews > 0)
-    |> select_merge([i], %{
+    |> select_merge_as([i], %{
       pageviews: sum(i.pageviews),
       __internal_visits: sum(i.visits)
     })

--- a/lib/plausible/stats/imported/sql/expression.ex
+++ b/lib/plausible/stats/imported/sql/expression.ex
@@ -456,17 +456,5 @@ defmodule Plausible.Stats.Imported.SQL.Expression do
     |> select_joined_metrics(rest)
   end
 
-  def naive_dimension_join(q1, q2, metrics) do
-    from(a in subquery(q1),
-      full_join: b in subquery(q2),
-      on: a.dim0 == b.dim0,
-      select: %{}
-    )
-    |> select_merge_as([a, b], %{
-      dim0: fragment("if(? != 0, ?, ?)", a.dim0, a.dim0, b.dim0)
-    })
-    |> select_joined_metrics(metrics)
-  end
-
   defp dim(dimension), do: Plausible.Stats.Filters.without_prefix(dimension)
 end

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -37,8 +37,7 @@ defmodule Plausible.Stats.QueryOptimizer do
     {
       Query.set(query,
         metrics: event_metrics,
-        include_imported: query.include_imported,
-        pagination: nil
+        include_imported: query.include_imported
       ),
       split_sessions_query(query, sessions_metrics)
     }
@@ -171,8 +170,7 @@ defmodule Plausible.Stats.QueryOptimizer do
       filters: filters,
       metrics: session_metrics,
       dimensions: dimensions,
-      include_imported: query.include_imported,
-      pagination: nil
+      include_imported: query.include_imported
     )
   end
 

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -27,6 +27,10 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     |> select_total_rows(query.include.total_rows)
   end
 
+  def build_order_by(q, query) do
+    Enum.reduce(query.order_by || [], q, &build_order_by(&2, query, &1))
+  end
+
   defp build_events_query(_site, %Query{metrics: []}), do: nil
 
   defp build_events_query(site, events_query) do
@@ -153,11 +157,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     |> group_by([], selected_as(^key))
   end
 
-  defp build_order_by(q, query) do
-    Enum.reduce(query.order_by || [], q, &build_order_by(&2, query, &1))
-  end
-
-  def build_order_by(q, query, {metric_or_dimension, order_direction}) do
+  defp build_order_by(q, query, {metric_or_dimension, order_direction}) do
     order_by(
       q,
       [t],

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -58,7 +58,8 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         |> Query.set(
           dimensions: [],
           include_imported: query.include_imported,
-          preloaded_goals: []
+          preloaded_goals: [],
+          pagination: nil
         )
 
       q
@@ -101,7 +102,8 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
           metrics: [:visitors],
           order_by: [],
           include_imported: query.include_imported,
-          preloaded_goals: []
+          preloaded_goals: [],
+          pagination: nil
         )
 
       from(e in subquery(q),

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -26,7 +26,8 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         |> remove_filters_ignored_in_totals_query()
         |> Query.set(
           dimensions: [],
-          include_imported: query.include_imported
+          include_imported: query.include_imported,
+          pagination: nil
         )
 
       q
@@ -57,7 +58,11 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         |> Query.set(
           dimensions: [],
           include_imported: query.include_imported,
+<<<<<<< HEAD
           preloaded_goals: []
+=======
+          pagination: nil
+>>>>>>> 71ef81755 (Splitting should no longer remove pagination. Handle special cases in special_metrics.ex)
         )
 
       q
@@ -100,7 +105,11 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
           metrics: [:visitors],
           order_by: [],
           include_imported: query.include_imported,
+<<<<<<< HEAD
           preloaded_goals: []
+=======
+          pagination: nil
+>>>>>>> 71ef81755 (Splitting should no longer remove pagination. Handle special cases in special_metrics.ex)
         )
 
       from(e in subquery(q),

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -58,11 +58,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         |> Query.set(
           dimensions: [],
           include_imported: query.include_imported,
-<<<<<<< HEAD
           preloaded_goals: []
-=======
-          pagination: nil
->>>>>>> 71ef81755 (Splitting should no longer remove pagination. Handle special cases in special_metrics.ex)
         )
 
       q
@@ -105,11 +101,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
           metrics: [:visitors],
           order_by: [],
           include_imported: query.include_imported,
-<<<<<<< HEAD
           preloaded_goals: []
-=======
-          pagination: nil
->>>>>>> 71ef81755 (Splitting should no longer remove pagination. Handle special cases in special_metrics.ex)
         )
 
       from(e in subquery(q),

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1249,7 +1249,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
           "date_range" => "all",
           "dimensions" => ["event:page"],
           "include" => %{"imports" => true},
-          "pagination" => %{limit: 1}
+          "pagination" => %{"limit" => 1}
         })
 
       assert json_response(conn, 200)["results"] == [%{"dimensions" => ["/99"], "metrics" => [3]}]


### PR DESCRIPTION
Ref: https://3.basecamp.com/5308029/buckets/39750953/card_tables/cards/8052057081

JOINs in ClickHouse are slow. In one degenerate case I found a user had over 20 million unique paths in an import, which resulted in extremely slow JOINs. This introduces a sort-of hacky solution to it by limiting the amount of data analyzed.

Query timing without this change:
```
9 rows in set. Elapsed: 11.383 sec. Processed 49.16 million rows, 5.75 GB (4.32 million rows/s., 505.29 MB/s.)
Peak memory usage: 14.75 GiB.
```

After:
```
9 rows in set. Elapsed: 0.572 sec. Processed 49.18 million rows, 5.75 GB (86.03 million rows/s., 10.06 GB/s.)
Peak memory usage: 9.01 GiB.
```