### PR TITLE
Increase sessions and user agents cache ttl check interval

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -36,11 +36,11 @@ defmodule Plausible.Application do
           global_ttl: :timer.minutes(60)
         ),
         Plausible.Cache.Adapter.child_spec(:user_agents, :cache_user_agents,
-          ttl_check_interval: :timer.seconds(5),
+          ttl_check_interval: :timer.minutes(5),
           global_ttl: :timer.minutes(60)
         ),
         Plausible.Cache.Adapter.child_spec(:sessions, :cache_sessions,
-          ttl_check_interval: :timer.seconds(1),
+          ttl_check_interval: :timer.minutes(5),
           global_ttl: :timer.minutes(30)
         ),
         warmed_cache(Plausible.Site.Cache,


### PR DESCRIPTION
As per [con_cache docs](https://hexdocs.pm/con_cache/ConCache.html#start_link/1-choosing-ttl_check_interval-time):

> Thus, a lower value of ttl_check_interval time means more frequent purging which may reduce your memory consumption, but could also cause performance penalties. Higher values put less pressure on processing, but item expiry is less precise.

The intention of this PR is to shift cache resource usage towards using more memory and putting less pressure on processing. The item expiry precision for these tables is not crucial in any way. If a session lingers in cache longer than 30 minutes it will still be [ignored](https://github.com/plausible/analytics/blob/a7ff6faf0098cc4593d8f313732e8f031c12b478/lib/plausible/session/cache_store.ex#L66).

For user agents I think the ideal behaviour would not be using ttls at all, but rather be based on the size of the cache. If the maximum size is reached, least recently used entries should be evicted. I don't think con_cache provides this mode unfortunately.