### PR TITLE
Scroll depth: update `site.scroll_depth_visible_at` in ingestion

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -24,6 +24,7 @@ defmodule Plausible.Application do
         {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
         {Plausible.RateLimit, clean_period: :timer.minutes(10)},
         Plausible.Ingestion.Counters,
+        Plausible.Ingestion.ScrollDepthVisibleAt,
         {Finch, name: Plausible.Finch, pools: finch_pool_config()},
         {Phoenix.PubSub, name: Plausible.PubSub},
         Plausible.Session.Salts,

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -24,7 +24,6 @@ defmodule Plausible.Application do
         {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
         {Plausible.RateLimit, clean_period: :timer.minutes(10)},
         Plausible.Ingestion.Counters,
-        Plausible.Ingestion.ScrollDepthVisibleAt,
         {Finch, name: Plausible.Finch, pools: finch_pool_config()},
         {Phoenix.PubSub, name: Plausible.PubSub},
         Plausible.Session.Salts,
@@ -121,6 +120,7 @@ defmodule Plausible.Application do
     setup_geolocation()
     Location.load_all()
     Plausible.Ingestion.Source.init()
+    Plausible.Ingestion.ScrollDepthVisibleAt.init()
     Plausible.Geo.await_loader()
 
     Supervisor.start_link(List.flatten(children), opts)

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -418,8 +418,6 @@ defmodule Plausible.Exports do
     site = Plausible.Repo.get(Plausible.Site, site_id)
     current_user = current_user_id && Plausible.Repo.get(Plausible.Auth.User, current_user_id)
 
-    include_scroll_depth? = Plausible.Stats.ScrollDepth.check_feature_visible!(site, current_user)
-
     base_q =
       from(e in sampled("events_v2"),
         where: ^export_filter(site_id, date_range),
@@ -428,7 +426,7 @@ defmodule Plausible.Exports do
         order_by: selected_as(:date)
       )
 
-    if include_scroll_depth? do
+    if Plausible.Stats.ScrollDepth.feature_visible?(site, current_user) do
       max_scroll_depth_per_visitor_q =
         from(e in "events_v2",
           where: ^export_filter(site_id, date_range),

--- a/lib/plausible/ingestion/scroll_depth_visible_at.ex
+++ b/lib/plausible/ingestion/scroll_depth_visible_at.ex
@@ -30,7 +30,7 @@ defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
 
   defp attempt_update_repo(site_id) do
     Repo.update_all(
-      from(s in Plausible.Site, where: s.id == ^site_id),
+      from(s in Plausible.Site, where: s.id == ^site_id and is_nil(s.scroll_depth_visible_at)),
       set: [
         scroll_depth_visible_at: DateTime.utc_now()
       ]

--- a/lib/plausible/ingestion/scroll_depth_visible_at.ex
+++ b/lib/plausible/ingestion/scroll_depth_visible_at.ex
@@ -1,5 +1,11 @@
 defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
-  @moduledoc false
+  @moduledoc """
+  GenServer that updates the `scroll_depth_visible_at` column for a site when needed.
+
+  This is called in a hot loop in ingestion, so it:
+  1. Only updates the database once per site (if SiteCache doesn't know about visibility yet)
+  2. Does not retry the update if it fails, to be retried on server restart
+  """
 
   use GenServer
   require Logger
@@ -7,14 +13,9 @@ defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
 
   import Ecto.Query
 
-  @initial_state %{
-    updated_sites: MapSet.new(),
-    pending: MapSet.new()
-  }
-
-  def start_link(opts) do
+  def start_link(opts \\ []) do
     opts = Keyword.merge(opts, name: __MODULE__)
-    GenServer.start_link(__MODULE__, @initial_state, opts)
+    GenServer.start_link(__MODULE__, opts, opts)
   end
 
   def mark_scroll_depth_visible(site_id) do
@@ -22,46 +23,20 @@ defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
   end
 
   @impl true
-  def init(state) do
-    {:ok, state}
+  def init(_opts) do
+    {:ok, MapSet.new()}
   end
 
   @impl true
-  def handle_cast({:update_site, site_id}, state) do
-    cond do
-      MapSet.member?(state.updated_sites, site_id) ->
-        {:noreply, state}
+  def handle_cast({:update_site, site_id}, touched_sites) do
+    # When receiving multiple update requests for a site, only process the first one
+    if MapSet.member?(touched_sites, site_id) do
+      {:noreply, touched_sites}
+    else
+      Task.start(fn -> attempt_update_repo(site_id) end)
 
-      MapSet.member?(state.pending, site_id) ->
-        {:noreply, state}
-
-      true ->
-        Task.start(fn -> attempt_update_repo(site_id) end)
-
-        {:noreply,
-         %{
-           updated_sites: state.updated_sites,
-           pending: MapSet.put(state.pending, site_id)
-         }}
+      {:noreply, MapSet.put(touched_sites, site_id)}
     end
-  end
-
-  @impl true
-  def handle_cast({:mark_updated, site_id}, state) do
-    {:noreply,
-     %{
-       updated_sites: MapSet.put(state.updated_sites, site_id),
-       pending: MapSet.delete(state.pending, site_id)
-     }}
-  end
-
-  @impl true
-  def handle_cast({:mark_update_failed, site_id}, state) do
-    {:noreply,
-     %{
-       updated_sites: state.updated_sites,
-       pending: MapSet.delete(state.pending, site_id)
-     }}
   end
 
   defp attempt_update_repo(site_id) do
@@ -71,15 +46,10 @@ defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
         scroll_depth_visible_at: DateTime.utc_now()
       ]
     )
-
-    # Call genserver with {:mark_updated, site_id}
-    GenServer.cast(__MODULE__, {:mark_updated, site_id})
   rescue
     error ->
       Logger.error(
-        "Error updating scroll depth visible at for site #{site_id}: #{inspect(error)}. Will retry later."
+        "Error updating scroll_depth_visible_at for site #{site_id}: #{inspect(error)}. This will not be retried until server restart."
       )
-
-      GenServer.cast(__MODULE__, {:mark_update_failed, site_id})
   end
 end

--- a/lib/plausible/ingestion/scroll_depth_visible_at.ex
+++ b/lib/plausible/ingestion/scroll_depth_visible_at.ex
@@ -1,0 +1,85 @@
+defmodule Plausible.Ingestion.ScrollDepthVisibleAt do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+  alias Plausible.Repo
+
+  import Ecto.Query
+
+  @initial_state %{
+    updated_sites: MapSet.new(),
+    pending: MapSet.new()
+  }
+
+  def start_link(opts) do
+    opts = Keyword.merge(opts, name: __MODULE__)
+    GenServer.start_link(__MODULE__, @initial_state, opts)
+  end
+
+  def mark_scroll_depth_visible(site_id) do
+    GenServer.cast(__MODULE__, {:update_site, site_id})
+  end
+
+  @impl true
+  def init(state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:update_site, site_id}, state) do
+    cond do
+      MapSet.member?(state.updated_sites, site_id) ->
+        {:noreply, state}
+
+      MapSet.member?(state.pending, site_id) ->
+        {:noreply, state}
+
+      true ->
+        Task.start(fn -> attempt_update_repo(site_id) end)
+
+        {:noreply,
+         %{
+           updated_sites: state.updated_sites,
+           pending: MapSet.put(state.pending, site_id)
+         }}
+    end
+  end
+
+  @impl true
+  def handle_cast({:mark_updated, site_id}, state) do
+    {:noreply,
+     %{
+       updated_sites: MapSet.put(state.updated_sites, site_id),
+       pending: MapSet.delete(state.pending, site_id)
+     }}
+  end
+
+  @impl true
+  def handle_cast({:mark_update_failed, site_id}, state) do
+    {:noreply,
+     %{
+       updated_sites: state.updated_sites,
+       pending: MapSet.delete(state.pending, site_id)
+     }}
+  end
+
+  defp attempt_update_repo(site_id) do
+    Repo.update_all(
+      from(s in Plausible.Site, where: s.id == ^site_id),
+      set: [
+        scroll_depth_visible_at: DateTime.utc_now()
+      ]
+    )
+
+    # Call genserver with {:mark_updated, site_id}
+    GenServer.cast(__MODULE__, {:mark_updated, site_id})
+  rescue
+    error ->
+      Logger.error(
+        "Error updating scroll depth visible at for site #{site_id}: #{inspect(error)}. Will retry later."
+      )
+
+      GenServer.cast(__MODULE__, {:mark_update_failed, site_id})
+  end
+end

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -31,6 +31,7 @@ defmodule Plausible.Site.Cache do
     domain_changed_from
     ingest_rate_limit_scale_seconds
     ingest_rate_limit_threshold
+    scroll_depth_visible_at
    )a
 
   @impl true

--- a/lib/plausible/stats/scroll_depth.ex
+++ b/lib/plausible/stats/scroll_depth.ex
@@ -3,11 +3,6 @@ defmodule Plausible.Stats.ScrollDepth do
   Module to check whether the scroll depth metric is available and visible for a site.
   """
 
-  import Ecto.Query
-  require Logger
-
-  alias Plausible.ClickhouseRepo
-
   def feature_available?(site, user) do
     FunWithFlags.enabled?(:scroll_depth, for: user) ||
       FunWithFlags.enabled?(:scroll_depth, for: site)
@@ -15,49 +10,5 @@ defmodule Plausible.Stats.ScrollDepth do
 
   def feature_visible?(site, user) do
     feature_available?(site, user) && not is_nil(site.scroll_depth_visible_at)
-  end
-
-  @doc """
-  Checks whether the scroll depth feature is visible for a site and updates the site record if it is.
-
-  Note this function queries ClickHouse and may take a while to complete.
-  """
-  def check_feature_visible!(site, user) do
-    cond do
-      not feature_available?(site, user) ->
-        false
-
-      not is_nil(site.scroll_depth_visible_at) ->
-        true
-
-      is_nil(site.scroll_depth_visible_at) ->
-        visible? = has_scroll_data_last_30d?(site)
-
-        # if visible? do
-        #   Plausible.Sites.set_scroll_depth_visible_at(site)
-        # end
-
-        visible?
-    end
-  end
-
-  defp has_scroll_data_last_30d?(site) do
-    try do
-      ClickhouseRepo.exists?(
-        from(e in "events_v2",
-          where:
-            e.site_id == ^site.id and
-              e.name == "pageleave" and
-              e.timestamp >= fragment("toStartOfDay(now() - toIntervalDay(30))") and
-              e.scroll_depth > 0 and e.scroll_depth <= 100
-        )
-      )
-    rescue
-      # Avoid propagating error to the user, bringing down the site.
-      error ->
-        Logger.error("Error checking scroll data for site #{site.id}: #{inspect(error)}")
-
-        false
-    end
   end
 end

--- a/lib/plausible/stats/scroll_depth.ex
+++ b/lib/plausible/stats/scroll_depth.ex
@@ -33,9 +33,9 @@ defmodule Plausible.Stats.ScrollDepth do
       is_nil(site.scroll_depth_visible_at) ->
         visible? = has_scroll_data_last_30d?(site)
 
-        if visible? do
-          Plausible.Sites.set_scroll_depth_visible_at(site)
-        end
+        # if visible? do
+        #   Plausible.Sites.set_scroll_depth_visible_at(site)
+        # end
 
         visible?
     end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.StatsController do
   use Plausible.Repo
 
   alias Plausible.Sites
-  alias Plausible.Stats.{Filters, Query}
+  alias Plausible.Stats.{Filters, Query, ScrollDepth}
   alias PlausibleWeb.Api
 
   plug(PlausibleWeb.Plugs.AuthorizeSiteAccess when action in [:stats, :csv_export])
@@ -59,9 +59,6 @@ defmodule PlausibleWeb.StatsController do
     dogfood_page_path = if demo, do: "/#{site.domain}", else: "/:dashboard"
     skip_to_dashboard? = conn.params["skip_to_dashboard"] == "true"
 
-    scroll_depth_visible? =
-      Plausible.Stats.ScrollDepth.check_feature_visible!(site, current_user)
-
     cond do
       (stats_start_date && can_see_stats?) || (can_see_stats? && skip_to_dashboard?) ->
         conn
@@ -72,7 +69,7 @@ defmodule PlausibleWeb.StatsController do
           revenue_goals: list_revenue_goals(site),
           funnels: list_funnels(site),
           has_props: Plausible.Props.configured?(site),
-          scroll_depth_visible: scroll_depth_visible?,
+          scroll_depth_visible: ScrollDepth.feature_visible?(site, current_user),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
           title: title(conn, site),
@@ -350,9 +347,6 @@ defmodule PlausibleWeb.StatsController do
         shared_link = Plausible.Repo.preload(shared_link, site: :owner)
         stats_start_date = Plausible.Sites.stats_start_date(shared_link.site)
 
-        scroll_depth_visible? =
-          Plausible.Stats.ScrollDepth.check_feature_visible!(shared_link.site, current_user)
-
         conn
         |> put_resp_header("x-robots-tag", "noindex, nofollow")
         |> delete_resp_header("x-frame-options")
@@ -362,7 +356,7 @@ defmodule PlausibleWeb.StatsController do
           revenue_goals: list_revenue_goals(shared_link.site),
           funnels: list_funnels(shared_link.site),
           has_props: Plausible.Props.configured?(shared_link.site),
-          scroll_depth_visible: scroll_depth_visible?,
+          scroll_depth_visible: ScrollDepth.feature_visible?(shared_link.site, current_user),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
           title: title(conn, shared_link.site),

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -1065,6 +1065,7 @@ defmodule Plausible.Imported.CSVImporterTest do
         |> Enum.map(fn event -> Map.put(event, :hostname, "csv.test") end)
 
       populate_stats(exported_site, stats)
+      Plausible.Sites.set_scroll_depth_visible_at(exported_site)
 
       initial_context = %{
         user: user,
@@ -1080,9 +1081,6 @@ defmodule Plausible.Imported.CSVImporterTest do
         |> unzip_archive()
         |> upload_csvs()
         |> run_import()
-
-      assert %NaiveDateTime{} =
-               Plausible.Repo.reload!(exported_site).scroll_depth_visible_at
 
       assert %SiteImport{
                start_date: start_date,

--- a/test/plausible/ingestion/scroll_depth_visible_at_test.exs
+++ b/test/plausible/ingestion/scroll_depth_visible_at_test.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Ingestion.ScrollDepthVisibleAtTest do
+  use Plausible.DataCase
+  use Plausible.Teams.Test
+
+  test "mark_scroll_depth_visible" do
+    site = new_site()
+    Plausible.Ingestion.ScrollDepthVisibleAt.mark_scroll_depth_visible(site.id)
+
+    Plausible.TestUtils.eventually(fn ->
+      site = Plausible.Repo.reload!(site)
+      {not is_nil(site.scroll_depth_visible_at), site.scroll_depth_visible_at}
+    end)
+  end
+end

--- a/test/plausible/ingestion/scroll_depth_visible_at_test.exs
+++ b/test/plausible/ingestion/scroll_depth_visible_at_test.exs
@@ -6,9 +6,10 @@ defmodule Plausible.Ingestion.ScrollDepthVisibleAtTest do
     site = new_site()
     Plausible.Ingestion.ScrollDepthVisibleAt.mark_scroll_depth_visible(site.id)
 
-    Plausible.TestUtils.eventually(fn ->
-      site = Plausible.Repo.reload!(site)
-      {not is_nil(site.scroll_depth_visible_at), site.scroll_depth_visible_at}
-    end)
+    assert Plausible.TestUtils.eventually(fn ->
+             site = Plausible.Repo.reload!(site)
+             success = not is_nil(site.scroll_depth_visible_at)
+             {success, success}
+           end)
   end
 end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -85,7 +85,6 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [build(:pageview)])
 
-      # No pageleaves yet - `scroll_depth_visible_at` will remain `nil`
       html =
         conn
         |> get("/#{site.domain}")
@@ -93,15 +92,8 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert text_of_attr(html, @react_container, "data-scroll-depth-visible") == "false"
 
-      site = Repo.reload!(site)
-      assert is_nil(site.scroll_depth_visible_at)
+      Plausible.Sites.set_scroll_depth_visible_at(site)
 
-      populate_stats(site, [
-        build(:pageview, user_id: 123),
-        build(:pageleave, user_id: 123, scroll_depth: 20)
-      ])
-
-      # Pageleaves exist now - `scroll_depth_visible_at` gets set to `utc_now`
       html =
         conn
         |> get("/#{site.domain}")
@@ -1098,7 +1090,6 @@ defmodule PlausibleWeb.StatsControllerTest do
       site = insert(:site)
       link = insert(:shared_link, site: site)
 
-      # No pageleaves yet - `scroll_depth_visible_at` will remain `nil`
       html =
         conn
         |> get("/share/#{site.domain}/?auth=#{link.slug}")
@@ -1106,15 +1097,8 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert text_of_attr(html, @react_container, "data-scroll-depth-visible") == "false"
 
-      site = Repo.reload!(site)
-      assert is_nil(site.scroll_depth_visible_at)
+      Plausible.Sites.set_scroll_depth_visible_at(site)
 
-      populate_stats(site, [
-        build(:pageview, user_id: 123),
-        build(:pageleave, user_id: 123, scroll_depth: 20)
-      ])
-
-      # Pageleaves exist now - `scroll_depth_visible_at` gets set to `utc_now`
       html =
         conn
         |> get("/share/#{site.domain}/?auth=#{link.slug}")


### PR DESCRIPTION
We decide what metrics to show dynamically based on whether site has sent us scroll depth data.

Previously, this data was queried dynamically from ClickHouse on page loads, but this approach adds 50-200ms to _every_ page load until a site has sent us scroll depth data.

Instead, we now update `site.scroll_depth_visible_at` in ingestion. To limit impact on ingestion:
1. `scroll_depth_visible_at` is now cached along with other ingestion site data.
2. updates are processed using ets, making sure only one database update is ever done per site
3. handles errors gracefully if postgres is ever in e.g. read-only mode or otherwise unavailable.

I'm curious whether I'm taking a sane approach with the GenServer here. cc @zoldar for feedback on that front.