### PR TITLE
Ignore excess logger errors from Cowboy when sending to Sentry

### DIFF
--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -23,9 +23,7 @@ defmodule Plausible.SentryFilter do
     %{event | fingerprint: ["ingestion_request"]}
   end
 
-  def before_send(
-        %{extra: %{logger_level: :error}, message: %{formatted: "Ranch listener" <> rest}} = event
-      ) do
+  def before_send(%{source: :logger, message: %{formatted: "Ranch listener" <> rest}} = event) do
     if String.contains?(rest, "had its request process") do
       false
     else

--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -23,6 +23,16 @@ defmodule Plausible.SentryFilter do
     %{event | fingerprint: ["ingestion_request"]}
   end
 
+  def before_send(
+        %{extra: %{logger_level: :error}, message: %{formatted: "Ranch listener" <> rest}} = event
+      ) do
+    if String.contains?(rest, "had its request process") do
+      false
+    else
+      event
+    end
+  end
+
   def before_send(event) do
     event
   end

--- a/test/plausible/sentry_filter_test.exs
+++ b/test/plausible/sentry_filter_test.exs
@@ -12,4 +12,25 @@ defmodule Plausible.SentryFilterTest do
     assert %Sentry.Event{fingerprint: ["ingestion_request"]} =
              Plausible.SentryFilter.before_send(event)
   end
+
+  test "ignores excess cowboy error messages" do
+    event = %Sentry.Event{
+      event_id: "5f0a9f9b04df4050884966c87a4e62b8",
+      timestamp: "2025-02-19T13:23:05.705493",
+      extra: %{logger_level: :error, logger_metadata: %{}},
+      level: :error,
+      logger: nil,
+      message: %Sentry.Interfaces.Message{
+        message: nil,
+        params: nil,
+        formatted:
+          "Ranch listener PlausibleWeb.Endpoint.HTTP, connection process #PID<0.1216.0>, " <>
+            "stream 1 had its request process #PID<0.1217.0> exit with " <>
+            "reason {{{%Plug.Parsers.ParseError{\n ..."
+      },
+      source: :logger
+    }
+
+    assert Plausible.SentryFilter.before_send(event) == false
+  end
 end


### PR DESCRIPTION
### Changes

After a recent dependency bump, we have observed excess of new errors in Sentry combing from cowboy in a following format:

```
Ranch listener PlausibleWeb.Endpoint.HTTP, connection process #PID<...>, 
stream .. had its request process #PID<...> exit with reason ...
```

After some digging, it turned out that between cowboy 2.12 and 2.13 there's https://github.com/ninenines/cowboy/commit/fbd680f0f6fb5fe99c4345b838cb42aa1afb3283 which plugs an apparent missed pattern case for and starts triggering error messages. This in turn seems to escape the special-cased pattern matching of ranch/cowboy errors in https://github.com/getsentry/sentry-elixir/commit/a14e3f85748e694492bb51d59fb1df9e95bbac16.

This patch is meant as a temporary measure meant to reduce the noise in sentry.

### Tests
- [x] Automated tests have been added
