### PR TITLE
Temporarily disable combobox spinner

### DIFF
--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -245,7 +245,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
     >
       <a
         x-ref={"dropdown-#{@ref}-option-#{@idx}"}
-        x-on:click={not @creatable && "selectionInProgress = true"}
+        x-on:click={not @creatable && "selectionInProgress = false"}
         phx-click={select_option(@ref, @submit_value, @display_value)}
         phx-value-submit-value={@submit_value}
         phx-value-display-value={@display_value}

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -303,7 +303,7 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
       {:ok, lv, html} = live_isolated(conn, CreatableView, session: %{})
       regular_option = find(html, "li#dropdown-test-creatable-component-option-1 a")
 
-      assert Floki.attribute(regular_option, "x-on:click") == ["selectionInProgress = true"]
+      assert Floki.attribute(regular_option, "x-on:click") == ["selectionInProgress = false"]
 
       creatable_option =
         lv


### PR DESCRIPTION
### Changes

Combobox spinner sometimes stays spinning, which will be confusing to users. It's not a critical part of the app that it spins in the first place, so this PR disables it until a fix can be made.

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
