### PR TITLE
Perf: Speed up conversions query

### DIFF
--- a/lib/plausible/stats/goals.ex
+++ b/lib/plausible/stats/goals.ex
@@ -86,12 +86,12 @@ defmodule Plausible.Stats.Goals do
         goals
         |> Enum.filter(&(Plausible.Goal.type(&1) == :page))
         |> Enum.map(&Filters.Utils.page_regex(&1.page_path)),
-      event_names_imports: Enum.map(goals, &to_string(&1.event_name)),
+      event_names_imports: goals |> Enum.map(&to_string(&1.event_name)),
       page_and_scroll_goal_indices:
-        Enum.with_index(page_and_scroll_goals, 1) |> Enum.map(fn {_goal, idx} -> idx end),
+        page_and_scroll_goals |> Enum.with_index(1) |> Enum.map(fn {_goal, idx} -> idx end),
       page_and_scroll_goal_regexes:
-        Enum.map(page_and_scroll_goals, &Filters.Utils.page_regex(&1.page_path)),
-      scroll_thresholds: Enum.map(page_and_scroll_goals, & &1.scroll_threshold),
+        page_and_scroll_goals |> Enum.map(&Filters.Utils.page_regex(&1.page_path)),
+      scroll_thresholds: page_and_scroll_goals |> Enum.map(& &1.scroll_threshold),
       custom_event_names: event_goals |> Enum.map(& &1.event_name),
       custom_event_names_start_index: length(page_and_scroll_goals)
     }

--- a/lib/plausible/stats/goals.ex
+++ b/lib/plausible/stats/goals.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Stats.Goals do
   def preload_needed_goals(site, dimensions, filters) do
     if Enum.member?(dimensions, "event:goal") or
          Filters.filtering_on_dimension?(filters, "event:goal") do
-      goals = Plausible.Goals.for_site(site)
+      goals = Plausible.Goals.for_site(site) |> sort_goals_by_type()
 
       %{
         # When grouping by event:goal, later pipeline needs to know which goals match filters exactly.
@@ -62,12 +62,13 @@ defmodule Plausible.Stats.Goals do
   end
 
   @type goal_join_data() :: %{
-          indices: [non_neg_integer()],
-          types: [String.t()],
+          page_goal_regexes: [String.t()],
           event_names_imports: [String.t()],
-          event_names_by_type: [String.t()],
-          page_regexes: [String.t()],
-          scroll_thresholds: [non_neg_integer()]
+          page_and_scroll_goal_indices: [non_neg_integer()],
+          page_and_scroll_goal_regexes: [String.t()],
+          scroll_thresholds: [non_neg_integer()],
+          custom_event_names: [String.t()],
+          custom_event_names_start_index: non_neg_integer()
         }
 
   @doc """
@@ -77,30 +78,22 @@ defmodule Plausible.Stats.Goals do
   def goal_join_data(query) do
     goals = query.preloaded_goals.matching_toplevel_filters
 
+    {page_and_scroll_goals, event_goals} =
+      Enum.split_while(goals, fn goal -> Plausible.Goal.type(goal) != :event end)
+
     %{
-      indices: Enum.with_index(goals, 1) |> Enum.map(fn {_goal, idx} -> idx end),
-      types: Enum.map(goals, &to_string(Plausible.Goal.type(&1))),
-      # :TRICKY: This will contain "" for non-event goals
+      page_goal_regexes:
+        goals
+        |> Enum.filter(&(Plausible.Goal.type(&1) == :page))
+        |> Enum.map(&Filters.Utils.page_regex(&1.page_path)),
       event_names_imports: Enum.map(goals, &to_string(&1.event_name)),
-      event_names_by_type:
-        Enum.map(goals, fn goal ->
-          case Plausible.Goal.type(goal) do
-            :event -> goal.event_name
-            :page -> "pageview"
-            :scroll -> "engagement"
-          end
-        end),
-      # :TRICKY: event goals are considered to match everything for the sake of efficient queries in query_builder.ex
-      # See also Plausible.Stats.SQL.Expression#event_goal_join
-      page_regexes:
-        Enum.map(goals, fn goal ->
-          case Plausible.Goal.type(goal) do
-            :event -> ".?"
-            :page -> Filters.Utils.page_regex(goal.page_path)
-            :scroll -> Filters.Utils.page_regex(goal.page_path)
-          end
-        end),
-      scroll_thresholds: Enum.map(goals, & &1.scroll_threshold)
+      page_and_scroll_goal_indices:
+        Enum.with_index(page_and_scroll_goals, 1) |> Enum.map(fn {_goal, idx} -> idx end),
+      page_and_scroll_goal_regexes:
+        Enum.map(page_and_scroll_goals, &Filters.Utils.page_regex(&1.page_path)),
+      scroll_thresholds: Enum.map(page_and_scroll_goals, & &1.scroll_threshold),
+      custom_event_names: event_goals |> Enum.map(& &1.event_name),
+      custom_event_names_start_index: length(page_and_scroll_goals)
     }
   end
 
@@ -209,6 +202,17 @@ defmodule Plausible.Stats.Goals do
     end
   end
 
-  def page_path_db_field(true = _imported?), do: :page
-  def page_path_db_field(false = _imported?), do: :pathname
+  defp page_path_db_field(true = _imported?), do: :page
+  defp page_path_db_field(false = _imported?), do: :pathname
+
+  defp sort_goals_by_type(goals) do
+    goals
+    |> Enum.sort_by(fn goal ->
+      case Plausible.Goal.type(goal) do
+        :page -> 0
+        :scroll -> 1
+        :event -> 2
+      end
+    end)
+  end
 end

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -265,16 +265,11 @@ defmodule Plausible.Stats.Imported do
           fragment(
             """
             notEmpty(
-              arrayFilter(
-                goal_idx -> ?[goal_idx] = 'page' AND match(?, ?[goal_idx]),
-                ?
-              ) as indices
+              multiMatchAllIndices(?, ?) AS indices
             )
             """,
-            type(^goal_join_data.types, {:array, :string}),
             i.page,
-            type(^goal_join_data.page_regexes, {:array, :string}),
-            type(^goal_join_data.indices, {:array, :integer})
+            type(^goal_join_data.page_goal_regexes, {:array, :string})
           )
         )
         |> join(:inner, [_i], index in fragment("indices"), hints: "ARRAY", on: true)

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -336,8 +336,8 @@ defmodule Plausible.Stats.SQL.Expression do
               ?,
               ?
             ),
-            arrayMap(
-              (threshold, index) -> if(? between threshold and 100, index, -1),
+            arrayFilter(
+              (index, threshold) -> ? between threshold and 100,
               ?,
               ?
             )
@@ -352,8 +352,8 @@ defmodule Plausible.Stats.SQL.Expression do
         e.pathname,
         type(^unquote(goal_join_data).page_and_scroll_goal_regexes, {:array, :string}),
         e.scroll_depth,
-        type(^unquote(goal_join_data).scroll_thresholds, {:array, :integer}),
         type(^unquote(goal_join_data).page_and_scroll_goal_indices, {:array, :integer}),
+        type(^unquote(goal_join_data).scroll_thresholds, {:array, :integer}),
         type(^unquote(goal_join_data).custom_event_names, {:array, :string}),
         e.name,
         ^unquote(goal_join_data).custom_event_names_start_index

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -329,23 +329,34 @@ defmodule Plausible.Stats.SQL.Expression do
     quote do
       fragment(
         """
-        arrayIntersect(
-          multiMatchAllIndices(?, ?),
-          arrayMap(
-            (expected_name, threshold, index) -> if(expected_name = ? and ? between threshold and 100, index, -1),
-            ?,
-            ?,
+        if(
+          ? IN ('pageview', 'engagement'),
+          arrayIntersect(
+            multiMatchAllIndices(
+              ?,
+              ?
+            ),
+            arrayMap(
+              (threshold, index) -> if(? between threshold and 100, index, -1),
+              ?,
+              ?
+            )
+          ),
+          createCustomEventArray(
+            indexOf(?, ?),
             ?
           )
         )
         """,
-        e.pathname,
-        type(^unquote(goal_join_data).page_regexes, {:array, :string}),
         e.name,
+        e.pathname,
+        type(^unquote(goal_join_data).page_and_scroll_goal_regexes, {:array, :string}),
         e.scroll_depth,
-        type(^unquote(goal_join_data).event_names_by_type, {:array, :string}),
         type(^unquote(goal_join_data).scroll_thresholds, {:array, :integer}),
-        type(^unquote(goal_join_data).indices, {:array, :integer})
+        type(^unquote(goal_join_data).page_and_scroll_goal_indices, {:array, :integer}),
+        type(^unquote(goal_join_data).custom_event_names, {:array, :string}),
+        e.name,
+        ^unquote(goal_join_data).custom_event_names_start_index
       )
     end
   end

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -329,8 +329,7 @@ defmodule Plausible.Stats.SQL.Expression do
     quote do
       fragment(
         """
-        if(
-          ? IN ('pageview', 'engagement'),
+        arrayConcat(
           arrayIntersect(
             multiMatchAllIndices(
               ?,
@@ -348,7 +347,6 @@ defmodule Plausible.Stats.SQL.Expression do
           )
         )
         """,
-        e.name,
         e.pathname,
         type(^unquote(goal_join_data).page_and_scroll_goal_regexes, {:array, :string}),
         e.scroll_depth,

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -330,16 +330,20 @@ defmodule Plausible.Stats.SQL.Expression do
       fragment(
         """
         arrayConcat(
-          arrayIntersect(
-            multiMatchAllIndices(
-              ?,
-              ?
+          if(
+            ? IN ('pageview', 'engagement'),
+            arrayIntersect(
+              multiMatchAllIndices(
+                ?,
+                ?
+              ),
+              arrayFilter(
+                (index, threshold) -> ? between threshold and 100,
+                ?,
+                ?
+              )
             ),
-            arrayFilter(
-              (index, threshold) -> ? between threshold and 100,
-              ?,
-              ?
-            )
+            []
           ),
           createCustomEventArray(
             indexOf(?, ?),
@@ -347,6 +351,7 @@ defmodule Plausible.Stats.SQL.Expression do
           )
         )
         """,
+        e.name,
         e.pathname,
         type(^unquote(goal_join_data).page_and_scroll_goal_regexes, {:array, :string}),
         e.scroll_depth,

--- a/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_goal_dimension_test.exs
@@ -596,5 +596,25 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryGoalDimensionTest do
                %{"dimensions" => ["Scroll /blog 50"], "metrics" => [2, nil, 50.0]}
              ]
     end
+
+    test "handles breakdown by custom event goal with event `pageview`", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "pageview", display_name: "Pageview")
+
+      populate_stats(site, [
+        build(:pageview, user_id: 1, pathname: "/blog", timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors", "events"],
+          "date_range" => "all",
+          "dimensions" => ["event:goal"]
+        })
+
+      assert json_response(conn, 200)["results"] == [
+               %{"dimensions" => ["Pageview"], "metrics" => [1, 1]}
+             ]
+    end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/5029. The conversions query became slow after this change.

The root cause was:
1. The extra string equality checks
2. The extra regex operations

This change fixes that by shuffling operations around and not matching e.g. page paths on custom event goals.

## Timing information

[Before:](https://staging.plausible.io/plausible.io/conversions?period=12mo&keybindHint=L) 14.4s
[After:](https://pr-5084.review.plausible.io/plausible.io/conversions?period=12mo&keybindHint=L) 1.1s