### PR TITLE
Change `team_memberships.is_autocreated` default to `true`

### DIFF
--- a/priv/repo/migrations/20250129120520_change_team_memberships_is_autocreated_default_to_true.exs
+++ b/priv/repo/migrations/20250129120520_change_team_memberships_is_autocreated_default_to_true.exs
@@ -1,0 +1,19 @@
+defmodule Plausible.Repo.Migrations.ChangeTeamMembershipsIsAutocreatedDefaultToTrue do
+  use Ecto.Migration
+
+  def up do
+    alter table(:team_memberships) do
+      modify :is_autocreated, :boolean, null: false, default: true
+    end
+
+    execute """
+    UPDATE team_memberships SET is_autocreated = true WHERE role = 'owner'
+    """
+  end
+
+  def down do
+    alter table(:team_memberships) do
+      modify :is_autocreated, :boolean, null: false, default: false
+    end
+  end
+end


### PR DESCRIPTION
### Changes

A follow-up to #5002. Intially, `is_autocreated` default must be `true` becuase otherwise there's a non-zero chance of an owner team membership getting added  with it set to false in between #5002 and #5003 which might eventually result in user becoming owner on two teams - we don't want to risk it. Eventually this default will be set back to `false` after logic switch in #5003 (it will have to be altered accordingly).


