### PR TITLE
Update queries to work off of `engagement` events over pageleaves

### DIFF
--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -432,7 +432,7 @@ defmodule Plausible.Exports do
       max_scroll_depth_per_visitor_q =
         from(e in "events_v2",
           where: ^export_filter(site_id, date_range),
-          where: e.name == "pageleave" and e.scroll_depth <= 100,
+          where: e.name == "engagement" and e.scroll_depth <= 100,
           select: %{
             date: date(e.timestamp, ^timezone),
             page: selected_as(e.pathname, :page),
@@ -453,7 +453,7 @@ defmodule Plausible.Exports do
                 p.max_scroll_depth,
                 p.max_scroll_depth
               ),
-            pageleave_visitors: count(p.user_id)
+            pageleave_visitors: fragment("uniq(?)", p.user_id)
           },
           group_by: [:date, :page]
         )

--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -126,8 +126,8 @@ defmodule Plausible.Goal do
     value = get_field(changeset, :event_name)
 
     cond do
-      value == "pageleave" ->
-        {:error, "The event name 'pageleave' is reserved and cannot be used as a goal"}
+      value == "engagement" ->
+        {:error, "The event name 'engagement' is reserved and cannot be used as a goal"}
 
       value && String.match?(value, ~r/^.+/) ->
         :ok

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -56,7 +56,7 @@ defmodule Plausible.Stats.Clickhouse do
         ClickhouseRepo.one(
           from(e in "events_v2",
             where: e.site_id in ^site_ids,
-            where: e.name != "pageleave",
+            where: e.name != "engagement",
             where: fragment("toDate(?)", e.timestamp) >= ^date_range.first,
             where: fragment("toDate(?)", e.timestamp) <= ^date_range.last,
             select: {

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Stats.GoalSuggestions do
     native_q =
       from(e in base_event_query(site, query),
         where: fragment("? ilike ?", e.name, ^matches),
-        where: e.name not in ["pageview", "pageleave"],
+        where: e.name not in ["pageview", "engagement"],
         where: fragment("trim(?)", e.name) != "",
         where: e.name == fragment("trim(?)", e.name),
         where: e.name not in ^excluded,

--- a/lib/plausible/stats/goals.ex
+++ b/lib/plausible/stats/goals.ex
@@ -87,7 +87,7 @@ defmodule Plausible.Stats.Goals do
           case Plausible.Goal.type(goal) do
             :event -> goal.event_name
             :page -> "pageview"
-            :scroll -> "pageleave"
+            :scroll -> "engagement"
           end
         end),
       # :TRICKY: event goals are considered to match everything for the sake of efficient queries in query_builder.ex
@@ -166,7 +166,7 @@ defmodule Plausible.Stats.Goals do
 
   defp goal_condition(:scroll, goal, false = _imported?) do
     pathname_condition = page_path_condition(goal.page_path, _imported? = false)
-    name_condition = dynamic([e], e.name == "pageleave")
+    name_condition = dynamic([e], e.name == "engagement")
 
     scroll_condition =
       dynamic([e], e.scroll_depth <= 100 and e.scroll_depth >= ^goal.scroll_threshold)

--- a/lib/plausible/stats/legacy/time_on_page.ex
+++ b/lib/plausible/stats/legacy/time_on_page.ex
@@ -30,7 +30,7 @@ defmodule Plausible.Stats.Legacy.TimeOnPage do
   defp aggregate_time_on_page(site, query) do
     windowed_pages_q =
       from e in Base.base_event_query(site, Query.remove_top_level_filters(query, ["event:page"])),
-        where: e.name != "pageleave",
+        where: e.name != "engagement",
         select: %{
           next_timestamp: over(fragment("leadInFrame(?)", e.timestamp), :event_horizon),
           next_pathname: over(fragment("leadInFrame(?)", e.pathname), :event_horizon),
@@ -83,7 +83,7 @@ defmodule Plausible.Stats.Legacy.TimeOnPage do
              site,
              Query.remove_top_level_filters(query, ["event:page", "event:props"])
            ),
-           where: e.name != "pageleave",
+           where: e.name != "engagement",
            select: %{
              next_timestamp: over(fragment("leadInFrame(?)", e.timestamp), :event_horizon),
              next_pathname: over(fragment("leadInFrame(?)", e.pathname), :event_horizon),

--- a/lib/plausible/stats/scroll_depth.ex
+++ b/lib/plausible/stats/scroll_depth.ex
@@ -47,7 +47,7 @@ defmodule Plausible.Stats.ScrollDepth do
         from(e in "events_v2",
           where:
             e.site_id == ^site.id and
-              e.name == "pageleave" and
+              e.name == "engagement" and
               e.timestamp >= fragment("toStartOfDay(now() - toIntervalDay(30))") and
               e.scroll_depth > 0 and e.scroll_depth <= 100
         )

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -196,10 +196,11 @@ defmodule Plausible.Stats.SQL.Expression do
     })
   end
 
-  # TODO: make it possible to query events from pageleave events (total conversions for page scroll goals)
+  # TODO: make it possible to query events from engagement events (total conversions for page scroll goals)
   def event_metric(:events) do
     wrap_alias([e], %{
-      events: fragment("toUInt64(round(countIf(? != 'pageleave') * any(_sample_factor)))", e.name)
+      events:
+        fragment("toUInt64(round(countIf(? != 'engagement') * any(_sample_factor)))", e.name)
     })
   end
 

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -131,7 +131,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
     if :scroll_depth in query.metrics do
       max_per_visitor_q =
         Base.base_event_query(site, query)
-        |> where([e], e.name == "pageleave" and e.scroll_depth <= 100)
+        |> where([e], e.name == "engagement" and e.scroll_depth <= 100)
         |> select([e], %{
           user_id: e.user_id,
           max_scroll_depth: max(e.scroll_depth)

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -681,7 +681,7 @@ defmodule Plausible.Billing.QuotaTest do
              } = Plausible.Teams.Billing.monthly_pageview_usage(team)
     end
 
-    test "pageleave events are not counted towards monthly pageview usage" do
+    test "engagement events are not counted towards monthly pageview usage" do
       user = new_user()
       site = new_site(owner: user)
       team = team_of(user)
@@ -690,7 +690,7 @@ defmodule Plausible.Billing.QuotaTest do
       populate_stats(site, [
         build(:event, timestamp: Timex.shift(now, days: -8), name: "custom"),
         build(:pageview, user_id: 199, timestamp: Timex.shift(now, days: -5, minutes: -2)),
-        build(:pageleave, user_id: 199, timestamp: Timex.shift(now, days: -5))
+        build(:engagement, user_id: 199, timestamp: Timex.shift(now, days: -5))
       ])
 
       assert %{

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -119,11 +119,11 @@ defmodule Plausible.GoalsTest do
     assert {"has already been taken", _} = changeset.errors[:event_name]
   end
 
-  test "create/2 fails to create a goal with 'pageleave' as event_name (reserved)" do
+  test "create/2 fails to create a goal with 'engagement' as event_name (reserved)" do
     site = new_site()
-    assert {:error, changeset} = Goals.create(site, %{"event_name" => "pageleave"})
+    assert {:error, changeset} = Goals.create(site, %{"event_name" => "engagement"})
 
-    assert {"The event name 'pageleave' is reserved and cannot be used as a goal", _} =
+    assert {"The event name 'engagement' is reserved and cannot be used as a goal", _} =
              changeset.errors[:event_name]
   end
 

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -1046,19 +1046,19 @@ defmodule Plausible.Imported.CSVImporterTest do
       stats =
         [
           build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-          build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+          build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
           build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-          build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+          build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
           build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-          build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+          build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
           build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-          build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+          build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
           build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-          build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+          build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
           build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-          build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100),
+          build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100),
           build(:pageview, user_id: 78, pathname: "/", timestamp: t0),
-          build(:pageleave, user_id: 78, pathname: "/", timestamp: t1, scroll_depth: 20),
+          build(:engagement, user_id: 78, pathname: "/", timestamp: t1, scroll_depth: 20),
           build(:pageview, pathname: "/", timestamp: t1),
           build(:pageview, pathname: "/blog", timestamp: NaiveDateTime.add(t0, 1, :day))
         ]
@@ -1151,7 +1151,7 @@ defmodule Plausible.Imported.CSVImporterTest do
     end
 
     @tag :tmp_dir
-    test "does not include scroll depth without existing pageleave data", %{
+    test "does not include scroll depth without existing engagement data", %{
       user: user,
       tmp_dir: tmp_dir
     } do

--- a/test/plausible/stats/goal_suggestions_test.exs
+++ b/test/plausible/stats/goal_suggestions_test.exs
@@ -56,14 +56,14 @@ defmodule Plausible.Stats.GoalSuggestionsTest do
              ]
     end
 
-    test "ignores 'pageview' and 'pageleave' event names", %{site: site} do
+    test "ignores 'pageview' and 'engagement' event names", %{site: site} do
       populate_stats(site, [
         build(:event, name: "Signup"),
         build(:pageview,
           user_id: 1,
           timestamp: NaiveDateTime.utc_now() |> NaiveDateTime.add(-1, :minute)
         ),
-        build(:pageleave, user_id: 1, timestamp: NaiveDateTime.utc_now())
+        build(:engagement, user_id: 1, timestamp: NaiveDateTime.utc_now())
       ])
 
       assert GoalSuggestions.suggest_event_names(site, "") == ["Signup"]

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -1642,11 +1642,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
       assert json_response(conn, 200)["results"] == %{"time_on_page" => %{"value" => nil}}
     end
 
-    test "pageleave events are ignored when querying time on page", %{conn: conn, site: site} do
+    test "engagement events are ignored when querying time on page", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:00], pathname: "/1"),
         build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:05], pathname: "/2"),
-        build(:pageleave, user_id: 1234, timestamp: ~N[2021-01-01 12:01:00], pathname: "/1")
+        build(:engagement, user_id: 1234, timestamp: ~N[2021-01-01 12:01:00], pathname: "/1")
       ])
 
       conn =

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -2599,11 +2599,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
              }
     end
 
-    test "pageleave events are ignored when querying time on page", %{conn: conn, site: site} do
+    test "engagement events are ignored when querying time on page", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:00], pathname: "/1"),
         build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:05], pathname: "/2"),
-        build(:pageleave, user_id: 1234, timestamp: ~N[2021-01-01 12:01:00], pathname: "/1")
+        build(:engagement, user_id: 1234, timestamp: ~N[2021-01-01 12:01:00], pathname: "/1")
       ])
 
       conn =

--- a/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
@@ -146,7 +146,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00],
@@ -181,7 +181,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00],
@@ -215,14 +215,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00],
           scroll_depth: 10
         ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00],
@@ -272,7 +272,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["john"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog/john-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -287,7 +287,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -302,7 +302,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -347,7 +347,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           timestamp: ~N[2021-01-01 00:00:00],
           referrer_source: "Google"
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -360,7 +360,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           timestamp: ~N[2021-01-01 00:00:00],
           referrer_source: "Twitter"
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -409,7 +409,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["john"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog/john-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -424,7 +424,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -439,7 +439,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -490,7 +490,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["john"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog/john-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -505,7 +505,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -520,7 +520,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
           "meta.key": ["author"],
           "meta.value": ["jane"]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           pathname: "/blog/jane-post",
           timestamp: ~N[2021-01-01 00:00:10],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1385,7 +1385,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -1435,7 +1435,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -1485,7 +1485,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -102,11 +102,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
-    test "does not count pageleave events towards the events metric in a simple aggregate query",
+    test "does not count engagement events towards the events metric in a simple aggregate query",
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 234, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 234, timestamp: ~N[2021-01-01 00:00:01])
+        build(:engagement, user_id: 234, timestamp: ~N[2021-01-01 00:00:01])
       ])
 
       conn =
@@ -121,13 +121,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
-    test "pageleave events do not affect bounce rate and visit duration", %{
+    test "engagement events do not affect bounce rate and visit duration", %{
       conn: conn,
       site: site
     } do
       populate_stats(site, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:03])
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:03])
       ])
 
       conn =
@@ -3739,11 +3739,11 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
     test "can query scroll_depth metric with a page filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:10]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
         build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
+        build(:engagement, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
       ])
 
       conn =
@@ -3762,14 +3762,14 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
     test "can query scroll_depth with page + custom prop filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
         build(:pageview,
           "meta.key": ["author"],
           "meta.value": ["john"],
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:10]
         ),
-        build(:pageleave,
+        build(:engagement,
           "meta.key": ["author"],
           "meta.value": ["john"],
           user_id: 123,
@@ -3777,7 +3777,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           scroll_depth: 60
         ),
         build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
+        build(:engagement, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
       ])
 
       conn =
@@ -3793,7 +3793,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
              ]
     end
 
-    test "scroll depth is 0 when no pageleave data in range", %{conn: conn, site: site} do
+    test "scroll depth is 0 when no engagement data in range", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2021-01-01 00:00:00])
       ])
@@ -3831,13 +3831,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, timestamp: t0),
-        build(:pageleave, user_id: 12, timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 34, timestamp: t0),
-        build(:pageleave, user_id: 34, timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, timestamp: t2),
-        build(:pageleave, user_id: 34, timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, timestamp: NaiveDateTime.add(t0, 1, :day)),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           timestamp: NaiveDateTime.add(t1, 1, :day),
           scroll_depth: 20
@@ -3865,17 +3865,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
       ])
 
       conn =
@@ -3898,17 +3898,17 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
       ])
 
       conn =
@@ -3937,7 +3937,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           referrer_source: "Google",
           user_id: 12,
           pathname: "/blog",
@@ -3950,7 +3950,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           referrer_source: "Google",
           user_id: 34,
           pathname: "/blog",
@@ -3963,7 +3963,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00] |> NaiveDateTime.add(2, :minute)
         ),
-        build(:pageleave,
+        build(:engagement,
           referrer_source: "Google",
           user_id: 34,
           pathname: "/blog",
@@ -3976,7 +3976,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           referrer_source: "Twitter",
           user_id: 56,
           pathname: "/blog",
@@ -3989,7 +3989,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           pathname: "/another",
           timestamp: ~N[2020-01-01 00:00:00] |> NaiveDateTime.add(1, :minute)
         ),
-        build(:pageleave,
+        build(:engagement,
           referrer_source: "Twitter",
           user_id: 56,
           pathname: "/another",
@@ -4017,49 +4017,49 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
     test "breakdown by event:page + time:day with scroll_depth metric", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:01:00],
           scroll_depth: 20
         ),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: ~N[2020-01-01 00:01:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/another",
           timestamp: ~N[2020-01-01 00:02:00],
           scroll_depth: 24
         ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:01:00],
           scroll_depth: 17
         ),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: ~N[2020-01-01 00:01:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/another",
           timestamp: ~N[2020-01-01 00:02:00],
           scroll_depth: 26
         ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: ~N[2020-01-01 00:02:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:03:00],
           scroll_depth: 60
         ),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: ~N[2020-01-02 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           pathname: "/blog",
           timestamp: ~N[2020-01-02 00:01:00],
           scroll_depth: 20
         ),
         build(:pageview, user_id: 56, pathname: "/another", timestamp: ~N[2020-01-02 00:01:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           pathname: "/another",
           timestamp: ~N[2020-01-02 00:02:00],
@@ -4086,7 +4086,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
     test "breakdown by a custom prop with a page filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00], pathname: "/blog"),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           timestamp: ~N[2021-01-01 00:01:00],
           pathname: "/blog",
@@ -4099,7 +4099,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "meta.value": ["john"],
           pathname: "/blog/john-post"
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           timestamp: ~N[2021-01-01 00:03:00],
           "meta.key": ["author"],
@@ -4114,7 +4114,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "meta.value": ["john"],
           pathname: "/another-blog/john-post"
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           timestamp: ~N[2021-01-01 00:03:00],
           "meta.key": ["author"],
@@ -4129,7 +4129,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           "meta.value": ["john"],
           pathname: "/blog/john-post"
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 456,
           timestamp: ~N[2021-01-01 00:03:00],
           "meta.key": ["author"],

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -57,14 +57,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       populate_stats(site, [
         # user 1: /blog -> /another -> blog/posts/1
         build(:pageview, user_id: 1, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 1,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:01:00],
           scroll_depth: 20
         ),
         build(:pageview, user_id: 1, pathname: "/another", timestamp: ~N[2020-01-01 00:01:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 1,
           pathname: "/another",
           timestamp: ~N[2020-01-01 00:02:00],
@@ -75,7 +75,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           pathname: "/blog/posts/1",
           timestamp: ~N[2020-01-01 00:02:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 1,
           pathname: "/blog/posts/1",
           timestamp: ~N[2020-01-01 00:03:00],
@@ -83,7 +83,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         ),
         # user 2: /blog -> /blog/posts/1 -> /blog/posts/2
         build(:pageview, user_id: 2, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 2,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:01:00],
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           pathname: "/blog/posts/1",
           timestamp: ~N[2020-01-01 00:02:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 2,
           pathname: "/blog/posts/1",
           timestamp: ~N[2020-01-01 00:03:00],
@@ -105,7 +105,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           pathname: "/blog/posts/2",
           timestamp: ~N[2020-01-01 00:02:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 2,
           pathname: "/blog/posts/2",
           timestamp: ~N[2020-01-01 00:03:00],

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -608,13 +608,13 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, timestamp: t0),
-        build(:pageleave, user_id: 12, timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 34, timestamp: t0),
-        build(:pageleave, user_id: 34, timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, timestamp: t2),
-        build(:pageleave, user_id: 34, timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, timestamp: NaiveDateTime.add(t0, 1, :day)),
-        build(:pageleave,
+        build(:engagement,
           user_id: 56,
           timestamp: NaiveDateTime.add(t1, 1, :day),
           scroll_depth: 20
@@ -640,14 +640,14 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       populate_stats(site, site_import.id, [
         # 2020-01-01 - only native data
         build(:pageview, user_id: 12, timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave, user_id: 12, timestamp: ~N[2020-01-01 00:01:00], scroll_depth: 20),
+        build(:engagement, user_id: 12, timestamp: ~N[2020-01-01 00:01:00], scroll_depth: 20),
         build(:pageview, user_id: 34, timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave, user_id: 34, timestamp: ~N[2020-01-01 00:01:00], scroll_depth: 17),
+        build(:engagement, user_id: 34, timestamp: ~N[2020-01-01 00:01:00], scroll_depth: 17),
         build(:pageview, user_id: 34, timestamp: ~N[2020-01-01 00:02:00]),
-        build(:pageleave, user_id: 34, timestamp: ~N[2020-01-01 00:03:00], scroll_depth: 60),
+        build(:engagement, user_id: 34, timestamp: ~N[2020-01-01 00:03:00], scroll_depth: 60),
         # 2020-01-02 - both imported and native data
         build(:pageview, user_id: 56, timestamp: ~N[2020-01-02 00:00:00]),
-        build(:pageleave, user_id: 56, timestamp: ~N[2020-01-02 00:01:00], scroll_depth: 20),
+        build(:engagement, user_id: 56, timestamp: ~N[2020-01-02 00:01:00], scroll_depth: 20),
         build(:imported_pages,
           date: ~D[2020-01-02],
           page: "/",

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -616,17 +616,17 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
       ])
 
       conn =
@@ -682,7 +682,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
     } do
       populate_stats(site, [
         build(:pageview, user_id: @user_id, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: @user_id,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00],
@@ -727,7 +727,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           pathname: "/native-and-imported",
           timestamp: ~N[2020-01-01 00:00:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: @user_id,
           pathname: "/native-and-imported",
           timestamp: ~N[2020-01-01 00:01:00],
@@ -738,7 +738,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           pathname: "/native-only",
           timestamp: ~N[2020-01-01 00:01:00]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: @user_id,
           pathname: "/native-only",
           timestamp: ~N[2020-01-01 00:02:00],

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -973,11 +973,11 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
     test "returns scroll_depth with a page filter", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:10]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
         build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
+        build(:engagement, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80)
       ])
 
       filters = Jason.encode!([[:is, "event:page", ["/"]]])
@@ -1000,11 +1000,11 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       populate_stats(site, site_import.id, [
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 40),
         build(:pageview, user_id: 123, timestamp: ~N[2021-01-01 00:00:10]),
-        build(:pageleave, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
+        build(:engagement, user_id: 123, timestamp: ~N[2021-01-01 00:00:20], scroll_depth: 60),
         build(:pageview, user_id: 456, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80),
+        build(:engagement, user_id: 456, timestamp: ~N[2021-01-01 00:00:10], scroll_depth: 80),
         build(:imported_pages,
           page: "/",
           date: ~D[2021-01-01],
@@ -1748,14 +1748,14 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 123, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
           scroll_depth: 60
         ),
         build(:pageview, user_id: 456, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 456,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -1786,21 +1786,21 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           name: "Signup",
           timestamp: ~N[2021-01-01 00:00:05]
         ),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
           scroll_depth: 60
         ),
         build(:pageview, user_id: 456, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 456,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
           scroll_depth: 40
         ),
         build(:pageview, user_id: 789, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 789,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
@@ -1833,14 +1833,14 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 123, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 123,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],
           scroll_depth: 60
         ),
         build(:pageview, user_id: 456, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 456,
           pathname: "/blog",
           timestamp: ~N[2021-01-01 00:00:10],

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -85,7 +85,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [build(:pageview)])
 
-      # No pageleaves yet - `scroll_depth_visible_at` will remain `nil`
+      # No engagements yet - `scroll_depth_visible_at` will remain `nil`
       html =
         conn
         |> get("/#{site.domain}")
@@ -98,10 +98,10 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 123),
-        build(:pageleave, user_id: 123, scroll_depth: 20)
+        build(:engagement, user_id: 123, scroll_depth: 20)
       ])
 
-      # Pageleaves exist now - `scroll_depth_visible_at` gets set to `utc_now`
+      # engagements exist now - `scroll_depth_visible_at` gets set to `utc_now`
       html =
         conn
         |> get("/#{site.domain}")
@@ -254,17 +254,17 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:pageleave, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:pageleave, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:pageleave, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
       ])
 
       pages =
@@ -703,21 +703,21 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "exports scroll depth in visitors.csv", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2020-01-05 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2020-01-05 00:01:00],
           scroll_depth: 40
         ),
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: ~N[2020-01-05 10:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 12,
           pathname: "/blog",
           timestamp: ~N[2020-01-05 10:01:00],
           scroll_depth: 17
         ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: ~N[2020-01-07 00:00:00]),
-        build(:pageleave,
+        build(:engagement,
           user_id: 34,
           pathname: "/blog",
           timestamp: ~N[2020-01-07 00:01:00],
@@ -1098,7 +1098,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       site = insert(:site)
       link = insert(:shared_link, site: site)
 
-      # No pageleaves yet - `scroll_depth_visible_at` will remain `nil`
+      # No engagements yet - `scroll_depth_visible_at` will remain `nil`
       html =
         conn
         |> get("/share/#{site.domain}/?auth=#{link.slug}")
@@ -1111,10 +1111,10 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 123),
-        build(:pageleave, user_id: 123, scroll_depth: 20)
+        build(:engagement, user_id: 123, scroll_depth: 20)
       ])
 
-      # Pageleaves exist now - `scroll_depth_visible_at` gets set to `utc_now`
+      # engagements exist now - `scroll_depth_visible_at` gets set to `utc_now`
       html =
         conn
         |> get("/share/#{site.domain}/?auth=#{link.slug}")

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -124,8 +124,8 @@ defmodule Plausible.Factory do
     Map.put(event_factory(attrs), :name, "pageview")
   end
 
-  def pageleave_factory(attrs) do
-    Map.put(event_factory(attrs), :name, "pageleave")
+  def engagement_factory(attrs) do
+    Map.put(event_factory(attrs), :name, "engagement")
   end
 
   def event_factory(attrs) do


### PR DESCRIPTION
Note that export pageleave_visitors column has not been updated here.