### PR TITLE
Revenue metrics in APIv2

### DIFF
--- a/extra/lib/plausible/stats/goal/revenue.ex
+++ b/extra/lib/plausible/stats/goal/revenue.ex
@@ -52,7 +52,8 @@ defmodule Plausible.Stats.Goal.Revenue do
       %{
         short: Money.to_string!(money, format: :short, fractional_digits: 1),
         long: Money.to_string!(money),
-        value: Decimal.to_float(money.amount)
+        value: Decimal.to_float(money.amount),
+        currency: currency
       }
     else
       value

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -19,7 +19,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_dimensions(params)
       |> put_interval(params)
       |> put_parsed_filters(params)
-      |> put_preloaded_goals(site)
+      |> preload_goals_and_revenue(site)
       |> put_order_by(params)
       |> put_include_comparisons(site, params)
       |> Query.put_imported_opts(site, params)
@@ -31,16 +31,20 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     query
   end
 
-  defp put_preloaded_goals(query, site) do
-    {preloaded_goals, revenue_currencies} =
-      Plausible.Stats.Filters.QueryParser.preload_needed_goals(
+  defp preload_goals_and_revenue(query, site) do
+    {preloaded_goals, revenue_warning, revenue_currencies} =
+      Plausible.Stats.Filters.QueryParser.preload_goals_and_revenue(
         site,
         query.metrics,
         query.filters,
         query.dimensions
       )
 
-    struct!(query, preloaded_goals: preloaded_goals, revenue_currencies: revenue_currencies)
+    struct!(query,
+      preloaded_goals: preloaded_goals,
+      revenue_warning: revenue_warning,
+      revenue_currencies: revenue_currencies
+    )
   end
 
   defp put_period(%Query{now: now} = query, _site, %{"period" => period})

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -15,12 +15,14 @@ defmodule Plausible.Stats.Query do
             order_by: nil,
             timezone: nil,
             legacy_breakdown: false,
-            remove_unavailable_revenue_metrics: false,
             preloaded_goals: [],
-            revenue_currencies: %{},
             include: Plausible.Stats.Filters.QueryParser.default_include(),
             debug_metadata: %{},
-            pagination: nil
+            pagination: nil,
+            # Revenue metric specific metadata
+            revenue_currencies: %{},
+            revenue_warning: nil,
+            remove_unavailable_revenue_metrics: false
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy}

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -40,10 +40,21 @@ defmodule Plausible.Stats.QueryResult do
     )
   end
 
-  @imports_unsupported_query_warning "Imported stats are not included in the results because query parameters are not supported. " <>
-                                       "For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats"
+  @imports_warnings %{
+    unsupported_query:
+      "Imported stats are not included in the results because query parameters are not supported. " <>
+        "For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats",
+    unsupported_interval:
+      "Imported stats are not included because the time dimension (i.e. the interval) is too short."
+  }
 
-  @imports_unsupported_interval_warning "Imported stats are not included because the time dimension (i.e. the interval) is too short."
+  @revenue_metrics_warnings %{
+    revenue_goals_unavailable:
+      "The owner of this site does not have access to the revenue metrics feature.",
+    no_single_revenue_currency:
+      "Revenue metrics are null as there are multiple currencies for the selected event:goals.",
+    no_revenue_goals_matching: "Revenue metrics are null as there are no matching revenue goals."
+  }
 
   defp meta(query, meta_extra) do
     %{
@@ -52,18 +63,14 @@ defmodule Plausible.Stats.QueryResult do
         if(query.include.imports and query.skip_imported_reason,
           do: to_string(query.skip_imported_reason)
         ),
-      imports_warning:
-        case query.skip_imported_reason do
-          :unsupported_query -> @imports_unsupported_query_warning
-          :unsupported_interval -> @imports_unsupported_interval_warning
-          _ -> nil
-        end,
+      imports_warning: @imports_warnings[query.skip_imported_reason],
+      metric_warnings: metric_warnings(query),
       time_labels:
         if(query.include.time_labels, do: Plausible.Stats.Time.time_labels(query), else: nil),
       total_rows: if(query.include.total_rows, do: meta_extra.total_rows, else: nil)
     }
     |> Enum.reject(fn {_, value} -> is_nil(value) end)
-    |> Enum.into(%{})
+    |> Map.new()
   end
 
   defp include(query) do
@@ -77,6 +84,23 @@ defmodule Plausible.Stats.QueryResult do
 
       nil ->
         query.include
+    end
+  end
+
+  defp metric_warnings(query) do
+    if query.revenue_warning do
+      query.metrics
+      |> Enum.filter(&(&1 in Plausible.Stats.Goal.Revenue.revenue_metrics()))
+      |> Enum.map(
+        &{&1,
+         %{
+           code: query.revenue_warning,
+           warning: @revenue_metrics_warnings[query.revenue_warning]
+         }}
+      )
+      |> Map.new()
+    else
+      nil
     end
   end
 

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -264,11 +264,13 @@
         },
         {
           "const": "total_revenue",
-          "$comment": "only :internal"
+          "markdownDescription": "Total revenue",
+          "$comment": "only :ee"
         },
         {
           "const": "average_revenue",
-          "$comment": "only :internal"
+          "markdownDescription": "Average revenue",
+          "$comment": "only :ee"
         },
         {
           "const": "scroll_depth",

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1694,266 +1694,267 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
   end
 
   describe "revenue metrics" do
-    on_ee do
-      setup %{user: user} do
-        subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.RevenueGoals])
-        :ok
-      end
+    @describetag :ee_only
 
-      test "can request", %{site: site} do
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all"
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [],
-            dimensions: [],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: [],
-          revenue_warning: :no_revenue_goals_matching,
-          revenue_currencies: %{}
-        )
-      end
-
-      test "no access" do
-        user = new_user()
-        site = new_site(owner: user)
-
-        subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.StatsAPI])
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all"
-        }
-        |> check_error(
-          site,
-          "The owner of this site does not have access to the revenue metrics feature."
-        )
-      end
-
-      test "with event:goal filters with same currency", %{site: site} do
-        insert(:goal,
-          site: site,
-          event_name: "Purchase",
-          currency: "USD",
-          display_name: "PurchaseUSD"
-        )
-
-        insert(:goal, site: site, event_name: "Subscription", currency: "USD")
-        insert(:goal, site: site, event_name: "Signup")
-        insert(:goal, site: site, event_name: "Logout")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "filters" => [["is", "event:goal", ["PurchaseUSD", "Signup", "Subscription"]]]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [[:is, "event:goal", ["PurchaseUSD", "Signup", "Subscription"]]],
-            dimensions: [],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["PurchaseUSD", "Signup", "Subscription"],
-          revenue_warning: nil,
-          revenue_currencies: %{default: :USD}
-        )
-      end
-
-      test "with event:goal filters with different currencies", %{site: site} do
-        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
-        insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
-        insert(:goal, site: site, event_name: "Signup")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "filters" => [["is", "event:goal", ["Purchase", "Signup", "Subscription"]]]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [[:is, "event:goal", ["Purchase", "Signup", "Subscription"]]],
-            dimensions: [],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["Purchase", "Signup", "Subscription"],
-          revenue_warning: :no_single_revenue_currency,
-          revenue_currencies: %{}
-        )
-      end
-
-      test "with event:goal filters with no revenue currencies", %{site: site} do
-        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
-        insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
-        insert(:goal, site: site, event_name: "Signup")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "filters" => [["is", "event:goal", ["Signup"]]]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [[:is, "event:goal", ["Signup"]]],
-            dimensions: [],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["Signup"],
-          revenue_warning: :no_revenue_goals_matching,
-          revenue_currencies: %{}
-        )
-      end
-
-      test "with event:goal dimension, different currencies", %{site: site} do
-        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
-        insert(:goal, site: site, event_name: "Donation", currency: "EUR")
-        insert(:goal, site: site, event_name: "Signup")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "dimensions" => ["event:goal"]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [],
-            dimensions: ["event:goal"],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["Donation", "Purchase", "Signup"],
-          revenue_warning: nil,
-          revenue_currencies: %{"Donation" => :EUR, "Purchase" => :USD}
-        )
-      end
-
-      test "with event:goal dimension and filters", %{site: site} do
-        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
-        insert(:goal, site: site, event_name: "Subscription", currency: "USD")
-        insert(:goal, site: site, event_name: "Signup")
-        insert(:goal, site: site, event_name: "Logout")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "dimensions" => ["event:goal"],
-          "filters" => [["is", "event:goal", ["Purchase", "Signup"]]]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [[:is, "event:goal", ["Purchase", "Signup"]]],
-            dimensions: ["event:goal"],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["Purchase", "Signup"],
-          revenue_warning: nil,
-          revenue_currencies: %{"Purchase" => :USD}
-        )
-      end
-
-      test "with event:goal dimension and filters with no revenue goals matching", %{
-        site: site
-      } do
-        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
-        insert(:goal, site: site, event_name: "Subscription", currency: "USD")
-        insert(:goal, site: site, event_name: "Signup")
-        insert(:goal, site: site, event_name: "Logout")
-
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all",
-          "dimensions" => ["event:goal"],
-          "filters" => [["is", "event:goal", ["Signup"]]]
-        }
-        |> check_success(
-          site,
-          %{
-            metrics: [:total_revenue, :average_revenue],
-            utc_time_range: @date_range_day,
-            filters: [[:is, "event:goal", ["Signup"]]],
-            dimensions: ["event:goal"],
-            order_by: nil,
-            timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-            pagination: %{limit: 10_000, offset: 0}
-          }
-        )
-        |> check_goals(
-          preloaded_goals: ["Signup"],
-          revenue_warning: :no_revenue_goals_matching,
-          revenue_currencies: %{}
-        )
-      end
-    else
-      test "revenue metrics are not available on CE", %{site: site} do
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["total_revenue", "average_revenue"],
-          "date_range" => "all"
-        }
-        |> check_error(
-          site,
-          "#/metrics/0: Invalid metric \"total_revenue\"\n#/metrics/1: Invalid metric \"average_revenue\""
-        )
-      end
+    setup %{user: user} do
+      subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.RevenueGoals])
+      :ok
     end
+
+    test "can request", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all"
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: [],
+        revenue_warning: :no_revenue_goals_matching,
+        revenue_currencies: %{}
+      )
+    end
+
+    test "no access" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.StatsAPI])
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all"
+      }
+      |> check_error(
+        site,
+        "The owner of this site does not have access to the revenue metrics feature."
+      )
+    end
+
+    test "with event:goal filters with same currency", %{site: site} do
+      insert(:goal,
+        site: site,
+        event_name: "Purchase",
+        currency: "USD",
+        display_name: "PurchaseUSD"
+      )
+
+      insert(:goal, site: site, event_name: "Subscription", currency: "USD")
+      insert(:goal, site: site, event_name: "Signup")
+      insert(:goal, site: site, event_name: "Logout")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "filters" => [["is", "event:goal", ["PurchaseUSD", "Signup", "Subscription"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:goal", ["PurchaseUSD", "Signup", "Subscription"]]],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["PurchaseUSD", "Signup", "Subscription"],
+        revenue_warning: nil,
+        revenue_currencies: %{default: :USD}
+      )
+    end
+
+    test "with event:goal filters with different currencies", %{site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "filters" => [["is", "event:goal", ["Purchase", "Signup", "Subscription"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:goal", ["Purchase", "Signup", "Subscription"]]],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["Purchase", "Signup", "Subscription"],
+        revenue_warning: :no_single_revenue_currency,
+        revenue_currencies: %{}
+      )
+    end
+
+    test "with event:goal filters with no revenue currencies", %{site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "filters" => [["is", "event:goal", ["Signup"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:goal", ["Signup"]]],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["Signup"],
+        revenue_warning: :no_revenue_goals_matching,
+        revenue_currencies: %{}
+      )
+    end
+
+    test "with event:goal dimension, different currencies", %{site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Donation", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "dimensions" => ["event:goal"]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [],
+          dimensions: ["event:goal"],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["Donation", "Purchase", "Signup"],
+        revenue_warning: nil,
+        revenue_currencies: %{"Donation" => :EUR, "Purchase" => :USD}
+      )
+    end
+
+    test "with event:goal dimension and filters", %{site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+      insert(:goal, site: site, event_name: "Logout")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "dimensions" => ["event:goal"],
+        "filters" => [["is", "event:goal", ["Purchase", "Signup", "Subscription"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:goal", ["Purchase", "Signup", "Subscription"]]],
+          dimensions: ["event:goal"],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["Purchase", "Signup", "Subscription"],
+        revenue_warning: nil,
+        revenue_currencies: %{"Purchase" => :USD, "Subscription" => :EUR}
+      )
+    end
+
+    test "with event:goal dimension and filters with no revenue goals matching", %{
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "USD")
+      insert(:goal, site: site, event_name: "Signup")
+      insert(:goal, site: site, event_name: "Logout")
+
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["total_revenue", "average_revenue"],
+        "date_range" => "all",
+        "dimensions" => ["event:goal"],
+        "filters" => [["is", "event:goal", ["Signup"]]]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:total_revenue, :average_revenue],
+          utc_time_range: @date_range_day,
+          filters: [[:is, "event:goal", ["Signup"]]],
+          dimensions: ["event:goal"],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        }
+      )
+      |> check_goals(
+        preloaded_goals: ["Signup"],
+        revenue_warning: :no_revenue_goals_matching,
+        revenue_currencies: %{}
+      )
+    end
+  end
+
+  @tag :ce_build_only
+  test "revenue metrics are not available on CE", %{site: site} do
+    %{
+      "site_id" => site.domain,
+      "metrics" => ["total_revenue", "average_revenue"],
+      "date_range" => "all"
+    }
+    |> check_error(
+      site,
+      "#/metrics/0: Invalid metric \"total_revenue\"\n#/metrics/1: Invalid metric \"average_revenue\""
+    )
   end
 
   describe "session metrics" do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4077,4 +4077,398 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              %{"metrics" => [2, 1, 0, 1500], "dimensions" => []}
            ]
   end
+
+  describe "revenue metrics" do
+    @describetag :ee_only
+
+    setup %{user: user} do
+      subscribe_to_enterprise_plan(user,
+        features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.RevenueGoals]
+      )
+
+      :ok
+    end
+
+    test "not requested leads to no metric_warnings", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["pageviews"]
+        })
+
+      assert json_response(conn, 200)["results"] == [%{"dimensions" => [], "metrics" => [0]}]
+      assert "metric_warnings" not in json_response(conn, 200)["meta"]
+    end
+
+    test "no revenue goals configured", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Signup",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["average_revenue", "total_revenue"],
+          "dimensions" => ["event:goal"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [nil, nil]}
+             ]
+
+      assert json_response(conn, 200)["meta"]["metric_warnings"] == %{
+               "average_revenue" => %{
+                 "code" => "no_revenue_goals_matching",
+                 "warning" => "Revenue metrics are null as there are no matching revenue goals."
+               },
+               "total_revenue" => %{
+                 "code" => "no_revenue_goals_matching",
+                 "warning" => "Revenue metrics are null as there are no matching revenue goals."
+               }
+             }
+    end
+
+    test "not filtering or grouping by goals leads to warnings", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["average_revenue", "total_revenue"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => [], "metrics" => [nil, nil]}
+             ]
+
+      assert json_response(conn, 200)["meta"]["metric_warnings"] == %{
+               "average_revenue" => %{
+                 "code" => "no_revenue_goals_matching",
+                 "warning" => "Revenue metrics are null as there are no matching revenue goals."
+               },
+               "total_revenue" => %{
+                 "code" => "no_revenue_goals_matching",
+                 "warning" => "Revenue metrics are null as there are no matching revenue goals."
+               }
+             }
+    end
+
+    test "filtering by revenue goals with same currency", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("40.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("60.6"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Subscription",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100"),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "Signup",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["events", "average_revenue", "total_revenue"],
+          "filters" => [
+            ["is", "event:goal", ["Signup", "Purchase", "Payment"]]
+          ]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "dimensions" => [],
+                 "metrics" => [
+                   4,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$67.07",
+                     "short" => "$67.1",
+                     "value" => 67.066
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$201.20",
+                     "short" => "$201.2",
+                     "value" => 201.2
+                   }
+                 ]
+               }
+             ]
+
+      assert "metric_warnings" not in json_response(conn, 200)["meta"]
+    end
+
+    test "filtering by revenue goals with different currencies", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("40.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("60.6"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Subscription",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100"),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "Signup",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["average_revenue", "total_revenue"],
+          "filters" => [
+            ["is", "event:goal", ["Subscription", "Payment"]]
+          ]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "dimensions" => [],
+                 "metrics" => [nil, nil]
+               }
+             ]
+
+      assert json_response(conn, 200)["meta"]["metric_warnings"] == %{
+               "average_revenue" => %{
+                 "code" => "no_single_revenue_currency",
+                 "warning" =>
+                   "Revenue metrics are null as there are multiple currencies for the selected event:goals."
+               },
+               "total_revenue" => %{
+                 "code" => "no_single_revenue_currency",
+                 "warning" =>
+                   "Revenue metrics are null as there are multiple currencies for the selected event:goals."
+               }
+             }
+    end
+
+    test "breakdown by revenue goals", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("40.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("60.6"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Subscription",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100"),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "Signup",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["average_revenue", "total_revenue"],
+          "dimensions" => ["event:goal"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "dimensions" => ["Purchase"],
+                 "metrics" => [
+                   %{
+                     "currency" => "USD",
+                     "long" => "$100.30",
+                     "short" => "$100.3",
+                     "value" => 100.3
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$100.30",
+                     "short" => "$100.3",
+                     "value" => 100.3
+                   }
+                 ]
+               },
+               %{
+                 "dimensions" => ["Subscription"],
+                 "metrics" => [
+                   %{
+                     "currency" => "EUR",
+                     "long" => "€100.00",
+                     "short" => "€100.0",
+                     "value" => 100.0
+                   },
+                   %{
+                     "currency" => "EUR",
+                     "long" => "€100.00",
+                     "short" => "€100.0",
+                     "value" => 100.0
+                   }
+                 ]
+               },
+               %{
+                 "dimensions" => ["Payment"],
+                 "metrics" => [
+                   %{
+                     "currency" => "USD",
+                     "long" => "$50.45",
+                     "short" => "$50.4",
+                     "value" => 50.45
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$100.90",
+                     "short" => "$100.9",
+                     "value" => 100.9
+                   }
+                 ]
+               },
+               %{"dimensions" => ["Signup"], "metrics" => [nil, nil]}
+             ]
+
+      assert "metric_warnings" not in json_response(conn, 200)["meta"]
+    end
+
+    test "breakdown by revenue goals + filtering", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+      insert(:goal, site: site, event_name: "Payment", currency: "USD")
+      insert(:goal, site: site, event_name: "Subscription", currency: "EUR")
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("40.3"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("60.6"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Subscription",
+          timestamp: ~N[2021-01-01 00:00:00],
+          revenue_reporting_amount: Decimal.new("100"),
+          revenue_reporting_currency: "EUR"
+        ),
+        build(:event,
+          name: "Signup",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "date_range" => "all",
+          "metrics" => ["average_revenue", "total_revenue"],
+          "filters" => [["is", "event:goal", ["Signup", "Purchase"]]],
+          "dimensions" => ["event:goal"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "dimensions" => ["Purchase"],
+                 "metrics" => [
+                   %{
+                     "currency" => "USD",
+                     "long" => "$100.30",
+                     "short" => "$100.3",
+                     "value" => 100.3
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$100.30",
+                     "short" => "$100.3",
+                     "value" => 100.3
+                   }
+                 ]
+               },
+               %{"dimensions" => ["Signup"], "metrics" => [nil, nil]}
+             ]
+
+      assert "metric_warnings" not in json_response(conn, 200)["meta"]
+    end
+  end
 end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -308,12 +308,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "average_revenue" => %{
                    "short" => "€166.7M",
                    "long" => "€166,733,566.75",
-                   "value" => 166_733_566.748
+                   "value" => 166_733_566.748,
+                   "currency" => "EUR"
                  },
                  "total_revenue" => %{
                    "short" => "€500.2M",
                    "long" => "€500,200,700.25",
-                   "value" => 500_200_700.246
+                   "value" => 500_200_700.246,
+                   "currency" => "EUR"
                  }
                }
              ]
@@ -390,11 +392,21 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       assert [
                %{
-                 "average_revenue" => %{"long" => "€10.00", "short" => "€10.0", "value" => 10.0},
+                 "average_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 },
                  "conversion_rate" => 16.7,
                  "name" => "Payment",
                  "events" => 1,
-                 "total_revenue" => %{"long" => "€10.00", "short" => "€10.0", "value" => 10.0},
+                 "total_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 },
                  "visitors" => 1
                },
                %{

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -810,16 +810,36 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "name" => "true",
                  "events" => 2,
                  "conversion_rate" => 66.7,
-                 "total_revenue" => %{"long" => "€112.00", "short" => "€112.0", "value" => 112.00},
-                 "average_revenue" => %{"long" => "€56.00", "short" => "€56.0", "value" => 56.00}
+                 "total_revenue" => %{
+                   "long" => "€112.00",
+                   "short" => "€112.0",
+                   "value" => 112.00,
+                   "currency" => "EUR"
+                 },
+                 "average_revenue" => %{
+                   "long" => "€56.00",
+                   "short" => "€56.0",
+                   "value" => 56.00,
+                   "currency" => "EUR"
+                 }
                },
                %{
                  "visitors" => 1,
                  "name" => "false",
                  "events" => 1,
                  "conversion_rate" => 33.3,
-                 "total_revenue" => %{"long" => "€8.00", "short" => "€8.0", "value" => 8.00},
-                 "average_revenue" => %{"long" => "€8.00", "short" => "€8.0", "value" => 8.00}
+                 "total_revenue" => %{
+                   "long" => "€8.00",
+                   "short" => "€8.0",
+                   "value" => 8.00,
+                   "currency" => "EUR"
+                 },
+                 "average_revenue" => %{
+                   "long" => "€8.00",
+                   "short" => "€8.0",
+                   "value" => 8.00,
+                   "currency" => "EUR"
+                 }
                }
              ]
     end
@@ -874,16 +894,36 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "name" => "true",
                  "events" => 2,
                  "conversion_rate" => 66.7,
-                 "total_revenue" => %{"long" => "€80.00", "short" => "€80.0", "value" => 80.0},
-                 "average_revenue" => %{"long" => "€40.00", "short" => "€40.0", "value" => 40.0}
+                 "total_revenue" => %{
+                   "long" => "€80.00",
+                   "short" => "€80.0",
+                   "value" => 80.0,
+                   "currency" => "EUR"
+                 },
+                 "average_revenue" => %{
+                   "long" => "€40.00",
+                   "short" => "€40.0",
+                   "value" => 40.0,
+                   "currency" => "EUR"
+                 }
                },
                %{
                  "visitors" => 1,
                  "name" => "false",
                  "events" => 1,
                  "conversion_rate" => 33.3,
-                 "total_revenue" => %{"long" => "€10.00", "short" => "€10.0", "value" => 10.0},
-                 "average_revenue" => %{"long" => "€10.00", "short" => "€10.0", "value" => 10.0}
+                 "total_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 },
+                 "average_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 }
                }
              ]
     end

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1414,13 +1414,23 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$1,659.50", "short" => "$1.7K", "value" => 1659.5},
+               "value" => %{
+                 "long" => "$1,659.50",
+                 "short" => "$1.7K",
+                 "value" => 1659.5,
+                 "currency" => "USD"
+               },
                "graph_metric" => "average_revenue"
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$3,319.00", "short" => "$3.3K", "value" => 3319.0},
+               "value" => %{
+                 "long" => "$3,319.00",
+                 "short" => "$3.3K",
+                 "value" => 3319.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "total_revenue"
              } in top_stats
     end
@@ -1473,13 +1483,23 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$1,659.50", "short" => "$1.7K", "value" => 1659.5},
+               "value" => %{
+                 "long" => "$1,659.50",
+                 "short" => "$1.7K",
+                 "value" => 1659.5,
+                 "currency" => "USD"
+               },
                "graph_metric" => "average_revenue"
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$6,638.00", "short" => "$6.6K", "value" => 6638.0},
+               "value" => %{
+                 "long" => "$6,638.00",
+                 "short" => "$6.6K",
+                 "value" => 6638.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "total_revenue"
              } in top_stats
     end
@@ -1549,13 +1569,23 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$1,000.00", "short" => "$1.0K", "value" => 1000.0},
+               "value" => %{
+                 "long" => "$1,000.00",
+                 "short" => "$1.0K",
+                 "value" => 1000.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "average_revenue"
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$2,000.00", "short" => "$2.0K", "value" => 2000.0},
+               "value" => %{
+                 "long" => "$2,000.00",
+                 "short" => "$2.0K",
+                 "value" => 2000.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "total_revenue"
              } in top_stats
     end
@@ -1571,13 +1601,23 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{
                "name" => "Average revenue",
-               "value" => %{"long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               "value" => %{
+                 "long" => "$0.00",
+                 "short" => "$0.0",
+                 "value" => 0.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "average_revenue"
              } in top_stats
 
       assert %{
                "name" => "Total revenue",
-               "value" => %{"long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               "value" => %{
+                 "long" => "$0.00",
+                 "short" => "$0.0",
+                 "value" => 0.0,
+                 "currency" => "USD"
+               },
                "graph_metric" => "total_revenue"
              } in top_stats
     end


### PR DESCRIPTION
### Changes

This PR exposes revenue metrics in APIv2 (only on ee).

There are a few scenarios where revenue metrics can't be calculated. On the dashboard we automagically remove these metrics but this isn't a great fit for APIv2. Instead, we return nulls and produce warnings under `response.meta`. This is similar to imports where we still return results for the rest of the query. 

Ref: https://3.basecamp.com/5308029/buckets/39750953/card_tables/cards/8070760266

Docs PR: https://github.com/plausible/docs/pull/571. Will wait for a :+1: from Looker integration before merging.