### PR TITLE
Tracker: Handle `document.body` not being available gracefully

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -55,13 +55,15 @@
   var pageLeaveSending = false
 
   function getDocumentHeight() {
+    var body = document.body || {}
+    var el = document.documentElement || {}
     return Math.max(
-      document.body.scrollHeight || 0,
-      document.body.offsetHeight || 0,
-      document.body.clientHeight || 0,
-      document.documentElement.scrollHeight || 0,
-      document.documentElement.offsetHeight || 0,
-      document.documentElement.clientHeight || 0
+      body.scrollHeight || 0,
+      body.offsetHeight || 0,
+      body.clientHeight || 0,
+      el.scrollHeight || 0,
+      el.offsetHeight || 0,
+      el.clientHeight || 0
     )
   }
 


### PR DESCRIPTION
I previously ran into an issue where the deferred plausible script ran into an error while loading, due to `document.body` being unavailable. This in turn results in no events being tracked for that page load.

I was _not_ able to reproduce the issue today despite 2 hours of trying, but here's a quick patch for the underlying issue making method access just a bit safer.