### PR TITLE
Drop `one_team_per_user` constraint from `team_memberships`

### DIFF
--- a/priv/repo/migrations/20250129132629_drop_old_one_team_per_user_constraint.exs
+++ b/priv/repo/migrations/20250129132629_drop_old_one_team_per_user_constraint.exs
@@ -1,0 +1,25 @@
+defmodule Plausible.Repo.Migrations.DropOldOneTeamPerUserConstraint do
+  use Ecto.Migration
+
+  def up do
+    alter table(:team_memberships) do
+      modify :is_autocreated, :boolean, null: false, default: false
+    end
+
+    drop unique_index(:team_memberships, [:user_id],
+           where: "role != 'guest'",
+           name: :one_team_per_user
+         )
+  end
+
+  def down do
+    create unique_index(:team_memberships, [:user_id],
+             where: "role != 'guest'",
+             name: :one_team_per_user
+           )
+
+    alter table(:team_memberships) do
+      modify :is_autocreated, :boolean, null: false, default: true
+    end
+  end
+end

--- a/priv/repo/migrations/20250129132629_drop_old_one_team_per_user_constraint.exs
+++ b/priv/repo/migrations/20250129132629_drop_old_one_team_per_user_constraint.exs
@@ -10,6 +10,11 @@ defmodule Plausible.Repo.Migrations.DropOldOneTeamPerUserConstraint do
            where: "role != 'guest'",
            name: :one_team_per_user
          )
+
+    # Might be redundant but redoing it anyway, just to be safe
+    execute """
+    UPDATE team_memberships SET is_autocreated = true WHERE role = 'owner'
+    """
   end
 
   def down do


### PR DESCRIPTION
### Changes

Dropping that constraint opens capability to support meany team meberships per user and many owner user per team.

This migration also sets `team_memberships.is_autocreated` value back to `false` for consistency.

Depends on #5003 

