### PR TITLE
Stop segment queries when not needed

### DIFF
--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -39,7 +39,13 @@ defmodule Plausible.Segments do
 
   @spec get_many(Plausible.Site.t(), list(pos_integer()), Keyword.t()) ::
           {:ok, [Segment.t()]}
-  def get_many(%Plausible.Site{} = site, segment_ids, opts) when is_list(segment_ids) do
+  def get_many(%Plausible.Site{} = _site, segment_ids, _opts)
+      when segment_ids == [] do
+    {:ok, []}
+  end
+
+  def get_many(%Plausible.Site{} = site, segment_ids, opts)
+      when is_list(segment_ids) do
     fields = Keyword.get(opts, :fields, [:id])
 
     query =


### PR DESCRIPTION
### Changes

When investigating some traces, we found that there's more database queries happening than needed. This removes one of them, which was running on all stats requests.

### Tests
- [x] Existing controller tests should cover this

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
