### PR TITLE
Fix debug controller domain filtering

### DIFF
--- a/lib/plausible_web/controllers/debug_controller.ex
+++ b/lib/plausible_web/controllers/debug_controller.ex
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.DebugController do
       where(
         q,
         [l],
-        fragment("JSONExtractInt(?, \'site_domain\') = ?", l.log_comment, ^site_domain)
+        fragment("JSONExtractString(?, \'site_domain\') = ?", l.log_comment, ^site_domain)
       )
 
   defp filter_by_params(q, conn, _),


### PR DESCRIPTION
This fixes an issue with /debug/clickhouse route - site_domain query param didn't work properly.