### PR TITLE
Solve a github action warning

### DIFF
--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -180,7 +180,7 @@ export default function SourceList() {
     if (currentTab == 'all' && isRemovingFilter('channel')) {
       setTab('channels')()
     }
-  }, [query, currentTab])
+  }, [query, currentTab, previousQuery, setTab])
 
   function setTab(tab) {
     return () => {


### PR DESCRIPTION
All PRs currently display the following warning:

![image](https://github.com/user-attachments/assets/e1737d98-6307-4df8-a8f8-0b264b9bd738)

This PR fixes that issue.