### PR TITLE
Make page scroll goals work in funnels

### DIFF
--- a/extra/lib/plausible/stats/funnel.ex
+++ b/extra/lib/plausible/stats/funnel.ex
@@ -80,7 +80,7 @@ defmodule Plausible.Stats.Funnel do
   defp select_funnel(db_query, funnel_definition) do
     window_funnel_steps =
       Enum.reduce(funnel_definition.steps, nil, fn step, acc ->
-        goal_condition = goal_condition(step.goal)
+        goal_condition = Plausible.Stats.Goals.goal_condition(step.goal)
 
         if acc do
           dynamic([q], fragment("?, ?", ^acc, ^goal_condition))
@@ -101,21 +101,6 @@ defmodule Plausible.Stats.Funnel do
           step: dynamic_window_funnel
         }
     )
-  end
-
-  defp goal_condition(goal) do
-    case goal do
-      %Plausible.Goal{event_name: event} when is_binary(event) ->
-        dynamic([], fragment("name = ?", ^event))
-
-      %Plausible.Goal{page_path: pathname} when is_binary(pathname) ->
-        if String.contains?(pathname, "*") do
-          regex = Plausible.Stats.Filters.Utils.page_regex(pathname)
-          dynamic([], fragment("match(pathname, ?)", ^regex))
-        else
-          dynamic([], fragment("pathname = ?", ^pathname))
-        end
-    end
   end
 
   defp backfill_steps(funnel_result, funnel) do

--- a/lib/plausible/stats/goals.ex
+++ b/lib/plausible/stats/goals.ex
@@ -168,10 +168,14 @@ defmodule Plausible.Stats.Goals do
       if is_nil(goal) do
         dynamic([e], ^dynamic_statement)
       else
-        type = Plausible.Goal.type(goal)
-        dynamic([e], ^goal_condition(type, goal, imported?) or ^dynamic_statement)
+        dynamic([e], ^goal_condition(goal, imported?) or ^dynamic_statement)
       end
     end)
+  end
+
+  def goal_condition(goal, imported? \\ false) do
+    type = Plausible.Goal.type(goal)
+    goal_condition(type, goal, imported?)
   end
 
   defp goal_condition(:event, goal, _) do


### PR DESCRIPTION
### Changes

Make sure page scroll goals can be added as funnel steps.

One single engagement event can count as multiple conversions in a funnel. E.g. we can add a funnel with goals like `Scroll 10`, `Scroll 20`, `Scroll 30`, ... `Scroll 90`, and see that a single `engagement` event with 70% scroll depth has completed every funnel step up to `Scroll 70`. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
