### PR TITLE
Hide dashboard import icons when redundant #2

### DIFF
--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Stats.Aggregate do
     query =
       query
       |> Query.set(metrics: metrics, remove_unavailable_revenue_metrics: true)
-      |> Query.set_include(:imports_meta, true)
+      |> Query.set_include(:dashboard_imports_meta, true)
       |> QueryOptimizer.optimize()
 
     %QueryResult{results: [entry], meta: meta} = QueryRunner.run(site, query)

--- a/lib/plausible/stats/aggregate.ex
+++ b/lib/plausible/stats/aggregate.ex
@@ -14,6 +14,7 @@ defmodule Plausible.Stats.Aggregate do
     query =
       query
       |> Query.set(metrics: metrics, remove_unavailable_revenue_metrics: true)
+      |> Query.set_include(:imports_meta, true)
       |> QueryOptimizer.optimize()
 
     %QueryResult{results: [entry], meta: meta} = QueryRunner.run(site, query)

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -11,7 +11,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
     # is false. Even if we don't want to include imported data, we
     # might still want to know whether imported data can be toggled
     # on/off on the dashboard.
-    imports_meta: false,
+    dashboard_imports_meta: false,
     time_labels: false,
     total_rows: false,
     comparisons: nil

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -2,7 +2,6 @@ defmodule Plausible.Stats.Query do
   use Plausible
 
   defstruct utc_time_range: nil,
-            comparison_utc_time_range: nil,
             interval: nil,
             period: nil,
             dimensions: [],
@@ -26,7 +25,9 @@ defmodule Plausible.Stats.Query do
             revenue_warning: nil,
             remove_unavailable_revenue_metrics: false,
             site_id: nil,
-            site_native_stats_start_at: nil
+            site_native_stats_start_at: nil,
+            comparison_utc_time_range: nil,
+            comparison_query: nil
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy, Comparisons}

--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Stats.QueryOptimizer do
   """
 
   use Plausible
-  alias Plausible.Stats.{DateTimeRange, Filters, Query, TableDecider, Util, Time}
+  alias Plausible.Stats.{Comparisons, DateTimeRange, Filters, Query, TableDecider, Util, Time}
 
   @doc """
     This module manipulates an existing query, updating it according to business logic.
@@ -49,7 +49,8 @@ defmodule Plausible.Stats.QueryOptimizer do
       &add_missing_order_by/1,
       &update_time_in_order_by/1,
       &extend_hostname_filters_to_visit/1,
-      &remove_revenue_metrics_if_unavailable/1
+      &remove_revenue_metrics_if_unavailable/1,
+      &add_comparison_query/1
     ]
   end
 
@@ -184,5 +185,14 @@ defmodule Plausible.Stats.QueryOptimizer do
     end
   else
     defp remove_revenue_metrics_if_unavailable(query), do: query
+  end
+
+  defp add_comparison_query(query) do
+    if query.include.comparisons do
+      comparison_query = Comparisons.get_comparison_query(query)
+      Query.set(query, comparison_query: comparison_query)
+    else
+      query
+    end
   end
 end

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -61,8 +61,7 @@ defmodule Plausible.Stats.QueryRunner do
   defp add_comparison_query(%__MODULE__{main_query: query, main_results: main_results} = runner)
        when is_map(query.include.comparisons) do
     comparison_query =
-      query
-      |> Comparisons.get_comparison_query()
+      query.comparison_query
       |> Comparisons.add_comparison_filters(main_results)
 
     struct!(runner, comparison_query: comparison_query)

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Stats.Timeseries do
   """
 
   use Plausible.ClickhouseRepo
-  alias Plausible.Stats.{Comparisons, Query, QueryRunner, QueryOptimizer, Time}
+  alias Plausible.Stats.{Query, QueryRunner, QueryOptimizer, Time}
 
   @time_dimension %{
     "month" => "time:month",
@@ -27,17 +27,11 @@ defmodule Plausible.Stats.Timeseries do
       )
       |> QueryOptimizer.optimize()
 
-    comparison_query =
-      if(query.include.comparisons,
-        do: Comparisons.get_comparison_query(query),
-        else: nil
-      )
-
     query_result = QueryRunner.run(site, query)
 
     {
       build_result(query_result, query, fn entry -> entry end),
-      build_result(query_result, comparison_query, fn entry -> entry.comparison end),
+      build_result(query_result, query.comparison_query, fn entry -> entry.comparison end),
       query_result.meta
     }
   end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -192,10 +192,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     params = realtime_period_to_30m(params)
 
-    query =
-      site
-      |> Query.from(params, debug_metadata(conn))
-      |> Query.set_include(:imports_meta, true)
+    query = Query.from(site, params, debug_metadata(conn))
 
     %{
       top_stats: top_stats,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -217,18 +217,19 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp with_imported_switch_info(%Jason.OrderedObject{} = meta) do
-    case {meta[:imports_included], meta[:imports_skip_reason]} do
-      {true, nil} ->
-        %{visible: true, togglable: true, tooltip_msg: "Click to exclude imported data"}
-
-      {false, nil} ->
-        %{visible: true, togglable: true, tooltip_msg: "Click to include imported data"}
-
-      {false, :unsupported_query} ->
+    case Map.new(meta) do
+      %{imports_included: false, imports_skip_reason: :unsupported_query} ->
         %{visible: true, togglable: false, tooltip_msg: "Imported data cannot be included"}
 
-      {false, reason} when reason in [:no_imported_data, :out_of_range] ->
+      %{imports_included: false, imports_skip_reason: reason}
+      when reason in [:no_imported_data, :out_of_range] ->
         %{visible: false, togglable: false, tooltip_msg: nil}
+
+      %{imports_included_for_main_query: true} ->
+        %{visible: true, togglable: true, tooltip_msg: "Click to exclude imported data"}
+
+      %{imports_included_for_main_query: false} ->
+        %{visible: true, togglable: true, tooltip_msg: "Click to include imported data"}
     end
   end
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -50,7 +50,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
 
   @default_include %{
     imports: false,
-    imports_meta: false,
+    dashboard_imports_meta: false,
     time_labels: false,
     total_rows: false,
     comparisons: nil
@@ -872,7 +872,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         timezone: site.timezone,
         include: %{
           imports: true,
-          imports_meta: false,
+          dashboard_imports_meta: false,
           time_labels: true,
           total_rows: true,
           comparisons: nil
@@ -937,7 +937,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "previous_period"
             },
             imports: false,
-            imports_meta: false,
+            dashboard_imports_meta: false,
             time_labels: false,
             total_rows: false
           },
@@ -968,7 +968,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "year_over_year"
             },
             imports: false,
-            imports_meta: false,
+            dashboard_imports_meta: false,
             time_labels: false,
             total_rows: false
           },
@@ -1001,7 +1001,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
               mode: "custom",
               date_range: @date_range_30d
             },
-            imports_meta: false,
+            dashboard_imports_meta: false,
             imports: false,
             time_labels: false,
             total_rows: false

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -791,7 +791,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       assert res["with_imported_switch"] == %{
                "visible" => true,
                "togglable" => true,
-               "tooltip_msg" => "Click to exclude imported data"
+               "tooltip_msg" => "Click to include imported data"
              }
     end
 
@@ -803,9 +803,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       res = json_response(conn, 200)
 
       assert res["with_imported_switch"] == %{
-               "visible" => true,
-               "togglable" => true,
-               "tooltip_msg" => "Click to include imported data"
+               "visible" => false,
+               "togglable" => false,
+               "tooltip_msg" => nil
              }
     end
   end


### PR DESCRIPTION
Alternative solution to https://github.com/plausible/analytics/pull/5097 to not show include/exclude imported data for comparisons in top stats.

What's changing:
- `query.imports_included` only applies to that query and not comparison query
- Query structure: 
    - query.comparison_query is populated in QueryOptimizer
    - `include_meta` -> `dashboard_include_meta` flag rename
    - `imports_exist` -> `completed_imports` list persisted on query

Previous solution was causing unneeded joins with imported tables.

Sadly now QueryResult needs to be somewhat aware of comparisons. I've tried to minimize the footprint though.