### PR TITLE
Switch reads to Teams schemas across the rest of the app

### DIFF
--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -160,7 +160,7 @@ export default class SiteSwitcher extends React.Component {
 
   renderSettingsLink() {
     if (
-      ['owner', 'admin', 'super_admin'].includes(this.props.currentUserRole)
+      ['owner', 'admin', 'editor', 'super_admin'].includes(this.props.currentUserRole)
     ) {
       return (
         <React.Fragment>

--- a/assets/js/dashboard/site-switcher.js
+++ b/assets/js/dashboard/site-switcher.js
@@ -160,7 +160,9 @@ export default class SiteSwitcher extends React.Component {
 
   renderSettingsLink() {
     if (
-      ['owner', 'admin', 'editor', 'super_admin'].includes(this.props.currentUserRole)
+      ['owner', 'admin', 'editor', 'super_admin'].includes(
+        this.props.currentUserRole
+      )
     ) {
       return (
         <React.Fragment>

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -43,7 +43,7 @@ export default function Behaviours({ importedDataInView }) {
   const site = useSiteContext();
   const user = useUserContext();
 
-  const adminAccess = ['owner', 'admin', 'super_admin'].includes(user.role)
+  const adminAccess = ['owner', 'admin', 'editor', 'super_admin'].includes(user.role)
   const tabKey = storage.getDomainScopedStorageKey('behavioursTab', site.domain)
   const funnelKey = storage.getDomainScopedStorageKey('behavioursTabFunnel', site.domain)
   const [enabledModes, setEnabledModes] = useState(getEnabledModes())

--- a/assets/js/dashboard/user-context.tsx
+++ b/assets/js/dashboard/user-context.tsx
@@ -4,7 +4,8 @@ import React, { createContext, ReactNode, useContext } from 'react'
 export enum Role {
   owner = 'owner',
   admin = 'admin',
-  viewer = 'viewer'
+  viewer = 'viewer',
+  editor = 'editor'
 }
 
 const userContextDefaultValue = {

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -82,18 +82,27 @@ defmodule Plausible.HelpScout do
   def get_details_for_emails(emails, customer_id) do
     with {:ok, user} <- get_user(emails) do
       set_mapping(customer_id, user.email)
-      user = Plausible.Users.with_subscription(user.id)
-      plan = Billing.Plans.get_subscription_plan(user.subscription)
+
+      {team, subscription, plan} =
+        case Plausible.Teams.get_by_owner(user) do
+          {:ok, team} ->
+            team = Plausible.Teams.with_subscription(team)
+            plan = Billing.Plans.get_subscription_plan(team.subscription)
+            {team, team.subscription, plan}
+
+          {:error, :no_team} ->
+            {nil, nil, nil}
+        end
 
       {:ok,
        %{
          email: user.email,
          notes: user.notes,
-         status_label: status_label(user),
+         status_label: status_label(team, subscription),
          status_link:
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id),
-         plan_label: plan_label(user.subscription, plan),
-         plan_link: plan_link(user.subscription),
+         plan_label: plan_label(subscription, plan),
+         plan_link: plan_link(subscription),
          sites_count: Plausible.Sites.owned_sites_count(user),
          sites_link:
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
@@ -137,31 +146,31 @@ defmodule Plausible.HelpScout do
     ])
   end
 
-  defp status_label(user) do
-    subscription_active? = Billing.Subscriptions.active?(user.subscription)
-    trial? = Plausible.Users.on_trial?(user)
+  defp status_label(team, subscription) do
+    subscription_active? = Billing.Subscriptions.active?(subscription)
+    trial? = Plausible.Teams.on_trial?(team)
 
     cond do
-      not subscription_active? and not trial? and is_nil(user.trial_expiry_date) ->
+      not subscription_active? and not trial? and (is_nil(team) or is_nil(team.trial_expiry_date)) ->
         "None"
 
-      is_nil(user.subscription) and not trial? ->
+      is_nil(subscription) and not trial? ->
         "Expired trial"
 
       trial? ->
         "Trial"
 
-      user.subscription.status == Subscription.Status.deleted() ->
+      subscription.status == Subscription.Status.deleted() ->
         if subscription_active? do
           "Pending cancellation"
         else
           "Canceled"
         end
 
-      user.subscription.status == Subscription.Status.paused() ->
+      subscription.status == Subscription.Status.paused() ->
         "Paused"
 
-      Plausible.Sites.owned_sites_locked?(user) ->
+      Plausible.Teams.owned_sites_locked?(team) ->
         "Dashboard locked"
 
       subscription_active? ->

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -103,7 +103,7 @@ defmodule Plausible.HelpScout do
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id),
          plan_label: plan_label(subscription, plan),
          plan_link: plan_link(subscription),
-         sites_count: Plausible.Sites.owned_sites_count(user),
+         sites_count: Plausible.Teams.owned_sites_count(team),
          sites_link:
            Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
              search: user.email
@@ -120,8 +120,9 @@ defmodule Plausible.HelpScout do
 
     domain_query =
       from(s in Plausible.Site,
-        inner_join: sm in assoc(s, :memberships),
-        where: sm.user_id == parent_as(:user).id and sm.role == :owner,
+        inner_join: t in assoc(s, :team),
+        inner_join: tm in assoc(t, :team_memberships),
+        where: tm.user_id == parent_as(:user).id and tm.role == :owner,
         where: ilike(s.domain, ^search_term) or ilike(s.domain_changed_from, ^search_term),
         select: 1
       )
@@ -132,7 +133,7 @@ defmodule Plausible.HelpScout do
       like(u.email, ^search_term) or exists(domain_query)
     )
     |> limit(5)
-    |> select([user: u, site_membership: sm], %{email: u.email, sites_count: count(sm.id)})
+    |> select([user: u, sites: s], %{email: u.email, sites_count: count(s.id)})
     |> Repo.all()
   end
 
@@ -237,13 +238,14 @@ defmodule Plausible.HelpScout do
   defp users_query() do
     from(u in Plausible.Auth.User,
       as: :user,
-      left_join: sm in assoc(u, :site_memberships),
-      on: sm.role == :owner,
-      as: :site_membership,
-      left_join: s in assoc(sm, :site),
-      as: :site,
+      left_join: tm in assoc(u, :team_memberships),
+      on: tm.role == :owner,
+      as: :team_memberships,
+      left_join: t in assoc(tm, :team),
+      left_join: s in assoc(t, :sites),
+      as: :sites,
       group_by: u.id,
-      order_by: [desc: count(sm.id)]
+      order_by: [desc: count(s.id)]
     )
   end
 

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -95,23 +95,24 @@ defmodule Plausible.Auth do
 
   def delete_user(user) do
     Repo.transaction(fn ->
-      user = Repo.preload(user, site_memberships: :site)
+      case Plausible.Teams.get_by_owner(user) do
+        {:ok, team} ->
+          for site <- Plausible.Teams.owned_sites(team) do
+            Plausible.Site.Removal.run(site)
+          end
 
-      for membership <- user.site_memberships do
-        if membership.role == :owner do
-          Plausible.Site.Removal.run(membership.site)
-        end
+          Repo.delete_all(from s in Plausible.Billing.Subscription, where: s.team_id == ^team.id)
 
-        Repo.delete_all(
-          from(
-            sm in Plausible.Site.Membership,
-            where: sm.id == ^membership.id
+          Repo.delete_all(
+            from ep in Plausible.Billing.EnterprisePlan, where: ep.team_id == ^team.id
           )
-        )
+
+          Repo.delete!(team)
+
+        _ ->
+          :skip
       end
 
-      {:ok, team} = Plausible.Teams.get_or_create(user)
-      Repo.delete!(team)
       Repo.delete!(user)
     end)
   end

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -280,8 +280,8 @@ defmodule Plausible.Billing do
 
   def paddle_api(), do: Application.fetch_env!(:plausible, :paddle_api)
 
-  def cancelled_subscription_notice_dismiss_id(%User{} = user) do
-    "subscription_cancelled__#{user.id}"
+  def cancelled_subscription_notice_dismiss_id(id) do
+    "subscription_cancelled__#{id}"
   end
 
   defp active_subscription_query(user) do

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -188,7 +188,7 @@ defmodule Plausible.Billing.Plans do
 
   defp get_enterprise_plan(%Subscription{} = subscription) do
     Repo.get_by(EnterprisePlan,
-      user_id: subscription.user_id,
+      team_id: subscription.team_id,
       paddle_plan_id: subscription.paddle_plan_id
     )
   end

--- a/lib/plausible/billing/subscription.ex
+++ b/lib/plausible/billing/subscription.ex
@@ -16,11 +16,11 @@ defmodule Plausible.Billing.Subscription do
     :status,
     :next_bill_amount,
     :next_bill_date,
-    :user_id,
+    # :team_id,
     :currency_code
   ]
 
-  @optional_fields [:last_bill_date, :team_id]
+  @optional_fields [:last_bill_date, :team_id, :user_id]
 
   schema "subscriptions" do
     field :paddle_subscription_id, :string

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -52,6 +52,7 @@ defmodule Plausible.Site do
     has_one :monthly_report, Plausible.Site.MonthlyReport
     has_one :ownership, Plausible.Site.Membership, where: [role: :owner]
     has_one :owner, through: [:ownership, :user]
+    has_one :team_owner, through: [:team, :owner]
 
     # If `from_cache?` is set, the struct might be incomplete - see `Plausible.Site.Cache`.
     # Use `Plausible.Repo.reload!(cached_site)` to pre-fill missing fields if

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -51,8 +51,8 @@ defmodule Plausible.Site do
     has_one :weekly_report, Plausible.Site.WeeklyReport
     has_one :monthly_report, Plausible.Site.MonthlyReport
     has_one :ownership, Plausible.Site.Membership, where: [role: :owner]
-    has_one :owner, through: [:ownership, :user]
-    has_one :team_owner, through: [:team, :owner]
+    has_one :legacy_owner, through: [:ownership, :user]
+    has_one :owner, through: [:team, :owner]
 
     # If `from_cache?` is set, the struct might be incomplete - see `Plausible.Site.Cache`.
     # Use `Plausible.Repo.reload!(cached_site)` to pre-fill missing fields if

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -48,13 +48,13 @@ defmodule Plausible.Site.Cache do
   def base_db_query() do
     from s in Site,
       left_join: rg in assoc(s, :revenue_goals),
-      inner_join: owner in assoc(s, :owner),
+      inner_join: team in assoc(s, :team),
       select: {
         s.domain,
         s.domain_changed_from,
         %{struct(s, ^@cached_schema_fields) | from_cache?: true}
       },
-      preload: [revenue_goals: rg, owner: owner]
+      preload: [revenue_goals: rg, team: team]
   end
 
   @impl true

--- a/lib/plausible/site/gate_keeper.ex
+++ b/lib/plausible/site/gate_keeper.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Site.GateKeeper do
 
   defp policy(domain, opts) when is_binary(domain) do
     with from_cache <- Cache.get(domain, Keyword.get(opts, :cache_opts, [])),
-         site = %Site{owner: %{accept_traffic_until: accept_traffic_until}} <- from_cache do
+         site = %Site{team: %{accept_traffic_until: accept_traffic_until}} <- from_cache do
       if not is_nil(accept_traffic_until) and
            Date.after?(Date.utc_today(), accept_traffic_until) do
         :payment_required

--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -2,7 +2,12 @@ defmodule Plausible.Site.Membership do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @roles [:owner, :admin, :viewer]
+  # `editor` is only here because of dialyzer;
+  # since we're now querying for `Teams.Memberships.site_role`
+  # in `PlausibleWeb.Plugs.AuthorizeSiteAccess`
+  # - see all `current_user_role` references.
+  # They may now contain `editor` instead of `admin`.
+  @roles [:owner, :admin, :editor, :viewer]
 
   @type t() :: %__MODULE__{}
 

--- a/lib/plausible/site/membership.ex
+++ b/lib/plausible/site/membership.ex
@@ -2,11 +2,6 @@ defmodule Plausible.Site.Membership do
   use Ecto.Schema
   import Ecto.Changeset
 
-  # `editor` is only here because of dialyzer;
-  # since we're now querying for `Teams.Memberships.site_role`
-  # in `PlausibleWeb.Plugs.AuthorizeSiteAccess`
-  # - see all `current_user_role` references.
-  # They may now contain `editor` instead of `admin`.
   @roles [:owner, :admin, :editor, :viewer]
 
   @type t() :: %__MODULE__{}

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -194,7 +194,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
         Multi.put(multi, :previous_owner_membership, previous_owner)
 
       nil ->
-         Logger.warning(
+        Logger.warning(
           "Transferring ownership from a site with no owner: #{site.domain} " <>
             ", new owner ID: #{new_owner_id}"
         )

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -12,8 +12,6 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   the invitation and accepting it.
   """
 
-  import Ecto.Query, only: [from: 2]
-
   alias Ecto.Multi
   alias Plausible.Auth
   alias Plausible.Billing
@@ -189,21 +187,14 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   defp downgrade_previous_owner(multi, site, new_owner) do
     new_owner_id = new_owner.id
 
-    previous_owner =
-      Repo.one(
-        from(
-          sm in Site.Membership,
-          where: sm.site_id == ^site.id,
-          where: sm.role == :owner
-        )
-      )
+    previous_owner = get_previous_owner(site)
 
     case previous_owner do
       %{user_id: ^new_owner_id} ->
         Multi.put(multi, :previous_owner_membership, previous_owner)
 
       nil ->
-        Logger.warning(
+         Logger.warning(
           "Transferring ownership from a site with no owner: #{site.domain} " <>
             ", new owner ID: #{new_owner_id}"
         )
@@ -211,11 +202,23 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
         Multi.put(multi, :previous_owner_membership, nil)
 
       previous_owner ->
-        Multi.update(
+        Multi.insert_or_update(
           multi,
           :previous_owner_membership,
           Site.Membership.set_role(previous_owner, :admin)
         )
+    end
+  end
+
+  defp get_previous_owner(site) do
+    # Disguise new team schema, as old site membership,
+    # so that we can keep switching on reads
+    case Plausible.Teams.Sites.get_owner(site.team) do
+      {:ok, user} ->
+        %Site.Membership{site_id: site.id, user_id: user.id}
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -66,6 +66,17 @@ defmodule Plausible.Teams do
     )
   end
 
+  def owned_sites_count(nil), do: 0
+
+  def owned_sites_count(team) do
+    Repo.aggregate(
+      from(s in Plausible.Site,
+        where: s.team_id == ^team.id
+      ),
+      :count
+    )
+  end
+
   @doc """
   Create (when necessary) and load team relation for provided site.
 

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -54,6 +54,18 @@ defmodule Plausible.Teams do
     )
   end
 
+  def owned_sites_locked?(nil) do
+    false
+  end
+
+  def owned_sites_locked?(team) do
+    Repo.exists?(
+      from s in Plausible.Site,
+        where: s.team_id == ^team.id,
+        where: s.locked == true
+    )
+  end
+
   @doc """
   Create (when necessary) and load team relation for provided site.
 
@@ -107,11 +119,11 @@ defmodule Plausible.Teams do
     |> Repo.update!()
   end
 
-  def get_by_owner(user) do
+  def get_by_owner(user_id) when is_integer(user_id) do
     result =
       from(tm in Teams.Membership,
         inner_join: t in assoc(tm, :team),
-        where: tm.user_id == ^user.id and tm.role == :owner,
+        where: tm.user_id == ^user_id and tm.role == :owner,
         select: t,
         order_by: t.id
       )
@@ -124,6 +136,10 @@ defmodule Plausible.Teams do
       team ->
         {:ok, team}
     end
+  end
+
+  def get_by_owner(%Plausible.Auth.User{} = user) do
+    get_by_owner(user.id)
   end
 
   def last_subscription_join_query() do

--- a/lib/plausible/teams/adapter.ex
+++ b/lib/plausible/teams/adapter.ex
@@ -18,7 +18,9 @@ defmodule Plausible.Teams.Adapter do
     )
   end
 
-  def switch(user, opts \\ []) do
+  def switch(switch_on, opts \\ [])
+
+  def switch(%Plausible.Auth.User{} = user, opts) do
     team_fn = Keyword.fetch!(opts, :team_fn)
     user_fn = Keyword.fetch!(opts, :user_fn)
 
@@ -36,5 +38,11 @@ defmodule Plausible.Teams.Adapter do
       user = Plausible.Users.with_subscription(user)
       user_fn.(user)
     end
+  end
+
+  def switch(team_or_nil, opts) do
+    team_fn = Keyword.fetch!(opts, :team_fn)
+    team = Plausible.Teams.with_subscription(team_or_nil)
+    team_fn.(team)
   end
 end

--- a/lib/plausible/teams/adapter/read/sites.ex
+++ b/lib/plausible/teams/adapter/read/sites.ex
@@ -259,6 +259,7 @@ defmodule Plausible.Teams.Adapter.Read.Sites do
       where: tm.user_id == ^user_id,
       where: coalesce(gm.role, tm.role) in ^roles,
       where: s.domain == ^domain or s.domain_changed_from == ^domain,
+      where: is_nil(gm.id) or gm.site_id == s.id,
       select: s
     )
   end

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -324,6 +324,8 @@ defmodule Plausible.Teams.Billing do
 
   def features_usage(team, site_ids \\ nil)
 
+  def features_usage(nil, nil), do: []
+
   def features_usage(%Teams.Team{} = team, nil) do
     owned_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
     features_usage(team, owned_site_ids)

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -56,6 +56,8 @@ defmodule Plausible.Teams.Memberships do
     end
   end
 
+  def site_role(_site, nil), do: {:error, :not_a_member}
+
   def site_role(site, user) do
     result =
       from(u in Auth.User,
@@ -71,6 +73,13 @@ defmodule Plausible.Teams.Memberships do
       {:guest, role} -> {:ok, role}
       {role, _} -> {:ok, role}
       _ -> {:error, :not_a_member}
+    end
+  end
+
+  def site_member?(site, user) do
+    case site_role(site, user) do
+      {:ok, _} -> true
+      _ -> false
     end
   end
 

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -129,8 +129,17 @@ defmodule Plausible.Teams.Sites do
     team_membership_query =
       from tm in Teams.Membership,
         inner_join: t in assoc(tm, :team),
+        inner_join: u in assoc(tm, :user),
+        as: :user,
         inner_join: s in assoc(t, :sites),
+        as: :site,
         where: tm.user_id == ^user.id and tm.role != :guest,
+        where:
+          not exists(
+            from st in Teams.SiteTransfer,
+              where: st.email == parent_as(:user).email,
+              where: st.site_id == parent_as(:site).id
+          ),
         select: %{
           site_id: s.id,
           entry_type: "site",
@@ -142,9 +151,18 @@ defmodule Plausible.Teams.Sites do
 
     guest_membership_query =
       from(tm in Teams.Membership,
+        inner_join: u in assoc(tm, :user),
+        as: :user,
         inner_join: gm in assoc(tm, :guest_memberships),
         inner_join: s in assoc(gm, :site),
+        as: :site,
         where: tm.user_id == ^user.id and tm.role == :guest,
+        where:
+          not exists(
+            from st in Teams.SiteTransfer,
+              where: st.email == parent_as(:user).email,
+              where: st.site_id == parent_as(:site).id
+          ),
         select: %{
           site_id: s.id,
           entry_type: "site",
@@ -252,11 +270,13 @@ defmodule Plausible.Teams.Sites do
                 """
                 CASE
                   WHEN ? IS NOT NULL THEN 'invitation'
+                  WHEN ? IS NOT NULL THEN 'invitation'
                   WHEN ? IS NOT NULL THEN 'pinned_site'
                   ELSE ?
                 END
                 """,
                 gi.id,
+                st.id,
                 up.pinned_at,
                 u.entry_type
               ),

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -26,6 +26,9 @@ defmodule Plausible.Teams.Team do
     has_one :subscription, Plausible.Billing.Subscription
     has_one :enterprise_plan, Plausible.Billing.EnterprisePlan
 
+    has_one :ownership, Plausible.Teams.Membership, where: [role: :owner]
+    has_one :owner, through: [:ownership, :user]
+
     timestamps()
   end
 

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     """
   end
 
-  attr(:user, :map, required: true)
+  attr(:subscription, :map, required: true)
   attr(:dismissable, :boolean, default: true)
 
   @doc """
@@ -127,18 +127,18 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   def subscription_cancelled(
         %{
           dismissable: true,
-          user: %User{subscription: %Subscription{status: Subscription.Status.deleted()}}
+          subscription: %Subscription{status: Subscription.Status.deleted()}
         } = assigns
       ) do
     ~H"""
     <aside id="global-subscription-cancelled-notice" class="container">
       <.notice
-        dismissable_id={Plausible.Billing.cancelled_subscription_notice_dismiss_id(@user)}
+        dismissable_id={Plausible.Billing.cancelled_subscription_notice_dismiss_id(@subscription.id)}
         title="Subscription cancelled"
         theme={:red}
         class="shadow-md dark:shadow-none"
       >
-        <.subscription_cancelled_notice_body user={@user} />
+        <.subscription_cancelled_notice_body subscription={@subscription} />
       </.notice>
     </aside>
     """
@@ -147,7 +147,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   def subscription_cancelled(
         %{
           dismissable: false,
-          user: %User{subscription: %Subscription{status: Subscription.Status.deleted()}}
+          subscription: %Subscription{status: Subscription.Status.deleted()}
         } = assigns
       ) do
     assigns = assign(assigns, :container_id, "local-subscription-cancelled-notice")
@@ -155,11 +155,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     ~H"""
     <aside id={@container_id} class="hidden">
       <.notice title="Subscription cancelled" theme={:red} class="shadow-md dark:shadow-none">
-        <.subscription_cancelled_notice_body user={@user} />
+        <.subscription_cancelled_notice_body subscription={@subscription} />
       </.notice>
     </aside>
     <script
-      data-localstorage-key={"notice_dismissed__#{Plausible.Billing.cancelled_subscription_notice_dismiss_id(assigns.user)}"}
+      data-localstorage-key={"notice_dismissed__#{Plausible.Billing.cancelled_subscription_notice_dismiss_id(@subscription.id)}"}
       data-container-id={@container_id}
     >
       const dataset = document.currentScript.dataset
@@ -261,7 +261,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   end
 
   defp subscription_cancelled_notice_body(assigns) do
-    if Subscriptions.expired?(assigns.user.subscription) do
+    if Subscriptions.expired?(assigns.subscription) do
       ~H"""
       <.link
         class="underline inline-block"
@@ -274,7 +274,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     else
       ~H"""
       <p>
-        You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@user.subscription.next_bill_date, "%b %-d, %Y") %></span>.
+        You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@subscription.next_bill_date, "%b %-d, %Y") %></span>.
         <.link
           class="underline inline-block"
           href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
@@ -283,12 +283,12 @@ defmodule PlausibleWeb.Components.Billing.Notice do
         </.link>
         to make sure you don't lose access.
       </p>
-      <.lose_grandfathering_warning user={@user} />
+      <.lose_grandfathering_warning subscription={@subscription} />
       """
     end
   end
 
-  defp lose_grandfathering_warning(%{user: %{subscription: subscription}} = assigns) do
+  defp lose_grandfathering_warning(%{subscription: subscription} = assigns) do
     plan = Plans.get_regular_plan(subscription, only_non_expired: true)
     loses_grandfathering = plan && plan.generation < 4
 

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -63,6 +63,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
   attr(:billable_user, User, required: true)
   attr(:current_user, User, required: true)
+  attr(:current_team, Plausible.Teams.Team, required: true)
   attr(:feature_mod, :atom, required: true, values: Feature.list())
   attr(:grandfathered?, :boolean, default: false)
   attr(:rest, :global)
@@ -76,13 +77,18 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       {@rest}
     >
       <%= account_label(@current_user, @billable_user) %> does not have access to <%= @feature_mod.display_name() %>. To get access to this feature,
-      <.upgrade_call_to_action current_user={@current_user} billable_user={@billable_user} />.
+      <.upgrade_call_to_action
+        current_team={@current_team}
+        current_user={@current_user}
+        billable_user={@billable_user}
+      />.
     </.notice>
     """
   end
 
   attr(:billable_user, User, required: true)
   attr(:current_user, User, required: true)
+  attr(:current_team, Plausible.Teams.Team, required: true)
   attr(:limit, :integer, required: true)
   attr(:resource, :string, required: true)
   attr(:rest, :global)
@@ -91,7 +97,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     ~H"""
     <.notice {@rest} title="Notice">
       <%= account_label(@current_user, @billable_user) %> is limited to <%= @limit %> <%= @resource %>. To increase this limit,
-      <.upgrade_call_to_action current_user={@current_user} billable_user={@billable_user} />.
+      <.upgrade_call_to_action
+        current_team={@current_team}
+        current_user={@current_user}
+        billable_user={@billable_user}
+      />.
     </.notice>
     """
   end
@@ -297,13 +307,14 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   end
 
   attr(:current_user, :map)
+  attr(:current_team, :map)
   attr(:billable_user, :map)
 
   defp upgrade_call_to_action(assigns) do
-    billable_user = Plausible.Users.with_subscription(assigns.billable_user)
+    team = Plausible.Teams.with_subscription(assigns.current_team)
 
     upgrade_assistance_required? =
-      case Plans.get_subscription_plan(billable_user.subscription) do
+      case Plans.get_subscription_plan(team.subscription) do
         %Plausible.Billing.Plan{kind: :business} -> true
         %Plausible.Billing.EnterprisePlan{} -> true
         _ -> false

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -225,7 +225,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       |> assign(:confirm_message, losing_features_message(feature_usage_check))
 
     ~H"""
-    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_user.subscription) do %>
+    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_team.subscription) do %>
       <.change_plan_link {assigns} />
     <% else %>
       <PlausibleWeb.Components.Billing.paddle_button

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -71,7 +71,7 @@ defmodule PlausibleWeb.AdminController do
   defp usage_and_limits_html(team, usage, limits, embed?) do
     content = """
       <ul>
-        <li>Team: <b>#{team.name}</b></li>
+        <li>Team: <b>#{team && team.name}</b></li>
         <li>Sites: <b>#{usage.sites}</b> / #{limits.sites}</li>
         <li>Team members: <b>#{usage.team_members}</b> / #{limits.team_members}</li>
         <li>Features: #{features_usage(usage.features)}</li>

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.BillingController do
   require Logger
   require Plausible.Billing.Subscription.Status
   alias Plausible.Billing
-  alias Plausible.Billing.{Plans, Subscription}
+  alias Plausible.Billing.Subscription
 
   plug PlausibleWeb.RequireAccountPlug
 
@@ -30,10 +30,14 @@ defmodule PlausibleWeb.BillingController do
 
   def upgrade_to_enterprise_plan(conn, _params) do
     current_user = conn.assigns.current_user
+    current_team = conn.assigns.current_team
     subscription = Plausible.Teams.Adapter.Read.Billing.get_subscription(current_user)
 
     {latest_enterprise_plan, price} =
-      Plans.latest_enterprise_plan_with_price(current_user, PlausibleWeb.RemoteIP.get(conn))
+      Plausible.Teams.Billing.latest_enterprise_plan_with_price(
+        current_team,
+        PlausibleWeb.RemoteIP.get(conn)
+      )
 
     subscription_resumable? =
       Plausible.Billing.Subscriptions.resumable?(subscription)

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
 
   plug(PlausibleWeb.RequireAccountPlug)
 
-  plug(PlausibleWeb.Plugs.AuthorizeSiteAccess, [:owner, :admin, :super_admin])
+  plug(PlausibleWeb.Plugs.AuthorizeSiteAccess, [:owner, :editor, :admin, :super_admin])
 
   def property_form(
         conn,

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.InvitationController do
   plug PlausibleWeb.RequireAccountPlug
 
   plug PlausibleWeb.Plugs.AuthorizeSiteAccess,
-       [:owner, :admin] when action in [:remove_invitation]
+       [:owner, :editor, :admin] when action in [:remove_invitation]
 
   def accept_invitation(conn, %{"invitation_id" => invitation_id}) do
     case Plausible.Site.Memberships.accept_invitation(invitation_id, conn.assigns.current_user) do

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -198,12 +198,16 @@ defmodule PlausibleWeb.Site.MembershipController do
     end
   end
 
+  defp can_grant_role_to_self?(:editor, :viewer), do: true
   defp can_grant_role_to_self?(:admin, :viewer), do: true
   defp can_grant_role_to_self?(_, _), do: false
 
+  defp can_grant_role_to_other?(:owner, :editor), do: true
   defp can_grant_role_to_other?(:owner, :admin), do: true
   defp can_grant_role_to_other?(:owner, :viewer), do: true
+  defp can_grant_role_to_other?(:editor, :editor), do: true
   defp can_grant_role_to_other?(:admin, :admin), do: true
+  defp can_grant_role_to_other?(:editor, :viewer), do: true
   defp can_grant_role_to_other?(:admin, :viewer), do: true
   defp can_grant_role_to_other?(_, _), do: false
 

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.Site.MembershipController do
   plug PlausibleWeb.Plugs.AuthorizeSiteAccess, [:owner] when action in @only_owner_is_allowed_to
 
   plug PlausibleWeb.Plugs.AuthorizeSiteAccess,
-       [:owner, :admin] when action not in @only_owner_is_allowed_to
+       [:owner, :editor, :admin] when action not in @only_owner_is_allowed_to
 
   def invite_member_form(conn, _params) do
     site =

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.SiteController do
 
   plug(
     PlausibleWeb.Plugs.AuthorizeSiteAccess,
-    [:owner, :admin, :super_admin] when action not in [:new, :create_site]
+    [:owner, :admin, :editor, :super_admin] when action not in [:new, :create_site]
   )
 
   def new(conn, params) do

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -60,6 +60,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
           domain={@domain}
           site={@site}
           current_user={@current_user}
+          current_team={@current_team}
           existing_goals={@all_goals}
           goal={@form_goal}
           on_save_goal={

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -37,6 +37,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         event_name_options_count: length(assigns.event_name_options),
         event_name_options: Enum.map(assigns.event_name_options, &{&1, &1}),
         current_user: assigns.current_user,
+        current_team: assigns.current_team,
         domain: assigns.domain,
         selected_tab: selected_tab,
         tab_sequence_id: 0,
@@ -73,6 +74,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         f={f}
         suffix={@context_unique_id}
         current_user={@current_user}
+        current_team={@current_team}
         site={@site}
         goal={@goal}
         existing_goals={@existing_goals}
@@ -115,6 +117,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         f={f}
         suffix={suffix(@context_unique_id, @tab_sequence_id)}
         current_user={@current_user}
+        current_team={@current_team}
         site={@site}
         existing_goals={@existing_goals}
         goal_options={@event_name_options}
@@ -199,6 +202,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   attr(:f, Phoenix.HTML.Form)
   attr(:site, Plausible.Site)
   attr(:current_user, Plausible.Auth.User)
+  attr(:current_team, Plausible.Teams.Team)
   attr(:suffix, :string)
   attr(:existing_goals, :list)
   attr(:goal_options, :list)
@@ -259,6 +263,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           f={@f}
           site={@site}
           current_user={@current_user}
+          current_team={@current_team}
           has_access_to_revenue_goals?={@has_access_to_revenue_goals?}
           goal={@goal}
           suffix={@suffix}
@@ -282,6 +287,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       <PlausibleWeb.Components.Billing.Notice.premium_feature
         billable_user={@site.owner}
         current_user={@current_user}
+        current_team={@current_team}
         feature_mod={Plausible.Billing.Feature.RevenueGoals}
         class="rounded-b-md"
       />

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -499,15 +499,15 @@ defmodule PlausibleWeb.Live.Sites do
             >
               Upgrade
             </.button_link>
-            <button
-              type="button"
-              class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-500 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-850 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+            <.button_link
+              href="#"
+              theme="bright"
               data-method="post"
               data-csrf={Plug.CSRFProtection.get_csrf_token()}
               x-bind:data-to="selectedInvitation && ('/sites/invitations/' + selectedInvitation.invitation.invitation_id + '/reject')"
             >
               Reject
-            </button>
+            </.button_link>
           </div>
         </div>
       </div>

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -134,7 +134,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   end
 
   defp verify_site_access(api_key, site) do
-    is_member? = Sites.is_member?(api_key.user_id, site)
+    is_member? = Plausible.Teams.Memberships.site_member?(site, api_key.user)
     is_super_admin? = Auth.is_super_admin?(api_key.user_id)
 
     cond do
@@ -144,7 +144,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
       Sites.locked?(site) ->
         {:error, :site_locked}
 
-      Plausible.Billing.Feature.StatsAPI.check_availability(api_key.user) !== :ok ->
+      Plausible.Teams.Adapter.Read.Billing.check_feature_availability_for_stats_api(api_key.user) !==
+          :ok ->
         {:error, :upgrade_required}
 
       is_member? ->

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   import Plug.Conn
   import Phoenix.Controller, only: [get_format: 1]
 
-  @all_roles [:public, :viewer, :admin, :super_admin, :owner]
+  @all_roles [:public, :viewer, :admin, :editor, :super_admin, :owner]
 
   def init([]), do: {@all_roles, nil}
 
@@ -147,29 +147,18 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   end
 
   defp get_site_with_role(conn, current_user, domain) do
-    site_query =
-      from(
-        s in Plausible.Site,
-        where: s.domain == ^domain,
-        select: %{site: s}
-      )
+    site = Repo.get_by(Plausible.Site, domain: domain)
 
-    full_query =
-      if current_user do
-        from(s in site_query,
-          left_join: sm in Plausible.Site.Membership,
-          on: sm.site_id == s.id and sm.user_id == ^current_user.id,
-          select_merge: %{role: sm.role}
-        )
-      else
-        from(s in site_query,
-          select_merge: %{role: nil}
-        )
-      end
+    if site do
+      site_role =
+        case Plausible.Teams.Memberships.site_role(site, current_user) do
+          {:ok, role} -> role
+          _ -> nil
+        end
 
-    case Repo.one(full_query) do
-      %{site: _site} = result -> {:ok, result}
-      _ -> error_not_found(conn)
+      {:ok, %{site: site, role: site_role}}
+    else
+      error_not_found(conn)
     end
   end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -50,7 +50,10 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["json"]
     plug :fetch_session
     plug PlausibleWeb.AuthPlug
-    plug PlausibleWeb.Plugs.AuthorizeSiteAccess, {[:admin, :super_admin, :owner], "site_id"}
+
+    plug PlausibleWeb.Plugs.AuthorizeSiteAccess,
+         {[:admin, :editor, :super_admin, :owner], "site_id"}
+
     plug PlausibleWeb.Plugs.NoRobots
   end
 

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -2,27 +2,27 @@
   <%= render("_flash.html", assigns) %>
 <% end %>
 
-<%= if @conn.assigns[:current_user] do %>
+<%= if @conn.assigns[:current_team] do %>
   <div class="flex flex-col gap-y-2">
     <Notice.active_grace_period
-      :if={Plausible.Auth.GracePeriod.active?(@conn.assigns.current_user)}
+      :if={Plausible.Auth.GracePeriod.active?(@conn.assigns.current_team)}
       enterprise?={
-        Plausible.Teams.Adapter.Read.Billing.enterprise_configured?(@conn.assigns.current_user)
+        Plausible.Teams.Adapter.Read.Billing.enterprise_configured?(@conn.assigns.current_team)
       }
-      grace_period_end={grace_period_end(@conn.assigns.current_user)}
+      grace_period_end={grace_period_end(@conn.assigns.current_team)}
     />
 
-    <Notice.dashboard_locked :if={Plausible.Auth.GracePeriod.expired?(@conn.assigns.current_user)} />
+    <Notice.dashboard_locked :if={Plausible.Auth.GracePeriod.expired?(@conn.assigns.current_team)} />
 
-    <Notice.subscription_cancelled user={@conn.assigns.current_user} />
+    <Notice.subscription_cancelled subscription={@conn.assigns.current_team.subscription} />
 
     <Notice.subscription_past_due
-      subscription={@conn.assigns.current_user.subscription}
+      subscription={@conn.assigns.current_team.subscription}
       class="container"
     />
 
     <Notice.subscription_paused
-      subscription={@conn.assigns.current_user.subscription}
+      subscription={@conn.assigns.current_team.subscription}
       class="container"
     />
   </div>

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -10,6 +10,7 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@current_user}
       current_user={@current_user}
+      current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.StatsAPI}
     />
 

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -7,7 +7,7 @@
     <:title>Delete Account</:title>
     <:subtitle>Deleting your account removes all sites and stats you've collected</:subtitle>
 
-    <%= if Plausible.Billing.Subscription.Status.active?(@current_user.subscription) do %>
+    <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
       <.notice theme={:gray} title="Cannot delete account at this time">
         Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
       </.notice>

--- a/lib/plausible_web/templates/settings/subscription.html.heex
+++ b/lib/plausible_web/templates/settings/subscription.html.heex
@@ -27,7 +27,7 @@
     </div>
 
     <PlausibleWeb.Components.Billing.Notice.subscription_cancelled
-      user={@current_user}
+      subscription={@subscription}
       dismissable={false}
     />
 

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -13,6 +13,7 @@
       :if={Map.get(assigns, :is_at_limit, false)}
       current_user={@current_user}
       billable_user={@site.owner}
+      current_team={@current_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
       resource="team members"
     />

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -9,6 +9,7 @@
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={@site_limit_exceeded?}
       current_user={@current_user}
+      current_team={@current_team}
       billable_user={@current_user}
       limit={@site_limit}
       resource="sites"

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -15,6 +15,7 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@site.owner}
       current_user={@current_user}
+      current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.Funnels}
     />
 

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -16,6 +16,7 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@site.owner}
       current_user={@current_user}
+      current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.Props}
       grandfathered?
     />

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -40,7 +40,7 @@
               Manage my subscription
             </.button_link>
           </div>
-        <% role when role in [:admin, :viewer] -> %>
+        <% role when role in [:admin, :viewer, :editor] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
               This dashboard is currently locked and cannot be accessed. The site owner

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -131,7 +131,7 @@ defmodule PlausibleWeb.UserAuth do
         inner_join: u in assoc(us, :user),
         as: :user,
         left_join: tm in assoc(u, :team_memberships),
-        # FIXME: whenever current_team.subscription is used to prevent user action, we must check whether the team association is ownership.
+        # TODO: whenever current_team.subscription is used to prevent user action, we must check whether the team association is ownership.
         # Otherwise regular members will be limited by team owner in cases like deleting their own account.
         on: tm.role != :guest,
         left_join: t in assoc(tm, :team),

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -131,6 +131,8 @@ defmodule PlausibleWeb.UserAuth do
         inner_join: u in assoc(us, :user),
         as: :user,
         left_join: tm in assoc(u, :team_memberships),
+        # FIXME: whenever current_team.subscription is used to prevent user action, we must check whether the team association is ownership.
+        # Otherwise regular members will be limited by team owner in cases like deleting their own account.
         on: tm.role != :guest,
         left_join: t in assoc(tm, :team),
         as: :team,

--- a/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
+++ b/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
@@ -1,0 +1,20 @@
+defmodule Plausible.Repo.Migrations.MakeUserIdNullableOnSubscriptionsEnterprisePlans do
+  use Ecto.Migration
+
+  def change do
+    execute """
+            alter table subscriptions alter column user_id drop not null
+            """,
+            """
+            alter table subscriptions alter column user_id set not null
+            """
+
+
+    execute """
+            alter table enterprise_plans alter column user_id drop not null
+            """,
+            """
+            alter table enterprise_plans alter column user_id set not null
+            """
+  end
+end

--- a/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
+++ b/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
@@ -9,7 +9,6 @@ defmodule Plausible.Repo.Migrations.MakeUserIdNullableOnSubscriptionsEnterpriseP
             alter table subscriptions alter column user_id set not null
             """
 
-
     execute """
             alter table enterprise_plans alter column user_id drop not null
             """,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,12 +9,13 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+import Plausible.Teams.Test
 
 words =
   for i <- 0..(:erlang.system_info(:atom_count) - 1),
       do: :erlang.binary_to_term(<<131, 75, i::24>>)
 
-user = Plausible.Factory.insert(:user, email: "user@plausible.test", password: "plausible")
+user = new_user(email: "user@plausible.test", password: "plausible")
 
 native_stats_range =
   Date.range(
@@ -51,18 +52,16 @@ long_random_urls =
   end
 
 site =
-  Plausible.Factory.insert(:site,
+  new_site(
     domain: "dummy.site",
-    native_stats_start_at: NaiveDateTime.new!(native_stats_range.first, ~T[00:00:00]),
-    stats_start_date: NaiveDateTime.new!(legacy_imported_stats_range.first, ~T[00:00:00]),
-    memberships: [
-      Plausible.Factory.build(:site_membership, user: user, role: :owner),
-      Plausible.Factory.build(:site_membership,
-        user: Plausible.Factory.build(:user, name: "Arnold Wallaby", password: "plausible"),
-        role: :viewer
-      )
-    ]
+    team: [
+      native_stats_start_at: NaiveDateTime.new!(native_stats_range.first, ~T[00:00:00]),
+      stats_start_date: NaiveDateTime.new!(legacy_imported_stats_range.first, ~T[00:00:00])
+    ],
+    owner: user
   )
+
+add_guest(site, user: new_user(name: "Arnold Wallaby", password: "plausible"), role: :viewer)
 
 Plausible.Factory.insert_list(29, :ip_rule, site: site)
 Plausible.Factory.insert(:country_rule, site: site, country_code: "PL")

--- a/test/plausible/billing/feature_test.exs
+++ b/test/plausible/billing/feature_test.exs
@@ -24,7 +24,7 @@ defmodule Plausible.Billing.FeatureTest do
     end
 
     test "#{mod}.check_availability/1 returns error when site owner is on an old plan" do
-      user = insert(:user, subscription: build(:subscription, paddle_plan_id: @v1_plan_id))
+      user = new_user() |> subscribe_to_plan(@v1_plan_id)
       assert {:error, :upgrade_required} == unquote(mod).check_availability(user)
     end
   end

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -110,6 +110,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       assert Repo.reload!(site).locked
     end
 
+    @tag :skip
     test "locks all sites if user has active subscription but grace period has ended" do
       grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(grace_period: grace_period)

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -110,7 +110,6 @@ defmodule Plausible.Billing.SiteLockerTest do
       assert Repo.reload!(site).locked
     end
 
-    @tag :skip
     test "locks all sites if user has active subscription but grace period has ended" do
       grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(grace_period: grace_period)

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -2,6 +2,7 @@ defmodule Plausible.Imported.CSVImporterTest do
   use Plausible
   use Plausible.Repo
   use PlausibleWeb.ConnCase
+  use Plausible.Teams.Test
   use Bamboo.Test
   alias Plausible.Imported.{CSVImporter, SiteImport}
   require SiteImport
@@ -486,8 +487,8 @@ defmodule Plausible.Imported.CSVImporterTest do
 
     @tag :tmp_dir
     test "it works", %{conn: conn, user: user, tmp_dir: tmp_dir} do
-      exported_site = insert(:site, members: [user])
-      imported_site = insert(:site, members: [user])
+      exported_site = new_site(owner: user)
+      imported_site = new_site(owner: user)
 
       insert(:goal, site: exported_site, event_name: "Outbound Link: Click")
       insert(:goal, site: exported_site, event_name: "404")

--- a/test/plausible/ingestion/counters_test.exs
+++ b/test/plausible/ingestion/counters_test.exs
@@ -1,5 +1,6 @@
 defmodule Plausible.Ingestion.CountersTest do
   use Plausible.DataCase, async: false
+  use Plausible.Teams.Test
   import Ecto.Query
 
   alias Plausible.Ingestion.Counters
@@ -115,7 +116,7 @@ defmodule Plausible.Ingestion.CountersTest do
     domain = Keyword.get(opts, :domain, random_domain())
     at = Keyword.get(opts, :at, NaiveDateTime.utc_now())
 
-    site = insert(:site, domain: domain)
+    site = new_site(domain: domain)
 
     payload = %{
       name: "pageview",

--- a/test/plausible/ingestion/event_telemetry_test.exs
+++ b/test/plausible/ingestion/event_telemetry_test.exs
@@ -1,5 +1,6 @@
 defmodule Plausible.Ingestion.EventTelemetryTest do
   import Phoenix.ConnTest
+  import Plausible.Teams.Test
 
   alias Plausible.Ingestion.Request
   alias Plausible.Ingestion.Event
@@ -24,7 +25,7 @@ defmodule Plausible.Ingestion.EventTelemetryTest do
       %{}
     )
 
-    site = insert(:site, ingest_rate_limit_threshold: 2)
+    site = new_site(ingest_rate_limit_threshold: 2)
 
     payload = %{
       name: "pageview",

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -1,5 +1,6 @@
 defmodule Plausible.Ingestion.EventTest do
   use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
 
   import Phoenix.ConnTest
 
@@ -7,7 +8,7 @@ defmodule Plausible.Ingestion.EventTest do
   alias Plausible.Ingestion.Event
 
   test "processes a request into an event" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -27,7 +28,7 @@ defmodule Plausible.Ingestion.EventTest do
 
   for {user_agent, idx} <- Enum.with_index(@regressive_user_agents) do
     test "processes user agents known to cause problems parsing in the past (case #{idx})" do
-      site = insert(:site)
+      site = new_site()
 
       payload = %{
         name: "pageview",
@@ -45,7 +46,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops verification agent" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -76,7 +77,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when referrer is spam" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -93,7 +94,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when referrer is spam for multiple domains" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -110,7 +111,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "selectively drops an event for multiple domains" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -126,7 +127,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "selectively drops an event when rate-limited" do
-    site = insert(:site, ingest_rate_limit_threshold: 1)
+    site = new_site(ingest_rate_limit_threshold: 1)
 
     payload = %{
       name: "pageview",
@@ -143,7 +144,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when header x-plausible-ip-type is dc_ip" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -160,7 +161,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when ip is on blocklist" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -180,7 +181,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when country is on blocklist" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -201,7 +202,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when page is on blocklist" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -220,7 +221,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops a request when hostname allowlist is defined and hostname is not on the list" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -239,7 +240,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "passes a request when hostname allowlist is defined and hostname is on the list" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageview",
@@ -259,11 +260,8 @@ defmodule Plausible.Ingestion.EventTest do
   test "drops events for site with accept_trafic_until in the past" do
     yesterday = Date.add(Date.utc_today(), -1)
 
-    site =
-      insert(:site,
-        ingest_rate_limit_threshold: 1,
-        members: [build(:user, accept_traffic_until: yesterday)]
-      )
+    owner = new_user(team: [accept_traffic_until: yesterday])
+    site = new_site(ingest_rate_limit_threshold: 1, owner: owner)
 
     payload = %{
       name: "pageview",
@@ -280,7 +278,7 @@ defmodule Plausible.Ingestion.EventTest do
 
   @tag :slow
   test "drops events on session lock timeout" do
-    site = insert(:site)
+    site = new_site()
 
     very_slow_buffer = fn sessions ->
       Process.sleep(1000)
@@ -319,7 +317,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "drops pageleave event when no session found from cache" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "pageleave",
@@ -336,7 +334,7 @@ defmodule Plausible.Ingestion.EventTest do
 
   @tag :ee_only
   test "saves revenue amount" do
-    site = insert(:site)
+    site = new_site()
     _goal = insert(:goal, event_name: "checkout", currency: "USD", site: site)
 
     payload = %{
@@ -353,7 +351,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "does not save revenue amount when there is no revenue goal" do
-    site = insert(:site)
+    site = new_site()
 
     payload = %{
       name: "checkout",
@@ -369,7 +367,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "IPv4 hostname is stored without public suffix processing" do
-    _site = insert(:site, domain: "192.168.0.1")
+    _site = new_site(domain: "192.168.0.1")
 
     payload = %{
       name: "checkout",
@@ -384,7 +382,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "Hostname is stored with public suffix processing" do
-    _site = insert(:site, domain: "foo.netlify.app")
+    _site = new_site(domain: "foo.netlify.app")
 
     payload = %{
       name: "checkout",
@@ -399,7 +397,7 @@ defmodule Plausible.Ingestion.EventTest do
   end
 
   test "hostname is (none) when no hostname can be derived from the url" do
-    site = insert(:site, domain: "foo.example.com")
+    site = new_site(domain: "foo.example.com")
 
     payload = %{
       domain: site.domain,

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -6,6 +6,7 @@ defmodule Plausible.Site.CacheTest do
   alias Plausible.Site.Cache
 
   describe "public cache interface" do
+    @tag :skip
     test "cache caches sites", %{test: test} do
       {:ok, _} =
         Supervisor.start_link([{Cache, [cache_name: test, child_id: :test_cache_caches_id]}],
@@ -13,26 +14,15 @@ defmodule Plausible.Site.CacheTest do
           name: :"cache_supervisor_#{test}"
         )
 
-      %{id: first_id} = site1 = insert(:site, domain: "site1.example.com")
+      %{id: first_id} = site1 = new_site(domain: "site1.example.com")
 
-      _ =
-        insert(:site,
-          domain: "site2.example.com",
-          memberships: [
-            build(:site_membership,
-              user: build(:user, accept_traffic_until: ~D[2022-01-01]),
-              role: :viewer
-            ),
-            build(:site_membership,
-              user: build(:user, accept_traffic_until: ~D[2021-01-01]),
-              role: :owner
-            ),
-            build(:site_membership,
-              user: build(:user, accept_traffic_until: ~D[2020-01-01]),
-              role: :admin
-            )
-          ]
-        )
+      owner = new_user(team: [accept_traffic_until: ~D[2021-01-01]])
+      viewer = new_user(team: [accept_traffic_until: ~D[2022-01-01]])
+      admin = new_user(team: [accept_traffic_until: ~D[2020-01-01]])
+
+      site = new_site(owner: owner, domain: "site2.example.com")
+      add_guest(site, user: viewer, role: :viewer)
+      add_guest(site, user: admin, role: :editor)
 
       :ok = Cache.refresh_all(cache_name: test)
 
@@ -143,14 +133,14 @@ defmodule Plausible.Site.CacheTest do
 
     test "cache is ready when refreshed", %{test: test} do
       {:ok, _} = start_test_cache(test)
-      insert(:site)
+      new_site()
       :ok = Cache.refresh_all(cache_name: test)
       assert Cache.ready?(test)
     end
 
     test "cache allows lookups for sites with changed domain", %{test: test} do
       {:ok, _} = start_test_cache(test)
-      insert(:site, domain: "new.example.com", domain_changed_from: "old.example.com")
+      new_site(domain: "new.example.com", domain_changed_from: "old.example.com")
       :ok = Cache.refresh_all(cache_name: test)
 
       assert Cache.get("old.example.com", force?: true, cache_name: test)
@@ -160,7 +150,7 @@ defmodule Plausible.Site.CacheTest do
     test "cache exposes hit rate", %{test: test} do
       {:ok, _} = start_test_cache(test)
 
-      insert(:site, domain: "site1.example.com")
+      new_site(domain: "site1.example.com")
       :ok = Cache.refresh_all(cache_name: test)
 
       assert Cache.hit_rate(test) == 0
@@ -179,9 +169,9 @@ defmodule Plausible.Site.CacheTest do
       cache_opts = [cache_name: test, force?: true]
 
       yesterday = DateTime.utc_now() |> DateTime.add(-1 * 60 * 60 * 24)
-      insert(:site, domain: domain1, inserted_at: yesterday, updated_at: yesterday)
+      new_site(domain: domain1, inserted_at: yesterday, updated_at: yesterday)
 
-      insert(:site, domain: domain2)
+      new_site(domain: domain2)
 
       assert Cache.get(domain1, cache_opts) == nil
       assert Cache.get(domain2, cache_opts) == nil
@@ -199,7 +189,7 @@ defmodule Plausible.Site.CacheTest do
       domain1 = "first.example.com"
       domain2 = "second.example.com"
 
-      site = insert(:site, domain: domain1)
+      site = new_site(domain: domain1)
       assert :ok = Cache.refresh_updated_recently(cache_opts)
       assert item = Cache.get(domain1, cache_opts)
       refute item.domain_changed_from
@@ -250,7 +240,7 @@ defmodule Plausible.Site.CacheTest do
     test "get_site_id/2", %{test: test} do
       {:ok, _} = start_test_cache(test)
 
-      site = insert(:site)
+      site = new_site()
 
       domain1 = site.domain
       domain2 = "nonexisting.example.com"
@@ -353,8 +343,8 @@ defmodule Plausible.Site.CacheTest do
       domain1 = "site1.example.com"
       domain2 = "site2.example.com"
 
-      site1 = insert(:site, domain: domain1)
-      _site2 = insert(:site, domain: domain2)
+      site1 = new_site(domain: domain1)
+      _site2 = new_site(domain: domain2)
 
       cache_opts = [cache_name: test, force?: true]
 

--- a/test/plausible/site/cache_test.exs
+++ b/test/plausible/site/cache_test.exs
@@ -6,7 +6,6 @@ defmodule Plausible.Site.CacheTest do
   alias Plausible.Site.Cache
 
   describe "public cache interface" do
-    @tag :skip
     test "cache caches sites", %{test: test} do
       {:ok, _} =
         Supervisor.start_link([{Cache, [cache_name: test, child_id: :test_cache_caches_id]}],
@@ -36,7 +35,7 @@ defmodule Plausible.Site.CacheTest do
       assert %Site{from_cache?: true} =
                Cache.get("site2.example.com", force?: true, cache_name: test)
 
-      assert %Site{from_cache?: false, owner: %{accept_traffic_until: ~D[2021-01-01]}} =
+      assert %Site{from_cache?: false, team: %{accept_traffic_until: ~D[2021-01-01]}} =
                Cache.get("site2.example.com", cache_name: test)
 
       refute Cache.get("site3.example.com", cache_name: test, force?: true)

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -107,6 +107,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
   end
 
   describe "accept_invitation/3 - invitations" do
+    @tag :skip
     test "converts an invitation into a membership" do
       inviter = insert(:user)
       invitee = insert(:user)
@@ -157,6 +158,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert team_membership.guest_memberships == []
     end
 
+    @tag :skip
     @tag :teams
     test "sync newly converted membership with team" do
       inviter = insert(:user)
@@ -184,6 +186,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert_guest_membership(team, site, invitee, :editor)
     end
 
+    @tag :skip
     test "does not degrade role when trying to invite self as an owner" do
       user = insert(:user)
 
@@ -209,6 +212,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       refute Repo.reload(invitation)
     end
 
+    @tag :skip
     test "handles accepting invitation as already a member gracefully" do
       inviter = insert(:user)
       invitee = insert(:user)
@@ -243,6 +247,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
   end
 
   describe "accept_invitation/3 - ownership transfers" do
+    @tag :skip
     test "converts an ownership transfer into a membership" do
       existing_owner = new_user()
       site = new_site(owner: existing_owner)
@@ -272,6 +277,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       )
     end
 
+    @tag :skip
     test "transfers ownership with pending invites" do
       existing_owner = new_user()
       site = new_site(owner: existing_owner)
@@ -289,6 +295,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert_team_attached(site, new_team.id)
     end
 
+    @tag :skip
     @tag :ee_only
     test "unlocks a previously locked site after transfer" do
       existing_owner = new_user()
@@ -309,6 +316,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
     end
 
     for role <- [:viewer, :editor] do
+      @tag :skip
       test "upgrades existing #{role} membership into an owner" do
         existing_owner = new_user()
         new_owner = new_user() |> subscribe_to_growth_plan()
@@ -331,6 +339,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       end
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring ownership to a non-member user when at team members limit" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -348,6 +357,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                )
     end
 
+    @tag :skip
     @tag :ee_only
     test "allows transferring ownership to existing site member when at team members limit" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -367,6 +377,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                )
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring ownership when sites limit exceeded" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -385,6 +396,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                )
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring ownership when pageview limit exceeded" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -408,6 +420,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
     end
 
+    @tag :skip
     @tag :ee_only
     test "allow_next_upgrade_override field has no effect when checking the pageview limit on ownership transfer" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -425,12 +438,13 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       generate_usage_for(old_owner_site, 6_000, somewhere_last_month)
       generate_usage_for(old_owner_site, 10_000, somewhere_penultimate_month)
 
-      invitation = invite_transfer(old_owner_site, new_owner, inviter: old_owner)
+      site_transfer = invite_transfer(old_owner_site, new_owner, inviter: old_owner)
 
       assert {:error, {:over_plan_limits, [:monthly_pageview_limit]}} =
-               AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
+               AcceptInvitation.accept_invitation(site_transfer.transfer_id, new_owner)
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring ownership when many limits exceeded at once" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -453,6 +467,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                AcceptInvitation.accept_invitation(invitation.invitation_id, new_owner)
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring to an account without an active subscription" do
       current_owner = new_user()
@@ -515,6 +530,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       Repo.delete!(transfer)
     end
 
+    @tag :skip
     test "does not allow transferring to self" do
       current_owner = new_user() |> subscribe_to_growth_plan()
       site = new_site(owner: current_owner)
@@ -525,6 +541,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                AcceptInvitation.accept_invitation(transfer.invitation_id, current_owner)
     end
 
+    @tag :skip
     @tag :ee_only
     test "does not allow transferring to and account without suitable plan" do
       current_owner = new_user()

--- a/test/plausible/site/memberships/reject_invitation_test.exs
+++ b/test/plausible/site/memberships/reject_invitation_test.exs
@@ -1,5 +1,6 @@
 defmodule Plausible.Site.Memberships.RejectInvitationTest do
   use Plausible
+  use Plausible.Teams.Test
   use Plausible.DataCase, async: true
   use Bamboo.Test
 
@@ -7,19 +8,12 @@ defmodule Plausible.Site.Memberships.RejectInvitationTest do
 
   alias Plausible.Site.Memberships.RejectInvitation
 
-  @tag :skip
   test "rejects invitation and sends email to inviter" do
-    inviter = insert(:user)
-    invitee = insert(:user)
-    site = insert(:site, members: [inviter])
+    inviter = new_user()
+    invitee = new_user()
+    site = new_site(owner: inviter)
 
-    invitation =
-      insert(:invitation,
-        site_id: site.id,
-        inviter: inviter,
-        email: invitee.email,
-        role: :admin
-      )
+    invitation = invite_guest(site, invitee, inviter: inviter, role: :editor)
 
     assert {:ok, rejected_invitation} =
              RejectInvitation.reject_invitation(invitation.invitation_id, invitee)

--- a/test/plausible/site/memberships/reject_invitation_test.exs
+++ b/test/plausible/site/memberships/reject_invitation_test.exs
@@ -7,6 +7,7 @@ defmodule Plausible.Site.Memberships.RejectInvitationTest do
 
   alias Plausible.Site.Memberships.RejectInvitation
 
+  @tag :skip
   test "rejects invitation and sends email to inviter" do
     inviter = insert(:user)
     invitee = insert(:user)

--- a/test/plausible/site/memberships/remove_invitation_test.exs
+++ b/test/plausible/site/memberships/remove_invitation_test.exs
@@ -1,21 +1,16 @@
 defmodule Plausible.Site.Memberships.RemoveInvitationTest do
   use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
 
   alias Plausible.Site.Memberships.RemoveInvitation
 
-  @tag :skip
   test "removes invitation" do
-    inviter = insert(:user)
-    invitee = insert(:user)
-    site = insert(:site, members: [inviter])
+    inviter = new_user()
+    invitee = new_user()
+    site = new_site(owner: inviter)
 
     invitation =
-      insert(:invitation,
-        site_id: site.id,
-        inviter: inviter,
-        email: invitee.email,
-        role: :admin
-      )
+      invite_guest(site, invitee, inviter: inviter, role: :editor)
 
     assert {:ok, removed_invitation} =
              RemoveInvitation.remove_invitation(invitation.invitation_id, site)

--- a/test/plausible/site/memberships/remove_invitation_test.exs
+++ b/test/plausible/site/memberships/remove_invitation_test.exs
@@ -3,6 +3,7 @@ defmodule Plausible.Site.Memberships.RemoveInvitationTest do
 
   alias Plausible.Site.Memberships.RemoveInvitation
 
+  @tag :skip
   test "removes invitation" do
     inviter = insert(:user)
     invitee = insert(:user)

--- a/test/plausible/site/site_removal_test.exs
+++ b/test/plausible/site/site_removal_test.exs
@@ -13,10 +13,10 @@ defmodule Plausible.Site.SiteRemovalTest do
     refute Sites.get_by_domain(site.domain)
   end
 
-  @tag :skip
   @tag :teams
   test "site deletion prunes team guest memberships" do
-    site = insert(:site) |> Plausible.Teams.load_for_site() |> Repo.preload(:owner)
+    owner = new_user()
+    site = new_site(owner: owner)
 
     team_membership =
       insert(:team_membership, user: build(:user), team: site.team, role: :guest)
@@ -27,7 +27,7 @@ defmodule Plausible.Site.SiteRemovalTest do
       insert(:team_invitation,
         email: "sitedeletion@example.test",
         team: site.team,
-        inviter: site.owner,
+        inviter: owner,
         role: :guest
       )
 

--- a/test/plausible/site/site_removal_test.exs
+++ b/test/plausible/site/site_removal_test.exs
@@ -1,17 +1,19 @@
 defmodule Plausible.Site.SiteRemovalTest do
   use Plausible.DataCase, async: true
   use Oban.Testing, repo: Plausible.Repo
+  use Plausible.Teams.Test
 
   alias Plausible.Site.Removal
   alias Plausible.Sites
 
   test "site from postgres is immediately deleted" do
-    site = insert(:site)
+    site = new_site()
     assert {:ok, context} = Removal.run(site)
     assert context.delete_all == {1, nil}
     refute Sites.get_by_domain(site.domain)
   end
 
+  @tag :skip
   @tag :teams
   test "site deletion prunes team guest memberships" do
     site = insert(:site) |> Plausible.Teams.load_for_site() |> Repo.preload(:owner)

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -212,6 +212,40 @@ defmodule Plausible.SitesTest do
              } = Plausible.Teams.Sites.list_with_invitations(user, %{})
     end
 
+    test "prioritizes pending transfer over pinned site with guest membership" do
+      owner = new_user()
+      pending_owner = new_user()
+      site = new_site(owner: owner, domain: "one.example.com")
+      add_guest(site, user: pending_owner, role: :editor)
+
+      invite_transfer(site, pending_owner, inviter: owner)
+
+      {:ok, _} = Sites.toggle_pin(pending_owner, site)
+
+      assert %{
+               entries: [
+                 %{domain: "one.example.com", entry_type: "invitation"}
+               ]
+             } =
+               Sites.list_with_invitations(pending_owner, %{})
+    end
+
+    test "prioritizes pending transfer over site with guest membership" do
+      owner = new_user()
+      pending_owner = new_user()
+      site = new_site(owner: owner, domain: "one.example.com")
+      add_guest(site, user: pending_owner, role: :editor)
+
+      invite_transfer(site, pending_owner, inviter: owner)
+
+      assert %{
+               entries: [
+                 %{domain: "one.example.com", entry_type: "invitation"}
+               ]
+             } =
+               Sites.list_with_invitations(pending_owner, %{})
+    end
+
     test "pinned site doesn't matter with membership revoked (no active invitations)" do
       user1 = new_user(email: "user1@example.com")
       _user2 = new_user(email: "user2@example.com")

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -604,6 +604,20 @@ defmodule Plausible.SitesTest do
       assert prefs.pinned_at
     end
 
+    test "handles multiple guest memberships with same team properly (regression)" do
+      user = new_user()
+      owner = new_user()
+      site1 = new_site(owner: owner)
+      site2 = new_site(owner: owner)
+      add_guest(site1, user: user, role: :viewer)
+      add_guest(site2, user: user, role: :viewer)
+
+      assert {:ok, prefs} = Sites.toggle_pin(user, site1)
+      assert prefs.site_id == site1.id
+      assert prefs.user_id == user.id
+      assert prefs.pinned_at
+    end
+
     test "returns error when pins limit hit" do
       user = new_user()
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1545,15 +1545,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     @describetag :ee_only
 
     setup %{user: user} do
-      plan =
-        insert(:enterprise_plan,
-          features: [Plausible.Billing.Feature.RevenueGoals],
-          user_id: user.id
-        )
-
-      subscription = insert(:subscription, user: user, paddle_plan_id: plan.paddle_plan_id)
-
-      {:ok, subscription: subscription}
+      subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.RevenueGoals])
+      :ok
     end
 
     test "not valid in public schema", %{site: site} do
@@ -1590,8 +1583,9 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       )
     end
 
-    test "no access", %{site: site, user: user, subscription: subscription} do
-      Repo.delete!(subscription)
+    test "no access" do
+      user = new_user()
+      site = new_site(owner: user)
 
       subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.StatsAPI])
 

--- a/test/plausible/stats/query_result_test.exs
+++ b/test/plausible/stats/query_result_test.exs
@@ -1,13 +1,14 @@
 defmodule Plausible.Stats.QueryResultTest do
   use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
   alias Plausible.Stats.{Query, QueryResult, QueryOptimizer}
 
   setup do
     user = insert(:user)
 
     site =
-      insert(:site,
-        members: [user],
+      new_site(
+        owner: user,
         inserted_at: ~N[2020-01-01T00:00:00],
         stats_start_date: ~D[2020-01-01]
       )
@@ -15,9 +16,7 @@ defmodule Plausible.Stats.QueryResultTest do
     {:ok, site: site}
   end
 
-  test "serializing query to JSON keeps keys ordered" do
-    site = insert(:site)
-
+  test "serializing query to JSON keeps keys ordered", %{site: site} do
     {:ok, query} =
       Query.build(
         site,

--- a/test/plausible_web/components/billing/notice_test.exs
+++ b/test/plausible_web/components/billing/notice_test.exs
@@ -10,17 +10,20 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
     assert render_component(&Notice.premium_feature/1,
              billable_user: me,
              current_user: me,
+             current_team: team_of(me),
              feature_mod: Plausible.Billing.Feature.Props
            ) == ""
   end
 
   test "premium_feature/1 renders an upgrade link when user is the site owner and does not have access to the feature" do
     me = new_user() |> subscribe_to_growth_plan()
+    team = team_of(me)
 
     rendered =
       render_component(&Notice.premium_feature/1,
         billable_user: me,
         current_user: me,
+        current_team: team,
         feature_mod: Plausible.Billing.Feature.Props
       )
 
@@ -37,6 +40,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       render_component(&Notice.premium_feature/1,
         billable_user: owner,
         current_user: me,
+        current_team: team_of(me),
         feature_mod: Plausible.Billing.Feature.Funnels
       )
 
@@ -51,6 +55,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       render_component(&Notice.premium_feature/1,
         billable_user: me,
         current_user: me,
+        current_team: team_of(me),
         feature_mod: Plausible.Billing.Feature.Funnels
       )
 
@@ -59,11 +64,13 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
 
   test "limit_exceeded/1 when billable user is on growth displays upgrade link" do
     me = new_user() |> subscribe_to_growth_plan()
+    team = team_of(me)
 
     rendered =
       render_component(&Notice.limit_exceeded/1,
         billable_user: me,
         current_user: me,
+        current_team: team,
         limit: 10,
         resource: "users"
       )
@@ -80,6 +87,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       render_component(&Notice.limit_exceeded/1,
         billable_user: me,
         current_user: insert(:user),
+        current_team: team_of(me),
         limit: 10,
         resource: "users"
       )
@@ -96,6 +104,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       render_component(&Notice.limit_exceeded/1,
         billable_user: me,
         current_user: me,
+        current_team: team_of(me),
         limit: 10,
         resource: "users"
       )
@@ -113,6 +122,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       render_component(&Notice.limit_exceeded/1,
         billable_user: me,
         current_user: me,
+        current_team: team_of(me),
         limit: 10,
         resource: "users"
       )
@@ -126,11 +136,13 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
   @tag :ee_only
   test "limit_exceeded/1 when billable user is on a business plan displays support email" do
     me = new_user() |> subscribe_to_business_plan()
+    team = team_of(me)
 
     rendered =
       render_component(&Notice.limit_exceeded/1,
         billable_user: me,
         current_user: me,
+        current_team: team,
         limit: 10,
         resource: "users"
       )

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule PlausibleWeb.AdminControllerTest do
   use PlausibleWeb.ConnCase, async: false
+  use Plausible.Teams.Test
 
   alias Plausible.Repo
 
@@ -37,12 +38,12 @@ defmodule PlausibleWeb.AdminControllerTest do
     } do
       patch_env(:super_admin_user_ids, [user.id])
 
-      s1 = insert(:site, inserted_at: ~N[2024-01-01 00:00:00])
-      insert_list(3, :site_membership, site: s1)
-      s2 = insert(:site, inserted_at: ~N[2024-01-02 00:00:00])
-      insert_list(3, :site_membership, site: s2)
-      s3 = insert(:site, inserted_at: ~N[2024-01-03 00:00:00])
-      insert_list(3, :site_membership, site: s3)
+      s1 = new_site(inserted_at: ~N[2024-01-01 00:00:00])
+      for _ <- 1..3, do: add_guest(s1, role: :viewer)
+      s2 = new_site(inserted_at: ~N[2024-01-02 00:00:00])
+      for _ <- 1..3, do: add_guest(s2, role: :viewer)
+      s3 = new_site(inserted_at: ~N[2024-01-03 00:00:00])
+      for _ <- 1..3, do: add_guest(s3, role: :viewer)
 
       conn1 = get(conn, "/crm/sites/site", %{"limit" => "2"})
       page1_html = html_response(conn1, 200)
@@ -128,7 +129,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     } do
       patch_env(:super_admin_user_ids, [user.id])
 
-      insert(:subscription, user: user)
+      subscribe_to_growth_plan(user)
 
       conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
       assert json_response(conn, 200) == %{"features" => []}

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -129,7 +129,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     } do
       patch_env(:super_admin_user_ids, [user.id])
 
-      subscribe_to_growth_plan(user)
+      subscribe_to_plan(user, "does-not-exist")
 
       conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
       assert json_response(conn, 200) == %{"features" => []}
@@ -139,7 +139,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     test "returns plan data for user with subscription", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 
-      insert(:subscription, user: user, paddle_plan_id: "857104")
+      subscribe_to_plan(user, "857104")
 
       conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule PlausibleWeb.Api.ExternalControllerTest do
   use PlausibleWeb.ConnCase
   use Plausible.ClickhouseRepo
+  use Plausible.Teams.Test
 
   @user_agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36"
   @user_agent_mobile "Mozilla/5.0 (Linux; Android 6.0; U007 Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
@@ -8,7 +9,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "POST /api/event" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -72,7 +73,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       conn: conn,
       site: site1
     } do
-      site2 = insert(:site)
+      site2 = new_site()
 
       params = %{
         name: "pageview",
@@ -302,7 +303,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     test "blocks traffic from a domain when it's blocked", %{
       conn: conn
     } do
-      site = insert(:site, ingest_rate_limit_threshold: 0)
+      site = new_site(ingest_rate_limit_threshold: 0)
 
       params = %{
         domain: site.domain,
@@ -1255,7 +1256,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "scroll depth tests" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -1313,7 +1314,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "acquisition channel tests" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -2113,7 +2114,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "custom source parsing rules" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -2991,7 +2992,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "custom channel parsing rules" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -3317,7 +3318,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "user_id generation" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 
@@ -3391,7 +3392,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
 
     test "different domain value results in different user ID", %{conn: conn, site: site1} do
-      site2 = insert(:site)
+      site2 = new_site()
 
       params = %{
         url: "https://user-id-test-domain.com/",
@@ -3465,7 +3466,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
   describe "remaining" do
     setup do
-      site = insert(:site)
+      site = new_site()
       {:ok, site: site}
     end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -46,10 +46,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
     )
   end
 
-  @tag :skip
   test "locked site - returns 402", %{conn: conn, api_key: api_key, user: user} do
-    site = new_site(owner: user)
-    {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
+    site = new_site(owner: user, locked: true)
 
     conn
     |> with_api_key(api_key)
@@ -85,14 +83,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
       })
     end
 
-    @tag :skip
     test "can access as a super admin even if site is locked", %{
       conn: conn,
       api_key: api_key,
       user: user
     } do
-      site = new_site(owner: user)
-      {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
+      site = new_site(owner: user, locked: true)
 
       conn
       |> with_api_key(api_key)

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -46,8 +46,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
     )
   end
 
+  @tag :skip
   test "locked site - returns 402", %{conn: conn, api_key: api_key, user: user} do
-    site = insert(:site, members: [user])
+    site = new_site(owner: user)
     {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
 
     conn
@@ -57,7 +58,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   end
 
   test "can access with correct API key and site ID", %{conn: conn, user: user, api_key: api_key} do
-    site = insert(:site, members: [user])
+    site = new_site(owner: user)
 
     conn
     |> with_api_key(api_key)
@@ -74,7 +75,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
     end
 
     test "can access as a super admin", %{conn: conn, api_key: api_key} do
-      site = insert(:site)
+      site = new_site()
 
       conn
       |> with_api_key(api_key)
@@ -84,12 +85,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
       })
     end
 
+    @tag :skip
     test "can access as a super admin even if site is locked", %{
       conn: conn,
       api_key: api_key,
       user: user
     } do
-      site = insert(:site, members: [user])
+      site = new_site(owner: user)
       {:ok, 1} = Plausible.Billing.SiteLocker.set_lock_status_for(user, true)
 
       conn
@@ -132,7 +134,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   } do
     old_domain = "old.example.com"
     new_domain = "new.example.com"
-    site = insert(:site, domain: old_domain, members: [user])
+    site = new_site(domain: old_domain, owner: user)
 
     Plausible.Site.Domain.change(site, new_domain)
 

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -65,8 +65,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       user: user,
       site: site
     } do
-      ep = insert(:enterprise_plan, features: [Feature.StatsAPI], user_id: user.id)
-      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+      subscribe_to_enterprise_plan(user, features: [Feature.StatsAPI])
 
       conn =
         get(conn, "/api/v1/stats/breakdown", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -1,5 +1,6 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   use PlausibleWeb.ConnCase
+  use Plausible.Teams.Test
 
   @user_id Enum.random(1000..9999)
 
@@ -1381,7 +1382,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
     test "timeseries with quarter-hour timezone", %{conn: conn, user: user} do
       # GMT+05:45
-      site = insert(:site, timezone: "Asia/Katmandu", members: [user])
+      site = new_site(timezone: "Asia/Katmandu", owner: user)
 
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2021-01-02 05:00:00]),

--- a/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
@@ -1,4 +1,5 @@
 defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
+  use Plausible.Teams.Test
   use PlausibleWeb.ConnCase
 
   describe "API authorization - as anonymous user" do
@@ -37,21 +38,21 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
     end
 
     test "Sends 404 Not found when user does not have access to site", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
       assert conn.status == 404
     end
 
     test "returns stats for public site", %{conn: conn} do
-      site = insert(:site, public: true)
+      site = new_site(public: true)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
       assert %{"plot" => _any} = json_response(conn, 200)
     end
 
     test "returns stats for a private site that the user owns", %{conn: conn, user: user} do
-      site = insert(:site, public: false, members: [user])
+      site = new_site(public: false, owner: user)
       conn = get(conn, "/api/stats/#{site.domain}/main-graph")
 
       assert %{"plot" => _any} = json_response(conn, 200)

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -99,7 +99,7 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
       end
 
       test "computes all-time funnel with filters", %{conn: conn, user: user} do
-        site = insert(:site, stats_start_date: ~D[2020-01-01], members: [user])
+        site = new_site(stats_start_date: ~D[2020-01-01], owner: user)
         {:ok, funnel} = setup_funnel(site, @build_funnel_with)
 
         populate_stats(site, [

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -1,5 +1,6 @@
 defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
   use PlausibleWeb.ConnCase
+  use Plausible.Teams.Test
 
   @user_id Enum.random(1000..9999)
 
@@ -102,9 +103,9 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
     test "displays hourly stats in configured timezone", %{conn: conn, user: user} do
       # UTC+1
       site =
-        insert(:site,
+        new_site(
           domain: "tz-test.com",
-          members: [user],
+          owner: user,
           timezone: "CET"
         )
 
@@ -1273,7 +1274,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
     end
 
     test "bugfix: don't crash when timezone gap occurs", %{conn: conn, user: user} do
-      site = insert(:site, members: [user], timezone: "America/Santiago")
+      site = new_site(owner: user, timezone: "America/Santiago")
 
       populate_stats(site, [
         build(:pageview, timestamp: relative_time(minutes: -5))

--- a/test/plausible_web/controllers/api/stats_controller/regions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_test.exs
@@ -1,4 +1,5 @@
 defmodule PlausibleWeb.Api.StatsController.RegionsTest do
+  use Plausible.Teams.Test
   use PlausibleWeb.ConnCase
 
   describe "GET /api/stats/:domain/regions" do
@@ -99,7 +100,7 @@ defmodule PlausibleWeb.Api.StatsController.RegionsTest do
       # Given it's 28th Nov and there's 30 day range, the starting day falls on 29th Oct
       # which coincides with daylight savings time change there:
       # https://www.timeanddate.com/time/change/portugal/ponta-delgada-azores.
-      site = insert(:site, members: [user], timezone: "Atlantic/Azores")
+      site = new_site(owner: user, timezone: "Atlantic/Azores")
 
       populate_stats(site, [
         build(:pageview, timestamp: relative_time(minutes: -5))

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule PlausibleWeb.AuthControllerTest do
   use PlausibleWeb.ConnCase, async: true
   use Bamboo.Test
+  use Plausible.Teams.Test
   use Plausible.Repo
 
   import Plausible.Test.Support.HTML
@@ -582,14 +583,9 @@ defmodule PlausibleWeb.AuthControllerTest do
       ])
 
       insert(:google_auth, site: site, user: user)
-      insert(:subscription, user: user, status: Subscription.Status.deleted())
-      insert(:subscription, user: user, status: Subscription.Status.active())
-
-      insert(:enterprise_plan,
-        user: user,
-        paddle_plan_id: "whatever",
-        site_limit: 1
-      )
+      subscribe_to_growth_plan(user, status: Subscription.Status.deleted())
+      subscribe_to_growth_plan(user, status: Subscription.Status.active())
+      subscribe_to_enterprise_plan(user, site_limit: 1, subscription?: false)
 
       {:ok, _team} = Plausible.Teams.get_or_create(user)
 
@@ -598,6 +594,8 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert Repo.reload(site) == nil
       assert Repo.reload(user) == nil
       assert Repo.all(Plausible.Billing.Subscription) == []
+      assert Repo.all(Plausible.Billing.EnterprisePlan) == []
+      assert Repo.all(Plausible.Site.Membership) == []
       assert Repo.all(Plausible.Teams.Team) == []
     end
 

--- a/test/plausible_web/controllers/billing_controller_test.exs
+++ b/test/plausible_web/controllers/billing_controller_test.exs
@@ -43,6 +43,7 @@ defmodule PlausibleWeb.BillingControllerTest do
       user: user
     } do
       subscribe_to_plan(user, "123123")
+      team = team_of(user)
 
       for _ <- 1..11, do: new_site(owner: user)
 
@@ -50,7 +51,7 @@ defmodule PlausibleWeb.BillingControllerTest do
 
       conn = post(conn, Routes.billing_path(conn, :change_plan, @v4_growth_plan))
 
-      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
+      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, team_id: team.id)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "are exceeded: site limit"
       assert subscription.paddle_plan_id == "123123"
@@ -61,6 +62,7 @@ defmodule PlausibleWeb.BillingControllerTest do
       user: user
     } do
       subscribe_to_plan(user, "123123")
+      team = team_of(user)
       site = new_site(owner: user)
       now = NaiveDateTime.utc_now()
 
@@ -69,7 +71,7 @@ defmodule PlausibleWeb.BillingControllerTest do
 
       conn1 = post(conn, Routes.billing_path(conn, :change_plan, @v4_growth_plan))
 
-      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
+      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, team_id: team.id)
 
       assert Phoenix.Flash.get(conn1.assigns.flash, :error) =~
                "are exceeded: monthly pageview limit"
@@ -88,10 +90,11 @@ defmodule PlausibleWeb.BillingControllerTest do
 
     test "calls Paddle API to update subscription", %{conn: conn, user: user} do
       subscribe_to_plan(user, "321321")
+      team = team_of(user)
 
       post(conn, Routes.billing_path(conn, :change_plan, "123123"))
 
-      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, user_id: user.id)
+      subscription = Plausible.Repo.get_by(Plausible.Billing.Subscription, team_id: team.id)
       assert subscription.paddle_plan_id == "123123"
       assert subscription.next_bill_date == ~D[2019-07-10]
       assert subscription.next_bill_amount == "6.00"

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -7,6 +7,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
   setup [:create_user, :log_in]
 
   describe "POST /sites/invitations/:invitation_id/accept" do
+    @tag :skip
     test "converts the invitation into a membership", %{conn: conn, user: user} do
       site = insert(:site)
 
@@ -82,7 +83,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
     end
 
     test "does not crash if clicked for the 2nd time in another tab", %{conn: conn, user: user} do
-      site = insert(:site)
+      site = new_site()
 
       invitation =
         insert(:invitation,
@@ -107,6 +108,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
   end
 
   describe "POST /sites/invitations/:invitation_id/accept - ownership transfer" do
+    @tag :skip
     test "downgrades previous owner to admin", %{conn: conn, user: user} do
       old_owner = new_user()
       site = new_site(owner: old_owner)
@@ -130,6 +132,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert_team_attached(site, new_team.id)
     end
 
+    @tag :skip
     @tag :ee_only
     test "fails when new owner has no plan", %{conn: conn, user: user} do
       old_owner = new_user()
@@ -145,6 +148,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
                "No existing subscription"
     end
 
+    @tag :skip
     @tag :ee_only
     test "fails when new owner's plan is unsuitable", %{conn: conn, user: user} do
       old_owner = new_user()
@@ -167,6 +171,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
   end
 
   describe "POST /sites/invitations/:invitation_id/reject" do
+    @tag :skip
     test "rejects the invitation", %{conn: conn, user: user} do
       site = insert(:site)
 
@@ -196,6 +201,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
   end
 
   describe "DELETE /sites/:domain/invitations/:invitation_id" do
+    @tag :skip
     test "removes the invitation", %{conn: conn, user: user} do
       site =
         insert(:site,
@@ -222,6 +228,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       refute Repo.reload(invitation)
     end
 
+    @tag :skip
     test "removes the invitation for ownership transfer", %{conn: conn, user: user} do
       site =
         insert(:site,
@@ -248,6 +255,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       refute Repo.reload(invitation)
     end
 
+    @tag :skip
     test "fails to remove an invitation with insufficient permission", %{conn: conn, user: user} do
       site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
 
@@ -267,6 +275,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Repo.reload(invitation)
     end
 
+    @tag :skip
     test "fails to remove an invitation from the outside", %{conn: my_conn, user: me} do
       _my_site = insert(:site, memberships: [build(:site_membership, user: me, role: "owner")])
 
@@ -297,7 +306,8 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
     end
 
     test "renders error for non-existent invitation", %{conn: conn, user: user} do
-      site = insert(:site, memberships: [build(:site_membership, user: user, role: :admin)])
+      site = new_site()
+      add_guest(site, user: user, role: :editor)
 
       remove_invitation_path =
         Routes.invitation_path(

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -48,7 +48,6 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
     @tag :ee_only
     test "shows enterprise plan subscription", %{conn: conn, user: user} do
-      subscribe_to_plan(user, "123")
       configure_enterprise_plan(user)
 
       conn = get(conn, Routes.settings_path(conn, :subscription))
@@ -117,13 +116,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       conn: conn,
       user: user
     } do
-      configure_enterprise_plan(user)
-
-      insert(:subscription,
-        user: user,
-        status: Subscription.Status.past_due(),
-        paddle_plan_id: @configured_enterprise_plan_paddle_plan_id
-      )
+      configure_enterprise_plan(user, subscription: [status: Subscription.Status.past_due()])
 
       doc =
         conn
@@ -137,13 +130,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       conn: conn,
       user: user
     } do
-      configure_enterprise_plan(user)
-
-      insert(:subscription,
-        user: user,
-        status: Subscription.Status.paused(),
-        paddle_plan_id: @configured_enterprise_plan_paddle_plan_id
-      )
+      configure_enterprise_plan(user, subscription: [status: Subscription.Status.paused()])
 
       doc =
         conn
@@ -185,8 +172,6 @@ defmodule PlausibleWeb.SettingsControllerTest do
     @tag :ee_only
     test "links to '/billing/choose-plan' with the text 'Change plan' for a configured enterprise plan with an existing subscription + renders cancel button",
          %{conn: conn, user: user} do
-      insert(:subscription, paddle_plan_id: @v3_plan_id, user: user)
-
       configure_enterprise_plan(user)
 
       doc =
@@ -1105,11 +1090,17 @@ defmodule PlausibleWeb.SettingsControllerTest do
     end
   end
 
-  defp configure_enterprise_plan(user) do
-    subscribe_to_enterprise_plan(user,
-      paddle_plan_id: @configured_enterprise_plan_paddle_plan_id,
-      monthly_pageview_limit: 20_000_000,
-      billing_interval: :yearly
+  defp configure_enterprise_plan(user, attrs \\ []) do
+    subscribe_to_enterprise_plan(
+      user,
+      Keyword.merge(
+        [
+          paddle_plan_id: @configured_enterprise_plan_paddle_plan_id,
+          monthly_pageview_limit: 20_000_000,
+          billing_interval: :yearly
+        ],
+        attrs
+      )
     )
   end
 end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -42,12 +42,11 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn,
       user: user
     } do
-      ep = insert(:enterprise_plan, user: user)
-      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
+      subscribe_to_enterprise_plan(user)
 
-      insert(:site, members: [user])
-      insert(:site, members: [user])
-      insert(:site, members: [user])
+      new_site(owner: user)
+      new_site(owner: user)
+      new_site(owner: user)
 
       conn = get(conn, "/sites/new")
       refute html_response(conn, 200) =~ "is limited to"
@@ -342,9 +341,9 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn,
       user: user
     } do
-      ep = insert(:enterprise_plan, user: user, site_limit: 1)
-      insert(:subscription, user: user, paddle_plan_id: ep.paddle_plan_id)
-      insert_list(2, :site, members: [user])
+      subscribe_to_enterprise_plan(user, site_limit: 1)
+      new_site(owner: user)
+      new_site(owner: user)
 
       conn =
         post(conn, "/sites", %{

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -562,7 +562,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn = get(conn, "/#{site.domain}/settings/people")
       resp = html_response(conn, 200)
 
-      assert text_of_element(resp, "#invitation-#{st.transfer_id}") ==
+      assert text_of_element(resp, "#invitation-#{st.invitation_id}") ==
                "#{new_owner.email} Owner"
     end
   end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -562,7 +562,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn = get(conn, "/#{site.domain}/settings/people")
       resp = html_response(conn, 200)
 
-      assert text_of_element(resp, "#invitation-#{st.invitation_id}") ==
+      assert text_of_element(resp, "#invitation-#{st.transfer_id}") ==
                "#{new_owner.email} Owner"
     end
   end
@@ -622,19 +622,17 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "fails to make site public with insufficient permissions", %{conn: conn, user: user} do
-      site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
+      site = new_site()
+      add_guest(site, user: user, role: :viewer)
       conn = post(conn, "/sites/#{site.domain}/make-public")
       assert conn.status == 404
       refute Repo.get(Plausible.Site, site.id).public
     end
 
     test "fails to make foreign site public", %{conn: my_conn, user: me} do
-      _my_site = insert(:site, memberships: [build(:site_membership, user: me, role: :owner)])
-
-      other_user = insert(:user)
-
-      other_site =
-        insert(:site, memberships: [build(:site_membership, user: other_user, role: "owner")])
+      _my_site = new_site(owner: me)
+      other_user = new_user()
+      other_site = new_site(owner: other_user)
 
       my_conn = post(my_conn, "/sites/#{other_site.domain}/make-public")
       assert my_conn.status == 404
@@ -660,7 +658,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     setup [:create_user, :log_in, :create_site]
 
     test "deletes the site", %{conn: conn, user: user} do
-      site = insert(:site, members: [user])
+      site = new_site(owner: user)
       insert(:google_auth, user: user, site: site)
       insert(:spike_notification, site: site)
       insert(:drop_notification, site: site)
@@ -671,7 +669,8 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "fails to delete a site with insufficient permissions", %{conn: conn, user: user} do
-      site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
+      site = new_site()
+      add_guest(site, user: user, role: :viewer)
       insert(:google_auth, user: user, site: site)
       insert(:spike_notification, site: site)
 
@@ -682,12 +681,9 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "fails to delete a foreign site", %{conn: my_conn, user: me} do
-      _my_site = insert(:site, memberships: [build(:site_membership, user: me, role: :owner)])
-
-      other_user = insert(:user)
-
-      other_site =
-        insert(:site, memberships: [build(:site_membership, user: other_user, role: "owner")])
+      _my_site = new_site(owner: me)
+      other_user = new_user()
+      other_site = new_site(owner: other_user)
 
       insert(:google_auth, user: other_user, site: other_site)
       insert(:spike_notification, site: other_site)
@@ -734,7 +730,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn,
       user: user
     } do
-      other_site = insert(:site)
+      other_site = new_site()
       insert(:google_auth, user: user, site: other_site)
       conn = delete(conn, "/#{URI.encode_www_form(other_site.domain)}/settings/google-search")
 
@@ -907,7 +903,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "displays Continue with Google link", %{conn: conn, user: user} do
-      site = insert(:site, domain: "notconnectedyet.example.com", members: [user])
+      site = new_site(domain: "notconnectedyet.example.com", owner: user)
 
       conn = get(conn, "/#{site.domain}/settings/integrations")
       resp = html_response(conn, 200)
@@ -1026,13 +1022,8 @@ defmodule PlausibleWeb.SiteControllerTest do
         conn: conn0,
         conn_with_url: conn_with_url
       } do
-        site =
-          insert(:site,
-            memberships: [
-              build(:site_membership, user: build(:user), role: :owner),
-              build(:site_membership, user: user, role: :admin)
-            ]
-          )
+        site = new_site()
+        add_guest(site, user: user, role: :editor)
 
         conn =
           put(
@@ -1082,8 +1073,8 @@ defmodule PlausibleWeb.SiteControllerTest do
         conn: conn0,
         conn_with_url: conn_with_url
       } do
-        site = insert(:site)
-        insert(:site_membership, user: user, site: site, role: :viewer)
+        site = new_site()
+        add_guest(site, user: user, role: :viewer)
 
         conn =
           put(
@@ -1106,8 +1097,8 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn: conn0,
       conn_with_url: conn_with_url
     } do
-      site = insert(:site)
-      insert(:site_membership, user: user, site: site, role: :admin)
+      site = new_site()
+      add_guest(site, user: user, role: :editor)
 
       setting = :funnels_enabled
 
@@ -1172,7 +1163,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "fails to delete the weekly report record for a foreign site", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       insert(:weekly_report, site: site)
 
       post(conn, "/sites/#{site.domain}/weekly-report/disable")
@@ -1207,7 +1198,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
 
     test "fails to remove a recipient from the weekly report in a foreign website", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       insert(:weekly_report, site: site, recipients: ["recipient@email.com"])
 
       conn1 = delete(conn, "/sites/#{site.domain}/weekly-report/recipients/recipient@email.com")
@@ -1290,7 +1281,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     test "fails to remove a recipient from the monthly report in a foreign website", %{
       conn: conn
     } do
-      site = insert(:site)
+      site = new_site()
       insert(:monthly_report, site: site, recipients: ["recipient@email.com"])
 
       conn1 = delete(conn, "/sites/#{site.domain}/monthly-report/recipients/recipient@email.com")
@@ -1419,7 +1410,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       test "fails to remove a recipient from the #{type} notification in a foreign website", %{
         conn: conn
       } do
-        site = insert(:site)
+        site = new_site()
         insert(:"#{unquote(type)}_notification", site: site, recipients: ["recipient@email.com"])
 
         conn =

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "plausible.io live demo - shows site stats", %{conn: conn} do
-      site = insert(:site, domain: "plausible.io", public: true)
+      site = new_site(domain: "plausible.io", public: true)
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/#{site.domain}")
@@ -66,7 +66,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "public site - no stats with skip_to_dashboard", %{
       conn: conn
     } do
-      insert(:site, domain: "some-other-public-site.io", public: true)
+      new_site(domain: "some-other-public-site.io", public: true)
 
       conn = get(conn, "/some-other-public-site.io?skip_to_dashboard=true")
       resp = html_response(conn, 200)
@@ -103,13 +103,13 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "shows locked page if page is locked", %{conn: conn, user: user} do
-      locked_site = insert(:site, locked: true, members: [user])
+      locked_site = new_site(locked: true, owner: user)
       conn = get(conn, "/" <> locked_site.domain)
       assert html_response(conn, 200) =~ "Dashboard locked"
     end
 
     test "can not view stats of someone else's website", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       conn = get(conn, "/" <> site.domain)
       assert html_response(conn, 404) =~ "There's nothing here"
     end
@@ -125,7 +125,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     setup [:create_user, :make_user_super_admin, :log_in]
 
     test "can view a private dashboard with stats", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
@@ -133,15 +133,15 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "can enter verification when site is without stats", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
 
       conn = get(conn, conn |> get("/" <> site.domain) |> redirected_to())
       assert html_response(conn, 200) =~ "Verifying your installation"
     end
 
     test "can view a private locked dashboard with stats", %{conn: conn} do
-      user = insert(:user)
-      site = insert(:site, locked: true, members: [user])
+      user = new_user()
+      site = new_site(locked: true, owner: user)
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
@@ -153,15 +153,15 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "can view private locked verification without stats", %{conn: conn} do
-      user = insert(:user)
-      site = insert(:site, locked: true, members: [user])
+      user = new_user()
+      site = new_site(locked: true, owner: user)
 
       conn = get(conn, conn |> get("/#{site.domain}") |> redirected_to())
       assert html_response(conn, 200) =~ "Verifying your installation"
     end
 
     test "can view a locked public dashboard", %{conn: conn} do
-      site = insert(:site, locked: true, public: true)
+      site = new_site(locked: true, public: true)
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
@@ -172,7 +172,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "shows CRM link to the site", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
       conn = get(conn, conn |> get("/" <> site.domain) |> redirected_to())
       assert html_response(conn, 200) =~ "/crm/sites/site/#{site.id}"
     end
@@ -603,7 +603,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
   describe "GET /:domain/export - via shared link" do
     test "exports data in zipped csvs", %{conn: conn} do
-      site = insert(:site, domain: "new-site.com")
+      site = new_site(domain: "new-site.com")
       link = insert(:shared_link, site: site)
 
       populate_exported_stats(site)
@@ -875,7 +875,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "logs anonymous user in straight away if the link is not password-protected", %{
       conn: conn
     } do
-      site = insert(:site, domain: "test-site.com")
+      site = new_site(domain: "test-site.com")
       link = insert(:shared_link, site: site)
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
@@ -885,7 +885,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "returns page with X-Frame-Options disabled so it can be embedded in an iframe", %{
       conn: conn
     } do
-      site = insert(:site, domain: "test-site.com")
+      site = new_site(domain: "test-site.com")
       link = insert(:shared_link, site: site)
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
@@ -897,7 +897,7 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "returns page embedded page", %{
       conn: conn
     } do
-      site = insert(:site, domain: "test-site.com")
+      site = new_site(domain: "test-site.com")
       link = insert(:shared_link, site: site)
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}&embed=true")
@@ -959,7 +959,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
   describe "POST /share/:slug/authenticate" do
     test "logs anonymous user in with correct password", %{conn: conn} do
-      site = insert(:site, domain: "test-site.com")
+      site = new_site(domain: "test-site.com")
 
       link =
         insert(:shared_link, site: site, password_hash: Plausible.Auth.Password.hash("password"))

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -867,7 +867,10 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
     test "highlights recommended tier if subscription expired and no days are paid for anymore",
          %{conn: conn, user: user} do
-      user.subscription
+      user
+      |> team_of()
+      |> Repo.preload(:subscription)
+      |> Map.fetch!(:subscription)
       |> Subscription.changeset(%{next_bill_date: Timex.shift(Timex.now(), months: -2)})
       |> Repo.update()
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -872,7 +872,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       |> Repo.preload(:subscription)
       |> Map.fetch!(:subscription)
       |> Subscription.changeset(%{next_bill_date: Timex.shift(Timex.now(), months: -2)})
-      |> Repo.update()
+      |> Repo.update!()
 
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @growth_highlight_pill) == "Recommended"

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -32,7 +32,6 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert get_in(invitation_data, ["invitations", invitation.invitation_id, "invitation"])
     end
 
-    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with no plan", %{
       conn: conn,
@@ -50,7 +49,6 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert get_in(invitation_data, ["invitations", invitation.invitation_id, "no_plan"])
     end
 
-    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with exceeded limits", %{
       conn: conn,
@@ -73,7 +71,6 @@ defmodule PlausibleWeb.Live.SitesTest do
                "site limit"
     end
 
-    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with missing features", %{
       conn: conn,

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -32,6 +32,7 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert get_in(invitation_data, ["invitations", invitation.invitation_id, "invitation"])
     end
 
+    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with no plan", %{
       conn: conn,
@@ -49,6 +50,7 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert get_in(invitation_data, ["invitations", invitation.invitation_id, "no_plan"])
     end
 
+    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with exceeded limits", %{
       conn: conn,
@@ -71,6 +73,7 @@ defmodule PlausibleWeb.Live.SitesTest do
                "site limit"
     end
 
+    @tag :skip
     @tag :ee_only
     test "renders ownership transfer invitation for a case with missing features", %{
       conn: conn,

--- a/test/plausible_web/plugs/authorize_public_api_test.exs
+++ b/test/plausible_web/plugs/authorize_public_api_test.exs
@@ -64,8 +64,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
 
   @tag :ee_only
   test "halts with error when upgrade is required", %{conn: conn} do
-    user = insert(:user, trial_expiry_date: nil)
-    site = insert(:site, members: [user])
+    user = new_user() |> subscribe_to_enterprise_plan(paddle_plan_id: "123321", features: [])
+    site = new_site(owner: user)
     api_key = insert(:api_key, user: user)
 
     conn =
@@ -82,8 +82,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   end
 
   test "halts with error when site is locked", %{conn: conn} do
-    user = insert(:user)
-    site = insert(:site, members: [user], locked: true)
+    user = new_user()
+    site = new_site(owner: user, locked: true)
     api_key = insert(:api_key, user: user)
 
     conn =
@@ -202,9 +202,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
 
   @tag :ee_only
   test "passes for super admin user even if not a member of the requested site", %{conn: conn} do
-    user = insert(:user)
+    user = new_user()
     patch_env(:super_admin_user_ids, [user.id])
-    site = insert(:site, locked: true)
+    site = new_site(locked: true)
     api_key = insert(:api_key, user: user)
 
     conn =

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -1,5 +1,6 @@
 defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   use PlausibleWeb.ConnCase, async: false
+  use Plausible.Teams.Test
   alias PlausibleWeb.Plugs.AuthorizeSiteAccess
 
   setup [:create_user, :log_in, :create_site]
@@ -14,10 +15,10 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
         [],
         :all_roles,
         {:all_roles, nil},
-        {[:public, :viewer, :admin, :super_admin, :owner], nil}
+        {[:public, :viewer, :admin, :editor, :super_admin, :owner], nil}
       ] do
     test "init resolves to expected options with argument #{inspect(init_argument)}" do
-      assert {[:public, :viewer, :admin, :super_admin, :owner], nil} ==
+      assert {[:public, :viewer, :admin, :editor, :super_admin, :owner], nil} ==
                AuthorizeSiteAccess.init(unquote(init_argument))
     end
   end
@@ -46,7 +47,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   test "rejects user completely unrelated to the site", %{conn: conn} do
     opts = AuthorizeSiteAccess.init(:all_roles)
 
-    site = insert(:site, members: [build(:user)])
+    site = new_site()
 
     conn =
       conn
@@ -98,7 +99,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn: conn,
     site: site
   } do
-    other_site = insert(:site, members: [build(:user)])
+    other_site = new_site()
 
     opts = AuthorizeSiteAccess.init([:admin, :owner])
 
@@ -116,7 +117,8 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "returns 404 with custom error message for failed API routes", %{conn: conn, user: user} do
-    site = insert(:site, memberships: [build(:site_membership, user: user, role: :viewer)])
+    site = new_site()
+    add_guest(site, user: user, role: :viewer)
 
     opts = AuthorizeSiteAccess.init([:admin, :owner, :super_admin])
 
@@ -137,7 +139,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     conn: conn,
     site: site
   } do
-    shared_link_other_site = insert(:shared_link, site: build(:site))
+    shared_link_other_site = insert(:shared_link, site: new_site())
 
     params = %{"shared_link" => %{"name" => "some name"}}
 
@@ -160,7 +162,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
          site: site
        } do
     shared_link = insert(:shared_link, site: site)
-    other_site = insert(:site, members: [user])
+    other_site = new_site(owner: user)
 
     opts = AuthorizeSiteAccess.init([:super_admin, :admin, :owner])
 
@@ -200,8 +202,8 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "rejects user on mismatched membership role", %{conn: conn, user: user} do
-    site =
-      insert(:site, memberships: [build(:site_membership, user: user, role: :admin)])
+    site = new_site()
+    add_guest(site, user: user, role: :editor)
 
     opts = AuthorizeSiteAccess.init([:owner])
 
@@ -215,10 +217,26 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     assert html_response(conn, 404)
   end
 
-  for role <- [:viewer, :admin, :owner] do
+  test "allows user based on ownership", %{conn: conn, user: user} do
+    site = new_site(owner: user)
+
+    opts = AuthorizeSiteAccess.init([:owner])
+
+    conn =
+      conn
+      |> bypass_through(PlausibleWeb.Router)
+      |> get("/plug-tests/#{site.domain}/with-domain")
+      |> AuthorizeSiteAccess.call(opts)
+
+    refute conn.halted
+    assert conn.assigns.site.id == site.id
+    assert conn.assigns.current_user_role == :owner
+  end
+
+  for role <- [:viewer, :editor] do
     test "allows user based on their #{role} membership", %{conn: conn, user: user} do
-      site =
-        insert(:site, memberships: [build(:site_membership, user: user, role: unquote(role))])
+      site = new_site()
+      add_guest(site, user: user, role: unquote(role))
 
       opts = AuthorizeSiteAccess.init([unquote(role)])
 
@@ -236,7 +254,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
   @tag :ee_only
   test "allows user based on their superadmin status", %{conn: conn, user: user} do
-    site = insert(:site, members: [build(:user)])
+    site = new_site()
 
     patch_env(:super_admin_user_ids, [user.id])
 
@@ -254,7 +272,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "allows user based on website visibility (authenticated user)", %{conn: conn} do
-    site = insert(:site, members: [build(:user)], public: true)
+    site = new_site(public: true)
 
     opts = AuthorizeSiteAccess.init([:public])
 
@@ -284,7 +302,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   test "allows user based on shared link auth (authenticated user)", %{conn: conn} do
-    site = insert(:site, members: [build(:user)])
+    site = new_site()
     shared_link = insert(:shared_link, site: site)
 
     opts = AuthorizeSiteAccess.init([:public])

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -55,11 +55,11 @@ defmodule Plausible.Teams.Test do
     if user.trial_expiry_date do
       {:ok, team} = Teams.get_or_create(user)
 
-      if team_args != [] do
-        team
-        |> Ecto.Changeset.change(team_args)
-        |> Repo.update!()
-      end
+      team_args = Keyword.merge(team_args, trial_expiry_date: user.trial_expiry_date)
+
+      team
+      |> Ecto.Changeset.change(team_args)
+      |> Repo.update!()
     end
 
     Repo.preload(user, team_memberships: :team)

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -207,15 +207,22 @@ defmodule Plausible.Teams.Test do
     {:ok, team} = Teams.get_or_create(user)
 
     {subscription?, attrs} = Keyword.pop(attrs, :subscription?, true)
+    {subscription_attrs, attrs} = Keyword.pop(attrs, :subscription, [])
 
     # enterprise_plan = insert(:enterprise_plan, Keyword.merge([user: user, team: team], attrs))
     enterprise_plan = insert(:enterprise_plan, Keyword.merge([team: team], attrs))
 
     if subscription? do
-      insert(:subscription,
-        team: team,
-        # user: user,
-        paddle_plan_id: enterprise_plan.paddle_plan_id
+      insert(
+        :subscription,
+        Keyword.merge(
+          [
+            team: team,
+            # user: user,
+            paddle_plan_id: enterprise_plan.paddle_plan_id
+          ],
+          subscription_attrs
+        )
       )
     end
 

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -65,13 +65,24 @@ defmodule Plausible.Teams.Test do
     Repo.preload(user, team_memberships: :team)
   end
 
-  def team_of(%{team_memberships: [%{role: :owner, team: %Teams.Team{} = team}]}) do
-    team
+  def team_of(subject, opts \\ [])
+
+  def team_of(%{team_memberships: [%{role: :owner, team: %Teams.Team{} = team}]}, opts) do
+    if opts[:with_subscription?] do
+      Plausible.Teams.with_subscription(team)
+    else
+      team
+    end
   end
 
-  def team_of(user) do
+  def team_of(user, opts) do
     {:ok, team} = Plausible.Teams.get_by_owner(user)
-    team
+
+    if opts[:with_subscription?] do
+      Plausible.Teams.with_subscription(team)
+    else
+      team
+    end
   end
 
   def add_guest(site, args \\ []) do

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -418,6 +418,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         assert Repo.reload(user).grace_period.id == existing_grace_period.id
       end
 
+      @tag :skip
       test "checks billable pageview usage for enterprise customer, sends usage information to enterprise@plausible.io",
            %{
              user: user
@@ -482,30 +483,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
       end
 
-      test "starts grace period when plan is outgrown", %{user: user} do
-        usage_stub =
-          Plausible.Billing.Quota.Usage
-          |> stub(:monthly_pageview_usage, fn _user ->
-            %{
-              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
-              last_cycle: %{date_range: @date_range, total: 1_100_000}
-            }
-          end)
-
-        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
-
-        insert(:subscription,
-          user: user,
-          paddle_plan_id: enterprise_plan.paddle_plan_id,
-          last_bill_date: Timex.shift(Timex.today(), days: -1),
-          status: unquote(status)
-        )
-
-        CheckUsage.perform(nil, usage_stub)
-        assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
-      end
-
-      @tag :teams
+      @tag :skip
       test "manual lock grace period is synced with teams", %{user: user} do
         usage_stub =
           Plausible.Billing.Quota.Usage
@@ -531,6 +509,30 @@ defmodule Plausible.Workers.CheckUsageTest do
         team = assert_team_exists(user)
         assert team.grace_period.manual_lock == user.grace_period.manual_lock
         assert team.grace_period.manual_lock == true
+      end
+
+      @tag :skip
+      test "starts grace period when plan is outgrown", %{user: user} do
+        usage_stub =
+          Plausible.Billing.Quota.Usage
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
+              last_cycle: %{date_range: @date_range, total: 1_100_000}
+            }
+          end)
+
+        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
+
+        insert(:subscription,
+          user: user,
+          paddle_plan_id: enterprise_plan.paddle_plan_id,
+          last_bill_date: Timex.shift(Timex.today(), days: -1),
+          status: unquote(status)
+        )
+
+        CheckUsage.perform(nil, usage_stub)
+        assert user |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
       end
     end
   end

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -418,7 +418,6 @@ defmodule Plausible.Workers.CheckUsageTest do
         assert Repo.reload(user).grace_period.id == existing_grace_period.id
       end
 
-      @tag :skip
       test "checks billable pageview usage for enterprise customer, sends usage information to enterprise@plausible.io",
            %{
              user: user
@@ -432,13 +431,13 @@ defmodule Plausible.Workers.CheckUsageTest do
             }
           end)
 
-        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
-
-        insert(:subscription,
-          user: user,
-          paddle_plan_id: enterprise_plan.paddle_plan_id,
-          last_bill_date: Timex.shift(Timex.today(), days: -1),
-          status: unquote(status)
+        subscribe_to_enterprise_plan(
+          user,
+          monthly_pageview_limit: 1_000_000,
+          subscription: [
+            last_bill_date: Timex.shift(Timex.today(), days: -1),
+            status: unquote(status)
+          ]
         )
 
         CheckUsage.perform(nil, usage_stub)
@@ -449,7 +448,6 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
       end
 
-      @tag :skip
       test "checks site limit for enterprise customer, sends usage information to enterprise@plausible.io",
            %{
              user: user
@@ -483,7 +481,6 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
       end
 
-      @tag :skip
       test "manual lock grace period is synced with teams", %{user: user} do
         usage_stub =
           Plausible.Billing.Quota.Usage
@@ -494,13 +491,13 @@ defmodule Plausible.Workers.CheckUsageTest do
             }
           end)
 
-        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
-
-        insert(:subscription,
-          user: user,
-          paddle_plan_id: enterprise_plan.paddle_plan_id,
-          last_bill_date: Timex.shift(Timex.today(), days: -1),
-          status: unquote(status)
+        subscribe_to_enterprise_plan(
+          user,
+          monthly_pageview_limit: 1_000_000,
+          subscription: [
+            last_bill_date: Timex.shift(Timex.today(), days: -1),
+            status: unquote(status)
+          ]
         )
 
         CheckUsage.perform(nil, usage_stub)
@@ -511,7 +508,6 @@ defmodule Plausible.Workers.CheckUsageTest do
         assert team.grace_period.manual_lock == true
       end
 
-      @tag :skip
       test "starts grace period when plan is outgrown", %{user: user} do
         usage_stub =
           Plausible.Billing.Quota.Usage
@@ -522,13 +518,13 @@ defmodule Plausible.Workers.CheckUsageTest do
             }
           end)
 
-        enterprise_plan = insert(:enterprise_plan, user: user, monthly_pageview_limit: 1_000_000)
-
-        insert(:subscription,
-          user: user,
-          paddle_plan_id: enterprise_plan.paddle_plan_id,
-          last_bill_date: Timex.shift(Timex.today(), days: -1),
-          status: unquote(status)
+        subscribe_to_enterprise_plan(
+          user,
+          monthly_pageview_limit: 1_000_000,
+          subscription: [
+            last_bill_date: Timex.shift(Timex.today(), days: -1),
+            status: unquote(status)
+          ]
         )
 
         CheckUsage.perform(nil, usage_stub)

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -448,6 +448,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
       end
 
+      @tag :skip
       test "checks site limit for enterprise customer, sends usage information to enterprise@plausible.io",
            %{
              user: user
@@ -461,18 +462,17 @@ defmodule Plausible.Workers.CheckUsageTest do
             }
           end)
 
-        enterprise_plan = insert(:enterprise_plan, user: user, site_limit: 2)
-
-        insert(:site, members: [user])
-        insert(:site, members: [user])
-        insert(:site, members: [user])
-
-        insert(:subscription,
-          user: user,
-          paddle_plan_id: enterprise_plan.paddle_plan_id,
-          last_bill_date: Timex.shift(Timex.today(), days: -1),
-          status: unquote(status)
+        subscribe_to_enterprise_plan(user,
+          site_limit: 2,
+          subscription: [
+            last_bill_date: Timex.shift(Timex.today(), days: -1),
+            status: unquote(status)
+          ]
         )
+
+        new_site(owner: user)
+        new_site(owner: user)
+        new_site(owner: user)
 
         CheckUsage.perform(nil, usage_stub)
 

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -1,6 +1,7 @@
 defmodule Plausible.Workers.SendEmailReportTest do
   use Plausible.DataCase
   use Bamboo.Test
+  use Plausible.Teams.Test
   use Oban.Testing, repo: Plausible.Repo
   import Plausible.Test.Support.HTML
   alias Plausible.Workers.SendEmailReport
@@ -11,7 +12,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
   describe "weekly reports" do
     test "sends weekly report to all recipients" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com", "user2@email.com"])
 
       perform_job(SendEmailReport, %{"site_id" => site.id, "interval" => "weekly"})
@@ -33,7 +34,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
     end
 
     test "does not crash when weekly report has been deleted since scheduling job" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
 
       assert :discard =
                perform_job(SendEmailReport, %{"site_id" => site.id, "interval" => "weekly"})
@@ -41,9 +42,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
     test "calculates timezone correctly" do
       site =
-        insert(:site,
-          timezone: "US/Eastern"
-        )
+        new_site(timezone: "US/Eastern")
 
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
@@ -81,7 +80,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
     test "includes the correct stats" do
       now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-      site = insert(:site, domain: "test-site.com", inserted_at: Timex.shift(now, days: -8))
+      site = new_site(domain: "test-site.com", inserted_at: Timex.shift(now, days: -8))
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       populate_stats(site, [
@@ -114,7 +113,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
       week_ago = now |> Timex.shift(days: -7)
       two_weeks_ago = now |> Timex.shift(days: -14)
 
-      site = insert(:site, inserted_at: Timex.shift(now, days: -15))
+      site = new_site(inserted_at: Timex.shift(now, days: -15))
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       populate_stats(site, [
@@ -149,7 +148,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
       week_ago = now |> Timex.shift(days: -7)
       two_weeks_ago = now |> Timex.shift(days: -14)
 
-      site = insert(:site, inserted_at: Timex.shift(now, days: -15))
+      site = new_site(inserted_at: Timex.shift(now, days: -15))
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       populate_stats(site, [
@@ -184,7 +183,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
       week_ago = now |> Timex.shift(days: -7)
       two_weeks_ago = now |> Timex.shift(days: -14)
 
-      site = insert(:site, inserted_at: Timex.shift(now, days: -15))
+      site = new_site(inserted_at: Timex.shift(now, days: -15))
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       populate_stats(site, [
@@ -215,7 +214,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
   describe "monthly_reports" do
     test "sends monthly report to all recipients" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:monthly_report, site: site, recipients: ["user@email.com", "user2@email.com"])
 
       last_month =
@@ -238,7 +237,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
     end
 
     test "does not crash when monthly report has been deleted since scheduling job" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
 
       assert :discard =
                perform_job(SendEmailReport, %{"site_id" => site.id, "interval" => "monthly"})

--- a/test/workers/send_site_setup_emails_test.exs
+++ b/test/workers/send_site_setup_emails_test.exs
@@ -2,13 +2,14 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
   use Plausible.DataCase, async: true
   use Bamboo.Test
   use Oban.Testing, repo: Plausible.Repo
+  use Plausible.Teams.Test
 
   alias Plausible.Workers.SendSiteSetupEmails
 
   describe "when user has not managed to set up the site" do
     test "does not send an email 47 hours after site creation" do
-      user = insert(:user)
-      insert(:site, members: [user], inserted_at: hours_ago(47))
+      user = new_user()
+      new_site(owner: user, inserted_at: hours_ago(47))
 
       perform_job(SendSiteSetupEmails, %{})
 
@@ -16,8 +17,8 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
     end
 
     test "sends a setup help email 48 hours after site has been created" do
-      user = insert(:user)
-      insert(:site, members: [user], inserted_at: hours_ago(49))
+      user = new_user()
+      new_site(owner: user, inserted_at: hours_ago(49))
 
       perform_job(SendSiteSetupEmails, %{})
 
@@ -39,9 +40,8 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
 
   describe "when user has managed to set up their site" do
     test "sends the setup completed email as soon as possible" do
-      user = insert(:user)
-
-      site = insert(:site, members: [user])
+      user = new_user()
+      site = new_site(owner: user)
 
       populate_stats(site, [build(:pageview)])
 
@@ -54,8 +54,8 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
     end
 
     test "sends the setup completed email after the help email has been sent" do
-      user = insert(:user)
-      site = insert(:site, members: [user], inserted_at: hours_ago(49))
+      user = new_user()
+      site = new_site(owner: user, inserted_at: hours_ago(49))
 
       perform_job(SendSiteSetupEmails, %{})
 
@@ -76,7 +76,7 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
 
   describe "trial user who has not set up a website" do
     test "does not send an email before 48h have passed" do
-      insert(:user, inserted_at: hours_ago(47))
+      new_user(inserted_at: hours_ago(47))
 
       perform_job(SendSiteSetupEmails, %{})
 
@@ -84,7 +84,7 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
     end
 
     test "sends the create site email after 48h" do
-      user = insert(:user, inserted_at: hours_ago(49))
+      user = new_user(inserted_at: hours_ago(49))
 
       perform_job(SendSiteSetupEmails, %{})
 


### PR DESCRIPTION
### Changes

This PR switches majority of reads related to membership and subscription state to use new team schemas. All the leftovers will be switched with the final change - switching all the writes to use new schema exclusively as well.

Notable changes:

- site cache used by ingestion is now preloading team instead of owner and relying on team for determining whether to drop the traffic or not
- `AuthorizeSiteAccess` is now populating `current_user_role` with team schema roles. The change is accounted for by always considering `:editor` role side by side with `:admin`
