### PR TITLE
Redo migration:

### DIFF
--- a/priv/ingest_repo/migrations/20241218102326_change_scroll_depth_type_in_imported_pages.exs
+++ b/priv/ingest_repo/migrations/20241218102326_change_scroll_depth_type_in_imported_pages.exs
@@ -1,4 +1,4 @@
-defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToImportedPages do
+defmodule Plausible.IngestRepo.Migrations.DropAndAddScrollDepthToImportedPages do
   use Ecto.Migration
 
   @on_cluster Plausible.MigrationUtils.on_cluster_statement("imported_pages")
@@ -7,7 +7,13 @@ defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToImportedPages do
     execute """
     ALTER TABLE imported_pages
     #{@on_cluster}
-    ADD COLUMN scroll_depth UInt8 DEFAULT 255
+    DROP COLUMN scroll_depth
+    """
+
+    execute """
+    ALTER TABLE imported_pages
+    #{@on_cluster}
+    ADD COLUMN scroll_depth Int64 DEFAULT -1
     """
   end
 
@@ -15,7 +21,7 @@ defmodule Plausible.IngestRepo.Migrations.AddScrollDepthToImportedPages do
     execute """
     ALTER TABLE imported_pages
     #{@on_cluster}
-    DROP COLUMN IF EXISTS scroll_depth
+    DROP COLUMN scroll_depth
     """
   end
 end


### PR DESCRIPTION
### Changes

This PR adds a migration that drops the currently unused `imported_pages.scroll_depth` column, and re-adds it with a different type.

UInt8 is good for representing an average value on an event basis, but not for already aggregated data. The new type is Int64 because:

* we still need to represent a missing value (this will be -1, hence we'll be using `Int` rather than `UInt`)
* the new value will represent a sum across all visitors, which makes it easier to calculate in the "merge_imported" queries.