### PR TITLE
Don't crash ingesting >1M bytes payloads

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -113,10 +113,12 @@ defmodule Plausible.Ingestion.Request do
     case conn.body_params do
       %Plug.Conn.Unfetched{} ->
         with max_length <- conn.assigns[:read_body_limit] || 1_000_000,
-             {:ok, body, _conn} <- Plug.Conn.read_body(conn, length: max_length, read_length: max_length),
+             {:ok, body, _conn} <-
+               Plug.Conn.read_body(conn, length: max_length, read_length: max_length),
              {:ok, params} when is_map(params) <- Jason.decode(body) do
-            {:ok, params}
-        else _ -> {:error, :invalid_json}
+          {:ok, params}
+        else
+          _ -> {:error, :invalid_json}
         end
 
       params ->


### PR DESCRIPTION
Currently we're failing to read a subsequent chunk of a >1M bytes request on ingest.

Those are rare and likely unintentional: https://sentry.plausible.io/organizations/plausible/issues/55/?environment=prod&project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0

Either way, this change only takes care responding with an error gracefully, rather than producing a crash. Details on what the limits should be and whether it's beneficial to produce a specific error message in such cases, is out of scope. Existing limit is kept as is for now.