### PR TITLE
Refactor comparison query & including imported data

### DIFF
--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -66,20 +66,17 @@ defmodule Plausible.Imported do
     @goals_with_path
   end
 
+  @spec any_completed_imports?(Site.t()) :: boolean()
+  def any_completed_imports?(site) do
+    get_completed_imports(site) != []
+  end
+
   @spec earliest_import_start_date(Site.t()) :: Date.t() | nil
   def earliest_import_start_date(site) do
     site
     |> get_completed_imports()
     |> Enum.map(& &1.start_date)
     |> Enum.min(Date, fn -> nil end)
-  end
-
-  @spec latest_import_end_date(Site.t()) :: Date.t() | nil
-  def latest_import_end_date(site) do
-    site
-    |> get_completed_imports()
-    |> Enum.map(& &1.end_date)
-    |> Enum.max(Date, fn -> nil end)
   end
 
   @spec complete_import_ids(Site.t()) :: [non_neg_integer()]
@@ -103,7 +100,8 @@ defmodule Plausible.Imported do
     site
     |> get_completed_imports()
     |> Enum.filter(fn site_import ->
-      site_import.start_date <= date_range.last && site_import.end_date >= date_range.first
+      Date.compare(site_import.start_date, date_range.last) in [:lt, :eq] and
+        Date.compare(site_import.end_date, date_range.first) in [:gt, :eq]
     end)
   end
 

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -99,9 +99,9 @@ defmodule Plausible.Imported do
 
     site
     |> get_completed_imports()
-    |> Enum.filter(fn site_import ->
-      Date.compare(site_import.start_date, date_range.last) in [:lt, :eq] and
-        Date.compare(site_import.end_date, date_range.first) in [:gt, :eq]
+    |> Enum.reject(fn site_import ->
+      Date.after?(site_import.start_date, date_range.last) or
+        Date.before?(site_import.end_date, date_range.first)
     end)
   end
 

--- a/lib/plausible/stats/breakdown.ex
+++ b/lib/plausible/stats/breakdown.ex
@@ -53,7 +53,7 @@ defmodule Plausible.Stats.Breakdown do
     if query.include.comparisons do
       comparison_date_range_label =
         query
-        |> Comparisons.get_comparison_query(query.include.comparisons)
+        |> Comparisons.get_comparison_query()
         |> format_date_range()
 
       Map.put(

--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -10,9 +10,10 @@ defmodule Plausible.Stats.Comparisons do
   alias Plausible.Stats
   alias Plausible.Stats.{Query, DateTimeRange, Time}
 
-  @spec get_comparison_query(Stats.Query.t(), map()) :: Stats.Query.t()
+  @spec get_comparison_utc_time_range(Stats.Query.t(), map()) :: DateTimeRange.t()
   @doc """
-  Generates a comparison query based on the source query and comparison mode.
+  Generates a `DateTimeRange` for the comparison period by the given source query
+  and comparison options.
 
   Currently only historical periods are supported for comparisons (not `realtime`
   and `30m` periods).
@@ -41,20 +42,22 @@ defmodule Plausible.Stats.Comparisons do
       January 1st. Defaults to false.
 
   """
-  def get_comparison_query(%Stats.Query{} = source_query, options) do
+  def get_comparison_utc_time_range(%Stats.Query{} = source_query, options) do
     comparison_date_range = get_comparison_date_range(source_query, options)
 
-    new_range =
-      DateTimeRange.new!(
-        comparison_date_range.first,
-        comparison_date_range.last,
-        source_query.timezone
-      )
-      |> DateTimeRange.to_timezone("Etc/UTC")
+    DateTimeRange.new!(
+      comparison_date_range.first,
+      comparison_date_range.last,
+      source_query.timezone
+    )
+    |> DateTimeRange.to_timezone("Etc/UTC")
+  end
 
+  def get_comparison_query(
+        %Query{comparison_utc_time_range: %DateTimeRange{} = comparison_range} = source_query
+      ) do
     source_query
-    |> Query.set(utc_time_range: new_range)
-    |> maybe_include_imported(source_query)
+    |> Query.set(utc_time_range: comparison_range)
   end
 
   @doc """
@@ -171,15 +174,5 @@ defmodule Plausible.Stats.Comparisons do
     days_to_subtract = if days_to_subtract > 0, do: days_to_subtract, else: days_to_subtract + 7
 
     Date.add(date, -days_to_subtract)
-  end
-
-  defp maybe_include_imported(query, source_query) do
-    requested? = source_query.include.imports
-    skip_imported_reason = Query.get_skip_imported_reason(query)
-
-    struct!(query,
-      include_imported: requested? and is_nil(skip_imported_reason),
-      skip_imported_reason: skip_imported_reason
-    )
   end
 end

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -14,27 +14,30 @@ defmodule Plausible.Stats.EmailReport do
   """
 
   alias Plausible.Stats
-  alias Plausible.Stats.{Query, Compare, Comparisons}
+  alias Plausible.Stats.{Query, QueryResult}
 
   def get(site, query) do
-    metrics = [:pageviews, :visitors, :bounce_rate]
-
-    %{results: results} = Stats.aggregate(site, query, metrics)
-
-    results
-    |> with_comparisons(site, query, metrics)
+    aggregate_and_compare(site, query)
     |> put_top_5_pages(site, query)
     |> put_top_5_sources(site, query)
   end
 
-  defp with_comparisons(stats, site, query, metrics) do
-    comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
-    %{results: prev_period_stats} = Stats.aggregate(site, comparison_query, metrics)
+  defp aggregate_and_compare(site, query) do
+    metrics = [:pageviews, :visitors, :bounce_rate]
 
-    stats
-    |> Enum.map(fn {metric, %{value: value}} ->
-      %{value: prev_value} = Map.fetch!(prev_period_stats, metric)
-      change = Compare.calculate_change(metric, prev_value, value)
+    query =
+      query
+      |> Query.set(metrics: metrics)
+      |> Query.set_include(:comparisons, %{mode: "previous_period"})
+      |> Query.put_comparison_utc_time_range()
+
+    %QueryResult{results: [result]} = Plausible.Stats.query(site, query)
+
+    metrics
+    |> Enum.with_index()
+    |> Enum.map(fn {metric, idx} ->
+      value = Enum.at(result.metrics, idx)
+      change = Enum.at(result.comparison.change, idx)
 
       {metric, %{value: value, change: change}}
     end)

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -16,6 +16,8 @@ defmodule Plausible.Stats.EmailReport do
   alias Plausible.Stats
   alias Plausible.Stats.{Query, QueryResult}
 
+  @aggregate_metrics [:pageviews, :visitors, :bounce_rate]
+
   def get(site, query) do
     aggregate_and_compare(site, query)
     |> put_top_5_pages(site, query)
@@ -23,17 +25,15 @@ defmodule Plausible.Stats.EmailReport do
   end
 
   defp aggregate_and_compare(site, query) do
-    metrics = [:pageviews, :visitors, :bounce_rate]
-
     query =
       query
-      |> Query.set(metrics: metrics)
+      |> Query.set(metrics: @aggregate_metrics)
       |> Query.set_include(:comparisons, %{mode: "previous_period"})
       |> Query.put_comparison_utc_time_range()
 
     %QueryResult{results: [result]} = Plausible.Stats.query(site, query)
 
-    metrics
+    @aggregate_metrics
     |> Enum.with_index()
     |> Enum.map(fn {metric, idx} ->
       value = Enum.at(result.metrics, idx)

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -28,6 +28,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> preload_goals_and_revenue(site)
       |> put_order_by(params)
       |> put_include(site, params)
+      |> Query.put_comparison_utc_time_range()
       |> Query.put_imported_opts(site)
 
     on_ee do
@@ -327,6 +328,11 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       date_range: date_range,
       match_day_of_week: params["match_day_of_week"] == "true"
     }
+  end
+
+  # Legacy support for Stats API v1
+  def parse_comparison_params(_site, %{"compare" => "previous_period"}) do
+    %{mode: "previous_period"}
   end
 
   def parse_comparison_params(_site, _options), do: nil

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -330,7 +330,6 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     }
   end
 
-  # Legacy support for Stats API v1
   def parse_comparison_params(_site, %{"compare" => "previous_period"}) do
     %{mode: "previous_period"}
   end

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -42,7 +42,7 @@ defmodule Plausible.Stats.Query do
           site_id: site.id,
           site_native_stats_start_at: site.native_stats_start_at
         }
-        |> set(Map.to_list(query_data))
+        |> struct!(Map.to_list(query_data))
         |> put_comparison_utc_time_range()
         |> put_imported_opts(site)
 
@@ -130,7 +130,7 @@ defmodule Plausible.Stats.Query do
 
   def put_comparison_utc_time_range(%__MODULE__{include: %{comparisons: comparison_opts}} = query) do
     datetime_range = Comparisons.get_comparison_utc_time_range(query, comparison_opts)
-    set(query, comparison_utc_time_range: datetime_range)
+    struct!(query, comparison_utc_time_range: datetime_range)
   end
 
   def put_imported_opts(query, site) do
@@ -138,7 +138,7 @@ defmodule Plausible.Stats.Query do
 
     query =
       if site do
-        set(query,
+        struct!(query,
           imports_exist: Plausible.Imported.any_completed_imports?(site),
           imports_in_range: get_imports_in_range(site, query)
         )

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -64,8 +64,7 @@ defmodule Plausible.Stats.QueryResult do
         imports_skip_reason: query.skip_imported_reason,
         imports_warning: @imports_warnings[query.skip_imported_reason]
       }
-      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-      |> Enum.into(%{})
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
       |> Map.merge(meta)
     else
       meta

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -62,7 +62,7 @@ defmodule Plausible.Stats.QueryRunner do
        when is_map(query.include.comparisons) do
     comparison_query =
       query
-      |> Comparisons.get_comparison_query(query.include.comparisons)
+      |> Comparisons.get_comparison_query()
       |> Comparisons.add_comparison_filters(main_results)
 
     struct!(runner, comparison_query: comparison_query)

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -29,7 +29,7 @@ defmodule Plausible.Stats.Timeseries do
 
     comparison_query =
       if(query.include.comparisons,
-        do: Comparisons.get_comparison_query(query, query.include.comparisons),
+        do: Comparisons.get_comparison_query(query),
         else: nil
       )
 

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -20,13 +20,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          :ok <- ensure_custom_props_access(site, query) do
-      query =
-        if params["compare"] == "previous_period" do
-          Query.set_include(query, :comparisons, %{mode: "previous_period"})
-        else
-          query
-        end
-
       %{results: results, meta: meta} = Plausible.Stats.aggregate(site, query, metrics)
 
       payload = maybe_add_warning(%{results: results}, meta)

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1631,7 +1631,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def comparison_query(query) do
     if query.include.comparisons do
-      Comparisons.get_comparison_query(query, query.include.comparisons)
+      Comparisons.get_comparison_query(query)
     end
   end
 

--- a/test/plausible/imported_test.exs
+++ b/test/plausible/imported_test.exs
@@ -75,48 +75,6 @@ defmodule Plausible.ImportedTest do
     end
   end
 
-  describe "latest_import_end_date/1" do
-    test "returns nil if no site_imports exist" do
-      site = insert(:site)
-
-      assert is_nil(Imported.latest_import_end_date(site))
-    end
-
-    test "returns nil when only incomplete or failed imports are present" do
-      site = insert(:site)
-
-      _import1 = insert(:site_import, site: site, status: :pending)
-      _import2 = insert(:site_import, site: site, status: :importing)
-      _import3 = insert(:site_import, site: site, status: :failed)
-      _rogue_import = insert(:site_import, site: build(:site), status: :completed)
-
-      assert is_nil(Imported.latest_import_end_date(site))
-    end
-
-    test "returns start and end dates considering all imports" do
-      site = insert(:site)
-
-      _import1 =
-        insert(:site_import,
-          site: site,
-          start_date: ~D[2020-04-02],
-          end_date: ~D[2022-06-22],
-          status: :completed,
-          legacy: true
-        )
-
-      _import2 =
-        insert(:site_import,
-          site: site,
-          start_date: ~D[2022-06-22],
-          end_date: ~D[2024-01-08],
-          status: :completed
-        )
-
-      assert Imported.latest_import_end_date(site) == ~D[2024-01-08]
-    end
-  end
-
   describe "completed_imports_in_query_range/2" do
     setup do
       site = insert(:site)

--- a/test/plausible/stats/comparisons_test.exs
+++ b/test/plausible/stats/comparisons_test.exs
@@ -1,14 +1,12 @@
 defmodule Plausible.Stats.ComparisonsTest do
   use Plausible.DataCase
-  alias Plausible.Stats.{DateTimeRange, Query, Comparisons}
+  alias Plausible.Stats.{Query, Comparisons}
   import Plausible.TestUtils
 
   setup [:create_user, :create_site]
 
   def build_query(site, params, now) do
-    query = Query.from(site, params)
-
-    Map.put(query, :now, now)
+    Query.from(site, params, %{}, now)
   end
 
   describe "with period set to this month" do
@@ -16,11 +14,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-03-02"},
+          %{"period" => "month", "date" => "2023-03-02", "comparison" => "previous_period"},
           ~U[2023-03-02 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-02-27 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-02-28 23:59:59Z]
@@ -31,11 +29,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-03-01"},
+          %{"period" => "month", "date" => "2023-03-01", "comparison" => "previous_period"},
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-02-28 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-02-28 23:59:59Z]
@@ -46,15 +44,16 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-03-02"},
+          %{
+            "period" => "month",
+            "date" => "2023-03-02",
+            "comparison" => "previous_period",
+            "match_day_of_week" => "true"
+          },
           ~U[2023-03-02 14:00:00Z]
         )
 
-      comparison_query =
-        Comparisons.get_comparison_query(query, %{
-          mode: "previous_period",
-          match_day_of_week: true
-        })
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-02-22 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-02-23 23:59:59Z]
@@ -66,11 +65,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-03-02"},
+          %{"period" => "month", "date" => "2023-03-02", "comparison" => "previous_period"},
           ~U[2023-03-02 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-02-27 05:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-03-01 04:59:59Z]
@@ -82,11 +81,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-02-01"},
+          %{"period" => "month", "date" => "2023-02-01", "comparison" => "previous_period"},
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-01-04 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-01-31 23:59:59Z]
@@ -96,11 +95,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-02-01"},
+          %{"period" => "month", "date" => "2023-02-01", "comparison" => "year_over_year"},
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-02-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-02-28 23:59:59Z]
@@ -112,11 +111,11 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2020-02-01"},
+          %{"period" => "month", "date" => "2020-02-01", "comparison" => "year_over_year"},
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2019-02-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2019-03-01 23:59:59Z]
@@ -128,15 +127,16 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-02-01"},
+          %{
+            "period" => "month",
+            "date" => "2023-02-01",
+            "comparison" => "previous_period",
+            "match_day_of_week" => "true"
+          },
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query =
-        Comparisons.get_comparison_query(query, %{
-          mode: "previous_period",
-          match_day_of_week: true
-        })
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2023-01-04 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-01-31 23:59:59Z]
@@ -146,15 +146,16 @@ defmodule Plausible.Stats.ComparisonsTest do
       query =
         build_query(
           site,
-          %{"period" => "month", "date" => "2023-01-01"},
+          %{
+            "period" => "month",
+            "date" => "2023-01-01",
+            "comparison" => "previous_period",
+            "match_day_of_week" => "true"
+          },
           ~U[2023-03-01 14:00:00Z]
         )
 
-      comparison_query =
-        Comparisons.get_comparison_query(query, %{
-          mode: "previous_period",
-          match_day_of_week: true
-        })
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-12-04 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2023-01-03 23:59:59Z]
@@ -163,8 +164,14 @@ defmodule Plausible.Stats.ComparisonsTest do
 
   describe "year_over_year, exact dates behavior with leap years" do
     test "start of the year matching", %{site: site} do
-      query = Query.from(site, %{"period" => "7d", "date" => "2021-01-05"})
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      query =
+        Query.from(site, %{
+          "period" => "7d",
+          "date" => "2021-01-05",
+          "comparison" => "year_over_year"
+        })
+
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2019-12-30 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2020-01-05 23:59:59Z]
@@ -172,8 +179,14 @@ defmodule Plausible.Stats.ComparisonsTest do
     end
 
     test "leap day matching", %{site: site} do
-      query = Query.from(site, %{"period" => "7d", "date" => "2021-03-03"})
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      query =
+        Query.from(site, %{
+          "period" => "7d",
+          "date" => "2021-03-03",
+          "comparison" => "year_over_year"
+        })
+
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2020-02-25 00:00:00Z]
       # :TRICKY: Since dates of the two months don't match precisely we cut off earlier
@@ -182,8 +195,14 @@ defmodule Plausible.Stats.ComparisonsTest do
     end
 
     test "end of the year matching", %{site: site} do
-      query = Query.from(site, %{"period" => "7d", "date" => "2021-11-25"})
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      query =
+        Query.from(site, %{
+          "period" => "7d",
+          "date" => "2021-11-25",
+          "comparison" => "year_over_year"
+        })
+
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2020-11-19 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2020-11-25 23:59:59Z]
@@ -194,9 +213,13 @@ defmodule Plausible.Stats.ComparisonsTest do
   describe "with period set to year to date" do
     test "shifts back by the same number of days when mode is previous_period", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
+        build_query(
+          site,
+          %{"period" => "year", "date" => "2023-03-01", "comparison" => "previous_period"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-11-02 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-12-31 23:59:59Z]
@@ -204,9 +227,13 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "shifts back by the same number of days when mode is year_over_year", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
+        build_query(
+          site,
+          %{"period" => "year", "date" => "2023-03-01", "comparison" => "year_over_year"},
+          ~U[2023-03-01 14:00:00Z]
+        )
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-01-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-03-01 23:59:59Z]
@@ -214,10 +241,18 @@ defmodule Plausible.Stats.ComparisonsTest do
 
     test "matches the day of the week when mode is year_over_year", %{site: site} do
       query =
-        build_query(site, %{"period" => "year", "date" => "2023-03-01"}, ~U[2023-03-01 14:00:00Z])
+        build_query(
+          site,
+          %{
+            "period" => "year",
+            "date" => "2023-03-01",
+            "comparison" => "year_over_year",
+            "match_day_of_week" => "true"
+          },
+          ~U[2023-03-01 14:00:00Z]
+        )
 
-      comparison_query =
-        Comparisons.get_comparison_query(query, %{mode: "year_over_year", match_day_of_week: true})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-01-02 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-03-02 23:59:59Z]
@@ -226,18 +261,28 @@ defmodule Plausible.Stats.ComparisonsTest do
 
   describe "with period set to previous year" do
     test "shifts back a whole year when mode is year_over_year", %{site: site} do
-      query = Query.from(site, %{"period" => "year", "date" => "2022-03-02"})
+      query =
+        Query.from(site, %{
+          "period" => "year",
+          "date" => "2022-03-02",
+          "comparison" => "year_over_year"
+        })
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2021-01-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2021-12-31 23:59:59Z]
     end
 
     test "shifts back a whole year when mode is previous_period", %{site: site} do
-      query = Query.from(site, %{"period" => "year", "date" => "2022-03-02"})
+      query =
+        Query.from(site, %{
+          "period" => "year",
+          "date" => "2022-03-02",
+          "comparison" => "previous_period"
+        })
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2021-01-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2021-12-31 23:59:59Z]
@@ -246,18 +291,28 @@ defmodule Plausible.Stats.ComparisonsTest do
 
   describe "with period set to custom" do
     test "shifts back by the same number of days when mode is previous_period", %{site: site} do
-      query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
+      query =
+        Query.from(site, %{
+          "period" => "custom",
+          "date" => "2023-01-01,2023-01-07",
+          "comparison" => "previous_period"
+        })
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-12-25 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-12-31 23:59:59Z]
     end
 
     test "shifts back to last year when mode is year_over_year", %{site: site} do
-      query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
+      query =
+        Query.from(site, %{
+          "period" => "custom",
+          "date" => "2023-01-01,2023-01-07",
+          "comparison" => "year_over_year"
+        })
 
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "year_over_year"})
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-01-01 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-01-07 23:59:59Z]
@@ -266,28 +321,19 @@ defmodule Plausible.Stats.ComparisonsTest do
 
   describe "with mode set to custom" do
     test "sets first and last dates", %{site: site} do
-      query = Query.from(site, %{"period" => "custom", "date" => "2023-01-01,2023-01-07"})
-
-      comparison_query =
-        Comparisons.get_comparison_query(query, %{
-          mode: "custom",
-          date_range: DateTimeRange.new!(~U[2022-05-25 00:00:00Z], ~U[2022-05-30 23:59:59Z])
+      query =
+        Query.from(site, %{
+          "period" => "custom",
+          "date" => "2023-01-01,2023-01-07",
+          "comparison" => "custom",
+          "compare_from" => "2022-05-25",
+          "compare_to" => "2022-05-30"
         })
+
+      comparison_query = Comparisons.get_comparison_query(query)
 
       assert comparison_query.utc_time_range.first == ~U[2022-05-25 00:00:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-05-30 23:59:59Z]
-    end
-  end
-
-  describe "include_imported" do
-    setup [:create_site_import]
-
-    test "defaults to source_query.include_imported", %{site: site} do
-      query = Query.from(site, %{"period" => "day", "date" => "2023-01-01"})
-      assert query.include_imported == false
-
-      comparison_query = Comparisons.get_comparison_query(query, %{mode: "previous_period"})
-      assert comparison_query.include_imported == false
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -94,7 +94,7 @@ defmodule Plausible.Factory do
     %Plausible.Imported.SiteImport{
       site: build(:site),
       imported_by: build(:user),
-      start_date: Date.add(today, -200),
+      start_date: ~D[2005-01-01],
       end_date: today,
       source: :universal_analytics,
       status: :completed,


### PR DESCRIPTION
### Changes

Refactor with changes discussed with @macobo:

* add a `comparison_utc_time_range` into the Query struct (happens right before `put_imported_opts` in the query-building pipeline)
* Use `query.comparison_utc_time_range` for:
  * deciding `query.include_imported` and `query.skip_imported_reason`
  * constructing the comparison query
* Simplify QueryResult (imports_included and metric_warnings.scroll_depth computation can now rely only on `query` without having to worry about `comparison_query`)

Also, what we didn't discuss before - add `imports_in_range` field to Query struct as well. This actually changes the behaviour a bit. Before, the start of query date range being **before** the last import end date meant that imported data was included. Now it does not, and there must be at least one `site_import` that overlaps with the queried range.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
