### PR TITLE
Split `current_team` into `site_team` and `my_team`

### DIFF
--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -31,6 +31,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
 
     {:ok,
      assign(socket,
+       site_team: socket.assigns.site.team,
        domain: domain,
        displayed_funnels: socket.assigns.all_funnels,
        setup_funnel?: false,

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -175,7 +175,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     change_plan_link_text = change_plan_link_text(assigns)
 
     subscription =
-      Plausible.Teams.Billing.get_subscription(assigns.current_team)
+      Plausible.Teams.Billing.get_subscription(assigns.my_team)
 
     billing_details_expired =
       Subscription.Status.in?(subscription, [
@@ -225,14 +225,10 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       |> assign(:confirm_message, losing_features_message(feature_usage_check))
 
     ~H"""
-    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_team.subscription) do %>
+    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@my_team.subscription) do %>
       <.change_plan_link {assigns} />
     <% else %>
-      <PlausibleWeb.Components.Billing.paddle_button
-        user={@current_user}
-        team={@current_team}
-        {assigns}
-      >
+      <PlausibleWeb.Components.Billing.paddle_button user={@current_user} team={@my_team} {assigns}>
         Upgrade
       </PlausibleWeb.Components.Billing.paddle_button>
     <% end %>
@@ -264,18 +260,18 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
   defp check_usage_within_plan_limits(%{
          available: true,
          usage: usage,
-         current_team: current_team,
+         my_team: my_team,
          plan_to_render: plan
        }) do
     # At this point, the user is *not guaranteed* to have a team,
     # with ongoing trial.
     trial_active_or_ended_recently? =
-      not is_nil(current_team) and not is_nil(current_team.trial_expiry_date) and
-        Plausible.Teams.trial_days_left(current_team) >= -10
+      not is_nil(my_team) and not is_nil(my_team.trial_expiry_date) and
+        Plausible.Teams.trial_days_left(my_team) >= -10
 
     limit_checking_opts =
       cond do
-        current_team && current_team.allow_next_upgrade_override ->
+        my_team && my_team.allow_next_upgrade_override ->
           [ignore_pageview_limit: true]
 
         trial_active_or_ended_recently? && plan.volume == "10k" ->

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -9,15 +9,15 @@ defmodule PlausibleWeb.BillingController do
   plug PlausibleWeb.RequireAccountPlug
 
   def ping_subscription(%Plug.Conn{} = conn, _params) do
-    subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.current_team)
+    subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.my_team)
 
     json(conn, %{is_subscribed: subscribed?})
   end
 
   def choose_plan(conn, _params) do
-    current_team = conn.assigns.current_team
+    my_team = conn.assigns.my_team
 
-    if Plausible.Teams.Billing.enterprise_configured?(current_team) do
+    if Plausible.Teams.Billing.enterprise_configured?(my_team) do
       redirect(conn, to: Routes.billing_path(conn, :upgrade_to_enterprise_plan))
     else
       render(conn, "choose_plan.html",
@@ -28,12 +28,12 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def upgrade_to_enterprise_plan(conn, _params) do
-    current_team = conn.assigns.current_team
-    subscription = Plausible.Teams.Billing.get_subscription(current_team)
+    my_team = conn.assigns.my_team
+    subscription = Plausible.Teams.Billing.get_subscription(my_team)
 
     {latest_enterprise_plan, price} =
       Plausible.Teams.Billing.latest_enterprise_plan_with_price(
-        current_team,
+        my_team,
         PlausibleWeb.RemoteIP.get(conn)
       )
 
@@ -70,9 +70,9 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def change_plan_preview(conn, %{"plan_id" => new_plan_id}) do
-    current_team = conn.assigns.current_team
+    my_team = conn.assigns.my_team
     current_user = conn.assigns.current_user
-    subscription = Plausible.Teams.Billing.active_subscription_for(current_team)
+    subscription = Plausible.Teams.Billing.active_subscription_for(my_team)
 
     case preview_subscription(subscription, new_plan_id) do
       {:ok, {subscription, preview_info}} ->
@@ -91,7 +91,7 @@ defmodule PlausibleWeb.BillingController do
           extra: %{
             message: msg,
             new_plan_id: new_plan_id,
-            current_team: current_team.id,
+            team_id: my_team.id,
             user_id: current_user.id
           }
         )
@@ -103,9 +103,9 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def change_plan(conn, %{"new_plan_id" => new_plan_id}) do
-    current_team = conn.assigns.current_team
+    my_team = conn.assigns.my_team
 
-    case Plausible.Teams.Billing.change_plan(current_team, new_plan_id) do
+    case Plausible.Teams.Billing.change_plan(my_team, new_plan_id) do
       {:ok, _subscription} ->
         conn
         |> put_flash(:success, "Plan changed successfully")
@@ -133,7 +133,7 @@ defmodule PlausibleWeb.BillingController do
             errors: inspect(e),
             message: msg,
             new_plan_id: new_plan_id,
-            current_team: current_team.id,
+            team_id: my_team.id,
             user_id: conn.assigns.current_user.id
           }
         )

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -21,23 +21,23 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   def subscription(conn, _params) do
-    current_team = conn.assigns.current_team
-    subscription = Teams.Billing.get_subscription(current_team)
+    my_team = conn.assigns.my_team
+    subscription = Teams.Billing.get_subscription(my_team)
 
     render(conn, :subscription,
       layout: {PlausibleWeb.LayoutView, :settings},
       subscription: subscription,
       pageview_limit: Teams.Billing.monthly_pageview_limit(subscription),
-      pageview_usage: Teams.Billing.monthly_pageview_usage(current_team),
-      site_usage: Teams.Billing.site_usage(current_team),
-      site_limit: Teams.Billing.site_limit(current_team),
-      team_member_limit: Teams.Billing.team_member_limit(current_team),
-      team_member_usage: Teams.Billing.team_member_usage(current_team)
+      pageview_usage: Teams.Billing.monthly_pageview_usage(my_team),
+      site_usage: Teams.Billing.site_usage(my_team),
+      site_limit: Teams.Billing.site_limit(my_team),
+      team_member_limit: Teams.Billing.team_member_limit(my_team),
+      team_member_usage: Teams.Billing.team_member_usage(my_team)
     )
   end
 
   def invoices(conn, _params) do
-    subscription = Teams.Billing.get_subscription(conn.assigns.current_team)
+    subscription = Teams.Billing.get_subscription(conn.assigns.my_team)
 
     invoices = Plausible.Billing.paddle_api().get_invoices(subscription)
     render(conn, :invoices, layout: {PlausibleWeb.LayoutView, :settings}, invoices: invoices)

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -155,7 +155,7 @@ defmodule PlausibleWeb.Site.MembershipController do
                  |> Enum.into(%{})
 
   def update_role_by_user(conn, %{"id" => user_id, "new_role" => new_role_str}) do
-    %{site: site, current_user: current_user, current_user_role: current_user_role} = conn.assigns
+    %{site: site, current_user: current_user, site_role: site_role} = conn.assigns
 
     membership =
       Membership |> Repo.get_by!(user_id: user_id, site_id: site.id) |> Repo.preload(:user)
@@ -164,9 +164,9 @@ defmodule PlausibleWeb.Site.MembershipController do
 
     can_grant_role? =
       if membership.user.id == current_user.id do
-        can_grant_role_to_self?(current_user_role, new_role)
+        can_grant_role_to_self?(site_role, new_role)
       else
-        can_grant_role_to_other?(current_user_role, new_role)
+        can_grant_role_to_other?(site_role, new_role)
       end
 
     if can_grant_role? do

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -14,19 +14,19 @@ defmodule PlausibleWeb.SiteController do
 
   def new(conn, params) do
     flow = params["flow"] || PlausibleWeb.Flows.register()
-    current_team = conn.assigns.current_team
+    my_team = conn.assigns.my_team
 
     render(conn, "new.html",
       changeset: Plausible.Site.changeset(%Plausible.Site{}),
-      site_limit: Plausible.Teams.Billing.site_limit(current_team),
-      site_limit_exceeded?: Plausible.Teams.Billing.ensure_can_add_new_site(current_team) != :ok,
+      site_limit: Plausible.Teams.Billing.site_limit(my_team),
+      site_limit_exceeded?: Plausible.Teams.Billing.ensure_can_add_new_site(my_team) != :ok,
       form_submit_url: "/sites?flow=#{flow}",
       flow: flow
     )
   end
 
   def create_site(conn, %{"site" => site_params}) do
-    team = conn.assigns.current_team
+    team = conn.assigns.my_team
     user = conn.assigns.current_user
     first_site? = Plausible.Teams.Billing.site_usage(team) == 0
     flow = conn.params["flow"]

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -53,7 +53,7 @@ defmodule PlausibleWeb.StatsController do
   def stats(%{assigns: %{site: site}} = conn, _params) do
     site = Plausible.Repo.preload(site, :owner)
     stats_start_date = Plausible.Sites.stats_start_date(site)
-    can_see_stats? = not Sites.locked?(site) or conn.assigns[:current_user_role] == :super_admin
+    can_see_stats? = not Sites.locked?(site) or conn.assigns[:site_role] == :super_admin
     demo = site.domain == PlausibleWeb.Endpoint.host()
     dogfood_page_path = if demo, do: "/#{site.domain}", else: "/:dashboard"
     skip_to_dashboard? = conn.params["skip_to_dashboard"] == "true"

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.Live.AuthContext do
           _ -> nil
         end
       end)
-      |> assign_new(:current_team, fn context ->
+      |> assign_new(:my_team, fn context ->
         case context.current_user do
           nil -> nil
           %{team_memberships: [%{team: team}]} -> team

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -22,16 +22,16 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         |> Enum.map(& &1.site_id)
       end)
       |> assign_new(:usage, fn %{
-                                 current_team: current_team,
+                                 my_team: my_team,
                                  pending_ownership_site_ids: pending_ownership_site_ids
                                } ->
-        Plausible.Teams.Billing.quota_usage(current_team,
+        Plausible.Teams.Billing.quota_usage(my_team,
           with_features: true,
           pending_ownership_site_ids: pending_ownership_site_ids
         )
       end)
-      |> assign_new(:subscription, fn %{current_team: current_team} ->
-        Plausible.Teams.Billing.get_subscription(current_team)
+      |> assign_new(:subscription, fn %{my_team: my_team} ->
+        Plausible.Teams.Billing.get_subscription(my_team)
       end)
       |> assign_new(:owned_plan, fn %{subscription: subscription} ->
         Plans.get_regular_plan(subscription, only_non_expired: true)

--- a/lib/plausible_web/live/csv_export.ex
+++ b/lib/plausible_web/live/csv_export.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.Live.CSVExport do
 
   # :not_mounted_at_router ensures we have already done auth checks in the controller
   # if this liveview becomes available from the router, please make sure
-  # to check that current_user_role is allowed to manage site exports
+  # to check that site_role is allowed to manage site exports
   @impl true
   def mount(:not_mounted_at_router, session, socket) do
     %{

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Live.CSVImport do
 
   # :not_mounted_at_router ensures we have already done auth checks in the controller
   # if this liveview becomes available from the router, please make sure
-  # to check that current_user_role is allowed to make site imports
+  # to check that site_role is allowed to make site imports
   @impl true
   def mount(:not_mounted_at_router, session, socket) do
     %{"site_id" => site_id, "storage" => storage} = session

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -36,7 +36,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
 
     {:ok,
      assign(socket,
-       current_team: socket.assigns.site.team,
+       site_team: socket.assigns.site.team,
        site_id: site_id,
        domain: domain,
        displayed_goals: socket.assigns.all_goals,
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
           domain={@domain}
           site={@site}
           current_user={@current_user}
-          current_team={@current_team}
+          site_team={@site_team}
           existing_goals={@all_goals}
           goal={@form_goal}
           on_save_goal={

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         event_name_options_count: length(assigns.event_name_options),
         event_name_options: Enum.map(assigns.event_name_options, &{&1, &1}),
         current_user: assigns.current_user,
-        current_team: assigns.current_team,
+        site_team: assigns.site_team,
         domain: assigns.domain,
         selected_tab: selected_tab,
         tab_sequence_id: 0,
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         f={f}
         suffix={@context_unique_id}
         current_user={@current_user}
-        current_team={@current_team}
+        site_team={@site_team}
         site={@site}
         goal={@goal}
         existing_goals={@existing_goals}
@@ -117,7 +117,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         f={f}
         suffix={suffix(@context_unique_id, @tab_sequence_id)}
         current_user={@current_user}
-        current_team={@current_team}
+        site_team={@site_team}
         site={@site}
         existing_goals={@existing_goals}
         goal_options={@event_name_options}
@@ -202,7 +202,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   attr(:f, Phoenix.HTML.Form)
   attr(:site, Plausible.Site)
   attr(:current_user, Plausible.Auth.User)
-  attr(:current_team, Plausible.Teams.Team)
+  attr(:site_team, Plausible.Teams.Team)
   attr(:suffix, :string)
   attr(:existing_goals, :list)
   attr(:goal_options, :list)
@@ -263,7 +263,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           f={@f}
           site={@site}
           current_user={@current_user}
-          current_team={@current_team}
+          site_team={@site_team}
           has_access_to_revenue_goals?={@has_access_to_revenue_goals?}
           goal={@goal}
           suffix={@suffix}
@@ -287,7 +287,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
       <PlausibleWeb.Components.Billing.Notice.premium_feature
         billable_user={@site.owner}
         current_user={@current_user}
-        current_team={@current_team}
+        current_team={@site_team}
         feature_mod={Plausible.Billing.Feature.RevenueGoals}
         class="rounded-b-md"
       />

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -26,6 +26,7 @@ defmodule PlausibleWeb.Live.PropsSettings do
 
     {:ok,
      assign(socket,
+       site_team: socket.assigns.site.team,
        site_id: site_id,
        domain: domain,
        add_prop?: false,

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -31,10 +31,10 @@ defmodule PlausibleWeb.Live.Sites do
       end)
       |> assign_new(:needs_to_upgrade, fn %{
                                             current_user: current_user,
-                                            current_team: current_team
+                                            my_team: my_team
                                           } ->
         Plausible.Teams.Users.owns_sites?(current_user, include_pending?: true) &&
-          Plausible.Teams.Billing.check_needs_to_upgrade(current_team)
+          Plausible.Teams.Billing.check_needs_to_upgrade(my_team)
       end)
 
     {:noreply, socket}

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.AuthPlug do
         conn
         |> assign(:current_user, user)
         |> assign(:current_user_session, user_session)
-        |> assign(:current_team, team)
+        |> assign(:my_team, team)
 
       _ ->
         conn

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -115,10 +115,10 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
             owner: [subscription: Plausible.Users.last_subscription_query()]
           )
 
-        conn = merge_assigns(conn, site: site, current_user_role: role)
+        conn = merge_assigns(conn, site: site, site_role: role)
 
         if not is_nil(current_user) and role not in [:public, nil] do
-          assign(conn, :current_team, site.team)
+          assign(conn, :site_team, site.team)
         else
           conn
         end

--- a/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
+++ b/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
@@ -67,7 +67,7 @@
           id="paddle-button"
           paddle_product_id={@latest_enterprise_plan.paddle_plan_id}
           user={@current_user}
-          team={@current_team}
+          team={@my_team}
         >
           <svg fill="currentColor" viewBox="0 0 20 20" class="inline w-4 h-4 mr-2">
             <path

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -2,18 +2,18 @@
   <%= render("_flash.html", assigns) %>
 <% end %>
 
-<div :if={assigns[:current_team]} class="flex flex-col gap-y-2">
+<div :if={assigns[:my_team]} class="flex flex-col gap-y-2">
   <Notice.active_grace_period
-    :if={Plausible.Auth.GracePeriod.active?(@current_team)}
-    enterprise?={Plausible.Teams.Billing.enterprise_configured?(@current_team)}
-    grace_period_end={grace_period_end(@current_team)}
+    :if={Plausible.Auth.GracePeriod.active?(@my_team)}
+    enterprise?={Plausible.Teams.Billing.enterprise_configured?(@my_team)}
+    grace_period_end={grace_period_end(@my_team)}
   />
 
-  <Notice.dashboard_locked :if={Plausible.Auth.GracePeriod.expired?(@current_team)} />
+  <Notice.dashboard_locked :if={Plausible.Auth.GracePeriod.expired?(@my_team)} />
 
-  <Notice.subscription_cancelled subscription={@current_team.subscription} />
+  <Notice.subscription_cancelled subscription={@my_team.subscription} />
 
-  <Notice.subscription_past_due subscription={@current_team.subscription} class="container" />
+  <Notice.subscription_past_due subscription={@my_team.subscription} class="container" />
 
-  <Notice.subscription_paused subscription={@current_team.subscription} class="container" />
+  <Notice.subscription_paused subscription={@my_team.subscription} class="container" />
 </div>

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -10,13 +10,13 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@current_user}
       current_user={@current_user}
-      current_team={@current_team}
+      current_team={@my_team}
       feature_mod={Plausible.Billing.Feature.StatsAPI}
     />
 
     <.filter_bar filtering_enabled?={false}>
       <.button_link
-        :if={Plausible.Billing.Feature.StatsAPI.check_availability(@current_team) == :ok}
+        :if={Plausible.Billing.Feature.StatsAPI.check_availability(@my_team) == :ok}
         href={Routes.settings_path(@conn, :new_api_key)}
       >
         New API Key

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -7,7 +7,7 @@
     <:title>Delete Account</:title>
     <:subtitle>Deleting your account removes all sites and stats you've collected</:subtitle>
 
-    <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
+    <%= if Plausible.Billing.Subscription.Status.active?(@my_team && @my_team.subscription) do %>
       <.notice theme={:gray} title="Cannot delete account at this time">
         Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
       </.notice>

--- a/lib/plausible_web/templates/settings/subscription.html.heex
+++ b/lib/plausible_web/templates/settings/subscription.html.heex
@@ -33,7 +33,7 @@
 
     <div class="flex flex-col items-center justify-between sm:flex-row sm:items-start">
       <PlausibleWeb.Components.Billing.monthly_quota_box
-        team={@current_team}
+        team={@my_team}
         subscription={@subscription}
       />
       <div class="w-full md:w-1/3 h-32 px-2 py-4 my-4 text-center bg-gray-100 rounded dark:bg-gray-900">

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -13,7 +13,7 @@
       :if={Map.get(assigns, :is_at_limit, false)}
       current_user={@current_user}
       billable_user={@site.owner}
-      current_team={@current_team}
+      current_team={@site_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
       resource="team members"
     />

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -9,7 +9,7 @@
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={@site_limit_exceeded?}
       current_user={@current_user}
-      current_team={@current_team}
+      current_team={@my_team}
       billable_user={@current_user}
       limit={@site_limit}
       resource="sites"

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -15,7 +15,7 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@site.owner}
       current_user={@current_user}
-      current_team={@current_team}
+      current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Funnels}
     />
 

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -100,7 +100,7 @@
                         </svg>
                       </span>
                     </li>
-                    <%= if @conn.assigns[:current_user_role] == :owner do %>
+                    <%= if @conn.assigns[:site_role] == :owner do %>
                       <li
                         class="select-none hover:bg-gray-100 dark:hover:bg-gray-900 text-red-600"
                         role="option"

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -16,7 +16,7 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@site.owner}
       current_user={@current_user}
-      current_team={@current_team}
+      current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Props}
       grandfathered?
     />

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -20,7 +20,7 @@
         Dashboard locked
       </h3>
 
-      <%= case @conn.assigns[:current_user_role] do %>
+      <%= case @conn.assigns[:site_role] do %>
         <% :owner -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -37,7 +37,7 @@
     data-embedded={to_string(@conn.assigns[:embedded])}
     data-background={@conn.assigns[:background]}
     data-is-dbip={to_string(@is_dbip)}
-    data-current-user-role={@conn.assigns[:current_user_role]}
+    data-current-user-role={@conn.assigns[:site_role]}
     data-flags={Jason.encode!(@flags)}
     data-valid-intervals-by-period={
       Plausible.Stats.Interval.valid_by_period(site: @site) |> Jason.encode!()

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -131,7 +131,7 @@ defmodule PlausibleWeb.UserAuth do
         inner_join: u in assoc(us, :user),
         as: :user,
         left_join: tm in assoc(u, :team_memberships),
-        # TODO: whenever current_team.subscription is used to prevent user action, we must check whether the team association is ownership.
+        # NOTE: whenever my_team.subscription is used to prevent user action, we must check whether the team association is ownership.
         # Otherwise regular members will be limited by team owner in cases like deleting their own account.
         on: tm.role != :guest,
         left_join: t in assoc(tm, :team),

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -71,7 +71,7 @@ defmodule PlausibleWeb.LayoutView do
         ]
       },
       %{key: "Email Reports", value: "email-reports", icon: :envelope},
-      if conn.assigns[:current_user_role] == :owner do
+      if conn.assigns[:site_role] == :owner do
         %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
       end
     ]

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -230,7 +230,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
-    assert conn.assigns.current_user_role == :owner
+    assert conn.assigns.site_role == :owner
   end
 
   for role <- [:viewer, :editor] do
@@ -248,7 +248,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
       refute conn.halted
       assert conn.assigns.site.id == site.id
-      assert conn.assigns.current_user_role == unquote(role)
+      assert conn.assigns.site_role == unquote(role)
     end
   end
 
@@ -268,7 +268,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
 
     refute conn.halted
     assert conn.assigns.site.id == site.id
-    assert conn.assigns.current_user_role == :super_admin
+    assert conn.assigns.site_role == :super_admin
   end
 
   test "allows user based on website visibility (authenticated user)", %{conn: conn} do


### PR DESCRIPTION
### Changes

This PR splits `current_team` into `site_team` and `my_team`. Presently, `current_team` is implicitly populated with site-related team when in the context to site team (via `AuthorizeSiteAccess` or explicit setup in LV plug). This can lead to using incorrect team for determining available features, for instance - or lead to other insiduous bugs in the future.

With that in mind, we have decided to tag teams explcitly by the context.

