### PR TITLE
Scroll depth dashboard warnings (imported data)

### DIFF
--- a/assets/js/dashboard/components/sort-button.tsx
+++ b/assets/js/dashboard/components/sort-button.tsx
@@ -17,11 +17,11 @@ export const SortButton = ({
   return (
     <button
       onClick={toggleSort}
-      title={next.hint}
       className={classNames('group', 'hover:underline', 'relative')}
     >
       {children}
       <span
+        title={next.hint}
         className={classNames(
           'absolute',
           'rounded inline-block h-4 w-4',

--- a/assets/js/dashboard/components/table.tsx
+++ b/assets/js/dashboard/components/table.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import React, { ReactNode } from 'react'
 import { SortDirection } from '../hooks/use-order-by'
 import { SortButton } from './sort-button'
+import { Tooltip } from '../util/tooltip'
 
 export type ColumnConfiguraton<T extends Record<string, unknown>> = {
   /** Unique column ID, used for sorting purposes and to get the value of the cell using rowItem[key] */
@@ -17,6 +18,8 @@ export type ColumnConfiguraton<T extends Record<string, unknown>> = {
   width: string
   /** Aligns column content. */
   align?: 'left' | 'right'
+  /** A warning to be rendered as a tooltip for the column header */
+  metricWarning?: string
   /**
    * Function used to transform the value found at item[key] for the cell. Superseded by renderItem if present. @example 1120 => "1.1k"
    */
@@ -100,6 +103,29 @@ export const Table = <T extends Record<string, string | number | ReactNode>>({
   columns: ColumnConfiguraton<T>[]
   data: T[] | { pages: T[][] }
 }) => {
+  const renderColumnLabel = (column: ColumnConfiguraton<T>) => {
+    if (column.metricWarning) {
+      return (
+        <Tooltip
+          info={warningSpan(column.metricWarning)}
+          className="inline-block"
+        >
+          {column.label + ' *'}
+        </Tooltip>
+      )
+    } else {
+      return column.label
+    }
+  }
+
+  const warningSpan = (warning: string) => {
+    return (
+      <span className="text-xs font-normal whitespace-nowrap">
+        {'*' + warning}
+      </span>
+    )
+  }
+
   return (
     <table className="w-max overflow-x-auto md:w-full table-striped table-fixed">
       <thead>
@@ -115,10 +141,10 @@ export const Table = <T extends Record<string, string | number | ReactNode>>({
                   toggleSort={column.onSort}
                   sortDirection={column.sortDirection ?? null}
                 >
-                  {column.label}
+                  {renderColumnLabel(column)}
                 </SortButton>
               ) : (
-                column.label
+                renderColumnLabel(column)
               )}
             </TableHeaderCell>
           ))}

--- a/assets/js/dashboard/query.ts
+++ b/assets/js/dashboard/query.ts
@@ -52,7 +52,7 @@ export type DashboardQuery = typeof queryDefaultValue
 export type BreakdownResultMeta = {
   date_range_label: string
   comparison_date_range_label?: string
-  metric_warnings: Record<string, string> | undefined
+  metric_warnings: Record<string, Record<string, string>> | undefined
 }
 
 export function addFilter(

--- a/assets/js/dashboard/query.ts
+++ b/assets/js/dashboard/query.ts
@@ -52,6 +52,7 @@ export type DashboardQuery = typeof queryDefaultValue
 export type BreakdownResultMeta = {
   date_range_label: string
   comparison_date_range_label?: string
+  metric_warnings: Record<string, string> | undefined
 }
 
 export function addFilter(

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -66,7 +66,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         )}
 
         {stat.name === 'Scroll depth' &&
-          stat.warning_code === 'no_imported_scroll_depth' && (
+          data.metric_warnings.scroll_depth === 'no_imported_scroll_depth' && (
             <p className="font-normal text-xs whitespace-nowrap">
               * Does not include imported data
             </p>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -68,7 +68,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         {stat.name === 'Scroll depth' &&
           stat.warning_code === 'no_imported_scroll_depth' && (
             <p className="font-normal text-xs whitespace-nowrap">
-              * Includes only native data
+              * Does not include imported data
             </p>
           )}
       </div>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -66,7 +66,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         )}
 
         {stat.name === 'Scroll depth' &&
-          data.metric_warnings.scroll_depth === 'no_imported_scroll_depth' && (
+          data.meta.metric_warnings?.scroll_depth?.code === 'no_imported_scroll_depth' && (
             <p className="font-normal text-xs whitespace-nowrap">
               * Does not include imported data
             </p>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -66,7 +66,8 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         )}
 
         {stat.name === 'Scroll depth' &&
-          data.meta.metric_warnings?.scroll_depth?.code === 'no_imported_scroll_depth' && (
+          data.meta.metric_warnings?.scroll_depth?.code ===
+            'no_imported_scroll_depth' && (
             <p className="font-normal text-xs whitespace-nowrap">
               * Does not include imported data
             </p>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -64,6 +64,12 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
             <SecondsSinceLastLoad lastLoadTimestamp={lastLoadTimestamp} />s ago
           </p>
         )}
+
+        {stat.name === 'Scroll depth' && stat.warning_code === 'no_imported_scroll_depth' && (
+          <p className="font-normal text-xs whitespace-nowrap">
+            * Includes only native data
+          </p>
+        )}
       </div>
     )
   }
@@ -114,6 +120,9 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         {statDisplayName}
         {statExtraName && (
           <span className="hidden sm:inline-block ml-1">{statExtraName}</span>
+        )}
+        {stat.warning_code && (
+          <span className="inline-block ml-1">*</span>
         )}
       </div>
     )

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -65,11 +65,12 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
           </p>
         )}
 
-        {stat.name === 'Scroll depth' && stat.warning_code === 'no_imported_scroll_depth' && (
-          <p className="font-normal text-xs whitespace-nowrap">
-            * Includes only native data
-          </p>
-        )}
+        {stat.name === 'Scroll depth' &&
+          stat.warning_code === 'no_imported_scroll_depth' && (
+            <p className="font-normal text-xs whitespace-nowrap">
+              * Includes only native data
+            </p>
+          )}
       </div>
     )
   }
@@ -121,9 +122,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
         {statExtraName && (
           <span className="hidden sm:inline-block ml-1">{statExtraName}</span>
         )}
-        {stat.warning_code && (
-          <span className="inline-block ml-1">*</span>
-        )}
+        {stat.warning_code && <span className="inline-block ml-1">*</span>}
       </div>
     )
   }

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -237,7 +237,7 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
 
 const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
   const warnings = meta?.metric_warnings
-  
+
   if (warnings) {
     const code = warnings[metric.key]?.code
 

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -240,7 +240,7 @@ const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
     const code = meta.metric_warnings[metric.key]
 
     if (code == 'no_imported_scroll_depth') {
-      return 'Includes only native data'
+      return 'Does not include imported data'
     }
   }
 }

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -152,6 +152,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
           key: m.key,
           width: m.width,
           align: 'right',
+          metricWarning: getMetricWarning(m, meta),
           renderValue: (item) => m.renderValue(item, meta),
           onSort: m.sortable ? () => toggleSortByMetric(m) : undefined,
           sortDirection: orderByDictionary[m.key]
@@ -233,3 +234,13 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
       </svg>
     </a>
   ) : null
+
+const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
+  if (meta && meta.metric_warnings) {
+    const code = meta.metric_warnings[metric.key]
+
+    if (code == 'no_imported_scroll_depth') {
+      return 'Includes only native data'
+    }
+  }
+}

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -236,8 +236,10 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
   ) : null
 
 const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
-  if (meta && meta.metric_warnings) {
-    const code = meta.metric_warnings[metric.key]
+  const warnings = meta?.metric_warnings
+  
+  if (warnings) {
+    const code = warnings[metric.key]?.code
 
     if (code == 'no_imported_scroll_depth') {
       return 'Does not include imported data'

--- a/lib/plausible/data_migration/site_imports.ex
+++ b/lib/plausible/data_migration/site_imports.ex
@@ -10,9 +10,6 @@ defmodule Plausible.DataMigration.SiteImports do
   import Ecto.Query
 
   alias Plausible.{Repo, ClickhouseRepo, Site}
-  alias Plausible.Imported.SiteImport
-
-  require Plausible.Imported.SiteImport
 
   defmodule SiteImportSnapshot do
     @moduledoc """
@@ -56,7 +53,7 @@ defmodule Plausible.DataMigration.SiteImports do
 
     site_import_query =
       from(i in SiteImportSnapshot,
-        where: i.site_id == parent_as(:site).id and i.status == ^SiteImport.completed(),
+        where: i.site_id == parent_as(:site).id and i.status == ^:completed,
         select: 1
       )
 
@@ -71,7 +68,7 @@ defmodule Plausible.DataMigration.SiteImports do
       |> Repo.all(log: false)
 
     site_imports =
-      from(i in SiteImportSnapshot, where: i.status == ^SiteImport.completed())
+      from(i in SiteImportSnapshot, where: i.status == ^:completed)
       |> Repo.all(log: false)
 
     legacy_site_imports = backfill_legacy_site_imports(sites_with_only_legacy_import, dry_run?)
@@ -256,12 +253,12 @@ defmodule Plausible.DataMigration.SiteImports do
   defp from_legacy(%Site.ImportedData{} = data) do
     status =
       case data.status do
-        "ok" -> SiteImport.completed()
-        "error" -> SiteImport.failed()
-        _ -> SiteImport.importing()
+        "ok" -> :completed
+        "error" -> :failed
+        _ -> :importing
       end
 
-    %SiteImport{
+    %SiteImportSnapshot{
       id: 0,
       legacy: true,
       start_date: data.start_date,

--- a/lib/plausible/data_migration/site_imports.ex
+++ b/lib/plausible/data_migration/site_imports.ex
@@ -15,6 +15,10 @@ defmodule Plausible.DataMigration.SiteImports do
   require Plausible.Imported.SiteImport
 
   defmodule SiteImportSnapshot do
+    @moduledoc """
+    A snapshot of the Plausible.Imported.SiteImport schema from April 2024.
+    """
+
     use Ecto.Schema
 
     schema "site_imports" do

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -9,10 +9,9 @@ defmodule Plausible.Imported do
 
   import Ecto.Query
 
-  alias Plausible.Imported
+  alias Plausible.{Site, Repo, Imported}
   alias Plausible.Imported.SiteImport
-  alias Plausible.Repo
-  alias Plausible.Site
+  alias Plausible.Stats.Query
 
   require Plausible.Imported.SiteImport
 
@@ -95,6 +94,17 @@ defmodule Plausible.Imported do
     else
       ids
     end
+  end
+
+  @spec completed_imports_in_query_range(Site.t(), Query.t()) :: [SiteImport.t()]
+  def completed_imports_in_query_range(%Site{} = site, %Query{} = query) do
+    date_range = Query.date_range(query)
+
+    site
+    |> get_completed_imports()
+    |> Enum.filter(fn site_import ->
+      site_import.start_date <= date_range.last && site_import.end_date >= date_range.first
+    end)
   end
 
   @spec get_import(Site.t(), non_neg_integer()) :: SiteImport.t() | nil

--- a/lib/plausible/imported/site_import.ex
+++ b/lib/plausible/imported/site_import.ex
@@ -22,6 +22,7 @@ defmodule Plausible.Imported.SiteImport do
     field :source, Ecto.Enum, values: ImportSources.names()
     field :status, Ecto.Enum, values: @statuses
     field :legacy, :boolean, default: false
+    field :has_scroll_depth, :boolean, default: false
 
     belongs_to :site, Site
     belongs_to :imported_by, User

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     json(conn, %{
       top_stats: top_stats,
-      metric_warnings: metric_warnings(meta),
+      meta: meta,
       interval: query.interval,
       sample_percent: sample_percent,
       with_imported_switch: with_imported_switch_info(meta),
@@ -901,17 +901,9 @@ defmodule PlausibleWeb.Api.StatsController do
         pages |> to_csv(cols)
       end
     else
-      response_meta = Stats.Breakdown.formatted_date_ranges(query)
-
-      response_meta =
-        case metric_warnings(meta) do
-          warnings when map_size(warnings) == 0 -> response_meta
-          warnings -> Map.put(response_meta, :metric_warnings, warnings)
-        end
-
       json(conn, %{
         results: pages,
-        meta: response_meta,
+        meta: Map.merge(meta, Stats.Breakdown.formatted_date_ranges(query)),
         skip_imported_reason: meta[:imports_skip_reason]
       })
     end
@@ -1683,12 +1675,5 @@ defmodule PlausibleWeb.Api.StatsController do
 
   defp toplevel_goal_filter?(query) do
     Filters.filtering_on_dimension?(query, "event:goal", max_depth: 0)
-  end
-
-  defp metric_warnings(query_result_meta) do
-    case query_result_meta[:metric_warnings] do
-      %{scroll_depth: %{code: code}} -> %{scroll_depth: code}
-      _ -> %{}
-    end
   end
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -909,9 +909,20 @@ defmodule PlausibleWeb.Api.StatsController do
         pages |> to_csv(cols)
       end
     else
+      response_meta = Stats.Breakdown.formatted_date_ranges(query)
+
+      response_meta =
+        case meta[:metric_warnings] do
+          %{scroll_depth: %{code: code}} ->
+            Map.put(response_meta, :metric_warnings, %{scroll_depth: code})
+
+          _ ->
+            response_meta
+        end
+
       json(conn, %{
         results: pages,
-        meta: Stats.Breakdown.formatted_date_ranges(query),
+        meta: response_meta,
         skip_imported_reason: meta[:imports_skip_reason]
       })
     end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -363,22 +363,6 @@ defmodule PlausibleWeb.Api.StatsController do
     %{top_stats: top_stats, meta: meta, sample_percent: 100}
   end
 
-  on_ee do
-    @goal_top_stats [
-      %{key: :visitors, name: "Unique conversions"},
-      %{key: :events, name: "Total conversions"},
-      %{key: :average_revenue, name: "Average revenue"},
-      %{key: :total_revenue, name: "Total revenue"},
-      %{key: :conversion_rate, name: "Conversion rate"}
-    ]
-  else
-    @goal_top_stats [
-      %{key: :visitors, name: "Unique conversions"},
-      %{key: :events, name: "Total conversions"},
-      %{key: :conversion_rate, name: "Conversion rate"}
-    ]
-  end
-
   defp fetch_goal_top_stats(site, query) do
     metrics =
       [:visitors, :events, :conversion_rate] ++ @revenue_metrics
@@ -386,23 +370,21 @@ defmodule PlausibleWeb.Api.StatsController do
     %{results: results, meta: meta} = Stats.aggregate(site, query, metrics)
 
     top_stats =
-      @goal_top_stats
-      |> Enum.map(&top_stats_entry(results, &1))
+      [
+        top_stats_entry(results, "Unique conversions", :visitors),
+        top_stats_entry(results, "Total conversions", :events),
+        on_ee do
+          top_stats_entry(results, "Average revenue", :average_revenue)
+        end,
+        on_ee do
+          top_stats_entry(results, "Total revenue", :total_revenue)
+        end,
+        top_stats_entry(results, "Conversion rate", :conversion_rate)
+      ]
       |> Enum.reject(&is_nil/1)
 
     %{top_stats: top_stats, meta: meta, sample_percent: 100}
   end
-
-  @other_top_stats [
-    %{key: :visitors, name: "Unique visitors"},
-    %{key: :visits, name: "Total visits"},
-    %{key: :pageviews, name: "Total pageviews"},
-    %{key: :views_per_visit, name: "Views per visit"},
-    %{key: :bounce_rate, name: "Bounce rate"},
-    %{key: :visit_duration, name: "Visit duration"},
-    %{key: :time_on_page, name: "Time on page"},
-    %{key: :scroll_depth, name: "Scroll depth"}
-  ]
 
   defp fetch_other_top_stats(site, query, current_user) do
     page_filter? =
@@ -433,29 +415,35 @@ defmodule PlausibleWeb.Api.StatsController do
     %{results: results, meta: meta} = Stats.aggregate(site, query, metrics)
 
     top_stats =
-      @other_top_stats
-      |> Enum.map(&top_stats_entry(results, &1))
-      |> Enum.reject(&is_nil/1)
+      [
+        top_stats_entry(results, "Unique visitors", :visitors),
+        top_stats_entry(results, "Total visits", :visits),
+        top_stats_entry(results, "Total pageviews", :pageviews),
+        top_stats_entry(results, "Views per visit", :views_per_visit),
+        top_stats_entry(results, "Bounce rate", :bounce_rate),
+        top_stats_entry(results, "Visit duration", :visit_duration),
+        top_stats_entry(results, "Time on page", :time_on_page,
+          formatter: fn
+            nil -> 0
+            value -> value
+          end
+        ),
+        top_stats_entry(results, "Scroll depth", :scroll_depth)
+      ]
+      |> Enum.filter(& &1)
 
     sample_percent = results[:sample_percent][:value]
 
     %{top_stats: top_stats, meta: meta, sample_percent: sample_percent}
   end
 
-  defp top_stats_entry(current_results, stat) do
-    if current_results[stat.key] do
-      formatter =
-        if stat.key == :time_on_page do
-          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-          &if is_nil(&1), do: 0, else: &1
-        else
-          & &1
-        end
+  defp top_stats_entry(current_results, name, key, opts \\ []) do
+    if current_results[key] do
+      formatter = Keyword.get(opts, :formatter, & &1)
+      value = get_in(current_results, [key, :value])
 
-      value = get_in(current_results, [stat.key, :value])
-
-      %{name: stat.name, value: formatter.(value), graph_metric: stat.key}
-      |> maybe_put_comparison(current_results, stat.key, formatter)
+      %{name: name, value: formatter.(value), graph_metric: key}
+      |> maybe_put_comparison(current_results, key, formatter)
     end
   end
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -445,6 +445,7 @@ defmodule PlausibleWeb.Api.StatsController do
     if current_results[stat.key] do
       formatter =
         if stat.key == :time_on_page do
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           &if is_nil(&1), do: 0, else: &1
         else
           & &1

--- a/priv/repo/migrations/20250203183445_add_has_scroll_depth_to_site_import.exs
+++ b/priv/repo/migrations/20250203183445_add_has_scroll_depth_to_site_import.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddHasScrollDepthToSiteImport do
+  use Ecto.Migration
+
+  def change do
+    alter table(:site_imports) do
+      add :has_scroll_depth, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/plausible/data_migration/site_imports_test.exs
+++ b/test/plausible/data_migration/site_imports_test.exs
@@ -253,10 +253,12 @@ defmodule Plausible.DataMigration.SiteImportsTest do
                ~D[2021-02-11]
     end
 
-    test "considers all imported tables" do
+    test "considers all imported tables (existing April 2024)" do
       date = ~D[2021-01-11]
 
-      for {table, idx} <- Enum.with_index(Imported.tables()) do
+      all_tables = SiteImports.imported_tables_april_2024()
+
+      for {table, idx} <- Enum.with_index(all_tables) do
         site_import = insert(:site_import)
         end_date = Date.add(date, idx)
 

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -1088,6 +1088,7 @@ defmodule Plausible.Imported.CSVImporterTest do
                start_date: start_date,
                end_date: end_date,
                source: :csv,
+               has_scroll_depth: true,
                status: :completed
              } = site_import
 
@@ -1166,11 +1167,15 @@ defmodule Plausible.Imported.CSVImporterTest do
         imported_site: new_site(owner: user)
       }
 
-      %{exported_files: exported_files} =
+      %{exported_files: exported_files, site_import: site_import} =
         context
         |> export_archive()
         |> download_archive()
         |> unzip_archive()
+        |> upload_csvs()
+        |> run_import()
+
+      assert %SiteImport{has_scroll_depth: false} = site_import
 
       imported_pages_content =
         exported_files

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -1144,7 +1144,9 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
         get(conn, "/api/stats/#{site.domain}/pages?period=day&detailed=true&with_imported=true")
 
       response = json_response(conn, 200)
-      assert response["meta"]["metric_warnings"]["scroll_depth"] == "no_imported_scroll_depth"
+
+      assert response["meta"]["metric_warnings"]["scroll_depth"]["code"] ==
+               "no_imported_scroll_depth"
     end
 
     test "returns imported pages with a pageview goal filter", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -1137,6 +1137,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    test "returns scroll depth warning code", %{conn: conn, site: site} do
+      Plausible.Sites.set_scroll_depth_visible_at(site)
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/pages?period=day&detailed=true&with_imported=true")
+
+      response = json_response(conn, 200)
+      assert response["meta"]["metric_warnings"]["scroll_depth"] == "no_imported_scroll_depth"
+    end
+
     test "returns imported pages with a pageview goal filter", %{conn: conn, site: site} do
       insert(:goal, site: site, page_path: "/blog**")
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -495,13 +495,14 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}&with_imported=true"
         )
 
-      top_stats = json_response(conn, 200)["top_stats"]
+      %{"top_stats" => top_stats, "metric_warnings" => metric_warnings} = json_response(conn, 200)
+
+      assert metric_warnings == %{"scroll_depth" => "no_imported_scroll_depth"}
 
       assert %{
                "graph_metric" => "scroll_depth",
                "name" => "Scroll depth",
-               "value" => nil,
-               "warning_code" => "no_imported_scroll_depth"
+               "value" => nil
              } in top_stats
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -495,9 +495,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}&with_imported=true"
         )
 
-      %{"top_stats" => top_stats, "metric_warnings" => metric_warnings} = json_response(conn, 200)
+      %{"top_stats" => top_stats, "meta" => meta} = json_response(conn, 200)
 
-      assert metric_warnings == %{"scroll_depth" => "no_imported_scroll_depth"}
+      assert meta["metric_warnings"]["scroll_depth"]["code"] == "no_imported_scroll_depth"
 
       assert %{
                "graph_metric" => "scroll_depth",


### PR DESCRIPTION
### Changes

Return a `scroll_depth` warning under `meta.metric_warnings` in the API response if imported data was included in the response, but no scroll depth data was found.

In the dashboard, we'll display warnings in two places (where the scroll depth metric is surfaced) - Top Stats and Top Pages > Details.

Screen recordings of how the dashboard tooltips work can be found at: https://3.basecamp.com/5308029/buckets/39034214/card_tables/cards/8130992150

This PR also changes `Plausible.DataMigration.SiteImports` to stop relying on the up-to-date SiteImport schema, defining an inline snapshot of the schema instead. Also does the same thing with the `imported_*` CH tables - defining a fixed list of imported tables that existed at that time.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
