### PR TITLE
Scroll Depth Release: make pageleave script the new default

### DIFF
--- a/test/plausible_web/plugs/tracker_test.exs
+++ b/test/plausible_web/plugs/tracker_test.exs
@@ -42,6 +42,17 @@ defmodule PlausibleWeb.TrackerTest do
     assert response == get_script("plausible.outbound-links.file-downloads.compat.hash.js")
   end
 
+  test "pageleave extension" do
+    # Some customers who have participated in the private preview of the
+    # scroll depth feature, have updated their tracking scripts to
+    # `script.pageleave.js` per our request. With the public release of
+    # scroll depth, this functionality is included in the default script,
+    # but we must continue to serve `script.pageleave.js` for as long as
+    # those customers are still using it.
+    assert get_script("script.pageleave.js") == get_script("script.js")
+    assert get_script("script.manual.pageleave.js") == get_script("script.manual.js")
+  end
+
   def get_script(filename) do
     opts = PlausibleWeb.Tracker.init([])
 

--- a/tracker/report-sizes.js
+++ b/tracker/report-sizes.js
@@ -6,9 +6,9 @@ const PrivTrackerDir = '../priv/tracker/js/';
 
 const toReport = [
   'plausible.js',
-  'plausible.pageleave.js',
-  'plausible.manual.pageleave.js',
-  'plausible.hash.pageleave.js'
+  'plausible.compat.js',
+  'plausible.manual.js',
+  'plausible.hash.js'
 ];
 
 const results = [];

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -16,11 +16,9 @@
     if (reason) console.warn('Ignoring Event: ' + reason);
     options && options.callback && options.callback()
 
-    {{#if pageleave}}
     if (eventName === 'pageview') {
       currentEngagementIgnored = true
     }
-    {{/if}}
   }
 
   function defaultEndpoint(el) {
@@ -34,9 +32,6 @@
     {{/if}}
   }
 
-  {{#if pageleave}}
-  // :NOTE: Tracking engagement events is currently experimental.
-
   var currentEngagementIgnored
   var currentEngagementURL = location.href
   var currentEngagementProps = {}
@@ -47,7 +42,7 @@
   // prevents registering multiple listeners in those cases.
   var listeningOnEngagement = false
 
-  // In SPA-s, multiple listeners that trigger the pageleave event
+  // In SPA-s, multiple listeners that trigger the engagement event
   // might fire nearly at the same time. E.g. when navigating back
   // in browser history while using hash-based routing - a popstate
   // and hashchange will be fired in a very quick succession. This
@@ -170,7 +165,6 @@
       listeningOnEngagement = true
     }
   }
-  {{/if}}
 
   function trigger(eventName, options) {
     var isPageview = eventName === 'pageview'
@@ -257,7 +251,6 @@
     payload.h = 1
     {{/if}}
 
-    {{#if pageleave}}
     if (isPageview) {
       currentEngagementIgnored = false
       currentEngagementURL = payload.u
@@ -267,7 +260,6 @@
       runningEnagementStart = Date.now()
       registerEngagementListener()
     }
-    {{/if}}
 
     sendRequest(endpoint, payload, options)
   }
@@ -315,13 +307,11 @@
       if (isSPANavigation && lastPage === location.pathname) return;
       {{/unless}}
 
-      {{#if pageleave}}
       if (isSPANavigation && listeningOnEngagement) {
         triggerEngagement()
         currentDocumentHeight = getDocumentHeight()
         maxScrollDepthPx = getCurrentScrollDepthPx()
       }
-      {{/if}}
 
       lastPage = location.pathname
       trigger('pageview')
@@ -355,14 +345,12 @@
       page()
     }
 
-    {{#if pageleave}}
     window.addEventListener('pageshow', function(event) {
       if (event.persisted) {
         // Page was restored from bfcache - trigger a pageview
         page();
       }
     })
-    {{/if}}
   {{/unless}}
 
   {{#if (any outbound_links file_downloads tagged_events)}}

--- a/tracker/test/fixtures/engagement-hash-exclusions.html
+++ b/tracker/test/fixtures/engagement-hash-exclusions.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer data-exclude='/*#*/hash/**/ignored' src="/tracker/js/plausible.exclusions.hash.local.pageleave.js"></script>
+  <script defer data-exclude='/*#*/hash/**/ignored' src="/tracker/js/plausible.exclusions.hash.local.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/engagement-hash-pageview-props.html
+++ b/tracker/test/fixtures/engagement-hash-pageview-props.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script id="plausible-script" defer src="/tracker/js/plausible.hash.local.pageleave.pageview-props.js"></script>
+  <script id="plausible-script" defer src="/tracker/js/plausible.hash.local.pageview-props.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/engagement-hash.html
+++ b/tracker/test/fixtures/engagement-hash.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.hash.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.hash.local.js"></script>
   <script>
 
   </script>

--- a/tracker/test/fixtures/engagement-manual.html
+++ b/tracker/test/fixtures/engagement-manual.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.manual.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.manual.js"></script>
   <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 </head>
 

--- a/tracker/test/fixtures/engagement-pageview-props.html
+++ b/tracker/test/fixtures/engagement-pageview-props.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer event-author="John" src="/tracker/js/plausible.local.pageleave.pageview-props.js"></script>
+  <script defer event-author="John" src="/tracker/js/plausible.local.pageview-props.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/engagement.html
+++ b/tracker/test/fixtures/engagement.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/scroll-depth-content-onscroll.html
+++ b/tracker/test/fixtures/scroll-depth-content-onscroll.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/scroll-depth-dynamic-content-load.html
+++ b/tracker/test/fixtures/scroll-depth-dynamic-content-load.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.js"></script>
 </head>
 <body>
   <br>

--- a/tracker/test/fixtures/scroll-depth-hash.html
+++ b/tracker/test/fixtures/scroll-depth-hash.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Plausible Playwright tests</title>
-  <script defer src="/tracker/js/plausible.hash.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.hash.local.js"></script>
 </head>
 
 <body>

--- a/tracker/test/fixtures/scroll-depth-slow-window-load.html
+++ b/tracker/test/fixtures/scroll-depth-slow-window-load.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.js"></script>
 </head>
 <body>
   <a id="navigate-away" href="/manual.html">

--- a/tracker/test/fixtures/scroll-depth.html
+++ b/tracker/test/fixtures/scroll-depth.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script defer src="/tracker/js/plausible.local.pageleave.js"></script>
+  <script defer src="/tracker/js/plausible.local.js"></script>
   <title>Document</title>
 </head>
 <body>


### PR DESCRIPTION
### Changes

This PR makes scroll depth and engagement time tracking part of the default `script.js`.

We will still continue serving the `pageleave` extension (as just a blank extension with no extra functionality) for as long as people are still using it.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
