### PR TITLE
Average Scroll Depth Metric: Track custom props on pageleaves

### DIFF
--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -648,6 +648,29 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert Map.get(event, :"meta.value") == ["true", "12"]
     end
 
+    test "records custom props for a pageleave event", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{
+        n: "pageview",
+        u: "https://ab.cd",
+        d: site.domain
+      })
+
+      post(conn, "/api/event", %{
+        name: "pageleave",
+        url: "http://ab.cd/",
+        domain: site.domain,
+        props: %{
+          bool_test: true,
+          number_test: 12
+        }
+      })
+
+      pageleave = get_events(site) |> Enum.find(&(&1.name == "pageleave"))
+
+      assert Map.get(pageleave, :"meta.key") == ["bool_test", "number_test"]
+      assert Map.get(pageleave, :"meta.value") == ["true", "12"]
+    end
+
     test "filters out bad props", %{conn: conn, site: site} do
       params = %{
         name: "Signup",

--- a/tracker/.eslintrc.json
+++ b/tracker/.eslintrc.json
@@ -19,8 +19,7 @@
       {
         "assertFunctionNames": [
           "expect",
-          "pageActionAndExpectEventRequests",
-          "expectCustomEvent"
+          "pageActionAndExpectEventRequests"
         ]
       }
     ]

--- a/tracker/.eslintrc.json
+++ b/tracker/.eslintrc.json
@@ -19,7 +19,7 @@
       {
         "assertFunctionNames": [
           "expect",
-          "clickPageElementAndExpectEventRequests",
+          "pageActionAndExpectEventRequests",
           "expectCustomEvent"
         ]
       }

--- a/tracker/.eslintrc.json
+++ b/tracker/.eslintrc.json
@@ -19,7 +19,7 @@
       {
         "assertFunctionNames": [
           "expect",
-          "pageActionAndExpectEventRequests"
+          "expectPlausibleInAction"
         ]
       }
     ]

--- a/tracker/src/customEvents.js
+++ b/tracker/src/customEvents.js
@@ -193,6 +193,8 @@ function handleTaggedElementClickEvent(event) {
     var eventAttrs = getTaggedEventAttributes(taggedElement)
 
     if (clickedLink) {
+      // if the clicked tagged element is a link, we attach the `url` property
+      // automatically for user convenience
       eventAttrs.props.url = clickedLink.href
       sendLinkClickEvent(event, clickedLink, eventAttrs)
     } else {

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -36,6 +36,8 @@
   // URL, and on SPA navigation.
   var currentPageLeaveURL = location.href
 
+  var currentPageLeaveProps = {}
+
   // Multiple pageviews might be sent by the same script when the page
   // uses client-side routing (e.g. hash or history-based). This flag
   // prevents registering multiple listeners in those cases.
@@ -101,6 +103,7 @@
       sd: Math.round((maxScrollDepthPx / currentDocumentHeight) * 100),
       d: dataDomain,
       u: currentPageLeaveURL,
+      p: currentPageLeaveProps
     }
 
     {{#if hash}}
@@ -220,6 +223,7 @@
       if (request.readyState === 4) {
         {{#if pageleave}}
         if (isPageview) {
+          currentPageLeaveProps = payload.p
           registerPageLeaveListener()
         }
         {{/if}}

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -31,11 +31,7 @@
   {{#if pageleave}}
   // :NOTE: Tracking pageleave events is currently experimental.
 
-  // Keeps track of the URL to be sent in the pageleave event payload.
-  // Should get updated on pageviews triggered manually with a custom
-  // URL, and on SPA navigation.
   var currentPageLeaveURL = location.href
-
   var currentPageLeaveProps = {}
 
   // Multiple pageviews might be sent by the same script when the page
@@ -170,10 +166,6 @@
     {{#if manual}}
     var customURL = options && options.u
 
-    {{#if pageleave}}
-    isPageview && customURL && (currentPageLeaveURL = customURL)
-    {{/if}}
-
     payload.u = customURL ? customURL : location.href
     {{else}}
     payload.u = location.href
@@ -223,6 +215,7 @@
       if (request.readyState === 4) {
         {{#if pageleave}}
         if (isPageview) {
+          currentPageLeaveURL = payload.u
           currentPageLeaveProps = payload.p
           registerPageLeaveListener()
         }
@@ -249,7 +242,6 @@
       {{#if pageleave}}
       if (isSPANavigation && listeningPageLeave) {
         triggerPageLeave();
-        currentPageLeaveURL = location.href;
         currentDocumentHeight = getDocumentHeight()
         maxScrollDepthPx = getCurrentScrollDepthPx()
       }

--- a/tracker/test/custom-event-edge-cases.spec.js
+++ b/tracker/test/custom-event-edge-cases.spec.js
@@ -1,4 +1,4 @@
-const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { expectPlausibleInAction } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -7,29 +7,30 @@ test.describe('script.file-downloads.outbound-links.tagged-events.js', () => {
         await page.goto('/custom-event-edge-case.html')
         const downloadURL = await page.locator('#outbound-download-link').getAttribute('href')
 
-        await pageActionAndExpectEventRequests(page, () => page.click('#outbound-download-link'), [
-            {n: 'Outbound Link: Click', p: {url: downloadURL}}
-        ])
+        await expectPlausibleInAction(page, {
+            action: () => page.click('#outbound-download-link'),
+            expectedRequests: [{n: 'Outbound Link: Click', p: {url: downloadURL}}]
+        })
     })
 
     test('sends file download event when local download link clicked', async ({ page }) => {
         await page.goto('/custom-event-edge-case.html')
         const downloadURL = LOCAL_SERVER_ADDR + '/' + await page.locator('#local-download').getAttribute('href')
 
-        await pageActionAndExpectEventRequests(page, () => page.click('#local-download'), [
-            {n: 'File Download', p: {url: downloadURL}}
-        ])
+        await expectPlausibleInAction(page, {
+            action: () => page.click('#local-download'),
+            expectedRequests: [{n: 'File Download', p: {url: downloadURL}}]
+        })
     })
 
     test('sends only tagged event when clicked link is tagged + outbound + download', async ({ page }) => {
         await page.goto('/custom-event-edge-case.html')
 
-        await pageActionAndExpectEventRequests(
-            page,
-            () => page.click('#tagged-outbound-download-link'),
-            [{n: 'Foo', p: {url: 'https://awesome.website.com/file.pdf'}}],
-            [],
-            3
-        )
+        await expectPlausibleInAction(page, {
+            action: () => page.click('#tagged-outbound-download-link'),
+            expectedRequests: [{n: 'Foo', p: {url: 'https://awesome.website.com/file.pdf'}}],
+            awaitedRequestCount: 3,
+            expectedRequestCount: 1
+        })
     })
 })

--- a/tracker/test/file-downloads.spec.js
+++ b/tracker/test/file-downloads.spec.js
@@ -1,4 +1,4 @@
-const { mockRequest, mockManyRequests, metaKey, pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { mockRequest, mockManyRequests, metaKey, expectPlausibleInAction } = require('./support/test-utils')
 const { expect, test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -9,12 +9,12 @@ test.describe('file-downloads extension', () => {
 
     const downloadRequestMock = mockRequest(page, downloadURL)
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#link', { modifiers: [metaKey()] }), [
-      {n: 'File Download', p: { url: downloadURL }}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link', { modifiers: [metaKey()] }),
+      expectedRequests: [{n: 'File Download', p: { url: downloadURL }}]
+    })
 
     expect(await downloadRequestMock, "should not make download request").toBeNull()
-    
   })
 
   test('sends event and starts download when link child is clicked', async ({ page }) => {
@@ -22,10 +22,11 @@ test.describe('file-downloads extension', () => {
     const downloadURL = await page.locator('#link').getAttribute('href')
 
     const downloadRequestMock = mockRequest(page, downloadURL)
-    
-    await pageActionAndExpectEventRequests(page, () => page.click('#link-child'), [
-      {n: 'File Download', p: { url: downloadURL }}
-    ])
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link-child'),
+      expectedRequests: [{n: 'File Download', p: { url: downloadURL }}]
+    })
 
     expect((await downloadRequestMock).url()).toContain(downloadURL)
   })
@@ -34,9 +35,10 @@ test.describe('file-downloads extension', () => {
     await page.goto('/file-download.html')
     const downloadURL = await page.locator('#link-query').getAttribute('href')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#link-query'), [
-      {n: 'File Download', p: { url: downloadURL.split("?")[0] }}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link-query'),
+      expectedRequests: [{n: 'File Download', p: { url: downloadURL.split("?")[0] }}]
+    })
   })
 
   test('starts download only once', async ({ page }) => {

--- a/tracker/test/fixtures/pageleave-hash-pageview-props.html
+++ b/tracker/test/fixtures/pageleave-hash-pageview-props.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Plausible Playwright tests</title>
+  <script id="plausible-script" defer src="/tracker/js/plausible.hash.local.pageleave.pageview-props.js"></script>
+</head>
+
+<body>
+  <h1>Blog</h1>
+
+  <button id="home" onclick="goHome()">Home</button>
+  <button id="john-post" onclick="goToBlogPost('john')">A blog post of John</button>
+  <button id="jane-post" onclick="goToBlogPost('jane')">A blog post of Jane</button>
+
+  <div id="content"></div>
+
+  <script>
+    function goToBlogPost(author) {
+      document.getElementById('plausible-script').setAttribute('event-author', author)
+      window.location.hash = `/${author}-post`
+      document.getElementById('content').innerHTML = `Hello, I'm ${author} and this is my post.`
+    }
+
+    function goHome() {
+      document.getElementById('plausible-script').removeAttribute('event-author')
+      window.location.hash = ''
+      document.getElementById('content').innerHTML = ''
+    }
+  </script>
+</body>
+
+</html>

--- a/tracker/test/fixtures/pageleave-manual.html
+++ b/tracker/test/fixtures/pageleave-manual.html
@@ -16,11 +16,16 @@
   <button id="pageview-trigger-custom-url">
     Triggers a pageview with custom URL
   </button>
+  <button id="pageview-trigger-custom-props">
+    Triggers a pageview with custom props
+  </button>
 
   <script>
     document.addEventListener('click', (e) => {
       if (e.target.id === 'pageview-trigger-custom-url') {
         window.plausible('pageview', {u: 'https://example.com/custom/location'})
+      } else if (e.target.id === 'pageview-trigger-custom-props') {
+        window.plausible('pageview', {props: {author: 'John'}})
       }
     })
   </script>

--- a/tracker/test/fixtures/pageleave-pageview-props.html
+++ b/tracker/test/fixtures/pageleave-pageview-props.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Plausible Playwright tests</title>
+  <script defer event-author="John" src="/tracker/js/plausible.local.pageleave.pageview-props.js"></script>
+</head>
+
+<body>
+  <a id="navigate-away" href="/manual.html">Navigate away</a>
+</body>
+
+</html>

--- a/tracker/test/manual.spec.js
+++ b/tracker/test/manual.spec.js
@@ -1,4 +1,4 @@
-const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { expectPlausibleInAction } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -6,28 +6,34 @@ test.describe('manual extension', () => {
   test('can trigger custom events with and without a custom URL if pageview was sent with the default URL', async ({ page }) => {
     await page.goto('/manual.html')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger'), [
-      {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/manual.html`}
-    ])
-    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger'), [
-      {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}
-    ])
-    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger-custom-url'), [
-      {n: 'CustomEvent', u: `https://example.com/custom/location`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#pageview-trigger'),
+      expectedRequests: [{n: 'pageview', u: `${LOCAL_SERVER_ADDR}/manual.html`}]
+    })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#custom-event-trigger'),
+      expectedRequests: [{n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}]
+    })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#custom-event-trigger-custom-url'),
+      expectedRequests: [{n: 'CustomEvent', u: `https://example.com/custom/location`}]
+    })
   })
 
   test('can trigger custom events with and without a custom URL if pageview was sent with a custom URL', async ({ page }) => {
     await page.goto('/manual.html')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-url'), [
-      {n: 'pageview', u: `https://example.com/custom/location`}
-    ])
-    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger'), [
-      {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}
-    ])
-    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger-custom-url'), [
-      {n: 'CustomEvent', u: `https://example.com/custom/location`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#pageview-trigger-custom-url'),
+      expectedRequests: [{n: 'pageview', u: `https://example.com/custom/location`}]
+    })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#custom-event-trigger'),
+      expectedRequests: [{n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}]
+    })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#custom-event-trigger-custom-url'),
+      expectedRequests: [{n: 'CustomEvent', u: `https://example.com/custom/location`}]
+    })
   })
 })

--- a/tracker/test/manual.spec.js
+++ b/tracker/test/manual.spec.js
@@ -1,4 +1,4 @@
-const { clickPageElementAndExpectEventRequests } = require('./support/test-utils')
+const { pageActionAndExpectEventRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -6,13 +6,13 @@ test.describe('manual extension', () => {
   test('can trigger custom events with and without a custom URL if pageview was sent with the default URL', async ({ page }) => {
     await page.goto('/manual.html')
 
-    await clickPageElementAndExpectEventRequests(page, '#pageview-trigger', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger'), [
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/manual.html`}
     ])
-    await clickPageElementAndExpectEventRequests(page, '#custom-event-trigger', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger'), [
       {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}
     ])
-    await clickPageElementAndExpectEventRequests(page, '#custom-event-trigger-custom-url', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger-custom-url'), [
       {n: 'CustomEvent', u: `https://example.com/custom/location`}
     ])
   })
@@ -20,13 +20,13 @@ test.describe('manual extension', () => {
   test('can trigger custom events with and without a custom URL if pageview was sent with a custom URL', async ({ page }) => {
     await page.goto('/manual.html')
 
-    await clickPageElementAndExpectEventRequests(page, '#pageview-trigger-custom-url', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-url'), [
       {n: 'pageview', u: `https://example.com/custom/location`}
     ])
-    await clickPageElementAndExpectEventRequests(page, '#custom-event-trigger', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger'), [
       {n: 'CustomEvent', u: `${LOCAL_SERVER_ADDR}/manual.html`}
     ])
-    await clickPageElementAndExpectEventRequests(page, '#custom-event-trigger-custom-url', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#custom-event-trigger-custom-url'), [
       {n: 'CustomEvent', u: `https://example.com/custom/location`}
     ])
   })

--- a/tracker/test/outbound-links.spec.js
+++ b/tracker/test/outbound-links.spec.js
@@ -1,17 +1,17 @@
-const { mockRequest, metaKey, pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { mockRequest, metaKey, expectPlausibleInAction } = require('./support/test-utils')
 const { expect, test } = require('@playwright/test')
 
 test.describe('outbound-links extension', () => {
-
   test('sends event and does not navigate when link opens in new tab', async ({ page }) => {
     await page.goto('/outbound-link.html')
     const outboundURL = await page.locator('#link').getAttribute('href')
 
     const navigationRequestMock = mockRequest(page, outboundURL)
     
-    await pageActionAndExpectEventRequests(page, () => page.click('#link', { modifiers: [metaKey()] }), [
-      {n: 'Outbound Link: Click', p: { url: outboundURL }}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link', { modifiers: [metaKey()] }),
+      expectedRequests: [{n: 'Outbound Link: Click', p: { url: outboundURL }}]
+    })
 
     expect(await navigationRequestMock, "should not have made navigation request").toBeNull()
   })
@@ -22,9 +22,10 @@ test.describe('outbound-links extension', () => {
 
     const navigationRequestMock = mockRequest(page, outboundURL)
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#link-child'), [
-      {n: 'Outbound Link: Click', p: { url: outboundURL }}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link-child'),
+      expectedRequests: [{n: 'Outbound Link: Click', p: { url: outboundURL }}]
+    })
 
     const navigationRequest = await navigationRequestMock
     expect(navigationRequest.url()).toContain(outboundURL)
@@ -35,10 +36,11 @@ test.describe('outbound-links extension', () => {
     const outboundURL = await page.locator('#link-default-prevented').getAttribute('href')
 
     const navigationRequestMock = mockRequest(page, outboundURL)
-    
-    await pageActionAndExpectEventRequests(page, () => page.click('#link-default-prevented'), [
-      {n: 'Outbound Link: Click', p: { url: outboundURL }}
-    ])
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#link-default-prevented'),
+      expectedRequests: [{n: 'Outbound Link: Click', p: { url: outboundURL }}]
+    })
 
     expect(await navigationRequestMock, "should not have made navigation request").toBeNull()
   })

--- a/tracker/test/outbound-links.spec.js
+++ b/tracker/test/outbound-links.spec.js
@@ -1,4 +1,4 @@
-const { mockRequest, expectCustomEvent, metaKey } = require('./support/test-utils')
+const { mockRequest, metaKey, pageActionAndExpectEventRequests } = require('./support/test-utils')
 const { expect, test } = require('@playwright/test')
 
 test.describe('outbound-links extension', () => {
@@ -7,12 +7,12 @@ test.describe('outbound-links extension', () => {
     await page.goto('/outbound-link.html')
     const outboundURL = await page.locator('#link').getAttribute('href')
 
-    const plausibleRequestMock = mockRequest(page, '/api/event')
     const navigationRequestMock = mockRequest(page, outboundURL)
+    
+    await pageActionAndExpectEventRequests(page, () => page.click('#link', { modifiers: [metaKey()] }), [
+      {n: 'Outbound Link: Click', p: { url: outboundURL }}
+    ])
 
-    await page.click('#link', { modifiers: [metaKey()] })
-
-    expectCustomEvent(await plausibleRequestMock, 'Outbound Link: Click', { url: outboundURL })
     expect(await navigationRequestMock, "should not have made navigation request").toBeNull()
   })
 
@@ -20,13 +20,13 @@ test.describe('outbound-links extension', () => {
     await page.goto('/outbound-link.html')
     const outboundURL = await page.locator('#link').getAttribute('href')
 
-    const plausibleRequestMock = mockRequest(page, '/api/event')
     const navigationRequestMock = mockRequest(page, outboundURL)
 
-    await page.click('#link-child')
+    await pageActionAndExpectEventRequests(page, () => page.click('#link-child'), [
+      {n: 'Outbound Link: Click', p: { url: outboundURL }}
+    ])
 
     const navigationRequest = await navigationRequestMock
-    expectCustomEvent(await plausibleRequestMock, 'Outbound Link: Click', { url: outboundURL })
     expect(navigationRequest.url()).toContain(outboundURL)
   })
 
@@ -34,12 +34,12 @@ test.describe('outbound-links extension', () => {
     await page.goto('/outbound-link.html')
     const outboundURL = await page.locator('#link-default-prevented').getAttribute('href')
 
-    const plausibleRequestMock = mockRequest(page, '/api/event')
     const navigationRequestMock = mockRequest(page, outboundURL)
+    
+    await pageActionAndExpectEventRequests(page, () => page.click('#link-default-prevented'), [
+      {n: 'Outbound Link: Click', p: { url: outboundURL }}
+    ])
 
-    await page.click('#link-default-prevented')
-
-    expectCustomEvent(await plausibleRequestMock, 'Outbound Link: Click', { url: outboundURL })
     expect(await navigationRequestMock, "should not have made navigation request").toBeNull()
   })
 })

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -103,4 +103,14 @@ test.describe('pageleave extension', () => {
       {n: 'pageleave', p: {author: 'John'}}
     ])
   })
+
+  test('sends pageleave with the same props as pageview (pageview-props extension)', async ({ page }) => {
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-pageview-props.html'), [
+      {n: 'pageview', p: {author: 'John'}}
+    ])
+
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
+      {n: 'pageleave', p: {author: 'John'}}
+    ])
+  })
 })

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { pageActionAndExpectEventRequests, pageleaveCooldown } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -124,15 +124,14 @@ test.describe('pageleave extension', () => {
       {n: 'pageview', p: {author: 'john'}}
     ])
 
-    // Wait 600ms before navigating again because pageleave events are throttled to 500ms.
-    await page.waitForTimeout(600)
+    await pageleaveCooldown(page)
 
     await pageActionAndExpectEventRequests(page, () => page.click('#jane-post'), [
       {n: 'pageleave', p: {author: 'john'}},
       {n: 'pageview', p: {author: 'jane'}}
     ])
 
-    await page.waitForTimeout(600)
+    await pageleaveCooldown(page)
 
     await pageActionAndExpectEventRequests(page, () => page.click('#home'), [
       {n: 'pageleave', p: {author: 'jane'}},

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -71,6 +71,8 @@ test.describe('pageleave extension', () => {
       {n: 'pageleave', u: pageBaseURL, h: 1}
     ])
 
+    await pageleaveCooldown(page)
+
     // Navigate from ignored page to a tracked page ->
     // no pageleave from the current page, pageview on the next page
     await pageActionAndExpectEventRequests(
@@ -79,6 +81,8 @@ test.describe('pageleave extension', () => {
       [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
       [{n: 'pageleave'}]
     )
+
+    await pageleaveCooldown(page)
 
     // Navigate from a tracked page to another tracked page ->
     // pageleave with the last page URL, pageview with the new URL

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageActionAndExpectEventRequests, pageleaveCooldown } = require('./support/test-utils')
+const { expectPlausibleInAction, pageleaveCooldown } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -7,139 +7,166 @@ test.describe('pageleave extension', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
   test('sends a pageleave when navigating to the next page', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}]
+    })
   })
 
   test('sends pageleave and pageview on hash-based SPA navigation', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash.html'), [
-      {n: 'pageview'}
-    ])
-    
-    await pageActionAndExpectEventRequests(page, () => page.click('#hash-nav'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
-      {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html#some-hash`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave-hash.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#hash-nav'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html#some-hash`}
+      ]
+    })
   })
 
   test('sends pageleave and pageview on history-based SPA navigation', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#history-nav'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
-      {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#history-nav'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
+      ]
+    })
   })
 
   test('sends pageleave with the manually overridden URL', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-url'), [
-      {n: 'pageview', u: 'https://example.com/custom/location'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#pageview-trigger-custom-url'),
+      expectedRequests: [{n: 'pageview', u: 'https://example.com/custom/location'}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: 'https://example.com/custom/location'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: 'https://example.com/custom/location'}]
+    })
   })
 
   test('does not send pageleave when pageview was not sent in manual mode', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [], [
-      {n: 'pageleave'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      refutedRequests: [{n: 'pageleave'}],
+    })
   })
 
   test('script.exclusions.hash.pageleave.js sends pageleave only from URLs where a pageview was sent', async ({ page }) => {
     const pageBaseURL = `${LOCAL_SERVER_ADDR}/pageleave-hash-exclusions.html`
 
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash-exclusions.html'), [
-      {n: 'pageview'}
-    ])    
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave-hash-exclusions.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
     // After the initial pageview is sent, navigate to ignored page ->
     // pageleave event is sent from the initial page URL
-    await pageActionAndExpectEventRequests(page, () => page.click('#ignored-hash-link'), [
-      {n: 'pageleave', u: pageBaseURL, h: 1}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#ignored-hash-link'),
+      expectedRequests: [{n: 'pageleave', u: pageBaseURL, h: 1}]
+    })
 
     await pageleaveCooldown(page)
 
     // Navigate from ignored page to a tracked page ->
     // no pageleave from the current page, pageview on the next page
-    await pageActionAndExpectEventRequests(
-      page,
-      () => page.click('#hash-link-1'),
-      [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
-      [{n: 'pageleave'}]
-    )
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#hash-link-1'),
+      expectedRequests: [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
+      refutedRequests: [{n: 'pageleave'}]
+    })
 
     await pageleaveCooldown(page)
 
     // Navigate from a tracked page to another tracked page ->
     // pageleave with the last page URL, pageview with the new URL
-    await pageActionAndExpectEventRequests(
-      page,
-      () => page.click('#hash-link-2'),
-      [
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#hash-link-2'),
+      expectedRequests: [
         {n: 'pageleave', u: `${pageBaseURL}#hash1`, h: 1},
         {n: 'pageview', u: `${pageBaseURL}#hash2`, h: 1}
       ],
-    )
+    })
   })
 
   test('sends pageleave with the same props as pageview (manual extension)', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-props'), [
-      {n: 'pageview', p: {author: 'John'}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#pageview-trigger-custom-props'),
+      expectedRequests: [{n: 'pageview', p: {author: 'John'}}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', p: {author: 'John'}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}]
+    })
   })
 
   test('sends pageleave with the same props as pageview (pageview-props extension)', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-pageview-props.html'), [
-      {n: 'pageview', p: {author: 'John'}}
-    ])
-
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', p: {author: 'John'}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave-pageview-props.html'),
+      expectedRequests: [{n: 'pageview', p: {author: 'John'}}]
+    })
+    
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}]
+    })
   })
 
   test('sends pageleave with the same props as pageview (hash navigation / pageview-props extension)', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash-pageview-props.html'), [
-      {n: 'pageview', p: {}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave-hash-pageview-props.html'),
+      expectedRequests: [{n: 'pageview', p: {}}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#john-post'), [
-      {n: 'pageleave', p: {}},
-      {n: 'pageview', p: {author: 'john'}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#john-post'),
+      expectedRequests: [
+        {n: 'pageleave', p: {}},
+        {n: 'pageview', p: {author: 'john'}}
+      ]
+    })
+    
+    await pageleaveCooldown(page)
+    
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#jane-post'),
+      expectedRequests: [
+        {n: 'pageleave', p: {author: 'john'}},
+        {n: 'pageview', p: {author: 'jane'}}
+      ]
+    })
 
     await pageleaveCooldown(page)
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#jane-post'), [
-      {n: 'pageleave', p: {author: 'john'}},
-      {n: 'pageview', p: {author: 'jane'}}
-    ])
-
-    await pageleaveCooldown(page)
-
-    await pageActionAndExpectEventRequests(page, () => page.click('#home'), [
-      {n: 'pageleave', p: {author: 'jane'}},
-      {n: 'pageview', p: {}}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#home'),
+      expectedRequests: [
+        {n: 'pageleave', p: {author: 'jane'}},
+        {n: 'pageview', p: {}}
+      ]
+    })
   })
 })

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -113,4 +113,30 @@ test.describe('pageleave extension', () => {
       {n: 'pageleave', p: {author: 'John'}}
     ])
   })
+
+  test('sends pageleave with the same props as pageview (hash navigation / pageview-props extension)', async ({ page }) => {
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash-pageview-props.html'), [
+      {n: 'pageview', p: {}}
+    ])
+
+    await pageActionAndExpectEventRequests(page, () => page.click('#john-post'), [
+      {n: 'pageleave', p: {}},
+      {n: 'pageview', p: {author: 'john'}}
+    ])
+
+    // Wait 600ms before navigating again because pageleave events are throttled to 500ms.
+    await page.waitForTimeout(600)
+
+    await pageActionAndExpectEventRequests(page, () => page.click('#jane-post'), [
+      {n: 'pageleave', p: {author: 'john'}},
+      {n: 'pageview', p: {author: 'jane'}}
+    ])
+
+    await page.waitForTimeout(600)
+
+    await pageActionAndExpectEventRequests(page, () => page.click('#home'), [
+      {n: 'pageleave', p: {author: 'jane'}},
+      {n: 'pageview', p: {}}
+    ])
+  })
 })

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { clickPageElementAndExpectEventRequests, mockRequest } = require('./support/test-utils')
+const { pageActionAndExpectEventRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -7,32 +7,32 @@ test.describe('pageleave extension', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
   test('sends a pageleave when navigating to the next page', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/pageleave.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave.html'), [
+      {n: 'pageview'}
+    ])
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}
     ])
   })
 
   test('sends pageleave and pageview on hash-based SPA navigation', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/pageleave-hash.html')
-    await pageviewRequestMock
-
-    await clickPageElementAndExpectEventRequests(page, '#hash-nav', [
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash.html'), [
+      {n: 'pageview'}
+    ])
+    
+    await pageActionAndExpectEventRequests(page, () => page.click('#hash-nav'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html#some-hash`}
     ])
   })
 
   test('sends pageleave and pageview on history-based SPA navigation', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/pageleave.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave.html'), [
+      {n: 'pageview'}
+    ])
 
-    await clickPageElementAndExpectEventRequests(page, '#history-nav', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#history-nav'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
     ])
@@ -41,11 +41,11 @@ test.describe('pageleave extension', () => {
   test('sends pageleave with the manually overridden URL', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await clickPageElementAndExpectEventRequests(page, '#pageview-trigger-custom-url', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-url'), [
       {n: 'pageview', u: 'https://example.com/custom/location'}
     ])
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: 'https://example.com/custom/location'}
     ])
   })
@@ -53,38 +53,38 @@ test.describe('pageleave extension', () => {
   test('does not send pageleave when pageview was not sent in manual mode', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [], [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [], [
       {n: 'pageleave'}
     ])
   })
 
   test('script.exclusions.hash.pageleave.js sends pageleave only from URLs where a pageview was sent', async ({ page }) => {
     const pageBaseURL = `${LOCAL_SERVER_ADDR}/pageleave-hash-exclusions.html`
-    
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/pageleave-hash-exclusions.html')
-    await pageviewRequestMock
+
+    await pageActionAndExpectEventRequests(page, () => page.goto('/pageleave-hash-exclusions.html'), [
+      {n: 'pageview'}
+    ])    
 
     // After the initial pageview is sent, navigate to ignored page ->
     // pageleave event is sent from the initial page URL
-    await clickPageElementAndExpectEventRequests(page, '#ignored-hash-link', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#ignored-hash-link'), [
       {n: 'pageleave', u: pageBaseURL, h: 1}
     ])
 
     // Navigate from ignored page to a tracked page ->
     // no pageleave from the current page, pageview on the next page
-    await clickPageElementAndExpectEventRequests(
+    await pageActionAndExpectEventRequests(
       page,
-      '#hash-link-1',
+      () => page.click('#hash-link-1'),
       [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
       [{n: 'pageleave'}]
     )
 
     // Navigate from a tracked page to another tracked page ->
     // pageleave with the last page URL, pageview with the new URL
-    await clickPageElementAndExpectEventRequests(
+    await pageActionAndExpectEventRequests(
       page,
-      '#hash-link-2',
+      () => page.click('#hash-link-2'),
       [
         {n: 'pageleave', u: `${pageBaseURL}#hash1`, h: 1},
         {n: 'pageview', u: `${pageBaseURL}#hash2`, h: 1}
@@ -95,11 +95,11 @@ test.describe('pageleave extension', () => {
   test('sends pageleave with the same props as pageview (manual extension)', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
-    await clickPageElementAndExpectEventRequests(page, '#pageview-trigger-custom-props', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#pageview-trigger-custom-props'), [
       {n: 'pageview', p: {author: 'John'}}
     ])
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', p: {author: 'John'}}
     ])
   })

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -91,4 +91,16 @@ test.describe('pageleave extension', () => {
       ],
     )
   })
+
+  test('sends pageleave with the same props as pageview (manual extension)', async ({ page }) => {
+    await page.goto('/pageleave-manual.html')
+
+    await clickPageElementAndExpectEventRequests(page, '#pageview-trigger-custom-props', [
+      {n: 'pageview', p: {author: 'John'}}
+    ])
+
+    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+      {n: 'pageleave', p: {author: 'John'}}
+    ])
+  })
 })

--- a/tracker/test/revenue.spec.js
+++ b/tracker/test/revenue.spec.js
@@ -1,22 +1,20 @@
-const { mockRequest, expectCustomEvent } = require('./support/test-utils')
-const { expect, test } = require('@playwright/test')
+const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { test } = require('@playwright/test')
 
 test.describe('with revenue script extension', () => {
   test('sends revenue currency and amount in manual mode', async ({ page }) => {
-    const plausibleRequestMock = mockRequest(page, '/api/event')
     await page.goto('/revenue.html')
-    await page.click('#manual-purchase')
-
-    const plausibleRequest = await plausibleRequestMock
-    expect(plausibleRequest.postDataJSON()["$"]).toEqual({amount: 15.99, currency: "USD"})
+    
+    await pageActionAndExpectEventRequests(page, () => page.click('#manual-purchase'), [
+      {n: "Purchase", $: {amount: 15.99, currency: "USD"}}
+    ])
   })
 
   test('sends revenue currency and amount with tagged class name', async ({ page }) => {
-    const plausibleRequestMock = mockRequest(page, '/api/event')
     await page.goto('/revenue.html')
-    await page.click('#tagged-purchase')
-
-    const plausibleRequest = await plausibleRequestMock
-    expect(plausibleRequest.postDataJSON()["$"]).toEqual({amount: "13.32", currency: "EUR"})
+    
+    await pageActionAndExpectEventRequests(page, () => page.click('#tagged-purchase'), [
+      {n: "Purchase", $: {amount: "13.32", currency: "EUR"}}
+    ])
   })
 })

--- a/tracker/test/revenue.spec.js
+++ b/tracker/test/revenue.spec.js
@@ -1,20 +1,22 @@
-const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { expectPlausibleInAction } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 
 test.describe('with revenue script extension', () => {
   test('sends revenue currency and amount in manual mode', async ({ page }) => {
     await page.goto('/revenue.html')
-    
-    await pageActionAndExpectEventRequests(page, () => page.click('#manual-purchase'), [
-      {n: "Purchase", $: {amount: 15.99, currency: "USD"}}
-    ])
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#manual-purchase'),
+      expectedRequests: [{n: "Purchase", $: {amount: 15.99, currency: "USD"}}]
+    })
   })
 
   test('sends revenue currency and amount with tagged class name', async ({ page }) => {
     await page.goto('/revenue.html')
-    
-    await pageActionAndExpectEventRequests(page, () => page.click('#tagged-purchase'), [
-      {n: "Purchase", $: {amount: "13.32", currency: "EUR"}}
-    ])
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#tagged-purchase'),
+      expectedRequests: [{n: "Purchase", $: {amount: "13.32", currency: "EUR"}}]
+    })
   })
 })

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageActionAndExpectEventRequests, pageleaveCooldown } = require('./support/test-utils')
+const { pageleaveCooldown, expectPlausibleInAction } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -7,67 +7,80 @@ test.describe('scroll depth', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
   test('sends scroll_depth in the pageleave payload when navigating to the next page', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
     await page.evaluate(() => window.scrollBy(0, 300))
     await page.evaluate(() => window.scrollBy(0, 0))
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}]
+    })
   })
 
   test('sends scroll depth on hash navigation', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-hash.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth-hash.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#about-link'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
-      {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#about-link'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
+      ]
+    })
 
     await pageleaveCooldown(page)
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#home-link'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
-      {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#home-link'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
+      ]
+    })
   })
 
   test('document height gets reevaluated after window load', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-slow-window-load.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth-slow-window-load.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
     // Wait for the image to be loaded
     await page.waitForFunction(() => {
       return document.getElementById('slow-image').complete
     })
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}]
+    })
   })
 
   test('dynamically loaded content affects documentHeight', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-dynamic-content-load.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth-dynamic-content-load.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
     
-
     // The link appears dynamically after 500ms.
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}]
+    })
   })
 
   test('document height gets reevaluated on scroll', async ({ page }) => {
-    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-content-onscroll.html'), [
-      {n: 'pageview'}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth-content-onscroll.html'),
+      expectedRequests: [{n: 'pageview'}]
+    })
 
     // During the first 3 seconds, the script periodically updates document height
     // to account for dynamically loaded content. Since we want to test document
@@ -82,8 +95,9 @@ test.describe('scroll depth', () => {
 
     await page.evaluate(() => window.scrollBy(0, 1000))
 
-    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
-      {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}
-    ])
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}]
+    })
   })
 })

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageActionAndExpectEventRequests } = require('./support/test-utils')
+const { pageActionAndExpectEventRequests, pageleaveCooldown } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -29,8 +29,7 @@ test.describe('scroll depth', () => {
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
     ])
 
-    // Wait 600ms before navigating again because pageleave events are throttled to 500ms.
-    await page.waitForTimeout(600)
+    await pageleaveCooldown(page)
 
     await pageActionAndExpectEventRequests(page, () => page.click('#home-link'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { clickPageElementAndExpectEventRequests, mockRequest } = require('./support/test-utils')
+const { pageActionAndExpectEventRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -7,24 +7,24 @@ test.describe('scroll depth', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
   test('sends scroll_depth in the pageleave payload when navigating to the next page', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/scroll-depth.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth.html'), [
+      {n: 'pageview'}
+    ])
 
     await page.evaluate(() => window.scrollBy(0, 300))
     await page.evaluate(() => window.scrollBy(0, 0))
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}
     ])
   })
 
   test('sends scroll depth on hash navigation', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/scroll-depth-hash.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-hash.html'), [
+      {n: 'pageview'}
+    ])
 
-    await clickPageElementAndExpectEventRequests(page, '#about-link', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#about-link'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
     ])
@@ -32,42 +32,43 @@ test.describe('scroll depth', () => {
     // Wait 600ms before navigating again because pageleave events are throttled to 500ms.
     await page.waitForTimeout(600)
 
-    await clickPageElementAndExpectEventRequests(page, '#home-link', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#home-link'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
       {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
     ])
   })
 
   test('document height gets reevaluated after window load', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/scroll-depth-slow-window-load.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-slow-window-load.html'), [
+      {n: 'pageview'}
+    ])
 
     // Wait for the image to be loaded
     await page.waitForFunction(() => {
       return document.getElementById('slow-image').complete
     })
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}
     ])
   })
 
   test('dynamically loaded content affects documentHeight', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/scroll-depth-dynamic-content-load.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-dynamic-content-load.html'), [
+      {n: 'pageview'}
+    ])
+    
 
     // The link appears dynamically after 500ms.
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}
     ])
   })
 
   test('document height gets reevaluated on scroll', async ({ page }) => {
-    const pageviewRequestMock = mockRequest(page, '/api/event')
-    await page.goto('/scroll-depth-content-onscroll.html')
-    await pageviewRequestMock
+    await pageActionAndExpectEventRequests(page, () => page.goto('/scroll-depth-content-onscroll.html'), [
+      {n: 'pageview'}
+    ])
 
     // During the first 3 seconds, the script periodically updates document height
     // to account for dynamically loaded content. Since we want to test document
@@ -82,7 +83,7 @@ test.describe('scroll depth', () => {
 
     await page.evaluate(() => window.scrollBy(0, 1000))
 
-    await clickPageElementAndExpectEventRequests(page, '#navigate-away', [
+    await pageActionAndExpectEventRequests(page, () => page.click('#navigate-away'), [
       {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}
     ])
   })

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -54,23 +54,22 @@ exports.expectCustomEvent = function (request, eventName, eventProps) {
   }
 }
 
-
 /**
  * A powerful utility function that makes it easy to assert on the event
- * requests that should or should not have been made after clicking a page
- * element. 
+ * requests that should or should not have been made after doing a page
+ * action (e.g. navigating to the page, clicking a page element, etc). 
  * 
  * This function accepts subsets of request bodies (the JSON payloads) as
  * arguments, and compares them with the bodies of the requests that were
  * actually made. For a body subset to match a request, all the key-value
  * pairs present in the subset should also appear in the request body.
  */
-exports.clickPageElementAndExpectEventRequests = async function (page, locatorToClick, expectedBodySubsets, refutedBodySubsets = []) {
+exports.pageActionAndExpectEventRequests = async function (page, pageActionFn, expectedBodySubsets, refutedBodySubsets = []) {
   const requestsToExpect = expectedBodySubsets.length
   const requestsToAwait = requestsToExpect + refutedBodySubsets.length
   
   const plausibleRequestMockList = mockManyRequests(page, '/api/event', requestsToAwait)
-  await page.click(locatorToClick)
+  await pageActionFn()
   const requestBodies = (await plausibleRequestMockList).map(r => r.postDataJSON())
 
   const expectedButNotFoundBodySubsets = []

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -104,6 +104,21 @@ exports.clickPageElementAndExpectEventRequests = async function (page, locatorTo
 
 function includesSubset(body, subset) {
   return Object.keys(subset).every((key) => {
-    return body[key] === subset[key]
+    if (typeof subset[key] === 'object') {
+      return typeof body[key] === 'object' && areFlatObjectsEqual(body[key], subset[key])
+    } else {
+      return body[key] === subset[key]
+    }
   })
+}
+
+// For comparing custom props - all key-value pairs
+// must match but the order is not important.
+function areFlatObjectsEqual(obj1, obj2) {
+  const keys1 = Object.keys(obj1)
+  const keys2 = Object.keys(obj2)
+
+  if (keys1.length !== keys2.length) return false;
+
+  return keys1.every(key => obj2[key] === obj1[key])
 }

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -1,5 +1,11 @@
 const { expect } = require("@playwright/test");
 
+// Since pageleave events in the Plausible script are throttled to 500ms, we
+// often need to wait for an artificial timeout before navigating in tests.
+exports.pageleaveCooldown = async function(page) {
+  return page.waitForTimeout(600)
+}
+
 // Mocks an HTTP request call with the given path. Returns a Promise that resolves to the request
 // data. If the request is not made, resolves to null after 3 seconds.
 const mockRequest = function (page, path) {

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -50,16 +50,6 @@ const mockManyRequests = function(page, path, numberOfRequests) {
 
 exports.mockManyRequests = mockManyRequests
 
-exports.expectCustomEvent = function (request, eventName, eventProps) {
-  const payload = request.postDataJSON()
-
-  expect(payload.n).toEqual(eventName)
-
-  for (const [key, value] of Object.entries(eventProps)) {
-    expect(payload.p[key]).toEqual(value)
-  }
-}
-
 /**
  * A powerful utility function that makes it easy to assert on the event
  * requests that should or should not have been made after doing a page
@@ -70,9 +60,9 @@ exports.expectCustomEvent = function (request, eventName, eventProps) {
  * actually made. For a body subset to match a request, all the key-value
  * pairs present in the subset should also appear in the request body.
  */
-exports.pageActionAndExpectEventRequests = async function (page, pageActionFn, expectedBodySubsets, refutedBodySubsets = []) {
+exports.pageActionAndExpectEventRequests = async function (page, pageActionFn, expectedBodySubsets, refutedBodySubsets = [], eventsToAwait = null) {
   const requestsToExpect = expectedBodySubsets.length
-  const requestsToAwait = requestsToExpect + refutedBodySubsets.length
+  const requestsToAwait = eventsToAwait ? eventsToAwait : requestsToExpect + refutedBodySubsets.length
   
   const plausibleRequestMockList = mockManyRequests(page, '/api/event', requestsToAwait)
   await pageActionFn()

--- a/tracker/test/tagged-events.spec.js
+++ b/tracker/test/tagged-events.spec.js
@@ -1,4 +1,4 @@
-const { mockRequest, mockManyRequests, expectCustomEvent, metaKey } = require('./support/test-utils')
+const { mockRequest, metaKey, pageActionAndExpectEventRequests } = require('./support/test-utils')
 const { expect, test } = require('@playwright/test')
 
 test.describe('tagged-events extension', () => {
@@ -7,47 +7,48 @@ test.describe('tagged-events extension', () => {
 
         const linkURL = await page.locator('#link').getAttribute('href')
 
-        const plausibleRequestMock = mockRequest(page, '/api/event')
-        await page.click('#link')
-        expectCustomEvent(await plausibleRequestMock, 'Payment Complete', { amount: '100', method: "Credit Card", url: linkURL })
+        await pageActionAndExpectEventRequests(page, () => page.click('#link'), [
+            {n: 'Payment Complete', p: {amount: '100', method: "Credit Card", url: linkURL}}
+        ])
     })
 
     test('tracks a tagged form submit with custom props when submitting by pressing enter', async ({ page }) => {
         await page.goto('/tagged-event.html')
-        const plausibleRequestMock = mockRequest(page, '/api/event')
 
-        const inputLocator = page.locator('#form-text-input')
-        await inputLocator.type('some input')
-        await inputLocator.press('Enter')
+        const submitForm = async function() {
+            const inputLocator = page.locator('#form-text-input')
+            await inputLocator.fill('some input')
+            await inputLocator.press('Enter')
+        }
 
-        expectCustomEvent(await plausibleRequestMock, 'Signup', { type: "Newsletter" })
+        await pageActionAndExpectEventRequests(page, submitForm, [
+            {n: 'Signup', p: {type: "Newsletter"}}
+        ])
     })
 
     test('tracks submit on a form with a tagged parent when submit button is clicked', async ({ page }) => {
         await page.goto('/tagged-event.html')
 
-        const plausibleRequestMockList = mockManyRequests(page, '/api/event', 2)
-
-        await page.click('#submit-form-with-tagged-parent')
-
-        const requests = await plausibleRequestMockList
-
-        expect(requests.length).toBe(1)
-        expectCustomEvent(requests[0], "Form Submit", {})
+        await pageActionAndExpectEventRequests(
+            page,
+            () => page.click('#submit-form-with-tagged-parent'),
+            [{n: 'Form Submit', p: {}}],
+            [],
+            2
+        )
     })
 
     test('tracks click and auxclick on any tagged HTML element', async ({ page }) => {
         await page.goto('/tagged-event.html')
 
-        const plausibleRequestMockList = mockManyRequests(page, '/api/event', 3)
+        const clickThreeElements = async function() {
+            await page.click('#button')
+            await page.click('#span')
+            await page.click('#div', { modifiers: [metaKey()] })
+        }
 
-        await page.click('#button')
-        await page.click('#span')
-        await page.click('#div', { modifiers: [metaKey()] })
-
-        const requests = await plausibleRequestMockList
-        expect(requests.length).toBe(3)
-        requests.forEach(request => expectCustomEvent(request, 'Custom Event', { foo: "bar" }))
+        const expected = new Array(3).fill({n: 'Custom Event', p: { foo: "bar" }})
+        await pageActionAndExpectEventRequests(page, clickThreeElements, expected)
     })
 
     test('does not track elements without plausible-event-name class + link elements navigate', async ({ page }) => {
@@ -70,28 +71,22 @@ test.describe('tagged-events extension', () => {
     test('tracks tagged HTML elements when their child element is clicked', async ({ page }) => {
         await page.goto('/tagged-event.html')
 
-        const plausibleRequestMockList = mockManyRequests(page, '/api/event', 2)
+        const clickLinks = async function() {
+            await page.click('#h2-with-link-parent', { modifiers: [metaKey()] })
+            await page.click('#link-with-div-parent')
+        }
 
-        await page.click('#h2-with-link-parent', { modifiers: [metaKey()] })
-        await page.click('#link-with-div-parent')
-
-        const requests = await plausibleRequestMockList
-        expect(requests.length).toBe(2)
-        requests.forEach(request => expectCustomEvent(request, 'Custom Event', { foo: "bar" }))
+        const expected = new Array(2).fill({n: 'Custom Event', p: { foo: "bar", url: "https://awesome.website.com/payment/"}})
+        await pageActionAndExpectEventRequests(page, clickLinks, expected)
     })
 
     test('tracks tagged element that is dynamically added to the DOM', async ({ page }) => {
         await page.goto('/tagged-event.html')
 
-        const plausibleRequestMock = mockRequest(page, '/api/event')
-
         const buttonLocator = page.locator('#dynamic-tagged-button')
         await buttonLocator.waitFor({state: 'visible'})
-        await page.waitForTimeout(500)
 
-        await buttonLocator.click()
-
-        expectCustomEvent(await plausibleRequestMock, 'Custom Event', {})
+        await pageActionAndExpectEventRequests(page, () => buttonLocator.click(), [{n: 'Custom Event', p: {}}])
     })
 
     test('does not track clicks inside a tagged form, except submit click', async ({ page }) => {


### PR DESCRIPTION
### Changes

_NOTE: Reviewing this PR commit by commit is highly recommended._

The main intent of this PR is to make scroll depth data available also in queries where a custom property dimension is used. That means that we'll start tracking custom props on pageleaves as well. The implementation is fairly straight forward - simply keep track of the props that were sent with the pageview and send them along with the pageleave as well.

In addition, this PR:

* Fixes an important bug with tracking pageleaves on ignored pages (a test asserting the broken behaviour was accidentally passing due to pageleaves being throttled)
* Refactors the `currentPageleaveURL` logic - I overcomplicated things in the beginning. 
* Refactors the tracker test suite quite a bit

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
