### PR TITLE
Fix membership role action and checks under Site Settings > People

### DIFF
--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -127,7 +127,7 @@
                           :update_role_by_user,
                           @site.domain,
                           membership.user.id,
-                          "admin"
+                          "editor"
                         )
                       }
                       method="put"
@@ -142,7 +142,7 @@
                         </p>
                       </div>
 
-                      <%= if membership.role == :admin do %>
+                      <%= if membership.role == "admin" do %>
                         <span class="text-indigo-500 group-hover:text-white">
                           <svg
                             class="h-5 w-5"
@@ -182,7 +182,7 @@
                         </p>
                       </div>
 
-                      <%= if membership.role == :viewer do %>
+                      <%= if membership.role == "viewer" do %>
                         <span class="text-indigo-500 group-hover:text-white">
                           <svg
                             class="h-5 w-5"

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -68,7 +68,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       conn =
         post(conn, "/sites/#{site.domain}/memberships/invite", %{
           email: "john.doe@example.com",
-          role: "admin"
+          role: "editor"
         })
 
       assert html_response(conn, 200) =~
@@ -82,7 +82,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       conn =
         post(conn, "/sites/#{site.domain}/memberships/invite", %{
           email: "john.doe@example.com",
-          role: "admin"
+          role: "editor"
         })
 
       assert conn.status == 404
@@ -164,7 +164,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       conn =
         post(conn, "/sites/#{site.domain}/memberships/invite", %{
           email: second_member.email,
-          role: "admin"
+          role: "editor"
         })
 
       assert html_response(conn, 200) =~


### PR DESCRIPTION
### Changes

This logic will be soon revised (and replaced) once we commence with implementing teams support.

This is a fix for a regression where Admin role update under Site Settings > People is failing due to wrong mapping.
