### PR TITLE
Scroll depth: hide total conversions metric on dashboard

### DIFF
--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -179,7 +179,7 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
     )
   }
 
-  const stats = data && data.top_stats.map(renderStat)
+  const stats = data && data.top_stats.filter(stat => stat.value !== null).map(renderStat)
 
   if (stats && query.period === 'realtime') {
     stats.push(blinkingDot())

--- a/assets/js/dashboard/stats/reports/metric-formatter.ts
+++ b/assets/js/dashboard/stats/reports/metric-formatter.ts
@@ -6,7 +6,8 @@ import {
   numberShortFormatter,
   durationFormatter,
   percentageFormatter,
-  numberLongFormatter
+  numberLongFormatter,
+  nullable
 } from '../../util/number-formatter'
 
 export type FormattableMetric =
@@ -23,7 +24,7 @@ export const MetricFormatterShort: Record<
   FormattableMetric,
   (value: ValueType) => string
 > = {
-  events: numberShortFormatter,
+  events: nullable(numberShortFormatter),
   pageviews: numberShortFormatter,
   total_visitors: numberShortFormatter,
   current_visitors: numberShortFormatter,
@@ -51,7 +52,7 @@ export const MetricFormatterLong: Record<
   FormattableMetric,
   (value: ValueType) => string
 > = {
-  events: numberLongFormatter,
+  events: nullable(numberLongFormatter),
   pageviews: numberLongFormatter,
   total_visitors: numberLongFormatter,
   current_visitors: numberShortFormatter,

--- a/assets/js/dashboard/util/number-formatter.ts
+++ b/assets/js/dashboard/util/number-formatter.ts
@@ -39,6 +39,15 @@ export function numberLongFormatter(num: number): string {
   return numberFormat.format(num)
 }
 
+export function nullable<T>(formatter: (num: T) => string): (num: T | null) => string {
+  return (num: T | null): string => {
+    if (num === null) {
+      return '-'
+    }
+    return formatter(num)
+  }
+}
+
 function pad(num: number, size: number): string {
   return ('000' + num).slice(size * -1);
 }

--- a/lib/plausible/stats/goals.ex
+++ b/lib/plausible/stats/goals.ex
@@ -104,6 +104,20 @@ defmodule Plausible.Stats.Goals do
     }
   end
 
+  def toplevel_scroll_goal_filters?(query) do
+    goal_filters? =
+      Enum.any?(query.filters, fn
+        [_, "event:goal", _] -> true
+        _ -> false
+      end)
+
+    any_scroll_goals_preloaded? =
+      query.preloaded_goals.matching_toplevel_filters
+      |> Enum.any?(fn goal -> Plausible.Goal.type(goal) == :scroll end)
+
+    goal_filters? and any_scroll_goals_preloaded?
+  end
+
   defp filter_preloaded(goals, filter, clause) do
     Enum.filter(goals, fn goal -> matches?(goal, filter, clause) end)
   end

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -126,20 +126,18 @@ defmodule Plausible.Stats.QueryRunner do
   defp build_from_ch(ch_results, query, time_on_page) do
     ch_results
     |> Enum.map(fn entry ->
-      dimensions = Enum.map(query.dimensions, &dimension_label(&1, entry, query))
+      dimension_labels = Enum.map(query.dimensions, &dimension_label(&1, entry, query))
 
       %{
-        dimensions: dimensions,
-        metrics: Enum.map(query.metrics, &get_metric(entry, &1, dimensions, query, time_on_page))
+        dimensions: dimension_labels,
+        metrics:
+          Enum.map(query.metrics, &get_metric(entry, &1, dimension_labels, query, time_on_page))
       }
     end)
   end
 
   defp dimension_label("event:goal", entry, query) do
-    goal_index = Map.get(entry, Util.shortname(query, "event:goal"))
-
-    query.preloaded_goals.matching_toplevel_filters
-    |> Enum.at(goal_index - 1)
+    get_dimension_goal(entry, query)
     |> Plausible.Goal.display_name()
   end
 
@@ -165,7 +163,30 @@ defmodule Plausible.Stats.QueryRunner do
   defp get_metric(_entry, :time_on_page, dimensions, _query, time_on_page),
     do: Map.get(time_on_page, dimensions)
 
+  defp get_metric(entry, :events, _dimensions, query, _time_on_page) do
+    scroll_goal_dimension? =
+      if "event:goal" in query.dimensions do
+        goal = get_dimension_goal(entry, query)
+        Plausible.Goal.type(goal) == :scroll
+      end
+
+    scroll_goal_filters? = Plausible.Stats.Goals.toplevel_scroll_goal_filters?(query)
+
+    if scroll_goal_dimension? || scroll_goal_filters? do
+      nil
+    else
+      Map.get(entry, :events)
+    end
+  end
+
   defp get_metric(entry, metric, _dimensions, _query, _time_on_page), do: Map.get(entry, metric)
+
+  defp get_dimension_goal(entry, query) do
+    goal_index = Map.get(entry, Util.shortname(query, "event:goal"))
+
+    query.preloaded_goals.matching_toplevel_filters
+    |> Enum.at(goal_index - 1)
+  end
 
   # Special case: If comparison and single time dimension, add 0 rows - otherwise
   # comparisons would not be shown for timeseries with 0 values.

--- a/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
@@ -242,7 +242,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
 
       assert json_response(conn, 200)["results"] == [
                %{"dimensions" => ["Visit /blog"], "metrics" => [2, 2, 100.0]},
-               %{"dimensions" => ["Scroll /blog 25"], "metrics" => [1, 0, 50.0]}
+               %{"dimensions" => ["Scroll /blog 25"], "metrics" => [1, nil, 50.0]}
              ]
     end
 
@@ -321,10 +321,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Scroll /blog 25", "jane"], "metrics" => [2, 0, 50.0]},
-               %{"dimensions" => ["Scroll /blog 50", "jane"], "metrics" => [2, 0, 50.0]},
-               %{"dimensions" => ["Scroll /blog 25", "john"], "metrics" => [1, 0, 25.0]},
-               %{"dimensions" => ["Scroll /blog 75", "jane"], "metrics" => [1, 0, 25.0]}
+               %{"dimensions" => ["Scroll /blog 25", "jane"], "metrics" => [2, nil, 50.0]},
+               %{"dimensions" => ["Scroll /blog 50", "jane"], "metrics" => [2, nil, 50.0]},
+               %{"dimensions" => ["Scroll /blog 25", "john"], "metrics" => [1, nil, 25.0]},
+               %{"dimensions" => ["Scroll /blog 75", "jane"], "metrics" => [1, nil, 25.0]}
              ]
     end
 
@@ -379,7 +379,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Twitter"], "metrics" => [1, 0, 50.0]}
+               %{"dimensions" => ["Twitter"], "metrics" => [1, nil, 50.0]}
              ]
     end
 
@@ -459,8 +459,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["jane"], "metrics" => [2, 0, 50.0]},
-               %{"dimensions" => ["john"], "metrics" => [1, 0, 25.0]}
+               %{"dimensions" => ["jane"], "metrics" => [2, nil, 50.0]},
+               %{"dimensions" => ["john"], "metrics" => [1, nil, 25.0]}
              ]
     end
 
@@ -540,9 +540,9 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
         })
 
       assert json_response(conn, 200)["results"] == [
-               %{"dimensions" => ["Scroll /blog 25"], "metrics" => [2, 0, 50.0]},
-               %{"dimensions" => ["Scroll /blog 50"], "metrics" => [2, 0, 50.0]},
-               %{"dimensions" => ["Scroll /blog 75"], "metrics" => [1, 0, 25.0]}
+               %{"dimensions" => ["Scroll /blog 25"], "metrics" => [2, nil, 50.0]},
+               %{"dimensions" => ["Scroll /blog 50"], "metrics" => [2, nil, 50.0]},
+               %{"dimensions" => ["Scroll /blog 75"], "metrics" => [1, nil, 25.0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -1412,7 +1412,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
                }
              } = json_response(conn, 200)
 
-      assert results == [%{"dimensions" => [], "metrics" => [1, 0, 100.0]}]
+      assert results == [%{"dimensions" => [], "metrics" => [1, nil, 100.0]}]
     end
 
     test "rejects imported data with warning when page scroll goal is filtered by (IN filter)", %{
@@ -1462,7 +1462,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
                }
              } = json_response(conn, 200)
 
-      assert results == [%{"dimensions" => [], "metrics" => [1, 1, 100.0]}]
+      assert results == [%{"dimensions" => [], "metrics" => [1, nil, 100.0]}]
     end
 
     test "ignores imported data for page scroll goal conversions in goal breakdown", %{
@@ -1511,7 +1511,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
 
       assert results == [
                %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 2, 100.0]},
-               %{"dimensions" => ["Scroll /blog 50"], "metrics" => [1, 0, 50.0]}
+               %{"dimensions" => ["Scroll /blog 50"], "metrics" => [1, nil, 50.0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -133,13 +133,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                %{
                  "name" => "Scroll 50 /blog/**",
                  "visitors" => 2,
-                 "events" => 0,
+                 "events" => nil,
                  "conversion_rate" => 100.0
                },
                %{
                  "name" => "Scroll 75 /blog/posts/1",
                  "visitors" => 1,
-                 "events" => 0,
+                 "events" => nil,
                  "conversion_rate" => 50.0
                }
              ]

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1770,7 +1770,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       assert [unique_conversions, total_conversions, conversion_rate] = top_stats
 
       assert %{"name" => "Unique conversions", "value" => 1} = unique_conversions
-      assert %{"name" => "Total conversions", "value" => 0} = total_conversions
+      assert %{"name" => "Total conversions", "value" => nil} = total_conversions
       assert %{"name" => "Conversion rate", "value" => 50.0} = conversion_rate
     end
 
@@ -1817,7 +1817,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       assert [unique_conversions, total_conversions, conversion_rate] = top_stats
 
       assert %{"name" => "Unique conversions", "value" => 3} = unique_conversions
-      assert %{"name" => "Total conversions", "value" => 2} = total_conversions
+      assert %{"name" => "Total conversions", "value" => nil} = total_conversions
       assert %{"name" => "Conversion rate", "value" => 60.0} = conversion_rate
     end
 
@@ -1856,7 +1856,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       assert [unique_conversions, total_conversions, conversion_rate] = top_stats
 
       assert %{"name" => "Unique conversions", "value" => 2} = unique_conversions
-      assert %{"name" => "Total conversions", "value" => 2} = total_conversions
+      assert %{"name" => "Total conversions", "value" => nil} = total_conversions
       assert %{"name" => "Conversion rate", "value" => 66.7} = conversion_rate
     end
   end


### PR DESCRIPTION
### Changes

TBD

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
