### PR TITLE
Add GTM installation option, when no GTM detected

### DIFF
--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -217,7 +217,10 @@ defmodule PlausibleWeb.Live.Installation do
           if you prefer WordPress installation method.
         </:footer>
 
-        <:footer :if={@initial_installation_type == "GTM" and @installation_type == "manual"}>
+        <:footer :if={
+          (@initial_installation_type == "GTM" and @installation_type == "manual") or
+            (@initial_installation_type == "manual" and @installation_type == "manual")
+        }>
           <.styled_link href={} phx-click="switch-installation-type" phx-value-method="GTM">
             Click here
           </.styled_link>


### PR DESCRIPTION
Just a minor addition for cases when GTM isn't detected due to a cookie banner. 