### PR TITLE
APIv2: validate combining event-only metrics with session-only dimensions

### DIFF
--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -592,7 +592,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   defp validate_metrics(query) do
     with :ok <- validate_list(query.metrics, &validate_metric(&1, query)) do
-      validate_no_metrics_filters_conflict(query)
+      TableDecider.validate_no_metrics_dimensions_conflict(query)
     end
   end
 
@@ -630,27 +630,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp validate_metric(_, _), do: :ok
-
-  defp validate_no_metrics_filters_conflict(query) do
-    {_event_metrics, sessions_metrics, _other_metrics} =
-      TableDecider.partition_metrics(query.metrics, query)
-
-    if Enum.empty?(sessions_metrics) or
-         not event_dimensions_not_allowing_session_metrics?(query.dimensions) do
-      :ok
-    else
-      {:error,
-       "Session metric(s) `#{sessions_metrics |> Enum.join(", ")}` cannot be queried along with event dimensions."}
-    end
-  end
-
-  defp event_dimensions_not_allowing_session_metrics?(dimensions) do
-    Enum.any?(dimensions, fn
-      "event:page" -> false
-      "event:" <> _ -> true
-      _ -> false
-    end)
-  end
 
   defp validate_include(query) do
     time_dimension? = Enum.any?(query.dimensions, &Time.time_dimension?/1)

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2187,7 +2187,20 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Session metric(s) `bounce_rate` cannot be queried along with event dimensions."
+        "Session metric(s) `bounce_rate` cannot be queried along with event dimension(s) `event:props:foo`"
+      )
+    end
+
+    test "fails if using event metric with session-only dimension", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["events"],
+        "date_range" => "all",
+        "dimensions" => ["visit:exit_page"]
+      }
+      |> check_error(
+        site,
+        "Event metric(s) `events` cannot be queried along with session dimension(s) `visit:exit_page`"
       )
     end
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_validations_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_validations_test.exs
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryValidationsTest do
         })
 
       assert json_response(conn, 400)["error"] =~
-               "Session metric(s) `bounce_rate` cannot be queried along with event dimensions."
+               "Session metric(s) `bounce_rate` cannot be queried along with event dimension(s) `event:name`"
     end
 
     test "session metrics cannot be used with event:props:* dimension", %{conn: conn, site: site} do
@@ -176,7 +176,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryValidationsTest do
         })
 
       assert json_response(conn, 400)["error"] =~
-               "Session metric(s) `bounce_rate` cannot be queried along with event dimensions."
+               "Session metric(s) `bounce_rate` cannot be queried along with event dimension(s) `event:props:url`"
     end
 
     test "validates that metric views_per_visit cannot be used with event:page filter", %{


### PR DESCRIPTION
Currently the following query results in a 500:

```json
{
  "site_id": "plausible.io",
  "metrics": ["visitors", "events", "pageviews"],
  "dimensions": ["visit:exit_page"],
  "date_range": "7d"
}
```

This adds proper validation for that case that was previously missing.

In the future we might be able to remove _some_ of these validations by selecting the appropriate value(s) from sessions table.

Basecamp ref: https://3.basecamp.com/5308029/buckets/39750953/card_tables/cards/8251923578