### PR TITLE
Ingestion: Add test demonstrating blank event name is not accepted

### DIFF
--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1258,6 +1258,25 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
              }
     end
 
+    test "responds 400 when event name is blank", %{conn: conn, site: site} do
+      params = %{
+        domain: site.domain,
+        name: "",
+        url: "http://example.com"
+      }
+
+      conn =
+        conn
+        |> put_req_header("user-agent", @user_agent)
+        |> post("/api/event", params)
+
+      assert json_response(conn, 400) == %{
+               "errors" => %{
+                 "event_name" => ["can't be blank"]
+               }
+             }
+    end
+
     test "salts rotating once does not", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
       Plausible.Session.WriteBuffer.flush()


### PR DESCRIPTION
Kind of a nothing-PR but while poking around in ingestion I thought I found an issue where we could ingest blank event names. This would cause problems in imports queries down the line.

Turns out we do validate event name length. I've added a (previously missing) test to this effect.