### PR TITLE
Drop Logger backends

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,11 +27,6 @@ log_level =
   |> String.to_existing_atom()
 
 config :logger, level: log_level
-
-config :logger, Sentry.LoggerBackend,
-  capture_log_messages: true,
-  level: :error
-
 config :logger, :default_formatter, metadata: [:request_id]
 
 case String.downcase(log_format) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,26 +26,20 @@ log_level =
   |> get_var_from_path_or_env("LOG_LEVEL", default_log_level)
   |> String.to_existing_atom()
 
-config :logger,
-  level: log_level,
-  backends: [:console]
+config :logger, level: log_level
 
 config :logger, Sentry.LoggerBackend,
   capture_log_messages: true,
   level: :error
 
+config :logger, :default_formatter, metadata: [:request_id]
+
 case String.downcase(log_format) do
   "standard" ->
-    config :logger, :console,
-      format: "$time $metadata[$level] $message\n",
-      metadata: [:request_id]
+    config :logger, :default_formatter, format: "$time $metadata[$level] $message\n"
 
   "json" ->
-    config :logger, :console,
-      format: {ExJsonLogger, :format},
-      metadata: [
-        :request_id
-      ]
+    config :logger, :default_formatter, format: {ExJsonLogger, :format}
 end
 
 # Listen IP supports IPv4 and IPv6 addresses.

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -226,7 +226,9 @@ defmodule Plausible.Application do
   end
 
   def setup_sentry() do
-    Logger.add_backend(Sentry.LoggerBackend)
+    :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
+      config: %{capture_log_messages: true, level: :error}
+    })
 
     :telemetry.attach_many(
       "oban-errors",


### PR DESCRIPTION
### Changes

This PR switches from Logger backends to `:logger` handlers.

Card: https://3.basecamp.com/5308029/buckets/29267832/card_tables/cards/7610404292

Some time later, once or if there is a need for structured logging, we can also replace ExJsonFormatter with [something else.](https://github.com/plausible/analytics/pull/4855)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI