### PR TITLE
Speed up salts lookup by serving them off ets

### DIFF
--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -7,37 +7,54 @@ defmodule Plausible.Session.Salts do
       fn ->
         clean_old_salts()
 
+        __MODULE__ =
+          :ets.new(__MODULE__, [
+            :named_table,
+            :set,
+            :protected,
+            {:read_concurrency, true}
+          ])
+
         salts =
           Repo.all(from s in "salts", select: s.salt, order_by: [desc: s.inserted_at], limit: 2)
 
-        case salts do
-          [current, prev] ->
-            %{previous: prev, current: current}
+        state =
+          case salts do
+            [current, prev] ->
+              %{previous: prev, current: current}
 
-          [current] ->
-            %{previous: nil, current: current}
+            [current] ->
+              %{previous: nil, current: current}
 
-          [] ->
-            new = generate_and_persist_new_salt()
-            %{previous: nil, current: new}
-        end
+            [] ->
+              new = generate_and_persist_new_salt()
+              %{previous: nil, current: new}
+          end
+
+        true = :ets.insert(__MODULE__, {:state, state})
+        :ok
       end,
       name: __MODULE__
     )
   end
 
   def fetch() do
-    Agent.get(__MODULE__, & &1)
+    [state: state] = :ets.lookup(__MODULE__, :state)
+    state
   end
 
   def rotate() do
-    Agent.update(__MODULE__, fn %{current: current} ->
+    Agent.update(__MODULE__, fn :ok ->
+      current = fetch().current
       clean_old_salts()
 
-      %{
+      state = %{
         current: generate_and_persist_new_salt(),
         previous: current
       }
+
+      true = :ets.insert(__MODULE__, {:state, state})
+      :ok
     end)
   end
 

--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -1,87 +1,81 @@
 defmodule Plausible.Session.Salts do
-  use Agent
+  use GenServer
   use Plausible.Repo
 
   def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name] || __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
     name = opts[:name] || __MODULE__
+    now = opts[:now] || DateTime.utc_now()
+    clean_old_salts(now)
 
-    Agent.start_link(
-      fn ->
-        now = opts[:now] || DateTime.utc_now()
-        IO.inspect(:clean, label: name)
-        clean_old_salts(now)
+    ^name =
+      :ets.new(name, [
+        :named_table,
+        :set,
+        :protected,
+        {:read_concurrency, true}
+      ])
 
-        ^name =
-          :ets.new(name, [
-            :named_table,
-            :set,
-            :protected,
-            {:read_concurrency, true}
-          ])
+    salts =
+      Repo.all(from s in "salts", select: s.salt, order_by: [desc: s.inserted_at], limit: 2)
 
-        salts =
-          Repo.all(from s in "salts", select: s.salt, order_by: [desc: s.inserted_at], limit: 2)
+    state =
+      case salts do
+        [current, prev] ->
+          %{previous: prev, current: current}
 
-        state =
-          case salts do
-            [current, prev] ->
-              %{previous: prev, current: current}
+        [current] ->
+          %{previous: nil, current: current}
 
-            [current] ->
-              %{previous: nil, current: current}
+        [] ->
+          new = generate_and_persist_new_salt(now)
+          %{previous: nil, current: new}
+      end
 
-            [] ->
-              new = generate_and_persist_new_salt(now)
-              %{previous: nil, current: new}
-          end
+    true = :ets.insert(name, {:state, state})
+    {:ok, name}
+  end
 
-        true = :ets.insert(name, {:state, state})
-        {:ok, name}
-      end,
-      name: name
-    )
+  def rotate(name \\ __MODULE__, now \\ DateTime.utc_now()) do
+    GenServer.call(name, {:rotate, now})
+  end
+
+  @impl true
+  def handle_call({:rotate, now}, _from, name) do
+    current = fetch(name).current
+    clean_old_salts(now)
+
+    state =
+      %{
+        current: generate_and_persist_new_salt(now),
+        previous: current
+      }
+
+    true = :ets.insert(name, {:state, state})
+    {:reply, :ok, name}
   end
 
   def fetch(name \\ __MODULE__) do
     [state: state] = :ets.lookup(name, :state)
 
     state
-    |> IO.inspect(label: :fetch)
-  end
-
-  def rotate(name \\ __MODULE__, now \\ DateTime.utc_now()) do
-    Agent.update(name, fn {:ok, ^name} ->
-      IO.inspect(now, label: :rotate)
-      current = fetch(name).current
-      IO.inspect :clean, label: name
-      clean_old_salts(now)
-
-      state =
-        %{
-          current: generate_and_persist_new_salt(now),
-          previous: current
-        }
-        |> IO.inspect(label: :insert)
-
-      true = :ets.insert(name, {:state, state})
-      {:ok, name}
-    end)
   end
 
   defp generate_and_persist_new_salt(now) do
     salt = :crypto.strong_rand_bytes(16)
 
     Repo.insert_all("salts", [%{salt: salt, inserted_at: now}])
-    IO.inspect(salt, label: now)
     salt
   end
 
   defp clean_old_salts(now) do
     h48_ago =
       DateTime.shift(now, hour: -48)
-      |> IO.inspect(label: :clean_old_salts)
 
     Repo.delete_all(from s in "salts", where: s.inserted_at < ^h48_ago)
-    |> IO.inspect(label: :number_cleaned)
   end
 end

--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -4,10 +4,10 @@ defmodule Plausible.Session.Salts do
 
   def start_link(opts) do
     name = opts[:name] || __MODULE__
-    now = opts[:now] || DateTime.utc_now()
 
     Agent.start_link(
       fn ->
+        now = opts[:now] || DateTime.utc_now()
         clean_old_salts(now)
 
         ^name =

--- a/test/plausible/session/salts_test.exs
+++ b/test/plausible/session/salts_test.exs
@@ -22,13 +22,11 @@ defmodule Plausible.Session.SaltsTest do
   test "old salts can be cleaned" do
     h30_ago =
       DateTime.shift(DateTime.utc_now(), hour: -48)
-      |> IO.inspect(label: :h30_ago)
 
     {:ok, _} = Salts.start_link(name: __MODULE__, now: h30_ago)
 
     h24_ago =
       DateTime.shift(DateTime.utc_now(), hour: -24)
-      |> IO.inspect(label: :h24_ago)
 
     :ok = Salts.rotate(__MODULE__, h24_ago)
 
@@ -41,7 +39,6 @@ defmodule Plausible.Session.SaltsTest do
 
     future =
       DateTime.shift(DateTime.utc_now(), hour: 24, minute: 5)
-      |> IO.inspect(label: :future)
 
     :ok = Salts.rotate(__MODULE__, future)
 

--- a/test/plausible/session/salts_test.exs
+++ b/test/plausible/session/salts_test.exs
@@ -35,7 +35,7 @@ defmodule Plausible.Session.SaltsTest do
     count = Repo.aggregate(q, :count)
     assert count == 2
 
-    future = DateTime.shift(DateTime.utc_now(), hour: 24)
+    future = DateTime.shift(DateTime.utc_now(), hour: 24, minute: -1)
 
     :ok = Salts.rotate(__MODULE__, future)
 

--- a/test/plausible/session/salts_test.exs
+++ b/test/plausible/session/salts_test.exs
@@ -1,0 +1,49 @@
+defmodule Plausible.Session.SaltsTest do
+  use Plausible.DataCase, async: false
+
+  alias Plausible.Session.Salts
+  import Ecto.Query
+
+  test "agent starts and responds with current salt" do
+    {:ok, _} = Salts.start_link(name: __MODULE__)
+    %{current: current, previous: nil} = Salts.fetch(__MODULE__)
+    assert is_binary(current)
+  end
+
+  test "agent starts and responds with current and previous salt after rotation" do
+    {:ok, _} = Salts.start_link(name: __MODULE__)
+    %{current: first, previous: nil} = Salts.fetch(__MODULE__)
+    :ok = Salts.rotate(__MODULE__)
+
+    %{current: current, previous: ^first} = Salts.fetch(__MODULE__)
+    assert is_binary(current)
+  end
+
+  test "old salts can be cleaned" do
+    h30_ago = DateTime.shift(DateTime.utc_now(), hour: -48)
+
+    {:ok, _} = Salts.start_link(name: __MODULE__, now: h30_ago)
+
+    h24_ago = DateTime.shift(DateTime.utc_now(), hour: -24)
+
+    :ok = Salts.rotate(__MODULE__, h24_ago)
+
+    %{current: old_current, previous: _old_previous} =
+      Salts.fetch(__MODULE__)
+
+    q = from(s in "salts")
+    count = Repo.aggregate(q, :count)
+    assert count == 2
+
+    future = DateTime.shift(DateTime.utc_now(), hour: 24)
+
+    :ok = Salts.rotate(__MODULE__, future)
+
+    %{current: _current, previous: ^old_current} =
+      Salts.fetch(__MODULE__)
+
+    q = from(s in "salts")
+    count = Repo.aggregate(q, :count)
+    assert count == 2
+  end
+end

--- a/test/plausible/session/salts_test.exs
+++ b/test/plausible/session/salts_test.exs
@@ -20,11 +20,15 @@ defmodule Plausible.Session.SaltsTest do
   end
 
   test "old salts can be cleaned" do
-    h30_ago = DateTime.shift(DateTime.utc_now(), hour: -48)
+    h30_ago =
+      DateTime.shift(DateTime.utc_now(), hour: -48)
+      |> IO.inspect(label: :h30_ago)
 
     {:ok, _} = Salts.start_link(name: __MODULE__, now: h30_ago)
 
-    h24_ago = DateTime.shift(DateTime.utc_now(), hour: -24)
+    h24_ago =
+      DateTime.shift(DateTime.utc_now(), hour: -24)
+      |> IO.inspect(label: :h24_ago)
 
     :ok = Salts.rotate(__MODULE__, h24_ago)
 
@@ -35,7 +39,9 @@ defmodule Plausible.Session.SaltsTest do
     count = Repo.aggregate(q, :count)
     assert count == 2
 
-    future = DateTime.shift(DateTime.utc_now(), hour: 24, minute: -1)
+    future =
+      DateTime.shift(DateTime.utc_now(), hour: 24, minute: 5)
+      |> IO.inspect(label: :future)
 
     :ok = Salts.rotate(__MODULE__, future)
 


### PR DESCRIPTION
A tiny patch to bypass synchronous gen server calls when looking up salts. Updates are still serialized.