### PR TITLE
APIv2: Behavioral filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Dashboard shows comparisons for all reports
 - UTM Medium report and API shows (gclid) and (msclkid) for paid searches when no explicit utm medium present.
 - Support for `case_sensitive: false` modifiers in Stats API V2 filters for case-insensitive searches.
+- Add support for behavioral filtering with `has_done` and `has_not_done` filters in APIv2 plausible/analytics#4980
 
 ### Removed
 
@@ -14,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Filters appear in the search bar as ?f=is,page,/docs,/blog&f=... instead of ?filters=((is,page,(/docs,/blog)),...) for Plausible links sent on various platforms to work reliably. 
+- Filters appear in the search bar as ?f=is,page,/docs,/blog&f=... instead of ?filters=((is,page,(/docs,/blog)),...) for Plausible links sent on various platforms to work reliably.
 - Details modal search inputs are now case-insensitive.
 - Improved report performance in cases where site has a lot of unique pathnames
 
@@ -46,7 +47,6 @@ All notable changes to this project will be documented in this file.
 - Add ability to review and revoke particular logged in user sessions
 - Add ability to change password from user settings screen
 - Add error logs for background jobs plausible/analytics#4657
-- Add support for behavioral filtering with `has_done` and `has_not_done` filters in APIv2 plausible/analytics#4980
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to review and revoke particular logged in user sessions
 - Add ability to change password from user settings screen
 - Add error logs for background jobs plausible/analytics#4657
+- Add support for behavioral filtering with `has_done` and `has_not_done` filters in APIv2 plausible/analytics#4980
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 - Dashboard shows comparisons for all reports
 - UTM Medium report and API shows (gclid) and (msclkid) for paid searches when no explicit utm medium present.
 - Support for `case_sensitive: false` modifiers in Stats API V2 filters for case-insensitive searches.
-- Add support for behavioral filtering with `has_done` and `has_not_done` filters in APIv2 plausible/analytics#4980
 
 ### Removed
 

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -63,7 +63,7 @@ export type SimpleFilterDimensions =
 export type CustomPropertyFilterDimensions = string;
 export type GoalDimension = "event:goal";
 export type TimeDimensions = "time" | "time:month" | "time:week" | "time:day" | "time:hour";
-export type FilterTree = FilterEntry | FilterAndOr | FilterNotHasDone;
+export type FilterTree = FilterEntry | FilterAndOr | FilterNot | FilterHasDone;
 export type FilterEntry = FilterWithoutGoals | FilterWithGoals | FilterWithPattern;
 /**
  * @minItems 3
@@ -124,7 +124,12 @@ export type FilterAndOr = ["and" | "or", [FilterTree, ...FilterTree[]]];
  * @minItems 2
  * @maxItems 2
  */
-export type FilterNotHasDone = ["not" | "has_done" | "has_not_done", FilterTree];
+export type FilterNot = ["not", FilterTree];
+/**
+ * @minItems 2
+ * @maxItems 2
+ */
+export type FilterHasDone = ["has_done" | "has_not_done", FilterTree];
 /**
  * @minItems 2
  * @maxItems 2

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -63,7 +63,7 @@ export type SimpleFilterDimensions =
 export type CustomPropertyFilterDimensions = string;
 export type GoalDimension = "event:goal";
 export type TimeDimensions = "time" | "time:month" | "time:week" | "time:day" | "time:hour";
-export type FilterTree = FilterEntry | FilterAndOr | FilterNot;
+export type FilterTree = FilterEntry | FilterAndOr | FilterNotHasDone;
 export type FilterEntry = FilterWithoutGoals | FilterWithGoals | FilterWithPattern;
 /**
  * @minItems 3
@@ -124,7 +124,7 @@ export type FilterAndOr = ["and" | "or", [FilterTree, ...FilterTree[]]];
  * @minItems 2
  * @maxItems 2
  */
-export type FilterNot = ["not", FilterTree];
+export type FilterNotHasDone = ["not" | "has_done" | "has_not_done", FilterTree];
 /**
  * @minItems 2
  * @maxItems 2

--- a/extra/lib/plausible/stats/goal/revenue.ex
+++ b/extra/lib/plausible/stats/goal/revenue.ex
@@ -24,11 +24,11 @@ defmodule Plausible.Stats.Goal.Revenue do
 
   The resulting data structure is attached to a `Query` and used below in `format_revenue_metric/3`.
   """
-  def preload(site, goals, metrics, dimensions) do
+  def preload(site, preloaded_goals, metrics, dimensions) do
     cond do
       not requested?(metrics) -> {nil, %{}}
       not available?(site) -> {:revenue_goals_unavailable, %{}}
-      true -> preload(goals, dimensions)
+      true -> preload(preloaded_goals.matching_toplevel_filters, dimensions)
     end
   end
 

--- a/lib/plausible/stats/base.ex
+++ b/lib/plausible/stats/base.ex
@@ -26,8 +26,8 @@ defmodule Plausible.Stats.Base do
     end
   end
 
-  defp query_events(site, query) do
-    q = from(e in "events_v2", where: ^SQL.WhereBuilder.build(:events, site, query))
+  defp query_events(_site, query) do
+    q = from(e in "events_v2", where: ^SQL.WhereBuilder.build(:events, query))
 
     on_ee do
       q = Plausible.Stats.Sampling.add_query_hint(q, query)
@@ -36,8 +36,8 @@ defmodule Plausible.Stats.Base do
     q
   end
 
-  def query_sessions(site, query) do
-    q = from(s in "sessions_v2", where: ^SQL.WhereBuilder.build(:sessions, site, query))
+  def query_sessions(_site, query) do
+    q = from(s in "sessions_v2", where: ^SQL.WhereBuilder.build(:sessions, query))
 
     on_ee do
       q = Plausible.Stats.Sampling.add_query_hint(q, query)

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -78,7 +78,7 @@ defmodule Plausible.Stats.Clickhouse do
   def top_sources_for_spike(site, query, limit, page) do
     offset = (page - 1) * limit
 
-    {first_datetime, last_datetime} = Plausible.Stats.Time.utc_boundaries(query, site)
+    {first_datetime, last_datetime} = Plausible.Stats.Time.utc_boundaries(query)
 
     referrers =
       from(s in "sessions_v2",

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -168,7 +168,8 @@ defmodule Plausible.Stats.Filters do
   defp transform_tree(filter, transformer) do
     case {transformer.(filter), filter} do
       # Transformer did not return that value - transform that subtree
-      {nil, [operator, child_filter]} when operator in [:not, :ignore_in_totals_query] ->
+      {nil, [operator, child_filter]}
+      when operator in [:not, :ignore_in_totals_query, :has_done, :has_not_done] ->
         [transformed_child] = transform_tree(child_filter, transformer)
         [[operator, transformed_child]]
 

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -101,13 +101,15 @@ defmodule Plausible.Stats.Filters do
         {depth + 1, is_behavioral_filter or operator in [:has_done, :has_not_done]}
       end
     )
-    |> Enum.filter(fn {_filter, {depth, _}} -> depth >= min_depth and depth <= max_depth end)
-    |> Enum.filter(fn {_filter, {_, is_behavioral_filter}} ->
-      case behavioral_filter_option do
-        :ignore -> not is_behavioral_filter
-        :only -> is_behavioral_filter
-        _ -> true
-      end
+    |> Enum.filter(fn {_filter, {depth, is_behavioral_filter}} ->
+      matches_behavioral_filter_option? =
+        case behavioral_filter_option do
+          :ignore -> not is_behavioral_filter
+          :only -> is_behavioral_filter
+          _ -> true
+        end
+
+      depth >= min_depth and depth <= max_depth and matches_behavioral_filter_option?
     end)
     |> Enum.map(fn {[_operator, dimension | _rest], _depth} -> dimension end)
   end

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -91,7 +91,7 @@ defmodule Plausible.Stats.Filters do
     min_depth = Keyword.get(opts, :min_depth, 0)
 
     filters
-    |> traverse()
+    |> traverse(0, fn depth, _ -> depth + 1 end)
     |> Enum.filter(fn {_filter, depth} -> depth >= min_depth end)
     |> Enum.map(fn {[_operator, dimension | _rest], _depth} -> dimension end)
   end
@@ -137,12 +137,12 @@ defmodule Plausible.Stats.Filters do
   defp transform_tree(filter, transformer) do
     case {transformer.(filter), filter} do
       # Transformer did not return that value - transform that subtree
-      {nil, [operation, child_filter]} when operation in [:not, :ignore_in_totals_query] ->
+      {nil, [operator, child_filter]} when operator in [:not, :ignore_in_totals_query] ->
         [transformed_child] = transform_tree(child_filter, transformer)
-        [[operation, transformed_child]]
+        [[operator, transformed_child]]
 
-      {nil, [operation, filters]} when operation in [:and, :or] ->
-        [[operation, transform_filters(filters, transformer)]]
+      {nil, [operator, filters]} when operator in [:and, :or] ->
+        [[operator, transform_filters(filters, transformer)]]
 
       # Reached a leaf node, return existing value
       {nil, filter} ->
@@ -154,22 +154,22 @@ defmodule Plausible.Stats.Filters do
     end
   end
 
-  defp traverse(filters, depth \\ -1) do
+  def traverse(filters, state, state_transformer) do
     filters
-    |> Enum.flat_map(&traverse_tree(&1, depth + 1))
+    |> Enum.flat_map(&traverse_tree(&1, state, state_transformer))
   end
 
-  defp traverse_tree(filter, depth) do
+  defp traverse_tree(filter, state, state_transformer) do
     case filter do
-      [operation, child_filter] when operation in [:not, :ignore_in_totals_query] ->
-        traverse_tree(child_filter, depth + 1)
+      [operation, child_filter] when operation in [:not, :ignore_in_totals_query, :has_done, :has_done_not] ->
+        traverse_tree(child_filter, state_transformer.(state, operation), state_transformer)
 
       [operation, filters] when operation in [:and, :or] ->
-        traverse(filters, depth + 1)
+        traverse(filters, state_transformer.(state, operation), state_transformer)
 
       # Leaf node
       _ ->
-        [{filter, depth}]
+        [{filter, state}]
     end
   end
 end

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -90,6 +90,7 @@ defmodule Plausible.Stats.Filters do
 
   def dimensions_used_in_filters(filters, opts \\ []) do
     min_depth = Keyword.get(opts, :min_depth, 0)
+    max_depth = Keyword.get(opts, :max_depth, 999)
     # :ignore or :only
     behavioral_filter_option = Keyword.get(opts, :behavioral_filters, nil)
 
@@ -100,7 +101,7 @@ defmodule Plausible.Stats.Filters do
         {depth + 1, is_behavioral_filter or operator in [:has_done, :has_done_not]}
       end
     )
-    |> Enum.filter(fn {_filter, {depth, _}} -> depth >= min_depth end)
+    |> Enum.filter(fn {_filter, {depth, _}} -> depth >= min_depth and depth <= max_depth end)
     |> Enum.filter(fn {_filter, {_, is_behavioral_filter}} ->
       case behavioral_filter_option do
         :ignore -> not is_behavioral_filter
@@ -111,7 +112,7 @@ defmodule Plausible.Stats.Filters do
     |> Enum.map(fn {[_operator, dimension | _rest], _depth} -> dimension end)
   end
 
-  def filtering_on_dimension?(query, dimension) do
+  def filtering_on_dimension?(query, dimension, opts \\ []) do
     filters =
       case query do
         %Query{filters: filters} -> filters
@@ -119,7 +120,7 @@ defmodule Plausible.Stats.Filters do
         filters when is_list(filters) -> filters
       end
 
-    dimension in dimensions_used_in_filters(filters)
+    dimension in dimensions_used_in_filters(filters, opts)
   end
 
   def all_leaf_filters(filters) do

--- a/lib/plausible/stats/filters/filters.ex
+++ b/lib/plausible/stats/filters/filters.ex
@@ -98,7 +98,7 @@ defmodule Plausible.Stats.Filters do
     |> traverse(
       {0, false},
       fn {depth, is_behavioral_filter}, operator ->
-        {depth + 1, is_behavioral_filter or operator in [:has_done, :has_done_not]}
+        {depth + 1, is_behavioral_filter or operator in [:has_done, :has_not_done]}
       end
     )
     |> Enum.filter(fn {_filter, {depth, _}} -> depth >= min_depth and depth <= max_depth end)
@@ -194,7 +194,7 @@ defmodule Plausible.Stats.Filters do
   defp traverse_tree(filter, state, state_transformer) do
     case filter do
       [operation, child_filter]
-      when operation in [:not, :ignore_in_totals_query, :has_done, :has_done_not] ->
+      when operation in [:not, :ignore_in_totals_query, :has_done, :has_not_done] ->
         traverse_tree(child_filter, state_transformer.(state, operation), state_transformer)
 
       [operation, filters] when operation in [:and, :or] ->

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -106,15 +106,18 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_operator(["matches_wildcard_not" | _rest]), do: {:ok, :matches_wildcard_not}
   defp parse_operator(["contains" | _rest]), do: {:ok, :contains}
   defp parse_operator(["contains_not" | _rest]), do: {:ok, :contains_not}
-  defp parse_operator(["not" | _rest]), do: {:ok, :not}
   defp parse_operator(["and" | _rest]), do: {:ok, :and}
   defp parse_operator(["or" | _rest]), do: {:ok, :or}
+  defp parse_operator(["not" | _rest]), do: {:ok, :not}
+  defp parse_operator(["has_done" | _rest]), do: {:ok, :has_done}
+  defp parse_operator(["has_done_not" | _rest]), do: {:ok, :has_done_not}
   defp parse_operator(filter), do: {:error, "Unknown operator for filter '#{i(filter)}'."}
-
-  def parse_filter_second(:not, [_, filter | _rest]), do: parse_filter(filter)
 
   def parse_filter_second(operator, [_, filters | _rest]) when operator in [:and, :or],
     do: parse_filters(filters)
+
+  def parse_filter_second(operator, [_, filter | _rest]) when operator in [:not, :has_done, :has_done_not],
+    do: parse_filter(filter)
 
   def parse_filter_second(_operator, filter), do: parse_filter_key(filter)
 
@@ -142,7 +145,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_filter_rest(operator, _filter)
-       when operator in [:not, :and, :or],
+       when operator in [:not, :and, :or, :has_done, :has_done_not],
        do: {:ok, []}
 
   defp parse_clauses_list([operator, filter_key, list | _rest] = filter) when is_list(list) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -493,8 +493,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
     cond do
       nested_behavioral_filter? ->
-        {:error,
-         "Invalid filters. Behavioral filters (has_done, has_done_not) cannot be nested."}
+        {:error, "Invalid filters. Behavioral filters (has_done, has_done_not) cannot be nested."}
 
       bad_behavioral_filter? ->
         {:error,
@@ -588,7 +587,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp validate_metric(metric, query) when metric in [:conversion_rate, :group_conversion_rate] do
     if Enum.member?(query.dimensions, "event:goal") or
-         Filters.filtering_on_dimension?(query, "event:goal") do
+         Filters.filtering_on_dimension?(query, "event:goal", behavioral_filters: :ignore) do
       :ok
     else
       {:error, "Metric `#{metric}` can only be queried with event:goal filters or dimensions."}
@@ -608,7 +607,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp validate_metric(:views_per_visit = metric, query) do
     cond do
-      Filters.filtering_on_dimension?(query, "event:page") ->
+      Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore) ->
         {:error, "Metric `#{metric}` cannot be queried with a filter on `event:page`."}
 
       length(query.dimensions) > 0 ->

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -111,14 +111,14 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_operator(["or" | _rest]), do: {:ok, :or}
   defp parse_operator(["not" | _rest]), do: {:ok, :not}
   defp parse_operator(["has_done" | _rest]), do: {:ok, :has_done}
-  defp parse_operator(["has_done_not" | _rest]), do: {:ok, :has_done_not}
+  defp parse_operator(["has_not_done" | _rest]), do: {:ok, :has_not_done}
   defp parse_operator(filter), do: {:error, "Unknown operator for filter '#{i(filter)}'."}
 
   def parse_filter_second(operator, [_, filters | _rest]) when operator in [:and, :or],
     do: parse_filters(filters)
 
   def parse_filter_second(operator, [_, filter | _rest])
-      when operator in [:not, :has_done, :has_done_not],
+      when operator in [:not, :has_done, :has_not_done],
       do: parse_filter(filter)
 
   def parse_filter_second(_operator, filter), do: parse_filter_key(filter)
@@ -147,7 +147,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_filter_rest(operator, _filter)
-       when operator in [:not, :and, :or, :has_done, :has_done_not],
+       when operator in [:not, :and, :or, :has_done, :has_not_done],
        do: {:ok, []}
 
   defp parse_clauses_list([operator, filter_key, list | _rest] = filter) when is_list(list) do
@@ -478,7 +478,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
     nested_behavioral_filter? =
       query.filters
       |> Filters.traverse(0, fn behavioral_depth, operator ->
-        if operator in [:has_done, :has_done_not] do
+        if operator in [:has_done, :has_not_done] do
           behavioral_depth + 1
         else
           behavioral_depth
@@ -493,11 +493,11 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
     cond do
       nested_behavioral_filter? ->
-        {:error, "Invalid filters. Behavioral filters (has_done, has_done_not) cannot be nested."}
+        {:error, "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested."}
 
       bad_behavioral_filter? ->
         {:error,
-         "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."}
+         "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters."}
 
       true ->
         :ok

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -144,7 +144,7 @@ defmodule Plausible.Stats.Imported.Base do
   defp do_decide_tables(%Query{dimensions: ["event:goal"]} = query) do
     filter_dimensions = dimensions_used_in_filters(query.filters)
 
-    filter_goals = query.preloaded_goals
+    filter_goals = query.preloaded_goals.matching_toplevel_filters
 
     any_event_goals? = Enum.any?(filter_goals, fn goal -> Plausible.Goal.type(goal) == :event end)
 
@@ -177,7 +177,7 @@ defmodule Plausible.Stats.Imported.Base do
       |> Enum.map(&@property_to_table_mappings[&1])
 
     filter_goal_table_candidates =
-      query.preloaded_goals
+      query.preloaded_goals.matching_toplevel_filters
       |> Enum.map(&Plausible.Goal.type/1)
       |> Enum.map(fn
         :event -> "imported_custom_events"

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -124,9 +124,9 @@ defmodule Plausible.Stats.Imported.Base do
       |> Enum.any?(&(&1 in special_goals_for(property)))
 
     has_unsupported_filters? =
-      Enum.any?(query.filters, fn [_, filter_key | _] ->
-        filter_key not in [property, "event:name", "event:goal"]
-      end)
+      query.filters
+      |> dimensions_used_in_filters()
+      |> Enum.any?(&(&1 not in [property, "event:name", "event:goal"]))
 
     if has_required_name_filter? and not has_unsupported_filters? do
       ["imported_custom_events"]

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -239,7 +239,8 @@ defmodule Plausible.Stats.Imported do
   end
 
   def merge_imported(q, site, %Query{dimensions: ["event:goal"]} = query, metrics) do
-    {events, page_regexes} = Filters.Utils.split_goals_query_expressions(query.preloaded_goals)
+    {events, page_regexes} =
+      Filters.Utils.split_goals_query_expressions(query.preloaded_goals.matching_toplevel_filters)
 
     Imported.Base.decide_tables(query)
     |> Enum.map(fn

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -13,7 +13,12 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
     query =
       Query
-      |> struct!(now: now, debug_metadata: debug_metadata)
+      |> struct!(
+        now: now,
+        debug_metadata: debug_metadata,
+        site_id: site.id,
+        site_native_stats_start_at: site.native_stats_start_at
+      )
       |> put_period(site, params)
       |> put_timezone(site)
       |> put_dimensions(params)

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -22,7 +22,9 @@ defmodule Plausible.Stats.Query do
             # Revenue metric specific metadata
             revenue_currencies: %{},
             revenue_warning: nil,
-            remove_unavailable_revenue_metrics: false
+            remove_unavailable_revenue_metrics: false,
+            site_id: nil,
+            site_native_stats_start_at: nil
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy}
@@ -34,7 +36,12 @@ defmodule Plausible.Stats.Query do
       query =
         struct!(__MODULE__, Map.to_list(query_data))
         |> put_imported_opts(site, %{})
-        |> struct!(now: DateTime.utc_now(:second), debug_metadata: debug_metadata)
+        |> struct!(
+          now: DateTime.utc_now(:second),
+          debug_metadata: debug_metadata,
+          site_id: site.id,
+          site_native_stats_start_at: site.native_stats_start_at
+        )
 
       on_ee do
         query = Plausible.Stats.Sampling.put_threshold(query, site, params)

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -154,7 +154,7 @@ defmodule Plausible.Stats.QueryRunner do
   end
 
   defp dimension_label("event:goal", entry, query) do
-    {events, paths} = Filters.Utils.split_goals(query.preloaded_goals)
+    {events, paths} = Filters.Utils.split_goals(query.preloaded_goals.matching_toplevel_filters)
 
     goal_index = Map.get(entry, Util.shortname(query, "event:goal"))
 

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -139,7 +139,8 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   end
 
   defp dimension_group_by(q, _table, query, "event:goal" = dimension) do
-    {events, page_regexes} = Filters.Utils.split_goals_query_expressions(query.preloaded_goals)
+    {events, page_regexes} =
+      Filters.Utils.split_goals_query_expressions(query.preloaded_goals.matching_toplevel_filters)
 
     from(e in q,
       join: goal in Expression.event_goal_join(events, page_regexes),

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -58,7 +58,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         |> Query.set(
           dimensions: [],
           include_imported: query.include_imported,
-          preloaded_goals: [],
+          preloaded_goals: Map.put(query.preloaded_goals, :matching_toplevel_filters, []),
           pagination: nil
         )
 
@@ -102,7 +102,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
           metrics: [:visitors],
           order_by: [],
           include_imported: query.include_imported,
-          preloaded_goals: [],
+          preloaded_goals: Map.put(query.preloaded_goals, :matching_toplevel_filters, []),
           pagination: nil
         )
 

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -95,17 +95,16 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
   end
 
   defp add_filter(_table, query, [:has_done, filter]) do
-    condition = dynamic([], ^filter_site_time_range(:events, query) and ^add_filter(:events, query, filter))
+    condition =
+      dynamic([], ^filter_site_time_range(:events, query) and ^add_filter(:events, query, filter))
 
     dynamic(
       [t],
-      t.user_id in subquery(
-        from(e in "events_v2", where: ^condition, select: e.user_id)
-      )
+      t.user_id in subquery(from(e in "events_v2", where: ^condition, select: e.user_id))
     )
   end
 
-  defp add_filter(table, query, [:has_done_not, filter]) do
+  defp add_filter(table, query, [:has_not_done, filter]) do
     dynamic([], not (^add_filter(table, query, [:has_done, filter])))
   end
 

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -100,7 +100,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
     dynamic(
       [t],
-      t.user_id in subquery(from(e in "events_v2", where: ^condition, select: e.user_id))
+      t.session_id in subquery(from(e in "events_v2", where: ^condition, select: e.session_id))
     )
   end
 

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -94,6 +94,21 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
     |> Enum.reduce(fn condition, acc -> dynamic([], ^acc or ^condition) end)
   end
 
+  defp add_filter(_table, query, [:has_done, filter]) do
+    condition = dynamic([], ^filter_site_time_range(:events, query) and ^add_filter(:events, query, filter))
+
+    dynamic(
+      [t],
+      t.user_id in subquery(
+        from(e in "events_v2", where: ^condition, select: e.user_id)
+      )
+    )
+  end
+
+  defp add_filter(table, query, [:has_done_not, filter]) do
+    dynamic([], not (^add_filter(table, query, [:has_done, filter])))
+  end
+
   defp add_filter(:events, _query, [:is, "event:name" | _rest] = filter) do
     in_clause(col_value(:name), filter)
   end

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -5,11 +5,14 @@ defmodule Plausible.Stats.Time do
 
   alias Plausible.Stats.{Query, DateTimeRange}
 
-  def utc_boundaries(%Query{utc_time_range: time_range}, site) do
+  def utc_boundaries(%Query{
+        utc_time_range: time_range,
+        site_native_stats_start_at: native_stats_start_at
+      }) do
     first =
       time_range.first
       |> DateTime.to_naive()
-      |> beginning_of_time(site.native_stats_start_at)
+      |> beginning_of_time(native_stats_start_at)
 
     last = DateTime.to_naive(time_range.last)
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -294,7 +294,7 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp fetch_top_stats(site, query, current_user) do
-    goal_filter? = Filters.filtering_on_dimension?(query, "event:goal")
+    goal_filter? = toplevel_goal_filter?(query)
 
     cond do
       query.period == "30m" && goal_filter? ->
@@ -392,7 +392,9 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp fetch_other_top_stats(site, query, current_user) do
-    page_filter? = Filters.filtering_on_dimension?(query, "event:page")
+    page_filter? =
+      Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore)
+
     scroll_depth_enabled? = scroll_depth_enabled?(site, current_user)
 
     metrics = [:visitors, :visits, :pageviews, :sample_percent]
@@ -477,7 +479,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{source: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -509,7 +511,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{channel: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -564,7 +566,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     defp validate_funnel_query(query) do
       cond do
-        Filters.filtering_on_dimension?(query, "event:goal") ->
+        toplevel_goal_filter?(query) ->
           {:error, {:invalid_funnel_query, "goals"}}
 
         Filters.filtering_on_dimension?(query, "event:page") ->
@@ -591,7 +593,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{utm_medium: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -619,7 +621,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{utm_campaign: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -647,7 +649,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{utm_content: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -675,7 +677,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{utm_term: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -703,7 +705,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{utm_source: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -731,7 +733,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{referrer: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         res
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -857,7 +859,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{page: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         pages
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -890,7 +892,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{entry_page: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         to_csv(entry_pages, [:name, :visitors, :conversion_rate], [
           :name,
           :conversions,
@@ -926,7 +928,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{exit_page: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         to_csv(exit_pages, [:name, :visitors, :conversion_rate], [
           :name,
           :conversions,
@@ -999,7 +1001,7 @@ defmodule PlausibleWeb.Api.StatsController do
           Map.put(country, :name, country_info.name)
         end)
 
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         countries
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1059,7 +1061,7 @@ defmodule PlausibleWeb.Api.StatsController do
       end)
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         regions
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1103,7 +1105,7 @@ defmodule PlausibleWeb.Api.StatsController do
       end)
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         cities
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1135,7 +1137,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{browser: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         browsers
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1167,7 +1169,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{browser_version: :version})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         results
         |> transform_keys(%{browser: :name, visitors: :conversions})
         |> to_csv([:name, :version, :conversions, :conversion_rate])
@@ -1208,7 +1210,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{os: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         systems
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1240,7 +1242,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{os_version: :version})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         results
         |> transform_keys(%{os: :name, visitors: :conversions})
         |> to_csv([:name, :version, :conversions, :conversion_rate])
@@ -1281,7 +1283,7 @@ defmodule PlausibleWeb.Api.StatsController do
       |> transform_keys(%{device: :name})
 
     if params["csv"] do
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         sizes
         |> transform_keys(%{visitors: :conversions})
         |> to_csv([:name, :conversions, :conversion_rate])
@@ -1371,7 +1373,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> Enum.concat()
 
       percent_or_cr =
-        if Filters.filtering_on_dimension?(query, "event:goal"),
+        if toplevel_goal_filter?(query),
           do: :conversion_rate,
           else: :percentage
 
@@ -1388,7 +1390,7 @@ defmodule PlausibleWeb.Api.StatsController do
     query = Query.from(site, params, debug_metadata(conn))
 
     metrics =
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if toplevel_goal_filter?(query) do
         [:visitors, :events, :conversion_rate] ++ @revenue_metrics
       else
         [:visitors, :events, :percentage] ++ @revenue_metrics
@@ -1559,10 +1561,12 @@ defmodule PlausibleWeb.Api.StatsController do
       end
 
     requires_goal_filter? = metric in [:conversion_rate, :events]
-    has_goal_filter? = Filters.filtering_on_dimension?(query, "event:goal")
+    has_goal_filter? = toplevel_goal_filter?(query)
 
     requires_page_filter? = metric == :scroll_depth
-    has_page_filter? = Filters.filtering_on_dimension?(query, "event:page")
+
+    has_page_filter? =
+      Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore)
 
     cond do
       requires_goal_filter? and not has_goal_filter? ->
@@ -1600,7 +1604,7 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp breakdown_metrics(query, extra_metrics \\ []) do
-    if Filters.filtering_on_dimension?(query, "event:goal") do
+    if toplevel_goal_filter?(query) do
       [:visitors, :conversion_rate, :total_visitors]
     else
       [:visitors] ++ extra_metrics
@@ -1624,6 +1628,10 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp realtime_period_to_30m(params), do: params
+
+  defp toplevel_goal_filter?(query) do
+    Filters.filtering_on_dimension?(query, "event:goal", max_depth: 0)
+  end
 
   def scroll_depth_enabled?(site, user) do
     FunWithFlags.enabled?(:scroll_depth, for: user) ||

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -194,10 +194,10 @@ defmodule PlausibleWeb.StatsController do
     include_scroll_depth? =
       !query.include_imported &&
         PlausibleWeb.Api.StatsController.scroll_depth_enabled?(site, current_user) &&
-        Filters.filtering_on_dimension?(query, "event:page")
+        Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore)
 
     {metrics, column_headers} =
-      if Filters.filtering_on_dimension?(query, "event:goal") do
+      if Filters.filtering_on_dimension?(query, "event:goal", max_depth: 0) do
         {
           [:visitors, :events, :conversion_rate],
           [:date, :unique_conversions, :total_conversions, :conversion_rate]

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -450,15 +450,21 @@
       "oneOf": [
         { "$ref": "#/definitions/filter_entry" },
         { "$ref": "#/definitions/filter_and_or" },
-        { "$ref": "#/definitions/filter_not" }
+        { "$ref": "#/definitions/filter_not_has_done" }
       ]
     },
-    "filter_not": {
+    "filter_not_has_done": {
       "type": "array",
       "additionalItems": false,
       "minItems": 2,
       "maxItems": 2,
-      "items": [{ "const": "not" }, { "$ref": "#/definitions/filter_tree" }]
+      "items": [
+        {
+          "type": "string",
+          "enum": ["not", "has_done", "has_done_not"]
+        },
+        { "$ref": "#/definitions/filter_tree" }
+      ]
     },
     "filter_and_or": {
       "type": "array",

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -450,10 +450,14 @@
       "oneOf": [
         { "$ref": "#/definitions/filter_entry" },
         { "$ref": "#/definitions/filter_and_or" },
-        { "$ref": "#/definitions/filter_not_has_done" }
+        { "$ref": "#/definitions/filter_not" },
+        {
+          "$ref": "#/definitions/filter_has_done",
+          "$comment": "only :internal"
+        }
       ]
     },
-    "filter_not_has_done": {
+    "filter_not": {
       "type": "array",
       "additionalItems": false,
       "minItems": 2,
@@ -461,7 +465,7 @@
       "items": [
         {
           "type": "string",
-          "enum": ["not", "has_done", "has_not_done"]
+          "enum": ["not"]
         },
         { "$ref": "#/definitions/filter_tree" }
       ]
@@ -481,6 +485,19 @@
           "items": { "$ref": "#/definitions/filter_tree" },
           "minItems": 1
         }
+      ]
+    },
+    "filter_has_done": {
+      "type": "array",
+      "additionalItems": false,
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "type": "string",
+          "enum": ["has_done", "has_not_done"]
+        },
+        { "$ref": "#/definitions/filter_tree" }
       ]
     },
     "order_by_entry": {

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -461,7 +461,7 @@
       "items": [
         {
           "type": "string",
-          "enum": ["not", "has_done", "has_done_not"]
+          "enum": ["not", "has_done", "has_not_done"]
         },
         { "$ref": "#/definitions/filter_tree" }
       ]

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -566,22 +566,26 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           ]
         ]
       }
-      |> check_success(site, %{
-        metrics: [:visitors],
-        utc_time_range: @date_range_day,
-        filters: [
-          [:has_done, [:is, "event:name", ["Signup"]]],
-          [
-            :has_not_done,
-            [:or, [[:is, "event:goal", ["Signup"]], [:is, "event:page", ["/signup"]]]]
-          ]
-        ],
-        dimensions: [],
-        order_by: nil,
-        timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
-        pagination: %{limit: 10_000, offset: 0}
-      })
+      |> check_success(
+        site,
+        %{
+          metrics: [:visitors],
+          utc_time_range: @date_range_day,
+          filters: [
+            [:has_done, [:is, "event:name", ["Signup"]]],
+            [
+              :has_not_done,
+              [:or, [[:is, "event:goal", ["Signup"]], [:is, "event:page", ["/signup"]]]]
+            ]
+          ],
+          dimensions: [],
+          order_by: nil,
+          timezone: site.timezone,
+          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          pagination: %{limit: 10_000, offset: 0}
+        },
+        :internal
+      )
     end
 
     test "fails when using visit filters within has_done filters", %{site: site} do
@@ -595,7 +599,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters."
+        "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters.",
+        :internal
       )
     end
 
@@ -610,7 +615,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested."
+        "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested.",
+        :internal
       )
     end
 
@@ -624,7 +630,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         }
         |> check_error(
           site,
-          "#/filters/0: Invalid filter [\"#{unquote(operator)}\", []]"
+          "#/filters/0: Invalid filter [\"#{unquote(operator)}\", []]",
+          :internal
         )
       end
     end
@@ -1209,7 +1216,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           timezone: site.timezone,
           include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
           pagination: %{limit: 10_000, offset: 0}
-        }
+        },
+        :internal
       )
       |> check_goals(
         preloaded_goals: %{all: ["Signup"], matching_toplevel_filters: ["Signup"]},
@@ -1229,7 +1237,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "The goal `Unknown` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"
+        "The goal `Unknown` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals",
+        :internal
       )
     end
   end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -268,7 +268,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           ["is_not"],
           ["is_not", "event:name"],
           ["has_done"],
-          ["has_done_not"]
+          ["has_not_done"]
         ] do
       test "errors on too short filter #{inspect(too_short_filter)}", %{
         site: site
@@ -545,7 +545,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       })
     end
 
-    test "valid has_done and has_done_not filters", %{site: site} do
+    test "valid has_done and has_not_done filters", %{site: site} do
       insert(:goal, %{site: site, event_name: "Signup"})
 
       %{
@@ -555,7 +555,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         "filters" => [
           ["has_done", ["is", "event:name", ["Signup"]]],
           [
-            "has_done_not",
+            "has_not_done",
             [
               "or",
               [
@@ -572,7 +572,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         filters: [
           [:has_done, [:is, "event:name", ["Signup"]]],
           [
-            :has_done_not,
+            :has_not_done,
             [:or, [[:is, "event:goal", ["Signup"]], [:is, "event:page", ["/signup"]]]]
           ]
         ],
@@ -595,7 +595,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."
+        "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters."
       )
     end
 
@@ -605,16 +605,16 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         "metrics" => ["visitors"],
         "date_range" => "all",
         "filters" => [
-          ["has_done", ["has_done_not", ["is", "visit:browser", ["Chrome"]]]]
+          ["has_done", ["has_not_done", ["is", "visit:browser", ["Chrome"]]]]
         ]
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_done_not) cannot be nested."
+        "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested."
       )
     end
 
-    for operator <- ["not", "or", "has_done", "has_done_not"] do
+    for operator <- ["not", "or", "has_done", "has_not_done"] do
       test "invalid `#{operator}` clause", %{site: site} do
         %{
           "site_id" => site.domain,

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -544,19 +544,24 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
 
     test "valid has_done and has_done_not filters", %{site: site} do
+      insert(:goal, %{site: site, event_name: "Signup"})
+
       %{
         "site_id" => site.domain,
         "metrics" => ["visitors"],
         "date_range" => "all",
         "filters" => [
           ["has_done", ["is", "event:name", ["Signup"]]],
-          ["has_done_not", [
-            "or",
+          [
+            "has_done_not",
             [
-              ["is", "event:name", ["Signup"]],
-              ["is", "event:page", ["/signup"]]
+              "or",
+              [
+                ["is", "event:goal", ["Signup"]],
+                ["is", "event:page", ["/signup"]]
+              ]
             ]
-          ]]
+          ]
         ]
       }
       |> check_success(site, %{
@@ -564,7 +569,10 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         utc_time_range: @date_range_day,
         filters: [
           [:has_done, [:is, "event:name", ["Signup"]]],
-          [:has_done_not, [:or, [[:is, "event:name", ["Signup"]], [:is, "event:page", ["/signup"]]]]]
+          [
+            :has_done_not,
+            [:or, [[:is, "event:goal", ["Signup"]], [:is, "event:page", ["/signup"]]]]
+          ]
         ],
         dimensions: [],
         order_by: nil,

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -29,11 +29,11 @@ defmodule Plausible.Stats.QueryTest do
   } do
     q1 = %{now: %DateTime{}} = Query.from(site, %{"period" => "realtime"})
     q2 = %{now: %DateTime{}} = Query.from(site, %{"period" => "30m"})
-    boundaries1 = Plausible.Stats.Time.utc_boundaries(q1, site)
-    boundaries2 = Plausible.Stats.Time.utc_boundaries(q2, site)
+    boundaries1 = Plausible.Stats.Time.utc_boundaries(q1)
+    boundaries2 = Plausible.Stats.Time.utc_boundaries(q2)
     :timer.sleep(1500)
-    assert ^boundaries1 = Plausible.Stats.Time.utc_boundaries(q1, site)
-    assert ^boundaries2 = Plausible.Stats.Time.utc_boundaries(q2, site)
+    assert ^boundaries1 = Plausible.Stats.Time.utc_boundaries(q1)
+    assert ^boundaries2 = Plausible.Stats.Time.utc_boundaries(q2)
   end
 
   test "parses day format", %{site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1326,7 +1326,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
                "Imported stats are not included in the results"
     end
 
-    test "imports are skipped when has_done_not filter is used", %{
+    test "imports are skipped when has_not_done filter is used", %{
       conn: conn,
       site: site,
       site_import: site_import
@@ -1350,7 +1350,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
           "date_range" => "all",
           "dimensions" => ["event:goal"],
           "filters" => [
-            ["has_done_not", ["is", "event:name", ["pageview"]]]
+            ["has_not_done", ["is", "event:name", ["pageview"]]]
           ],
           "include" => %{"imports" => true}
         })

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1344,7 +1344,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
           "date_range" => "all",

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1309,7 +1309,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
           "date_range" => "all",

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4688,5 +4688,21 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         %{"dimensions" => [], "metrics" => [4, 3]}
       ]
     end
+
+    test "visit filters are not allowed with has_done/has_done_not filters", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors"],
+          "date_range" => "all",
+          "dimensions" => ["visit:browser"],
+          "filters" => [
+            ["has_done", ["is", "visit:browser", ["Chrome"]]]
+          ]
+        })
+
+      assert %{"error" => error} = json_response(conn, 400)
+      assert error =~ "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."
+    end
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4593,7 +4593,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "events", "pageviews"],
           "date_range" => "all",
@@ -4634,7 +4634,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4675,7 +4675,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4721,7 +4721,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4766,7 +4766,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4797,7 +4797,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4817,7 +4817,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       site: site
     } do
       conn =
-        post(conn, "/api/v2/query", %{
+        post(conn, "/api/v2/query-internal-test", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
           "date_range" => "all",

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4646,7 +4646,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
-    test "has_done_not event:page filter", %{conn: conn, site: site} do
+    test "has_not_done event:page filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:event,
           name: "pageview",
@@ -4679,7 +4679,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
-          "filters" => [["has_done_not", ["contains", "event:page", ["/blog/"]]]]
+          "filters" => [["has_not_done", ["contains", "event:page", ["/blog/"]]]]
         })
 
       assert json_response(conn, 200)["results"] == [
@@ -4802,7 +4802,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
           "filters" => [
-            ["has_done_not", ["is", "event:goal", ["Conversion"]]],
+            ["has_not_done", ["is", "event:goal", ["Conversion"]]],
             ["is", "event:name", ["pageview"]]
           ]
         })
@@ -4812,7 +4812,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
-    test "visit filters are not allowed with has_done/has_done_not filters", %{
+    test "visit filters are not allowed with has_done/has_not_done filters", %{
       conn: conn,
       site: site
     } do
@@ -4830,7 +4830,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       assert %{"error" => error} = json_response(conn, 400)
 
       assert error =~
-               "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."
+               "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters."
     end
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4579,7 +4579,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   end
 
   describe "behavioral (has_done/has_not_done) filters" do
-    test "has_done returns all events by users who match condition if no further filters are provided", %{conn: conn, site: site} do
+    test "has_done returns all events by users who match condition if no further filters are provided",
+         %{conn: conn, site: site} do
       populate_stats(site, [
         build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
         build(:event, name: "AddToCart", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
@@ -4606,10 +4607,30 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
     test "has_done event:page filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:event, name: "pageview", user_id: 1, pathname: "/blog/post/1", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 1, pathname: "/", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 2, pathname: "/", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 3, pathname: "/blog/post/1", timestamp: ~N[2021-01-01 00:00:00])
+        build(:event,
+          name: "pageview",
+          user_id: 1,
+          pathname: "/blog/post/1",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 1,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 2,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 3,
+          pathname: "/blog/post/1",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
       ])
 
       conn =
@@ -4621,16 +4642,36 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-        %{"dimensions" => [], "metrics" => [2, 3]}
-      ]
+               %{"dimensions" => [], "metrics" => [2, 3]}
+             ]
     end
 
     test "has_done_not event:page filter", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:event, name: "pageview", user_id: 1, pathname: "/blog/post/1", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 1, pathname: "/", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 2, pathname: "/", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 3, pathname: "/blog/post/1", timestamp: ~N[2021-01-01 00:00:00])
+        build(:event,
+          name: "pageview",
+          user_id: 1,
+          pathname: "/blog/post/1",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 1,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 2,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "pageview",
+          user_id: 3,
+          pathname: "/blog/post/1",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
       ])
 
       conn =
@@ -4642,8 +4683,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-        %{"dimensions" => [], "metrics" => [1, 1]}
-      ]
+               %{"dimensions" => [], "metrics" => [1, 1]}
+             ]
     end
 
     test "has_done with complex event:props and event:name filters", %{conn: conn, site: site} do
@@ -4651,18 +4692,32 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         build(:event, name: "Purchase", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
         build(:event, name: "Purchase", user_id: 1, timestamp: ~N[2021-01-02 00:00:00]),
         build(:event, name: "Purchase", user_id: 1, timestamp: ~N[2021-01-03 00:00:00]),
-
         build(:event, name: "pageview", user_id: 2, timestamp: ~N[2021-01-01 00:00:00]),
         build(:event, name: "Purchase", user_id: 2, timestamp: ~N[2021-01-03 00:00:00]),
-
-        build(:event, name: "Signup", user_id: 3, "meta.key": ["paid"], "meta.value": ["true"], timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event,
+          name: "Signup",
+          user_id: 3,
+          "meta.key": ["paid"],
+          "meta.value": ["true"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
         build(:event, name: "pageview", user_id: 3, timestamp: ~N[2021-01-01 00:00:00]),
-
-        build(:event, name: "Signup", user_id: 4, "meta.key": ["paid"], "meta.value": ["true"], timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event,
+          name: "Signup",
+          user_id: 4,
+          "meta.key": ["paid"],
+          "meta.value": ["true"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
         build(:event, name: "pageview", user_id: 4, timestamp: ~N[2021-01-01 00:00:00]),
-
-        build(:event, name: "Signup", user_id: 5, "meta.key": ["paid"], "meta.value": ["false"], timestamp: ~N[2021-01-01 00:00:00]),
-        build(:event, name: "pageview", user_id: 5, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event,
+          name: "Signup",
+          user_id: 5,
+          "meta.key": ["paid"],
+          "meta.value": ["false"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event, name: "pageview", user_id: 5, timestamp: ~N[2021-01-01 00:00:00])
       ])
 
       conn =
@@ -4671,25 +4726,96 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
           "filters" => [
-            ["has_done", [
-              "or", [
-                ["is", "event:name", ["Purchase"]],
-                ["and", [
-                  ["is", "event:name", ["Signup"]],
-                  ["is", "event:props:paid", ["true"]]
-                ]]
-              ]]
+            [
+              "has_done",
+              [
+                "or",
+                [
+                  ["is", "event:name", ["Purchase"]],
+                  [
+                    "and",
+                    [
+                      ["is", "event:name", ["Signup"]],
+                      ["is", "event:props:paid", ["true"]]
+                    ]
+                  ]
+                ]
+              ]
             ]
           ]
         })
 
-
       assert json_response(conn, 200)["results"] == [
-        %{"dimensions" => [], "metrics" => [4, 3]}
-      ]
+               %{"dimensions" => [], "metrics" => [4, 3]}
+             ]
     end
 
-    test "visit filters are not allowed with has_done/has_done_not filters", %{conn: conn, site: site} do
+    test "has_done event:goal filter", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Conversion")
+
+      populate_stats(site, [
+        build(:event, name: "Conversion", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 2, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 2, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 3, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 4, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors", "pageviews"],
+          "date_range" => "all",
+          "filters" => [
+            ["has_done", ["is", "event:goal", ["Conversion"]]],
+            ["is", "event:name", ["pageview"]]
+          ]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => [], "metrics" => [2, 4]}
+             ]
+    end
+
+    test "has_not_done event:goal filter", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Conversion")
+
+      populate_stats(site, [
+        build(:event, name: "Conversion", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 1, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 2, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 2, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "Conversion", user_id: 3, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:event, name: "pageview", user_id: 4, timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors", "pageviews"],
+          "date_range" => "all",
+          "filters" => [
+            ["has_done_not", ["is", "event:goal", ["Conversion"]]],
+            ["is", "event:name", ["pageview"]]
+          ]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => [], "metrics" => [1, 1]}
+             ]
+    end
+
+    test "visit filters are not allowed with has_done/has_done_not filters", %{
+      conn: conn,
+      site: site
+    } do
       conn =
         post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
@@ -4702,7 +4828,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         })
 
       assert %{"error" => error} = json_response(conn, 400)
-      assert error =~ "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."
+
+      assert error =~
+               "Invalid filters. Behavioral filters (has_done, has_done_not) can only be used with event dimension filters."
     end
   end
 end


### PR DESCRIPTION
### Changes

This PR adds support for behavioral filtering by adding two new operators `has_done` and `has_not_done` to APIv2.

These operators can be used to filter whether users have completed (or not completed) a given at any point in their session. This can be used to exclude goals or check whether a user has done an additional action in their session.

In the following example, we could pageviews and visitors on /pricing page, but only by users who _have_ opened support chat but have not registered or logged in either before or after visiting the page.

```json
{
  "site_id": "dummy.site",
  "metrics": ["visitors", "pageviews"],
  "date_range": "7d",
  "filters": [
    ["is", "event:page", ["/pricing"]],
    ["has_done", ["is", "event:goal", ["Open Support Chat"]]],
    ["has_not_done", ["is", "event:goal", ["Register", "Login"]]]
  ]
}

```

~~Docs PR: https://github.com/plausible/docs/pull/575~~ The operators are currently internal-only.
Basecamp ref: https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/7793417773

## What's to be done

I'll open another PR to add support for users checking whether user has not done a goal. This turned out to be a bigger rabbit hole due to UI issues hence the split.