### PR TITLE
Handle non-string binary input before postgres

### DIFF
--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -128,8 +128,12 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
+  defp valid_path_fragment?(fragment), do: is_binary(fragment) and String.valid?(fragment)
+
   defp get_domain(conn, nil) do
-    if domain = conn.path_params["domain"] do
+    domain = conn.path_params["domain"]
+
+    if valid_path_fragment?(domain) do
       {:ok, domain}
     else
       error_not_found(conn)
@@ -139,7 +143,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   defp get_domain(conn, site_param) do
     domain = conn.params[site_param]
 
-    if is_binary(domain) do
+    if valid_path_fragment?(domain) do
       {:ok, domain}
     else
       error_not_found(conn)
@@ -165,7 +169,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   defp maybe_get_shared_link(conn, site) do
     slug = conn.path_params["slug"] || conn.params["auth"]
 
-    if is_binary(slug) do
+    if valid_path_fragment?(slug) do
       if shared_link = Repo.get_by(Plausible.Site.SharedLink, slug: slug, site_id: site.id) do
         {:ok, shared_link}
       else

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -44,6 +44,19 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
     assert html_response(conn, 404)
   end
 
+  test "returns 404 on hacky :domain input", %{conn: conn} do
+    opts = AuthorizeSiteAccess.init(:all_roles)
+
+    conn =
+      conn
+      |> bypass_through(PlausibleWeb.Router)
+      |> get("/plug-tests/%c0%ae/with-domain")
+      |> AuthorizeSiteAccess.call(opts)
+
+    assert conn.halted
+    assert html_response(conn, 404)
+  end
+
   test "rejects user completely unrelated to the site", %{conn: conn} do
     opts = AuthorizeSiteAccess.init(:all_roles)
 


### PR DESCRIPTION
### Changes

Stops internal server errors stemming from binary but non-string input reaching postgres queries.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
