### PR TITLE
Implement service for inviting to a team

### DIFF
--- a/lib/plausible/teams/invitation.ex
+++ b/lib/plausible/teams/invitation.ex
@@ -7,12 +7,14 @@ defmodule Plausible.Teams.Invitation do
 
   import Ecto.Changeset
 
+  @roles Plausible.Teams.Membership.roles()
+
   @type t() :: %__MODULE__{}
 
   schema "team_invitations" do
     field :invitation_id, :string
     field :email, :string
-    field :role, Ecto.Enum, values: [:guest, :viewer, :editor, :admin, :owner]
+    field :role, Ecto.Enum, values: @roles
 
     belongs_to :inviter, Plausible.Auth.User
     belongs_to :team, Plausible.Teams.Team
@@ -21,6 +23,8 @@ defmodule Plausible.Teams.Invitation do
 
     timestamps()
   end
+
+  def roles(), do: @roles
 
   def changeset(team, opts) do
     email = Keyword.fetch!(opts, :email)

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -87,7 +87,11 @@ defmodule Plausible.Teams.Invitations do
     end
   end
 
-  def invite(site, invitee_email, role, inviter) do
+  def invite(%Teams.Team{} = team, invitee_email, role, inviter) do
+    create_team_invitation(team, invitee_email, inviter, role: role)
+  end
+
+  def invite(%Plausible.Site{} = site, invitee_email, role, inviter) do
     site = Teams.load_for_site(site)
 
     if role == :owner do
@@ -376,7 +380,27 @@ defmodule Plausible.Teams.Invitations do
   end
 
   @doc false
-  def check_invitation_permissions(site, inviter, invitation_role, opts) do
+  def check_invitation_permissions(%Teams.Team{} = team, inviter, invitation_role, opts) do
+    check_permissions? = Keyword.get(opts, :check_permissions, true)
+
+    if check_permissions? do
+      case Teams.Memberships.team_role(team, inviter) do
+        {:ok, :owner} when invitation_role == :owner ->
+          :ok
+
+        {:ok, inviter_role}
+        when inviter_role in [:owner, :admin] and invitation_role != :owner ->
+          :ok
+
+        _ ->
+          {:error, :forbidden}
+      end
+    else
+      :ok
+    end
+  end
+
+  def check_invitation_permissions(%Plausible.Site{} = site, inviter, invitation_role, opts) do
     check_permissions? = Keyword.get(opts, :check_permissions, true)
 
     if check_permissions? do
@@ -411,11 +435,19 @@ defmodule Plausible.Teams.Invitations do
   end
 
   @doc false
-  def ensure_new_membership(_site, nil, _role), do: :ok
+  def ensure_new_membership(_site_or_team, nil, _role), do: :ok
 
-  def ensure_new_membership(_site, _invitee, :owner), do: :ok
+  def ensure_new_membership(_site_or_team, _invitee, :owner), do: :ok
 
-  def ensure_new_membership(site, invitee, _role) do
+  def ensure_new_membership(%Teams.Team{} = team, invitee, _role) do
+    if Teams.Memberships.team_role(team, invitee) == {:error, :not_a_member} do
+      :ok
+    else
+      {:error, :already_a_member}
+    end
+  end
+
+  def ensure_new_membership(%Plausible.Site{} = site, invitee, _role) do
     if Teams.Memberships.site_role(site, invitee) == {:error, :not_a_member} do
       :ok
     else
@@ -439,12 +471,13 @@ defmodule Plausible.Teams.Invitations do
 
   defp create_team_invitation(team, invitee_email, inviter, opts \\ []) do
     now = NaiveDateTime.utc_now(:second)
+    role = Keyword.get(opts, :role, :guest)
 
     result =
       Ecto.Multi.new()
       |> Ecto.Multi.put(
         :changeset,
-        Teams.Invitation.changeset(team, email: invitee_email, role: :guest, inviter: inviter)
+        Teams.Invitation.changeset(team, email: invitee_email, role: role, inviter: inviter)
       )
       |> Ecto.Multi.run(:ensure_no_site_transfers, fn _repo, %{changeset: changeset} ->
         ensure_no_site_transfers(changeset, opts[:ensure_no_site_transfers_for], invitee_email)
@@ -452,7 +485,7 @@ defmodule Plausible.Teams.Invitations do
       |> Ecto.Multi.insert(
         :team_invitation,
         & &1.changeset,
-        on_conflict: [set: [updated_at: now]],
+        on_conflict: [set: [updated_at: now, role: role]],
         conflict_target: [:team_id, :email],
         returning: true
       )
@@ -489,6 +522,26 @@ defmodule Plausible.Teams.Invitations do
         transfer.initiator,
         invitee
       )
+
+    Plausible.Mailer.send(email)
+  end
+
+  def send_invitation_email(%Teams.Invitation{} = team_invitation, invitee) do
+    email =
+      if invitee do
+        PlausibleWeb.Email.existing_user_team_invitation(
+          team_invitation.email,
+          team_invitation.team,
+          team_invitation.inviter
+        )
+      else
+        PlausibleWeb.Email.new_user_team_invitation(
+          team_invitation.email,
+          team_invitation.invitation_id,
+          team_invitation.team,
+          team_invitation.inviter
+        )
+      end
 
     Plausible.Mailer.send(email)
   end

--- a/lib/plausible/teams/invitations/invite_to_team.ex
+++ b/lib/plausible/teams/invitations/invite_to_team.ex
@@ -1,0 +1,46 @@
+defmodule Plausible.Teams.Invitations.InviteToTeam do
+  @moduledoc """
+  Service for inviting new or existing users to team.
+  """
+
+  alias Plausible.Teams
+  alias Plausible.Repo
+
+  def create(team, inviter, invitee_email, role, opts \\ []) do
+    with team <- Repo.preload(team, [:owner]),
+         :ok <-
+           Teams.Invitations.check_invitation_permissions(
+             team,
+             inviter,
+             role,
+             opts
+           ),
+         :ok <-
+           Teams.Invitations.check_team_member_limit(
+             team,
+             role,
+             invitee_email
+           ),
+         invitee = Plausible.Auth.find_user_by(email: invitee_email),
+         :ok <-
+           Teams.Invitations.ensure_new_membership(
+             team,
+             invitee,
+             role
+           ),
+         {:ok, invitation} <-
+           Teams.Invitations.invite(team, invitee_email, role, inviter) do
+      send_invitation_email(invitation, invitee)
+
+      invitation
+    else
+      {:error, cause} -> Repo.rollback(cause)
+    end
+  end
+
+  defp send_invitation_email(invitation, invitee) do
+    invitation
+    |> Repo.preload([:team, :inviter])
+    |> Teams.Invitations.send_invitation_email(invitee)
+  end
+end

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -7,10 +7,12 @@ defmodule Plausible.Teams.Membership do
 
   import Ecto.Changeset
 
+  @roles [:guest, :viewer, :editor, :admin, :owner]
+
   @type t() :: %__MODULE__{}
 
   schema "team_memberships" do
-    field :role, Ecto.Enum, values: [:guest, :viewer, :editor, :admin, :owner]
+    field :role, Ecto.Enum, values: @roles
 
     belongs_to :user, Plausible.Auth.User
     belongs_to :team, Plausible.Teams.Team
@@ -19,6 +21,8 @@ defmodule Plausible.Teams.Membership do
 
     timestamps()
   end
+
+  def roles(), do: @roles
 
   def changeset(team, user, role) do
     %__MODULE__{}

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -263,6 +263,29 @@ defmodule PlausibleWeb.Email do
     )
   end
 
+  def new_user_team_invitation(email, invitation_id, team, inviter) do
+    priority_email()
+    |> to(email)
+    |> tag("new-user-team-invitation")
+    |> subject("[#{Plausible.product_name()}] You've been invited to \"#{team.name}\" team")
+    |> render("new_user_team_invitation.html",
+      invitation_id: invitation_id,
+      team: team,
+      inviter: inviter
+    )
+  end
+
+  def existing_user_team_invitation(email, team, inviter) do
+    priority_email()
+    |> to(email)
+    |> tag("existing-user-team-invitation")
+    |> subject("[#{Plausible.product_name()}] You've been invited to \"#{team.name}\" team")
+    |> render("existing_user_team_invitation.html",
+      team: team,
+      inviter: inviter
+    )
+  end
+
   def ownership_transfer_request(email, invitation_id, site, inviter, new_owner_account) do
     priority_email()
     |> to(email)

--- a/lib/plausible_web/templates/email/existing_user_team_invitation.html.heex
+++ b/lib/plausible_web/templates/email/existing_user_team_invitation.html.heex
@@ -1,0 +1,3 @@
+<%= @inviter.email %> has invited you to the "<%= @team.name %>" team on <%= Plausible.product_name() %>.
+<a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a> to view and respond to the invitation. The invitation
+will expire 48 hours after this email is sent.

--- a/lib/plausible_web/templates/email/new_user_team_invitation.html.heex
+++ b/lib/plausible_web/templates/email/new_user_team_invitation.html.heex
@@ -1,0 +1,10 @@
+<%= @inviter.email %> has invited you to join the "<%= @team.name %>" team on <%= Plausible.product_name() %>.
+<a href={
+  Routes.auth_url(
+    PlausibleWeb.Endpoint,
+    :register_from_invitation_form,
+    @invitation_id
+  )
+}>Click here</a> to create your account. The link is valid for 48 hours after this email is sent.
+<br /><br />
+Plausible is a lightweight and open-source website analytics tool. We hope you like our simple and ethical approach to tracking website visitors.

--- a/test/plausible/teams/invitations/invite_to_team_test.exs
+++ b/test/plausible/teams/invitations/invite_to_team_test.exs
@@ -1,0 +1,220 @@
+defmodule Plausible.Teams.Invitations.InviteToTeamTest do
+  use Plausible.DataCase
+  use Plausible
+  use Bamboo.Test
+  use Plausible.Teams.Test
+
+  alias Plausible.Repo
+  alias Plausible.Teams
+  alias Plausible.Teams.Invitations.InviteToTeam
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
+
+  describe "invite/4,5" do
+    for role <- Teams.Invitation.roles() -- [:guest] do
+      test "creates an invitation with role #{role} for existing user" do
+        inviter = new_user()
+        invitee = new_user()
+        _site = new_site(owner: inviter)
+        team = team_of(inviter)
+
+        assert {:ok, %Plausible.Teams.Invitation{} = team_invitation} =
+                 InviteToTeam.invite(team, inviter, invitee.email, unquote(role))
+
+        assert team_invitation.team_id == team.id
+        assert team_invitation.role == unquote(role)
+        assert team_invitation.email == invitee.email
+        assert team_invitation.inviter_id == inviter.id
+        assert is_binary(team_invitation.invitation_id)
+        assert [] = Repo.preload(team_invitation, :guest_invitations).guest_invitations
+
+        assert_email_delivered_with(
+          to: [nil: invitee.email],
+          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        )
+      end
+    end
+
+    for role <- Teams.Invitation.roles() -- [:guest] do
+      test "creates an invitation with role #{role} for new user" do
+        inviter = new_user()
+        invitee = build(:user)
+        _site = new_site(owner: inviter)
+        team = team_of(inviter)
+
+        assert {:ok, %Plausible.Teams.Invitation{} = team_invitation} =
+                 InviteToTeam.invite(team, inviter, invitee.email, unquote(role))
+
+        assert team_invitation.team_id == team.id
+        assert team_invitation.role == unquote(role)
+        assert team_invitation.email == invitee.email
+        assert team_invitation.inviter_id == inviter.id
+        assert is_binary(team_invitation.invitation_id)
+        assert [] = Repo.preload(team_invitation, :guest_invitations).guest_invitations
+
+        assert_email_delivered_with(
+          to: [nil: invitee.email],
+          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team",
+          html_body: ~r/#{team_invitation.invitation_id}/
+        )
+      end
+    end
+
+    for role <- Enum.map(Teams.Invitation.roles() -- [:guest], &to_string/1) do
+      test "creates an invitation with role #{role} as a string" do
+        inviter = new_user()
+        invitee = new_user()
+        _site = new_site(owner: inviter)
+        team = team_of(inviter)
+
+        assert {:ok, %Plausible.Teams.Invitation{} = team_invitation} =
+                 InviteToTeam.invite(team, inviter, invitee.email, unquote(role))
+
+        assert team_invitation.team_id == team.id
+        assert team_invitation.role == unquote(String.to_existing_atom(role))
+        assert team_invitation.email == invitee.email
+        assert team_invitation.inviter_id == inviter.id
+        assert is_binary(team_invitation.invitation_id)
+        assert [] = Repo.preload(team_invitation, :guest_invitations).guest_invitations
+
+        assert_email_delivered_with(
+          to: [nil: invitee.email],
+          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        )
+      end
+    end
+
+    test "crashes on attempt to invite guest on a team level" do
+      inviter = new_user()
+      invitee = new_user()
+      _site = new_site(owner: inviter)
+      team = team_of(inviter)
+
+      assert_raise RuntimeError, ~r/Invalid role passed/, fn ->
+        InviteToTeam.invite(team, inviter, invitee.email, :guest)
+      end
+
+      assert_raise RuntimeError, ~r/Invalid role passed/, fn ->
+        InviteToTeam.invite(team, inviter, invitee.email, "guest")
+      end
+    end
+
+    test "overwrites existing invitation" do
+      inviter = new_user()
+      invitee = new_user()
+      _site = new_site(owner: inviter)
+      team = team_of(inviter)
+      existing_invitation = invite_member(team, invitee.email, role: :viewer, inviter: inviter)
+
+      assert {:ok, team_invitation} =
+               InviteToTeam.invite(team, inviter, invitee.email, :editor)
+
+      assert team_invitation.id == existing_invitation.id
+      assert team_invitation.team_id == existing_invitation.team_id
+      assert team_invitation.email == invitee.email
+      assert team_invitation.role == :editor
+    end
+
+    test "overwrites existing guest invitation and prunes guest invitation entries" do
+      inviter = new_user()
+      invitee = new_user()
+      site = new_site(owner: inviter)
+      team = team_of(inviter)
+      existing_invitation = invite_guest(site, invitee.email, role: :viewer, inviter: inviter)
+
+      assert {:ok, team_invitation} =
+               InviteToTeam.invite(team, inviter, invitee.email, :viewer)
+
+      assert team_invitation.id == existing_invitation.team_invitation.id
+      assert team_invitation.team_id == existing_invitation.team_invitation.team_id
+      assert team_invitation.email == invitee.email
+      assert team_invitation.role == :viewer
+      assert [] = Repo.preload(team_invitation, :guest_invitations).guest_invitations
+    end
+
+    test "returns validation errors" do
+      inviter = new_user()
+      _site = new_site(owner: inviter)
+      team = team_of(inviter)
+
+      assert {:error, changeset} = InviteToTeam.invite(team, inviter, "", :viewer)
+      assert {"can't be blank", _} = changeset.errors[:email]
+    end
+
+    for role <- Teams.Invitation.roles() -- [:guest] do
+      test "returns error when existing user is already a member (role #{role})" do
+        inviter = new_user()
+        invitee = new_user()
+        _site = new_site(owner: inviter)
+        team = team_of(inviter)
+        add_member(team, user: invitee, role: unquote(role))
+
+        assert {:error, :already_a_member} =
+                 InviteToTeam.invite(team, inviter, invitee.email, :editor)
+      end
+    end
+
+    test "succeeds when existing user is only a guest member" do
+      inviter = new_user()
+      invitee = new_user()
+      site = new_site(owner: inviter)
+      team = team_of(inviter)
+      add_guest(site, user: invitee, role: :viewer)
+
+      assert {:ok, _team_invitation} =
+               InviteToTeam.invite(team, inviter, invitee.email, :viewer)
+    end
+
+    @tag :ee_only
+    test "returns error when owner is over their team member limit" do
+      [owner, inviter, invitee] = for _ <- 1..3, do: new_user()
+      _site = new_site(owner: owner)
+      team = team_of(owner)
+      inviter = add_member(team, user: inviter, role: :admin)
+      for _ <- 1..2, do: add_member(team, role: :viewer)
+
+      assert {:error, {:over_limit, 3}} =
+               InviteToTeam.invite(team, inviter, invitee.email, :viewer)
+    end
+
+    @tag :ee_only
+    test "allows creating an ownership transfer even when at team member limit" do
+      inviter = new_user()
+      invitee = build(:user)
+      _site = new_site(owner: inviter)
+      team = team_of(inviter)
+      for _ <- 1..3, do: add_member(team, role: :viewer)
+
+      assert {:ok, _team_invitation} =
+               InviteToTeam.invite(team, inviter, invitee.email, :owner)
+    end
+
+    for role <- Teams.Invitation.roles() -- [:guest, :owner] do
+      test "allows admins to invite new members except owners (invite role: #{role})" do
+        owner = new_user()
+        inviter = new_user()
+        invitee = build(:user)
+        _site = new_site(owner: owner)
+        team = team_of(owner)
+        add_member(team, user: inviter, role: :admin)
+
+        assert {:ok, _team_invitation} =
+                 InviteToTeam.invite(team, inviter, invitee.email, unquote(role))
+      end
+    end
+
+    for role <- Teams.Invitation.roles() -- [:owner] do
+      test "only allows owners to invite new owners (inviter role: #{role})" do
+        owner = new_user()
+        inviter = new_user()
+        invitee = build(:user)
+        _site = new_site(owner: owner)
+        team = team_of(owner)
+        add_member(team, user: inviter, role: unquote(role))
+
+        assert {:error, :forbidden} =
+                 InviteToTeam.invite(team, inviter, invitee.email, :owner)
+      end
+    end
+  end
+end

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -110,6 +110,15 @@ defmodule Plausible.Teams.Test do
     user |> Repo.preload(:team_memberships)
   end
 
+  def add_member(team, args \\ []) do
+    user = Keyword.get(args, :user, new_user())
+    role = Keyword.fetch!(args, :role)
+
+    insert(:team_membership, team: team, user: user, role: role)
+
+    user |> Repo.preload(:team_memberships)
+  end
+
   def invite_guest(site, invitee_or_email, args \\ []) when not is_nil(invitee_or_email) do
     {role, args} = Keyword.pop!(args, :role)
     {inviter, args} = Keyword.pop!(args, :inviter)
@@ -142,6 +151,30 @@ defmodule Plausible.Teams.Test do
         [
           team_invitation: team_invitation,
           site: site,
+          role: role
+        ],
+        args
+      )
+    )
+  end
+
+  def invite_member(team, invitee_or_email, args \\ []) when not is_nil(invitee_or_email) do
+    {role, args} = Keyword.pop!(args, :role)
+    {inviter, args} = Keyword.pop!(args, :inviter)
+
+    email =
+      case invitee_or_email do
+        %{email: email} -> email
+        email when is_binary(email) -> email
+      end
+
+    insert(
+      :team_invitation,
+      Keyword.merge(
+        [
+          team: team,
+          email: email,
+          inviter: inviter,
           role: role
         ],
         args


### PR DESCRIPTION
### Changes

This service implements a service for inviting new members on a team.

- if there's an existing team invite for a given email, it's overwritten
- if overwritten invite is a guest invite, its guest invitation entries (site-bound) are pruned
- only an owner can invite another owner
- inviting members on a team is only possible for admins and up
- registering from invitation link now supports team invitation id as well

### Tests
- [x] Automated tests have been added

