### PR TITLE
Fix Top Stats crashing with imported data + page filter

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -405,6 +405,9 @@ defmodule PlausibleWeb.Api.StatsController do
         page_filter? && scroll_depth_enabled? ->
           metrics ++ [:bounce_rate, :scroll_depth, :time_on_page]
 
+        page_filter? && query.include_imported ->
+          metrics
+
         page_filter? ->
           metrics ++ [:bounce_rate, :time_on_page]
 


### PR DESCRIPTION
### Changes

Fixes a bug that surfaced in Sentry after I deployed #4915 today.

A page filter + include_imported query should not include time on page and bounce rate in Top Stats. The condition got messed up with the addition of scroll depth.

This only concerns the case where scroll depth flag is off. I did not bother covering this with a test since the test setup has the flag enabled globally. This was just a typo.