### PR TITLE
Implement `assert_matches` with expanded expressions support in match assertions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,5 +7,6 @@
     "{config,lib,test,extra}/**/*.{heex,ex,exs}",
     "priv/*/seeds.exs",
     "storybook/**/*.exs"
-  ]
+  ],
+  locals_without_parens: [assert_matches: 1]
 ]

--- a/test/plausible/stats/time_test.exs
+++ b/test/plausible/stats/time_test.exs
@@ -232,4 +232,27 @@ defmodule Plausible.Stats.TimeTest do
              ]
     end
   end
+
+  test "foobar" do
+    n = %{z: 2}
+
+    assert_matches %{
+                     a: ^any(:integer, &(&1 > 2)),
+                     b: ^any(:string, ~r/baz/),
+                     d: [_ | _],
+                     e: ^~r/invalid/,
+                     f: ^n.z,
+                     g: ^(&is_float/1),
+                     h: ^exact(%{foo: :bar})
+                   } = %{
+                     a: 1,
+                     b: "twofer",
+                     c: :other,
+                     d: [1, 2, 3],
+                     e: "another string",
+                     f: 1,
+                     g: 4.2,
+                     h: %{foo: :bar, other: "stuff"}
+                   }
+  end
 end

--- a/test/plausible/stats/time_test.exs
+++ b/test/plausible/stats/time_test.exs
@@ -232,27 +232,4 @@ defmodule Plausible.Stats.TimeTest do
              ]
     end
   end
-
-  test "foobar" do
-    n = %{z: 2}
-
-    assert_matches %{
-                     a: ^any(:integer, &(&1 > 2)),
-                     b: ^any(:string, ~r/baz/),
-                     d: [_ | _],
-                     e: ^~r/invalid/,
-                     f: ^n.z,
-                     g: ^(&is_float/1),
-                     h: ^exact(%{foo: :bar})
-                   } = %{
-                     a: 1,
-                     b: "twofer",
-                     c: :other,
-                     d: [1, 2, 3],
-                     e: "another string",
-                     f: 1,
-                     g: 4.2,
-                     h: %{foo: :bar, other: "stuff"}
-                   }
-  end
 end

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -359,7 +359,8 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                          "id" => ^any(:integer),
                          "name" => "Some segment",
                          "type" => ^"#{unquote(type)}",
-                         "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
+                         "segment_data" =>
+                           ^strict_map(%{"filters" => [["is", "visit:entry_page", ["/blog"]]]}),
                          "owner_id" => ^user.id,
                          "inserted_at" => ^any(:string),
                          "updated_at" => ^any(:string)

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -355,16 +355,16 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
           })
           |> json_response(200)
 
-        assert %{
-                 "name" => "Some segment",
-                 "type" => "#{unquote(type)}",
-                 "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
-                 "owner_id" => user.id
-               } == Map.drop(response, ["id", "inserted_at", "updated_at"])
+        assert_matches %{
+                         "id" => ^any(:integer),
+                         "name" => "Some segment",
+                         "type" => ^"#{unquote(type)}",
+                         "segment_data" => %{"filters" => [["is", "visit:entry_page", ["/blog"]]]},
+                         "owner_id" => ^user.id,
+                         "inserted_at" => ^any(:string),
+                         "updated_at" => ^any(:string)
+                       } = response
 
-        assert is_integer(response["id"])
-        assert is_binary(response["inserted_at"])
-        assert is_binary(response["updated_at"])
         assert response["inserted_at"] == response["updated_at"]
 
         verify_segment_in_db(%Plausible.Segments.Segment{

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -355,7 +355,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
           })
           |> json_response(200)
 
-        assert_matches %{
+        assert_matches ^strict_map(%{
                          "id" => ^any(:integer),
                          "name" => "Some segment",
                          "type" => ^"#{unquote(type)}",
@@ -363,7 +363,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                          "owner_id" => ^user.id,
                          "inserted_at" => ^any(:string),
                          "updated_at" => ^any(:string)
-                       } = response
+                       }) = response
 
         assert response["inserted_at"] == response["updated_at"]
 

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -356,14 +356,14 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
           |> json_response(200)
 
         assert_matches ^strict_map(%{
-                         "id" => ^any(:integer),
+                         "id" => ^any(:pos_integer),
                          "name" => "Some segment",
                          "type" => ^"#{unquote(type)}",
                          "segment_data" =>
                            ^strict_map(%{"filters" => [["is", "visit:entry_page", ["/blog"]]]}),
                          "owner_id" => ^user.id,
-                         "inserted_at" => ^any(:string),
-                         "updated_at" => ^any(:string)
+                         "inserted_at" => ^any(:iso8601_naive_datetime),
+                         "updated_at" => ^any(:iso8601_naive_datetime)
                        }) = response
 
         assert response["inserted_at"] == response["updated_at"]

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -17,10 +17,16 @@ defmodule Plausible.AssertMatches do
     * `any(:string)`
     * `any(:binary)`
     * `any(:integer)`
+    * `any(:pos_integer)`
+    * `any(:number)`
     * `any(:float)`
     * `any(:boolean)`
     * `any(:map)`
     * `any(:list)`
+    * `any(:tuple)`
+    * `any(:iso8601_date)`
+    * `any(:iso8601_datetime)`
+    * `any(:iso8601_naive_datetime)`
     * all above variants of any with a one argument predicate function accepting
       value and returning a boolean, like: `any(:integer, & &1 > 20)`
     * a special case of `any(:string, ~r/regex pattern/)` checking that value is
@@ -344,10 +350,45 @@ defmodule Plausible.AssertMatches do
     def any(:string), do: &is_binary/1
     def any(:binary), do: &is_binary/1
     def any(:integer), do: &is_integer/1
+    def any(:number), do: &is_number/1
     def any(:float), do: &is_float/1
     def any(:boolean), do: &is_boolean/1
     def any(:map), do: &is_map/1
     def any(:list), do: &is_list/1
+    def any(:tuple), do: &is_tuple/1
+
+    def any(:pos_integer) do
+      fn value ->
+        is_integer(value) and value > 0
+      end
+    end
+
+    def any(:iso8601_date) do
+      fn value ->
+        case Date.from_iso8601(value) do
+          {:ok, _} -> true
+          _ -> false
+        end
+      end
+    end
+
+    def any(:iso8601_datetime) do
+      fn value ->
+        case DateTime.from_iso8601(value) do
+          {:ok, _} -> true
+          _ -> false
+        end
+      end
+    end
+
+    def any(:iso8601_naive_datetime) do
+      fn value ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, _} -> true
+          _ -> false
+        end
+      end
+    end
 
     def any(:string, %Regex{} = regex) do
       fn value ->

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -28,11 +28,11 @@ defmodule Plausible.AssertMatches do
     * shorthand version of the above, `~r/regex pattern/`
     * any artibrary one argument function returning a boolean, like `&is_float/1`
       or `&(&1 < 40 or &1 > 300)`
-    * exact(expression) where expression is compared using equality, so that can
-      enforce full equality inside a pattern, like: `exact(%{foo: 2})` which will
+    * exactly(expression) where expression is compared using equality, so that can
+      enforce full equality inside a pattern, like: `exactly(%{foo: 2})` which will
       fail if the value is something like `%{foo: 2, other: "something}`
     * any other arbitrary expression which is compared the way as if it was wrapped
-      with exact * this allows "interpolating" values from schemas and maps without
+      with `exactly()`; this allows "interpolating" values from schemas and maps without
       rebinding like `user.id` (instead of having to rebind to `user_id` first)
 
   Usage example:
@@ -46,7 +46,7 @@ defmodule Plausible.AssertMatches do
                       e: ^~r/invalid/,
                       f: ^n.z,
                       g: ^(&is_float/1),
-                      h: ^exact(%{foo: :bar})
+                      h: ^exactly(%{foo: :bar})
                     } = %{
                       a: 1,
                       b: "twofer",
@@ -147,9 +147,9 @@ defmodule Plausible.AssertMatches do
       end
     end
 
-    def transform_predicate({:exact, _, [value]}) do
+    def transform_predicate({:exactly, _, [value]}) do
       quote do
-        Plausible.AssertMatches.Internal.exact(unquote(value))
+        Plausible.AssertMatches.Internal.exactly(unquote(value))
       end
     end
 
@@ -170,7 +170,7 @@ defmodule Plausible.AssertMatches do
 
     def transform_predicate(other), do: other
 
-    def strip_prefix({{:., _, [_prefix, f]}, _, args}) when f in [:any, :regex, :exact] do
+    def strip_prefix({{:., _, [_prefix, f]}, _, args}) when f in [:any, :regex, :exactly] do
       {f, [], args}
     end
 
@@ -205,7 +205,7 @@ defmodule Plausible.AssertMatches do
       end
     end
 
-    def exact(expr) do
+    def exactly(expr) do
       fn value ->
         value == expr
       end

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -1,0 +1,159 @@
+defmodule Plausible.AssertMatches do
+  @doc """
+  Pattern match assertions wrapper macro extending it with checks expressed
+  directly within the pattern.
+  """
+
+  defmacro assert_matches({:=, meta, [pattern, value]}) do
+    {var_pattern, pins} =
+      Macro.postwalk(pattern, [], fn
+        {:^, _meta, {pinned, _, module}} = normal_pin, acc
+        when is_atom(pinned) and is_atom(module) ->
+          {normal_pin, acc}
+
+        {:^, _meta, [pinned]}, acc ->
+          pinned = Plausible.AssertMatches.Internal.transform_predicate(pinned)
+          pinned_var = Macro.unique_var(:match, __MODULE__)
+          {pinned_var, [{pinned_var, pinned} | acc]}
+
+        other, acc ->
+          {other, acc}
+      end)
+
+    clean_pattern =
+      Enum.reduce(pins, var_pattern, fn {var, _predicate}, pattern ->
+        Macro.postwalk(pattern, fn
+          ^var -> {:_, [], __MODULE__}
+          other -> other
+        end)
+      end)
+
+    predicate_pattern =
+      quote bind_quoted: [
+              var_pattern: Macro.escape(var_pattern),
+              escaped_pins: Macro.escape(pins),
+              pins: pins
+            ] do
+        escaped_pins
+        |> Enum.zip(pins)
+        |> Enum.reduce({false, var_pattern}, fn {{escaped_var, escaped_predicate},
+                                                 {var, predicate}},
+                                                {errors?, pattern} ->
+          result =
+            if is_function(predicate, 1) do
+              not predicate.(var)
+            else
+              predicate != var
+            end
+
+          if result do
+            escaped_predicate = Plausible.AssertMatches.Internal.strip_prefix(escaped_predicate)
+
+            {true,
+             Macro.postwalk(pattern, fn
+               ^escaped_var -> "__#{Macro.to_string(escaped_predicate)}__"
+               other -> other
+             end)}
+          else
+            {errors?,
+             Macro.postwalk(pattern, fn
+               ^escaped_var -> {:_, [], __MODULE__}
+               other -> other
+             end)}
+          end
+        end)
+      end
+
+    quote do
+      value = unquote(value)
+      assert unquote(clean_pattern) = value
+      assert unquote(var_pattern) = value
+      {errors?, predicate_pattern} = unquote(predicate_pattern)
+
+      if errors? do
+        raise ExUnit.AssertionError,
+          message: "match (=) failed",
+          left: predicate_pattern,
+          right: value,
+          expr:
+            {:assert_matches, unquote(meta),
+             [{:=, [], [unquote(Macro.escape(pattern)), Macro.escape(value)]}]},
+          context: {:match, []}
+      end
+    end
+  end
+
+  defmodule Internal do
+    @moduledoc false
+
+    def transform_predicate({:any, _, [value]}) do
+      quote do
+        Plausible.AssertMatches.Internal.any(unquote(value))
+      end
+    end
+
+    def transform_predicate({:exact, _, [value]}) do
+      quote do
+        Plausible.AssertMatches.Internal.exact(unquote(value))
+      end
+    end
+
+    def transform_predicate({:any, _, [value, extra_predicate]}) do
+      quote do
+        Plausible.AssertMatches.Internal.any(
+          unquote(value),
+          unquote(extra_predicate)
+        )
+      end
+    end
+
+    def transform_predicate({:sigil_r, _, _} = regex) do
+      quote do
+        Plausible.AssertMatches.Internal.regex(unquote(regex))
+      end
+    end
+
+    def transform_predicate(other), do: other
+
+    def strip_prefix({{:., _, [_prefix, f]}, _, args}) when f in [:any, :regex, :exact] do
+      {f, [], args}
+    end
+
+    def strip_prefix(predicate) do
+      predicate
+    end
+
+    def any(:atom), do: &is_atom/1
+    def any(:string), do: &is_binary/1
+    def any(:binary), do: &is_binary/1
+    def any(:integer), do: &is_integer/1
+    def any(:float), do: &is_float/1
+    def any(:boolean), do: &is_boolean/1
+    def any(:map), do: &is_map/1
+    def any(:list), do: &is_list/1
+
+    def any(:string, %Regex{} = regex) do
+      fn value ->
+        any(:string).(value) and regex(regex).(value)
+      end
+    end
+
+    def any(type, predicate_fn) when is_function(predicate_fn, 1) do
+      fn value ->
+        any(type).(value) and predicate_fn.(value)
+      end
+    end
+
+    def regex(regex) do
+      fn value ->
+        String.match?(value, regex)
+      end
+    end
+
+    def exact(expr) do
+      fn value ->
+        value == expr
+      end
+    end
+  end
+end

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -1,5 +1,5 @@
 defmodule Plausible.AssertMatches do
-  @doc """
+  @moduledoc """
   Pattern match assertions wrapper macro extending it with checks expressed
   directly within the pattern.
 
@@ -71,6 +71,7 @@ defmodule Plausible.AssertMatches do
                     }
   """
 
+  @doc @moduledoc
   defmacro assert_matches({:=, meta, [pattern, value]}) do
     {base_strict_pattern, strict_vars} = build_base_strict_pattern(pattern)
 

--- a/test/support/assert_matches.ex
+++ b/test/support/assert_matches.ex
@@ -51,7 +51,7 @@ defmodule Plausible.AssertMatches do
 
             {true,
              Macro.postwalk(pattern, fn
-               ^escaped_var -> "__#{Macro.to_string(escaped_predicate)}__"
+               ^escaped_var -> escaped_predicate
                other -> other
              end)}
           else

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,6 +24,7 @@ defmodule PlausibleWeb.ConnCase do
       import Phoenix.ConnTest
       alias PlausibleWeb.Router.Helpers, as: Routes
       import Plausible.Factory
+      import Plausible.AssertMatches
 
       # The default endpoint for testing
       @endpoint PlausibleWeb.Endpoint

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -22,6 +22,7 @@ defmodule Plausible.DataCase do
       import Ecto.Changeset
       import Plausible.DataCase
       import Plausible.Factory
+      import Plausible.AssertMatches
     end
   end
 


### PR DESCRIPTION
### Changes

This is a proposal for implementing a more expressive match assertion mechanism. It was prompted by the original idea by @macobo in #5019.

The idea here is that the pin (^) operator does not only rebind existing binding in the scope but also allows embedding basically any other expression to match against the given part of the pattern. Normal pattern matching is also supported and both can be mixed. The only caveat so far is that when normal patterns fail, only they are listed in the error even if there are potentially failing expressions. However, once the normal pattern is fixed, they surface.

Currently, the following expressions can be pinned:

* `any(:atom)`
* `any(:string)`
* `any(:binary)`
* `any(:integer)`
* `any(:float)`
* `any(:boolean)`
* `any(:map)`
* `any(:list)`
* all above variants of `any` with a one argument predicate function accepting value and returning a boolean, like: `any(:integer, & &1 > 20)`
* a special case of `any(:string, ~r/regex pattern/)` checking that value is a string and matches a pattern
* shorthand version of the above, `~r/regex pattern`
* any artibrary one argument function returning a boolean, like `&is_float/1` or `&(&1 < 40 or &1 > 300)`
* `exact(expression)` where expression is compared using equality, so that can enforce full equality inside a pattern, like: `exact(%{foo: 2})` which will fail if the value is something like `%{foo: 2, other: "something}`
* any other arbitrary expression which is compared the way as if it was wrapped with `exact` - this allows "interpolating" values from schemas and maps without rebinding like `user.id` (instead of having to rebind to `user_id` first)

```elixir
    n = %{z: 2}

    assert_matches %{
                     a: ^any(:integer, &(&1 > 2)),
                     b: ^any(:string, ~r/baz/),
                     d: [_ | _],
                     e: ^~r/invalid/,
                     f: ^n.z,
                     g: ^(&is_float/1),
                     h: ^exact(%{foo: :bar})
                   } = %{
                     a: 1,
                     b: "twofer",
                     c: :other,
                     d: [1, 2, 3],
                     e: "another string",
                     f: 1,
                     g: 4.2,
                     h: %{foo: :bar, other: "stuff"}
                   }
  end
```

![image](https://github.com/user-attachments/assets/81317474-37c1-48c2-b199-057305cfa5dc)

Although the macro seems to be relatively feature complete, more testing against some real world scenarios must be done before merging.

