### PR TITLE
Fix breakdown comparisons breaking after pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Fix typo on login screen
 - Fix Direct / None details modal not opening
 - Fix year over year comparisons being offset by a day for leap years
+- Breakdown modals now display correct comparison values instead of 0 after pagination
 
 ## v2.1.4 - 2024-10-08
 

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -75,11 +75,15 @@ defmodule Plausible.Stats.Comparisons do
   defp add_query_filters(query, []), do: query
 
   defp add_query_filters(query, [filter]) do
-    Query.add_filter(query, [:ignore_in_totals_query, filter])
+    query
+    |> Query.add_filter([:ignore_in_totals_query, filter])
+    |> Query.set(pagination: nil)
   end
 
   defp add_query_filters(query, filters) do
-    Query.add_filter(query, [:ignore_in_totals_query, [:or, filters]])
+    query
+    |> Query.add_filter([:ignore_in_totals_query, [:or, filters]])
+    |> Query.set(pagination: nil)
   end
 
   defp build_comparison_filter(%{dimensions: dimension_labels}, query) do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -125,7 +125,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
       build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:00:00]),
       build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
       build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
-      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
+      build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00]),
+      build(:pageview, browser: "Safari", timestamp: ~N[2021-01-08 00:00:00])
     ])
 
     conn =
@@ -143,20 +146,44 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     assert json_response(conn, 200)["results"] == [
              %{
                "dimensions" => ["Chrome"],
-               "metrics" => [2, 66.7],
+               "metrics" => [3, 50.0],
                "comparison" => %{
                  "dimensions" => ["Chrome"],
                  "metrics" => [1, 12.5],
-                 "change" => [100, 434]
+                 "change" => [200, 300]
                }
              },
              %{
                "dimensions" => ["Firefox"],
-               "metrics" => [1, 33.3],
+               "metrics" => [2, 33.3],
                "comparison" => %{
                  "dimensions" => ["Firefox"],
                  "metrics" => [4, 50.0],
-                 "change" => [-75, -33]
+                 "change" => [-50, -33]
+               }
+             }
+           ]
+
+    conn2 =
+      post(conn, "/api/v2/query-internal-test", %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors", "percentage"],
+        "date_range" => ["2021-01-07", "2021-01-13"],
+        "dimensions" => ["visit:browser"],
+        "include" => %{
+          "comparisons" => %{"mode" => "previous_period"}
+        },
+        "pagination" => %{"limit" => 2, "offset" => 2}
+      })
+
+    assert json_response(conn2, 200)["results"] == [
+             %{
+               "dimensions" => ["Safari"],
+               "metrics" => [1, 16.7],
+               "comparison" => %{
+                 "dimensions" => ["Safari"],
+                 "metrics" => [3, 37.5],
+                 "change" => [-67, -55]
                }
              }
            ]


### PR DESCRIPTION
https://github.com/plausible/analytics/pull/4697 introduced some comparisons fixes which changed how comparisons interacted with main queries. Sadly this broke under pagination and due to lack of coverage wasn't caught.

The bug can also be tested manually on localhost:
- Change assets/js/dashboard/hooks/api-client.ts LIMIT to e.g. 3
- Open any modal, click load more
- Check tooltips

Before the fix this would have displayed 0 values, after the fix this works as expected.