### PR TITLE
Proposal: Remove `unique users` from dashboard when filtering by goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - Internal stats API routes no longer support legacy dashboard filter format.
+- Dashboard no longer shows "Unique visitors" in top stats when filtering by a goal which used to count all users including ones who didn't complete the goal. "Unique conversions" shows the number of unique visitors who completed the goal.
 
 ### Changed
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -364,13 +364,12 @@ defmodule PlausibleWeb.Api.StatsController do
 
   defp fetch_goal_top_stats(site, query) do
     metrics =
-      [:total_visitors, :visitors, :events, :conversion_rate] ++ @revenue_metrics
+      [:visitors, :events, :conversion_rate] ++ @revenue_metrics
 
     %{results: results, meta: meta} = Stats.aggregate(site, query, metrics)
 
     top_stats =
       [
-        top_stats_entry(results, "Unique visitors", :total_visitors),
         top_stats_entry(results, "Unique conversions", :visitors),
         top_stats_entry(results, "Total conversions", :events),
         on_ee do


### PR DESCRIPTION
In the current dashboard, "Unique users" denotes the number of users who match the filter _except_ in one case: When filtering by a goal. In that case this number means number of users without the goal filter.

This caused confusion in another review and I find this confusing. I confirmed this with @metmarkosaric that this might be a historical quirk that's safe to remove.

This can cause extra confusion since "excluding" goals would not behave the same.

Sending this to @ukutaht since he has historical context. I'm not confident in this change and the goal is to spark a discussion.

Before:
![image](https://github.com/user-attachments/assets/e5f667d8-18f7-40ef-a094-219d2eaefaf6)

After:
![image](https://github.com/user-attachments/assets/44d7d395-169a-407b-86df-54ca2e2ceac5)
