### PR TITLE
Proposal: New testing utility `assert_matches`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,5 +7,8 @@
     "{config,lib,test,extra}/**/*.{heex,ex,exs}",
     "priv/*/seeds.exs",
     "storybook/**/*.exs"
+  ],
+  locals_without_parens: [
+    assert_matches: 2
   ]
 ]

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -19,13 +19,22 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
         "include" => %{"comparisons" => %{"mode" => "previous_period"}}
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{
-               "dimensions" => [],
-               "metrics" => [1],
-               "comparison" => %{"change" => [-67], "dimensions" => [], "metrics" => [3]}
-             }
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{
+          "dimensions" => [],
+          "metrics" => [1],
+          "comparison" => %{"change" => [-67], "dimensions" => [], "metrics" => [3]}
+        }
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["pageviews"],
+          "date_range" => ["2021-01-07T00:00:00+00:00", "2021-01-13T23:59:59+00:00"],
+          "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+        })
+    }
   end
 
   test "timeseries comparison", %{conn: conn, site: site} do
@@ -46,71 +55,81 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
         "include" => %{"comparisons" => %{"mode" => "previous_period"}}
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{
-               "dimensions" => ["2021-01-07"],
-               "metrics" => [1],
-               "comparison" => %{
-                 "dimensions" => ["2020-12-31"],
-                 "metrics" => [0],
-                 "change" => [100]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-08"],
-               "metrics" => [1],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-01"],
-                 "metrics" => [2],
-                 "change" => [-50]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-09"],
-               "metrics" => [0],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-02"],
-                 "metrics" => [0],
-                 "change" => [0]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-10"],
-               "metrics" => [0],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-03"],
-                 "metrics" => [0],
-                 "change" => [0]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-11"],
-               "metrics" => [0],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-04"],
-                 "metrics" => [0],
-                 "change" => [0]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-12"],
-               "metrics" => [0],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-05"],
-                 "metrics" => [0],
-                 "change" => [0]
-               }
-             },
-             %{
-               "dimensions" => ["2021-01-13"],
-               "metrics" => [0],
-               "comparison" => %{
-                 "dimensions" => ["2021-01-06"],
-                 "metrics" => [1],
-                 "change" => [-100]
-               }
-             }
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{
+          "dimensions" => ["2021-01-07"],
+          "metrics" => [1],
+          "comparison" => %{
+            "dimensions" => ["2020-12-31"],
+            "metrics" => [0],
+            "change" => [100]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-08"],
+          "metrics" => [1],
+          "comparison" => %{
+            "dimensions" => ["2021-01-01"],
+            "metrics" => [2],
+            "change" => [-50]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-09"],
+          "metrics" => [0],
+          "comparison" => %{
+            "dimensions" => ["2021-01-02"],
+            "metrics" => [0],
+            "change" => [0]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-10"],
+          "metrics" => [0],
+          "comparison" => %{
+            "dimensions" => ["2021-01-03"],
+            "metrics" => [0],
+            "change" => [0]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-11"],
+          "metrics" => [0],
+          "comparison" => %{
+            "dimensions" => ["2021-01-04"],
+            "metrics" => [0],
+            "change" => [0]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-12"],
+          "metrics" => [0],
+          "comparison" => %{
+            "dimensions" => ["2021-01-05"],
+            "metrics" => [0],
+            "change" => [0]
+          }
+        },
+        %{
+          "dimensions" => ["2021-01-13"],
+          "metrics" => [0],
+          "comparison" => %{
+            "dimensions" => ["2021-01-06"],
+            "metrics" => [1],
+            "change" => [-100]
+          }
+        }
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "date_range" => ["2021-01-07T00:00:00+00:00", "2021-01-13T23:59:59+00:00"],
+          "metrics" => ["pageviews"],
+          "dimensions" => ["time:day"],
+          "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+        })
+    }
   end
 
   test "dimensional comparison with low limit", %{conn: conn, site: site} do
@@ -143,26 +162,36 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
         "pagination" => %{"limit" => 2}
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{
-               "dimensions" => ["Chrome"],
-               "metrics" => [3, 50.0],
-               "comparison" => %{
-                 "dimensions" => ["Chrome"],
-                 "metrics" => [1, 12.5],
-                 "change" => [200, 300]
-               }
-             },
-             %{
-               "dimensions" => ["Firefox"],
-               "metrics" => [2, 33.3],
-               "comparison" => %{
-                 "dimensions" => ["Firefox"],
-                 "metrics" => [4, 50.0],
-                 "change" => [-50, -33]
-               }
-             }
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{
+          "dimensions" => ["Chrome"],
+          "metrics" => [3, 50.0],
+          "comparison" => %{
+            "dimensions" => ["Chrome"],
+            "metrics" => [1, 12.5],
+            "change" => [200, 300]
+          }
+        },
+        %{
+          "dimensions" => ["Firefox"],
+          "metrics" => [2, 33.3],
+          "comparison" => %{
+            "dimensions" => ["Firefox"],
+            "metrics" => [4, 50.0],
+            "change" => [-50, -33]
+          }
+        }
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "date_range" => ["2021-01-07T00:00:00+00:00", "2021-01-13T23:59:59+00:00"],
+          "metrics" => ["visitors", "percentage"],
+          "dimensions" => ["visit:browser"],
+          "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+        })
+    }
 
     conn2 =
       post(conn, "/api/v2/query-internal-test", %{
@@ -176,17 +205,27 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
         "pagination" => %{"limit" => 2, "offset" => 2}
       })
 
-    assert json_response(conn2, 200)["results"] == [
-             %{
-               "dimensions" => ["Safari"],
-               "metrics" => [1, 16.7],
-               "comparison" => %{
-                 "dimensions" => ["Safari"],
-                 "metrics" => [3, 37.5],
-                 "change" => [-67, -55]
-               }
-             }
-           ]
+    assert_matches json_response(conn2, 200), %{
+      "results" => [
+        %{
+          "dimensions" => ["Safari"],
+          "metrics" => [1, 16.7],
+          "comparison" => %{
+            "dimensions" => ["Safari"],
+            "metrics" => [3, 37.5],
+            "change" => [-67, -55]
+          }
+        }
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "date_range" => ["2021-01-07T00:00:00+00:00", "2021-01-13T23:59:59+00:00"],
+          "metrics" => ["visitors", "percentage"],
+          "dimensions" => ["visit:browser"],
+          "include" => %{"comparisons" => %{"mode" => "previous_period"}}
+        })
+    }
   end
 
   test "dimensional comparison with imported data", %{
@@ -233,25 +272,37 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
         "pagination" => %{"limit" => 2}
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{
-               "dimensions" => ["Chrome"],
-               "metrics" => [2, 66.7],
-               "comparison" => %{
-                 "dimensions" => ["Chrome"],
-                 "metrics" => [40, 40.0],
-                 "change" => [-95, 67]
-               }
-             },
-             %{
-               "dimensions" => ["Firefox"],
-               "metrics" => [1, 33.3],
-               "comparison" => %{
-                 "dimensions" => ["Firefox"],
-                 "metrics" => [50, 50.0],
-                 "change" => [-98, -33]
-               }
-             }
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{
+          "dimensions" => ["Chrome"],
+          "metrics" => [2, 66.7],
+          "comparison" => %{
+            "dimensions" => ["Chrome"],
+            "metrics" => [40, 40.0],
+            "change" => [-95, 67]
+          }
+        },
+        %{
+          "dimensions" => ["Firefox"],
+          "metrics" => [1, 33.3],
+          "comparison" => %{
+            "dimensions" => ["Firefox"],
+            "metrics" => [50, 50.0],
+            "change" => [-98, -33]
+          }
+        }
+      ],
+      "meta" => %{
+        "imports_included" => true
+      },
+      "query" =>
+        response_query(site, %{
+          "date_range" => ["2021-01-07T00:00:00+00:00", "2021-01-13T23:59:59+00:00"],
+          "metrics" => ["visitors", "percentage"],
+          "dimensions" => ["visit:browser"],
+          "include" => %{"imports" => true, "comparisons" => %{"mode" => "previous_period"}}
+        })
+    }
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
@@ -33,10 +33,18 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "dimensions" => ["event:goal"]
         })
 
-      assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Purchase"], "metrics" => [2]},
-               %{"dimensions" => ["Visit /test"], "metrics" => [1]}
-             ]
+      assert_matches json_response(conn, 200), %{
+        "results" => [
+          %{"dimensions" => ["Purchase"], "metrics" => [2]},
+          %{"dimensions" => ["Visit /test"], "metrics" => [1]}
+        ],
+        "meta" => %{},
+        "query" =>
+          response_query(site, %{
+            "metrics" => ["visitors"],
+            "dimensions" => ["event:goal"]
+          })
+      }
     end
 
     test "returns pageview goals containing wildcards", %{conn: conn, site: site} do
@@ -60,10 +68,18 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "order_by" => [["pageviews", "desc"]]
         })
 
-      assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 4]},
-               %{"dimensions" => ["Visit /**/post"], "metrics" => [2, 2]}
-             ]
+      assert_matches json_response(conn, 200), %{
+        "results" => [
+          %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 4]},
+          %{"dimensions" => ["Visit /**/post"], "metrics" => [2, 2]}
+        ],
+        "meta" => %{},
+        "query" =>
+          response_query(site, %{
+            "metrics" => ["visitors", "pageviews"],
+            "dimensions" => ["event:goal"]
+          })
+      }
     end
 
     test "does not return goals that are not configured for the site", %{conn: conn, site: site} do
@@ -80,7 +96,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "dimensions" => ["event:goal"]
         })
 
-      assert json_response(conn, 200)["results"] == []
+      assert_matches json_response(conn, 200), %{
+        "results" => [],
+        "meta" => %{},
+        "query" =>
+          response_query(site, %{
+            "metrics" => ["visitors", "pageviews"],
+            "dimensions" => ["event:goal"]
+          })
+      }
     end
 
     test "returns conversion_rate in an event:goal breakdown", %{conn: conn, site: site} do
@@ -103,10 +127,18 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "dimensions" => ["event:goal"]
         })
 
-      assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 2, 50.0]},
-               %{"dimensions" => ["Signup"], "metrics" => [1, 2, 25.0]}
-             ]
+      assert_matches json_response(conn, 200), %{
+        "results" => [
+          %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 2, 50.0]},
+          %{"dimensions" => ["Signup"], "metrics" => [1, 2, 25.0]}
+        ],
+        "meta" => %{},
+        "query" =>
+          response_query(site, %{
+            "metrics" => ["visitors", "events", "conversion_rate"],
+            "dimensions" => ["event:goal"]
+          })
+      }
     end
 
     test "returns conversion_rate alone in an event:goal breakdown", %{conn: conn, site: site} do
@@ -125,9 +157,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "dimensions" => ["event:goal"]
         })
 
-      assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Signup"], "metrics" => [50.0]}
-             ]
+      assert_matches json_response(conn, 200), %{
+        "results" => [%{"dimensions" => ["Signup"], "metrics" => [50.0]}],
+        "meta" => %{},
+        "query" =>
+          response_query(site, %{
+            "metrics" => ["conversion_rate"],
+            "dimensions" => ["event:goal"]
+          })
+      }
     end
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_special_metrics_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_special_metrics_test.exs
@@ -40,11 +40,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "dimensions" => ["event:props:author"]
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{"dimensions" => ["Uku"], "metrics" => [3, 3, 37.5]},
-             %{"dimensions" => ["Marko"], "metrics" => [2, 3, 25.0]},
-             %{"dimensions" => ["(none)"], "metrics" => [1, 1, 12.5]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{"dimensions" => ["Uku"], "metrics" => [3, 3, 37.5]},
+        %{"dimensions" => ["Marko"], "metrics" => [2, 3, 25.0]},
+        %{"dimensions" => ["(none)"], "metrics" => [1, 1, 12.5]}
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["visitors", "events", "conversion_rate"],
+          "dimensions" => ["event:props:author"],
+          "filters" => [["is", "event:goal", ["Visit /blog**"]]]
+        })
+    }
   end
 
   test "returns conversion_rate alone in a goal filtered custom prop breakdown", %{
@@ -67,11 +76,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "filters" => [["is", "event:goal", ["Visit /blog**"]]]
       })
 
-    %{"results" => results} = json_response(conn, 200)
-
-    assert results == [
-             %{"dimensions" => ["Uku"], "metrics" => [50]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [%{"dimensions" => ["Uku"], "metrics" => [50]}],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["conversion_rate"],
+          "dimensions" => ["event:props:author"],
+          "filters" => [["is", "event:goal", ["Visit /blog**"]]]
+        })
+    }
   end
 
   test "returns conversion_rate in a goal filtered event:page breakdown", %{
@@ -98,10 +112,19 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "metrics" => ["visitors", "events", "group_conversion_rate"]
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{"dimensions" => ["/en/register"], "metrics" => [2, 2, 66.7]},
-             %{"dimensions" => ["/it/register"], "metrics" => [1, 2, 50.0]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{"dimensions" => ["/en/register"], "metrics" => [2, 2, 66.7]},
+        %{"dimensions" => ["/it/register"], "metrics" => [1, 2, 50.0]}
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["visitors", "events", "group_conversion_rate"],
+          "dimensions" => ["event:page"],
+          "filters" => [["is", "event:goal", ["Signup"]]]
+        })
+    }
   end
 
   test "returns conversion_rate alone in a goal filtered event:page breakdown", %{
@@ -124,9 +147,16 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "dimensions" => ["event:page"]
       })
 
-    assert json_response(conn, 200)["results"] == [
-             %{"dimensions" => ["/en/register"], "metrics" => [50.0]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [%{"dimensions" => ["/en/register"], "metrics" => [50.0]}],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["group_conversion_rate"],
+          "dimensions" => ["event:page"],
+          "filters" => [["is", "event:goal", ["Signup"]]]
+        })
+    }
   end
 
   test "returns conversion_rate in a multi-goal filtered visit:screen_size breakdown", %{
@@ -156,12 +186,19 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "filters" => [["is", "event:goal", ["AddToCart", "Purchase"]]]
       })
 
-    %{"results" => results} = json_response(conn, 200)
-
-    assert results == [
-             %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.7]},
-             %{"dimensions" => ["Desktop"], "metrics" => [1, 2, 50]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [
+        %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.7]},
+        %{"dimensions" => ["Desktop"], "metrics" => [1, 2, 50]}
+      ],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["visitors", "events", "group_conversion_rate"],
+          "dimensions" => ["visit:device"],
+          "filters" => [["is", "event:goal", ["AddToCart", "Purchase"]]]
+        })
+    }
   end
 
   test "returns conversion_rate alone in a goal filtered visit:screen_size breakdown", %{
@@ -184,10 +221,15 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
         "filters" => [["is", "event:goal", ["AddToCart"]]]
       })
 
-    %{"results" => results} = json_response(conn, 200)
-
-    assert results == [
-             %{"dimensions" => ["Mobile"], "metrics" => [50]}
-           ]
+    assert_matches json_response(conn, 200), %{
+      "results" => [%{"dimensions" => ["Mobile"], "metrics" => [50]}],
+      "meta" => %{},
+      "query" =>
+        response_query(site, %{
+          "metrics" => ["conversion_rate"],
+          "dimensions" => ["visit:device"],
+          "filters" => [["is", "event:goal", ["AddToCart"]]]
+        })
+    }
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -6,20 +6,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
   setup [:create_user, :create_site, :create_api_key, :use_api_key]
 
-  def response_query(site, overrides) do
-    %{
-      "metrics" => ["pageviews"],
-      "filters" => [],
-      "dimensions" => [],
-      "site_id" => site.domain,
-      "date_range" => [expect_any(:string), expect_any(:string)],
-      "order_by" => expect_any(:list),
-      "pagination" => expect_any(:map),
-      "include" => %{}
-    }
-    |> Map.merge(overrides)
-  end
-
   test "aggregates a single metric", %{conn: conn, site: site} do
     populate_stats(site, [
       build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -355,16 +355,16 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
           })
           |> json_response(200)
 
-        assert %{
-                 "name" => "Some segment",
-                 "type" => "#{unquote(type)}",
-                 "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
-                 "owner_id" => user.id
-               } == Map.drop(response, ["id", "inserted_at", "updated_at"])
+        assert_matches response, %{
+          "id" => expect_any(:integer),
+          "name" => "Some segment",
+          "type" => "#{unquote(type)}",
+          "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
+          "owner_id" => user.id,
+          "inserted_at" => expect_any(:string),
+          "updated_at" => expect_any(:string)
+        }
 
-        assert is_integer(response["id"])
-        assert is_binary(response["inserted_at"])
-        assert is_binary(response["updated_at"])
         assert response["inserted_at"] == response["updated_at"]
 
         verify_segment_in_db(%Plausible.Segments.Segment{

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -1,4 +1,6 @@
 defmodule Plausible.AssertMatches do
+  @moduledoc false
+
   @doc """
   Custom assertion function that allows for flexible matching of expected results.
 

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -15,9 +15,9 @@ defmodule Plausible.AssertMatches do
 
   """
   def assert_matches(data, expected) do
-    {equivelent?, left, right} = check_matches(data, expected)
+    {equivalent?, left, right} = check_matches(data, expected)
 
-    if not equivelent? do
+    if not equivalent? do
       raise ExUnit.AssertionError,
         left: left,
         right: right,
@@ -43,8 +43,8 @@ defmodule Plausible.AssertMatches do
         match_maps(value, expected)
 
       {a, b} when is_tuple(a) and is_tuple(b) ->
-        {equivelent?, left, right} = match_lists(Tuple.to_list(a), Tuple.to_list(b))
-        {equivelent?, List.to_tuple(left), List.to_tuple(right)}
+        {equivalent?, left, right} = match_lists(Tuple.to_list(a), Tuple.to_list(b))
+        {equivalent?, List.to_tuple(left), List.to_tuple(right)}
 
       {value, expected} ->
         {value == expected, value, expected}
@@ -56,9 +56,9 @@ defmodule Plausible.AssertMatches do
   defp match_lists(left, []), do: {false, left, []}
 
   defp match_lists([left | left_rest], [right | right_rest]) do
-    {equivelent?, left_acc, right_acc} = match_lists(left_rest, right_rest)
+    {equivalent?, left_acc, right_acc} = match_lists(left_rest, right_rest)
     {eq, l, r} = check_matches(left, right)
-    {equivelent? and eq, [l | left_acc], [r | right_acc]}
+    {equivalent? and eq, [l | left_acc], [r | right_acc]}
   end
 
   defp match_maps(left, expected) do
@@ -72,12 +72,12 @@ defmodule Plausible.AssertMatches do
   defp match_maps([], _, _), do: {true, %{}, %{}}
 
   defp match_maps([key | keys], left, expected) do
-    {equivelent?, left_result, right_result} = match_maps(keys, left, expected)
+    {equivalent?, left_result, right_result} = match_maps(keys, left, expected)
 
     case {left, expected} do
       {%{^key => left_value}, %{^key => right_value}} ->
         {eq, l, r} = check_matches(left_value, right_value)
-        {equivelent? and eq, Map.put(left_result, key, l), Map.put(right_result, key, r)}
+        {equivalent? and eq, Map.put(left_result, key, l), Map.put(right_result, key, r)}
 
       {%{^key => left_value}, _} ->
         {false, Map.put(left_result, key, left_value), right_result}

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -1,0 +1,109 @@
+defmodule Plausible.AssertMatches do
+  @doc """
+  Custom assertion function that allows for flexible matching of expected results.
+
+  This is useful when testing APIs, where some response fields are not deterministic.
+
+  Examples:
+
+      iex> assert_matches %{ key: 1 }, %{ key: expect_any(:integer) }
+
+      iex> assert_matches %{ string: "abc" }, %{ string: "abc" }
+
+      iex> # assert_matches %{ key: 1 }, %{ key: expect_any(:string) }
+      # This would raise ExUnit.AssertionError with a diff.
+
+  """
+  def assert_matches(data, expected) do
+    {equivelent?, left, right} = check_matches(data, expected)
+
+    if not equivelent? do
+      raise ExUnit.AssertionError,
+        left: left,
+        right: right,
+        message: "Values did not match"
+    end
+  end
+
+  defp check_matches(value, expected) do
+    case {value, expected} do
+      # Main case: If expected value is a function, we assume it's a predicate passed from expect_any
+      {value, predicate_fn} when not is_function(value) and is_function(predicate_fn) ->
+        if predicate_fn.(value) do
+          # :TRICKY: To make ex_unit not highlight the predicate_fn, pretend it was the value passed from left
+          {true, value, value}
+        else
+          {false, value, predicate_fn}
+        end
+
+      {value, expected} when is_list(value) and is_list(expected) ->
+        match_lists(value, expected)
+
+      {value, expected} when is_map(value) and is_map(expected) ->
+        match_maps(value, expected)
+
+      {a, b} when is_tuple(a) and is_tuple(b) ->
+        {equivelent?, left, right} = match_lists(Tuple.to_list(a), Tuple.to_list(b))
+        {equivelent?, List.to_tuple(left), List.to_tuple(right)}
+
+      {value, expected} ->
+        {value == expected, value, expected}
+    end
+  end
+
+  defp match_lists([], []), do: {true, [], []}
+  defp match_lists([], right), do: {false, [], right}
+  defp match_lists(left, []), do: {false, left, []}
+
+  defp match_lists([left | left_rest], [right | right_rest]) do
+    {equivelent?, left_acc, right_acc} = match_lists(left_rest, right_rest)
+    {eq, l, r} = check_matches(left, right)
+    {equivelent? and eq, [l | left_acc], [r | right_acc]}
+  end
+
+  defp match_maps(left, expected) do
+    keys =
+      Map.keys(left)
+      |> Enum.concat(Map.keys(expected))
+
+    match_maps(keys, left, expected)
+  end
+
+  defp match_maps([], _, _), do: {true, %{}, %{}}
+
+  defp match_maps([key | keys], left, expected) do
+    {equivelent?, left_result, right_result} = match_maps(keys, left, expected)
+
+    case {left, expected} do
+      {%{^key => left_value}, %{^key => right_value}} ->
+        {eq, l, r} = check_matches(left_value, right_value)
+        {equivelent? and eq, Map.put(left_result, key, l), Map.put(right_result, key, r)}
+
+      {%{^key => left_value}, _} ->
+        {false, Map.put(left_result, key, left_value), right_result}
+
+      {_, %{^key => right_value}} ->
+        {false, left_result, Map.put(right_result, key, right_value)}
+    end
+  end
+
+  @doc """
+  Asserts that the value matches the expected type. To be used together with `assert_matches`.
+  """
+  def expect_any(type \\ :any)
+
+  def expect_any(:atom), do: &is_atom/1
+  def expect_any(:string), do: &is_binary/1
+  def expect_any(:integer), do: &is_integer/1
+  def expect_any(:float), do: &is_float/1
+  def expect_any(:boolean), do: &is_boolean/1
+  def expect_any(:map), do: &is_map/1
+  def expect_any(:list), do: &is_list/1
+  def expect_any(:any), do: fn _ -> true end
+
+  def expect_any(type, predicate_fn) do
+    fn value ->
+      expect_any(type).(value) and predicate_fn.(value)
+    end
+  end
+end

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -67,6 +67,7 @@ defmodule Plausible.AssertMatches do
     keys =
       Map.keys(left)
       |> Enum.concat(Map.keys(expected))
+      |> Enum.uniq()
 
     match_maps(keys, left, expected)
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,6 +24,7 @@ defmodule PlausibleWeb.ConnCase do
       import Phoenix.ConnTest
       alias PlausibleWeb.Router.Helpers, as: Routes
       import Plausible.Factory
+      import Plausible.AssertMatches
 
       # The default endpoint for testing
       @endpoint PlausibleWeb.Endpoint

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -1,6 +1,7 @@
 defmodule Plausible.TestUtils do
   use Plausible.Repo
   alias Plausible.Factory
+  alias Plausible.AssertMatches
 
   defmacro __using__(_) do
     quote do
@@ -286,6 +287,21 @@ defmodule Plausible.TestUtils do
     def maybe_fake_minio(_context) do
       :ok
     end
+  end
+
+  @doc "Helper for checking responses of API query tests in combination with `assert_matches`"
+  def response_query(site, overrides) do
+    %{
+      "metrics" => ["pageviews"],
+      "filters" => [],
+      "dimensions" => [],
+      "site_id" => site.domain,
+      "date_range" => [AssertMatches.expect_any(:string), AssertMatches.expect_any(:string)],
+      "order_by" => AssertMatches.expect_any(:list),
+      "pagination" => AssertMatches.expect_any(:map),
+      "include" => %{}
+    }
+    |> Map.merge(overrides)
   end
 
   defp secret_key_base() do


### PR DESCRIPTION
This PR introduces a new testing utility called `assert_matches` to more flexibly test our API responses.

## Motivation

In previous reviews, @apata and I discussed how best test API responses for fields that either aren't deterministic or relevant for the test at hand (e.g. inserted_at/updated_at or APIv2 "query"). Removing these fields creates a lot of boilerplate code in tests, making them harder to read and violating the broad one-assert-per-test rule.

This is not an elixir-specific problem with various solutions in other languages. The one I like is "structural testing". For example, jest has [`expect.any(type)`](https://jestjs.io/docs/expect#expectanyconstructor) and other utility functions that don't require exact equality. RSpec in ruby world has a [whole slate of matchers for similar dynamic checking](https://www.rubydoc.info/gems/rspec-expectations/RSpec/Matchers).

## Proposal

`assert_matches api_response, expected_structure`

If expected structure is fixed and all fields known ahead of time, this would behave exactly like `assert api_response == expected_structure`

However `assert_matches` also allows to only assert the types of some values. Consider this example:

```elixir
        assert_matches response, %{
          "id" => expect_any(:integer),
          "name" => "Some segment",
          "type" => "personal",
          "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
          "owner_id" => user.id,
          "inserted_at" => expect_any(:string),
          "updated_at" => expect_any(:string)
        }
```

In this example, for the case `id`, `inserted_at` and `updated_at` types are asserted but the value is not checked to be equal to some precise predetermined value.

If there's an issue (e.g. id is a string), this would report the following diff, highlighting only the fields that are incorrect.
![image](https://github.com/user-attachments/assets/e1c191c6-9926-4832-8993-5b97489648b6)

## How to review this PR

If you think this proposal is worth it without reviewing the code fully, feel free to add a :+1: reaction to the PR.

If you want to review "meat" of the PR is in [test/support/assert_matches.ex](https://github.com/plausible/analytics/pull/5019/files#diff-148c449601b36a602063fda037f9d43ab402b15373fa075a6ceab37ec5718532)

This PR made no behavioral changes, but I went ahead and refactored all APIv2 query tests to also check `meta` and `query` response values. This added some extra coverage for cases that were previously somewhat untested.