### PR TITLE
Fix year-over-year comparisons for leap years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Fix returning filter suggestions for multiple custom property values in the dashboard Filter modal
 - Fix typo on login screen
 - Fix Direct / None details modal not opening
+- Fix year over year comparisons being offset by a day for leap years
 
 ## v2.1.4 - 2024-10-08
 

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -99,8 +99,9 @@ defmodule Plausible.Stats.Comparisons do
   defp get_comparison_date_range(source_query, %{mode: "year_over_year"} = options) do
     source_date_range = Query.date_range(source_query, trim_trailing: true)
 
-    start_date = Date.add(source_date_range.first, -365)
-    end_date = source_date_range.last |> Date.add(-365)
+    start_date = source_date_range.first |> Date.shift(year: -1)
+    diff_in_days = Date.diff(source_date_range.last, source_date_range.first)
+    end_date = Date.add(start_date, diff_in_days)
 
     Date.range(start_date, end_date)
     |> maybe_match_day_of_week(source_date_range, options)


### PR DESCRIPTION
When comparing dates year-over-year, the previous logic always shifted by 365 days, which caused issues with leap years.

This means when comparing e.g. last 7 days vs a year ago in 2025, you would compare Jan 6th and Jan 7th.

The new logic uses `Date.shift` while ensuring that the compared date range stays the same length as original date range. This can cause some oddities around Feb 29th where dates can get offset by 1 at the end of the range (see tests)

Helpscout ref: https://secure.helpscout.net/conversation/2809180400/22224?viewId=6980900