### PR TITLE
time-on-page: Ingestion logic for engagement_time

### DIFF
--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -18,6 +18,7 @@ defmodule Plausible.ClickhouseEventV2 do
     field :"meta.key", {:array, :string}
     field :"meta.value", {:array, :string}
     field :scroll_depth, Ch, type: "UInt8"
+    field :engagement_time, Ch, type: "UInt32"
 
     field :revenue_source_amount, Ch, type: "Nullable(Decimal64(3))"
     field :revenue_source_currency, Ch, type: "FixedString(3)"
@@ -62,6 +63,7 @@ defmodule Plausible.ClickhouseEventV2 do
         :"meta.key",
         :"meta.value",
         :scroll_depth,
+        :engagement_time,
         :revenue_source_amount,
         :revenue_source_currency,
         :revenue_reporting_amount,

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -251,7 +251,8 @@ defmodule Plausible.Ingestion.Event do
       name: event.request.event_name,
       hostname: event.request.hostname,
       pathname: event.request.pathname,
-      scroll_depth: event.request.scroll_depth
+      scroll_depth: event.request.scroll_depth,
+      engagement_time: event.request.engagement_time
     })
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -42,6 +42,7 @@ defmodule Plausible.Ingestion.Request do
     field :pathname, :string
     field :props, :map
     field :scroll_depth, :integer
+    field :engagement_time, :integer
 
     on_ee do
       field :revenue_source, :map
@@ -79,6 +80,7 @@ defmodule Plausible.Ingestion.Request do
         |> put_referrer(request_body)
         |> put_props(request_body)
         |> put_scroll_depth(request_body)
+        |> put_engagement_time(request_body)
         |> put_pathname()
         |> put_query_params()
         |> put_revenue_source(request_body)
@@ -259,6 +261,20 @@ defmodule Plausible.Ingestion.Request do
         end
 
       Changeset.put_change(changeset, :scroll_depth, scroll_depth)
+    else
+      changeset
+    end
+  end
+
+  defp put_engagement_time(changeset, %{} = request_body) do
+    if Changeset.get_field(changeset, :event_name) == "engagement" do
+      engagement_time =
+        case request_body["e"] do
+          e when is_integer(e) and e >= 0 -> e
+          _ -> 0
+        end
+
+      Changeset.put_change(changeset, :engagement_time, engagement_time)
     else
       changeset
     end

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -432,7 +432,7 @@ defmodule Plausible.Ingestion.RequestTest do
   test "long body length" do
     payload = """
     {
-      "name": "pageview", 
+      "name": "pageview",
       "domain": "dummy.site",
       "url": "#{:binary.copy("a", 1_000)}"
     }
@@ -490,7 +490,8 @@ defmodule Plausible.Ingestion.RequestTest do
              "uri" => "https://dummy.site/pictures/index.html?foo=bar&baz=bam",
              "user_agent" => "Mozilla",
              "ip_classification" => nil,
-             "scroll_depth" => nil
+             "scroll_depth" => nil,
+             "engagement_time" => nil
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1294,35 +1294,61 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     end
   end
 
-  describe "scroll depth tests" do
+  describe "engagement event tests" do
     setup do
       site = new_site()
       {:ok, site: site}
     end
 
-    test "ingests scroll_depth as 255 when sd not in params", %{conn: conn, site: site} do
+    test "ingests scroll_depth and engagement_time when not in params", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
       post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain})
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
       assert engagement.scroll_depth == 255
+      assert engagement.engagement_time == 0
     end
 
-    test "sd field is ignored if name is not engagement", %{conn: conn, site: site} do
-      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain, sd: 10})
-      post(conn, "/api/event", %{n: "custom_e", u: "https://test.com", d: site.domain, sd: 10})
+    test "sd and e fields are ignored if name is not engagement", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{
+        n: "pageview",
+        u: "https://test.com",
+        d: site.domain,
+        sd: 10,
+        e: 789
+      })
 
-      assert [%{scroll_depth: 0}, %{scroll_depth: 0}] = get_events(site)
+      post(conn, "/api/event", %{
+        n: "custom_e",
+        u: "https://test.com",
+        d: site.domain,
+        sd: 10,
+        e: 789
+      })
+
+      assert [%{scroll_depth: 0, engagement_time: 0}, %{scroll_depth: 0, engagement_time: 0}] =
+               get_events(site)
     end
 
-    test "ingests valid scroll_depth for a engagement", %{conn: conn, site: site} do
+    test "ingests valid scroll_depth and engagement_time for a engagement", %{
+      conn: conn,
+      site: site
+    } do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: 25})
+
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        sd: 25,
+        e: 789
+      })
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
       assert engagement.scroll_depth == 25
+      assert engagement.engagement_time == 789
     end
 
     test "ingests scroll_depth as 100 when sd > 100", %{conn: conn, site: site} do
@@ -1352,13 +1378,23 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert engagement.scroll_depth == 255
     end
 
-    test "ingests valid scroll_depth for a engagement event", %{conn: conn, site: site} do
+    test "ingests engagement_time as 0 when e is a string", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: 25})
 
-      event = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, e: "789"})
 
-      assert event.scroll_depth == 25
+      engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
+      assert engagement.engagement_time == 0
+    end
+
+    test "ingests engagement_time as 0 when e is a negative integer", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
+      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, e: -100})
+
+      engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
+      assert engagement.engagement_time == 0
     end
   end
 


### PR DESCRIPTION
### Changes

Straight-forward ingestion logic for engagement_time column. Depends on https://github.com/plausible/analytics/pull/5092