### PR TITLE
Revert to `Sentry.LoggerBackend`

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,6 +29,10 @@ log_level =
 config :logger, level: log_level
 config :logger, :default_formatter, metadata: [:request_id]
 
+config :logger, Sentry.LoggerBackend,
+  capture_log_messages: true,
+  level: :error
+
 case String.downcase(log_format) do
   "standard" ->
     config :logger, :default_formatter, format: "$time $metadata[$level] $message\n"

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -226,9 +226,7 @@ defmodule Plausible.Application do
   end
 
   def setup_sentry() do
-    :logger.add_handler(:sentry_handler, Sentry.LoggerHandler, %{
-      config: %{capture_log_messages: true, level: :error}
-    })
+    Logger.add_backend(Sentry.LoggerBackend)
 
     :telemetry.attach_many(
       "oban-errors",


### PR DESCRIPTION
This PR reverts the Sentry part of https://github.com/plausible/analytics/pull/4862 since in 10.2.0 the logger handler implementation is incomplete: https://github.com/plausible/analytics/pull/4914