### PR TITLE
Average Scroll Depth Metric: another imported schema migration

### DIFF
--- a/priv/ingest_repo/migrations/20241231083407_add_pageleave_visitors_to_imported_pages.exs
+++ b/priv/ingest_repo/migrations/20241231083407_add_pageleave_visitors_to_imported_pages.exs
@@ -1,0 +1,21 @@
+defmodule Plausible.IngestRepo.Migrations.AddPageleaveVisitorsToImportedPages do
+  use Ecto.Migration
+
+  @on_cluster Plausible.MigrationUtils.on_cluster_statement("imported_pages")
+
+  def up do
+    execute """
+    ALTER TABLE imported_pages
+    #{@on_cluster}
+    ADD COLUMN pageleave_visitors UInt64
+    """
+  end
+
+  def down do
+    execute """
+    ALTER TABLE imported_pages
+    #{@on_cluster}
+    DROP COLUMN pageleave_visitors
+    """
+  end
+end


### PR DESCRIPTION
### Changes

When merging imported data into stats queries, we cannot simply divide `scroll_depth` / `visitors` to get the imported scroll depth. That’s wrong because `visitors` is based on pageviews, not pageleaves. Therefore, we’ll need to export an additional metric - `pageleave_visitors` which we can use specifically for that calculation.

Note: This field should also be used for our new time on page in the future

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
