### PR TITLE
Scroll depth: Engagement events should refresh in-memory session cache

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -385,17 +385,17 @@ defmodule Plausible.Ingestion.Event do
       )
 
     case session_result do
+      {:ok, :no_session_for_pageleave} ->
+        drop(event, :no_session_for_pageleave)
+
+      {:error, :timeout} ->
+        drop(event, :lock_timeout)
+
       {:ok, session} ->
         %{
           event
           | clickhouse_event: ClickhouseEventV2.merge_session(event.clickhouse_event, session)
         }
-
-      {:error, :no_session_for_pageleave} ->
-        drop(event, :no_session_for_pageleave)
-
-      {:error, :timeout} ->
-        drop(event, :lock_timeout)
     end
   end
 

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -23,6 +23,7 @@ defmodule Plausible.Session.CacheStore do
         handle_event(event, found_session, session_attributes, buffer_insert)
       end
     )
+    |> unwrap_error()
   end
 
   defp handle_event(%{name: name} = event, found_session, _, _)
@@ -31,7 +32,7 @@ defmodule Plausible.Session.CacheStore do
       # Make sure the session is kept active in the in-memory session cache
       refresh_session_cache(found_session, event.timestamp)
 
-      {:ok, found_session}
+      found_session
     else
       {:error, :no_session_for_pageleave}
     end
@@ -140,4 +141,7 @@ defmodule Plausible.Session.CacheStore do
       "entry_meta.value": Map.get(event, :"meta.value")
     }
   end
+
+  defp unwrap_error({:ok, {:error, error}}), do: {:error, error}
+  defp unwrap_error(response), do: response
 end

--- a/lib/plausible/session/cache_store.ex
+++ b/lib/plausible/session/cache_store.ex
@@ -23,7 +23,6 @@ defmodule Plausible.Session.CacheStore do
         handle_event(event, found_session, session_attributes, buffer_insert)
       end
     )
-    |> unwrap_error()
   end
 
   defp handle_event(%{name: name} = event, found_session, _, _)
@@ -34,7 +33,7 @@ defmodule Plausible.Session.CacheStore do
 
       found_session
     else
-      {:error, :no_session_for_pageleave}
+      :no_session_for_pageleave
     end
   end
 
@@ -141,7 +140,4 @@ defmodule Plausible.Session.CacheStore do
       "entry_meta.value": Map.get(event, :"meta.value")
     }
   end
-
-  defp unwrap_error({:ok, {:error, error}}), do: {:error, error}
-  defp unwrap_error(response), do: response
 end


### PR DESCRIPTION
This will drop less events when session was actually active but didn't have any pageviews/custom events arrive.

Ref: https://3.basecamp.com/5308029/buckets/39034214/card_tables/cards/8314968048