### PR TITLE
Bugfix: allow Team updates via CRM

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -275,8 +275,8 @@ defmodule Plausible.Teams do
 
   defp create_my_team(user) do
     team =
-      "My Team"
-      |> Teams.Team.changeset()
+      %Teams.Team{}
+      |> Teams.Team.changeset(%{name: "My Team"})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -46,14 +46,19 @@ defmodule Plausible.Teams.Team do
     timestamps()
   end
 
-  def crm_sync_changeset(team, params) do
+  def crm_changeset(team, params) do
     team
-    |> cast(params, [:trial_expiry_date, :allow_next_upgrade_override, :accept_traffic_until])
+    |> cast(params, [
+      :name,
+      :trial_expiry_date,
+      :allow_next_upgrade_override,
+      :accept_traffic_until
+    ])
   end
 
-  def changeset(name, today \\ Date.utc_today()) do
-    %__MODULE__{}
-    |> cast(%{name: name}, [:name])
+  def changeset(team \\ %__MODULE__{}, attrs \\ %{}, today \\ Date.utc_today()) do
+    team
+    |> cast(attrs, [:name])
     |> validate_required(:name)
     |> start_trial(today)
     |> maybe_bump_accept_traffic_until()

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -38,6 +38,10 @@ defmodule Plausible.Teams.TeamAdmin do
     )
   end
 
+  def update_changeset(entry, attrs) do
+    Teams.Team.crm_changeset(entry, attrs)
+  end
+
   def index(_) do
     [
       name: %{value: &team_name/1},


### PR DESCRIPTION
Due to a regression in #5008, it was impossible to update `%Team{}` via CRM. Kaffy calls the regular `schema.changeset` before looking up an `update_changeset` override. This caused a crash. Additionally, `crm_sync_changeset` was left unused.