### PR TITLE
Refactor including imports in stats queries

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -62,13 +62,7 @@ defmodule Plausible.Site do
     field :invitations, {:array, :map}, virtual: true
     field :pinned_at, :naive_datetime, virtual: true
 
-    # Used for caching imports data for the duration of the whole request
-    # to avoid multiple identical fetches. Populated by plugs putting
-    # `site` in `assigns`.
-    field :import_data_loaded, :boolean, default: false, virtual: true
-    field :earliest_import_start_date, :date, virtual: true
-    field :latest_import_end_date, :date, virtual: true
-    field :complete_import_ids, {:array, :integer}, default: [], virtual: true
+    has_many :completed_imports, Plausible.Imported.SiteImport, where: [status: :completed]
 
     timestamps()
   end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -231,11 +231,9 @@ defmodule Plausible.Sites do
   end
 
   def stats_start_date(%Site{} = site) do
-    site = Plausible.Imported.load_import_data(site)
-
     start_date =
       [
-        site.earliest_import_start_date,
+        Plausible.Imported.earliest_import_start_date(site),
         native_stats_start_date(site)
       ]
       |> Enum.reject(&is_nil/1)

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Stats.Aggregate do
   """
 
   use Plausible.ClickhouseRepo
-  alias Plausible.Stats.{Query, QueryRunner, QueryOptimizer}
+  alias Plausible.Stats.{Query, QueryRunner, QueryResult, QueryOptimizer}
 
   def aggregate(site, query, metrics) do
     Query.trace(query, metrics)
@@ -16,19 +16,20 @@ defmodule Plausible.Stats.Aggregate do
       |> Query.set(metrics: metrics, remove_unavailable_revenue_metrics: true)
       |> QueryOptimizer.optimize()
 
-    query_result = QueryRunner.run(site, query)
+    %QueryResult{results: [entry], meta: meta} = QueryRunner.run(site, query)
 
-    [entry] = query_result.results
+    results =
+      query.metrics
+      |> Enum.with_index()
+      |> Enum.map(fn {metric, index} ->
+        {
+          metric,
+          metric_map(entry, index, metric)
+        }
+      end)
+      |> Enum.into(%{})
 
-    query.metrics
-    |> Enum.with_index()
-    |> Enum.map(fn {metric, index} ->
-      {
-        metric,
-        metric_map(entry, index, metric)
-      }
-    end)
-    |> Enum.into(%{})
+    %{results: results, meta: meta}
   end
 
   def metric_map(

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -175,21 +175,11 @@ defmodule Plausible.Stats.Comparisons do
 
   defp maybe_include_imported(query, source_query) do
     requested? = source_query.include.imports
+    skip_imported_reason = Query.get_skip_imported_reason(query)
 
-    case Query.ensure_include_imported(query, requested?) do
-      :ok ->
-        struct!(query,
-          include_imported: true,
-          skip_imported_reason: nil,
-          include: Map.put(query.include, :imports, true)
-        )
-
-      {:error, reason} ->
-        struct!(query,
-          include_imported: false,
-          skip_imported_reason: reason,
-          include: Map.put(query.include, :imports, requested?)
-        )
-    end
+    struct!(query,
+      include_imported: requested? and is_nil(skip_imported_reason),
+      skip_imported_reason: skip_imported_reason
+    )
   end
 end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -7,6 +7,11 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   @default_include %{
     imports: false,
+    # `include.imports_meta` can be true even when `include.imports`
+    # is false. Even if we don't want to include imported data, we
+    # might still want to know whether imported data can be toggled
+    # on/off on the dashboard.
+    imports_meta: false,
     time_labels: false,
     total_rows: false,
     comparisons: nil

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -29,7 +29,6 @@ defmodule Plausible.Stats.GoalSuggestions do
     site =
       site
       |> Repo.preload(:goals)
-      |> Plausible.Imported.load_import_data()
 
     excluded =
       opts
@@ -62,7 +61,7 @@ defmodule Plausible.Stats.GoalSuggestions do
     imported_q =
       from(i in "imported_custom_events",
         where: i.site_id == ^site.id,
-        where: i.import_id in ^site.complete_import_ids,
+        where: i.import_id in ^Plausible.Imported.complete_import_ids(site),
         where: i.date >= ^date_range.first and i.date <= ^date_range.last,
         where: i.visitors > 0,
         where: fragment("? ilike ?", i.name, ^matches),

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -60,7 +60,7 @@ defmodule Plausible.Stats.Imported.Base do
   end
 
   def query_imported(table, site, query) do
-    import_ids = site.complete_import_ids
+    import_ids = Imported.complete_import_ids(site)
     # Assumption: dates in imported table are in user-local timezone.
     %{first: date_from, last: date_to} = Query.date_range(query)
 

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -26,8 +26,8 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_parsed_filters(params)
       |> preload_goals_and_revenue(site)
       |> put_order_by(params)
-      |> put_include_comparisons(site, params)
-      |> Query.put_imported_opts(site, params)
+      |> put_include(site, params)
+      |> Query.put_imported_opts(site)
 
     on_ee do
       query = Plausible.Stats.Sampling.put_threshold(query, site, params)
@@ -205,9 +205,10 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     end
   end
 
-  defp put_include_comparisons(query, site, params) do
-    comparisons = parse_comparison_params(site, params)
-    struct!(query, include: Map.put(query.include, :comparisons, comparisons))
+  defp put_include(query, site, params) do
+    query
+    |> Query.set_include(:comparisons, parse_comparison_params(site, params))
+    |> Query.set_include(:imports, params["with_imported"] == "true")
   end
 
   @doc """

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -128,7 +128,7 @@ defmodule Plausible.Stats.Query do
 
     latest_import_end_date =
       if site do
-        site.latest_import_end_date
+        Plausible.Imported.latest_import_end_date(site)
       else
         query.latest_import_end_date
       end

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -35,7 +35,7 @@ defmodule Plausible.Stats.Query do
     with {:ok, query_data} <- Filters.QueryParser.parse(site, schema_type, params) do
       query =
         struct!(__MODULE__, Map.to_list(query_data))
-        |> put_imported_opts(site, %{})
+        |> put_imported_opts(site)
         |> struct!(
           now: DateTime.utc_now(:second),
           debug_metadata: debug_metadata,
@@ -120,11 +120,11 @@ defmodule Plausible.Stats.Query do
   end
 
   defp refresh_imported_opts(query) do
-    put_imported_opts(query, nil, %{})
+    put_imported_opts(query, nil)
   end
 
-  def put_imported_opts(query, site, params) do
-    requested? = params["with_imported"] == "true" || query.include.imports
+  def put_imported_opts(query, site) do
+    requested? = query.include.imports
 
     latest_import_end_date =
       if site do
@@ -135,46 +135,33 @@ defmodule Plausible.Stats.Query do
 
     query = struct!(query, latest_import_end_date: latest_import_end_date)
 
-    case ensure_include_imported(query, requested?) do
-      :ok ->
-        struct!(query,
-          include_imported: true,
-          include: Map.put(query.include, :imports, true)
-        )
+    skip_imported_reason = get_skip_imported_reason(query)
 
-      {:error, reason} ->
-        struct!(query,
-          include_imported: false,
-          skip_imported_reason: reason,
-          include: Map.put(query.include, :imports, requested?)
-        )
-    end
+    struct!(query,
+      include_imported: requested? and is_nil(skip_imported_reason),
+      skip_imported_reason: skip_imported_reason
+    )
   end
 
-  @spec ensure_include_imported(t(), boolean()) ::
-          :ok | {:error, :no_imported_data | :out_of_range | :unsupported_query | :not_requested}
-  def ensure_include_imported(query, requested?) do
+  @spec get_skip_imported_reason(t()) ::
+          nil | :no_imported_data | :out_of_range | :unsupported_query
+  def get_skip_imported_reason(query) do
     cond do
-      not requested? ->
-        {:error, :not_requested}
-
       is_nil(query.latest_import_end_date) ->
-        {:error, :no_imported_data}
+        :no_imported_data
 
-      query.period in ["realtime", "30m"] ->
-        {:error, :unsupported_query}
+      query.period in ["realtime", "30m"] or
+          Date.after?(date_range(query).first, query.latest_import_end_date) ->
+        :out_of_range
 
       "time:minute" in query.dimensions or "time:hour" in query.dimensions ->
-        {:error, :unsupported_interval}
-
-      Date.after?(date_range(query).first, query.latest_import_end_date) ->
-        {:error, :out_of_range}
+        :unsupported_interval
 
       not Imported.schema_supports_query?(query) ->
-        {:error, :unsupported_query}
+        :unsupported_query
 
       true ->
-        :ok
+        nil
     end
   end
 

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -92,8 +92,6 @@ defmodule Plausible.Stats.QueryResult do
     end
   end
 
-  defp add_imports_meta(meta, _), do: meta
-
   defp add_metric_warnings_meta(meta, %QueryRunner{main_query: query}) do
     warnings = metric_warnings(query)
 

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Stats.QueryResult do
     struct!(
       __MODULE__,
       results: results,
-      meta: meta(runner),
+      meta: meta(runner) |> Enum.sort_by(&elem(&1, 0)) |> Jason.OrderedObject.new(),
       query:
         Jason.OrderedObject.new(
           site_id: site.domain,

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -8,7 +8,7 @@ defmodule Plausible.Stats.QueryResult do
   """
 
   use Plausible
-  alias Plausible.Stats.DateTimeRange
+  alias Plausible.Stats.{DateTimeRange, Query, QueryRunner}
 
   defstruct results: [],
             meta: %{},
@@ -19,11 +19,11 @@ defmodule Plausible.Stats.QueryResult do
 
   `results` should already-built by Plausible.Stats.QueryRunner
   """
-  def from(results, site, query, meta_extra) do
+  def from(%QueryRunner{site: site, main_query: query, results: results} = runner) do
     struct!(
       __MODULE__,
       results: results,
-      meta: meta(query, meta_extra),
+      meta: meta(runner),
       query:
         Jason.OrderedObject.new(
           site_id: site.domain,
@@ -41,6 +41,14 @@ defmodule Plausible.Stats.QueryResult do
     )
   end
 
+  defp meta(%QueryRunner{} = runner) do
+    %{}
+    |> add_imports_meta(runner)
+    |> add_metric_warnings_meta(runner)
+    |> add_time_labels_meta(runner.main_query)
+    |> add_total_rows_meta(runner.main_query, runner.total_rows)
+  end
+
   @imports_warnings %{
     unsupported_query:
       "Imported stats are not included in the results because query parameters are not supported. " <>
@@ -49,21 +57,67 @@ defmodule Plausible.Stats.QueryResult do
       "Imported stats are not included because the time dimension (i.e. the interval) is too short."
   }
 
-  defp meta(query, meta_extra) do
-    %{
-      imports_included: if(query.include.imports, do: query.include_imported, else: nil),
-      imports_skip_reason:
-        if(query.include.imports and query.skip_imported_reason,
-          do: to_string(query.skip_imported_reason)
-        ),
-      imports_warning: @imports_warnings[query.skip_imported_reason],
-      metric_warnings: metric_warnings(query),
-      time_labels:
-        if(query.include.time_labels, do: Plausible.Stats.Time.time_labels(query), else: nil),
-      total_rows: if(query.include.total_rows, do: meta_extra.total_rows, else: nil)
-    }
-    |> Enum.reject(fn {_, value} -> is_nil(value) end)
-    |> Map.new()
+  defp add_imports_meta(meta, %QueryRunner{} = runner) do
+    %{main_query: %{include: include} = main_query} = runner
+
+    if include.imports or include[:imports_meta] do
+      comparison_query = Map.get(runner, :comparison_query)
+
+      imports_included =
+        case comparison_query do
+          %Query{include_imported: true} -> true
+          _ -> main_query.include_imported
+        end
+
+      imports_skip_reason =
+        case comparison_query do
+          %Query{skip_imported_reason: nil} -> nil
+          _ -> main_query.skip_imported_reason
+        end
+
+      imports_warning =
+        if imports_skip_reason in Map.keys(@imports_warnings) do
+          @imports_warnings[imports_skip_reason]
+        end
+
+      %{
+        imports_included: imports_included,
+        imports_skip_reason: imports_skip_reason,
+        imports_warning: imports_warning
+      }
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.merge(meta)
+    else
+      meta
+    end
+  end
+
+  defp add_imports_meta(meta, _), do: meta
+
+  defp add_metric_warnings_meta(meta, %QueryRunner{main_query: query}) do
+    warnings = metric_warnings(query)
+
+    if map_size(warnings) > 0 do
+      Map.put(meta, :metric_warnings, warnings)
+    else
+      meta
+    end
+  end
+
+  defp add_time_labels_meta(meta, query) do
+    if query.include.time_labels do
+      Map.put(meta, :time_labels, Plausible.Stats.Time.time_labels(query))
+    else
+      meta
+    end
+  end
+
+  defp add_total_rows_meta(meta, query, total_rows) do
+    if query.include.total_rows do
+      Map.put(meta, :total_rows, total_rows)
+    else
+      meta
+    end
   end
 
   defp include(query) do
@@ -80,7 +134,18 @@ defmodule Plausible.Stats.QueryResult do
     end
   end
 
+  defp metric_warnings(query) do
+    Enum.reduce(query.metrics, %{}, fn metric, acc ->
+      case metric_warning(metric, query) do
+        nil -> acc
+        %{} = warning -> Map.put(acc, metric, warning)
+      end
+    end)
+  end
+
   on_ee do
+    @revenue_metrics Plausible.Stats.Goal.Revenue.revenue_metrics()
+
     @revenue_metrics_warnings %{
       revenue_goals_unavailable:
         "The owner of this site does not have access to the revenue metrics feature.",
@@ -90,25 +155,19 @@ defmodule Plausible.Stats.QueryResult do
         "Revenue metrics are null as there are no matching revenue goals."
     }
 
-    defp metric_warnings(query) do
+    defp metric_warning(metric, query) when metric in @revenue_metrics do
       if query.revenue_warning do
-        query.metrics
-        |> Enum.filter(&(&1 in Plausible.Stats.Goal.Revenue.revenue_metrics()))
-        |> Enum.map(
-          &{&1,
-           %{
-             code: query.revenue_warning,
-             warning: @revenue_metrics_warnings[query.revenue_warning]
-           }}
-        )
-        |> Map.new()
+        %{
+          code: query.revenue_warning,
+          warning: @revenue_metrics_warnings[query.revenue_warning]
+        }
       else
         nil
       end
     end
-  else
-    defp metric_warnings(_query), do: nil
   end
+
+  defp metric_warning(_metric, _query), do: nil
 
   defp to_iso8601(datetime, timezone) do
     datetime

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -75,10 +75,7 @@ defmodule Plausible.Stats.QueryResult do
           _ -> main_query.skip_imported_reason
         end
 
-      imports_warning =
-        if imports_skip_reason in Map.keys(@imports_warnings) do
-          @imports_warnings[imports_skip_reason]
-        end
+      imports_warning = @imports_warnings[imports_skip_reason]
 
       %{
         imports_included: imports_included,

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -378,16 +378,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     "The goal `#{goal}` is not configured for this site. "
   end
 
-  defp maybe_add_warning(payload, %{imports_skip_reason: :unsupported_query}) do
-    Map.put(
-      payload,
-      :warning,
-      "Imported stats are not included in the results because query parameters are not supported. " <>
-        "For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats"
-    )
-  end
+  @imported_query_unsupported_warning "Imported stats are not included in the results because query parameters are not supported. For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats"
 
-  defp maybe_add_warning(payload, _), do: payload
+  defp maybe_add_warning(payload, %Jason.OrderedObject{} = meta) do
+    case meta[:imports_skip_reason] do
+      :unsupported_query -> Map.put(payload, :warning, @imported_query_unsupported_warning)
+      _ -> payload
+    end
+  end
 
   defp send_json_error_response(conn, {:error, {status, msg}}) do
     conn

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -2,7 +2,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
   use PlausibleWeb, :controller
   use Plausible.Repo
   use PlausibleWeb.Plugs.ErrorHandler
-  alias Plausible.Stats.{Query, Compare, Comparisons, Metrics, Filters}
+  alias Plausible.Stats.{Query, Metrics, Filters}
 
   def realtime_visitors(conn, _params) do
     site = conn.assigns.site
@@ -20,28 +20,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do
-      results =
+      query =
         if params["compare"] == "previous_period" do
-          comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
-
-          [prev_result, curr_result] =
-            Plausible.ClickhouseRepo.parallel_tasks([
-              fn -> Plausible.Stats.aggregate(site, comparison_query, metrics) end,
-              fn -> Plausible.Stats.aggregate(site, query, metrics) end
-            ])
-
-          Enum.map(curr_result, fn {metric, %{value: current_val}} ->
-            %{value: prev_val} = prev_result[metric]
-            change = Compare.calculate_change(metric, prev_val, current_val)
-
-            {metric, %{value: current_val, change: change}}
-          end)
-          |> Enum.into(%{})
+          Query.set_include(query, :comparisons, %{mode: "previous_period"})
         else
-          Plausible.Stats.aggregate(site, query, metrics)
+          query
         end
 
-      payload = maybe_add_warning(%{results: results}, query)
+      %{results: results, meta: meta} = Plausible.Stats.aggregate(site, query, metrics)
+
+      payload = maybe_add_warning(%{results: results}, meta)
 
       json(conn, payload)
     else
@@ -61,8 +49,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          {:ok, limit} <- validate_or_default_limit(params),
          :ok <- ensure_custom_props_access(site, query) do
       page = String.to_integer(Map.get(params, "page", "1"))
-      results = Plausible.Stats.breakdown(site, query, metrics, {limit, page})
-      payload = maybe_add_warning(%{results: results}, query)
+
+      %{results: results, meta: meta} =
+        Plausible.Stats.breakdown(site, query, metrics, {limit, page})
+
+      payload = maybe_add_warning(%{results: results}, meta)
 
       json(conn, payload)
     else
@@ -387,12 +378,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
     "The goal `#{goal}` is not configured for this site. "
   end
 
-  defp maybe_add_warning(payload, %{skip_imported_reason: reason})
-       when reason in [nil, :not_requested, :no_imported_data, :out_of_range, :manual_exclusion] do
-    payload
-  end
-
-  defp maybe_add_warning(payload, %{skip_imported_reason: :unsupported_query}) do
+  defp maybe_add_warning(payload, %{imports_skip_reason: :unsupported_query}) do
     Map.put(
       payload,
       :warning,
@@ -400,6 +386,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
         "For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats"
     )
   end
+
+  defp maybe_add_warning(payload, _), do: payload
 
   defp send_json_error_response(conn, {:error, {status, msg}}) do
     conn

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.Api.StatsController do
       sample_percent: sample_percent,
       with_imported_switch: with_imported_switch_info(query, comparison_query),
       includes_imported: includes_imported?(query, comparison_query),
-      imports_exist: site.complete_import_ids != [],
+      imports_exist: Plausible.Imported.complete_import_ids(site) != [],
       comparing_from: query.include.comparisons && Query.date_range(comparison_query).first,
       comparing_to: query.include.comparisons && Query.date_range(comparison_query).last,
       from: Query.date_range(query).first,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -218,8 +218,8 @@ defmodule PlausibleWeb.Api.StatsController do
     })
   end
 
-  defp with_imported_switch_info(%{} = meta) do
-    case {meta.imports_included, meta[:imports_skip_reason]} do
+  defp with_imported_switch_info(%Jason.OrderedObject{} = meta) do
+    case {meta[:imports_included], meta[:imports_skip_reason]} do
       {true, nil} ->
         %{visible: true, togglable: true, tooltip_msg: "Click to exclude imported data"}
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -68,9 +68,6 @@ defmodule PlausibleWeb.Api.StatsController do
     * `includes_imported` - boolean indicating whether imported data
       was queried or not.
 
-    * `imports_exist` - boolean indicating whether there are any completed
-      imports for a given site or not.
-
     * `full_intervals` - map of dates indicating whether the interval has been
       cut off by the requested date range or not. For example, if looking at a
       month week-by-week, some weeks may be cut off by the month boundaries.
@@ -87,7 +84,6 @@ defmodule PlausibleWeb.Api.StatsController do
       "2021-11-01" => true,
       "2021-12-01" => false
     },
-    "imports_exist" => false,
     "interval" => "month",
     "labels" => ["2021-09-01", "2021-10-01", "2021-11-01", "2021-12-01"],
     "plot" => [0, 0, 0, 0],
@@ -207,7 +203,6 @@ defmodule PlausibleWeb.Api.StatsController do
       sample_percent: sample_percent,
       with_imported_switch: with_imported_switch_info(query, comparison_query),
       includes_imported: includes_imported?(query, comparison_query),
-      imports_exist: Plausible.Imported.complete_import_ids(site) != [],
       comparing_from: query.include.comparisons && Query.date_range(comparison_query).first,
       comparing_to: query.include.comparisons && Query.date_range(comparison_query).last,
       from: Query.date_range(query).first,

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -17,7 +17,6 @@ defmodule PlausibleWeb.Live.GoalSettings do
       |> assign_new(:site, fn %{current_user: current_user} ->
         current_user
         |> Plausible.Sites.get_for_user!(domain, [:owner, :admin, :super_admin])
-        |> Plausible.Imported.load_import_data()
       end)
       |> assign_new(:all_goals, fn %{site: site} ->
         Goals.for_site(site, preload_funnels?: true)

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -65,6 +65,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
          {:ok, site} <- find_site(conn.params["site_id"]),
          :ok <- verify_site_access(api_key, site) do
       Plausible.OpenTelemetry.add_site_attributes(site)
+      site = Plausible.Repo.preload(site, :completed_imports)
       {:ok, assign(conn, :site, site)}
     end
   end

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -65,7 +65,6 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
          {:ok, site} <- find_site(conn.params["site_id"]),
          :ok <- verify_site_access(api_key, site) do
       Plausible.OpenTelemetry.add_site_attributes(site)
-      site = Plausible.Imported.load_import_data(site)
       {:ok, assign(conn, :site, site)}
     end
   end

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -111,6 +111,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
           site
           |> Repo.preload([
             :owner,
+            :completed_imports,
             team: [subscription: Plausible.Teams.last_subscription_query()]
           ])
 

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -109,7 +109,6 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
 
         site =
           site
-          |> Plausible.Imported.load_import_data()
           |> Repo.preload([
             :owner,
             team: [subscription: Plausible.Teams.last_subscription_query()]

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -48,6 +48,14 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     last: DateTime.new!(~D[2021-05-31], ~T[23:59:59], "Etc/UTC")
   }
 
+  @default_include %{
+    imports: false,
+    imports_meta: false,
+    time_labels: false,
+    total_rows: false,
+    comparisons: nil
+  }
+
   def check_success(params, site, expected_result, schema_type \\ :public) do
     assert {:ok, result} = parse(site, schema_type, params, @now)
 
@@ -76,7 +84,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       }
 
@@ -111,7 +119,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -152,7 +160,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal
@@ -218,7 +226,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
             dimensions: [],
             order_by: nil,
             timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+            include: @default_include,
             pagination: %{limit: 10_000, offset: 0}
           },
           :internal
@@ -345,7 +353,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -370,7 +378,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
             dimensions: [],
             order_by: nil,
             timezone: site.timezone,
-            include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+            include: @default_include,
             pagination: %{limit: 10_000, offset: 0}
           })
         end
@@ -396,7 +404,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         })
       end
@@ -462,7 +470,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
 
@@ -481,7 +489,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -541,7 +549,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -582,7 +590,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal
@@ -653,7 +661,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -702,7 +710,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         })
       end
@@ -755,7 +763,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -781,7 +789,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -807,7 +815,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -833,7 +841,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -862,7 +870,13 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["time"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: true, time_labels: true, total_rows: true, comparisons: nil},
+        include: %{
+          imports: true,
+          imports_meta: false,
+          time_labels: true,
+          total_rows: true,
+          comparisons: nil
+        },
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -923,6 +937,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "previous_period"
             },
             imports: false,
+            imports_meta: false,
             time_labels: false,
             total_rows: false
           },
@@ -953,6 +968,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "year_over_year"
             },
             imports: false,
+            imports_meta: false,
             time_labels: false,
             total_rows: false
           },
@@ -985,6 +1001,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "custom",
               date_range: @date_range_30d
             },
+            imports_meta: false,
             imports: false,
             time_labels: false,
             total_rows: false
@@ -1045,7 +1062,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["time"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 100, offset: 200}
       })
     end
@@ -1095,7 +1112,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -1215,7 +1232,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal
@@ -1441,7 +1458,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:#{unquote(dimension)}"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         })
       end
@@ -1462,7 +1479,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["visit:#{unquote(dimension)}"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         })
       end
@@ -1482,7 +1499,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:props:foobar"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -1543,7 +1560,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: [{:events, :desc}, {:visitors, :asc}],
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -1563,7 +1580,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:name"],
         order_by: [{"event:name", :desc}],
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -1667,7 +1684,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -1696,7 +1713,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:goal"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -1725,7 +1742,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:goal"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -1789,7 +1806,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal
@@ -1812,7 +1829,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:page"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal
@@ -1837,7 +1854,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
       |> check_goals(
@@ -1896,7 +1913,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -1954,7 +1971,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -1988,7 +2005,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -2022,7 +2039,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -2056,7 +2073,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:goal"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -2092,7 +2109,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:goal"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -2130,7 +2147,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: ["event:goal"],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         }
       )
@@ -2173,7 +2190,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["visit:device"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -2205,7 +2222,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: ["event:page"],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -2224,7 +2241,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         dimensions: [],
         order_by: nil,
         timezone: site.timezone,
-        include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+        include: @default_include,
         pagination: %{limit: 10_000, offset: 0}
       })
     end
@@ -2433,7 +2450,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           dimensions: [],
           order_by: nil,
           timezone: site.timezone,
-          include: %{imports: false, time_labels: false, total_rows: false, comparisons: nil},
+          include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
         },
         :internal

--- a/test/plausible/stats/query_result_test.exs
+++ b/test/plausible/stats/query_result_test.exs
@@ -1,7 +1,7 @@
 defmodule Plausible.Stats.QueryResultTest do
   use Plausible.DataCase, async: true
   use Plausible.Teams.Test
-  alias Plausible.Stats.{Query, QueryResult, QueryOptimizer}
+  alias Plausible.Stats.{Query, QueryRunner, QueryResult, QueryOptimizer}
 
   setup do
     user = insert(:user)
@@ -33,7 +33,8 @@ defmodule Plausible.Stats.QueryResultTest do
     query = QueryOptimizer.optimize(query)
 
     query_result_json =
-      QueryResult.from([], site, query, %{})
+      %QueryRunner{site: site, results: [], main_query: query}
+      |> QueryResult.from()
       |> Jason.encode!(pretty: true)
       |> String.replace(site.domain, "dummy.site")
 

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -286,7 +286,7 @@ defmodule Plausible.Stats.QueryTest do
     test "is false in realtime even when imported data from today exists", %{site: site} do
       insert(:site_import, site: site)
 
-      assert %{include_imported: false, skip_imported_reason: :unsupported_query} =
+      assert %{include_imported: false, skip_imported_reason: :out_of_range} =
                Query.from(site, %{"period" => "realtime", "with_imported" => "true"})
     end
 

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -266,7 +266,6 @@ defmodule Plausible.Stats.QueryTest do
 
     test "is true when requested via params and imported data exists", %{site: site} do
       insert(:site_import, site: site)
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: true} =
                Query.from(site, %{"period" => "day", "with_imported" => "true"})
@@ -279,7 +278,6 @@ defmodule Plausible.Stats.QueryTest do
 
     test "is false when imported data exists but is out of the date range", %{site: site} do
       insert(:site_import, site: site, start_date: ~D[2021-01-01], end_date: ~D[2022-01-01])
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false, skip_imported_reason: :out_of_range} =
                Query.from(site, %{"period" => "day", "with_imported" => "true"})
@@ -287,7 +285,6 @@ defmodule Plausible.Stats.QueryTest do
 
     test "is false in realtime even when imported data from today exists", %{site: site} do
       insert(:site_import, site: site)
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false, skip_imported_reason: :unsupported_query} =
                Query.from(site, %{"period" => "realtime", "with_imported" => "true"})
@@ -295,7 +292,6 @@ defmodule Plausible.Stats.QueryTest do
 
     test "is false when an arbitrary custom property filter is used", %{site: site} do
       insert(:site_import, site: site)
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false, skip_imported_reason: :unsupported_query} =
                Query.from(site, %{
@@ -309,7 +305,6 @@ defmodule Plausible.Stats.QueryTest do
     test "is true when breaking down by url and filtering by outbound link or file download goal",
          %{site: site} do
       insert(:site_import, site: site)
-      site = Plausible.Imported.load_import_data(site)
 
       Enum.each(["Outbound Link: Click", "File Download"], fn goal_name ->
         insert(:goal, site: site, event_name: goal_name)
@@ -327,7 +322,6 @@ defmodule Plausible.Stats.QueryTest do
     test "is false when breaking down by url but without a special goal filter",
          %{site: site} do
       insert(:site_import, site: site)
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -341,7 +335,6 @@ defmodule Plausible.Stats.QueryTest do
          %{site: site} do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "404")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -356,7 +349,6 @@ defmodule Plausible.Stats.QueryTest do
          %{site: site} do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "Outbound Link: Click")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -376,7 +368,6 @@ defmodule Plausible.Stats.QueryTest do
            %{site: site} do
         insert(:site_import, site: site)
         insert(:goal, site: site, event_name: "Outbound Link: Click")
-        site = Plausible.Imported.load_import_data(site)
 
         assert %{include_imported: true} =
                  Query.from(site, %{
@@ -397,7 +388,6 @@ defmodule Plausible.Stats.QueryTest do
     } do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "Outbound Link: Click")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: true} =
                Query.from(site, %{
@@ -421,7 +411,6 @@ defmodule Plausible.Stats.QueryTest do
     } do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "Outbound Link: Click")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -441,7 +430,6 @@ defmodule Plausible.Stats.QueryTest do
          %{site: site} do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "404")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -460,7 +448,6 @@ defmodule Plausible.Stats.QueryTest do
          %{site: site} do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "Outbound Link: Click")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{
@@ -479,7 +466,6 @@ defmodule Plausible.Stats.QueryTest do
     test "is false with a custom prop filter and non-matching property", %{site: site} do
       insert(:site_import, site: site)
       insert(:goal, site: site, event_name: "Outbound Link: Click")
-      site = Plausible.Imported.load_import_data(site)
 
       assert %{include_imported: false} =
                Query.from(site, %{

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -378,10 +378,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "pageviews" => %{"value" => 3, "change" => 200},
-               "visitors" => %{"value" => 2, "change" => 100},
-               "bounce_rate" => %{"value" => 50, "change" => -50},
-               "visit_duration" => %{"value" => 750, "change" => 100}
+               "pageviews" => %{"value" => 3, "change" => 200, "comparison_value" => 1},
+               "visitors" => %{"value" => 2, "change" => 100, "comparison_value" => 1},
+               "bounce_rate" => %{"value" => 50, "change" => -50, "comparison_value" => 100},
+               "visit_duration" => %{"value" => 750, "change" => 100, "comparison_value" => 0}
              }
     end
 
@@ -409,10 +409,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "pageviews" => %{"value" => 4, "change" => 100},
-               "visitors" => %{"value" => 3, "change" => 100},
-               "bounce_rate" => %{"value" => 100, "change" => nil},
-               "visit_duration" => %{"value" => 0, "change" => 0}
+               "pageviews" => %{"value" => 4, "change" => 100, "comparison_value" => 0},
+               "visitors" => %{"value" => 3, "change" => 100, "comparison_value" => 0},
+               "bounce_rate" => %{"value" => 100, "change" => nil, "comparison_value" => 0},
+               "visit_duration" => %{"value" => 0, "change" => 0, "comparison_value" => 0}
              }
     end
 
@@ -441,7 +441,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "conversion_rate" => %{"value" => 50.0, "change" => 16.7}
+               "conversion_rate" => %{
+                 "value" => 50.0,
+                 "change" => 16.7,
+                 "comparison_value" => 33.3
+               }
              }
     end
 
@@ -466,7 +470,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "time_on_page" => %{"value" => 90, "change" => 50.0}
+               "time_on_page" => %{"value" => 90, "change" => 50.0, "comparison_value" => 60}
              }
     end
 
@@ -491,7 +495,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "time_on_page" => %{"value" => nil, "change" => nil}
+               "time_on_page" => %{"value" => nil, "change" => nil, "comparison_value" => 60}
              }
     end
   end
@@ -565,12 +569,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "visitors" => %{"value" => 2, "change" => 100},
-               "visits" => %{"value" => 5, "change" => 150},
-               "pageviews" => %{"value" => 9, "change" => -10},
-               "bounce_rate" => %{"value" => 40, "change" => -10},
-               "views_per_visit" => %{"value" => 1.8, "change" => -64},
-               "visit_duration" => %{"value" => 20, "change" => -80}
+               "visitors" => %{"value" => 2, "change" => 100, "comparison_value" => 1},
+               "visits" => %{"value" => 5, "change" => 150, "comparison_value" => 2},
+               "pageviews" => %{"value" => 9, "change" => -10, "comparison_value" => 10},
+               "bounce_rate" => %{"value" => 40, "change" => -10, "comparison_value" => 50},
+               "views_per_visit" => %{"value" => 1.8, "change" => -64, "comparison_value" => 5.0},
+               "visit_duration" => %{"value" => 20, "change" => -80, "comparison_value" => 100}
              }
     end
 
@@ -600,7 +604,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "visitors" => %{"value" => 1, "change" => -67}
+               "visitors" => %{"value" => 1, "change" => -67, "comparison_value" => 3}
              }
     end
 
@@ -629,7 +633,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{
-               "visitors" => %{"change" => 100, "value" => 1}
+               "visitors" => %{"change" => 100, "value" => 1, "comparison_value" => 0}
              }
 
       assert json_response(conn, 200)["warning"] =~

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1592,8 +1592,6 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       assert Enum.find(imports, &(&1.id == import_id))
 
-      site = Plausible.Imported.load_import_data(site)
-
       assert eventually(fn ->
                count = Plausible.Stats.Clickhouse.imported_pageview_count(site)
                {count == 22, count}


### PR DESCRIPTION
### Changes

This PR prepares the codebase with a refactor in order to make `SiteImport` structs available in stats queries. The plan is to use `SiteImport`s to decide whether or not `scroll_depth` gets included from imported data or not. This information will be included in `meta.metric_warnings`.

This PR also aims to move the logic of responding with imported flags (such as `imports_included` and `skip_imported_reason`) into a single place - `QueryResult`. The values for these fields depend on both `query` and `comparison_query` which this PR makes available in `QueryResult`. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
