### PR TITLE
Add a special goal: "WP Form Completions"

### DIFF
--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -15,7 +15,7 @@ export const SPECIAL_GOALS = {
   'Cloaked Link: Click': { title: 'Cloaked Links', prop: 'url' },
   'File Download': { title: 'File Downloads', prop: 'url' },
   'WP Search Queries': { title: 'WordPress Search Queries', prop: 'search_query' },
-  'WP Form Completion': { title: 'WordPress Form Completions', prop: 'path' },
+  'WP Form Completions': { title: 'WordPress Form Completions', prop: 'path' },
 }
 
 function getSpecialGoal(query) {

--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -15,6 +15,7 @@ export const SPECIAL_GOALS = {
   'Cloaked Link: Click': { title: 'Cloaked Links', prop: 'url' },
   'File Download': { title: 'File Downloads', prop: 'url' },
   'WP Search Queries': { title: 'WordPress Search Queries', prop: 'search_query' },
+  'WP Form Completion': { title: 'WordPress Form Completions', prop: 'form' },
 }
 
 function getSpecialGoal(query) {

--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -15,7 +15,7 @@ export const SPECIAL_GOALS = {
   'Cloaked Link: Click': { title: 'Cloaked Links', prop: 'url' },
   'File Download': { title: 'File Downloads', prop: 'url' },
   'WP Search Queries': { title: 'WordPress Search Queries', prop: 'search_query' },
-  'WP Form Completion': { title: 'WordPress Form Completions', prop: 'form' },
+  'WP Form Completion': { title: 'WordPress Form Completions', prop: 'path' },
 }
 
 function getSpecialGoal(query) {

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -52,8 +52,8 @@ defmodule Plausible.Imported do
   @spec imported_custom_props() :: [String.t()]
   def imported_custom_props do
     # NOTE: Keep up to date with `Plausible.Props.internal_keys/1`,
-    # but _ignore_ unsupported keys. Currently, `search_query` and
-    # `form` are not supported in imported queries.
+    # but _ignore_ unsupported keys. Currently, `search_query` is
+    # not supported in imported queries.
     Enum.map(~w(url path), &("event:props:" <> &1))
   end
 

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -36,7 +36,7 @@ defmodule Plausible.Imported do
   # Goals which can be filtered by url property
   @goals_with_url ["Outbound Link: Click", "Cloaked Link: Click", "File Download"]
   # Goals which can be filtered by path property
-  @goals_with_path ["404"]
+  @goals_with_path ["404", "WP Form Completion"]
 
   @spec schemas() :: [module()]
   def schemas, do: @tables

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -36,7 +36,7 @@ defmodule Plausible.Imported do
   # Goals which can be filtered by url property
   @goals_with_url ["Outbound Link: Click", "Cloaked Link: Click", "File Download"]
   # Goals which can be filtered by path property
-  @goals_with_path ["404", "WP Form Completion"]
+  @goals_with_path ["404", "WP Form Completions"]
 
   @spec schemas() :: [module()]
   def schemas, do: @tables

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -52,8 +52,8 @@ defmodule Plausible.Imported do
   @spec imported_custom_props() :: [String.t()]
   def imported_custom_props do
     # NOTE: Keep up to date with `Plausible.Props.internal_keys/1`,
-    # but _ignore_ unsupported keys. Currently, `search_query` is
-    # not supported in imported queries.
+    # but _ignore_ unsupported keys. Currently, `search_query` and
+    # `form` are not supported in imported queries.
     Enum.map(~w(url path), &("event:props:" <> &1))
   end
 

--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -17,7 +17,7 @@ defmodule Plausible.Props do
   def max_prop_value_length, do: @max_prop_value_length
 
   # NOTE: Keep up to date with `Plausible.Imported.imported_custom_props/0`.
-  @internal_keys ~w(url path search_query form)
+  @internal_keys ~w(url path search_query)
 
   @doc """
   Lists prop keys used internally.

--- a/lib/plausible/props.ex
+++ b/lib/plausible/props.ex
@@ -17,7 +17,7 @@ defmodule Plausible.Props do
   def max_prop_value_length, do: @max_prop_value_length
 
   # NOTE: Keep up to date with `Plausible.Imported.imported_custom_props/0`.
-  @internal_keys ~w(url path search_query)
+  @internal_keys ~w(url path search_query form)
 
   @doc """
   Lists prop keys used internally.

--- a/test/plausible/props_test.exs
+++ b/test/plausible/props_test.exs
@@ -277,7 +277,7 @@ defmodule Plausible.PropsTest do
         "meta.value": ["something", "12"]
       ),
       build(:event,
-        name: "WP Form Completion",
+        name: "WP Form Completions",
         "meta.key": ["path"],
         "meta.value": ["/contact"]
       )

--- a/test/plausible/props_test.exs
+++ b/test/plausible/props_test.exs
@@ -275,6 +275,11 @@ defmodule Plausible.PropsTest do
         name: "WP Search Queries",
         "meta.key": ["search_query", "result_count"],
         "meta.value": ["something", "12"]
+      ),
+      build(:event,
+        name: "WP Form Completion",
+        "meta.key": ["path"],
+        "meta.value": ["/contact"]
       )
     ])
 

--- a/test/plausible/props_test.exs
+++ b/test/plausible/props_test.exs
@@ -275,6 +275,11 @@ defmodule Plausible.PropsTest do
         name: "WP Search Queries",
         "meta.key": ["search_query", "result_count"],
         "meta.value": ["something", "12"]
+      ),
+      build(:event,
+        name: "WP Form Completion",
+        "meta.key": ["form"],
+        "meta.value": ["something"]
       )
     ])
 

--- a/test/plausible/props_test.exs
+++ b/test/plausible/props_test.exs
@@ -275,11 +275,6 @@ defmodule Plausible.PropsTest do
         name: "WP Search Queries",
         "meta.key": ["search_query", "result_count"],
         "meta.value": ["something", "12"]
-      ),
-      build(:event,
-        name: "WP Form Completion",
-        "meta.key": ["form"],
-        "meta.value": ["something"]
       )
     ])
 

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -1184,7 +1184,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
       :ok
     end
 
-    for special_prop <- ["url", "path", "search_query"] do
+    for special_prop <- Plausible.Props.internal_keys() do
       test "returns breakdown for the internally used #{special_prop} prop key", %{
         site: site,
         conn: conn

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -1184,7 +1184,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
       :ok
     end
 
-    for special_prop <- ["url", "path", "search_query", "form"] do
+    for special_prop <- ["url", "path", "search_query"] do
       test "returns breakdown for the internally used #{special_prop} prop key", %{
         site: site,
         conn: conn

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -1261,64 +1261,66 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
              ]
     end
 
-    test "returns path breakdown for 404 goal", %{conn: conn, site: site} do
-      insert(:goal, event_name: "404", site: site)
-      site_import = insert(:site_import, site: site)
+    for goal_name <- Plausible.Imported.goals_with_path() do
+      test "returns path breakdown for #{goal_name} goal", %{conn: conn, site: site} do
+        insert(:goal, event_name: unquote(goal_name), site: site)
+        site_import = insert(:site_import, site: site)
 
-      populate_stats(site, site_import.id, [
-        build(:event,
-          name: "404",
-          "meta.key": ["path"],
-          "meta.value": ["/some/path/first.bin"]
-        ),
-        build(:imported_custom_events,
-          name: "404",
-          visitors: 2,
-          events: 5,
-          path: "/some/path/first.bin"
-        ),
-        build(:imported_custom_events,
-          name: "404",
-          visitors: 5,
-          events: 10,
-          path: "/some/path/second.bin"
-        ),
-        build(:imported_custom_events,
-          name: "view_search_results",
-          visitors: 100,
-          events: 200
-        ),
-        build(:imported_visitors, visitors: 9)
-      ])
-
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["404"]]
+        populate_stats(site, site_import.id, [
+          build(:event,
+            name: unquote(goal_name),
+            "meta.key": ["path"],
+            "meta.value": ["/some/path/first.bin"]
+          ),
+          build(:imported_custom_events,
+            name: unquote(goal_name),
+            visitors: 2,
+            events: 5,
+            path: "/some/path/first.bin"
+          ),
+          build(:imported_custom_events,
+            name: unquote(goal_name),
+            visitors: 5,
+            events: 10,
+            path: "/some/path/second.bin"
+          ),
+          build(:imported_custom_events,
+            name: "view_search_results",
+            visitors: 100,
+            events: 200
+          ),
+          build(:imported_visitors, visitors: 9)
         ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/custom-prop-values/path?period=day&with_imported=true&filters=#{filters}"
-        )
+        filters =
+          Jason.encode!([
+            [:is, "event:goal", [unquote(goal_name)]]
+          ])
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "visitors" => 5,
-                 "name" => "/some/path/second.bin",
-                 "events" => 10,
-                 "conversion_rate" => 50.0
-               },
-               %{
-                 "visitors" => 3,
-                 "name" => "/some/path/first.bin",
-                 "events" => 6,
-                 "conversion_rate" => 30.0
-               }
-             ]
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/custom-prop-values/path?period=day&with_imported=true&filters=#{filters}"
+          )
+
+        assert json_response(conn, 200)["results"] == [
+                 %{
+                   "visitors" => 5,
+                   "name" => "/some/path/second.bin",
+                   "events" => 10,
+                   "conversion_rate" => 50.0
+                 },
+                 %{
+                   "visitors" => 3,
+                   "name" => "/some/path/first.bin",
+                   "events" => 6,
+                   "conversion_rate" => 30.0
+                 }
+               ]
+      end
     end
 
-    for goal_name <- ["Outbound Link: Click", "File Download", "Cloaked Link: Click"] do
+    for goal_name <- Plausible.Imported.goals_with_url() do
       test "returns url breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)


### PR DESCRIPTION
### Changes

https://3.basecamp.com/5308029/buckets/32037438/card_tables/cards/6013863433#__recording_8250028578

Adds a new special goal (`WP Form Completion`) with a special property (`path`). This will behave exactly the same as the `404` goal (that has the `path` property too):

* It will be included in the full Plausible CSV export (`imported_custom_events.csv`) with the `path` prop
* it will be included from imported data in stats queries if it exists (from imports where it doesn't, e.g. GA4, we will silently not return any data for this goal)
* In the dashboard, clicking on the goal in the goals breakdown, the "special goal contents" will pop up in the conversions tab:

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/48a9ddaa-b8b7-43b6-afbf-8b9c951398d7" />

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
