### PR TITLE
Create migration adding `is_autocreated` to `team_memberships`

### DIFF
--- a/priv/repo/migrations/20250122100320_add_autocreated_to_team_memberships.exs
+++ b/priv/repo/migrations/20250122100320_add_autocreated_to_team_memberships.exs
@@ -1,0 +1,21 @@
+defmodule Plausible.Repo.Migrations.AddAutocreatedToTeamMemberships do
+  use Ecto.Migration
+
+  def change do
+    alter table(:team_memberships) do
+      add :is_autocreated, :boolean, null: false, default: false
+    end
+
+    create unique_index(:team_memberships, [:user_id],
+             where: "role = 'owner' and is_autocreated = true",
+             name: :one_autocreated_owner_per_user
+           )
+
+    execute """
+            UPDATE team_memberships SET is_autocreated = true WHERE role = 'owner'
+            """,
+            """
+            SELECT 1
+            """
+  end
+end


### PR DESCRIPTION
### Changes

This is a pre-requisite for enabling support for multiple owners per team.