### PR TITLE
Use `XHR` over `fetch` in all non-pageleave scripts

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -273,19 +273,7 @@
   }
 
   function sendRequest(endpoint, payload, options) {
-    {{#if compat}}
-    var request = new XMLHttpRequest();
-    request.open('POST', endpoint, true);
-    request.setRequestHeader('Content-Type', 'text/plain');
-
-    request.send(JSON.stringify(payload));
-
-    request.onreadystatechange = function() {
-      if (request.readyState === 4) {
-        options && options.callback && options.callback({status: request.status})
-      }
-    }
-    {{else}}
+    {{#if pageleave}}
     if (window.fetch) {
       fetch(endpoint, {
         method: 'POST',
@@ -297,6 +285,18 @@
       }).then(function(response) {
         options && options.callback && options.callback({status: response.status})
       })
+    }
+    {{else}}
+    var request = new XMLHttpRequest();
+    request.open('POST', endpoint, true);
+    request.setRequestHeader('Content-Type', 'text/plain');
+
+    request.send(JSON.stringify(payload));
+
+    request.onreadystatechange = function() {
+      if (request.readyState === 4) {
+        options && options.callback && options.callback({status: request.status})
+      }
     }
     {{/if}}
   }


### PR DESCRIPTION
We're experiencing some ingestion-adjacent issues and want to confirm whether it's caused by `fetch` changes.

We're not reverting it in `pageleave` script variants (used on plausible.io and by a few other small clients) as it'd break scroll depth and engagement time data gathering and make the data gathered so far useless and in need to be deleted.

I'd like to revert this in a week+ if it's not the core cause.

Related PR: https://github.com/plausible/analytics/pull/5025
