### PR TITLE
Scroll depth: Register `pageleave` listener earlier

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -6,3 +6,4 @@ taht
 referer
 referers
 statics
+firs

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -212,6 +212,15 @@
     payload.h = 1
     {{/if}}
 
+    {{#if pageleave}}
+    if (isPageview) {
+      currentPageLeaveIgnored = false
+      currentPageLeaveURL = payload.u
+      currentPageLeaveProps = payload.p
+      registerPageLeaveListener()
+    }
+    {{/if}}
+
     var request = new XMLHttpRequest();
     request.open('POST', endpoint, true);
     request.setRequestHeader('Content-Type', 'text/plain');
@@ -220,14 +229,6 @@
 
     request.onreadystatechange = function() {
       if (request.readyState === 4) {
-        {{#if pageleave}}
-        if (isPageview) {
-          currentPageLeaveIgnored = false
-          currentPageLeaveURL = payload.u
-          currentPageLeaveProps = payload.p
-          registerPageLeaveListener()
-        }
-        {{/if}}
         options && options.callback && options.callback({status: request.status})
       }
     }
@@ -246,7 +247,7 @@
       {{#unless hash}}
       if (lastPage === location.pathname) return;
       {{/unless}}
-      
+
       {{#if pageleave}}
       if (isSPANavigation && listeningPageLeave) {
         triggerPageLeave();

--- a/tracker/test/file-downloads.spec.js
+++ b/tracker/test/file-downloads.spec.js
@@ -45,7 +45,7 @@ test.describe('file-downloads extension', () => {
     await page.goto('/file-download.html')
     const downloadURL = LOCAL_SERVER_ADDR + '/' + await page.locator('#local-download').getAttribute('href')
 
-    const downloadRequestMockList = mockManyRequests(page, downloadURL, 2)
+    const downloadRequestMockList = mockManyRequests({ page, path: downloadURL, numberOfRequests: 2 })
     await page.click('#local-download')
 
     expect((await downloadRequestMockList).length).toBe(1)

--- a/tracker/test/fixtures/manual.html
+++ b/tracker/test/fixtures/manual.html
@@ -26,16 +26,16 @@
   <script>
     document.addEventListener('click', (e) => {
       if (e.target.id === 'pageview-trigger') {
-        window.plausible('pageview') 
+        window.plausible('pageview')
       }
       if (e.target.id === 'pageview-trigger-custom-url') {
         window.plausible('pageview', {u: 'https://example.com/custom/location'})
       }
       if (e.target.id === 'custom-event-trigger') {
-        window.plausible('CustomEvent') 
+        window.plausible('CustomEvent')
       }
       if (e.target.id === 'custom-event-trigger-custom-url') {
-        window.plausible('CustomEvent', {u: 'https://example.com/custom/location'}) 
+        window.plausible('CustomEvent', {u: 'https://example.com/custom/location'})
       }
     })
   </script>

--- a/tracker/test/fixtures/pageleave-pageview-props.html
+++ b/tracker/test/fixtures/pageleave-pageview-props.html
@@ -11,6 +11,14 @@
 
 <body>
   <a id="navigate-away" href="/manual.html">Navigate away</a>
+  <button id="back-button-trigger">Back button</button>
 </body>
 
+<script>
+  document.addEventListener('click', (e) => {
+    if (e.target.id === 'back-button-trigger') {
+      window.history.back()
+    }
+  })
+</script>
 </html>

--- a/tracker/test/fixtures/pageleave.html
+++ b/tracker/test/fixtures/pageleave.html
@@ -11,6 +11,7 @@
 
 <body>
   <a id="navigate-away" href="/manual.html">Navigate away</a>
+  <a id="to-pageleave-pageview-props" href="/pageleave-pageview-props.html">Navigate to pageleave-pageview props</a>
 
   <button id="history-nav">Navigate with history</button>
 

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -128,7 +128,7 @@ test.describe('pageleave extension', () => {
       action: () => page.goto('/pageleave-pageview-props.html'),
       expectedRequests: [{n: 'pageview', p: {author: 'John'}}]
     })
-    
+
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
       expectedRequests: [{n: 'pageleave', p: {author: 'John'}}]
@@ -148,9 +148,9 @@ test.describe('pageleave extension', () => {
         {n: 'pageview', p: {author: 'john'}}
       ]
     })
-    
+
     await pageleaveCooldown(page)
-    
+
     await expectPlausibleInAction(page, {
       action: () => page.click('#jane-post'),
       expectedRequests: [
@@ -167,6 +167,27 @@ test.describe('pageleave extension', () => {
         {n: 'pageleave', p: {author: 'jane'}},
         {n: 'pageview', p: {}}
       ]
+    })
+  })
+
+  test('sends a pageleave when plausible API is slow and user navigates away before response is received', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/pageleave.html'),
+      expectedRequests: [{n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}]
+    })
+
+    await expectPlausibleInAction(page, {
+      action: async () => {
+        await page.click('#to-pageleave-pageview-props')
+        await page.click('#back-button-trigger')
+      },
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}
+      ],
+      responseDelay: 1000
     })
   })
 })


### PR DESCRIPTION
Currently, pageleave listener is only registered when a successful response is received from plausible API.

After this change pageleave listener is registered immediately when pageview is triggered, hopefully increasing capture rate.

TODO after deploy:
- [ ] Purge bunny cache
- [ ] Measure impact (taking into account pageleaves without pageviews)