### PR TITLE
Spike Team Settings section

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,6 +12,10 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
+  def enabled?(_team) do
+    true
+  end
+
   @spec get!(pos_integer()) :: Teams.Team.t()
   def get!(team_id) do
     Repo.get!(Teams.Team, team_id)

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,8 +12,8 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
-  def enabled?(_team) do
-    true
+  def enabled?(team) do
+    not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
   end
 
   @spec get!(pos_integer()) :: Teams.Team.t()

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -46,6 +46,12 @@ defmodule Plausible.Teams.Team do
     |> maybe_bump_accept_traffic_until()
   end
 
+  def name_changeset(team, attrs \\ %{}) do
+    team
+    |> cast(attrs, [:name])
+    |> validate_required(:name)
+  end
+
   def start_trial(team, today \\ Date.utc_today()) do
     trial_expiry = trial_expiry(today)
 

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -3,6 +3,12 @@ defmodule Plausible.Teams.Team do
   Team schema
   """
 
+  defimpl FunWithFlags.Actor, for: __MODULE__ do
+    def id(%{id: id}) do
+      "team:#{id}"
+    end
+  end
+
   use Ecto.Schema
   use Plausible
 

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -12,6 +12,38 @@ defmodule PlausibleWeb.SettingsController do
     redirect(conn, to: Routes.settings_path(conn, :preferences))
   end
 
+  def team_general(conn, _params) do
+    render_team_general(conn)
+  end
+
+  def update_team_name(conn, %{"team" => params}) do
+    changeset = Plausible.Teams.Team.name_changeset(conn.assigns.my_team, params)
+
+    case Repo.update(changeset) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:success, "Team name changed")
+        |> redirect(to: Routes.settings_path(conn, :team_general) <> "#update-name")
+
+      {:error, changeset} ->
+        render_team_general(conn, team_name_changeset: changeset)
+    end
+  end
+
+  defp render_team_general(conn, opts \\ []) do
+    name_changeset =
+      Keyword.get(
+        opts,
+        :team_name_changeset,
+        Plausible.Teams.Team.name_changeset(conn.assigns.my_team)
+      )
+
+    render(conn, :team_general,
+      team_name_changeset: name_changeset,
+      layout: {PlausibleWeb.LayoutView, :settings}
+    )
+  end
+
   def preferences(conn, _params) do
     render_preferences(conn)
   end

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -359,7 +359,6 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr :options, :list, required: true
   attr :value, :any, default: nil
   attr :href_base, :string, default: "/"
-  attr :action, :string, default: nil
   attr :selected_fn, :any, required: true
 
   def mobile_nav_dropdown(%{options: options} = assigns) do
@@ -375,7 +374,7 @@ defmodule PlausibleWeb.Live.Components.Form do
     assigns = assign(assigns, :options, options)
 
     ~H"""
-    <.form for={@conn} class="lg:hidden" action={@action}>
+    <.form for={@conn} class="lg:hidden">
       <.input
         value={
           @options

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -353,4 +353,47 @@ defmodule PlausibleWeb.Live.Components.Form do
       String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
     end)
   end
+
+  attr :conn, Plug.Conn, required: true
+  attr :name, :string, required: true
+  attr :options, :list, required: true
+  attr :value, :any, default: nil
+  attr :href_base, :string, default: "/"
+  attr :action, :string, default: nil
+  attr :selected_fn, :any, required: true
+
+  def mobile_nav_dropdown(%{options: options} = assigns) do
+    options =
+      Enum.reduce(options, Map.new(), fn
+        {section, opts}, acc when is_list(opts) ->
+          Map.put(acc, section, for(o <- opts, do: {o.key, o.value}))
+
+        {key, value}, _acc when is_binary(key) and is_binary(value) ->
+          options
+      end)
+
+    assigns = assign(assigns, :options, options)
+
+    ~H"""
+    <.form for={@conn} class="lg:hidden" action={@action}>
+      <.input
+        value={
+          @options
+          |> Enum.flat_map(fn
+            {_section, opts} when is_list(opts) -> opts
+            {k, v} when is_binary(k) and is_binary(v) -> [{k, v}]
+          end)
+          |> Enum.find_value(fn {_k, v} ->
+            apply(@selected_fn, [v]) && v
+          end)
+        }
+        name={@name}
+        type="select"
+        options={@options}
+        onchange={"if (event.target.value) { location.href = '#{@href_base}' + event.target.value }"}
+        class="dark:bg-gray-800 mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 outline-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:text-gray-100"
+      />
+    </.form>
+    """
+  end
 end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -363,10 +363,8 @@ defmodule PlausibleWeb.Router do
 
     get "/danger-zone", SettingsController, :danger_zone
 
-    on_ee do
-      get "/team/general", SettingsController, :team_general
-      post "/team/general/name", SettingsController, :update_team_name
-    end
+    get "/team/general", SettingsController, :team_general
+    post "/team/general/name", SettingsController, :update_team_name
   end
 
   scope "/", PlausibleWeb do

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -362,6 +362,11 @@ defmodule PlausibleWeb.Router do
     delete "/api-keys/:id", SettingsController, :delete_api_key
 
     get "/danger-zone", SettingsController, :danger_zone
+
+    on_ee do
+      get "/team/general", SettingsController, :team_general
+      post "/team/general/name", SettingsController, :update_team_name
+    end
   end
 
   scope "/", PlausibleWeb do

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -1,19 +1,17 @@
 <%= render_layout "app.html", assigns do %>
-  <% options = [
-    %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
-    %{key: "Security", value: "security", icon: :lock_closed},
-    %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
-    %{key: "Invoices", value: "billing/invoices", icon: :banknotes},
-    %{key: "API Keys", value: "api-keys", icon: :key},
-    %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
-  ]
-
-  options =
-    if Plausible.ee?() do
-      options
-    else
-      Enum.reject(options, fn option -> String.contains?(option.value, "billing") end)
-    end %>
+  <% options = %{
+    "Account Settings" => [
+      %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
+      %{key: "Security", value: "security", icon: :lock_closed},
+      %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
+      %{key: "Invoices", value: "billing/invoices", icon: :banknotes},
+      %{key: "API Keys", value: "api-keys", icon: :key},
+      %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
+    ],
+    "Team Settings" => [
+      %{key: "General", value: "team/general", icon: :adjustments_horizontal}
+    ]
+  } %>
 
   <div class="container pt-6">
     <.styled_link class="text-indigo-600 font-bold text-sm" href="/sites">
@@ -26,24 +24,41 @@
     </div>
     <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-4">
       <div class="py-4 g:py-0 lg:col-span-3">
-        <div class="mb-4">
+        <div class="mb-4 hidden lg:block">
           <h3 class="uppercase text-sm text-indigo-600 font-semibold">Account Settings</h3>
-          <p class="text-xs dark:text-gray-400"><%= @current_user.email %></p>
+          <p class="text-xs dark:text-gray-400 truncate"><%= @current_user.email %></p>
         </div>
 
-        <.form for={@conn} class="lg:hidden">
-          <.input
-            value={Enum.find_value(options, &(is_current_tab(@conn, &1.value) && &1.value))}
-            name="setting"
-            type="select"
-            options={Enum.map(options, fn opt -> {opt.key, opt.value} end)}
-            onchange="location.href = '/settings/' + event.target.value"
-            class="dark:bg-gray-800 mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 outline-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:text-gray-100"
-          />
-        </.form>
+        <.mobile_nav_dropdown
+          name="settings"
+          options={options}
+          selected_fn={&is_current_tab(@conn, &1)}
+          conn={@conn}
+          href_base="/settings/"
+        />
 
         <div class="hidden lg:block">
-          <%= for %{key: key, value: value, icon: icon} <- options  do %>
+          <%= for %{key: key, value: value, icon: icon} <- options["Account Settings"]  do %>
+            <%= render("_settings_tab.html",
+              icon: icon,
+              this_tab: value,
+              text: key,
+              conn: @conn,
+              submenu?: false
+            ) %>
+          <% end %>
+        </div>
+
+        <div
+          :if={@my_team && Plausible.Teams.enabled?(@my_team)}
+          class="mb-4 mt-4 hidden lg:block"
+        >
+          <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
+          <p class="text-xs dark:text-gray-400 truncate"><%= @my_team.name %></p>
+        </div>
+
+        <div class="hidden lg:block">
+          <%= for %{key: key, value: value, icon: icon} <- options["Team Settings"]  do %>
             <%= render("_settings_tab.html",
               icon: icon,
               this_tab: value,

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -1,18 +1,5 @@
 <%= render_layout "app.html", assigns do %>
-  <% options = %{
-    "Account Settings" => [
-      %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
-      %{key: "Security", value: "security", icon: :lock_closed},
-      %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
-      %{key: "Invoices", value: "billing/invoices", icon: :banknotes},
-      %{key: "API Keys", value: "api-keys", icon: :key},
-      %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
-    ],
-    "Team Settings" => [
-      %{key: "General", value: "team/general", icon: :adjustments_horizontal}
-    ]
-  } %>
-
+  <% options = account_settings_sidebar(@conn) %>
   <div class="container pt-6">
     <.styled_link class="text-indigo-600 font-bold text-sm" href="/sites">
       ← Back to Sites
@@ -49,24 +36,23 @@
           <% end %>
         </div>
 
-        <div
-          :if={@my_team && Plausible.Teams.enabled?(@my_team)}
-          class="mb-4 mt-4 hidden lg:block"
-        >
-          <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
-          <p class="text-xs dark:text-gray-400 truncate"><%= @my_team.name %></p>
-        </div>
+        <div :if={Plausible.Teams.enabled?(@my_team)}>
+          <div class="mb-4 mt-4 hidden lg:block">
+            <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
+            <p class="text-xs dark:text-gray-400 truncate"><%= @my_team.name %></p>
+          </div>
 
-        <div class="hidden lg:block">
-          <%= for %{key: key, value: value, icon: icon} <- options["Team Settings"]  do %>
-            <%= render("_settings_tab.html",
-              icon: icon,
-              this_tab: value,
-              text: key,
-              conn: @conn,
-              submenu?: false
-            ) %>
-          <% end %>
+          <div class="hidden lg:block">
+            <%= for %{key: key, value: value, icon: icon} <- options["Team Settings"]  do %>
+              <%= render("_settings_tab.html",
+                icon: icon,
+                this_tab: value,
+                text: key,
+                conn: @conn,
+                submenu?: false
+              ) %>
+            <% end %>
+          </div>
         </div>
       </div>
 

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -13,21 +13,16 @@
     </div>
     <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-4">
       <div class="py-4 g:py-0 lg:col-span-3">
-        <.form
-          for={@conn}
+        <% options = flat_settings_options(@conn) %>
+        <.mobile_nav_dropdown
+          conn={@conn}
           action={"/sites/#{URI.encode_www_form(@site.domain)}"}
-          class="lg:hidden"
-        >
-          <% options = flat_settings_options(@conn) %>
-          <.input
-            type="select"
-            name="tab"
-            options={options}
-            class="dark:bg-gray-800 mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 dark:border-gray-500 outline-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:text-gray-100"
-            onchange={"location.href = '/" <> URI.encode_www_form(@site.domain) <> "/settings/' + event.target.value"}
-            value={Enum.find_value(options, &(is_current_tab(@conn, elem(&1, 1)) && elem(&1, 1)))}
-          />
-        </.form>
+          options={options}
+          name="tab"
+          href_base={"/#{URI.encode_www_form(@site.domain)}/settings/"}
+          selected_fn={&is_current_tab(@conn, &1)}
+        />
+
         <div class="hidden lg:block">
           <%= for %{key: key, value: value, icon: icon} <- settings_tabs(@conn) do %>
             <%= if is_binary(value) do %>

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -16,7 +16,6 @@
         <% options = flat_site_settings_options(@conn) %>
         <.mobile_nav_dropdown
           conn={@conn}
-          action={"/sites/#{URI.encode_www_form(@site.domain)}"}
           options={options}
           name="tab"
           href_base={"/#{URI.encode_www_form(@site.domain)}/settings/"}

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -13,7 +13,7 @@
     </div>
     <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-4">
       <div class="py-4 g:py-0 lg:col-span-3">
-        <% options = flat_settings_options(@conn) %>
+        <% options = flat_site_settings_options(@conn) %>
         <.mobile_nav_dropdown
           conn={@conn}
           action={"/sites/#{URI.encode_www_form(@site.domain)}"}
@@ -24,7 +24,7 @@
         />
 
         <div class="hidden lg:block">
-          <%= for %{key: key, value: value, icon: icon} <- settings_tabs(@conn) do %>
+          <%= for %{key: key, value: value, icon: icon} <- site_settings_sidebar(@conn) do %>
             <%= if is_binary(value) do %>
               <%= render("_site_settings_tab.html",
                 icon: icon,

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -1,0 +1,22 @@
+<.settings_tiles>
+  <.tile>
+    <:title>
+      <a id="update-name">Team Name</a>
+    </:title>
+    <:subtitle>
+      Change the name of your team
+    </:subtitle>
+    <.form
+      :let={f}
+      action={Routes.settings_path(@conn, :update_team_name)}
+      for={@team_name_changeset}
+      method="post"
+    >
+      <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
+
+      <.button type="submit">
+        Change Name
+      </.button>
+    </.form>
+  </.tile>
+</.settings_tiles>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -48,7 +48,7 @@ defmodule PlausibleWeb.LayoutView do
     end
   end
 
-  def settings_tabs(conn) do
+  def site_settings_sidebar(conn) do
     [
       %{key: "General", value: "general", icon: :rocket_launch},
       %{key: "People", value: "people", icon: :users},
@@ -78,9 +78,9 @@ defmodule PlausibleWeb.LayoutView do
     |> Enum.reject(&is_nil/1)
   end
 
-  def flat_settings_options(conn) do
+  def flat_site_settings_options(conn) do
     conn
-    |> settings_tabs()
+    |> site_settings_sidebar()
     |> Enum.map(fn
       %{value: value, key: key} when is_binary(value) ->
         {key, value}
@@ -91,6 +91,27 @@ defmodule PlausibleWeb.LayoutView do
         end)
     end)
     |> List.flatten()
+  end
+
+  def account_settings_sidebar(conn) do
+    options = %{
+      "Account Settings" => [
+        %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
+        %{key: "Security", value: "security", icon: :lock_closed},
+        %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
+        %{key: "Invoices", value: "billing/invoices", icon: :banknotes},
+        %{key: "API Keys", value: "api-keys", icon: :key},
+        %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
+      ]
+    }
+
+    if Plausible.Teams.enabled?(conn.assigns[:my_team]) do
+      Map.put(options, "Team Settings", [
+        %{key: "General", value: "team/general", icon: :adjustments_horizontal}
+      ])
+    else
+      options
+    end
   end
 
   def trial_notification(team) do

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -126,6 +126,16 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def is_current_tab(conn, tab) do
-    String.ends_with?(Enum.join(conn.path_info, "/"), tab)
+    full_path = Path.join(conn.path_info)
+
+    one_up =
+      conn.path_info
+      |> Enum.drop(-1)
+      |> Path.join()
+
+    case conn.method do
+      :get -> String.ends_with?(full_path, tab)
+      _ -> String.ends_with?(full_path, tab) or String.ends_with?(one_up, tab)
+    end
   end
 end

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1104,6 +1104,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
   end
 
   describe "Team Settings" do
+    @describetag :ee_only
     setup [:create_user, :log_in]
 
     test "does not render team settings, when no team assigned", %{conn: conn} do

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1104,7 +1104,6 @@ defmodule PlausibleWeb.SettingsControllerTest do
   end
 
   describe "Team Settings" do
-    @describetag :ee_only
     setup [:create_user, :log_in]
 
     test "does not render team settings, when no team assigned", %{conn: conn} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,7 @@ Application.ensure_all_started(:double)
 
 FunWithFlags.enable(:channels)
 FunWithFlags.enable(:scroll_depth)
+FunWithFlags.enable(:teams)
 
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 


### PR DESCRIPTION
### Changes

This PR adds basic "change team name" ability within new Team Settings sidebar section. This is feature-flagged and will serve as a base for upcoming Teams UI changes.

![image](https://github.com/user-attachments/assets/e8f45dd4-00ca-4bf7-9ddd-8256ecdb364a)

https://github.com/user-attachments/assets/a7c972a9-678f-4449-ab93-13d516431a5d


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
