### PR TITLE
Remove "priority" Postmark message stream from CE

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -500,8 +500,13 @@ defmodule PlausibleWeb.Email do
   def priority_email(), do: priority_email(%{layout: "priority_email.html"})
 
   def priority_email(%{layout: layout}) do
-    base_email(%{layout: layout})
-    |> put_param("MessageStream", "priority")
+    email = base_email(%{layout: layout})
+
+    if Plausible.ee?() do
+      put_param(email, "MessageStream", "priority")
+    else
+      email
+    end
   end
 
   def base_email(), do: base_email(%{layout: "base_email.html"})

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -63,7 +63,8 @@ defmodule PlausibleWeb.EmailTest do
   end
 
   describe "priority email layout" do
-    test "uses the `priority` message stream in Postmark" do
+    @tag :ee_only
+    test "uses the `priority` message stream in Postmark in EE" do
       email =
         Email.priority_email()
         |> Email.render("activation_email.html", %{
@@ -73,6 +74,19 @@ defmodule PlausibleWeb.EmailTest do
 
       assert %{"MessageStream" => "priority"} = email.private[:message_params]
     end
+
+    @tag :ce_build_only
+    test "doesn't use the `priority` message stream in Postmark in CE" do
+      email =
+        Email.priority_email()
+        |> Email.render("activation_email.html", %{
+          user: build(:user, name: "John Doe"),
+          code: "123"
+        })
+
+      refute email.private[:message_params]["MessageStream"]
+    end
+
 
     test "greets user by first name if user in template assigns" do
       email =

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -87,7 +87,6 @@ defmodule PlausibleWeb.EmailTest do
       refute email.private[:message_params]["MessageStream"]
     end
 
-
     test "greets user by first name if user in template assigns" do
       email =
         Email.priority_email()


### PR DESCRIPTION
This PR stops CE from settings MessageStream=priority in emails.

The issue was reported here: https://github.com/plausible/analytics/discussions/4986#discussioncomment-11883709