### PR TITLE
Test out fetch-with-keepalive on plausible.io

### DIFF
--- a/lib/plausible_web/templates/layout/_tracking.html.heex
+++ b/lib/plausible_web/templates/layout/_tracking.html.heex
@@ -5,6 +5,7 @@
       data-api={PlausibleWeb.Dogfood.api_destination()}
       data-domain={PlausibleWeb.Dogfood.domain(@conn)}
       src={PlausibleWeb.Dogfood.script_url()}
+      data-allow-fetch
     >
     </script>
     <script>


### PR DESCRIPTION
Fetch with keepalive is a
[widely-supported](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive) which indicates whether the browser will keep the associated request alive if the page that initiated it is unloaded before the request is complete.

We're hoping it will improve event capture rates for `pageleave` and `pageview` events when the user closes the tab

To use it, we also need to start using `fetch` (with fallback to xhr).

For extra safety, we will only deploy this on `plausible.io` initially. This will ensure that if there are issues we will be able to react without affecting any other customers.

I tested this locally by adding temporary logging to the script:
1. Modifying lib/plausible_web/templates/layout/_tracking.html.heex to track locally
2. Making fetch the default and running the test suite.

TODO after this PR:
- [ ] Companion docs PR
- [ ] Purge bunny cache
- [ ] Make fetch the default request method without data-property