### PR TITLE
time-on-page: track engagement time in plausible.js

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -56,9 +56,9 @@
 
   // Timestamp indicating when this particular page last became visible.
   // Reset during pageviews, set to null when page is closed.
-  var currentEngagementStartTime
+  var runningEnagementStart
   // When page is hidden, this 'engaged' time is saved to this variable
-  var currentEngagementBeforeHideTime
+  var currentEngagementTime
 
   function getDocumentHeight() {
     var body = document.body || {}
@@ -108,10 +108,10 @@
 
   function triggerEngagement() {
     var engagementTime
-    if (currentEngagementStartTime) {
-      engagementTime = currentEngagementBeforeHideTime + (Date.now() - currentEngagementStartTime)
+    if (runningEnagementStart) {
+      engagementTime = currentEngagementTime + (Date.now() - runningEnagementStart)
     } else {
-      engagementTime = currentEngagementBeforeHideTime
+      engagementTime = currentEngagementTime
     }
 
     // Avoid sending redundant engagement events if user has not scrolled the page and not engaged for at least 1 second
@@ -130,8 +130,8 @@
         e: engagementTime
       }
 
-      currentEngagementStartTime = (document.visibilityState === 'hidden') ? Date.now() : null
-      currentEngagementBeforeHideTime = 0
+      runningEnagementStart = (document.visibilityState === 'hidden') ? Date.now() : null
+      currentEngagementTime = 0
 
       {{#if hash}}
       payload.h = 1
@@ -147,12 +147,12 @@
       document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'hidden') {
           // Tab went back to background. Save the engaged time so far
-          currentEngagementBeforeHideTime += (Date.now() - currentEngagementStartTime)
-          currentEngagementStartTime = null
+          currentEngagementTime += (Date.now() - runningEnagementStart)
+          runningEnagementStart = null
 
           triggerEngagement()
         } else {
-          currentEngagementStartTime = Date.now()
+          runningEnagementStart = Date.now()
         }
       })
       listeningOnEngagement = true
@@ -251,8 +251,8 @@
       currentEngagementURL = payload.u
       currentEngagementProps = payload.p
       currentEngagementMaxScrollDepth = -1
-      currentEngagementBeforeHideTime = 0
-      currentEngagementStartTime = Date.now()
+      currentEngagementTime = 0
+      runningEnagementStart = Date.now()
       registerEngagementListener()
     }
     {{/if}}

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -120,7 +120,7 @@
     /*
     We send engagements if there's new relevant engagement information to share:
     - If the user has scrolled more than the previously sent max scroll depth.
-    - If the user has been engaged for more than 1 second since the last engagement event.
+    - If the user has been engaged for more than 3 seconds since the last engagement event.
 
     The first engagement event is always sent due to containing at leastthe initial scroll depth.
 
@@ -128,7 +128,7 @@
     - Less than 300ms have passed since the last engagement event
     - The current pageview is ignored (onIgnoredEvent)
     */
-    if (!engagementCooldown && !currentEngagementIgnored && (currentEngagementMaxScrollDepth < maxScrollDepthPx || engagementTime > 1000)) {
+    if (!engagementCooldown && !currentEngagementIgnored && (currentEngagementMaxScrollDepth < maxScrollDepthPx || engagementTime >= 3000)) {
       currentEngagementMaxScrollDepth = maxScrollDepthPx
       setTimeout(function () {engagementCooldown = false}, 300)
 

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -141,7 +141,8 @@
         e: engagementTime
       }
 
-      runningEnagementStart = (document.visibilityState === 'hidden') ? Date.now() : null
+      // Reset current engagement time metrics. They will restart upon when page becomes visible or the next SPA pageview
+      runningEnagementStart = null
       currentEngagementTime = 0
 
       {{#if hash}}

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -80,6 +80,14 @@
     return currentDocumentHeight <= viewportHeight ? currentDocumentHeight : scrollTop + viewportHeight
   }
 
+  function getEngagementTime() {
+    if (runningEnagementStart) {
+      return currentEngagementTime + (Date.now() - runningEnagementStart)
+    } else {
+      return currentEngagementTime
+    }
+  }
+
   var currentDocumentHeight = getDocumentHeight()
   var maxScrollDepthPx = getCurrentScrollDepthPx()
 
@@ -107,12 +115,7 @@
   })
 
   function triggerEngagement() {
-    var engagementTime
-    if (runningEnagementStart) {
-      engagementTime = currentEngagementTime + (Date.now() - runningEnagementStart)
-    } else {
-      engagementTime = currentEngagementTime
-    }
+    var engagementTime = getEngagementTime()
 
     /*
     We send engagements if there's new relevant engagement information to share:

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -122,7 +122,7 @@
     - If the user has scrolled more than the previously sent max scroll depth.
     - If the user has been engaged for more than 3 seconds since the last engagement event.
 
-    The first engagement event is always sent due to containing at leastthe initial scroll depth.
+    The first engagement event is always sent due to containing at least the initial scroll depth.
 
     We don't send engagements if:
     - Less than 300ms have passed since the last engagement event

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -54,7 +54,7 @@
   // flag prevents sending multiple engagement events in those cases.
   var engagementCooldown = false
 
-  // Timestamp indicating when this particular page last become visible
+  // Timestamp indicating when this particular page last became visible.
   // Reset during pageviews, set to null when page is closed.
   var currentEngagementStartTime
   // When page is hidden, this 'engaged' time is saved to this variable

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -114,9 +114,17 @@
       engagementTime = currentEngagementTime
     }
 
-    // Avoid sending redundant engagement events if user has not scrolled the page and not engaged for at least 1 second
-    // Note that `currentEngagementMaxScrollDepth` default of -1 ensures that at least one engagement event is sent
-    // per pageview.
+    /*
+    We send engagements if there's new relevant engagement information to share:
+    - If the user has scrolled more than the previously sent max scroll depth.
+    - If the user has been engaged for more than 1 second since the last engagement event.
+
+    The first engagement event is always sent due to containing at leastthe initial scroll depth.
+
+    We don't send engagements if:
+    - Less than 300ms have passed since the last engagement event
+    - The current pageview is ignored (onIgnoredEvent)
+    */
     if (!engagementCooldown && !currentEngagementIgnored && (currentEngagementMaxScrollDepth < maxScrollDepthPx || engagementTime > 1000)) {
       currentEngagementMaxScrollDepth = maxScrollDepthPx
       setTimeout(function () {engagementCooldown = false}, 300)

--- a/tracker/test/engagement.spec.js
+++ b/tracker/test/engagement.spec.js
@@ -1,18 +1,24 @@
-const { expectPlausibleInAction, engagementCooldown } = require('./support/test-utils')
+const { expect } = require("@playwright/test")
+const { expectPlausibleInAction, engagementCooldown, hideAndShowCurrentTab } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
 test.describe('engagement events', () => {
-  test('sends a pageleave when navigating to the next page', async ({ page }) => {
+  test('sends an engagement event with time measurement when navigating to the next page', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/engagement.html'),
       expectedRequests: [{n: 'pageview'}],
     })
 
-    await expectPlausibleInAction(page, {
+    await page.waitForTimeout(1000)
+
+    const [request] = await expectPlausibleInAction(page, {
       action: () => page.click('#navigate-away'),
       expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`}]
     })
+
+    expect(request.e).toBeGreaterThan(1000)
+    expect(request.e).toBeLessThan(1500)
   })
 
   test('sends an event and a pageview on hash-based SPA navigation', async ({ page }) => {
@@ -21,13 +27,18 @@ test.describe('engagement events', () => {
       expectedRequests: [{n: 'pageview'}],
     })
 
-    await expectPlausibleInAction(page, {
+    await page.waitForTimeout(1000)
+
+    const [request] = await expectPlausibleInAction(page, {
       action: () => page.click('#hash-nav'),
       expectedRequests: [
         {n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement-hash.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/engagement-hash.html#some-hash`}
       ]
     })
+
+    expect(request.e).toBeGreaterThan(1000)
+    expect(request.e).toBeLessThan(1500)
   })
 
   test('sends an event and a pageview on history-based SPA navigation', async ({ page }) => {
@@ -36,13 +47,18 @@ test.describe('engagement events', () => {
       expectedRequests: [{n: 'pageview'}],
     })
 
-    await expectPlausibleInAction(page, {
+    await page.waitForTimeout(1000)
+
+    const [request] = await expectPlausibleInAction(page, {
       action: () => page.click('#history-nav'),
       expectedRequests: [
         {n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`},
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/another-page`}
       ]
     })
+
+    expect(request.e).toBeGreaterThan(1000)
+    expect(request.e).toBeLessThan(1500)
   })
 
   test('sends an event with the manually overridden URL', async ({ page }) => {
@@ -86,7 +102,7 @@ test.describe('engagement events', () => {
     await engagementCooldown(page)
 
     // Navigate from ignored page to a tracked page ->
-    // no pageleave from the current page, pageview on the next page
+    // no engagement from the current page, pageview on the next page
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-link-1'),
       expectedRequests: [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
@@ -96,7 +112,7 @@ test.describe('engagement events', () => {
     await engagementCooldown(page)
 
     // Navigate from a tracked page to another tracked page ->
-    // pageleave with the last page URL, pageview with the new URL
+    // engagement with the last page URL, pageview with the new URL
     await expectPlausibleInAction(page, {
       action: () => page.click('#hash-link-2'),
       expectedRequests: [
@@ -188,4 +204,45 @@ test.describe('engagement events', () => {
     })
   })
 
+  test('sends engagement events when tab toggles between foreground and background', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/engagement.html'),
+      expectedRequests: [{n: 'pageview'}],
+    })
+
+    const [request1] = await expectPlausibleInAction(page, {
+      action: () => hideAndShowCurrentTab(page, {delay: 2000}),
+      expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`}],
+    })
+    expect(request1.e).toBeLessThan(500)
+
+    await page.waitForTimeout(2000)
+
+    const [request2] = await expectPlausibleInAction(page, {
+      action: () => hideAndShowCurrentTab(page, {delay: 2000}),
+      expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`}],
+    })
+
+    expect(request2.e).toBeGreaterThan(2000)
+    expect(request2.e).toBeLessThan(2500)
+  })
+
+  test('does not send engagement events when tab is only open for a short time', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/engagement.html'),
+      expectedRequests: [{n: 'pageview'}],
+    })
+
+    await expectPlausibleInAction(page, {
+      action: () => hideAndShowCurrentTab(page),
+      expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`}],
+    })
+
+    await page.waitForTimeout(100)
+
+    await expectPlausibleInAction(page, {
+      action: () => hideAndShowCurrentTab(page),
+      refutedRequests: [{n: 'engagement'}],
+    })
+  })
 })

--- a/tracker/test/engagement.spec.js
+++ b/tracker/test/engagement.spec.js
@@ -216,18 +216,18 @@ test.describe('engagement events', () => {
     })
     expect(request1.e).toBeLessThan(500)
 
-    await page.waitForTimeout(2000)
+    await page.waitForTimeout(3000)
 
     const [request2] = await expectPlausibleInAction(page, {
       action: () => hideAndShowCurrentTab(page, {delay: 2000}),
       expectedRequests: [{n: 'engagement', u: `${LOCAL_SERVER_ADDR}/engagement.html`}],
     })
 
-    expect(request2.e).toBeGreaterThan(2000)
-    expect(request2.e).toBeLessThan(2500)
+    expect(request2.e).toBeGreaterThan(3000)
+    expect(request2.e).toBeLessThan(3500)
   })
 
-  test('does not send engagement events when tab is only open for a short time until over 1000ms has passed', async ({ page }) => {
+  test('does not send engagement events when tab is only open for a short time until over 3000ms has passed', async ({ page }) => {
     await expectPlausibleInAction(page, {
       action: () => page.goto('/engagement.html'),
       expectedRequests: [{n: 'pageview'}],
@@ -247,7 +247,7 @@ test.describe('engagement events', () => {
       mockRequestTimeout: 100
     })
 
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(2500)
 
     const [request2] = await expectPlausibleInAction(page, {
       action: () => hideAndShowCurrentTab(page, {delay: 3000}),
@@ -255,8 +255,8 @@ test.describe('engagement events', () => {
     })
 
     // Sum of both visibility times
-    expect(request2.e).toBeGreaterThan(1000)
-    expect(request2.e).toBeLessThan(1500)
+    expect(request2.e).toBeGreaterThan(3000)
+    expect(request2.e).toBeLessThan(3500)
   })
 
   test('tracks engagement time properly in a SPA', async ({ page }) => {

--- a/tracker/test/fixtures/engagement-hash.html
+++ b/tracker/test/fixtures/engagement-hash.html
@@ -14,6 +14,7 @@
 
 <body>
   <a id="hash-nav" href="#some-hash">Hash link</a>
+  <a id="hash-nav-2" href="#another-hash">Another hash link</a>
 </body>
 
 </html>

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -131,6 +131,8 @@ exports.expectPlausibleInAction = async function (page, {
   expect(refutedButFoundRequestBodies, refutedBodySubsetsErrorMessage).toHaveLength(0)
 
   expect(requestBodies.length).toBe(requestsToExpect)
+
+  return requestBodies
 }
 
 exports.ignoreEngagementRequests = function(requestPostData) {
@@ -157,8 +159,11 @@ exports.showCurrentTab = async function(page) {
   return toggleTabVisibility(page, false)
 }
 
-exports.hideAndShowCurrentTab = async function(page) {
+exports.hideAndShowCurrentTab = async function(page, options = {}) {
   await exports.hideCurrentTab(page)
+  if (options.delay > 0) {
+    await delay(options.delay)
+  }
   await exports.showCurrentTab(page)
 }
 

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -32,10 +32,10 @@ exports.metaKey = function() {
 
 // Mocks a specified number of HTTP requests with given path. Returns a promise that resolves to a
 // list of requests as soon as the specified number of requests is made, or 3 seconds has passed.
-const mockManyRequests = function({ page, path, numberOfRequests, responseDelay, shouldIgnoreRequest }) {
+const mockManyRequests = function({ page, path, numberOfRequests, responseDelay, shouldIgnoreRequest, mockRequestTimeout = 3000 }) {
   return new Promise((resolve, _reject) => {
     let requestList = []
-    const requestTimeoutTimer = setTimeout(() => resolve(requestList), 3000)
+    const requestTimeoutTimer = setTimeout(() => resolve(requestList), mockRequestTimeout)
 
     page.route(path, async (route, request) => {
       const postData = request.postDataJSON()
@@ -89,7 +89,8 @@ exports.expectPlausibleInAction = async function (page, {
   awaitedRequestCount,
   expectedRequestCount,
   responseDelay,
-  shouldIgnoreRequest
+  shouldIgnoreRequest,
+  mockRequestTimeout = 3000
 }) {
   const requestsToExpect = expectedRequestCount ? expectedRequestCount : expectedRequests.length
   const requestsToAwait = awaitedRequestCount ? awaitedRequestCount : requestsToExpect + refutedRequests.length
@@ -99,7 +100,8 @@ exports.expectPlausibleInAction = async function (page, {
     path: '/api/event',
     responseDelay,
     shouldIgnoreRequest,
-    numberOfRequests: requestsToAwait
+    numberOfRequests: requestsToAwait,
+    mockRequestTimeout: mockRequestTimeout
   })
   await action()
   const requestBodies = await plausibleRequestMockList


### PR DESCRIPTION
### Changes

In `pageleave` extension plausible.js, we now track engagement_time for engagement events. This represents the number of milliseconds the user was _active_ on the page.

To calculate the variable, we keep track of:
- When the page became last active (currentEngagementStartTime)
- How many milliseconds was the page active before going to the background the last time (currentEngagementBeforeHideTime)

We also continue to avoid sending engagement events if there isn't much interesting to report (new max scroll depth or engagement_time above 1s)