### PR TITLE
Don't preload goal settings modal to avoid issues with opening in edit mode

### DIFF
--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -131,7 +131,12 @@ defmodule PlausibleWeb.Live.Components.Modal do
 
   @impl true
   def update(assigns, socket) do
-    preload? = Map.get(assigns, :preload?, true)
+    preload? =
+      if Mix.env() in [:test, :ce_test] do
+        true
+      else
+        Map.get(assigns, :preload?, true)
+      end
 
     socket =
       assign(socket,

--- a/lib/plausible_web/live/components/modal.ex
+++ b/lib/plausible_web/live/components/modal.ex
@@ -101,6 +101,8 @@ defmodule PlausibleWeb.Live.Components.Modal do
 
   """
 
+  @test_preload_override? Mix.env() in [:test, :ce_test]
+
   use PlausibleWeb, :live_component
 
   alias Phoenix.LiveView
@@ -131,12 +133,11 @@ defmodule PlausibleWeb.Live.Components.Modal do
 
   @impl true
   def update(assigns, socket) do
-    preload? =
-      if Mix.env() in [:test, :ce_test] do
-        true
-      else
-        Map.get(assigns, :preload?, true)
-      end
+    # NOTE: This is a workaround for @test_preload_override? being computed
+    # at build time, where Mix.env() is available. Otherwise, dialyzer
+    # complains.
+    preload_override? = :erlang.phash2(1, 1) == 0 and @test_preload_override?
+    preload? = preload_override? || Map.get(assigns, :preload?, true)
 
     socket =
       assign(socket,

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -51,7 +51,12 @@ defmodule PlausibleWeb.Live.GoalSettings do
     <div id="goal-settings-main">
       <.flash_messages flash={@flash} />
 
-      <.live_component :let={modal_unique_id} module={Modal} preload?={false} id="goals-form-modal">
+      <.live_component
+        :let={modal_unique_id}
+        module={Modal}
+        preload?={Mix.env() == :test}
+        id="goals-form-modal"
+      >
         <.live_component
           module={PlausibleWeb.Live.GoalSettings.Form}
           id={"goals-form-#{modal_unique_id}"}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -51,12 +51,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
     <div id="goal-settings-main">
       <.flash_messages flash={@flash} />
 
-      <.live_component
-        :let={modal_unique_id}
-        module={Modal}
-        preload?={Mix.env() == :test}
-        id="goals-form-modal"
-      >
+      <.live_component :let={modal_unique_id} module={Modal} preload?={false} id="goals-form-modal">
         <.live_component
           module={PlausibleWeb.Live.GoalSettings.Form}
           id={"goals-form-#{modal_unique_id}"}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -51,7 +51,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
     <div id="goal-settings-main">
       <.flash_messages flash={@flash} />
 
-      <.live_component :let={modal_unique_id} module={Modal} id="goals-form-modal">
+      <.live_component :let={modal_unique_id} module={Modal} preload?={false} id="goals-form-modal">
         <.live_component
           module={PlausibleWeb.Live.GoalSettings.Form}
           id={"goals-form-#{modal_unique_id}"}

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -165,18 +165,6 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
       refute html =~ "No goals found for this site. Please refine or"
     end
 
-    test "Add Goal form view is rendered immediately, though hidden", %{conn: conn, site: site} do
-      {:ok, _goals} = setup_goals(site)
-      {_, html} = get_liveview(conn, site, with_html?: true)
-
-      assert html =~ "Add Goal for #{site.domain}"
-
-      assert element_exists?(
-               html,
-               ~s/#goals-form-modal form[phx-submit="save-goal"]/
-             )
-    end
-
     test "auto-configuring custom event goals", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:event, name: "Signup"),


### PR DESCRIPTION
This PR fixes an issue where, on a fresh view load, when trying to open edit dialog for an existing goal, the form is not loaded properly. The preloading optimisation (meant load modal contents in the background in a  state defined on page load - in this case, an empty form) breaks it, as first open does not force contents to be reloaded when they should. The modal preopen routine can probably be improved to account for this case with a switch of sorts but currently this is the simplest solution for that particular case.

All the other current uses of the modal component do not have "edit" state currently (Funnel settings still rely on a custom-made solution).

