### PR TITLE
Disable searching by member/owner emails in sites and enterprise plan CRMs (temporary)

### DIFF
--- a/lib/plausible/billing/enterprise_plan_admin.ex
+++ b/lib/plausible/billing/enterprise_plan_admin.ex
@@ -12,8 +12,7 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
 
   def search_fields(_schema) do
     [
-      :paddle_plan_id,
-      team: [owner: [:name, :email]]
+      :paddle_plan_id
     ]
   end
 

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -10,14 +10,12 @@ defmodule Plausible.SiteAdmin do
   def search_fields(_schema) do
     [
       :domain,
-      members: [:name, :email]
     ]
   end
 
   def custom_index_query(_conn, _schema, query) do
     from(r in query,
       inner_join: o in assoc(r, :owner),
-      as: :owner,
       preload: [owner: o, team: [team_memberships: :user]]
     )
   end

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -9,7 +9,7 @@ defmodule Plausible.SiteAdmin do
 
   def search_fields(_schema) do
     [
-      :domain,
+      :domain
     ]
   end
 

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -69,6 +69,22 @@ defmodule PlausibleWeb.AdminController do
   end
 
   defp usage_and_limits_html(team, usage, limits, embed?) do
+    sites =
+      if team do
+        Plausible.Repo.preload(team, :sites).sites
+      else
+        []
+      end
+
+    sites_list =
+      sites
+      |> Enum.map(fn site ->
+        """
+        <li><a href="/crm/sites/site/#{site.id}">#{site.domain}</a></li>
+        """
+      end)
+      |> Enum.join("\n")
+
     content = """
       <ul>
         <li>Team: <b>#{team && team.name}</b></li>
@@ -76,6 +92,13 @@ defmodule PlausibleWeb.AdminController do
         <li>Team members: <b>#{usage.team_members}</b> / #{limits.team_members}</li>
         <li>Features: #{features_usage(usage.features)}</li>
         <li>Monthly pageviews: #{monthly_pageviews_usage(usage.monthly_pageviews, limits.monthly_pageviews)}</li>
+        <li>
+          Owned sites:
+
+          <ul>
+            #{sites_list}
+          </ul>
+        </li>
       </ul>
     """
 

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -77,13 +77,11 @@ defmodule PlausibleWeb.AdminController do
       end
 
     sites_list =
-      sites
-      |> Enum.map(fn site ->
+      Enum.map_join(sites, "\n", fn site ->
         """
         <li><a href="/crm/sites/site/#{site.id}">#{site.domain}</a></li>
         """
       end)
-      |> Enum.join("\n")
 
     content = """
       <ul>


### PR DESCRIPTION

This is a quick fix for CRM search which got broken after full switch to team schemas. Searching by member/owner emails is temporarily disabled in Sites and Enterprise Plan CRMs and a temporary list of owned sites is exposed in user CRM.
