### PR TITLE
Flatten :and groups stemming from segment filters on first level

### DIFF
--- a/lib/plausible/segments/filters.ex
+++ b/lib/plausible/segments/filters.ex
@@ -63,6 +63,13 @@ defmodule Plausible.Segments.Filters do
     end
   end
 
+  defp expand_first_level_and_filters(filter) do
+    case filter do
+      [:and, clauses] -> clauses
+      filter -> [filter]
+    end
+  end
+
   defp replace_segment_with_filter_tree([_, "segment", clauses], preloaded_segments) do
     if length(clauses) == 1 do
       [[:and, Map.get(preloaded_segments, Enum.at(clauses, 0))]]
@@ -84,8 +91,17 @@ defmodule Plausible.Segments.Filters do
     iex> resolve_segments([[:is, "visit:entry_page", ["/home"]], [:is, "segment", [1]]], %{1 => [[:contains, "visit:entry_page", ["blog"]], [:is, "visit:country", ["PL"]]]})
     {:ok, [
       [:is, "visit:entry_page", ["/home"]],
-      [:and, [[:contains, "visit:entry_page", ["blog"]], [:is, "visit:country", ["PL"]]]]
+      [:contains, "visit:entry_page", ["blog"]],
+      [:is, "visit:country", ["PL"]]
     ]}
+
+    iex> resolve_segments([[:is, "visit:entry_page", ["/home"]], [:is, "segment", [1]], [:is, "segment", [2]]], %{1 => [[:is, "visit:country", ["PL"]]], 2 => [[:is, "event:goal", ["Signup"]]]})
+    {:ok, [
+      [:is, "visit:entry_page", ["/home"]],
+      [:is, "visit:country", ["PL"]],
+      [:is, "event:goal", ["Signup"]]
+    ]}
+
 
     iex> resolve_segments([[:is, "segment", [1, 2]]], %{1 => [[:contains, "event:goal", ["Singup"]], [:is, "visit:country", ["PL"]]], 2 => [[:contains, "event:goal", ["Sauna"]], [:is, "visit:country", ["EE"]]]})
     {:ok, [
@@ -98,9 +114,11 @@ defmodule Plausible.Segments.Filters do
   def resolve_segments(original_filters, preloaded_segments) do
     if map_size(preloaded_segments) > 0 do
       {:ok,
-       Filters.transform_filters(original_filters, fn f ->
+       original_filters
+       |> Filters.transform_filters(fn f ->
          replace_segment_with_filter_tree(f, preloaded_segments)
-       end)}
+       end)
+       |> Filters.transform_filters(&expand_first_level_and_filters/1)}
     else
       {:ok, original_filters}
     end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2441,22 +2441,17 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           utc_time_range: @date_range_day,
           filters: [
             [
+              :or,
+              [
+                [:and, [[:is, "visit:country", ["AU", "NZ"]]]],
+                [:and, [[:is, "visit:country", ["FR", "DE"]]]]
+              ]
+            ],
+            [
               :and,
               [
-                [
-                  :or,
-                  [
-                    [:and, [[:is, "visit:country", ["AU", "NZ"]]]],
-                    [:and, [[:is, "visit:country", ["FR", "DE"]]]]
-                  ]
-                ],
-                [
-                  :and,
-                  [
-                    [:is, "visit:browser", ["Firefox"]],
-                    [:is, "visit:os", ["Linux"]]
-                  ]
-                ]
+                [:is, "visit:browser", ["Firefox"]],
+                [:is, "visit:os", ["Linux"]]
               ]
             ]
           ],

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4959,7 +4959,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
           site: site,
           name: "Signups",
           segment_data: %{
-            "filters" => [["is", "event:name", ["Signup"]]]
+            "filters" => [["is", "event:goal", ["Signup"]]]
           }
         )
 
@@ -4998,7 +4998,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
 
       # response shows what filters the segment was resolved to
       assert json_response(conn, 200)["query"]["filters"] == [
-               ["and", [["is", "event:name", ["Signup"]]]]
+               ["is", "event:goal", ["Signup"]]
              ]
     end
   end


### PR DESCRIPTION
### Changes

Currently, segment BC (_containing filters `[B, C]`_) is resolved in the following way:
`[A, segment BC] -> [A, [:and, [B, C]]]`. 

That's a problem when B or C is an `event:goal` filter, because that's only allowed at the top level. 

This PR leverages the logical equivalency between `[A, [:and, [B, C]]]` and `[A, B, C]` to circumvent the problem.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
