### PR TITLE
Fix passthrough processing billing callback

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -157,14 +157,6 @@ defmodule Plausible.Billing do
         ["ee:true", "user:" <> user_id] ->
           {user_id, "0"}
 
-        # NOTE: legacy pattern, to be removed in a follow-up
-        ["user:" <> user_id, "team:" <> team_id] ->
-          {user_id, team_id}
-
-        # NOTE: legacy pattern, to be removed in a follow-up
-        [user_id] ->
-          {user_id, "0"}
-
         _ ->
           raise "Invalid passthrough sent via Paddle: #{inspect(passthrough)}"
       end

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -172,7 +172,7 @@ defmodule Plausible.BillingTest do
       user = new_user()
       Repo.delete!(user)
 
-      assert_raise RuntimeError, ~r/Invalid passthrough sent via Paddle/, fn ->
+      assert_raise Ecto.NoResultsError, fn ->
         %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id}"}
         |> Billing.subscription_created()
       end
@@ -207,6 +207,41 @@ defmodule Plausible.BillingTest do
       assert subscription.last_bill_date == ~D[2019-05-01]
       assert subscription.next_bill_amount == "6.00"
       assert subscription.currency_code == "EUR"
+    end
+
+    test "supports user without a team case" do
+      user = new_user()
+
+      %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id}"}
+      |> Billing.subscription_created()
+
+      subscription =
+        user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
+
+      assert subscription.paddle_subscription_id == @subscription_id
+      assert subscription.next_bill_date == ~D[2019-06-01]
+      assert subscription.last_bill_date == ~D[2019-05-01]
+      assert subscription.next_bill_amount == "6.00"
+      assert subscription.currency_code == "EUR"
+    end
+
+    test "supports old format without prefix" do
+      user = new_user()
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      %{@subscription_created_params | "passthrough" => "user:#{user.id};team:#{team.id}"}
+      |> Billing.subscription_created()
+
+      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
+    end
+
+    test "supports old format without prefix for user without a team" do
+      user = new_user()
+
+      %{@subscription_created_params | "passthrough" => user.id}
+      |> Billing.subscription_created()
+
+      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
     end
 
     test "unlocks sites if user has any locked sites" do

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -225,25 +225,6 @@ defmodule Plausible.BillingTest do
       assert subscription.currency_code == "EUR"
     end
 
-    test "supports old format without prefix" do
-      user = new_user()
-      {:ok, team} = Plausible.Teams.get_or_create(user)
-
-      %{@subscription_created_params | "passthrough" => "user:#{user.id};team:#{team.id}"}
-      |> Billing.subscription_created()
-
-      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
-    end
-
-    test "supports old format without prefix for user without a team" do
-      user = new_user()
-
-      %{@subscription_created_params | "passthrough" => user.id}
-      |> Billing.subscription_created()
-
-      assert user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
-    end
-
     test "unlocks sites if user has any locked sites" do
       user = new_user()
       site = new_site(owner: user, locked: true)

--- a/test/plausible_web/controllers/api/paddle_controller_test.exs
+++ b/test/plausible_web/controllers/api/paddle_controller_test.exs
@@ -33,10 +33,8 @@ defmodule PlausibleWeb.Api.PaddleControllerTest do
     test "is verified when signature is correct", %{conn: conn} do
       insert(:user, id: 235)
 
-      # NOTE: signature check happens sooner
-      assert_raise RuntimeError, ~r/Invalid passthrough sent via Paddle/, fn ->
-        post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
-      end
+      conn = post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
+      assert conn.status == 200
     end
 
     test "not verified when signature is corrupted", %{conn: conn} do

--- a/test/plausible_web/controllers/api/paddle_controller_test.exs
+++ b/test/plausible_web/controllers/api/paddle_controller_test.exs
@@ -33,8 +33,10 @@ defmodule PlausibleWeb.Api.PaddleControllerTest do
     test "is verified when signature is correct", %{conn: conn} do
       insert(:user, id: 235)
 
-      conn = post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
-      assert conn.status == 200
+      # NOTE: signature check happens sooner
+      assert_raise RuntimeError, ~r/Invalid passthrough sent via Paddle/, fn ->
+        post(conn, Routes.paddle_path(conn, :webhook), @webhook_body)
+      end
     end
 
     test "not verified when signature is corrupted", %{conn: conn} do

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -151,7 +151,7 @@ defmodule PlausibleWeb.Live.SitesTest do
 
       {:ok, lv, _html} = live(conn, "/sites")
 
-      type_into_input(lv, "filter_text", "first")
+      type_into_input(lv, "filter_text", "firs")
       html = render(lv)
 
       assert html =~ "first.example.com"


### PR DESCRIPTION
### Changes

Removal of legacy passthrough support in #4939 was too aggressive and removed support for a still legit case of user without a team. We will eventually drop it in order to facilitate multi-team membership but this requires a different approach.


