### PR TITLE
Fix docker build + FE test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN mkdir /app
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache git nodejs yarn python3 npm ca-certificates wget gnupg make gcc libc-dev brotli && \
-  npm install npm@latest -g
+RUN apk add --no-cache git nodejs yarn python3 npm ca-certificates wget gnupg make gcc libc-dev brotli
 
 COPY mix.exs ./
 COPY mix.lock ./

--- a/assets/js/dashboard/query-dates.test.tsx
+++ b/assets/js/dashboard/query-dates.test.tsx
@@ -96,7 +96,7 @@ test.each([
 test.each([
   [
     { period: 'custom', from: '2024-08-10', to: '2024-08-20' },
-    '10 Aug - 20 Aug'
+    '10 Aug - 20 Aug 24'
   ],
   [{ period: 'realtime' }, 'Realtime']
 ])(


### PR DESCRIPTION
### Changes

* Hotfix for resolving a mismatch between NPM and Node JS versions in `build-private-images.yml`.
* Fix a FE test that started failing due to year change from 2024 to 2025.