### PR TITLE
Drop null constraint on user_id from subscriptions and enterprise_plans

### DIFF
--- a/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
+++ b/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
@@ -1,0 +1,20 @@
+defmodule Plausible.Repo.Migrations.MakeUserIdNullableOnSubscriptionsEnterprisePlans do
+  use Ecto.Migration
+
+  def change do
+    execute """
+            alter table subscriptions alter column user_id drop not null
+            """,
+            """
+            alter table subscriptions alter column user_id set not null
+            """
+
+
+    execute """
+            alter table enterprise_plans alter column user_id drop not null
+            """,
+            """
+            alter table enterprise_plans alter column user_id set not null
+            """
+  end
+end

--- a/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
+++ b/priv/repo/migrations/20241126103023_make_user_id_nullable_on_subscriptions_enterprise_plans.exs
@@ -9,7 +9,6 @@ defmodule Plausible.Repo.Migrations.MakeUserIdNullableOnSubscriptionsEnterpriseP
             alter table subscriptions alter column user_id set not null
             """
 
-
     execute """
             alter table enterprise_plans alter column user_id drop not null
             """,


### PR DESCRIPTION
Migration extracted from #4860 