### PR TITLE
Implement support for multiple team owners and multiple teams per user 

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -802,6 +802,11 @@ if config_env() in [:dev, :staging, :prod, :test] do
           api_key: [schema: Plausible.Auth.ApiKey, admin: Plausible.Auth.ApiKeyAdmin]
         ]
       ],
+      teams: [
+        resources: [
+          team: [schema: Plausible.Teams.Team, admin: Plausible.Teams.TeamAdmin]
+        ]
+      ],
       sites: [
         resources: [
           site: [schema: Plausible.Site, admin: Plausible.SiteAdmin]

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -90,6 +90,12 @@ defmodule Plausible.HelpScout do
             plan = Billing.Plans.get_subscription_plan(team.subscription)
             {team, team.subscription, plan}
 
+          {:error, :multiple_teams} ->
+            [team | _] = Plausible.Teams.Users.owned_teams(user)
+            team = Plausible.Teams.with_subscription(team)
+            plan = Billing.Plans.get_subscription_plan(team.subscription)
+            {team, team.subscription, plan}
+
           {:error, :no_team} ->
             {nil, nil, nil}
         end

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -108,6 +108,17 @@ defmodule Plausible.HelpScout do
           Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id)
         end
 
+      sites_link =
+        if team do
+          Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
+            custom_search: team.identifier
+          )
+        else
+          Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
+            custom_search: user.email
+          )
+        end
+
       {:ok,
        %{
          email: user.email,
@@ -117,10 +128,7 @@ defmodule Plausible.HelpScout do
          plan_label: plan_label(subscription, plan),
          plan_link: plan_link(subscription),
          sites_count: Plausible.Teams.owned_sites_count(team),
-         sites_link:
-           Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
-             custom_search: user.email
-           )
+         sites_link: sites_link
        }}
     end
   end

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -91,6 +91,7 @@ defmodule Plausible.HelpScout do
             {team, team.subscription, plan}
 
           {:error, :multiple_teams} ->
+            # NOTE: We might consider exposing the other teams later on
             [team | _] = Plausible.Teams.Users.owned_teams(user)
             team = Plausible.Teams.with_subscription(team)
             plan = Billing.Plans.get_subscription_plan(team.subscription)

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -101,13 +101,19 @@ defmodule Plausible.HelpScout do
             {nil, nil, nil}
         end
 
+      status_link =
+        if team do
+          Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :teams, :team, team.id)
+        else
+          Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id)
+        end
+
       {:ok,
        %{
          email: user.email,
          notes: user.notes,
          status_label: status_label(team, subscription),
-         status_link:
-           Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :show, :auth, :user, user.id),
+         status_link: status_link,
          plan_label: plan_label(subscription, plan),
          plan_link: plan_link(subscription),
          sites_count: Plausible.Teams.owned_sites_count(team),

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -8,16 +8,18 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
   alias Plausible.Sites
   alias Plausible.Goal
   alias Plausible.Goals
+  alias Plausible.Teams
   alias PlausibleWeb.Api.Helpers, as: H
 
   @pagination_opts [cursor_fields: [{:id, :desc}], limit: 100, maximum_limit: 1000]
 
   def index(conn, params) do
+    team = Teams.get(params["team_id"])
     user = conn.assigns.current_user
 
     page =
       user
-      |> Sites.for_user_query()
+      |> Sites.for_user_query(team)
       |> paginate(params, @pagination_opts)
 
     json(conn, %{

--- a/extra/lib/plausible_web/live/funnel_settings.ex
+++ b/extra/lib/plausible_web/live/funnel_settings.ex
@@ -19,6 +19,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)
@@ -110,7 +111,7 @@ defmodule PlausibleWeb.Live.FunnelSettings do
       Plausible.Sites.get_for_user!(
         socket.assigns.current_user,
         socket.assigns.domain,
-        [:owner, :admin]
+        [:owner, :admin, :editor]
       )
 
     id = String.to_integer(id)

--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -16,6 +16,7 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
       Plausible.Sites.get_for_user!(socket.assigns.current_user, domain, [
         :owner,
         :admin,
+        :editor,
         :super_admin
       ])
 

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -51,6 +51,8 @@ defmodule Plausible.Auth.User do
     has_one :google_auth, Plausible.Site.GoogleAuth
     has_one :owner_membership, Plausible.Teams.Membership, where: [role: :owner]
     has_one :my_team, through: [:owner_membership, :team]
+    has_many :owner_memberships, Plausible.Teams.Membership, where: [role: :owner]
+    has_many :owned_teams, through: [:owner_memberships, :team]
 
     timestamps()
   end

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -34,11 +34,6 @@ defmodule Plausible.Auth.User do
     # Field for purely informational purposes in CRM context
     field :notes, :string
 
-    # Fields used only by CRM for mapping to the ones in the owned team
-    field :trial_expiry_date, :date, virtual: true
-    field :allow_next_upgrade_override, :boolean, virtual: true
-    field :accept_traffic_until, :date, virtual: true
-
     # Fields for TOTP authentication. See `Plausible.Auth.TOTP`.
     field :totp_enabled, :boolean, default: false
     field :totp_secret, Plausible.Auth.TOTP.EncryptedBinary
@@ -115,16 +110,7 @@ defmodule Plausible.Auth.User do
 
   def changeset(user, attrs \\ %{}) do
     user
-    |> cast(attrs, [
-      :email,
-      :name,
-      :email_verified,
-      :theme,
-      :notes,
-      :trial_expiry_date,
-      :allow_next_upgrade_override,
-      :accept_traffic_until
-    ])
+    |> cast(attrs, [:email, :name, :email_verified, :theme, :notes])
     |> validate_required([:email, :name, :email_verified])
     |> unique_constraint(:email)
   end

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -44,8 +44,6 @@ defmodule Plausible.Auth.User do
     has_many :team_memberships, Plausible.Teams.Membership
     has_many :api_keys, Plausible.Auth.ApiKey
     has_one :google_auth, Plausible.Site.GoogleAuth
-    has_one :owner_membership, Plausible.Teams.Membership, where: [role: :owner]
-    has_one :my_team, through: [:owner_membership, :team]
     has_many :owner_memberships, Plausible.Teams.Membership, where: [role: :owner]
     has_many :owned_teams, through: [:owner_memberships, :team]
 

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Auth.UserAdmin do
     [
       name: nil,
       email: nil,
-      owned_teams: %{value: &teams(&1.owned_teams)},
+      owned_teams: %{value: &Phoenix.HTML.raw(teams(&1.owned_teams))},
       inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)}
     ]
   end
@@ -51,18 +51,17 @@ defmodule Plausible.Auth.UserAdmin do
     Plausible.Auth.TOTP.force_disable(user)
   end
 
-  defp teams([]) do
+  def teams([]) do
     "(none)"
   end
 
-  defp teams(teams) do
+  def teams(teams) do
     teams
     |> Enum.map_join("<br>\n", fn team ->
       """
       <a href="/crm/teams/team/#{team.id}">#{team.name}</a>
       """
     end)
-    |> Phoenix.HTML.raw()
   end
 
   defp format_date(nil), do: "--"

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -1,24 +1,13 @@
 defmodule Plausible.Auth.UserAdmin do
   use Plausible.Repo
   use Plausible
-  require Plausible.Billing.Subscription.Status
-  alias Plausible.Billing.Subscription
 
   def custom_index_query(_conn, _schema, query) do
-    subscripton_q = from(s in Plausible.Billing.Subscription, order_by: [desc: s.inserted_at])
-    from(r in query, preload: [my_team: [subscription: ^subscripton_q]])
+    from(r in query, preload: [:owned_teams])
   end
 
   def custom_show_query(_conn, _schema, query) do
-    from(u in query,
-      left_join: t in assoc(u, :my_team),
-      select: %{
-        u
-        | trial_expiry_date: t.trial_expiry_date,
-          allow_next_upgrade_override: t.allow_next_upgrade_override,
-          accept_traffic_until: t.accept_traffic_until
-      }
-    )
+    from(u in query, preload: [:owned_teams])
   end
 
   def form_fields(_) do
@@ -26,46 +15,8 @@ defmodule Plausible.Auth.UserAdmin do
       name: nil,
       email: nil,
       previous_email: nil,
-      trial_expiry_date: %{
-        help_text: "Change will also update Accept Traffic Until date"
-      },
-      allow_next_upgrade_override: nil,
-      accept_traffic_until: %{
-        help_text: "Change will take up to 15 minutes to propagate"
-      },
       notes: %{type: :textarea, rows: 6}
     ]
-  end
-
-  def update(_conn, changeset) do
-    my_team = Repo.preload(changeset.data, :my_team).my_team
-
-    team_changed_params =
-      [:trial_expiry_date, :allow_next_upgrade_override, :accept_traffic_until]
-      |> Enum.map(&{&1, Ecto.Changeset.get_change(changeset, &1, :no_change)})
-      |> Enum.reject(fn {_, val} -> val == :no_change end)
-      |> Map.new()
-
-    with {:ok, user} <- Repo.update(changeset) do
-      cond do
-        my_team && map_size(team_changed_params) > 0 ->
-          my_team
-          |> Plausible.Teams.Team.crm_sync_changeset(team_changed_params)
-          |> Repo.update!()
-
-        team_changed_params[:trial_expiry_date] ->
-          {:ok, team} = Plausible.Teams.get_or_create(user)
-
-          team
-          |> Plausible.Teams.Team.crm_sync_changeset(team_changed_params)
-          |> Repo.update!()
-
-        true ->
-          :ignore
-      end
-
-      {:ok, user}
-    end
   end
 
   def delete(_conn, %{data: user}) do
@@ -82,28 +33,13 @@ defmodule Plausible.Auth.UserAdmin do
     [
       name: nil,
       email: nil,
-      inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)},
-      trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},
-      subscription_plan: %{value: &subscription_plan/1},
-      subscription_status: %{value: &subscription_status/1},
-      grace_period: %{value: &grace_period_status/1},
-      accept_traffic_until: %{
-        name: "Accept traffic until",
-        value: &format_date(&1.accept_traffic_until)
-      }
+      owned_teams: %{value: &teams(&1.owned_teams)},
+      inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)}
     ]
   end
 
   def resource_actions(_) do
     [
-      unlock: %{
-        name: "Unlock",
-        action: fn _, user -> unlock(user) end
-      },
-      lock: %{
-        name: "Lock",
-        action: fn _, user -> lock(user) end
-      },
       reset_2fa: %{
         name: "Reset 2FA",
         action: fn _, user -> disable_2fa(user) end
@@ -111,94 +47,22 @@ defmodule Plausible.Auth.UserAdmin do
     ]
   end
 
-  defp lock(user) do
-    user = Repo.preload(user, :my_team)
-
-    if user.my_team && user.my_team.grace_period do
-      Plausible.Billing.SiteLocker.set_lock_status_for(user.my_team, true)
-      Plausible.Teams.end_grace_period(user.my_team)
-      {:ok, user}
-    else
-      {:error, user, "No active grace period on this user"}
-    end
-  end
-
-  defp unlock(user) do
-    user = Repo.preload(user, :my_team)
-
-    if user.my_team && user.my_team.grace_period do
-      Plausible.Teams.remove_grace_period(user.my_team)
-      Plausible.Billing.SiteLocker.set_lock_status_for(user.my_team, false)
-      {:ok, user}
-    else
-      {:error, user, "No active grace period on this user"}
-    end
-  end
-
   def disable_2fa(user) do
     Plausible.Auth.TOTP.force_disable(user)
   end
 
-  defp grace_period_status(user) do
-    grace_period = user.my_team && user.my_team.grace_period
-
-    case grace_period do
-      nil ->
-        "--"
-
-      %{manual_lock: true, is_over: true} ->
-        "Manually locked"
-
-      %{manual_lock: true, is_over: false} ->
-        "Waiting for manual lock"
-
-      %{is_over: true} ->
-        "ended"
-
-      %{end_date: %Date{} = end_date} ->
-        days_left = Date.diff(end_date, Date.utc_today())
-        "#{days_left} days left"
-    end
+  defp teams([]) do
+    "(none)"
   end
 
-  defp subscription_plan(user) do
-    subscription = user.my_team && user.my_team.subscription
-
-    if Subscription.Status.active?(subscription) && subscription.paddle_subscription_id do
-      quota = PlausibleWeb.AuthView.subscription_quota(subscription)
-      interval = PlausibleWeb.AuthView.subscription_interval(subscription)
-
-      {:safe, ~s(<a href="#{manage_url(subscription)}">#{quota} \(#{interval}\)</a>)}
-    else
-      "--"
-    end
-  end
-
-  defp subscription_status(user) do
-    team = user.my_team
-
-    cond do
-      team && team.subscription ->
-        status_str =
-          PlausibleWeb.SettingsView.present_subscription_status(team.subscription.status)
-
-        if team.subscription.paddle_subscription_id do
-          {:safe, ~s(<a href="#{manage_url(team.subscription)}">#{status_str}</a>)}
-        else
-          status_str
-        end
-
-      Plausible.Teams.on_trial?(team) ->
-        "On trial"
-
-      true ->
-        "Trial expired"
-    end
-  end
-
-  defp manage_url(%{paddle_subscription_id: paddle_id} = _subscription) do
-    Plausible.Billing.PaddleApi.vendors_domain() <>
-      "/subscriptions/customers/manage/" <> paddle_id
+  defp teams(teams) do
+    teams
+    |> Enum.map_join("<br>\n", fn team ->
+      """
+      <a href="/crm/teams/team/#{team.id}">#{team.name}</a>
+      """
+    end)
+    |> Phoenix.HTML.raw()
   end
 
   defp format_date(nil), do: "--"

--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -69,7 +69,13 @@ defmodule Plausible.Auth.UserAdmin do
   end
 
   def delete(_conn, %{data: user}) do
-    Plausible.Auth.delete_user(user)
+    case Plausible.Auth.delete_user(user) do
+      {:ok, :deleted} ->
+        :ok
+
+      {:error, :is_only_team_owner} ->
+        "The user is the only public team owner on one or more teams."
+    end
   end
 
   def index(_) do

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -140,30 +140,16 @@ defmodule Plausible.Billing do
         Teams.get!(team_id)
 
       {:user_id, user_id} ->
-        # FIXME: This is very problematic for a number of reasons.
-        #
         # Given a guest or non-owner member user initiates the new subscription payment
         # and becomes an owner of an existing team already with a subscription in between,
-        # this will result in assigning this new subscription to the newly owned team,
+        # this could result in assigning this new subscription to the newly owned team,
         # effectively "shadowing" any old one.
         #
-        # This also applies to teams where user has "autocreated" membership.
-        #
-        # Autocreated or not, defaulting to a team where user is already an owner
-        # in this case is not desirable as the payment is started with an assumption
-        # that a team doesn't exist.
-        #
-        # Always defaulting to creating a new team is an option but requires
-        # clearing any existing "autocreated" flag on any other membership then.
-        #
-        # Yet another possibility is to _always_ require team to exist before initiating
-        # the payment. This is not optimal though. Or maybe it is? As at this stage
-        # we intend to support multiple teams membership (and, by extension, ownership),
-        # it shouldn't be a problem to provisin the team before the procedure. Even
-        # if user backs out, they can remove the team if they change their mind, eventually.
-        user = Repo.get!(Auth.User, user_id)
-        {:ok, team} = Teams.get_or_create(user)
-        team
+        # That's why we are always defaulting to creating a new "My Team" team regardless
+        # if they were owner of one before or not.
+        Auth.User
+        |> Repo.get!(user_id)
+        |> Teams.force_create_my_team()
     end
   end
 

--- a/lib/plausible/billing/enterprise_plan.ex
+++ b/lib/plausible/billing/enterprise_plan.ex
@@ -24,9 +24,6 @@ defmodule Plausible.Billing.EnterprisePlan do
     field :features, Plausible.Billing.Ecto.FeatureList, default: []
     field :hourly_api_request_limit, :integer
 
-    # Field used only by CRM for mapping to the ones in the owned team
-    field :user_id, :integer, virtual: true
-
     belongs_to :team, Plausible.Teams.Team
 
     timestamps()

--- a/lib/plausible/billing/enterprise_plan_admin.ex
+++ b/lib/plausible/billing/enterprise_plan_admin.ex
@@ -2,7 +2,7 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
   use Plausible.Repo
 
   @numeric_fields [
-    "user_id",
+    "team_id",
     "paddle_plan_id",
     "monthly_pageview_limit",
     "site_limit",
@@ -18,7 +18,7 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
 
   def form_fields(_schema) do
     [
-      user_id: nil,
+      team_id: nil,
       paddle_plan_id: nil,
       billing_interval: %{choices: [{"Yearly", "yearly"}, {"Monthly", "monthly"}]},
       monthly_pageview_limit: nil,
@@ -42,23 +42,17 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
       inner_join: t in assoc(r, :team),
       inner_join: o in assoc(t, :owners),
       or_where: ilike(r.paddle_plan_id, ^search_term),
-      or_where: ilike(o.email, ^search_term) or ilike(o.name, ^search_term),
+      or_where: ilike(o.email, ^search_term),
+      or_where: ilike(o.name, ^search_term),
+      or_where: ilike(t.name, ^search_term),
       preload: [team: {t, owners: o}]
-    )
-  end
-
-  def custom_show_query(_conn, _schema, query) do
-    from(ep in query,
-      inner_join: t in assoc(ep, :team),
-      inner_join: o in assoc(t, :owners),
-      select: %{ep | user_id: o.id}
     )
   end
 
   def index(_) do
     [
       id: nil,
-      user_email: %{value: &get_user_email/1},
+      user_email: %{value: &owner_emails(&1.team)},
       paddle_plan_id: nil,
       billing_interval: nil,
       monthly_pageview_limit: nil,
@@ -68,19 +62,14 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
     ]
   end
 
-  defp get_user_email(plan), do: List.first(plan.team.owners).email
+  defp owner_emails(team) do
+    team.owners
+    |> Enum.map_join("<br>", & &1.email)
+    |> Phoenix.HTML.raw()
+  end
 
   def create_changeset(schema, attrs) do
     attrs = sanitize_attrs(attrs)
-
-    team_id =
-      if user_id = attrs["user_id"] do
-        user = Repo.get!(Plausible.Auth.User, user_id)
-        {:ok, team} = Plausible.Teams.get_or_create(user)
-        team.id
-      end
-
-    attrs = Map.put(attrs, "team_id", team_id)
 
     Plausible.Billing.EnterprisePlan.changeset(struct(schema, %{}), attrs)
   end

--- a/lib/plausible/billing/enterprise_plan_admin.ex
+++ b/lib/plausible/billing/enterprise_plan_admin.ex
@@ -40,17 +40,17 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
 
     from(r in query,
       inner_join: t in assoc(r, :team),
-      inner_join: o in assoc(t, :owner),
+      inner_join: o in assoc(t, :owners),
       or_where: ilike(r.paddle_plan_id, ^search_term),
       or_where: ilike(o.email, ^search_term) or ilike(o.name, ^search_term),
-      preload: [team: {t, owner: o}]
+      preload: [team: {t, owners: o}]
     )
   end
 
   def custom_show_query(_conn, _schema, query) do
     from(ep in query,
       inner_join: t in assoc(ep, :team),
-      inner_join: o in assoc(t, :owner),
+      inner_join: o in assoc(t, :owners),
       select: %{ep | user_id: o.id}
     )
   end
@@ -68,7 +68,7 @@ defmodule Plausible.Billing.EnterprisePlanAdmin do
     ]
   end
 
-  defp get_user_email(plan), do: plan.team.owner.email
+  defp get_user_email(plan), do: List.first(plan.team.owners).email
 
   def create_changeset(schema, attrs) do
     attrs = sanitize_attrs(attrs)

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Billing.SiteLocker do
           Plausible.Teams.end_grace_period(team)
 
           if send_email? do
-            team = Repo.preload(team, :owner)
+            team = Repo.preload(team, :owners)
             send_grace_period_end_email(team)
           end
 
@@ -64,8 +64,10 @@ defmodule Plausible.Billing.SiteLocker do
     usage = Teams.Billing.monthly_pageview_usage(team)
     suggested_plan = Plausible.Billing.Plans.suggest(team, usage.last_cycle.total)
 
-    team.owner
-    |> PlausibleWeb.Email.dashboard_locked(usage, suggested_plan)
-    |> Plausible.Mailer.send()
+    for owner <- team.owners do
+      owner
+      |> PlausibleWeb.Email.dashboard_locked(usage, suggested_plan)
+      |> Plausible.Mailer.send()
+    end
   end
 end

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -28,6 +28,25 @@ defmodule Plausible.CrmExtensions do
       ]
     end
 
+    def javascripts(%{assigns: %{context: "auth", resource: "user", entry: %{} = user}}) do
+      [
+        Phoenix.HTML.raw("""
+        <script type="text/javascript">
+          (async () => {
+            const response = await fetch("/crm/auth/user/#{user.id}/info")
+            const usageHTML = await response.text()
+            const cardBody = document.querySelector(".card-body")
+            if (cardBody) {
+              const usageDOM = document.createElement("div")
+              usageDOM.innerHTML = usageHTML
+              cardBody.prepend(usageDOM)
+            }
+          })()
+        </script>
+        """)
+      ]
+    end
+
     def javascripts(%{assigns: %{context: "sites", resource: "site", entry: %{domain: domain}}}) do
       base_url = PlausibleWeb.Endpoint.url()
 

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -54,15 +54,21 @@ defmodule Plausible.CrmExtensions do
         <script type="text/javascript">
           (async () => {
             const CHECK_INTERVAL = 300
-            const userIdField = document.querySelector("#enterprise_plan_user_id")
-            const userIdLabel = document.querySelector("label[for=enterprise_plan_user_id]")
+
+            const teamPicker = document.querySelector("#pick-raw-resource")
+            if (teamPicker) {
+              teamPicker.style.display = "none";
+            }
+            const teamIdField = document.querySelector("#enterprise_plan_team_id") || 
+                            document.querySelector("#team_id")
+            const teamIdLabel = document.querySelector("label[for=enterprise_plan_team_id]")
             const dataList = document.createElement("datalist")
-            dataList.id = "user-choices"
-            userIdField.after(dataList)
-            userIdField.setAttribute("list", "user-choices")
-            userIdField.setAttribute("type", "text")
+            dataList.id = "team-choices"
+            teamIdField.after(dataList)
+            teamIdField.setAttribute("list", "team-choices")
+            teamIdField.setAttribute("type", "text")
             const labelSpan = document.createElement("span")
-            userIdLabel.appendChild(labelSpan)
+            teamIdLabel.appendChild(labelSpan)
 
             let updateAction;
 
@@ -70,17 +76,17 @@ defmodule Plausible.CrmExtensions do
               id = Number(id)
 
               if (!isNaN(id) && id > 0) {
-                const response = await fetch(`/crm/billing/search/user-by-id/${id}`)
+                const response = await fetch(`/crm/billing/search/team-by-id/${id}`)
                 labelSpan.innerHTML = ` <i>(${await response.text()})</i>`
               }
             }
 
             const updateSearch = async () => {
-              const search = userIdField.value
+              const search = teamIdField.value
 
               updateLabel(search)
 
-              const response = await fetch("/crm/billing/search/user", {
+              const response = await fetch("/crm/billing/search/team", {
                 headers: { "Content-Type": "application/json" },
                 method: "POST",
                 body: JSON.stringify({ search: search })
@@ -100,9 +106,9 @@ defmodule Plausible.CrmExtensions do
               dataList.replaceChildren(...options)
             }
 
-            updateLabel(userIdField.value)
+            updateLabel(teamIdField.value)
 
-            userIdField.addEventListener("input", async (e) => {
+            teamIdField.addEventListener("input", async (e) => {
               if (updateAction) {
                 clearTimeout(updateAction)
                 updateAction = null
@@ -136,20 +142,20 @@ defmodule Plausible.CrmExtensions do
         <script type="text/javascript">
           (async () => {
             const CHECK_INTERVAL = 300
-            const userIdField = document.getElementById("enterprise_plan_user_id") || document.getElementById("user_id")
+            const teamIdField = document.getElementById("enterprise_plan_team_id") || document.getElementById("team_id")
             let planRequest
-            let lastValue = Number(userIdField.value)
+            let lastValue = Number(teamIdField.value)
             let currentValue = lastValue
 
             setTimeout(prefillCallback, CHECK_INTERVAL)
 
             async function prefillCallback() {
-              currentValue = Number(userIdField.value)
+              currentValue = Number(teamIdField.value)
               if (Number.isInteger(currentValue)
                     && currentValue > 0
                     && currentValue != lastValue
                     && !planRequest) {
-                planRequest = await fetch("/crm/billing/user/" + currentValue + "/current_plan")
+                planRequest = await fetch("/crm/billing/team/" + currentValue + "/current_plan")
                 const result = await planRequest.json()
 
                 fillForm(result)
@@ -178,7 +184,10 @@ defmodule Plausible.CrmExtensions do
 
               ['stats_api', 'props', 'funnels', 'revenue_goals'].forEach(feature => {
                 const checked = result.features.includes(feature)
-                document.getElementById('enterprise_plan_features_' + feature).checked = checked
+                const field = document.querySelector(`input[type=checkbox][value=${feature}]`)
+                if (field) {
+                  field.checked = checked
+                }
               });
             }
           })()

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -9,25 +9,6 @@ defmodule Plausible.CrmExtensions do
     # Kaffy uses String.to_existing_atom when listing params
     @custom_search :custom_search
 
-    def javascripts(%{assigns: %{context: "auth", resource: "user", entry: %{} = user}}) do
-      [
-        Phoenix.HTML.raw("""
-        <script type="text/javascript">
-          (async () => {
-            const response = await fetch("/crm/auth/user/#{user.id}/usage?embed=true")
-            const usageHTML = await response.text()
-            const cardBody = document.querySelector(".card-body")
-            if (cardBody) {
-              const usageDOM = document.createElement("div")
-              usageDOM.innerHTML = usageHTML
-              cardBody.prepend(usageDOM)
-            }
-          })()
-        </script>
-        """)
-      ]
-    end
-
     def javascripts(%{assigns: %{context: "teams", resource: "team", entry: %{} = team}}) do
       [
         Phoenix.HTML.raw("""

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -28,6 +28,25 @@ defmodule Plausible.CrmExtensions do
       ]
     end
 
+    def javascripts(%{assigns: %{context: "teams", resource: "team", entry: %{} = team}}) do
+      [
+        Phoenix.HTML.raw("""
+        <script type="text/javascript">
+          (async () => {
+            const response = await fetch("/crm/teams/team/#{team.id}/usage?embed=true")
+            const usageHTML = await response.text()
+            const cardBody = document.querySelector(".card-body")
+            if (cardBody) {
+              const usageDOM = document.createElement("div")
+              usageDOM.innerHTML = usageHTML
+              cardBody.prepend(usageDOM)
+            }
+          })()
+        </script>
+        """)
+      ]
+    end
+
     def javascripts(%{assigns: %{context: "sites", resource: "site", entry: %{domain: domain}}}) do
       base_url = PlausibleWeb.Endpoint.url()
 
@@ -188,7 +207,7 @@ defmodule Plausible.CrmExtensions do
     end
 
     def javascripts(%{assigns: %{context: context}})
-        when context in ["sites", "billing"] do
+        when context in ["teams", "sites", "billing"] do
       [
         Phoenix.HTML.raw("""
         <script type="text/javascript">

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -67,6 +67,7 @@ defmodule Plausible.CrmExtensions do
             teamIdField.after(dataList)
             teamIdField.setAttribute("list", "team-choices")
             teamIdField.setAttribute("type", "text")
+            teamIdField.setAttribute("autocomplete", "off")
             const labelSpan = document.createElement("span")
             teamIdLabel.appendChild(labelSpan)
 

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -47,7 +47,7 @@ defmodule Plausible.Site do
     has_one :google_auth, GoogleAuth
     has_one :weekly_report, Plausible.Site.WeeklyReport
     has_one :monthly_report, Plausible.Site.MonthlyReport
-    has_many :ownerships, through: [:team, :ownerships]
+    has_many :ownerships, through: [:team, :ownerships], preload_order: [asc: :id]
     has_many :owners, through: [:team, :owners]
 
     # If `from_cache?` is set, the struct might be incomplete - see `Plausible.Site.Cache`.

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -47,8 +47,8 @@ defmodule Plausible.Site do
     has_one :google_auth, GoogleAuth
     has_one :weekly_report, Plausible.Site.WeeklyReport
     has_one :monthly_report, Plausible.Site.MonthlyReport
-    has_one :ownership, through: [:team, :ownership]
-    has_one :owner, through: [:team, :owner]
+    has_many :ownerships, through: [:team, :ownerships]
+    has_many :owners, through: [:team, :owners]
 
     # If `from_cache?` is set, the struct might be incomplete - see `Plausible.Site.Cache`.
     # Use `Plausible.Repo.reload!(cached_site)` to pre-fill missing fields if

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -36,6 +36,7 @@ defmodule Plausible.SiteAdmin do
       inner_join: o in assoc(r, :owners),
       inner_join: t in assoc(r, :team),
       preload: [owners: o, team: t, guest_memberships: [team_membership: :user]],
+      or_where: type(t.identifier, :string) == ^search,
       or_where: ilike(t.name, ^search_term),
       or_where: ilike(r.domain, ^search_term),
       or_where: ilike(o.email, ^search_term),

--- a/lib/plausible/site/memberships.ex
+++ b/lib/plausible/site/memberships.ex
@@ -5,7 +5,9 @@ defmodule Plausible.Site.Memberships do
 
   alias Plausible.Site.Memberships
 
-  defdelegate accept_invitation(invitation_id, user), to: Memberships.AcceptInvitation
+  defdelegate accept_invitation(invitation_id, user, team \\ nil),
+    to: Memberships.AcceptInvitation
+
   defdelegate reject_invitation(invitation_id, user), to: Memberships.RejectInvitation
   defdelegate remove_invitation(invitation_id, site), to: Memberships.RemoveInvitation
 
@@ -15,6 +17,6 @@ defmodule Plausible.Site.Memberships do
   defdelegate bulk_create_invitation(sites, inviter, invitee_email, role, opts),
     to: Memberships.CreateInvitation
 
-  defdelegate bulk_transfer_ownership_direct(sites, new_owner),
+  defdelegate bulk_transfer_ownership_direct(sites, new_owner, team \\ nil),
     to: Memberships.AcceptInvitation
 end

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -80,9 +80,9 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
          :ok <- check_can_transfer_site(new_team, new_owner),
          :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
          :ok <- Teams.Invitations.transfer_site(site, new_team) do
-      site = site |> Repo.reload!() |> Repo.preload(ownership: :user)
+      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
 
-      {:ok, site.ownership}
+      {:ok, site.ownerships}
     end
   end
 
@@ -96,9 +96,9 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
          :ok <- Teams.Invitations.accept_site_transfer(site_transfer, new_team) do
       Teams.Invitations.send_transfer_accepted_email(site_transfer)
 
-      site = site |> Repo.reload!() |> Repo.preload(ownership: :user)
+      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
 
-      {:ok, %{team: new_team, team_membership: site.ownership, site: site}}
+      {:ok, %{team: new_team, team_memberships: site.ownerships, site: site}}
     end
   end
 

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -30,7 +30,6 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
 
   @type accept_error() ::
           :invitation_not_found
-          | :already_other_team_member
           | Billing.Quota.Limits.over_limits_error()
           | Ecto.Changeset.t()
           | :no_plan
@@ -124,16 +123,6 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   end
 
   defp do_accept_team_invitation(team_invitation, user) do
-    with :ok <- ensure_no_other_team_membership(team_invitation.team, user) do
-      Teams.Invitations.accept_team_invitation(team_invitation, user)
-    end
-  end
-
-  defp ensure_no_other_team_membership(team, user) do
-    if Teams.Users.team_member?(user, except: [team.id]) do
-      {:error, :already_other_team_member}
-    else
-      :ok
-    end
+    Teams.Invitations.accept_team_invitation(team_invitation, user)
   end
 end

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -50,7 +50,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   end
 
   defp do_invite(site, inviter, invitee_email, role, opts \\ []) do
-    with site <- Repo.preload(site, [:owner, :team]),
+    with site <- Repo.preload(site, [:owners, :team]),
          :ok <-
            Teams.Invitations.check_invitation_permissions(
              site,

--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -9,7 +9,7 @@ defmodule Plausible.Site.Removal do
   @spec run(Plausible.Site.t()) :: {:ok, map()}
   def run(site) do
     Repo.transaction(fn ->
-      site = Plausible.Teams.load_for_site(site)
+      site = Repo.preload(site, :team)
 
       result = Repo.delete_all(from(s in Plausible.Site, where: s.domain == ^site.domain))
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -313,9 +313,7 @@ defmodule Plausible.Sites do
     locked
   end
 
-  def get_for_user!(user, domain, roles \\ [:owner, :admin, :viewer]) do
-    roles = translate_roles(roles)
-
+  def get_for_user!(user, domain, roles \\ [:owner, :admin, :editor, :viewer]) do
     site =
       if :super_admin in roles and Plausible.Auth.is_super_admin?(user.id) do
         get_by_domain!(domain)
@@ -328,9 +326,7 @@ defmodule Plausible.Sites do
     Repo.preload(site, :team)
   end
 
-  def get_for_user(user, domain, roles \\ [:owner, :admin, :viewer]) do
-    roles = translate_roles(roles)
-
+  def get_for_user(user, domain, roles \\ [:owner, :admin, :editor, :viewer]) do
     if :super_admin in roles and Plausible.Auth.is_super_admin?(user.id) do
       get_by_domain(domain)
     else
@@ -338,13 +334,6 @@ defmodule Plausible.Sites do
       |> get_for_user_query(domain, List.delete(roles, :super_admin))
       |> Repo.one()
     end
-  end
-
-  defp translate_roles(roles) do
-    Enum.map(roles, fn
-      :admin -> :editor
-      role -> role
-    end)
   end
 
   defp get_for_user_query(user_id, domain, roles) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -75,7 +75,7 @@ defmodule Plausible.Sites do
     to: Plausible.Teams.Sites
 
   def list_people(site) do
-    owner_membership =
+    owner_memberships =
       from(
         tm in Teams.Membership,
         inner_join: u in assoc(tm, :user),
@@ -86,7 +86,7 @@ defmodule Plausible.Sites do
           role: tm.role
         }
       )
-      |> Repo.one!()
+      |> Repo.all()
 
     memberships =
       from(
@@ -111,7 +111,7 @@ defmodule Plausible.Sites do
       )
       |> Repo.all()
 
-    memberships = [owner_membership | memberships]
+    memberships = owner_memberships ++ memberships
 
     invitations =
       from(

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -16,6 +16,17 @@ defmodule Plausible.Teams do
     not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
   end
 
+  @spec get(pos_integer() | binary() | nil) :: Teams.Team.t() | nil
+  def get(nil), do: nil
+
+  def get(team_id) when is_integer(team_id) do
+    Repo.get(Teams.Team, team_id)
+  end
+
+  def get(team_identifier) when is_binary(team_identifier) do
+    Repo.get_by(Teams.Team, identifier: team_identifier)
+  end
+
   @spec get!(pos_integer() | binary()) :: Teams.Team.t()
   def get!(team_id) when is_integer(team_id) do
     Repo.get!(Teams.Team, team_id)

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -36,15 +36,6 @@ defmodule Plausible.Teams do
     Repo.get_by!(Teams.Team, identifier: team_identifier)
   end
 
-  @spec get_owner(Teams.Team.t()) ::
-          {:ok, Auth.User.t()} | {:error, :no_owner | :multiple_owners}
-  def get_owner(team) do
-    case Repo.preload(team, :owner).owner do
-      nil -> {:error, :no_owner}
-      owner_user -> {:ok, owner_user}
-    end
-  end
-
   @spec on_trial?(Teams.Team.t() | nil) :: boolean()
   on_ee do
     def on_trial?(nil), do: false

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -122,27 +122,6 @@ defmodule Plausible.Teams do
   end
 
   @doc """
-  Create (when necessary) and load team relation for provided site.
-
-  Used for sync logic to work smoothly during transitional period.
-  """
-  def load_for_site(site) do
-    site = Repo.preload(site, [:team, :owner])
-
-    if site.team do
-      site
-    else
-      {:ok, team} = get_or_create(site.owner)
-
-      site
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_assoc(:team, team)
-      |> Ecto.Changeset.force_change(:updated_at, site.updated_at)
-      |> Repo.update!()
-    end
-  end
-
-  @doc """
   Get or create user's team.
 
   If the user has no non-guest membership yet, an implicit "My Team" team is

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -382,7 +382,7 @@ defmodule Plausible.Teams.Billing do
   def team_member_usage(nil, _), do: 0
 
   def team_member_usage(team, opts) do
-    {:ok, owner} = Teams.get_owner(team)
+    [owner | _] = Repo.preload(team, :owners).owners
     exclude_emails = Keyword.get(opts, :exclude_emails, []) ++ [owner.email]
 
     pending_site_ids = Keyword.get(opts, :pending_ownership_site_ids, [])

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -188,10 +188,9 @@ defmodule Plausible.Teams.Invitations do
     )
   end
 
-  def accept_site_transfer(site_transfer, user) do
+  def accept_site_transfer(site_transfer, team) do
     {:ok, _} =
       Repo.transaction(fn ->
-        {:ok, team} = Teams.get_or_create(user)
         :ok = transfer_site_ownership(site_transfer.site, team, NaiveDateTime.utc_now(:second))
         Repo.delete_all(from st in Teams.SiteTransfer, where: st.id == ^site_transfer.id)
       end)
@@ -199,10 +198,9 @@ defmodule Plausible.Teams.Invitations do
     :ok
   end
 
-  def transfer_site(site, user) do
+  def transfer_site(site, team) do
     {:ok, _} =
       Repo.transaction(fn ->
-        {:ok, team} = Teams.get_or_create(user)
         :ok = transfer_site_ownership(site, team, NaiveDateTime.utc_now(:second))
       end)
 

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -143,7 +143,7 @@ defmodule Plausible.Teams.Invitations do
   end
 
   def invite(%Plausible.Site{} = site, invitee_email, role, inviter) do
-    site = Teams.load_for_site(site)
+    site = Repo.preload(site, :team)
 
     if role == :owner do
       create_site_transfer(

--- a/lib/plausible/teams/invitations/invite_to_team.ex
+++ b/lib/plausible/teams/invitations/invite_to_team.ex
@@ -12,7 +12,7 @@ defmodule Plausible.Teams.Invitations.InviteToTeam do
   def invite(team, inviter, invitee_email, role, opts \\ [])
 
   def invite(team, inviter, invitee_email, role, opts) when role in @valid_roles do
-    with team <- Repo.preload(team, [:owner]),
+    with team <- Repo.preload(team, [:owners]),
          :ok <-
            Teams.Invitations.check_invitation_permissions(
              team,

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -46,6 +46,26 @@ defmodule Plausible.Teams.Memberships do
     end
   end
 
+  def can_add_site?(team, user) do
+    case team_role(team, user) do
+      {:ok, role} when role in [:owner, :admin, :editor] ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  def can_transfer_site?(team, user) do
+    case team_role(team, user) do
+      {:ok, role} when role in [:owner, :admin] ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
   def site_role(_site, nil), do: {:error, :not_a_member}
 
   def site_role(site, user) do

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -8,18 +8,21 @@ defmodule Plausible.Teams.Sites do
   alias Plausible.Site
   alias Plausible.Teams
 
-  @type list_opt() :: {:filter_by_domain, String.t()}
+  @type list_opt() :: {:filter_by_domain, String.t()} | {:team, Teams.Team.t() | nil}
 
   @spec list(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
   def list(user, pagination_params, opts \\ []) do
     domain_filter = Keyword.get(opts, :filter_by_domain)
+    team = Keyword.get(opts, :team)
 
     team_membership_query =
-      from tm in Teams.Membership,
+      from(tm in Teams.Membership,
         inner_join: t in assoc(tm, :team),
         inner_join: s in assoc(t, :sites),
         where: tm.user_id == ^user.id and tm.role != :guest,
         select: %{site_id: s.id, entry_type: "site"}
+      )
+      |> maybe_filter_by_team(team)
 
     guest_membership_query =
       from tm in Teams.Membership,
@@ -71,9 +74,10 @@ defmodule Plausible.Teams.Sites do
   @spec list_with_invitations(Auth.User.t(), map(), [list_opt()]) :: Scrivener.Page.t()
   def list_with_invitations(user, pagination_params, opts \\ []) do
     domain_filter = Keyword.get(opts, :filter_by_domain)
+    team = Keyword.get(opts, :team)
 
     team_membership_query =
-      from tm in Teams.Membership,
+      from(tm in Teams.Membership,
         inner_join: t in assoc(tm, :team),
         inner_join: u in assoc(tm, :user),
         as: :user,
@@ -94,6 +98,8 @@ defmodule Plausible.Teams.Sites do
           role: tm.role,
           transfer_id: 0
         }
+      )
+      |> maybe_filter_by_team(team)
 
     guest_membership_query =
       from(tm in Teams.Membership,
@@ -264,6 +270,12 @@ defmodule Plausible.Teams.Sites do
       end)
     end)
   end
+
+  defp maybe_filter_by_team(team_membership_query, %Teams.Team{} = team) do
+    where(team_membership_query, [tm], tm.team_id == ^team.id)
+  end
+
+  defp maybe_filter_by_team(team_membership_query, _), do: team_membership_query
 
   defp maybe_filter_by_domain(query, domain)
        when byte_size(domain) >= 1 and byte_size(domain) <= 64 do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -39,6 +39,8 @@ defmodule Plausible.Teams.Team do
 
     has_one :ownership, Plausible.Teams.Membership, where: [role: :owner]
     has_one :owner, through: [:ownership, :user]
+    has_many :ownerships, Plausible.Teams.Membership, where: [role: :owner]
+    has_many :owners, through: [:ownerships, :user]
 
     timestamps()
   end

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -37,8 +37,6 @@ defmodule Plausible.Teams.Team do
     has_one :subscription, Plausible.Billing.Subscription
     has_one :enterprise_plan, Plausible.Billing.EnterprisePlan
 
-    has_one :ownership, Plausible.Teams.Membership, where: [role: :owner]
-    has_one :owner, through: [:ownership, :user]
     has_many :ownerships, Plausible.Teams.Membership, where: [role: :owner]
     has_many :owners, through: [:ownerships, :user]
 

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -37,7 +37,10 @@ defmodule Plausible.Teams.Team do
     has_one :subscription, Plausible.Billing.Subscription
     has_one :enterprise_plan, Plausible.Billing.EnterprisePlan
 
-    has_many :ownerships, Plausible.Teams.Membership, where: [role: :owner]
+    has_many :ownerships, Plausible.Teams.Membership,
+      where: [role: :owner],
+      preload_order: [asc: :id]
+
     has_many :owners, through: [:ownerships, :user]
 
     timestamps()

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -45,9 +45,9 @@ defmodule Plausible.Teams.TeamAdmin do
       owners: %{value: &get_owners/1},
       other_members: %{value: &get_other_members/1},
       trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},
-      subscription_plan: %{value: &subscription_plan/1},
-      subscription_status: %{value: &subscription_status/1},
-      grace_period: %{value: &grace_period_status/1},
+      subscription_plan: %{value: &Phoenix.HTML.raw(subscription_plan(&1))},
+      subscription_status: %{value: &Phoenix.HTML.raw(subscription_status(&1))},
+      grace_period: %{value: &Phoenix.HTML.raw(grace_period_status(&1))},
       accept_traffic_until: %{
         name: "Accept traffic until",
         value: &format_date(&1.accept_traffic_until)
@@ -116,7 +116,7 @@ defmodule Plausible.Teams.TeamAdmin do
       quota = PlausibleWeb.AuthView.subscription_quota(subscription)
       interval = PlausibleWeb.AuthView.subscription_interval(subscription)
 
-      {:safe, ~s(<a href="#{manage_url(subscription)}">#{quota} \(#{interval}\)</a>)}
+      ~s(<a href="#{manage_url(subscription)}">#{quota} \(#{interval}\)</a>)
     else
       "--"
     end
@@ -129,7 +129,7 @@ defmodule Plausible.Teams.TeamAdmin do
           PlausibleWeb.SettingsView.present_subscription_status(team.subscription.status)
 
         if team.subscription.paddle_subscription_id do
-          {:safe, ~s(<a href="#{manage_url(team.subscription)}">#{status_str}</a>)}
+          ~s(<a href="#{manage_url(team.subscription)}">#{status_str}</a>)
         else
           status_str
         end

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -1,0 +1,115 @@
+defmodule Plausible.Teams.TeamAdmin do
+  @moduledoc """
+  Kaffy CRM definition for Team.
+  """
+
+  use Plausible
+  use Plausible.Repo
+
+  alias Plausible.Teams
+  alias Plausible.Billing.Subscription
+
+  require Plausible.Billing.Subscription.Status
+
+  def custom_index_query(_conn, _schema, query) do
+    from(t in query,
+      as: :team,
+      left_lateral_join: s in subquery(Teams.last_subscription_join_query()),
+      on: true,
+      preload: [:owners, team_memberships: :user, subscription: s]
+    )
+  end
+
+  def index(_) do
+    [
+      name: %{value: &team_name/1},
+      inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)},
+      other_members: %{value: &get_other_members/1},
+      trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},
+      subscription_plan: %{value: &subscription_plan/1},
+      subscription_status: %{value: &subscription_status/1},
+      grace_period: %{value: &grace_period_status/1},
+      accept_traffic_until: %{
+        name: "Accept traffic until",
+        value: &format_date(&1.accept_traffic_until)
+      }
+    ]
+  end
+
+  defp team_name(team) do
+    "#{team.name} (#{team.owners |> Enum.map(& &1.email) |> Enum.join(", ")})"
+  end
+
+  defp grace_period_status(team) do
+    grace_period = team.grace_period
+
+    case grace_period do
+      nil ->
+        "--"
+
+      %{manual_lock: true, is_over: true} ->
+        "Manually locked"
+
+      %{manual_lock: true, is_over: false} ->
+        "Waiting for manual lock"
+
+      %{is_over: true} ->
+        "ended"
+
+      %{end_date: %Date{} = end_date} ->
+        days_left = Date.diff(end_date, Date.utc_today())
+        "#{days_left} days left"
+    end
+  end
+
+  defp subscription_plan(team) do
+    subscription = team.subscription
+
+    if Subscription.Status.active?(subscription) && subscription.paddle_subscription_id do
+      quota = PlausibleWeb.AuthView.subscription_quota(subscription)
+      interval = PlausibleWeb.AuthView.subscription_interval(subscription)
+
+      {:safe, ~s(<a href="#{manage_url(subscription)}">#{quota} \(#{interval}\)</a>)}
+    else
+      "--"
+    end
+  end
+
+  defp subscription_status(team) do
+    cond do
+      team && team.subscription ->
+        status_str =
+          PlausibleWeb.SettingsView.present_subscription_status(team.subscription.status)
+
+        if team.subscription.paddle_subscription_id do
+          {:safe, ~s(<a href="#{manage_url(team.subscription)}">#{status_str}</a>)}
+        else
+          status_str
+        end
+
+      Plausible.Teams.on_trial?(team) ->
+        "On trial"
+
+      true ->
+        "Trial expired"
+    end
+  end
+
+  defp manage_url(%{paddle_subscription_id: paddle_id} = _subscription) do
+    Plausible.Billing.PaddleApi.vendors_domain() <>
+      "/subscriptions/customers/manage/" <> paddle_id
+  end
+
+  defp get_other_members(team) do
+    team.team_memberships
+    |> Enum.reject(&(&1.role == :owner))
+    |> Enum.map(fn tm -> tm.user.email <> "(#{tm.role})" end)
+    |> Enum.join(", ")
+  end
+
+  defp format_date(nil), do: "--"
+
+  defp format_date(date) do
+    Calendar.strftime(date, "%b %-d, %Y")
+  end
+end

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -57,6 +57,7 @@ defmodule Plausible.Teams.TeamAdmin do
 
   def form_fields(_) do
     [
+      identifier: %{create: :hidden, update: :readonly},
       name: nil,
       trial_expiry_date: %{
         help_text: "Change will also update Accept Traffic Until date"

--- a/lib/plausible/teams/users.ex
+++ b/lib/plausible/teams/users.ex
@@ -8,6 +8,18 @@ defmodule Plausible.Teams.Users do
   alias Plausible.Repo
   alias Plausible.Teams
 
+  def owned_teams(user) do
+    Repo.all(
+      from(
+        tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        where: tm.user_id == ^user.id,
+        where: tm.role == :owner,
+        select: t
+      )
+    )
+  end
+
   def team_member?(user, opts \\ []) do
     excluded_team_ids = Keyword.get(opts, :except, [])
 

--- a/lib/plausible/teams/users.ex
+++ b/lib/plausible/teams/users.ex
@@ -33,15 +33,6 @@ defmodule Plausible.Teams.Users do
     |> Repo.preload(:owners)
   end
 
-  def teams_count(user) do
-    from(
-      tm in Teams.Membership,
-      where: tm.user_id == ^user.id,
-      where: tm.role != :guest
-    )
-    |> Repo.aggregate(:count)
-  end
-
   def team_member?(user, opts \\ []) do
     excluded_team_ids = Keyword.get(opts, :except, [])
 

--- a/lib/plausible/teams/users.ex
+++ b/lib/plausible/teams/users.ex
@@ -20,6 +20,28 @@ defmodule Plausible.Teams.Users do
     )
   end
 
+  def teams(user) do
+    from(
+      tm in Teams.Membership,
+      inner_join: t in assoc(tm, :team),
+      where: tm.user_id == ^user.id,
+      where: tm.role != :guest,
+      select: t,
+      order_by: [t.name, t.id]
+    )
+    |> Repo.all()
+    |> Repo.preload(:owners)
+  end
+
+  def teams_count(user) do
+    from(
+      tm in Teams.Membership,
+      where: tm.user_id == ^user.id,
+      where: tm.role != :guest
+    )
+    |> Repo.aggregate(:count)
+  end
+
   def team_member?(user, opts \\ []) do
     excluded_team_ids = Keyword.get(opts, :except, [])
 

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -210,7 +210,7 @@ defmodule PlausibleWeb.AdminController do
 
       sites_link =
         Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
-          custom_search: List.first(team.owners).email
+          custom_search: team.identifier
         )
 
       """

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -124,7 +124,10 @@ defmodule PlausibleWeb.AdminController do
             from t in Teams.Team,
               inner_join: o in assoc(t, :owners),
               where:
-                t.id == ^team_id or ilike(t.name, ^term) or ilike(o.email, ^term) or
+                t.id == ^team_id or
+                  type(t.identifier, :string) == ^search or
+                  ilike(t.name, ^term) or
+                  ilike(o.email, ^term) or
                   ilike(o.name, ^term),
               order_by: [t.name, t.id],
               group_by: t.id,
@@ -132,18 +135,20 @@ defmodule PlausibleWeb.AdminController do
                 fragment(
                   """
                   case when ? = ? then 
-                    string_agg(concat(?, ' (', ?, ')'), ',') 
+                    concat(string_agg(concat(?, ' (', ?, ')'), ','), ' - ', ?)
                   else 
-                    concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']') 
+                    concat(concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']'), ' - ', ?)
                   end
                   """,
                   t.name,
                   "My Team",
                   o.name,
                   o.email,
+                  t.identifier,
                   t.name,
                   o.name,
-                  o.email
+                  o.email,
+                  t.identifier
                 ),
                 t.id
               ],

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -167,7 +167,10 @@ defmodule PlausibleWeb.AdminController do
   defp usage_and_limits_html(team, usage, limits, embed?) do
     content = """
       <ul>
-        <li>Team: <b>#{team && team.name}</b></li>
+        <li>Team: <b>#{team.name}</b></li>
+        <li>Subscription plan: #{Teams.TeamAdmin.subscription_plan(team)}</li>
+        <li>Subscription status: #{Teams.TeamAdmin.subscription_status(team)}</li>
+        <li>Grace period: #{Teams.TeamAdmin.grace_period_status(team)}</li>
         <li>Sites: <b>#{usage.sites}</b> / #{limits.sites}</li>
         <li>Team members: <b>#{usage.team_members}</b> / #{limits.team_members}</li>
         <li>Features: #{features_usage(usage.features)}</li>

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -14,6 +14,7 @@ defmodule PlausibleWeb.AdminController do
       team_id
       |> Teams.get()
       |> Repo.preload([:owners, team_memberships: :user])
+      |> Teams.with_subscription()
 
     usage = Teams.Billing.quota_usage(team, with_features: true)
 

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -31,6 +31,28 @@ defmodule PlausibleWeb.AdminController do
     |> send_resp(200, html_response)
   end
 
+  def user_info(conn, params) do
+    user_id = String.to_integer(params["user_id"])
+
+    user =
+      Plausible.Auth.User
+      |> Repo.get!(user_id)
+      |> Repo.preload(:owned_teams)
+
+    teams_list = Plausible.Auth.UserAdmin.teams(user.owned_teams)
+
+    html_response = """
+      <div style="margin-bottom: 1.1em;">
+        <p><b>Owned teams:</b></p>
+        #{teams_list}
+      </div>
+    """
+
+    conn
+    |> put_resp_content_type("text/html")
+    |> send_resp(200, html_response)
+  end
+
   def current_plan(conn, params) do
     team_id = String.to_integer(params["team_id"])
 

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -15,7 +15,7 @@ defmodule PlausibleWeb.AdminController do
         {:ok, team} ->
           team
           |> Teams.with_subscription()
-          |> Plausible.Repo.preload(:owner)
+          |> Plausible.Repo.preload(:owners)
 
         {:error, :no_team} ->
           nil
@@ -177,7 +177,7 @@ defmodule PlausibleWeb.AdminController do
 
       sites_link =
         Routes.kaffy_resource_url(PlausibleWeb.Endpoint, :index, :sites, :site,
-          custom_search: team.owner.email
+          custom_search: List.first(team.owners).email
         )
 
       """

--- a/lib/plausible_web/controllers/api/external_query_api_controller.ex
+++ b/lib/plausible_web/controllers/api/external_query_api_controller.ex
@@ -7,7 +7,7 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
   alias Plausible.Stats.Query
 
   def query(conn, params) do
-    site = Repo.preload(conn.assigns.site, :owner)
+    site = Repo.preload(conn.assigns.site, :owners)
 
     case Query.build(site, conn.assigns.schema_type, params, debug_metadata(conn)) do
       {:ok, query} ->

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def aggregate(conn, params) do
-    site = Repo.preload(conn.assigns.site, :owner)
+    site = Repo.preload(conn.assigns.site, :owners)
 
     params = Map.put(params, "property", nil)
 
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   end
 
   def breakdown(conn, params) do
-    site = Repo.preload(conn.assigns.site, :owner)
+    site = Repo.preload(conn.assigns.site, :owners)
 
     with :ok <- validate_period(params),
          :ok <- validate_date(params),
@@ -239,7 +239,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   defp event_only_property?(_), do: false
 
   def timeseries(conn, params) do
-    site = Repo.preload(conn.assigns.site, :owner)
+    site = Repo.preload(conn.assigns.site, :owners)
 
     params = Map.put(params, "property", nil)
 

--- a/lib/plausible_web/controllers/api/internal_controller.ex
+++ b/lib/plausible_web/controllers/api/internal_controller.ex
@@ -6,9 +6,10 @@ defmodule PlausibleWeb.Api.InternalController do
 
   def sites(conn, _params) do
     current_user = conn.assigns[:current_user]
+    current_team = conn.assigns[:current_team]
 
     if current_user do
-      sites = sites_for(current_user)
+      sites = sites_for(current_user, current_team)
 
       json(conn, %{data: sites})
     else
@@ -54,8 +55,8 @@ defmodule PlausibleWeb.Api.InternalController do
     end
   end
 
-  defp sites_for(user) do
-    pagination = Sites.list(user, %{page_size: 9})
+  defp sites_for(user, team) do
+    pagination = Sites.list(user, %{page_size: 9}, team: team)
     Enum.map(pagination.entries, &%{domain: &1.domain})
   end
 end

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -433,9 +433,18 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def delete_me(conn, params) do
-    Plausible.Auth.delete_user(conn.assigns[:current_user])
+    case Plausible.Auth.delete_user(conn.assigns[:current_user]) do
+      {:ok, :deleted} ->
+        logout(conn, params)
 
-    logout(conn, params)
+      {:error, :is_only_team_owner} ->
+        conn
+        |> put_flash(
+          :error,
+          "You can't delete your account when you are the only owner on a team."
+        )
+        |> redirect(to: Routes.settings_path(conn, :danger_zone))
+    end
   end
 
   def logout(conn, params) do

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -3,6 +3,7 @@ defmodule PlausibleWeb.AuthController do
   use Plausible.Repo
 
   alias Plausible.Auth
+  alias Plausible.Teams
   alias PlausibleWeb.TwoFactor
   alias PlausibleWeb.UserAuth
 
@@ -33,7 +34,9 @@ defmodule PlausibleWeb.AuthController do
            :verify_2fa_setup_form,
            :verify_2fa_setup,
            :disable_2fa,
-           :generate_2fa_recovery_codes
+           :generate_2fa_recovery_codes,
+           :select_team,
+           :switch_team
          ]
   )
 
@@ -50,6 +53,67 @@ defmodule PlausibleWeb.AuthController do
   # Plug purging 2FA user session cookie outsite 2FA flow
   defp clear_2fa_user(conn, _opts) do
     TwoFactor.Session.clear_2fa_user(conn)
+  end
+
+  def select_team(conn, _params) do
+    current_user = conn.assigns.current_user
+
+    owner_name_fn = fn owner ->
+      if owner.id == current_user.id do
+        "You"
+      else
+        owner.name
+      end
+    end
+
+    teams =
+      current_user
+      |> Teams.Users.teams()
+      |> Enum.map(fn team ->
+        current_team? = team.id == conn.assigns.current_team.id
+
+        owners =
+          Enum.map_join(team.owners, ", ", &owner_name_fn.(&1))
+
+        many_owners? = length(team.owners) > 1
+
+        %{
+          identifier: team.identifier,
+          name: team.name,
+          current?: current_team?,
+          many_owners?: many_owners?,
+          owners: owners
+        }
+      end)
+
+    render(conn, "select_team.html", teams: teams)
+  end
+
+  def switch_team(conn, params) do
+    current_user = conn.assigns.current_user
+    team = Teams.get(params["team_id"])
+
+    if team do
+      case Teams.Memberships.team_role(team, current_user) do
+        {:ok, role} when role != :guest ->
+          conn
+          |> put_session("current_team_id", team.identifier)
+          |> put_flash(
+            :success,
+            "You have switched to \"#{conn.assigns.current_team.name}\" team"
+          )
+          |> redirect(to: Routes.site_path(conn, :index))
+
+        _ ->
+          conn
+          |> put_flash(:error, "You have select an invalid team")
+          |> redirect(to: Routes.site_path(conn, :index))
+      end
+    else
+      conn
+      |> put_flash(:error, "You have select an invalid team")
+      |> redirect(to: Routes.site_path(conn, :index))
+    end
   end
 
   def activate_form(conn, params) do

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -43,6 +43,11 @@ defmodule PlausibleWeb.InvitationController do
         |> put_flash(:error, "You already are a team member in another team")
         |> redirect(to: "/sites")
 
+      {:error, :permission_denied} ->
+        conn
+        |> put_flash(:error, "You can't add sites in the current team")
+        |> redirect(to: "/sites")
+
       {:error, :no_plan} ->
         conn
         |> put_flash(:error, "No existing subscription")

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -7,7 +7,10 @@ defmodule PlausibleWeb.InvitationController do
        [:owner, :editor, :admin] when action in [:remove_invitation]
 
   def accept_invitation(conn, %{"invitation_id" => invitation_id}) do
-    case Plausible.Site.Memberships.accept_invitation(invitation_id, conn.assigns.current_user) do
+    current_user = conn.assigns.current_user
+    team = conn.assigns.current_team
+
+    case Plausible.Site.Memberships.accept_invitation(invitation_id, current_user, team) do
       {:ok, result} ->
         team = result.team
 

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -41,11 +41,6 @@ defmodule PlausibleWeb.InvitationController do
         |> put_flash(:error, "Invitation missing or already accepted")
         |> redirect(to: "/sites")
 
-      {:error, :already_other_team_member} ->
-        conn
-        |> put_flash(:error, "You already are a team member in another team")
-        |> redirect(to: "/sites")
-
       {:error, :permission_denied} ->
         conn
         |> put_flash(:error, "You can't add sites in the current team")

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -27,7 +27,7 @@ defmodule PlausibleWeb.Site.MembershipController do
     site =
       conn.assigns.current_user
       |> Plausible.Sites.get_for_user!(conn.assigns.site.domain)
-      |> Plausible.Repo.preload(:owner)
+      |> Plausible.Repo.preload(:owners)
 
     limit = Plausible.Teams.Billing.team_member_limit(site.team)
     usage = Plausible.Teams.Billing.team_member_usage(site.team)
@@ -48,7 +48,7 @@ defmodule PlausibleWeb.Site.MembershipController do
 
     site =
       Plausible.Sites.get_for_user!(conn.assigns.current_user, site_domain)
-      |> Plausible.Repo.preload(:owner)
+      |> Plausible.Repo.preload(:owners)
 
     case Memberships.create_invitation(site, conn.assigns.current_user, email, role) do
       {:ok, invitation} ->

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Site.MembershipController do
     This controller deals with user management via the UI in Site Settings -> People. It's important to enforce permissions in this controller.
 
     Owner - Can manage users, can trigger a 'transfer ownership' request
-    Admin - Can manage users
+    Admin and Editor - Can manage users
     Viewer - Can not access user management settings
     Anyone - Can accept invitations
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -54,7 +54,7 @@ defmodule PlausibleWeb.SiteController do
           changeset: Plausible.Site.changeset(%Plausible.Site{}),
           first_site?: first_site?,
           site_limit: Plausible.Teams.Billing.site_limit(team),
-          site_limit_exceeded?: true,
+          site_limit_exceeded?: false,
           flow: flow,
           form_submit_url: "/sites?flow=#{flow}"
         )

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -26,12 +26,13 @@ defmodule PlausibleWeb.SiteController do
   end
 
   def create_site(conn, %{"site" => site_params}) do
-    team = conn.assigns.my_team
+    current_team = conn.assigns.current_team
+    team = Plausible.Teams.get(site_params["team_id"]) || current_team
     user = conn.assigns.current_user
     first_site? = Plausible.Teams.Billing.site_usage(team) == 0
     flow = conn.params["flow"]
 
-    case Sites.create(user, site_params) do
+    case Sites.create(user, site_params, team) do
       {:ok, %{site: site}} ->
         if first_site? do
           PlausibleWeb.Email.welcome_email(user)
@@ -44,6 +45,18 @@ defmodule PlausibleWeb.SiteController do
               site_created: true,
               flow: flow
             )
+        )
+
+      {:error, _, :permission_denied, _} ->
+        conn
+        |> put_flash(:error, "You are not permitted to add sites in the current team")
+        |> render("new.html",
+          changeset: Plausible.Site.changeset(%Plausible.Site{}),
+          first_site?: first_site?,
+          site_limit: Plausible.Teams.Billing.site_limit(team),
+          site_limit_exceeded?: true,
+          flow: flow,
+          form_submit_url: "/sites?flow=#{flow}"
         )
 
       {:error, _, {:over_limit, limit}, _} ->

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.StatsController do
   )
 
   def stats(%{assigns: %{site: site}} = conn, _params) do
-    site = Plausible.Repo.preload(site, :owner)
+    site = Plausible.Repo.preload(site, :owners)
     current_user = conn.assigns[:current_user]
     stats_start_date = Plausible.Sites.stats_start_date(site)
     can_see_stats? = not Sites.locked?(site) or conn.assigns[:site_role] == :super_admin
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.StatsController do
         redirect(conn, external: Routes.site_path(conn, :verification, site.domain))
 
       Sites.locked?(site) ->
-        site = Plausible.Repo.preload(site, :owner)
+        site = Plausible.Repo.preload(site, :owners)
         render(conn, "site_locked.html", site: site, dogfood_page_path: dogfood_page_path)
     end
   end
@@ -119,7 +119,7 @@ defmodule PlausibleWeb.StatsController do
   """
   def csv_export(conn, params) do
     if is_nil(params["interval"]) or Plausible.Stats.Interval.valid?(params["interval"]) do
-      site = Plausible.Repo.preload(conn.assigns.site, :owner)
+      site = Plausible.Repo.preload(conn.assigns.site, :owners)
       query = Query.from(site, params, debug_metadata(conn))
 
       date_range = Query.date_range(query)
@@ -346,7 +346,7 @@ defmodule PlausibleWeb.StatsController do
     cond do
       !shared_link.site.locked ->
         current_user = conn.assigns[:current_user]
-        shared_link = Plausible.Repo.preload(shared_link, site: :owner)
+        shared_link = Plausible.Repo.preload(shared_link, site: :owners)
         stats_start_date = Plausible.Sites.stats_start_date(shared_link.site)
 
         scroll_depth_visible? =
@@ -377,10 +377,10 @@ defmodule PlausibleWeb.StatsController do
         )
 
       Sites.locked?(shared_link.site) ->
-        owner = Plausible.Repo.preload(shared_link.site, :owner)
+        owners = Plausible.Repo.preload(shared_link.site, :owners)
 
         render(conn, "site_locked.html",
-          owner: owner,
+          owners: owners,
           site: shared_link.site,
           dogfood_page_path: "/share/:dashboard"
         )

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -94,15 +94,7 @@ defmodule PlausibleWeb.Email do
     |> render("trial_one_week_reminder.html", user: user)
   end
 
-  def trial_upgrade_email(user, day, usage) do
-    team =
-      case Plausible.Teams.get_by_owner(user) do
-        {:ok, team} -> team
-        _ -> nil
-      end
-
-    suggested_plan = Plausible.Billing.Plans.suggest(team, usage.total)
-
+  def trial_upgrade_email(user, day, usage, suggested_plan) do
     base_email()
     |> to(user)
     |> tag("trial-upgrade-email")

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -190,22 +190,22 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  def yearly_renewal_notification(team) do
+  def yearly_renewal_notification(team, owner) do
     date = Calendar.strftime(team.subscription.next_bill_date, "%B %-d, %Y")
 
     priority_email()
-    |> to(team.owner)
+    |> to(owner)
     |> tag("yearly-renewal")
     |> subject("Your Plausible subscription is up for renewal")
     |> render("yearly_renewal_notification.html", %{
-      user: team.owner,
+      user: owner,
       date: date,
       next_bill_amount: team.subscription.next_bill_amount,
       currency: team.subscription.currency_code
     })
   end
 
-  def yearly_expiration_notification(team) do
+  def yearly_expiration_notification(team, owner) do
     next_bill_date = Calendar.strftime(team.subscription.next_bill_date, "%B %-d, %Y")
 
     accept_traffic_until =
@@ -214,11 +214,11 @@ defmodule PlausibleWeb.Email do
       |> Calendar.strftime("%B %-d, %Y")
 
     priority_email()
-    |> to(team.owner)
+    |> to(owner)
     |> tag("yearly-expiration")
     |> subject("Your Plausible subscription is about to expire")
     |> render("yearly_expiration_notification.html", %{
-      user: team.owner,
+      user: owner,
       next_bill_date: next_bill_date,
       accept_traffic_until: accept_traffic_until
     })

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -58,6 +58,11 @@ defmodule PlausibleWeb.Live.AuthContext do
       |> assign_new(:current_team, fn context ->
         context.team_from_session || context.my_team
       end)
+      |> assign_new(:multiple_teams?, fn context ->
+        if context.current_user do
+          Teams.Users.teams_count(context.current_user) > 1
+        end
+      end)
 
     {:cont, socket}
   end

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -8,6 +8,7 @@ defmodule PlausibleWeb.Live.AuthContext do
 
   import Phoenix.Component
 
+  alias Plausible.Teams
   alias PlausibleWeb.UserAuth
 
   defmacro __using__(_) do
@@ -32,11 +33,17 @@ defmodule PlausibleWeb.Live.AuthContext do
         end
       end)
       |> assign_new(:my_team, fn context ->
-        case context.current_user do
-          nil -> nil
-          %{team_memberships: [%{team: team}]} -> team
-          %{team_memberships: []} -> nil
+        current_team = Teams.get(session["current_team_id"])
+
+        case {current_team, context.current_user} do
+          {nil, nil} -> nil
+          {%Teams.Team{}, _} -> current_team
+          {nil, %{team_memberships: [%{team: team} | _]}} -> team
+          {nil, %{team_memberships: []}} -> nil
         end
+      end)
+      |> assign_new(:current_team, fn context ->
+        context.my_team
       end)
 
     {:cont, socket}

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -8,7 +8,6 @@ defmodule PlausibleWeb.Live.AuthContext do
 
   import Phoenix.Component
 
-  alias Plausible.Teams
   alias PlausibleWeb.UserAuth
 
   defmacro __using__(_) do
@@ -32,36 +31,49 @@ defmodule PlausibleWeb.Live.AuthContext do
           _ -> nil
         end
       end)
-      |> assign_new(:team_from_session, fn _ ->
-        session["current_team_id"]
-        |> Teams.get()
-        |> Teams.with_subscription()
-        |> Plausible.Repo.preload(:owners)
-      end)
-      |> assign_new(:my_team, fn context ->
-        current_team = context.team_from_session
+      |> assign_new(:team_from_session, fn
+        %{current_user: nil} ->
+          nil
 
-        current_team_owner? =
-          case current_team &&
-                 Plausible.Teams.Memberships.team_role(current_team, context.current_user) do
-            {:ok, :owner} -> true
-            _ -> false
+        %{current_user: user} ->
+          if current_team_id = session["current_team_id"] do
+            user.team_memberships
+            |> Enum.find(%{}, &(&1.team_id == current_team_id))
+            |> Map.get(:team)
           end
+      end)
+      |> assign_new(:my_team, fn
+        %{current_user: nil} ->
+          nil
 
-        case {current_team_owner?, current_team, context.current_user} do
-          {_, nil, nil} -> nil
-          {true, %Teams.Team{}, _} -> current_team
-          {_, _, %{team_memberships: [%{team: team} | _]}} -> team
-          {_, _, %{team_memberships: []}} -> nil
-        end
+        %{current_user: user} = context ->
+          current_team = context.team_from_session
+
+          current_team_owner? =
+            (current_team || %{})
+            |> Map.get(:owners, [])
+            |> Enum.any?(&(&1.id == user.id))
+
+          if current_team_owner? do
+            current_team
+          else
+            user.team_memberships
+            # NOTE: my_team should eventually only hold user's personal team. This requires
+            # additional adjustments, which will be done in follow-up work.
+            # |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
+            |> List.first(%{})
+            |> Map.get(:team)
+          end
       end)
       |> assign_new(:current_team, fn context ->
         context.team_from_session || context.my_team
       end)
+      |> assign_new(:teams_count, fn
+        %{current_user: nil} -> 0
+        %{current_user: user} -> length(user.team_memberships)
+      end)
       |> assign_new(:multiple_teams?, fn context ->
-        if context.current_user do
-          Teams.Users.teams_count(context.current_user) > 1
-        end
+        context.teams_count > 1
       end)
 
     {:cont, socket}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -16,7 +16,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
       socket
       |> assign_new(:site, fn %{current_user: current_user} ->
         current_user
-        |> Plausible.Sites.get_for_user!(domain, [:owner, :admin, :super_admin])
+        |> Plausible.Sites.get_for_user!(domain, [:owner, :admin, :editor, :super_admin])
       end)
       |> assign_new(:all_goals, fn %{site: site} ->
         Goals.for_site(site, preload_funnels?: true)

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   alias Plausible.Repo
 
   def update(assigns, socket) do
-    site = Repo.preload(assigns.site, [:team, :owner])
+    site = Repo.preload(assigns.site, [:team, :owners])
 
     has_access_to_revenue_goals? =
       Plausible.Billing.Feature.RevenueGoals.check_availability(site.team) == :ok
@@ -297,7 +297,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     ~H"""
     <div class="mt-6 space-y-3" x-data={@js_data}>
       <PlausibleWeb.Components.Billing.Notice.premium_feature
-        billable_user={@site.owner}
+        billable_user={List.first(@site.owners)}
         current_user={@current_user}
         current_team={@site_team}
         feature_mod={Plausible.Billing.Feature.RevenueGoals}

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -18,6 +18,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -35,6 +35,7 @@ defmodule PlausibleWeb.Live.Installation do
       Plausible.Sites.get_for_user!(socket.assigns.current_user, domain, [
         :owner,
         :admin,
+        :editor,
         :super_admin,
         :viewer
       ])

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -14,6 +14,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -22,6 +22,7 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/props_settings.ex
+++ b/lib/plausible_web/live/props_settings.ex
@@ -14,6 +14,7 @@ defmodule PlausibleWeb.Live.PropsSettings do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/props_settings/form.ex
+++ b/lib/plausible_web/live/props_settings/form.ex
@@ -21,6 +21,7 @@ defmodule PlausibleWeb.Live.PropsSettings.Form do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/shields/countries.ex
+++ b/lib/plausible_web/live/shields/countries.ex
@@ -17,6 +17,7 @@ defmodule PlausibleWeb.Live.Shields.Countries do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/shields/hostnames.ex
+++ b/lib/plausible_web/live/shields/hostnames.ex
@@ -13,6 +13,7 @@ defmodule PlausibleWeb.Live.Shields.Hostnames do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/shields/ip_addresses.ex
+++ b/lib/plausible_web/live/shields/ip_addresses.ex
@@ -20,6 +20,7 @@ defmodule PlausibleWeb.Live.Shields.IPAddresses do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/shields/pages.ex
+++ b/lib/plausible_web/live/shields/pages.ex
@@ -13,6 +13,7 @@ defmodule PlausibleWeb.Live.Shields.Pages do
         Plausible.Sites.get_for_user!(current_user, domain, [
           :owner,
           :admin,
+          :editor,
           :super_admin
         ])
       end)

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -664,7 +664,7 @@ defmodule PlausibleWeb.Live.Sites do
         end)
       end
 
-    invitations = extract_invitations(sites.entries, assigns.current_user)
+    invitations = extract_invitations(sites.entries, assigns.current_team)
 
     assign(
       socket,
@@ -674,20 +674,14 @@ defmodule PlausibleWeb.Live.Sites do
     )
   end
 
-  defp extract_invitations(sites, user) do
+  defp extract_invitations(sites, team) do
     sites
     |> Enum.filter(&(&1.entry_type == "invitation"))
     |> Enum.flat_map(& &1.invitations)
-    |> Enum.map(&check_limits(&1, user))
+    |> Enum.map(&check_limits(&1, team))
   end
 
-  defp check_limits(%{role: :owner, site: site} = invitation, user) do
-    team =
-      case Plausible.Teams.get_by_owner(user) do
-        {:ok, team} -> team
-        _ -> nil
-      end
-
+  defp check_limits(%{role: :owner, site: site} = invitation, team) do
     case ensure_can_take_ownership(site, team) do
       :ok ->
         check_features(invitation, team)

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -651,7 +651,8 @@ defmodule PlausibleWeb.Live.Sites do
   defp load_sites(%{assigns: assigns} = socket) do
     sites =
       Sites.list_with_invitations(assigns.current_user, assigns.params,
-        filter_by_domain: assigns.filter_text
+        filter_by_domain: assigns.filter_text,
+        team: assigns.current_team
       )
 
     hourly_stats =

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -21,6 +21,7 @@ defmodule PlausibleWeb.Live.Verification do
       Plausible.Sites.get_for_user!(socket.assigns.current_user, domain, [
         :owner,
         :admin,
+        :editor,
         :super_admin,
         :viewer
       ])

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -49,6 +49,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_user_session, user_session)
         |> assign(:my_team, my_team)
         |> assign(:current_team, current_team || my_team)
+        |> assign(:multiple_teams?, Teams.Users.teams_count(user) > 1)
 
       _ ->
         conn

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -134,11 +134,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   end
 
   defp verify_site_access(api_key, site) do
-    team =
-      case Plausible.Teams.get_by_owner(api_key.user) do
-        {:ok, team} -> team
-        _ -> nil
-      end
+    team = Repo.preload(site, :team).team
 
     is_member? = Plausible.Teams.Memberships.site_member?(site, api_key.user)
     is_super_admin? = Auth.is_super_admin?(api_key.user_id)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -112,7 +112,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
         site =
           site
           |> Repo.preload([
-            :owner,
+            :owners,
             :completed_imports,
             team: [subscription: Plausible.Teams.last_subscription_query()]
           ])

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -406,6 +406,9 @@ defmodule PlausibleWeb.Router do
     get "/logout", AuthController, :logout
     delete "/me", AuthController, :delete_me
 
+    get "/team/select", AuthController, :select_team
+    post "/team/select/:team_id", AuthController, :switch_team
+
     get "/auth/google/callback", AuthController, :google_auth_callback
 
     on_ee do

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -101,9 +101,9 @@ defmodule PlausibleWeb.Router do
     scope "/crm", PlausibleWeb do
       pipe_through :flags
       get "/teams/team/:team_id/usage", AdminController, :usage
-      get "/billing/user/:user_id/current_plan", AdminController, :current_plan
-      get "/billing/search/user-by-id/:user_id", AdminController, :user_by_id
-      post "/billing/search/user", AdminController, :user_search
+      get "/billing/team/:team_id/current_plan", AdminController, :current_plan
+      get "/billing/search/team-by-id/:team_id", AdminController, :team_by_id
+      post "/billing/search/team", AdminController, :team_search
     end
   end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -101,6 +101,7 @@ defmodule PlausibleWeb.Router do
     scope "/crm", PlausibleWeb do
       pipe_through :flags
       get "/teams/team/:team_id/usage", AdminController, :usage
+      get "/auth/user/:user_id/info", AdminController, :user_info
       get "/billing/team/:team_id/current_plan", AdminController, :current_plan
       get "/billing/search/team-by-id/:team_id", AdminController, :team_by_id
       post "/billing/search/team", AdminController, :team_search

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -100,7 +100,6 @@ defmodule PlausibleWeb.Router do
   on_ee do
     scope "/crm", PlausibleWeb do
       pipe_through :flags
-      get "/auth/user/:user_id/usage", AdminController, :usage
       get "/teams/team/:team_id/usage", AdminController, :usage
       get "/billing/user/:user_id/current_plan", AdminController, :current_plan
       get "/billing/search/user-by-id/:user_id", AdminController, :user_by_id

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -101,6 +101,7 @@ defmodule PlausibleWeb.Router do
     scope "/crm", PlausibleWeb do
       pipe_through :flags
       get "/auth/user/:user_id/usage", AdminController, :usage
+      get "/teams/team/:team_id/usage", AdminController, :usage
       get "/billing/user/:user_id/current_plan", AdminController, :current_plan
       get "/billing/search/user-by-id/:user_id", AdminController, :user_by_id
       post "/billing/search/user", AdminController, :user_search

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -5,7 +5,10 @@
 
   <div>
     <ul>
-      <li :for={team <- @teams} class={if team.current?, do: ["border-l m-2"], else: ["m-2"]}>
+      <li
+        :for={team <- @teams}
+        class={if team.current?, do: ["border-indigo-400 border-l-4 m-2"], else: ["m-2"]}
+      >
         <.unstyled_link
           method={if team.current?, do: "get", else: "post"}
           href={
@@ -14,7 +17,7 @@
               else: Routes.auth_path(@conn, :switch_team, team.identifier)
           }
         >
-          <div class="hover:bg-gray-700 p-4">
+          <div class="hover:bg-indigo-100 dark:hover:bg-gray-700 p-4">
             <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">
               {team.name}
             </p>

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -1,0 +1,29 @@
+<.focus_box>
+  <:title>Switch Team</:title>
+
+  <:subtitle>Switch your current team.</:subtitle>
+
+  <div>
+    <ul>
+      <li :for={team <- @teams} class={if team.current?, do: ["border-l m-2"], else: ["m-2"]}>
+        <.unstyled_link
+          method={if team.current?, do: "get", else: "post"}
+          href={
+            if team.current?,
+              do: "#",
+              else: Routes.auth_path(@conn, :switch_team, team.identifier)
+          }
+        >
+          <div class="hover:bg-gray-700 p-4">
+            <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">
+              {team.name}
+            </p>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+              Owner{if team.many_owners?, do: "s"}: {team.owners}
+            </p>
+          </div>
+        </.unstyled_link>
+      </li>
+    </ul>
+  </div>
+</.focus_box>

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -78,16 +78,24 @@
                         {@current_team.name}
                       </p>
                     </.dropdown_item>
-                    <.dropdown_item
-                      :if={@conn.assigns[:multiple_teams?]}
-                      href={Routes.auth_path(@conn, :select_team)}
-                    >
-                      Switch Team
-                    </.dropdown_item>
+
                     <.dropdown_divider />
                     <.dropdown_item href={Routes.settings_path(@conn, :index)}>
                       Account Settings
                     </.dropdown_item>
+
+                    <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
+                      <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
+                        <span class="flex-1">
+                          Create a Team
+                        </span>
+                        <span class="ml-1 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
+                          NEW
+                        </span>
+                      </.dropdown_item>
+                      <.dropdown_divider />
+                    </div>
+
                     <div :if={Plausible.Teams.enabled?(@my_team) and @my_team.setup_complete}>
                       <.dropdown_item
                         class="flex"
@@ -96,6 +104,12 @@
                         <span class="flex-1">
                           Team Settings
                         </span>
+                      </.dropdown_item>
+                      <.dropdown_item
+                        :if={@conn.assigns[:multiple_teams?]}
+                        href={Routes.auth_path(@conn, :select_team)}
+                      >
+                        Switch Team
                       </.dropdown_item>
                       <.dropdown_divider />
                     </div>
@@ -130,18 +144,6 @@
                     >
                       Github Repo
                     </.dropdown_item>
-                    <.dropdown_divider />
-                    <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
-                      <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
-                        <span class="flex-1">
-                          Create a Team
-                        </span>
-                        <span class="ml-1 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
-                          NEW
-                        </span>
-                      </.dropdown_item>
-                      <.dropdown_divider />
-                    </div>
                     <.dropdown_item href="/logout">Log Out</.dropdown_item>
                   </:menu>
                 </.dropdown>

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -72,6 +72,18 @@
                         {@conn.assigns[:current_user].email}
                       </p>
                     </.dropdown_item>
+                    <.dropdown_item :if={@conn.assigns[:multiple_teams?]}>
+                      <div class="text-xs text-gray-500 dark:text-gray-400">Team</div>
+                      <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">
+                        {@current_team.name}
+                      </p>
+                    </.dropdown_item>
+                    <.dropdown_item
+                      :if={@conn.assigns[:multiple_teams?]}
+                      href={Routes.auth_path(@conn, :select_team)}
+                    >
+                      Switch Team
+                    </.dropdown_item>
                     <.dropdown_divider />
                     <.dropdown_item href={Routes.settings_path(@conn, :index)}>
                       Account Settings

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -12,7 +12,7 @@
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={Map.get(assigns, :is_at_limit, false)}
       current_user={@current_user}
-      billable_user={@site.owner}
+      billable_user={List.first(@site.owners)}
       current_team={@site_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
       resource="team members"

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -13,7 +13,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      billable_user={@site.owner}
+      billable_user={List.first(@site.owners)}
       current_user={@current_user}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Funnels}

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -14,7 +14,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      billable_user={@site.owner}
+      billable_user={List.first(@site.owners)}
       current_user={@current_user}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Props}

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -48,7 +48,10 @@
               must upgrade their subscription plan in order to
               unlock the stats.
             </p>
-            <div class="mt-6 text-sm text-gray-500">
+            <div
+              :if={not Plausible.Teams.enabled?(@conn.assigns[:my_team])}
+              class="mt-6 text-sm text-gray-500"
+            >
               <p>Want to pay for this site with the account you're logged in with?</p>
               <p class="mt-1">
                 Contact {List.first(@site.owners).email} and ask them to

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -44,14 +44,14 @@
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
               This dashboard is currently locked and cannot be accessed. The site owner
-              <b>{@site.owner.email}</b>
+              <b>{List.first(@site.owners).email}</b>
               must upgrade their subscription plan in order to
               unlock the stats.
             </p>
             <div class="mt-6 text-sm text-gray-500">
               <p>Want to pay for this site with the account you're logged in with?</p>
               <p class="mt-1">
-                Contact {@site.owner.email} and ask them to
+                Contact {List.first(@site.owners).email} and ask them to
                 <.styled_link href="https://plausible.io/docs/transfer-ownership" new_tab={true}>
                   transfer the ownership
                 </.styled_link>

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -134,16 +134,19 @@ defmodule PlausibleWeb.UserAuth do
         inner_join: u in assoc(us, :user),
         as: :user,
         left_join: tm in assoc(u, :team_memberships),
-        # NOTE: whenever my_team.subscription is used to prevent user action, we must check whether the team association is ownership.
-        # Otherwise regular members will be limited by team owner in cases like deleting their own account.
+        # NOTE: whenever my_team.subscription is used to prevent user action,
+        # we must check whether the team association is ownership.
+        # Otherwise regular members will be limited by team owner in cases
+        # like deleting their own account.
         on: tm.role != :guest,
         left_join: t in assoc(tm, :team),
         as: :team,
+        left_join: o in assoc(t, :owners),
         left_lateral_join: ts in subquery(last_team_subscription_query),
         on: true,
         where: us.token == ^token and us.timeout_at > ^now,
         order_by: t.id,
-        preload: [user: {u, team_memberships: {tm, team: {t, subscription: ts}}}]
+        preload: [user: {u, team_memberships: {tm, team: {t, subscription: ts, owners: o}}}]
       )
 
     case Repo.one(token_query) do

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -142,6 +142,7 @@ defmodule PlausibleWeb.UserAuth do
         left_lateral_join: ts in subquery(last_team_subscription_query),
         on: true,
         where: us.token == ^token and us.timeout_at > ^now,
+        order_by: t.id,
         preload: [user: {u, team_memberships: {tm, team: {t, subscription: ts}}}]
       )
 

--- a/lib/workers/accept_traffic_until_notification.ex
+++ b/lib/workers/accept_traffic_until_notification.ex
@@ -26,14 +26,14 @@ defmodule Plausible.Workers.AcceptTrafficUntil do
     # send at most one notification per user, per day
     sent_today_query =
       from s in "sent_accept_traffic_until_notifications",
-        where: s.user_id == parent_as(:user).id and s.sent_on == ^today,
+        where: s.user_id == parent_as(:users).id and s.sent_on == ^today,
         select: true
 
     notifications =
       Repo.all(
         from t in Plausible.Teams.Team,
-          inner_join: u in assoc(t, :owner),
-          as: :user,
+          inner_join: u in assoc(t, :owners),
+          as: :users,
           inner_join: s in assoc(t, :sites),
           where: t.accept_traffic_until == ^tomorrow or t.accept_traffic_until == ^next_week,
           where: not exists(sent_today_query),

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -40,7 +40,7 @@ defmodule Plausible.Workers.CheckUsage do
       Repo.all(
         from(t in Teams.Team,
           as: :team,
-          inner_join: o in assoc(t, :owner),
+          inner_join: o in assoc(t, :owners),
           inner_lateral_join: s in subquery(Teams.last_subscription_join_query()),
           on: true,
           left_join: ep in Plausible.Billing.EnterprisePlan,
@@ -58,7 +58,7 @@ defmodule Plausible.Workers.CheckUsage do
             least(day_of_month(s.last_bill_date), day_of_month(last_day_of_month(^yesterday))) ==
               day_of_month(^yesterday),
           order_by: t.id,
-          preload: [subscription: s, enterprise_plan: ep, owner: o]
+          preload: [subscription: s, enterprise_plan: ep, owners: o]
         )
       )
 
@@ -110,8 +110,10 @@ defmodule Plausible.Workers.CheckUsage do
         suggested_plan =
           Plausible.Billing.Plans.suggest(subscriber, pageview_usage.last_cycle.total)
 
-        PlausibleWeb.Email.over_limit_email(subscriber.owner, pageview_usage, suggested_plan)
-        |> Plausible.Mailer.send()
+        for owner <- subscriber.owners do
+          PlausibleWeb.Email.over_limit_email(owner, pageview_usage, suggested_plan)
+          |> Plausible.Mailer.send()
+        end
 
         Plausible.Teams.start_grace_period(subscriber)
 
@@ -129,13 +131,15 @@ defmodule Plausible.Workers.CheckUsage do
         nil
 
       {{_, pageview_usage}, {_, {site_usage, site_allowance}}} ->
-        PlausibleWeb.Email.enterprise_over_limit_internal_email(
-          subscriber.owner,
-          pageview_usage,
-          site_usage,
-          site_allowance
-        )
-        |> Plausible.Mailer.send()
+        for owner <- subscriber.owners do
+          PlausibleWeb.Email.enterprise_over_limit_internal_email(
+            owner,
+            pageview_usage,
+            site_usage,
+            site_allowance
+          )
+          |> Plausible.Mailer.send()
+        end
 
         Plausible.Teams.start_manual_lock_grace_period(subscriber)
     end

--- a/lib/workers/notify_annual_renewal.ex
+++ b/lib/workers/notify_annual_renewal.ex
@@ -25,7 +25,7 @@ defmodule Plausible.Workers.NotifyAnnualRenewal do
       Repo.all(
         from t in Teams.Team,
           as: :team,
-          inner_join: o in assoc(t, :owner),
+          inner_join: o in assoc(t, :owners),
           inner_lateral_join: s in subquery(Teams.last_subscription_join_query()),
           on: true,
           left_join: sent in ^sent_notification,
@@ -35,29 +35,38 @@ defmodule Plausible.Workers.NotifyAnnualRenewal do
           where:
             s.next_bill_date > fragment("now()::date") and
               s.next_bill_date <= fragment("now()::date + INTERVAL '7 days'"),
-          preload: [owner: o, subscription: s]
+          preload: [owners: o, subscription: s]
       )
 
     for team <- teams do
       case team.subscription.status do
         Subscription.Status.active() ->
-          template = PlausibleWeb.Email.yearly_renewal_notification(team)
-          Plausible.Mailer.send(template)
+          for owner <- team.owners do
+            template = PlausibleWeb.Email.yearly_renewal_notification(team, owner)
+            Plausible.Mailer.send(template)
+          end
 
         Subscription.Status.deleted() ->
-          template = PlausibleWeb.Email.yearly_expiration_notification(team)
-          Plausible.Mailer.send(template)
+          for owner <- team.owners do
+            template = PlausibleWeb.Email.yearly_expiration_notification(team, owner)
+            Plausible.Mailer.send(template)
+          end
 
         _ ->
-          Sentry.capture_message("Invalid subscription for renewal", team: team, user: team.owner)
+          Sentry.capture_message("Invalid subscription for renewal",
+            team: team,
+            user: List.first(team.owner)
+          )
       end
 
-      Repo.insert_all("sent_renewal_notifications", [
-        %{
-          user_id: team.owner.id,
-          timestamp: NaiveDateTime.utc_now()
-        }
-      ])
+      for owner <- team.owners do
+        Repo.insert_all("sent_renewal_notifications", [
+          %{
+            user_id: owner.id,
+            timestamp: NaiveDateTime.utc_now()
+          }
+        ])
+      end
     end
 
     :ok

--- a/lib/workers/send_trial_notifications.ex
+++ b/lib/workers/send_trial_notifications.ex
@@ -14,34 +14,34 @@ defmodule Plausible.Workers.SendTrialNotifications do
     teams =
       Repo.all(
         from t in Teams.Team,
-          inner_join: o in assoc(t, :owner),
+          inner_join: o in assoc(t, :owners),
           left_join: s in assoc(t, :subscription),
           where: not is_nil(t.trial_expiry_date),
           where: is_nil(s.id),
           order_by: t.inserted_at,
-          preload: [owner: o]
+          preload: [owners: o]
       )
 
     for team <- teams do
       case Date.diff(team.trial_expiry_date, Date.utc_today()) do
         7 ->
           if Teams.has_active_sites?(team) do
-            send_one_week_reminder(team.owner)
+            send_one_week_reminder(team.owners)
           end
 
         1 ->
           if Teams.has_active_sites?(team) do
-            send_tomorrow_reminder(team.owner, team)
+            send_tomorrow_reminder(team.owners, team)
           end
 
         0 ->
           if Teams.has_active_sites?(team) do
-            send_today_reminder(team.owner, team)
+            send_today_reminder(team.owners, team)
           end
 
         -1 ->
           if Teams.has_active_sites?(team) do
-            send_over_reminder(team.owner)
+            send_over_reminder(team.owners)
           end
 
         _ ->
@@ -52,27 +52,37 @@ defmodule Plausible.Workers.SendTrialNotifications do
     :ok
   end
 
-  defp send_one_week_reminder(user) do
-    PlausibleWeb.Email.trial_one_week_reminder(user)
-    |> Plausible.Mailer.send()
+  defp send_one_week_reminder(users) do
+    for user <- users do
+      PlausibleWeb.Email.trial_one_week_reminder(user)
+      |> Plausible.Mailer.send()
+    end
   end
 
-  defp send_tomorrow_reminder(user, team) do
+  defp send_tomorrow_reminder(users, team) do
     usage = Plausible.Teams.Billing.usage_cycle(team, :last_30_days)
+    suggested_plan = Plausible.Billing.Plans.suggest(team, usage.total)
 
-    PlausibleWeb.Email.trial_upgrade_email(user, "tomorrow", usage)
-    |> Plausible.Mailer.send()
+    for user <- users do
+      PlausibleWeb.Email.trial_upgrade_email(user, "tomorrow", usage, suggested_plan)
+      |> Plausible.Mailer.send()
+    end
   end
 
-  defp send_today_reminder(user, team) do
+  defp send_today_reminder(users, team) do
     usage = Plausible.Teams.Billing.usage_cycle(team, :last_30_days)
+    suggested_plan = Plausible.Billing.Plans.suggest(team, usage.total)
 
-    PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
-    |> Plausible.Mailer.send()
+    for user <- users do
+      PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
+      |> Plausible.Mailer.send()
+    end
   end
 
-  defp send_over_reminder(user) do
-    PlausibleWeb.Email.trial_over_email(user)
-    |> Plausible.Mailer.send()
+  defp send_over_reminder(users) do
+    for user <- users do
+      PlausibleWeb.Email.trial_over_email(user)
+      |> Plausible.Mailer.send()
+    end
   end
 end

--- a/test/plausible/auth/auth_test.exs
+++ b/test/plausible/auth/auth_test.exs
@@ -64,6 +64,15 @@ defmodule Plausible.AuthTest do
       assert {:error, :upgrade_required} =
                Auth.create_api_key(user, "my new key", Ecto.UUID.generate())
     end
+
+    test "creates a key for user on a growth plan when they are an owner of more than one team" do
+      user = new_user() |> subscribe_to_growth_plan()
+      another_site = new_site()
+      add_member(another_site.team, user: user, role: :owner)
+
+      assert {:ok, %Auth.ApiKey{}} =
+               Auth.create_api_key(user, "my new key", Ecto.UUID.generate())
+    end
   end
 
   describe "delete_api_key/2" do

--- a/test/plausible/billing/enterprise_plan_admin_test.exs
+++ b/test/plausible/billing/enterprise_plan_admin_test.exs
@@ -9,10 +9,12 @@ defmodule Plausible.Billing.EnterprisePlanAdminTest do
 
   test "sanitizes number inputs and whitespace" do
     user = new_user()
+    _site = new_site(owner: user)
+    team = team_of(user)
 
     changeset =
       EnterprisePlanAdmin.create_changeset(%EnterprisePlan{}, %{
-        "user_id" => to_string(user.id),
+        "team_id" => to_string(team.id),
         "paddle_plan_id" => " . 123456 ",
         "billing_interval" => "monthly",
         "monthly_pageview_limit" => "100,000,000",
@@ -34,10 +36,12 @@ defmodule Plausible.Billing.EnterprisePlanAdminTest do
 
   test "scrubs empty attrs" do
     user = new_user()
+    _site = new_site(owner: user)
+    team = team_of(user)
 
     changeset =
       EnterprisePlanAdmin.create_changeset(%EnterprisePlan{}, %{
-        "user_id" => to_string(user.id),
+        "team_id" => to_string(team.id),
         "paddle_plan_id" => " ,.     ",
         "billing_interval" => "monthly",
         "monthly_pageview_limit" => "100,000,000",

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -62,7 +62,7 @@ defmodule Plausible.HelpScoutTest do
         crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team.id}"
 
         owned_sites_url =
-          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(email)}"
+          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(team.identifier)}"
 
         assert {:ok,
                 %{
@@ -412,7 +412,7 @@ defmodule Plausible.HelpScoutTest do
         crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team.id}"
 
         owned_sites_url =
-          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(email)}"
+          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(team.identifier)}"
 
         assert {:ok,
                 %{
@@ -451,7 +451,7 @@ defmodule Plausible.HelpScoutTest do
         crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team2.id}"
 
         owned_sites_url =
-          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(user2.email)}"
+          "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(team2.identifier)}"
 
         assert {:ok,
                 %{

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -55,10 +55,11 @@ defmodule Plausible.HelpScoutTest do
 
     describe "get_details_for_customer/2" do
       test "returns details for user on trial" do
-        %{id: user_id, email: email} = new_user(trial_expiry_date: Date.utc_today())
+        %{email: email} = user = new_user(trial_expiry_date: Date.utc_today())
         stub_help_scout_requests(email)
+        team = team_of(user)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/auth/user/#{user_id}"
+        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team.id}"
 
         owned_sites_url =
           "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(email)}"
@@ -405,9 +406,10 @@ defmodule Plausible.HelpScoutTest do
 
     describe "get_details_for_emails/2" do
       test "returns details for user and persists mapping" do
-        %{id: user_id, email: email} = new_user(trial_expiry_date: Date.utc_today())
+        %{email: email} = user = new_user(trial_expiry_date: Date.utc_today())
+        team = team_of(user)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/auth/user/#{user_id}"
+        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team.id}"
 
         owned_sites_url =
           "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(email)}"
@@ -444,8 +446,9 @@ defmodule Plausible.HelpScoutTest do
         user2 = new_user()
         new_site(owner: user2)
         new_site(owner: user2)
+        team2 = team_of(user2)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/auth/user/#{user2.id}"
+        crm_url = "#{PlausibleWeb.Endpoint.url()}/crm/teams/team/#{team2.id}"
 
         owned_sites_url =
           "#{PlausibleWeb.Endpoint.url()}/crm/sites/site?custom_search=#{URI.encode_www_form(user2.email)}"

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -89,6 +89,64 @@ defmodule Plausible.Site.AdminTest do
                action.(conn, [site], %{"email" => current_owner.email})
     end
 
+    test "the provided team identifier must be valid UUID format", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
+      today = Date.utc_today()
+      current_owner = new_user()
+      site = new_site(owner: current_owner)
+
+      new_owner =
+        new_user()
+        |> subscribe_to_growth_plan(last_bill_date: Date.shift(today, day: -5))
+
+      assert {:error, "The provided team identifier is invalid"} =
+               action.(conn, [site], %{"email" => new_owner.email, "team_id" => "invalid"})
+    end
+
+    test "new owner must be owner on a single team if no team identifier provided", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
+      today = Date.utc_today()
+      current_owner = new_user()
+      site = new_site(owner: current_owner)
+
+      new_owner =
+        new_user()
+        |> subscribe_to_growth_plan(last_bill_date: Date.shift(today, day: -5))
+
+      another_site = new_site()
+      add_member(another_site.team, user: new_owner, role: :owner)
+
+      assert {:error, "The new owner owns more than one team"} =
+               action.(conn, [site], %{"email" => new_owner.email})
+    end
+
+    test "new owner must be permitted to add sites in the selected team", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
+      today = Date.utc_today()
+      current_owner = new_user()
+      site = new_site(owner: current_owner)
+
+      new_owner =
+        new_user()
+        |> subscribe_to_growth_plan(last_bill_date: Date.shift(today, day: -5))
+
+      another_site = new_site()
+      new_team = another_site.team
+      add_member(new_team, user: new_owner, role: :viewer)
+
+      assert {:error, "The new owner can't add sites in the selected team"} =
+               action.(conn, [site], %{
+                 "email" => new_owner.email,
+                 "team_id" => new_team.identifier
+               })
+    end
+
     @tag :ee_only
     test "new owner's plan must accommodate the transferred site", %{
       conn: conn,
@@ -125,6 +183,33 @@ defmodule Plausible.Site.AdminTest do
       site2 = new_site(owner: current_owner)
 
       assert :ok = action.(conn, [site1, site2], %{"email" => new_owner.email})
+    end
+
+    test "executes ownership transfer for multiple sites in one action for provided team", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
+      today = Date.utc_today()
+      current_owner = new_user()
+
+      new_owner = new_user()
+
+      another_owner =
+        new_user()
+        |> subscribe_to_growth_plan(last_bill_date: Date.shift(today, day: -5))
+
+      another_site = new_site(owner: another_owner)
+      another_team = another_site.team
+      add_member(another_team, user: new_owner, role: :admin)
+
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert :ok =
+               action.(conn, [site1, site2], %{
+                 "email" => new_owner.email,
+                 "team_id" => another_team.identifier
+               })
     end
   end
 end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -46,6 +46,67 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert_team_membership(new_owner, site2.team, :owner)
     end
 
+    test "does not allow transferring ownership without selecting team for owner of more than one team" do
+      new_owner = new_user() |> subscribe_to_growth_plan()
+
+      other_site1 = new_site()
+      add_member(other_site1.team, user: new_owner, role: :owner)
+      other_site2 = new_site()
+      add_member(other_site2.team, user: new_owner, role: :owner)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:error, :multiple_teams} =
+               AcceptInvitation.bulk_transfer_ownership_direct(
+                 [site1, site2],
+                 new_owner
+               )
+    end
+
+    test "does not allow transferring ownership to a team where user has no permission" do
+      other_owner = new_user() |> subscribe_to_growth_plan()
+      other_team = team_of(other_owner)
+      new_owner = new_user()
+      add_member(other_team, user: new_owner, role: :viewer)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:error, :permission_denied} =
+               AcceptInvitation.bulk_transfer_ownership_direct(
+                 [site1, site2],
+                 new_owner,
+                 other_team
+               )
+    end
+
+    test "allows transferring ownership to a team where user has permission" do
+      other_owner = new_user() |> subscribe_to_growth_plan()
+      other_team = team_of(other_owner)
+      new_owner = new_user()
+      add_member(other_team, user: new_owner, role: :admin)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:ok, _} =
+               AcceptInvitation.bulk_transfer_ownership_direct(
+                 [site1, site2],
+                 new_owner,
+                 other_team
+               )
+
+
+      assert Repo.reload(site1).team_id == other_team.id
+      assert_guest_membership(other_team, site1, current_owner, :editor)
+      assert Repo.reload(site2).team_id == other_team.id
+      assert_guest_membership(other_team, site2, current_owner, :editor)
+    end
+
     @tag :ee_only
     test "does not allow transferring ownership to a non-member user when at team members limit" do
       old_owner = new_user() |> subscribe_to_business_plan()
@@ -356,6 +417,56 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
         refute Repo.reload(transfer)
       end
+    end
+
+    test "does not allow transferring ownership without selecting team for owner of more than one team" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: old_owner)
+
+      site1 = new_site()
+      add_member(site1.team, user: new_owner, role: :owner)
+      site2 = new_site()
+      add_member(site2.team, user: new_owner, role: :owner)
+
+      transfer = invite_transfer(site, new_owner, inviter: old_owner)
+
+      assert {:error, :multiple_teams} =
+               AcceptInvitation.accept_invitation(transfer.transfer_id, new_owner)
+    end
+
+    test "does not allow transferring ownership to a team where user has no permission" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: old_owner)
+
+      another_site = new_site()
+      another_team = another_site.team
+      add_member(another_team, user: new_owner, role: :viewer)
+
+      transfer = invite_transfer(site, new_owner, inviter: old_owner)
+
+      assert {:error, :permission_denied} =
+               AcceptInvitation.accept_invitation(transfer.transfer_id, new_owner, another_team)
+    end
+
+    test "allows transferring ownership to a team where user has permission" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user()
+      site = new_site(owner: old_owner)
+
+      another_owner = new_user() |> subscribe_to_growth_plan()
+      another_site = new_site(owner: another_owner)
+      another_team = another_site.team
+      add_member(another_team, user: new_owner, role: :admin)
+
+      transfer = invite_transfer(site, new_owner, inviter: old_owner)
+
+      assert {:ok, _} =
+               AcceptInvitation.accept_invitation(transfer.transfer_id, new_owner, another_team)
+
+      assert_guest_membership(another_team, site, old_owner, :editor)
+      assert Repo.reload(site).team_id == another_team.id
     end
 
     @tag :ee_only

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -220,7 +220,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
     end
 
     for role <- @roles do
-      test "does not allow accepting invite by a member of another team (role: #{role})" do
+      test "does allow accepting invite by a member of another team (role: #{role})" do
         user = new_user()
         _site = new_site(owner: user)
         team = team_of(user)
@@ -229,7 +229,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
         invitation = invite_member(team, member, inviter: user, role: unquote(role))
 
-        assert {:error, :already_other_team_member} =
+        assert {:ok, _} =
                  AcceptInvitation.accept_invitation(invitation.invitation_id, member)
       end
     end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -100,7 +100,6 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                  other_team
                )
 
-
       assert Repo.reload(site1).team_id == other_team.id
       assert_guest_membership(other_team, site1, current_owner, :editor)
       assert Repo.reload(site2).team_id == other_team.id

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -6,6 +6,217 @@ defmodule Plausible.TeamsTest do
   alias Plausible.Teams
   alias Plausible.Repo
 
+  describe "get_or_create/1" do
+    test "creates 'My Team' if user is a member of none" do
+      today = Date.utc_today()
+      user = new_user()
+      user_id = user.id
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.name == "My Team"
+      assert Date.compare(team.trial_expiry_date, today) == :gt
+
+      assert [
+               %{user_id: ^user_id, role: :owner, is_autocreated: true}
+             ] = Repo.preload(team, :team_memberships).team_memberships
+    end
+
+    test "returns existing 'My Team' if user already owns one" do
+      user = new_user(trial_expiry_date: ~D[2020-04-01])
+      user_id = user.id
+      existing_team = team_of(user)
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.id == existing_team.id
+      assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+
+      assert [
+               %{user_id: ^user_id, role: :owner, is_autocreated: true}
+             ] = Repo.preload(team, :team_memberships).team_memberships
+    end
+
+    test "returns existing owned team even if explicitly assigned as owner" do
+      user = new_user()
+      user_id = user.id
+      site = new_site()
+      existing_team = site.team
+      add_member(existing_team, user: user, role: :owner)
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.id == existing_team.id
+
+      assert [
+               %{role: :owner},
+               %{user_id: ^user_id, role: :owner, is_autocreated: false}
+             ] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+               |> Enum.sort_by(& &1.id)
+    end
+
+    test "creates 'My Team' if user is a guest on another team" do
+      user = new_user()
+      user_id = user.id
+      site = new_site()
+      existing_team = site.team
+      add_guest(site, user: user, role: :editor)
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.id != existing_team.id
+
+      assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+    end
+
+    test "creates 'My Team' if user is a non-owner member on existing teams" do
+      user = new_user()
+      user_id = user.id
+      site1 = new_site()
+      team1 = site1.team
+      site2 = new_site()
+      team2 = site2.team
+      add_member(team1, user: user, role: :viewer)
+      add_member(team2, user: user, role: :editor)
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.id != team1.id
+      assert team.id != team2.id
+
+      assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+    end
+
+    test "returns existing owned team if user is also a non-owner member on existing teams" do
+      user = new_user()
+      _site = new_site(owner: user)
+      user_id = user.id
+      owned_team = team_of(user)
+      site1 = new_site()
+      team1 = site1.team
+      site2 = new_site()
+      team2 = site2.team
+      add_member(team1, user: user, role: :viewer)
+      add_member(team2, user: user, role: :editor)
+
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.id == owned_team.id
+
+      assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+    end
+
+    test "returns error if user is an owner of more than one team already" do
+      user = new_user()
+      site1 = new_site()
+      team1 = site1.team
+      site2 = new_site()
+      team2 = site2.team
+      add_member(team1, user: user, role: :owner)
+      add_member(team2, user: user, role: :owner)
+
+      assert {:error, :multiple_teams} = Teams.get_or_create(user)
+    end
+  end
+
+  describe "get_by_owner/1" do
+    test "returns error if user does not own any team" do
+      user = new_user()
+
+      assert {:error, :no_team} = Teams.get_by_owner(user)
+    end
+
+    test "returns error if user does not exist anymore" do
+      user = new_user()
+      _site = new_site(owner: user)
+      Repo.delete!(user)
+
+      assert {:error, :no_team} = Teams.get_by_owner(user)
+    end
+
+    test "returns existing 'My Team' if user already owns one" do
+      user = new_user(trial_expiry_date: ~D[2020-04-01])
+      user_id = user.id
+      existing_team = team_of(user)
+
+      assert {:ok, team} = Teams.get_by_owner(user)
+
+      assert team.id == existing_team.id
+      assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+
+      assert [
+               %{user_id: ^user_id, role: :owner, is_autocreated: true}
+             ] = Repo.preload(team, :team_memberships).team_memberships
+    end
+
+    test "returns existing owned team if explicitly assigned as owner" do
+      user = new_user()
+      user_id = user.id
+      site = new_site()
+      existing_team = site.team
+      add_member(existing_team, user: user, role: :owner)
+
+      assert {:ok, team} = Teams.get_by_owner(user)
+
+      assert team.id == existing_team.id
+
+      assert [
+               %{role: :owner},
+               %{user_id: ^user_id, role: :owner, is_autocreated: false}
+             ] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+               |> Enum.sort_by(& &1.id)
+    end
+
+    test "returns existing owned team if user is also a non-owner member on existing teams" do
+      user = new_user()
+      _site = new_site(owner: user)
+      user_id = user.id
+      owned_team = team_of(user)
+      site1 = new_site()
+      team1 = site1.team
+      site2 = new_site()
+      team2 = site2.team
+      add_member(team1, user: user, role: :viewer)
+      add_member(team2, user: user, role: :editor)
+
+      assert {:ok, team} = Teams.get_by_owner(user)
+
+      assert team.id == owned_team.id
+
+      assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
+               team
+               |> Repo.preload(:team_memberships)
+               |> Map.fetch!(:team_memberships)
+    end
+
+    test "returns error if user is an owner of more than one team" do
+      user = new_user()
+      site1 = new_site()
+      team1 = site1.team
+      site2 = new_site()
+      team2 = site2.team
+      add_member(team1, user: user, role: :owner)
+      add_member(team2, user: user, role: :owner)
+
+      assert {:error, :multiple_teams} = Teams.get_by_owner(user)
+    end
+  end
+
   describe "trial_days_left" do
     test "is 30 days for new signup" do
       user = new_user(trial_expiry_date: Teams.Team.trial_expiry())

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -4,26 +4,30 @@ defmodule PlausibleWeb.AdminControllerTest do
 
   alias Plausible.Repo
 
-  describe "GET /crm/auth/user/:user_id/usage" do
-    setup [:create_user, :log_in]
+  describe "GET /crm/teams/team/:team_id/usage" do
+    setup [:create_user, :log_in, :create_team]
 
     @tag :ee_only
     test "returns 403 if the logged in user is not a super admin", %{conn: conn} do
-      conn = get(conn, "/crm/auth/user/1/usage")
+      conn = get(conn, "/crm/teams/team/1/usage")
       assert response(conn, 403) == "Not allowed"
     end
 
     @tag :ee_only
-    test "returns usage data as a standalone page", %{conn: conn, user: user} do
+    test "returns usage data as a standalone page", %{conn: conn, user: user, team: team} do
       patch_env(:super_admin_user_ids, [user.id])
-      conn = get(conn, "/crm/auth/user/#{user.id}/usage")
+      conn = get(conn, "/crm/teams/team/#{team.id}/usage")
       assert response(conn, 200) =~ "<html"
     end
 
     @tag :ee_only
-    test "returns usage data in embeddable form when requested", %{conn: conn, user: user} do
+    test "returns usage data in embeddable form when requested", %{
+      conn: conn,
+      user: user,
+      team: team
+    } do
       patch_env(:super_admin_user_ids, [user.id])
-      conn = get(conn, "/crm/auth/user/#{user.id}/usage?embed=true")
+      conn = get(conn, "/crm/teams/team/#{team.id}/usage?embed=true")
       refute response(conn, 200) =~ "<html"
     end
   end

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -106,23 +106,25 @@ defmodule PlausibleWeb.AdminControllerTest do
 
     @tag :ee_only
     test "returns 403 if the logged in user is not a super admin", %{conn: conn} do
-      conn = get(conn, "/crm/billing/user/0/current_plan")
+      conn = get(conn, "/crm/billing/team/0/current_plan")
       assert response(conn, 403) == "Not allowed"
     end
 
     @tag :ee_only
-    test "returns empty state for non-existent user", %{conn: conn, user: user} do
+    test "returns empty state for non-existent team", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 
-      conn = get(conn, "/crm/billing/user/0/current_plan")
+      conn = get(conn, "/crm/billing/team/0/current_plan")
       assert json_response(conn, 200) == %{"features" => []}
     end
 
     @tag :ee_only
     test "returns empty state for user without subscription", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
+      _site = new_site(owner: user)
+      team = team_of(user)
 
-      conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
+      conn = get(conn, "/crm/billing/team/#{team.id}/current_plan")
       assert json_response(conn, 200) == %{"features" => []}
     end
 
@@ -135,7 +137,9 @@ defmodule PlausibleWeb.AdminControllerTest do
 
       subscribe_to_plan(user, "does-not-exist")
 
-      conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
+      team = team_of(user)
+
+      conn = get(conn, "/crm/billing/team/#{team.id}/current_plan")
       assert json_response(conn, 200) == %{"features" => []}
     end
 
@@ -144,8 +148,9 @@ defmodule PlausibleWeb.AdminControllerTest do
       patch_env(:super_admin_user_ids, [user.id])
 
       subscribe_to_plan(user, "857104")
+      team = team_of(user)
 
-      conn = get(conn, "/crm/billing/user/#{user.id}/current_plan")
+      conn = get(conn, "/crm/billing/team/#{team.id}/current_plan")
 
       assert json_response(conn, 200) == %{
                "features" => ["goals"],

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -567,6 +567,23 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                } = json_response(conn, 200)
       end
 
+      test "returns sites scoped to a given team for full memberships", %{conn: conn, user: user} do
+        _owned_site = new_site(owner: user)
+        other_site = new_site()
+        add_guest(other_site, user: user, role: :viewer)
+        other_team_site = new_site()
+        add_member(other_team_site.team, user: user, role: :viewer)
+
+        conn = get(conn, "/api/v1/sites?team_id=" <> other_team_site.team.identifier)
+
+        assert_matches %{
+                         "sites" => [
+                           %{"domain" => ^other_team_site.domain},
+                           %{"domain" => ^other_site.domain}
+                         ]
+                       } = json_response(conn, 200)
+      end
+
       test "handles pagination correctly", %{conn: conn, user: user} do
         [
           %{domain: site1_domain},

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -610,6 +610,62 @@ defmodule PlausibleWeb.AuthControllerTest do
       assert Repo.get(Plausible.Site, viewer_site.id)
       refute Repo.get(Plausible.Site, owner_site.id)
     end
+
+    test "refuses to delete user when an only owner of a setup team", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      site.team
+      |> Plausible.Teams.Team.setup_changeset()
+      |> Repo.update!()
+
+      conn = delete(conn, "/me")
+
+      assert redirected_to(conn, 302) == Routes.settings_path(conn, :danger_zone)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "You can't delete your account when you are the only owner on a team"
+
+      assert Repo.reload(user)
+    end
+
+    test "refuses to delete user when an only owner of multiple setup teams", %{
+      conn: conn,
+      user: user,
+      site: site
+    } do
+      site.team
+      |> Plausible.Teams.Team.setup_changeset()
+      |> Repo.update!()
+
+      another_owner = new_user()
+      another_site = new_site(owner: another_owner)
+      add_member(another_site.team, user: user, role: :owner)
+      Repo.delete!(another_owner)
+
+      conn = delete(conn, "/me")
+
+      assert redirected_to(conn, 302) == Routes.settings_path(conn, :danger_zone)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "You can't delete your account when you are the only owner on a team"
+
+      assert Repo.reload(user)
+    end
+
+    test "allows to delete user when not the only owner of a setup team", %{
+      conn: conn,
+      user: user
+    } do
+      another_owner = new_user()
+      another_site = new_site(owner: another_owner)
+      add_member(another_site.team, user: user, role: :owner)
+
+      delete(conn, "/me")
+
+      refute Repo.reload(user)
+    end
   end
 
   describe "GET /auth/google/callback" do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -256,6 +256,21 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html_response(conn, 200) =~ "can&#39;t be blank"
     end
 
+    test "fails to create site when not allowed to in selected team", %{conn: conn, user: user} do
+      site = new_site()
+      add_member(site.team, user: user, role: :viewer)
+
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "domain" => "example.com",
+            "timezone" => "Europe/London"
+          }
+        })
+
+      assert html_response(conn, 200) =~ "You are not permitted to add sites in the current team"
+    end
+
     test "starts trial if user does not have trial yet", %{conn: conn, user: user} do
       refute team_of(user)
 

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -287,8 +287,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     } do
       {:ok, site} = Plausible.Props.allow(site, ["author"])
 
-      site = Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       populate_stats(site, [
         build(:pageview, "meta.key": ["author"], "meta.value": ["a"]),
@@ -315,8 +315,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     } do
       {:ok, site} = Plausible.Props.allow(site, ["author"])
 
-      site = Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       populate_stats(site, [
         build(:pageview, "meta.key": ["author"], "meta.value": ["a"])

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -999,7 +999,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       user: user
     } do
       user
-      |> Plausible.Auth.User.changeset(%{trial_expiry_date: nil})
+      |> team_of()
+      |> Ecto.Changeset.change(trial_expiry_date: nil)
       |> Repo.update!()
 
       {:ok, lv, _doc} = get_liveview(conn)

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -88,8 +88,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
 
     @tag :ee_only
     test "growth", %{conn: conn, site: site, token: token} do
-      site = Plausible.Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       resp =
         conn

--- a/test/plausible_web/plugins/api/controllers/custom_props_test.exs
+++ b/test/plausible_web/plugins/api/controllers/custom_props_test.exs
@@ -42,8 +42,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CustomPropsTest do
       token: token,
       conn: conn
     } do
-      site = Plausible.Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       url = Routes.plugins_api_custom_props_url(PlausibleWeb.Endpoint, :enable)
 
@@ -66,8 +66,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CustomPropsTest do
       token: token,
       conn: conn
     } do
-      site = Plausible.Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       url = Routes.plugins_api_custom_props_url(PlausibleWeb.Endpoint, :enable)
 

--- a/test/plausible_web/plugins/api/controllers/funnels_test.exs
+++ b/test/plausible_web/plugins/api/controllers/funnels_test.exs
@@ -249,8 +249,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.FunnelsTest do
       end
 
       test "fails for insufficient plan", %{conn: conn, token: token, site: site} do
-        site = Plausible.Repo.preload(site, :owner)
-        subscribe_to_growth_plan(site.owner)
+        [owner | _] = Plausible.Repo.preload(site, :owners).owners
+        subscribe_to_growth_plan(owner)
 
         url = Routes.plugins_api_funnels_url(PlausibleWeb.Endpoint, :create)
 

--- a/test/plausible_web/plugins/api/controllers/goals_test.exs
+++ b/test/plausible_web/plugins/api/controllers/goals_test.exs
@@ -53,8 +53,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
       token: token,
       conn: conn
     } do
-      site = Plausible.Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       url = Routes.plugins_api_goals_url(PlausibleWeb.Endpoint, :create)
 
@@ -79,8 +79,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.GoalsTest do
       token: token,
       conn: conn
     } do
-      site = Plausible.Repo.preload(site, :owner)
-      subscribe_to_growth_plan(site.owner)
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+      subscribe_to_growth_plan(owner)
 
       url = Routes.plugins_api_goals_url(PlausibleWeb.Endpoint, :create)
 

--- a/test/plausible_web/plugs/authorize_public_api_test.exs
+++ b/test/plausible_web/plugs/authorize_public_api_test.exs
@@ -63,6 +63,30 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   end
 
   @tag :ee_only
+  test "halts with error when site's team lacks feature access", %{conn: conn} do
+    user = new_user()
+    _site = new_site(owner: user)
+    api_key = insert(:api_key, user: user)
+
+    another_owner =
+      new_user() |> subscribe_to_enterprise_plan(paddle_plan_id: "123321", features: [])
+
+    another_site = new_site(owner: another_owner)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/", %{"site_id" => another_site.domain})
+      |> assign(:api_scope, "stats:read:*")
+      |> AuthorizePublicAPI.call(nil)
+
+    assert conn.halted
+
+    assert json_response(conn, 402)["error"] =~
+             "The account that owns this API key does not have access"
+  end
+
+  @tag :ee_only
   test "halts with error when upgrade is required", %{conn: conn} do
     user = new_user() |> subscribe_to_enterprise_plan(paddle_plan_id: "123321", features: [])
     site = new_site(owner: user)

--- a/test/workers/send_trial_notifications_test.exs
+++ b/test/workers/send_trial_notifications_test.exs
@@ -62,6 +62,7 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
       user = new_user(trial_expiry_date: Date.utc_today() |> Date.shift(day: 1))
       site = new_site(owner: user)
       usage = %{total: 3, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
       populate_stats(site, [
         build(:pageview),
@@ -71,13 +72,16 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
 
       perform_job(SendTrialNotifications, %{})
 
-      assert_delivered_email(PlausibleWeb.Email.trial_upgrade_email(user, "tomorrow", usage))
+      assert_delivered_email(
+        PlausibleWeb.Email.trial_upgrade_email(user, "tomorrow", usage, suggested_plan)
+      )
     end
 
     test "sends an upgrade email the day the trial ends" do
       user = new_user(trial_expiry_date: Date.utc_today())
       site = new_site(owner: user)
       usage = %{total: 3, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
       populate_stats(site, [
         build(:pageview),
@@ -87,14 +91,18 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
 
       perform_job(SendTrialNotifications, %{})
 
-      assert_delivered_email(PlausibleWeb.Email.trial_upgrade_email(user, "today", usage))
+      assert_delivered_email(
+        PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
+      )
     end
 
     test "does not include custom event note if user has not used custom events" do
       user = new_user(trial_expiry_date: Date.utc_today())
+      site = new_site(owner: user)
       usage = %{total: 9_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
 
       assert email.html_body =~
                "In the last month, your account has used 9,000 billable pageviews."
@@ -102,9 +110,11 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
 
     test "includes custom event note if user has used custom events" do
       user = new_user(trial_expiry_date: Date.utc_today())
+      site = new_site(owner: user)
       usage = %{total: 9_100, custom_events: 100}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
 
       assert email.html_body =~
                "In the last month, your account has used 9,100 billable pageviews and custom events in total."
@@ -146,82 +156,102 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
   describe "Suggested plans" do
     test "suggests 10k/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 9_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 10k/mo plan."
     end
 
     test "suggests 100k/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 90_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 100k/mo plan."
     end
 
     test "suggests 200k/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 180_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 200k/mo plan."
     end
 
     test "suggests 500k/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 450_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 500k/mo plan."
     end
 
     test "suggests 1m/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 900_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 1M/mo plan."
     end
 
     test "suggests 2m/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 1_800_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 2M/mo plan."
     end
 
     test "suggests 5m/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 4_500_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 5M/mo plan."
     end
 
     test "suggests 10m/mo plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 9_000_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "we recommend you select a 10M/mo plan."
     end
 
     test "does not suggest a plan above that" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 20_000_000, custom_events: 0}
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "please reply back to this email to get a quote for your volume"
     end
 
     test "does not suggest a plan when user is switching to an enterprise plan" do
       user = new_user()
+      site = new_site(owner: user)
       usage = %{total: 10_000, custom_events: 0}
       subscribe_to_enterprise_plan(user, paddle_plan_id: "enterprise-plan-id")
+      suggested_plan = Plausible.Billing.Plans.suggest(site.team, usage.total)
 
-      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage)
+      email = PlausibleWeb.Email.trial_upgrade_email(user, "today", usage, suggested_plan)
       assert email.html_body =~ "please reply back to this email to get a quote for your volume"
     end
   end


### PR DESCRIPTION
This PR addresses enabling support for following across the whole application:

- more than one user as an owner of a single team
- more than one non-guest membership per user

Summary of changes:

- Teams are exposed in CRM now and all team related fields were moved there from User CRM with a link to it
- Enterprise Plan CRM refers to team directly as well now though the team is still searchable via owner's name or email; the workarounds for limited Kaffy association selection are left in place because default way of using team name only when listing and looking up are not sufficient; A faulty feature selection prefill on enterprise plan create was fixed BTW
- The Editor role is now checked for consistently across all `AuthorizeSiteAccess` calls instead of implicit translation of legacy `Admin` in the input roles to `Editor`
- Team is now can now be explicitly provided during site creation service. In Sites API it's exposed as an optional argument, `team_id` (required though if user is an owner on more than one team already). If the argument is not passed, an implicit team is used or created if there isn't one already. In case of adding a website from the dashboard, a currently selected team is used. The controller action has an option to accept "team_id" but it's not exposed in the UI yet; This leads to a problematic corner case mentioned below
- User deletion is prevented when user is the only owner on a setup team; the handling logic will be extended in a follow-up
- API key provisioning is checked against Stats API availability only if the user is an owner of at most 1 team; otherwise, they are allowed to create the API regardless of feature availability on any of the owned teams; The feature availability is checked at the time the key is used anyway; We may consider removing the check at the provisioning time entirely - currently it's only preserved for "legacy" behavior
- notification emails directed at site or team owner are now sent to all owners at once, if there's more than one
- when handling Paddle webhook for subscription creation for a user without a team yet (a case of non-member user with pending site ownership transfer), we always default to creating a new "My Team" even if there are an owner on existing one to avoid ending up with 2 active subscriptions on one existing team
- site invitation accept routine is now passed a team the user is currently switched to. This is only relevant for site ownership transfer; the transfer will be attempted with a current team (and will fail early if permissions are insufficient)
- when checking team member usage quota, only one owner is subtracted from the usage calculation even there are multiple
- when site transfer ownership is executed, all existing owners are added as guest editors to the transferred site (if they aren't members on the other team already)
- direct site ownership transfer from CRM is now accepting optional "Team Identifier" for gracefully handling cases of users owning more than one team; the identifier is exposed in Teams CRM when viewing a particular team
- there's a team switcher in the upper right menu now; the currently switched team is stored in session cookie; the switcher is only shown when user is team member on more than one team
- there are now 3 assigns populated by `AuthPlug` and `AuthContext` - `my_team` (existing), `current_team` and `multiple_teams?`; `multiple_teams?` is a flag used to determine whether to show the team switcher in the upper menu; `current_team` is a team set via team switcher and stored under `current_team_id` in session cookie; if there's none set, it falls back to `my_team`; `my_team` is either the same as `current_team` is user's team role is `owner` or the first found team where the user is an owner otherwise - they may differ
- Listing sites via /sites is now scoping the list with current team; That applies to only full memberships -  sites where user is a guest and guest invitations are all visible regardless of which team the user is currently switched to
- Listing sites via Sites API has an option to scope via team identifier with `team_id` parameter

There still is a number of corner cases to consider, most likely in a follow-up:

- HelpScout integration implicitly falls back on the first team found owned by a user when they are an owner of more than one team; the integration will probably get extended with a way to list those teams and let support folks switch easily between them
- Notes exposed in HelpScout integration are still on user only; it will probably make sense to have them on a team as well
- when trying to create a site as a viewer member of another team (without any other team membership, including implicit one), the user is basically locked out of creating a team of their own until the are removed from the current one; We might want to provide an "exit hatch" where, on failed attempt, we suggest user an option to create a site under their own account
- team Identifier is not yet explicitly exposed anywhere; given Sites API has now ability use it, the identifier should be exposed somehow - via Team Switcher in the UI and/or with additional endpoint in Sites API
- ~when a user has their own implicit team and gets added as a team member to another team, when switched to their team, they still see CTA option and can't access team member management until they complete it. It feels a bit weird but maybe it's fine?~ Leaving it as is for now.
- ~the /sites view still lists all sites the user has access to, regardless of which team they are switched to; the view will probably be scoped to the currently switched team, though the Sites API endpoint should probably still list everything, with an optional team ID parameter?~ Added
- ~add ability to choose team to transfer ownership to in CRM~

## TODO

- [x] set `is_autocreated` to `false` either on role downgrade or team membership upsert where role is downgraded (or at least double-check the implications of leaving it on)
- [x] hide team switcher when there's only one team to choose from
- [x] list owned teams in user CRM edit form for easy navigation
- [x] add as view-only team CRM  edit form: subscription plan, subscription status, grace period
- [x] properly enable lookup by team identifier in Enterprise Plan CRM edit picker
- [ ] more manual testing, possibly extending automated test suite

### Changes

Depends on https://github.com/plausible/analytics/pull/5004

### Tests
- [x] Automated tests have been added

