### PR TITLE
Expand segments also when using Query.from

### DIFF
--- a/assets/js/dashboard/util/filter-text.test.tsx
+++ b/assets/js/dashboard/util/filter-text.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DashboardQuery, Filter, FilterClauseLabels } from '../query'
+import { Filter, FilterClauseLabels } from '../query'
 import { plainFilterText, styledFilterText } from './filter-text'
 import { render, screen } from '@testing-library/react'
 
@@ -13,7 +13,7 @@ describe('styledFilterText() and plainFilterText()', () => {
   ])(
     'when filter is %p and labels are %p, functions return %p',
     (filter, labels, expectedPlainText) => {
-      const query = { labels } as unknown as DashboardQuery
+      const query = { labels }
 
       expect(plainFilterText(query, filter)).toBe(expectedPlainText)
 

--- a/assets/js/dashboard/util/filter-text.tsx
+++ b/assets/js/dashboard/util/filter-text.tsx
@@ -11,7 +11,7 @@ import {
 } from './filters'
 
 export function styledFilterText(
-  query: DashboardQuery,
+  query: Pick<DashboardQuery, 'labels'>,
   [operation, filterKey, clauses]: Filter
 ) {
   if (filterKey.startsWith(EVENT_PROPS_PREFIX)) {
@@ -43,7 +43,10 @@ export function styledFilterText(
   )
 }
 
-export function plainFilterText(query: DashboardQuery, filter: Filter) {
+export function plainFilterText(
+  query: Pick<DashboardQuery, 'labels'>,
+  filter: Filter
+) {
   return reactNodeToString(styledFilterText(query, filter))
 }
 

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -24,6 +24,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_dimensions(params)
       |> put_interval(params)
       |> put_parsed_filters(params)
+      |> resolve_segments(site)
       |> preload_goals_and_revenue(site)
       |> put_order_by(params)
       |> put_include(site, params)
@@ -34,6 +35,17 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     end
 
     query
+  end
+
+  defp resolve_segments(query, site) do
+    with {:ok, preloaded_segments} <-
+           Plausible.Segments.Filters.preload_needed_segments(site, query.filters),
+         {:ok, filters} <-
+           Plausible.Segments.Filters.resolve_segments(query.filters, preloaded_segments) do
+      struct!(query,
+        filters: filters
+      )
+    end
   end
 
   defp preload_goals_and_revenue(query, site) do

--- a/test/plausible/stats/table_decider_test.exs
+++ b/test/plausible/stats/table_decider_test.exs
@@ -181,7 +181,7 @@ defmodule Plausible.Stats.TableDeciderTest do
   end
 
   defp make_query(filter_dimensions \\ [], dimensions \\ []) do
-    Query.from(build(:site), %{
+    Query.from(build(:site, id: :rand.uniform(100_000)), %{
       "filters" =>
         Enum.map(filter_dimensions, fn filter_dimension -> ["is", filter_dimension, []] end),
       "dimensions" => dimensions
@@ -189,7 +189,7 @@ defmodule Plausible.Stats.TableDeciderTest do
   end
 
   defp make_query_full_filters(filters) do
-    Query.from(build(:site), %{
+    Query.from(build(:site, id: :rand.uniform(100_000)), %{
       "dimensions" => [],
       "filters" => filters
     })

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -342,5 +342,75 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                }
              ]
     end
+
+    test "handles multiple segment filters", %{conn: conn, site: site, user: user} do
+      %{id: segment_alfa} =
+        insert(:segment,
+          site_id: site.id,
+          owner_id: user.id,
+          name: "Ireland and Britain (excl London)",
+          type: :site,
+          segment_data: %{
+            "filters" => [
+              ["is", "visit:country", ["IE", "GB"]],
+              ["is_not", "visit:city", [2_643_743]]
+            ]
+          }
+        )
+
+      %{id: segment_beta} =
+        insert(:segment,
+          site_id: site.id,
+          owner_id: user.id,
+          name: "Entered on root or blog",
+          type: :personal,
+          segment_data: %{
+            "filters" => [
+              ["is", "visit:entry_page", ["/", "/blog"]]
+            ]
+          }
+        )
+
+      populate_stats(site, [
+        build(:pageview, country_code: "EE"),
+        build(:pageview,
+          country_code: "GB",
+          # London
+          city_geoname_id: 2_643_743
+        ),
+        build(:pageview,
+          country_code: "GB",
+          # London
+          city_geoname_id: 2_643_743
+        ),
+        build(:pageview, country_code: "GB"),
+        build(:pageview, country_code: "IE", pathname: "/other"),
+        build(:pageview, country_code: "IE")
+      ])
+
+      filters =
+        Jason.encode!([["is", "segment", [segment_alfa]], ["is", "segment", [segment_beta]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 1,
+                 "percentage" => 50
+               },
+               %{
+                 "code" => "IE",
+                 "alpha_3" => "IRL",
+                 "name" => "Ireland",
+                 "flag" => "🇮🇪",
+                 "visitors" => 1,
+                 "percentage" => 50
+               }
+             ]
+    end
   end
 end


### PR DESCRIPTION
### Changes

* Adds resolve segments logic in Query.from
* Changes filter-text utility arg type to handle the labels stored within segment.segment_data

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
