### PR TITLE
Use host network with `make clickhouse`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ server: ## Start the web server
 CH_FLAGS ?= --detach -p 8123:8123 -p 9000:9000 --ulimit nofile=262144:262144 --name plausible_clickhouse
 
 clickhouse: ## Start a container with a recent version of clickhouse
-	docker run $(CH_FLAGS) --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:latest-alpine
+	docker run $(CH_FLAGS) --network host --volume=$$PWD/.clickhouse_db_vol:/var/lib/clickhouse clickhouse/clickhouse-server:latest-alpine
 
 clickhouse-client: ## Connect to clickhouse
 	docker exec -it plausible_clickhouse clickhouse-client -d plausible_events_db


### PR DESCRIPTION
Without this I couldn't get S3 exports to work locally as the ClickHouse container wasn't able to access minio.