### PR TITLE
Stop storing internal referrer

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -265,7 +265,7 @@ defmodule Plausible.Ingestion.Event do
 
     update_session_attrs(event, %{
       referrer_source: Plausible.Ingestion.Source.resolve(event.request),
-      referrer: Plausible.Ingestion.Source.format_referrer(event.request.referrer),
+      referrer: Plausible.Ingestion.Source.format_referrer(event.request),
       click_id_param: get_click_id_param(event.request.query_params),
       utm_source: tagged_source,
       utm_medium: query_params["utm_medium"],

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -337,6 +337,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert response(conn, 202) == "ok"
       assert session.referrer_source == ""
+      assert session.referrer == ""
     end
 
     test "ignores localhost referrer", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Internal referrals were not historically stored by design. I changed that inadvertently with the channels work. This PR makes sure this behaviour is tested and fixes it along the way.

Unfortunately we collected some bad data over the last 2 months. Probably need a data migration to fix it.

### Tests
- [x] Automated tests have been added
