### PR TITLE
Permit :has_not_done filter in segments

### DIFF
--- a/lib/plausible/segments/filters.ex
+++ b/lib/plausible/segments/filters.ex
@@ -63,6 +63,13 @@ defmodule Plausible.Segments.Filters do
     end
   end
 
+  defp expand_first_level_and_filters(filter) do
+    case filter do
+      [:and, clauses] -> clauses
+      filter -> [filter]
+    end
+  end
+
   defp replace_segment_with_filter_tree([_, "segment", clauses], preloaded_segments) do
     if length(clauses) == 1 do
       [[:and, Map.get(preloaded_segments, Enum.at(clauses, 0))]]
@@ -84,8 +91,17 @@ defmodule Plausible.Segments.Filters do
     iex> resolve_segments([[:is, "visit:entry_page", ["/home"]], [:is, "segment", [1]]], %{1 => [[:contains, "visit:entry_page", ["blog"]], [:is, "visit:country", ["PL"]]]})
     {:ok, [
       [:is, "visit:entry_page", ["/home"]],
-      [:and, [[:contains, "visit:entry_page", ["blog"]], [:is, "visit:country", ["PL"]]]]
+      [:contains, "visit:entry_page", ["blog"]],
+      [:is, "visit:country", ["PL"]]
     ]}
+
+    iex> resolve_segments([[:is, "visit:entry_page", ["/home"]], [:is, "segment", [1]], [:is, "segment", [2]]], %{1 => [[:is, "visit:country", ["PL"]]], 2 => [[:is, "event:goal", ["Signup"]]]})
+    {:ok, [
+      [:is, "visit:entry_page", ["/home"]],
+      [:is, "visit:country", ["PL"]],
+      [:is, "event:goal", ["Signup"]]
+    ]}
+
 
     iex> resolve_segments([[:is, "segment", [1, 2]]], %{1 => [[:contains, "event:goal", ["Singup"]], [:is, "visit:country", ["PL"]]], 2 => [[:contains, "event:goal", ["Sauna"]], [:is, "visit:country", ["EE"]]]})
     {:ok, [
@@ -98,9 +114,11 @@ defmodule Plausible.Segments.Filters do
   def resolve_segments(original_filters, preloaded_segments) do
     if map_size(preloaded_segments) > 0 do
       {:ok,
-       Filters.transform_filters(original_filters, fn f ->
+       original_filters
+       |> Filters.transform_filters(fn f ->
          replace_segment_with_filter_tree(f, preloaded_segments)
-       end)}
+       end)
+       |> Filters.transform_filters(&expand_first_level_and_filters/1)}
     else
       {:ok, original_filters}
     end

--- a/lib/plausible/segments/filters.ex
+++ b/lib/plausible/segments/filters.ex
@@ -64,7 +64,7 @@ defmodule Plausible.Segments.Filters do
   end
 
   defp replace_segment_with_filter_tree([_, "segment", clauses], preloaded_segments) do
-    if length(clauses) === 1 do
+    if length(clauses) == 1 do
       [[:and, Map.get(preloaded_segments, Enum.at(clauses, 0))]]
     else
       [[:or, Enum.map(clauses, fn id -> [:and, Map.get(preloaded_segments, id)] end)]]

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -197,15 +197,10 @@ defmodule Plausible.Segments.Segment do
   end
 
   defp dashboard_compatible_filter?(filter) do
-    regular_filter? =
-      is_list(filter) and length(filter) == 3 and
-        is_atom(Enum.at(filter, 0)) and
-        is_binary(Enum.at(filter, 1)) and
-        is_list(Enum.at(filter, 2))
-
-    has_not_done_filter? =
-      is_list(filter) and length(filter) == 2 and Enum.at(filter, 0) == :has_not_done
-
-    regular_filter? or has_not_done_filter?
+    case filter do
+      [operation, dimension, _clauses] when is_atom(operation) and is_binary(dimension) -> true
+      [:has_not_done, _] -> true
+      _ -> false
+    end
   end
 end

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -197,9 +197,15 @@ defmodule Plausible.Segments.Segment do
   end
 
   defp dashboard_compatible_filter?(filter) do
-    is_list(filter) and length(filter) === 3 and
-      is_atom(Enum.at(filter, 0)) and
-      is_binary(Enum.at(filter, 1)) and
-      is_list(Enum.at(filter, 2))
+    regular_filter? =
+      is_list(filter) and length(filter) == 3 and
+        is_atom(Enum.at(filter, 0)) and
+        is_binary(Enum.at(filter, 1)) and
+        is_list(Enum.at(filter, 2))
+
+    has_not_done_filter? =
+      is_list(filter) and length(filter) == 2 and Enum.at(filter, 0) == :has_not_done
+
+    regular_filter? or has_not_done_filter?
   end
 end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -566,7 +566,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
       :ok
     else
       {:error,
-       "The goal `#{clause}` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"}
+       "Invalid filters. The goal `#{clause}` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"}
     end
   end
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2441,22 +2441,17 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           utc_time_range: @date_range_day,
           filters: [
             [
+              :or,
+              [
+                [:and, [[:is, "visit:country", ["AU", "NZ"]]]],
+                [:and, [[:is, "visit:country", ["FR", "DE"]]]]
+              ]
+            ],
+            [
               :and,
               [
-                [
-                  :or,
-                  [
-                    [:and, [[:is, "visit:country", ["AU", "NZ"]]]],
-                    [:and, [[:is, "visit:country", ["FR", "DE"]]]]
-                  ]
-                ],
-                [
-                  :and,
-                  [
-                    [:is, "visit:browser", ["Firefox"]],
-                    [:is, "visit:os", ["Linux"]]
-                  ]
-                ]
+                [:is, "visit:browser", ["Firefox"]],
+                [:is, "visit:os", ["Linux"]]
               ]
             ]
           ],

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1137,7 +1137,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "The goal `Signup` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"
+        "Invalid filters. The goal `Signup` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"
       )
     end
 
@@ -1152,7 +1152,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "The goal `Visit /thank-you` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"
+        "Invalid filters. The goal `Visit /thank-you` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals"
       )
     end
 
@@ -1255,7 +1255,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "The goal `Unknown` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals",
+        "Invalid filters. The goal `Unknown` is not configured for this site. Find out how to configure goals here: https://plausible.io/docs/stats-api#filtering-by-goals",
         :internal
       )
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4959,7 +4959,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           site: site,
           name: "Signups",
           segment_data: %{
-            "filters" => [["is", "event:name", ["Signup"]]]
+            "filters" => [["is", "event:goal", ["Signup"]]]
           }
         )
 
@@ -4998,7 +4998,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
       # response shows what filters the segment was resolved to
       assert json_response(conn, 200)["query"]["filters"] == [
-               ["and", [["is", "event:name", ["Signup"]]]]
+               ["is", "event:goal", ["Signup"]]
              ]
     end
   end


### PR DESCRIPTION
### Changes

- Permits has_not_done filter in segments
- Adds extra tests about having non-existing goals within segments. 
- Slightly changes error message upon having non-existing goals within segments, to bring it in line with other errors about selected filters. 
- Removes JS-style triple equals comparison from backend: it isn't standard

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR makes an incredibly small user-facing change, which probably doesn't warrant a mention in the changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
