### PR TITLE
Provide site-related team for current team in goal settings LV

### DIFF
--- a/lib/plausible/teams/adapter/read/sites.ex
+++ b/lib/plausible/teams/adapter/read/sites.ex
@@ -199,13 +199,16 @@ defmodule Plausible.Teams.Adapter.Read.Sites do
   def get_for_user!(user, domain, roles \\ [:owner, :admin, :viewer]) do
     {query_fn, roles} = for_user_query_and_roles(user, roles)
 
-    if :super_admin in roles and Plausible.Auth.is_super_admin?(user.id) do
-      Plausible.Sites.get_by_domain!(domain)
-    else
-      user.id
-      |> query_fn.(domain, List.delete(roles, :super_admin))
-      |> Repo.one!()
-    end
+    site =
+      if :super_admin in roles and Plausible.Auth.is_super_admin?(user.id) do
+        Plausible.Sites.get_by_domain!(domain)
+      else
+        user.id
+        |> query_fn.(domain, List.delete(roles, :super_admin))
+        |> Repo.one!()
+      end
+
+    Repo.preload(site, :team)
   end
 
   def get_for_user(user, domain, roles \\ [:owner, :admin, :viewer]) do

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
   attr(:billable_user, User, required: true)
   attr(:current_user, User, required: true)
-  attr(:current_team, Plausible.Teams.Team, required: true)
+  attr(:current_team, :any, required: true)
   attr(:feature_mod, :atom, required: true, values: Feature.list())
   attr(:grandfathered?, :boolean, default: false)
   attr(:rest, :global)
@@ -88,7 +88,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
   attr(:billable_user, User, required: true)
   attr(:current_user, User, required: true)
-  attr(:current_team, Plausible.Teams.Team, required: true)
+  attr(:current_team, :any, required: true)
   attr(:limit, :integer, required: true)
   attr(:resource, :string, required: true)
   attr(:rest, :global)
@@ -307,14 +307,14 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   end
 
   attr(:current_user, :map)
-  attr(:current_team, :map)
+  attr(:current_team, :any)
   attr(:billable_user, :map)
 
   defp upgrade_call_to_action(assigns) do
     team = Plausible.Teams.with_subscription(assigns.current_team)
 
     upgrade_assistance_required? =
-      case Plans.get_subscription_plan(team.subscription) do
+      case Plans.get_subscription_plan(team && team.subscription) do
         %Plausible.Billing.Plan{kind: :business} -> true
         %Plausible.Billing.EnterprisePlan{} -> true
         _ -> false

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -36,6 +36,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
 
     {:ok,
      assign(socket,
+       current_team: socket.assigns.site.team,
        site_id: site_id,
        domain: domain,
        displayed_goals: socket.assigns.all_goals,

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1004,6 +1004,20 @@ defmodule PlausibleWeb.SettingsControllerTest do
     end
   end
 
+  describe "GET /settings/api-keys" do
+    setup [:create_user, :log_in]
+
+    test "handles user without a team gracefully", %{conn: conn, user: user} do
+      user
+      |> team_of()
+      |> Repo.delete!()
+
+      conn = get(conn, Routes.settings_path(conn, :api_keys))
+
+      assert html_response(conn, 200)
+    end
+  end
+
   describe "POST /settings/api-keys" do
     setup [:create_user, :log_in]
 


### PR DESCRIPTION
### Changes

This PR addresses a problem where `current_team` is empty when opening goal creation form in goal settings view. In static view, the `AuthorizeSiteAccess` plug ensures `current_team` is populated with current site's team (overriding user's `current_team` from `AuthPlug`). In LV, `AuthContext` replicates what `AuthPlug` does but there's no respective mechanism for override by site's team. Currently only Goal Settings LV relies on `current_team` value, so this fix addresses this one particular case for now.

A smiliar problem occurs when assuming current team is always present in views where there's no site in context. The "Account Settings > API Keys" view is an example of that. The billing notice components used across static and LV views got updated here to handle missing team gracefully.

This problem only manifests for users who registered from invitation and don't have their implicit team created yet (because they haven't added any page of their own yet).