### PR TITLE
Fix error layout

### DIFF
--- a/lib/plausible_web/templates/layout/base_error.html.heex
+++ b/lib/plausible_web/templates/layout/base_error.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full plausible">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
For [storybook integration](https://github.com/plausible/analytics/pull/4947) we had to scope all of our styling to the `.plausible` parent class. This class should have been added to all layouts but I missed the `base_error.html.heex` layout.