### PR TITLE
Make sure goal changeset error can be handled outside transaction

### DIFF
--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -71,6 +71,9 @@ defmodule Plausible.Goals do
       else
         {:error, %Ecto.Changeset{} = changeset} ->
           Repo.rollback(changeset)
+
+        {:error, :upgrade_required} ->
+          Repo.rollback(:upgrade_required)
       end
     end)
   end

--- a/lib/plausible/goals/goals.ex
+++ b/lib/plausible/goals/goals.ex
@@ -68,6 +68,9 @@ defmodule Plausible.Goals do
         else
           updated_goal
         end
+      else
+        {:error, %Ecto.Changeset{} = changeset} ->
+          Repo.rollback(changeset)
       end
     end)
   end

--- a/test/plausible_web/live/goal_settings/form_test.exs
+++ b/test/plausible_web/live/goal_settings/form_test.exs
@@ -278,6 +278,24 @@ defmodule PlausibleWeb.Live.GoalSettings.FormTest do
       assert updated.display_name == "Visit /updated"
       assert updated.id == g.id
     end
+
+    test "renders error when goal is invalid", %{conn: conn, site: site} do
+      {:ok, [g, g2, _]} = setup_goals(site)
+      lv = get_liveview(conn, site)
+
+      lv |> element(~s/button#edit-goal-#{g.id}/) |> render_click()
+
+      html = render(lv)
+      assert element_exists?(html, ~s|#page_path_input_modalseq0[value="/go/to/blog/**"|)
+
+      lv
+      |> element("#goals-form-modalseq0 form")
+      |> render_submit(%{goal: %{page_path: "/updated", display_name: g2.display_name}})
+
+      html = render(lv)
+
+      assert html =~ "has already been taken"
+    end
   end
 
   describe "Combos integration" do


### PR DESCRIPTION
### Changes

When goal display name, page path or event name is not unique we should display an error. A recent [PR](https://github.com/plausible/analytics/pull/5027) broke that behaviour, bringing it back now.

### Tests
- [x] Automated tests have been added