### PR TITLE
Tracker: Use fetch with keepalive over beacon for pageleaves

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -114,10 +114,7 @@
     payload.h = 1
     {{/if}}
 
-    if (navigator.sendBeacon) {
-      var blob = new Blob([JSON.stringify(payload)], { type: 'text/plain' });
-      navigator.sendBeacon(endpoint, blob)
-    }
+    sendRequest(endpoint, payload)
   }
 
   function registerPageLeaveListener() {

--- a/tracker/test/fixtures/pageleave-hash-exclusions.html
+++ b/tracker/test/fixtures/pageleave-hash-exclusions.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer data-exclude='/*#*/hash/**/ignored' src="/tracker/js/plausible.exclusions.hash.local.pageleave.js"></script>
+  <script defer data-exclude='/*#*/hash/**/ignored' src="/tracker/js/plausible.exclusions.hash.local.pageleave.js" data-allow-fetch></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/pageleave-hash-pageview-props.html
+++ b/tracker/test/fixtures/pageleave-hash-pageview-props.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script id="plausible-script" defer src="/tracker/js/plausible.hash.local.pageleave.pageview-props.js"></script>
+  <script id="plausible-script" defer src="/tracker/js/plausible.hash.local.pageleave.pageview-props.js" data-allow-fetch></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/pageleave-hash.html
+++ b/tracker/test/fixtures/pageleave-hash.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.hash.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.hash.local.pageleave.js" data-allow-fetch></script>
   <script>
 
   </script>

--- a/tracker/test/fixtures/pageleave-manual.html
+++ b/tracker/test/fixtures/pageleave-manual.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.manual.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.manual.pageleave.js" data-allow-fetch></script>
   <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 </head>
 

--- a/tracker/test/fixtures/pageleave-pageview-props.html
+++ b/tracker/test/fixtures/pageleave-pageview-props.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer event-author="John" src="/tracker/js/plausible.local.pageleave.pageview-props.js"></script>
+  <script defer event-author="John" src="/tracker/js/plausible.local.pageleave.pageview-props.js" data-allow-fetch></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/pageleave.html
+++ b/tracker/test/fixtures/pageleave.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.pageleave.js" data-allow-fetch></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/scroll-depth-content-onscroll.html
+++ b/tracker/test/fixtures/scroll-depth-content-onscroll.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.pageleave.js" data-allow-fetch></script>
 </head>
 
 <body>
@@ -22,7 +22,7 @@
       window.addEventListener("scroll", () => {
         if (!loadedMore && window.innerHeight + window.scrollY >= document.body.offsetHeight) {
           loadedMore = true
-          
+
           const newDiv = document.createElement("div")
           newDiv.setAttribute("id", "more-content")
           newDiv.setAttribute("style", "height: 2000px; background-color: lightcoral;")

--- a/tracker/test/fixtures/scroll-depth-dynamic-content-load.html
+++ b/tracker/test/fixtures/scroll-depth-dynamic-content-load.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.pageleave.js" data-allow-fetch></script>
 </head>
 <body>
   <br>

--- a/tracker/test/fixtures/scroll-depth-hash.html
+++ b/tracker/test/fixtures/scroll-depth-hash.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.hash.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.hash.local.pageleave.js" data-allow-fetch></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/scroll-depth-slow-window-load.html
+++ b/tracker/test/fixtures/scroll-depth-slow-window-load.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.pageleave.js" data-allow-fetch></script>
 </head>
 <body>
   <a id="navigate-away" href="/manual.html">

--- a/tracker/test/fixtures/scroll-depth.html
+++ b/tracker/test/fixtures/scroll-depth.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.pageleave.js" data-allow-fetch></script>
   <title>Document</title>
 </head>
 <body>


### PR DESCRIPTION
### Changes

:facepalm: I didn't realize pageleaves had their own tracking code. After this change fetch with keepalive is used instead of beacon.