### PR TITLE
Perf: Improve performance of top stats query with long time windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 ### Changed
+
+- Improved performance of top stats query with longer time windows
+
 ### Fixed
 
 - Fix returning filter suggestions for multiple custom property values in the dashboard Filter modal


### PR DESCRIPTION
We usually don't read events/pageviews from sessions table as sessions can start before or after the time window of the query. This is particularly pronounced with realtime queries.

After this change we start reading events/pageviews from sessions table for longer time periods as the inaccuracies introduced by the session timing is minimized this way.

The end result is that queries for e.g. top stats on dashboard load for 7 days or longer periods only requires reading sessions table.