### PR TITLE
Scroll Depth Release: ingestion flag check for incremental load increase

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -57,15 +57,15 @@ defmodule Plausible.Ingestion.Event do
         for domain <- domains, do: drop(new(domain, request), :spam_referrer)
       else
         Enum.reduce(domains, [], fn domain, acc ->
-          case GateKeeper.check(domain) do
-            {:allow, site} ->
-              processed =
-                domain
-                |> new(site, request)
-                |> process_unless_dropped(pipeline(), context)
+          with {:allow, site} <- GateKeeper.check(domain),
+               :ok <- check_engagements_flag(domain, request) do
+            processed =
+              domain
+              |> new(site, request)
+              |> process_unless_dropped(pipeline(), context)
 
-              [processed | acc]
-
+            [processed | acc]
+          else
             {:deny, reason} ->
               [drop(new(domain, request), reason) | acc]
           end
@@ -75,6 +75,16 @@ defmodule Plausible.Ingestion.Event do
     {dropped, buffered} = Enum.split_with(processed_events, & &1.dropped?)
     {:ok, %{dropped: dropped, buffered: buffered}}
   end
+
+  defp check_engagements_flag(domain, %{event_name: "engagement"}) do
+    if FunWithFlags.enabled?(:engagements, for: %Plausible.Site{domain: domain}) do
+      :ok
+    else
+      {:deny, :engagement_ff_throttle}
+    end
+  end
+
+  defp check_engagements_flag(_, _), do: :ok
 
   @spec telemetry_event_buffered() :: [atom()]
   def telemetry_event_buffered() do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -36,6 +36,7 @@ defmodule Plausible.Ingestion.Event do
           | :verification_agent
           | :lock_timeout
           | :no_session_for_engagement
+          | :engagement_ff_throttle
 
   @type t() :: %__MODULE__{
           domain: String.t() | nil,

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -336,6 +336,24 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :no_session_for_engagement
   end
 
+  test "TEMPORARY: drops engagement if FF not enabled for site" do
+    site = new_site()
+
+    FunWithFlags.disable(:engagements, for_actor: "site:#{site.domain}")
+
+    payload = %{
+      name: "engagement",
+      url: "https://#{site.domain}/123",
+      d: "#{site.domain}"
+    }
+
+    conn = build_conn(:post, "/api/events", payload)
+
+    assert {:ok, request} = Request.build(conn)
+    assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(request)
+    assert dropped.drop_reason == :engagement_ff_throttle
+  end
+
   @tag :ee_only
   test "saves revenue amount" do
     site = new_site()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,7 @@ Application.ensure_all_started(:double)
 
 FunWithFlags.enable(:channels)
 FunWithFlags.enable(:scroll_depth)
+FunWithFlags.enable(:engagements)
 FunWithFlags.enable(:teams)
 FunWithFlags.enable(:saved_segments)
 


### PR DESCRIPTION
### Changes

Implements a straight-forward feature flag check to drop engagements and not process them. The `engagements` flag should already be enabled for all sites that are currently getting engagements (including e.g. plausible.io).

We can use the feature flag to incrementally crank up the percentage of sites for which we **will** process engagements.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
