### PR TITLE
Install nodejs specced in tool-versions in Dockerfile

### DIFF
--- a/.github/workflows/build-private-images-ghcr.yml
+++ b/.github/workflows/build-private-images-ghcr.yml
@@ -44,6 +44,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+        id: versions
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6
@@ -56,6 +60,7 @@ jobs:
           build-args: |
             MIX_ENV=prod
             BUILD_METADATA=${{ steps.meta.outputs.json }}
+            NODE_VERSION=${{steps.versions.outputs.nodejs}}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-private-images-ghcr.yml
+++ b/.github/workflows/build-private-images-ghcr.yml
@@ -21,6 +21,13 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+        id: versions
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.0.0
@@ -43,10 +50,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read .tool-versions
-        uses: marocchino/tool-versions-action@v1
-        id: versions
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/build-public-images-ghcr.yml
+++ b/.github/workflows/build-public-images-ghcr.yml
@@ -40,6 +40,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+        id: versions
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6
@@ -54,6 +58,7 @@ jobs:
             MIX_ENV=ce
             BUILD_METADATA=${{ steps.meta.outputs.json }}
             ERL_FLAGS=+JMsingle true
+            NODE_VERSION=${{steps.versions.outputs.nodejs}}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-public-images-ghcr.yml
+++ b/.github/workflows/build-public-images-ghcr.yml
@@ -17,6 +17,13 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Read .tool-versions
+        uses: marocchino/tool-versions-action@v1
+        id: versions
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -39,10 +46,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read .tool-versions
-        uses: marocchino/tool-versions-action@v1
-        id: versions
 
       - name: Build and push
         id: docker_build

--- a/.github/workflows/build-public-images-ghcr.yml
+++ b/.github/workflows/build-public-images-ghcr.yml
@@ -65,12 +65,3 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
-      - name: Notify team on failure
-        if: ${{ failure() }}
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: ${{ secrets.BUILD_NOTIFICATION_URL }}
-          method: 'POST'
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"content": "<a href=\"https://github.com/plausible/analytics/actions/workflows/build-public-images.yml\">Build failed</a>"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN mkdir /app
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache git yarn python3 ca-certificates wget gnupg make gcc libc-dev brotli bash \
+RUN apk add --no-cache git yarn python3 ca-certificates wget gnupg make gcc g++ libc-dev brotli bash \
   && wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+  && export NVM_DIR="$HOME/.nvm" \
+  && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" \
   && nvm install ${NODE_VERSION}
 
 COPY mix.exs ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ENV MIX_ENV=$MIX_ENV
 ENV NODE_ENV=production
 ENV NODE_OPTIONS=--openssl-legacy-provider
 
+ARG NODE_VERSION
+ENV NODE_VERSION=$NODE_VERSION
+
 # custom ERL_FLAGS are passed for (public) multi-platform builds
 # to fix qemu segfault, more info: https://github.com/erlang/otp/pull/6340
 ARG ERL_FLAGS
@@ -20,7 +23,9 @@ RUN mkdir /app
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache git nodejs yarn python3 npm ca-certificates wget gnupg make gcc libc-dev brotli
+RUN apk add --no-cache git yarn python3 ca-certificates wget gnupg make gcc libc-dev brotli bash \
+  && wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+  && nvm install ${NODE_VERSION}
 
 COPY mix.exs ./
 COPY mix.lock ./


### PR DESCRIPTION
### Changes

Follow-up to https://github.com/plausible/analytics/pull/4933.

We'll use `nvm` to install the same version of nodejs as specified in the `.tool-versions` file. Also, rather than always installing the latest version of NPM (as it was before #4933), nvm will install the one that's bundled with the specific nodejs version (the same happens via `asdf install`).