### PR TITLE
[WIP] Pin nodejs version to be the same as .tool-versions

### DIFF
--- a/.github/workflows/build-private-images-ghcr.yml
+++ b/.github/workflows/build-private-images-ghcr.yml
@@ -61,14 +61,14 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - name: Notify team on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.BUILD_NOTIFICATION_URL }}
           method: 'POST'
           customHeaders: '{"Content-Type": "application/json"}'
           data: '{"content": "<a href=\"https://github.com/plausible/analytics/actions/workflows/build-private-images.yml\">Build failed</a>"}'
-      
+
       - name: Notify team on success
         if: ${{ success() && github.ref == 'refs/heads/master' }}
         uses: fjogeleit/http-request-action@v1
@@ -78,7 +78,7 @@ jobs:
           customHeaders: '{"Content-Type": "application/json"}'
           escapeData: 'true'
           data: '{"content": "<h1>🚀 New changes are about to be deployed to production!</h1><br/><h3>👷 Author: ${{ github.actor }}</h3><br/><p>📝 Commit message: ${{ github.event.head_commit.message }}</p><br/>"}'
-      
+
       - name: Set Honeycomb marker on success
         if: ${{ success() && github.ref == 'refs/heads/master' }}
         uses: cnkk/honeymarker-action@1bd92aec746e38efe43a0faee94ced1ebb930712

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /app
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache git nodejs yarn python3 npm ca-certificates wget gnupg make gcc libc-dev brotli
+RUN apk add --no-cache git "nodejs-current=21.7.3-r0" yarn npm python3 ca-certificates wget gnupg make gcc libc-dev brotli
 
 COPY mix.exs ./
 COPY mix.lock ./


### PR DESCRIPTION
Proposed follow-up to https://github.com/plausible/analytics/pull/4933

Alpine index only exposes a single version of nodejs, which this PR now explicitly pins against. See also: https://pkgs.alpinelinux.org/packages?name=nodejs-current&branch=v3.20&repo=&arch=x86_64&origin=&flagged=&maintainer=