### PR TITLE
Allow over-limit site ownership transfer for users having grandfathered plans

### DIFF
--- a/lib/plausible/billing/qouta/quota.ex
+++ b/lib/plausible/billing/qouta/quota.ex
@@ -68,9 +68,16 @@ defmodule Plausible.Billing.Quota do
   end
 
   defp exceeded_limits(usage, plan, opts) do
+    site_limit_exceeded? =
+      if opts[:skip_site_limit_check?] do
+        false
+      else
+        not within_limit?(usage.sites, plan.site_limit)
+      end
+
     for {limit, exceeded?} <- [
           {:team_member_limit, not within_limit?(usage.team_members, plan.team_member_limit)},
-          {:site_limit, not within_limit?(usage.sites, plan.site_limit)},
+          {:site_limit, site_limit_exceeded?},
           {:monthly_pageview_limit,
            exceeds_monthly_pageview_limit?(usage.monthly_pageviews, plan, opts)}
         ],

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -436,7 +436,9 @@ defmodule Plausible.Teams.Invitations do
       if active_subscription? and plan != :free_10k do
         team
         |> Teams.Billing.quota_usage(pending_ownership_site_ids: [site.id])
-        |> Billing.Quota.ensure_within_plan_limits(plan)
+        |> Billing.Quota.ensure_within_plan_limits(plan,
+          skip_site_limit_check?: Teams.Billing.grandfathered_team?(team)
+        )
       else
         {:error, :no_plan}
       end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -70,7 +70,7 @@ defmodule Plausible.Billing.QuotaTest do
 
     test "grandfathered site limit should be unlimited when accepting transfer invitations" do
       # must be before ~D[2021-05-05]
-      owner = new_user(inserted_at: ~N[2021-01-01 00:00:00])
+      owner = new_user(team: [inserted_at: ~N[2021-01-01 00:00:00]])
       # plan with site_limit: 10
       subscribe_to_plan(owner, "857097")
       _site = for _ <- 1..10, do: new_site(owner: owner)

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -67,6 +67,23 @@ defmodule Plausible.Billing.QuotaTest do
 
       assert Plausible.Teams.Billing.site_limit(team) == 10
     end
+
+    test "grandfathered site limit should be unlimited when accepting transfer invitations" do
+      # must be before ~D[2021-05-05]
+      owner = new_user(inserted_at: ~N[2021-01-01 00:00:00])
+      # plan with site_limit: 10
+      subscribe_to_plan(owner, "857097")
+      _site = for _ <- 1..10, do: new_site(owner: owner)
+
+      other_owner = new_user()
+      other_site = new_site(owner: other_owner)
+      invite_transfer(other_site, owner, inviter: other_owner)
+
+      team = owner |> team_of()
+
+      assert Plausible.Teams.Billing.site_limit(team) == :unlimited
+      assert Plausible.Teams.Invitations.ensure_can_take_ownership(other_site, team) == :ok
+    end
   end
 
   test "site_usage/1 returns the amount of sites the user owns" do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -324,7 +324,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       for _ <- 1..51, do: new_site(owner: user)
 
-      Ecto.Changeset.change(user, %{inserted_at: ~N[2021-05-04 00:00:00]})
+      Ecto.Changeset.change(team_of(user), %{inserted_at: ~N[2021-05-04 00:00:00]})
       |> Repo.update()
 
       conn =


### PR DESCRIPTION
### Changes

This PR fixes an old bug, where users on grandfathered plans would be unable to accept site transfer ownership above their subscription's site limit.
The changes rely on teams migration rewriting owner's `inserted_at` onto the `Team` schema.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
