### PR TITLE
Send correct invitation ID in email for new users

### DIFF
--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -450,7 +450,7 @@ defmodule Plausible.Teams.Invitations do
       else
         PlausibleWeb.Email.new_user_invitation(
           team_invitation.email,
-          team_invitation.invitation_id,
+          guest_invitation.invitation_id,
           guest_invitation.site,
           team_invitation.inviter
         )

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -55,12 +55,13 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       inviter = new_user()
       site = new_site(owner: inviter)
 
-      assert {:ok, %Plausible.Auth.Invitation{}} =
+      assert {:ok, %Plausible.Auth.Invitation{invitation_id: invitation_id}} =
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :viewer)
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to #{site.domain}",
+        html_body: ~r/#{invitation_id}/
       )
     end
 


### PR DESCRIPTION
### Changes

Fix to a regression which surfaced after enabling `read_team_schema` FF.

### Tests
- [x] Automated tests have been added

