### PR TITLE
Rework team creation constraints

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Teams do
   import Ecto.Query
 
   alias __MODULE__
-  alias Plausible.Auth.GracePeriod
+  alias Plausible.Auth
   alias Plausible.Repo
   use Plausible
 
@@ -26,7 +26,7 @@ defmodule Plausible.Teams do
   end
 
   @spec get_owner(Teams.Team.t()) ::
-          {:ok, Plausible.Auth.User.t()} | {:error, :no_owner | :multiple_owners}
+          {:ok, Auth.User.t()} | {:error, :no_owner | :multiple_owners}
   def get_owner(team) do
     case Repo.preload(team, :owner).owner do
       nil -> {:error, :no_owner}
@@ -193,25 +193,25 @@ defmodule Plausible.Teams do
 
   def start_grace_period(team) do
     team
-    |> GracePeriod.start_changeset()
+    |> Teams.GracePeriod.start_changeset()
     |> Repo.update!()
   end
 
   def start_manual_lock_grace_period(team) do
     team
-    |> GracePeriod.start_manual_lock_changeset()
+    |> Teams.GracePeriod.start_manual_lock_changeset()
     |> Repo.update!()
   end
 
   def end_grace_period(team) do
     team
-    |> GracePeriod.end_changeset()
+    |> Teams.GracePeriod.end_changeset()
     |> Repo.update!()
   end
 
   def remove_grace_period(team) do
     team
-    |> GracePeriod.remove_changeset()
+    |> Teams.GracePeriod.remove_changeset()
     |> Repo.update!()
   end
 
@@ -289,7 +289,7 @@ defmodule Plausible.Teams do
     case result do
       {:ok, invitations} ->
         Enum.each(invitations, fn invitation ->
-          invitee = Plausible.Auth.find_user_by(email: invitation.email)
+          invitee = Auth.find_user_by(email: invitation.email)
           Teams.Invitations.InviteToTeam.send_invitation_email(invitation, invitee)
         end)
 

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -149,7 +149,7 @@ defmodule Plausible.Teams.Billing do
       trial_over? and not subscription_active? ->
         {:needs_to_upgrade, :no_active_subscription}
 
-      Plausible.Auth.GracePeriod.expired?(team) ->
+      Teams.GracePeriod.expired?(team) ->
         {:needs_to_upgrade, :grace_period_ended}
 
       true ->

--- a/lib/plausible/teams/grace_period.ex
+++ b/lib/plausible/teams/grace_period.ex
@@ -1,9 +1,9 @@
-defmodule Plausible.Auth.GracePeriod do
+defmodule Plausible.Teams.GracePeriod do
   @moduledoc """
   This embedded schema stores information about the account locking grace
   period.
 
-  Users are given this 7-day grace period to upgrade their account after
+  Teams are given this 7-day grace period to upgrade their account after
   outgrowing their subscriptions. The actual account locking happens in
   background with `Plausible.Workers.LockSites`.
 
@@ -29,7 +29,7 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec start_changeset(Teams.Team.t()) :: Ecto.Changeset.t()
   @doc """
-  Starts a account locking grace period of 7 days by changing the User struct.
+  Starts a account locking grace period of 7 days by changing the Team struct.
   """
   def start_changeset(%Teams.Team{} = team) do
     grace_period = %__MODULE__{
@@ -43,7 +43,7 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec start_manual_lock_changeset(Teams.Team.t()) :: Ecto.Changeset.t()
   @doc """
-  Starts a manual account locking grace period by changing the User struct.
+  Starts a manual account locking grace period by changing the Team struct.
   Manual locking means the grace period can only be removed manually from the
   CRM.
   """
@@ -59,7 +59,7 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec end_changeset(Teams.Team.t()) :: Ecto.Changeset.t()
   @doc """
-  Ends an existing grace period by `setting users.grace_period.is_over` to true.
+  Ends an existing grace period by setting `teams.grace_period.is_over` to true.
   This means the grace period has expired.
   """
   def end_changeset(%Teams.Team{} = team) do
@@ -68,7 +68,7 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec remove_changeset(Teams.Team.t()) :: Ecto.Changeset.t()
   @doc """
-  Removes the grace period from the User completely.
+  Removes the grace period from the Team completely.
   """
   def remove_changeset(%Teams.Team{} = team) do
     Ecto.Changeset.change(team, grace_period: nil)
@@ -76,8 +76,8 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec active?(Teams.Team.t() | nil) :: boolean()
   @doc """
-  Returns whether the grace period is still active for a User. Defaults to
-  false if the user is nil or there is no grace period.
+  Returns whether the grace period is still active for a Team. Defaults to
+  false if the team is nil or there is no grace period.
   """
   def active?(team)
 
@@ -93,8 +93,8 @@ defmodule Plausible.Auth.GracePeriod do
 
   @spec expired?(Teams.Team.t() | nil) :: boolean()
   @doc """
-  Returns whether the grace period has already expired for a User. Defaults to
-  false if the user is nil or there is no grace period.
+  Returns whether the grace period has already expired for a Team. Defaults to
+  false if the team is nil or there is no grace period.
   """
   def expired?(team) do
     if team && team.grace_period, do: !active?(team), else: false

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -13,6 +13,7 @@ defmodule Plausible.Teams.Membership do
 
   schema "team_memberships" do
     field :role, Ecto.Enum, values: @roles
+    field :is_autocreated, :boolean, default: false
 
     belongs_to :user, Plausible.Auth.User
     belongs_to :team, Plausible.Teams.Team

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -31,6 +31,5 @@ defmodule Plausible.Teams.Membership do
     |> put_change(:role, role)
     |> put_assoc(:team, team)
     |> put_assoc(:user, user)
-    |> unique_constraint(:user_id, name: :one_team_per_user)
   end
 end

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -29,7 +29,7 @@ defmodule Plausible.Teams.Team do
     field :setup_complete, :boolean, default: false
     field :setup_at, :naive_datetime
 
-    embeds_one :grace_period, Plausible.Auth.GracePeriod, on_replace: :update
+    embeds_one :grace_period, Plausible.Teams.GracePeriod, on_replace: :update
 
     has_many :sites, Plausible.Site
     has_many :team_memberships, Plausible.Teams.Membership

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -4,12 +4,12 @@
 
 <div :if={assigns[:my_team]} class="flex flex-col gap-y-2">
   <Notice.active_grace_period
-    :if={Plausible.Auth.GracePeriod.active?(@my_team)}
+    :if={Plausible.Teams.GracePeriod.active?(@my_team)}
     enterprise?={Plausible.Teams.Billing.enterprise_configured?(@my_team)}
     grace_period_end={grace_period_end(@my_team)}
   />
 
-  <Notice.dashboard_locked :if={Plausible.Auth.GracePeriod.expired?(@my_team)} />
+  <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@my_team)} />
 
   <Notice.subscription_cancelled subscription={@my_team.subscription} />
 

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -412,8 +412,8 @@ defmodule Plausible.BillingTest do
       assert Repo.reload!(api_key).hourly_request_limit == 10_000
     end
 
-    test "if user's grace period has ended, upgrading will unlock sites and remove grace period" do
-      grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
+    test "if teams's grace period has ended, upgrading will unlock sites and remove grace period" do
+      grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
 
       subscribe_to_growth_plan(user)

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -46,8 +46,8 @@ defmodule Plausible.Billing.SiteLockerTest do
       refute Repo.reload!(site).locked
     end
 
-    test "does not lock user who has an active subscription and is on grace period" do
-      grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: 1)}
+    test "does not lock team which has an active subscription and is on grace period" do
+      grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: 1)}
 
       user =
         new_user(team: [grace_period: grace_period])
@@ -77,8 +77,8 @@ defmodule Plausible.Billing.SiteLockerTest do
       assert Repo.reload!(site).locked
     end
 
-    test "locks all sites if user has active subscription but grace period has ended" do
-      grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
+    test "locks all sites if team has active subscription but grace period has ended" do
+      grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
       subscribe_to_plan(user, "123")
       site = new_site(owner: user)
@@ -90,7 +90,7 @@ defmodule Plausible.Billing.SiteLockerTest do
     end
 
     test "sends email if grace period has ended" do
-      grace_period = %Plausible.Auth.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
+      grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
       subscribe_to_plan(user, "123")
       new_site(owner: user)
@@ -105,7 +105,7 @@ defmodule Plausible.Billing.SiteLockerTest do
     end
 
     test "does not send grace period email if site is already locked" do
-      grace_period = %Plausible.Auth.GracePeriod{
+      grace_period = %Plausible.Teams.GracePeriod{
         end_date: Timex.shift(Timex.today(), days: -1),
         is_over: false
       }

--- a/test/plausible/teams/grace_period_test.exs
+++ b/test/plausible/teams/grace_period_test.exs
@@ -1,4 +1,4 @@
-defmodule Plausible.Auth.GracePeriodTest do
+defmodule Plausible.Teams.GracePeriodTest do
   use Plausible.DataCase, async: true
   use Plausible.Teams.Test
 
@@ -7,16 +7,16 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: nil])
       |> team_of()
 
-    refute Plausible.Auth.GracePeriod.active?(without_grace_period)
+    refute Plausible.Teams.GracePeriod.active?(without_grace_period)
 
     without_team = nil
-    refute Plausible.Auth.GracePeriod.active?(without_team)
+    refute Plausible.Teams.GracePeriod.active?(without_team)
   end
 
   test "active?/1 returns false when grace period is expired" do
     yesterday = Date.add(Date.utc_today(), -1)
 
-    grace_period = %Plausible.Auth.GracePeriod{
+    grace_period = %Plausible.Teams.GracePeriod{
       end_date: yesterday,
       is_over: false
     }
@@ -25,13 +25,13 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
       |> team_of()
 
-    refute Plausible.Auth.GracePeriod.active?(team)
+    refute Plausible.Teams.GracePeriod.active?(team)
   end
 
   test "active?/1 returns true when grace period is still active" do
     tomorrow = Date.add(Date.utc_today(), 1)
 
-    grace_period = %Plausible.Auth.GracePeriod{
+    grace_period = %Plausible.Teams.GracePeriod{
       end_date: tomorrow,
       is_over: false
     }
@@ -40,7 +40,7 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
       |> team_of()
 
-    assert Plausible.Auth.GracePeriod.active?(team)
+    assert Plausible.Teams.GracePeriod.active?(team)
   end
 
   test "expired?/1 returns false when grace period cannot be telled" do
@@ -48,16 +48,16 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: nil])
       |> team_of()
 
-    refute Plausible.Auth.GracePeriod.expired?(without_grace_period)
+    refute Plausible.Teams.GracePeriod.expired?(without_grace_period)
 
     without_team = nil
-    refute Plausible.Auth.GracePeriod.expired?(without_team)
+    refute Plausible.Teams.GracePeriod.expired?(without_team)
   end
 
   test "expired?/1 returns true when grace period is expired" do
     yesterday = Date.add(Date.utc_today(), -1)
 
-    grace_period = %Plausible.Auth.GracePeriod{
+    grace_period = %Plausible.Teams.GracePeriod{
       end_date: yesterday,
       is_over: true
     }
@@ -66,13 +66,13 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
       |> team_of()
 
-    assert Plausible.Auth.GracePeriod.expired?(team)
+    assert Plausible.Teams.GracePeriod.expired?(team)
   end
 
   test "expired?/1 returns false when grace period is still active" do
     tomorrow = Date.add(Date.utc_today(), 1)
 
-    grace_period = %Plausible.Auth.GracePeriod{
+    grace_period = %Plausible.Teams.GracePeriod{
       end_date: tomorrow,
       is_over: false
     }
@@ -81,36 +81,36 @@ defmodule Plausible.Auth.GracePeriodTest do
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
       |> team_of()
 
-    refute Plausible.Auth.GracePeriod.expired?(team)
+    refute Plausible.Teams.GracePeriod.expired?(team)
   end
 
   test "start_manual_lock_changeset/1 creates an active grace period" do
     team = new_user(trial_expiry_date: Date.utc_today()) |> team_of()
-    changeset = Plausible.Auth.GracePeriod.start_manual_lock_changeset(team)
+    changeset = Plausible.Teams.GracePeriod.start_manual_lock_changeset(team)
     team = Ecto.Changeset.apply_changes(changeset)
 
-    assert Plausible.Auth.GracePeriod.active?(team)
-    refute Plausible.Auth.GracePeriod.expired?(team)
+    assert Plausible.Teams.GracePeriod.active?(team)
+    refute Plausible.Teams.GracePeriod.expired?(team)
   end
 
   test "start_changeset/1 creates an active grace period" do
     team = new_user(trial_expiry_date: Date.utc_today()) |> team_of()
-    changeset = Plausible.Auth.GracePeriod.start_changeset(team)
+    changeset = Plausible.Teams.GracePeriod.start_changeset(team)
     team = Ecto.Changeset.apply_changes(changeset)
 
-    assert Plausible.Auth.GracePeriod.active?(team)
-    refute Plausible.Auth.GracePeriod.expired?(team)
+    assert Plausible.Teams.GracePeriod.active?(team)
+    refute Plausible.Teams.GracePeriod.expired?(team)
   end
 
   test "remove_changeset/1 removes the active grace period" do
     team = new_user(trial_expiry_date: Date.utc_today()) |> team_of()
-    start_changeset = Plausible.Auth.GracePeriod.start_changeset(team)
+    start_changeset = Plausible.Teams.GracePeriod.start_changeset(team)
     team = Ecto.Changeset.apply_changes(start_changeset)
 
-    remove_changeset = Plausible.Auth.GracePeriod.remove_changeset(team)
+    remove_changeset = Plausible.Teams.GracePeriod.remove_changeset(team)
     team = Ecto.Changeset.apply_changes(remove_changeset)
 
-    refute Plausible.Auth.GracePeriod.active?(team)
-    refute Plausible.Auth.GracePeriod.expired?(team)
+    refute Plausible.Teams.GracePeriod.active?(team)
+    refute Plausible.Teams.GracePeriod.expired?(team)
   end
 end

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -296,7 +296,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
 
         CheckUsage.perform(nil, usage_stub)
-        assert user |> team_of() |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+        assert user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
 
         usage_stub =
           Plausible.Teams.Billing
@@ -308,7 +308,7 @@ defmodule Plausible.Workers.CheckUsageTest do
           end)
 
         CheckUsage.perform(nil, usage_stub)
-        refute user |> team_of() |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+        refute user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
       end
     end
   end
@@ -457,7 +457,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
 
         CheckUsage.perform(nil, usage_stub)
-        assert user |> team_of() |> Repo.reload() |> Plausible.Auth.GracePeriod.active?()
+        assert user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
       end
     end
   end


### PR DESCRIPTION
### Changes

This PR switches upsert used for creating team membership in `Teams.get_or_create/1`  to the newly introduced constraint which opens up the capability of user being a member in more than one team. The final step to follow will be removal of the `one_team_per_user` constraint. Only after this it will be possible to implement and test the rest of the logic relying on that constraint being loosened.

The change in question is done in https://github.com/plausible/analytics/pull/5003/commits/2910de304da7d91b625fd8d036ebec02d5b19a94 while https://github.com/plausible/analytics/pull/5003/commits/a1e97b59879f63f15f6c7f66ea7f7de72698fc4c is purely a refactor moving `Auth.GracePeriod` under `Teams.GracePeriod` and correcting phrasing of the docs strings which were out of date.

Depends on #5002 

