### PR TITLE
Reorder application supervision tree

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -22,15 +22,6 @@ defmodule Plausible.Application do
         Plausible.IngestRepo,
         Plausible.AsyncInsertRepo,
         Plausible.ImportDeletionRepo,
-        {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
-        {Plausible.RateLimit, clean_period: :timer.minutes(10)},
-        Plausible.Ingestion.Counters,
-        {Finch, name: Plausible.Finch, pools: finch_pool_config()},
-        {Phoenix.PubSub, name: Plausible.PubSub},
-        Plausible.Session.Salts,
-        Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
-        Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
-        ReferrerBlocklist,
         Plausible.Cache.Adapter.child_spec(:customer_currency, :cache_customer_currency,
           ttl_check_interval: :timer.minutes(5),
           global_ttl: :timer.minutes(60)
@@ -103,6 +94,15 @@ defmodule Plausible.Application do
             ]
           )
         end,
+        Plausible.Ingestion.Counters,
+        Plausible.Session.Salts,
+        Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
+        Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
+        ReferrerBlocklist,
+        {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
+        {Plausible.RateLimit, clean_period: :timer.minutes(10)},
+        {Finch, name: Plausible.Finch, pools: finch_pool_config()},
+        {Phoenix.PubSub, name: Plausible.PubSub},
         endpoint,
         {Oban, Application.get_env(:plausible, Oban)},
         on_ee do

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -15,9 +15,9 @@ defmodule Plausible.Application do
 
     children =
       [
+        Plausible.Cache.Stats,
         Plausible.PromEx,
         {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
-        Plausible.Cache.Stats,
         Plausible.Repo,
         Plausible.ClickhouseRepo,
         Plausible.IngestRepo,

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -16,6 +16,7 @@ defmodule Plausible.Application do
     children =
       [
         Plausible.PromEx,
+        {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
         Plausible.Cache.Stats,
         Plausible.Repo,
         Plausible.ClickhouseRepo,
@@ -99,7 +100,6 @@ defmodule Plausible.Application do
         Supervisor.child_spec(Plausible.Event.WriteBuffer, id: Plausible.Event.WriteBuffer),
         Supervisor.child_spec(Plausible.Session.WriteBuffer, id: Plausible.Session.WriteBuffer),
         ReferrerBlocklist,
-        {Plausible.Auth.TOTP.Vault, key: totp_vault_key()},
         {Plausible.RateLimit, clean_period: :timer.minutes(10)},
         {Finch, name: Plausible.Finch, pools: finch_pool_config()},
         {Phoenix.PubSub, name: Plausible.PubSub},


### PR DESCRIPTION
Minor addition to #5048 

This increases the odds of getting to "ingest-ready" state a bit quicker.