### PR TITLE
Tracker: Send `engagement` events on visibilitychange (if pageleave extension)

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -250,7 +250,7 @@ defmodule Plausible.Ingestion.Request do
   end
 
   defp put_scroll_depth(changeset, %{} = request_body) do
-    if Changeset.get_field(changeset, :event_name) == "pageleave" do
+    if Changeset.get_field(changeset, :event_name) in ["pageleave", "engagement"] do
       scroll_depth =
         case request_body["sd"] do
           sd when is_integer(sd) and sd >= 0 and sd <= 100 -> sd

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -10,7 +10,8 @@ defmodule Plausible.Session.CacheStore do
 
   def on_event(event, session_attributes, prev_user_id, buffer_insert \\ &WriteBuffer.insert/1)
 
-  def on_event(%{name: "pageleave"} = event, _, prev_user_id, _) do
+  def on_event(%{name: name} = event, _, prev_user_id, _)
+      when name in ["pageleave", "engagement"] do
     # The `pageleave` event is currently experimental. In a real use case we would
     # probably want to update the session as well (e.g. `is_bounce` or `duration`).
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1335,6 +1335,15 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       assert pageleave.scroll_depth == 255
     end
+
+    test "ingests valid scroll_depth for a engagement event", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
+      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: 25})
+
+      event = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
+      assert event.scroll_depth == 25
+    end
   end
 
   describe "acquisition channel tests" do

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -1,100 +1,105 @@
 /* eslint-disable playwright/no-skipped-test */
-const { expectPlausibleInAction, pageleaveCooldown, ignoreEngagementRequests } = require('./support/test-utils')
+const { expectPlausibleInAction, pageleaveCooldown, ignoreEngagementRequests, ignorePageleaveRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
-test.describe('pageleave extension', () => {
+test.describe('pageleave extension (pageleave events)', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
+  sharedTests('pageleave', ignoreEngagementRequests)
+})
+
+test.describe('pageleave extension (engagement events)', () => {
+  test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
+
+  sharedTests('engagement', ignorePageleaveRequests)
+})
+
+function sharedTests(expectedEvent, ignoreRequests) {
   test('sends a pageleave when navigating to the next page', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/pageleave.html`}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave and pageview on hash-based SPA navigation', async ({ page }) => {
+  test('sends an event and a pageview on hash-based SPA navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-nav'),
       expectedRequests: [
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
+        {n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html#some-hash`}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave and pageview on history-based SPA navigation', async ({ page }) => {
+  test('sends an event and a pageview on history-based SPA navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#history-nav'),
       expectedRequests: [
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
+        {n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave with the manually overridden URL', async ({ page }) => {
+  test('sends an event with the manually overridden URL', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#pageview-trigger-custom-url'),
       expectedRequests: [{n: 'pageview', u: 'https://example.com/custom/location'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: 'https://example.com/custom/location'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: 'https://example.com/custom/location'}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('does not send pageleave when pageview was not sent in manual mode', async ({ page }) => {
+  test('does not send an event when pageview was not sent in manual mode', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      refutedRequests: [{n: 'pageleave'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      refutedRequests: [{n: expectedEvent}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('script.exclusions.hash.pageleave.js sends pageleave only from URLs where a pageview was sent', async ({ page }) => {
+  test('script.exclusions.hash.pageleave.js sends an event only from URLs where a pageview was sent', async ({ page }) => {
     const pageBaseURL = `${LOCAL_SERVER_ADDR}/pageleave-hash-exclusions.html`
 
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash-exclusions.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // After the initial pageview is sent, navigate to ignored page ->
     // pageleave event is sent from the initial page URL
     await expectPlausibleInAction(page, {
       action: () => page.click('#ignored-hash-link'),
-      expectedRequests: [{n: 'pageleave', u: pageBaseURL, h: 1}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: pageBaseURL, h: 1}],
+      shouldIgnoreRequest: ignoreRequests
     })
 
     await pageleaveCooldown(page)
@@ -104,8 +109,8 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-link-1'),
       expectedRequests: [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
-      refutedRequests: [{n: 'pageleave'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      refutedRequests: [{n: expectedEvent}],
+      shouldIgnoreRequest: ignoreRequests
     })
 
     await pageleaveCooldown(page)
@@ -115,57 +120,54 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-link-2'),
       expectedRequests: [
-        {n: 'pageleave', u: `${pageBaseURL}#hash1`, h: 1},
+        {n: expectedEvent, u: `${pageBaseURL}#hash1`, h: 1},
         {n: 'pageview', u: `${pageBaseURL}#hash2`, h: 1}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave with the same props as pageview (manual extension)', async ({ page }) => {
+  test('sends an event with the same props as pageview (manual extension)', async ({ page }) => {
     await page.goto('/pageleave-manual.html')
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#pageview-trigger-custom-props'),
       expectedRequests: [{n: 'pageview', p: {author: 'John'}}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave with the same props as pageview (pageview-props extension)', async ({ page }) => {
+  test('sends an event with the same props as pageview (pageview-props extension)', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-pageview-props.html'),
       expectedRequests: [{n: 'pageview', p: {author: 'John'}}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends pageleave with the same props as pageview (hash navigation / pageview-props extension)', async ({ page }) => {
+  test('sends an event with the same props as pageview (hash navigation / pageview-props extension)', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash-pageview-props.html'),
       expectedRequests: [{n: 'pageview', p: {}}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#john-post'),
       expectedRequests: [
-        {n: 'pageleave', p: {}},
+        {n: expectedEvent, p: {}},
         {n: 'pageview', p: {author: 'john'}}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
 
     await pageleaveCooldown(page)
@@ -173,10 +175,10 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#jane-post'),
       expectedRequests: [
-        {n: 'pageleave', p: {author: 'john'}},
+        {n: expectedEvent, p: {author: 'john'}},
         {n: 'pageview', p: {author: 'jane'}}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
 
     await pageleaveCooldown(page)
@@ -184,18 +186,17 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#home'),
       expectedRequests: [
-        {n: 'pageleave', p: {author: 'jane'}},
+        {n: expectedEvent, p: {author: 'jane'}},
         {n: 'pageview', p: {}}
       ],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
-  test('sends a pageleave when plausible API is slow and user navigates away before response is received', async ({ page }) => {
+  test('sends an event when plausible API is slow and user navigates away before response is received', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
       expectedRequests: [{n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -204,13 +205,13 @@ test.describe('pageleave extension', () => {
         await page.click('#back-button-trigger')
       },
       expectedRequests: [
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
+        {n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
+        {n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}
       ],
       responseDelay: 1000,
-      shouldIgnoreRequest: ignoreEngagementRequests
+      shouldIgnoreRequest: ignoreRequests
     })
   })
-})
+}

--- a/tracker/test/pageleave.spec.js
+++ b/tracker/test/pageleave.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { expectPlausibleInAction, pageleaveCooldown } = require('./support/test-utils')
+const { expectPlausibleInAction, pageleaveCooldown, ignoreEngagementRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -9,19 +9,22 @@ test.describe('pageleave extension', () => {
   test('sends a pageleave when navigating to the next page', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}]
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends pageleave and pageview on hash-based SPA navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -29,14 +32,16 @@ test.describe('pageleave extension', () => {
       expectedRequests: [
         {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave-hash.html#some-hash`}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends pageleave and pageview on history-based SPA navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -44,7 +49,8 @@ test.describe('pageleave extension', () => {
       expectedRequests: [
         {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
@@ -53,12 +59,14 @@ test.describe('pageleave extension', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#pageview-trigger-custom-url'),
-      expectedRequests: [{n: 'pageview', u: 'https://example.com/custom/location'}]
+      expectedRequests: [{n: 'pageview', u: 'https://example.com/custom/location'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: 'https://example.com/custom/location'}]
+      expectedRequests: [{n: 'pageleave', u: 'https://example.com/custom/location'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
@@ -68,6 +76,7 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
       refutedRequests: [{n: 'pageleave'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
@@ -76,14 +85,16 @@ test.describe('pageleave extension', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash-exclusions.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // After the initial pageview is sent, navigate to ignored page ->
     // pageleave event is sent from the initial page URL
     await expectPlausibleInAction(page, {
       action: () => page.click('#ignored-hash-link'),
-      expectedRequests: [{n: 'pageleave', u: pageBaseURL, h: 1}]
+      expectedRequests: [{n: 'pageleave', u: pageBaseURL, h: 1}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await pageleaveCooldown(page)
@@ -93,7 +104,8 @@ test.describe('pageleave extension', () => {
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-link-1'),
       expectedRequests: [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
-      refutedRequests: [{n: 'pageleave'}]
+      refutedRequests: [{n: 'pageleave'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await pageleaveCooldown(page)
@@ -106,6 +118,7 @@ test.describe('pageleave extension', () => {
         {n: 'pageleave', u: `${pageBaseURL}#hash1`, h: 1},
         {n: 'pageview', u: `${pageBaseURL}#hash2`, h: 1}
       ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
@@ -114,31 +127,36 @@ test.describe('pageleave extension', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#pageview-trigger-custom-props'),
-      expectedRequests: [{n: 'pageview', p: {author: 'John'}}]
+      expectedRequests: [{n: 'pageview', p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}]
+      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends pageleave with the same props as pageview (pageview-props extension)', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-pageview-props.html'),
-      expectedRequests: [{n: 'pageview', p: {author: 'John'}}]
+      expectedRequests: [{n: 'pageview', p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}]
+      expectedRequests: [{n: 'pageleave', p: {author: 'John'}}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends pageleave with the same props as pageview (hash navigation / pageview-props extension)', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave-hash-pageview-props.html'),
-      expectedRequests: [{n: 'pageview', p: {}}]
+      expectedRequests: [{n: 'pageview', p: {}}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -146,7 +164,8 @@ test.describe('pageleave extension', () => {
       expectedRequests: [
         {n: 'pageleave', p: {}},
         {n: 'pageview', p: {author: 'john'}}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await pageleaveCooldown(page)
@@ -156,7 +175,8 @@ test.describe('pageleave extension', () => {
       expectedRequests: [
         {n: 'pageleave', p: {author: 'john'}},
         {n: 'pageview', p: {author: 'jane'}}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await pageleaveCooldown(page)
@@ -166,14 +186,16 @@ test.describe('pageleave extension', () => {
       expectedRequests: [
         {n: 'pageleave', p: {author: 'jane'}},
         {n: 'pageview', p: {}}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends a pageleave when plausible API is slow and user navigates away before response is received', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/pageleave.html'),
-      expectedRequests: [{n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}]
+      expectedRequests: [{n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -187,7 +209,8 @@ test.describe('pageleave extension', () => {
         {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/pageleave-pageview-props.html`, p: {author: 'John'}},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/pageleave.html`}
       ],
-      responseDelay: 1000
+      responseDelay: 1000,
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 })

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -7,34 +7,6 @@ test.describe('scroll depth (pageleave events)', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
   sharedTests('pageleave', ignoreEngagementRequests)
-
-  test('sends scroll depth on hash navigation', async ({ page }) => {
-    await expectPlausibleInAction(page, {
-      action: () => page.goto('/scroll-depth-hash.html'),
-      expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
-    })
-
-    await expectPlausibleInAction(page, {
-      action: () => page.click('#about-link'),
-      expectedRequests: [
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
-        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
-      ],
-      shouldIgnoreRequest: ignoreEngagementRequests
-    })
-
-    await pageleaveCooldown(page)
-
-    await expectPlausibleInAction(page, {
-      action: () => page.click('#home-link'),
-      expectedRequests: [
-        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
-        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
-      ],
-      shouldIgnoreRequest: ignoreEngagementRequests
-    })
-  })
 })
 
 test.describe('scroll depth (engagement events)', () => {
@@ -97,6 +69,34 @@ function sharedTests(expectedEvent, ignoreRequests) {
       action: () => page.click('#navigate-away'),
       expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
       shouldIgnoreRequest: ignoreRequests
+    })
+  })
+
+  test('sends scroll depth on hash navigation', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth-hash.html'),
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
+    })
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#about-link'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
+    })
+
+    await pageleaveCooldown(page)
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#home-link'),
+      expectedRequests: [
+        {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageleaveCooldown, expectPlausibleInAction } = require('./support/test-utils')
+const { pageleaveCooldown, expectPlausibleInAction, ignoreEngagementRequests } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -9,7 +9,8 @@ test.describe('scroll depth', () => {
   test('sends scroll_depth in the pageleave payload when navigating to the next page', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await page.evaluate(() => window.scrollBy(0, 300))
@@ -17,14 +18,16 @@ test.describe('scroll depth', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}]
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('sends scroll depth on hash navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-hash.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await expectPlausibleInAction(page, {
@@ -32,7 +35,8 @@ test.describe('scroll depth', () => {
       expectedRequests: [
         {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html`, sd: 100},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     await pageleaveCooldown(page)
@@ -42,14 +46,16 @@ test.describe('scroll depth', () => {
       expectedRequests: [
         {n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`, sd: 34},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#home`}
-      ]
+      ],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('document height gets reevaluated after window load', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-slow-window-load.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // Wait for the image to be loaded
@@ -59,27 +65,31 @@ test.describe('scroll depth', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}]
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('dynamically loaded content affects documentHeight', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-dynamic-content-load.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
-    
+
     // The link appears dynamically after 500ms.
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}]
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 
   test('document height gets reevaluated on scroll', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-content-onscroll.html'),
-      expectedRequests: [{n: 'pageview'}]
+      expectedRequests: [{n: 'pageview'}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // During the first 3 seconds, the script periodically updates document height
@@ -89,7 +99,7 @@ test.describe('scroll depth', () => {
 
     // scroll to the bottom of the page
     await page.evaluate(() => window.scrollBy(0, document.body.scrollHeight))
-    
+
     // Wait until documentHeight gets increased by the fixture JS
     await page.waitForSelector('#more-content')
 
@@ -97,7 +107,8 @@ test.describe('scroll depth', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}]
+      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}],
+      shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
 })

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,27 +1,12 @@
 /* eslint-disable playwright/no-skipped-test */
-const { pageleaveCooldown, expectPlausibleInAction, ignoreEngagementRequests } = require('./support/test-utils')
+const { pageleaveCooldown, expectPlausibleInAction, ignoreEngagementRequests, ignorePageleaveRequests, hideCurrentTab, hideAndShowCurrentTab } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
-test.describe('scroll depth', () => {
+test.describe('scroll depth (pageleave events)', () => {
   test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
 
-  test('sends scroll_depth in the pageleave payload when navigating to the next page', async ({ page }) => {
-    await expectPlausibleInAction(page, {
-      action: () => page.goto('/scroll-depth.html'),
-      expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
-    })
-
-    await page.evaluate(() => window.scrollBy(0, 300))
-    await page.evaluate(() => window.scrollBy(0, 0))
-
-    await expectPlausibleInAction(page, {
-      action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
-      shouldIgnoreRequest: ignoreEngagementRequests
-    })
-  })
+  sharedTests('pageleave', ignoreEngagementRequests)
 
   test('sends scroll depth on hash navigation', async ({ page }) => {
     await expectPlausibleInAction(page, {
@@ -50,12 +35,75 @@ test.describe('scroll depth', () => {
       shouldIgnoreRequest: ignoreEngagementRequests
     })
   })
+})
+
+test.describe('scroll depth (engagement events)', () => {
+  test.skip(({browserName}) => browserName === 'webkit', 'Not testable on Webkit')
+
+  sharedTests('engagement', ignorePageleaveRequests)
+
+  test('sends scroll depth when minimizing the tab', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth.html'),
+      expectedRequests: [{n: 'pageview'}],
+    })
+
+    await page.evaluate(() => window.scrollBy(0, 300))
+    await page.waitForTimeout(100) // Wait for the scroll event to be processed
+
+    await expectPlausibleInAction(page, {
+      action: () => hideCurrentTab(page),
+      expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
+    })
+  })
+
+  test('re-sends engagement events only when user has scrolled in-between', async ({ page, context }) => {
+    await expectPlausibleInAction(page, {
+      action: async () => {
+        await page.goto('/scroll-depth.html')
+        await hideAndShowCurrentTab(page)
+      },
+      expectedRequests: [
+        {n: 'pageview'},
+        {n: 'engagement', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 14}
+      ],
+    })
+
+    await expectPlausibleInAction(page, {
+      action: () => hideAndShowCurrentTab(page),
+      expectedRequests: [],
+    })
+
+    await page.evaluate(() => window.scrollBy(0, 300))
+
+    await expectPlausibleInAction(page, {
+      action: () => hideCurrentTab(page),
+      expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
+    })
+  })
+})
+
+function sharedTests(expectedEvent, ignoreRequests) {
+  test('sends scroll_depth in the pageleave payload when navigating to the next page', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/scroll-depth.html'),
+      expectedRequests: [{n: 'pageview'}],
+    })
+
+    await page.evaluate(() => window.scrollBy(0, 300))
+    await page.evaluate(() => window.scrollBy(0, 0))
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#navigate-away'),
+      expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/scroll-depth.html`, sd: 20}],
+      shouldIgnoreRequest: ignoreRequests
+    })
+  })
 
   test('document height gets reevaluated after window load', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-slow-window-load.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // Wait for the image to be loaded
@@ -65,8 +113,8 @@ test.describe('scroll depth', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/scroll-depth-slow-window-load.html`, sd: 24}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
@@ -74,14 +122,13 @@ test.describe('scroll depth', () => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-dynamic-content-load.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // The link appears dynamically after 500ms.
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/scroll-depth-dynamic-content-load.html`, sd: 14}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
 
@@ -89,7 +136,6 @@ test.describe('scroll depth', () => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/scroll-depth-content-onscroll.html'),
       expectedRequests: [{n: 'pageview'}],
-      shouldIgnoreRequest: ignoreEngagementRequests
     })
 
     // During the first 3 seconds, the script periodically updates document height
@@ -107,8 +153,8 @@ test.describe('scroll depth', () => {
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
-      expectedRequests: [{n: 'pageleave', u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}],
-      shouldIgnoreRequest: ignoreEngagementRequests
+      expectedRequests: [{n: expectedEvent, u: `${LOCAL_SERVER_ADDR}/scroll-depth-content-onscroll.html`, sd: 80}],
+      shouldIgnoreRequest: ignoreRequests
     })
   })
-})
+}

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -137,6 +137,31 @@ exports.ignoreEngagementRequests = function(requestPostData) {
   return requestPostData.n === 'engagement'
 }
 
+exports.ignorePageleaveRequests = function(requestPostData) {
+  return requestPostData.n === 'pageleave'
+}
+
+async function toggleTabVisibility(page, hide) {
+  await page.evaluate((hide) => {
+    Object.defineProperty(document, 'visibilityState', { value: hide ? 'hidden' : 'visible', writable: true })
+    Object.defineProperty(document, 'hidden', { value: hide, writable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+  }, hide)
+}
+
+exports.hideCurrentTab = async function(page) {
+  return toggleTabVisibility(page, true)
+}
+
+exports.showCurrentTab = async function(page) {
+  return toggleTabVisibility(page, false)
+}
+
+exports.hideAndShowCurrentTab = async function(page) {
+  await exports.hideCurrentTab(page)
+  await exports.showCurrentTab(page)
+}
+
 function includesSubset(body, subset) {
   return Object.keys(subset).every((key) => {
     if (typeof subset[key] === 'object') {

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -32,13 +32,16 @@ exports.metaKey = function() {
 
 // Mocks a specified number of HTTP requests with given path. Returns a promise that resolves to a
 // list of requests as soon as the specified number of requests is made, or 3 seconds has passed.
-const mockManyRequests = function({ page, path, numberOfRequests, responseDelay }) {
+const mockManyRequests = function({ page, path, numberOfRequests, responseDelay, shouldIgnoreRequest }) {
   return new Promise((resolve, _reject) => {
     let requestList = []
     const requestTimeoutTimer = setTimeout(() => resolve(requestList), 3000)
 
     page.route(path, async (route, request) => {
-      requestList.push(request)
+      const postData = request.postDataJSON()
+      if (!shouldIgnoreRequest || !shouldIgnoreRequest(postData)) {
+        requestList.push(postData)
+      }
       if (responseDelay) {
         await delay(responseDelay)
       }
@@ -85,7 +88,8 @@ exports.expectPlausibleInAction = async function (page, {
   refutedRequests = [],
   awaitedRequestCount,
   expectedRequestCount,
-  responseDelay
+  responseDelay,
+  shouldIgnoreRequest
 }) {
   const requestsToExpect = expectedRequestCount ? expectedRequestCount : expectedRequests.length
   const requestsToAwait = awaitedRequestCount ? awaitedRequestCount : requestsToExpect + refutedRequests.length
@@ -93,11 +97,12 @@ exports.expectPlausibleInAction = async function (page, {
   const plausibleRequestMockList = mockManyRequests({
     page,
     path: '/api/event',
-    numberOfRequests: requestsToAwait,
-    responseDelay: responseDelay
+    responseDelay,
+    shouldIgnoreRequest,
+    numberOfRequests: requestsToAwait
   })
   await action()
-  const requestBodies = (await plausibleRequestMockList).map(r => r.postDataJSON())
+  const requestBodies = await plausibleRequestMockList
 
   const expectedButNotFoundBodySubsets = []
 
@@ -126,6 +131,10 @@ exports.expectPlausibleInAction = async function (page, {
   expect(refutedButFoundRequestBodies, refutedBodySubsetsErrorMessage).toHaveLength(0)
 
   expect(requestBodies.length).toBe(requestsToExpect)
+}
+
+exports.ignoreEngagementRequests = function(requestPostData) {
+  return requestPostData.n === 'engagement'
 }
 
 function includesSubset(body, subset) {


### PR DESCRIPTION
### Changes

Consider this an experiement to see whether engagement events would do the trick. 

`visibilitychange` nicely fires when the page is loaded, user closes or switches the tab or when they navigate away from the page.

To avoid sending redundant events we:
1. Don't send engagement events when pageview was ignored and on initial page load 
2. When user has not scrolled in-between tab-in-and-tab-out (initial engagement event is always sent)

For the future:
1. If we find this doesn't help us, I'll revert the PR and delete the redundant events
2. If we find this _does_ help us:
    1. I'll update the rest of the backend codebase to work off of engagement events 
    2. migrate historical data on cloud
    3. figure out whether we need a workaround for old Safari implementation issues: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event