### PR TITLE
Migration: Add scroll_depth to imported_pages

### DIFF
--- a/priv/ingest_repo/migrations/20241216133031_add_scroll_depth_to_imported_pages.exs
+++ b/priv/ingest_repo/migrations/20241216133031_add_scroll_depth_to_imported_pages.exs
@@ -1,0 +1,17 @@
+defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToImportedPages do
+  use Ecto.Migration
+
+  def up do
+    on_cluster = Plausible.MigrationUtils.on_cluster_statement("imported_pages")
+
+    execute """
+    ALTER TABLE imported_pages
+    #{on_cluster}
+    ADD COLUMN scroll_depth UInt8 DEFAULT 255
+    """
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end

--- a/priv/ingest_repo/migrations/20241216133031_add_scroll_depth_to_imported_pages.exs
+++ b/priv/ingest_repo/migrations/20241216133031_add_scroll_depth_to_imported_pages.exs
@@ -1,17 +1,21 @@
 defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToImportedPages do
   use Ecto.Migration
 
-  def up do
-    on_cluster = Plausible.MigrationUtils.on_cluster_statement("imported_pages")
+  @on_cluster Plausible.MigrationUtils.on_cluster_statement("imported_pages")
 
+  def up do
     execute """
     ALTER TABLE imported_pages
-    #{on_cluster}
+    #{@on_cluster}
     ADD COLUMN scroll_depth UInt8 DEFAULT 255
     """
   end
 
   def down do
-    raise "Irreversible"
+    execute """
+    ALTER TABLE imported_pages
+    #{@on_cluster}
+    DROP COLUMN scroll_depth
+    """
   end
 end


### PR DESCRIPTION
### Changes

This PR only contains the migration adding the `scroll_depth UInt8` column to the `imported_pages` ClickHouse table.

The column will have a default value of 255 which hints that the value is non-existent (a valid scroll depth has to be from 0 to 100). The alternatives default values are:

* 0 - cannot use because it can be a valid value in rare cases
* NULL - bad performance in ClickHouse

When querying scroll depth from imported data, we'll simply filter out rows where `scroll_depth` is more than 100. 