### PR TITLE
Only check usage for EPs by _current_ subscription

### DIFF
--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -43,7 +43,8 @@ defmodule Plausible.Workers.CheckUsage do
           inner_join: o in assoc(t, :owner),
           inner_lateral_join: s in subquery(Teams.last_subscription_join_query()),
           on: true,
-          left_join: ep in assoc(t, :enterprise_plan),
+          left_join: ep in Plausible.Billing.EnterprisePlan,
+          on: ep.team_id == t.id and ep.paddle_plan_id == s.paddle_plan_id,
           where:
             s.status in [
               ^Subscription.Status.active(),


### PR DESCRIPTION
### Changes

This fixes a bug, for when the customer having two enterprise plans, triggers a wrongful CRM notification about limits exceeded. Previously, we'd have joined a single enterprise plan instance, but at random (with undefined order). Currently the join is guaranteed to be done on latest subscription's `paddle_plan_id`, providing the latest enterprise plan quotas to check against.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
