### PR TITLE
Remove support for legacy Paddle webhook passthrough formats

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -2,7 +2,6 @@ defmodule Plausible.Billing do
   use Plausible
   use Plausible.Repo
   require Plausible.Billing.Subscription.Status
-  alias Plausible.Auth
   alias Plausible.Billing.Subscription
   alias Plausible.Teams
 
@@ -133,15 +132,9 @@ defmodule Plausible.Billing do
   end
 
   defp get_team!(%{"passthrough" => passthrough}) do
-    case parse_passthrough!(passthrough) do
-      {:team_id, team_id} ->
-        Teams.get!(team_id)
-
-      {:user_id, user_id} ->
-        user = Repo.get!(Auth.User, user_id)
-        {:ok, team} = Teams.get_or_create(user)
-        team
-    end
+    passthrough
+    |> parse_passthrough!()
+    |> Teams.get!()
   end
 
   defp get_team!(_params) do
@@ -149,24 +142,18 @@ defmodule Plausible.Billing do
   end
 
   defp parse_passthrough!(passthrough) do
-    {user_id, team_id} =
+    team_id =
       case String.split(to_string(passthrough), ";") do
-        ["ee:true", "user:" <> user_id, "team:" <> team_id] ->
-          {user_id, team_id}
-
-        ["ee:true", "user:" <> user_id] ->
-          {user_id, "0"}
+        ["ee:true", "user:" <> _user_id, "team:" <> team_id] ->
+          team_id
 
         _ ->
           raise "Invalid passthrough sent via Paddle: #{inspect(passthrough)}"
       end
 
-    case {Integer.parse(user_id), Integer.parse(team_id)} do
-      {{user_id, ""}, {0, ""}} when user_id > 0 ->
-        {:user_id, user_id}
-
-      {{_user_id, ""}, {team_id, ""}} when team_id > 0 ->
-        {:team_id, team_id}
+    case Integer.parse(team_id) do
+      {team_id, ""} when team_id > 0 ->
+        team_id
 
       _ ->
         raise "Invalid passthrough sent via Paddle: #{inspect(passthrough)}"

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -157,14 +157,6 @@ defmodule Plausible.Billing do
         ["ee:true", "user:" <> user_id] ->
           {user_id, "0"}
 
-        # NOTE: legacy pattern, to be removed in a follow-up
-        ["user:" <> user_id, "team:" <> team_id] ->
-          {user_id, team_id}
-
-        # NOTE: legacy pattern, to be removed in a follow-up
-        [user_id] ->
-          {user_id, "0"}
-
         _ ->
           raise "Invalid passthrough sent via Paddle: #{inspect(passthrough)}"
       end

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -225,25 +225,6 @@ defmodule Plausible.BillingTest do
       assert subscription.currency_code == "EUR"
     end
 
-    test "supports old format without prefix" do
-      user = new_user()
-      {:ok, team} = Plausible.Teams.get_or_create(user)
-
-      %{@subscription_created_params | "passthrough" => "user:#{user.id};team:#{team.id}"}
-      |> Billing.subscription_created()
-
-      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
-    end
-
-    test "supports old format without prefix for user without a team" do
-      user = new_user()
-
-      %{@subscription_created_params | "passthrough" => user.id}
-      |> Billing.subscription_created()
-
-      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
-    end
-
     test "unlocks sites if user has any locked sites" do
       user = new_user()
       site = new_site(owner: user, locked: true)

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -172,7 +172,7 @@ defmodule Plausible.BillingTest do
       user = new_user()
       Repo.delete!(user)
 
-      assert_raise Ecto.NoResultsError, fn ->
+      assert_raise RuntimeError, ~r/Invalid passthrough sent via Paddle/, fn ->
         %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id}"}
         |> Billing.subscription_created()
       end
@@ -197,22 +197,6 @@ defmodule Plausible.BillingTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
 
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
-      |> Billing.subscription_created()
-
-      subscription =
-        user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
-
-      assert subscription.paddle_subscription_id == @subscription_id
-      assert subscription.next_bill_date == ~D[2019-06-01]
-      assert subscription.last_bill_date == ~D[2019-05-01]
-      assert subscription.next_bill_amount == "6.00"
-      assert subscription.currency_code == "EUR"
-    end
-
-    test "supports user without a team case" do
-      user = new_user()
-
-      %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id}"}
       |> Billing.subscription_created()
 
       subscription =

--- a/test/plausible_web/controllers/api/paddle_controller_test.exs
+++ b/test/plausible_web/controllers/api/paddle_controller_test.exs
@@ -33,8 +33,10 @@ defmodule PlausibleWeb.Api.PaddleControllerTest do
     test "is verified when signature is correct", %{conn: conn} do
       insert(:user, id: 235)
 
-      conn = post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
-      assert conn.status == 200
+      # NOTE: signature check happens sooner
+      assert_raise RuntimeError, ~r/Invalid passthrough sent via Paddle/, fn ->
+        post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
+      end
     end
 
     test "not verified when signature is corrupted", %{conn: conn} do

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -151,7 +151,7 @@ defmodule PlausibleWeb.Live.SitesTest do
 
       {:ok, lv, _html} = live(conn, "/sites")
 
-      type_into_input(lv, "filter_text", "firs")
+      type_into_input(lv, "filter_text", "first")
       html = render(lv)
 
       assert html =~ "first.example.com"


### PR DESCRIPTION
### Changes

Follow-up to #4938 

On hold for now

### Tests
- [x] Automated tests have been added

