### PR TITLE
Remove total_visitors metric from dashboard breakdown reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Internal stats API routes no longer support legacy dashboard filter format.
 - Dashboard no longer shows "Unique visitors" in top stats when filtering by a goal which used to count all users including ones who didn't complete the goal. "Unique conversions" shows the number of unique visitors who completed the goal.
+- Dashboard no longer shows "Total visitors" in breakdown details modals.
 
 ### Changed
 

--- a/assets/js/dashboard/stats/modals/devices/choose-metrics.js
+++ b/assets/js/dashboard/stats/modals/devices/choose-metrics.js
@@ -4,7 +4,6 @@ import * as metrics from '../../reports/metrics'
 export default function chooseMetrics(query) {
   if (hasConversionGoalFilter(query)) {
     return [
-      metrics.createTotalVisitors(),
       metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
       metrics.createConversionRate()
     ]

--- a/assets/js/dashboard/stats/modals/entry-pages.js
+++ b/assets/js/dashboard/stats/modals/entry-pages.js
@@ -35,7 +35,6 @@ function EntryPagesModal() {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/modals/exit-pages.js
+++ b/assets/js/dashboard/stats/modals/exit-pages.js
@@ -35,7 +35,6 @@ function ExitPagesModal() {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/modals/locations-modal.js
+++ b/assets/js/dashboard/stats/modals/locations-modal.js
@@ -38,7 +38,6 @@ function LocationsModal({ currentView }) {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/modals/pages.js
+++ b/assets/js/dashboard/stats/modals/pages.js
@@ -35,7 +35,6 @@ function PagesModal() {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({renderLabel: (_query) => 'Conversions', width: 'w-28'}),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/modals/referrer-drilldown.js
+++ b/assets/js/dashboard/stats/modals/referrer-drilldown.js
@@ -39,7 +39,6 @@ function ReferrerDrilldownModal() {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/modals/sources.js
+++ b/assets/js/dashboard/stats/modals/sources.js
@@ -63,7 +63,6 @@ function SourcesModal({ currentView }) {
   function chooseMetrics() {
     if (hasConversionGoalFilter(query)) {
       return [
-        metrics.createTotalVisitors(),
         metrics.createVisitors({ renderLabel: (_query) => 'Conversions', width: 'w-28' }),
         metrics.createConversionRate()
       ]

--- a/assets/js/dashboard/stats/reports/metric-formatter.ts
+++ b/assets/js/dashboard/stats/reports/metric-formatter.ts
@@ -11,7 +11,6 @@ import {
 
 export type FormattableMetric =
   | Metric
-  | 'total_visitors'
   | 'current_visitors'
   | 'exit_rate'
   | 'conversions'
@@ -25,7 +24,6 @@ export const MetricFormatterShort: Record<
 > = {
   events: numberShortFormatter,
   pageviews: numberShortFormatter,
-  total_visitors: numberShortFormatter,
   current_visitors: numberShortFormatter,
   views_per_visit: numberShortFormatter,
   visitors: numberShortFormatter,
@@ -53,7 +51,6 @@ export const MetricFormatterLong: Record<
 > = {
   events: numberLongFormatter,
   pageviews: numberLongFormatter,
-  total_visitors: numberLongFormatter,
   current_visitors: numberShortFormatter,
   views_per_visit: numberLongFormatter,
   visitors: numberLongFormatter,

--- a/assets/js/dashboard/stats/reports/metrics.js
+++ b/assets/js/dashboard/stats/reports/metrics.js
@@ -143,17 +143,6 @@ export const createAverageRevenue = (props) => {
   })
 }
 
-export const createTotalVisitors = (props) => {
-  const renderLabel = (_query) => 'Total Visitors'
-  return new Metric({
-    width: 'w-28',
-    ...props,
-    key: 'total_visitors',
-    renderLabel,
-    sortable: false
-  })
-}
-
 export const createVisits = (props) => {
   return new Metric({ width: 'w-24', sortable: true, ...props, key: 'visits' })
 }

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -247,7 +247,6 @@ defmodule Plausible.Stats.SQL.Expression do
   def event_metric(:conversion_rate), do: %{}
   def event_metric(:scroll_depth), do: %{}
   def event_metric(:group_conversion_rate), do: %{}
-  def event_metric(:total_visitors), do: %{}
 
   def event_metric(unknown), do: raise("Unknown metric: #{unknown}")
 

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -116,7 +116,6 @@ defmodule Plausible.Stats.TableDecider do
 
   # Calculated metrics - handled on callsite separately from other metrics.
   defp metric_partitioner(_, :time_on_page), do: :other
-  defp metric_partitioner(_, :total_visitors), do: :other
   # Sample percentage is included in both tables if queried.
   defp metric_partitioner(_, :sample_percent), do: :sample_percent
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1636,7 +1636,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   defp breakdown_metrics(query, extra_metrics \\ []) do
     if toplevel_goal_filter?(query) do
-      [:visitors, :conversion_rate, :total_visitors]
+      [:visitors, :conversion_rate]
     else
       [:visitors] ++ extra_metrics
     end

--- a/test/plausible/stats/table_decider_test.exs
+++ b/test/plausible/stats/table_decider_test.exs
@@ -79,8 +79,8 @@ defmodule Plausible.Stats.TableDeciderTest do
     test "other metrics put in its own result" do
       query = make_query([])
 
-      assert partition_metrics([:time_on_page, :percentage, :total_visitors], query) ==
-               {[], [:percentage], [:time_on_page, :total_visitors]}
+      assert partition_metrics([:time_on_page, :percentage], query) ==
+               {[], [:percentage], [:time_on_page]}
     end
 
     test "metrics that can be calculated on either when event-only metrics" do

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -104,7 +104,6 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Chrome",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }
@@ -309,7 +308,6 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
                "browser" => "Chrome",
                "conversion_rate" => 66.7,
                "version" => "110",
-               "total_visitors" => 3,
                "visitors" => 2
              } == List.first(json_response)
 
@@ -318,7 +316,6 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
                "browser" => "Firefox",
                "conversion_rate" => 100.0,
                "version" => "121",
-               "total_visitors" => 1,
                "visitors" => 1
              } == List.last(json_response)
     end

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -98,7 +98,6 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                  "alpha_3" => "EST",
                  "name" => "Estonia",
                  "flag" => "🇪🇪",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                },
@@ -107,7 +106,6 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                  "alpha_3" => "GBR",
                  "name" => "United Kingdom",
                  "flag" => "🇬🇧",
-                 "total_visitors" => 1,
                  "visitors" => 1,
                  "conversion_rate" => 100.0
                }
@@ -148,7 +146,6 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                  "alpha_3" => "GBR",
                  "name" => "United Kingdom",
                  "flag" => "🇬🇧",
-                 "total_visitors" => 1,
                  "visitors" => 1,
                  "conversion_rate" => 100.0
                },
@@ -157,7 +154,6 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
                  "alpha_3" => "EST",
                  "name" => "Estonia",
                  "flag" => "🇪🇪",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -79,7 +79,6 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Mac",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }
@@ -206,7 +205,6 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Mac",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -1155,14 +1155,12 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                %{
                  "visitors" => 2,
                  "name" => "/blog/post-1",
-                 "conversion_rate" => 100.0,
-                 "total_visitors" => 2
+                 "conversion_rate" => 100.0
                },
                %{
                  "visitors" => 1,
                  "name" => "/blog",
-                 "conversion_rate" => 100.0,
-                 "total_visitors" => 1
+                 "conversion_rate" => 100.0
                }
              ]
     end
@@ -1497,7 +1495,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&filters=#{filters}")
 
       assert json_response(conn, 200)["results"] == [
-               %{"total_visitors" => 3, "visitors" => 1, "name" => "/", "conversion_rate" => 33.3}
+               %{"visitors" => 1, "name" => "/", "conversion_rate" => 33.3}
              ]
     end
 
@@ -2055,13 +2053,11 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       assert json_response(conn, 200)["results"] == [
                %{
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "name" => "/page1",
                  "conversion_rate" => 50.0
                },
                %{
-                 "total_visitors" => 1,
                  "visitors" => 1,
                  "name" => "/page2",
                  "conversion_rate" => 100.0
@@ -2396,13 +2392,11 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                %{
                  "name" => "/exit1",
                  "visitors" => 1,
-                 "total_visitors" => 1,
                  "conversion_rate" => 100.0
                },
                %{
                  "name" => "/exit2",
                  "visitors" => 1,
-                 "total_visitors" => 1,
                  "conversion_rate" => 100.0
                }
              ]

--- a/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/screen_sizes_test.exs
@@ -288,7 +288,6 @@ defmodule PlausibleWeb.Api.StatsController.ScreenSizesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Desktop",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1489,7 +1489,6 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Twitter",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }
@@ -1573,7 +1572,6 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
                %{
                  "conversion_rate" => 100.0,
                  "name" => "Facebook",
-                 "total_visitors" => 1,
                  "visitors" => 1
                }
              ]
@@ -1629,8 +1627,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
                %{
                  "name" => "DuckDuckGo",
                  "visitors" => 1,
-                 "conversion_rate" => 50.0,
-                 "total_visitors" => 2
+                 "conversion_rate" => 50.0
                }
              ]
     end
@@ -1686,14 +1683,12 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
                %{
                  "name" => "DuckDuckGo",
                  "visitors" => 1,
-                 "conversion_rate" => 100.0,
-                 "total_visitors" => 1
+                 "conversion_rate" => 100.0
                },
                %{
                  "name" => "Google",
                  "visitors" => 1,
-                 "conversion_rate" => 50.0,
-                 "total_visitors" => 2
+                 "conversion_rate" => 50.0
                }
              ]
     end
@@ -1728,7 +1723,6 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "Twitter",
-                 "total_visitors" => 2,
                  "visitors" => 1,
                  "conversion_rate" => 50.0
                }
@@ -1912,7 +1906,6 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "10words.com",
-                 "total_visitors" => 2,
                  "conversion_rate" => 50.0,
                  "visitors" => 1
                }
@@ -1952,7 +1945,6 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "name" => "10words.com",
-                 "total_visitors" => 2,
                  "conversion_rate" => 50.0,
                  "visitors" => 1
                }


### PR DESCRIPTION
### Changes

This metric was only shown in some details modals and with scroll depth goals incoming cause confusion and complexity.
    
Long-term we plan to show the fraction(s) in tooltips.

Follow-up to https://github.com/plausible/analytics/pull/4999

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
