### PR TITLE
Lower sessions cache TTL check interval

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -32,7 +32,7 @@ defmodule Plausible.Application do
           global_ttl: :timer.minutes(60)
         ),
         Plausible.Cache.Adapter.child_spec(:sessions, :cache_sessions,
-          ttl_check_interval: :timer.minutes(5),
+          ttl_check_interval: :timer.seconds(60),
           global_ttl: :timer.minutes(30)
         ),
         warmed_cache(Plausible.Site.Cache,


### PR DESCRIPTION
### Changes

Lowering the TTL back down to reduce the issue of ttl update messages queueing up and cache balooning.


