### PR TITLE
Resolve segment owner names and dates in site timezone in the BE

### DIFF
--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -15,9 +15,17 @@ export type SavedSegment = {
   name: string
   type: SegmentType
   owner_id: number
+  owner_name: string
+  /** datetime in site timezone, example 2025-02-26 10:00:00 */
   inserted_at: string
+  /** datetime in site timezone, example 2025-02-26 10:00:00 */
   updated_at: string
 }
+
+export type SavedPublicSiteSegment = Pick<
+  SavedSegment,
+  'id' | 'type' | 'name' | 'inserted_at' | 'updated_at'
+>
 
 export type SegmentDataFromApi = {
   filters: unknown[]

--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -114,3 +114,8 @@ export function getSearchToApplySingleSegmentFilter(
     }
   }
 }
+
+export const SEGMENT_TYPE_LABELS = {
+  [SegmentType.personal]: 'Personal segment',
+  [SegmentType.site]: 'Site segment'
+}

--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -10,27 +10,31 @@ export enum SegmentType {
   site = 'site'
 }
 
+/** This type signifies that the owner can't be shown. */
+type SegmentOwnershipHidden = { owner_id: null; owner_name: null }
+
+/** This type signifies that the original owner has been removed from the site. */
+type SegmentOwnershipDangling = { owner_id: null; owner_name: null }
+
+type SegmentOwnership =
+  | SegmentOwnershipDangling
+  | { owner_id: number; owner_name: string }
+
 export type SavedSegment = {
   id: number
   name: string
   type: SegmentType
-  /** null owner_id or owner_name signifies that the owner has been removed from the site */
-  owner_id: number | null
-  owner_name: string | null
   /** datetime in site timezone, example 2025-02-26 10:00:00 */
   inserted_at: string
   /** datetime in site timezone, example 2025-02-26 10:00:00 */
   updated_at: string
-}
+} & SegmentOwnership
 
 export type SavedSegmentPublic = Pick<
   SavedSegment,
   'id' | 'type' | 'name' | 'inserted_at' | 'updated_at'
-> & {
-  /** null owner_id signifies that the owner can't be shown */
-  owner_id: null
-  owner_name: null
-}
+> &
+  SegmentOwnershipHidden
 
 export type SegmentDataFromApi = {
   filters: unknown[]

--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -14,18 +14,23 @@ export type SavedSegment = {
   id: number
   name: string
   type: SegmentType
-  owner_id: number
-  owner_name: string
+  /** null owner_id or owner_name signifies that the owner has been removed from the site */
+  owner_id: number | null
+  owner_name: string | null
   /** datetime in site timezone, example 2025-02-26 10:00:00 */
   inserted_at: string
   /** datetime in site timezone, example 2025-02-26 10:00:00 */
   updated_at: string
 }
 
-export type SavedPublicSiteSegment = Pick<
+export type SavedSegmentPublic = Pick<
   SavedSegment,
   'id' | 'type' | 'name' | 'inserted_at' | 'updated_at'
->
+> & {
+  /** null owner_id signifies that the owner can't be shown */
+  owner_id: null
+  owner_name: null
+}
 
 export type SegmentDataFromApi = {
   filters: unknown[]

--- a/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
+++ b/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
@@ -11,9 +11,15 @@ import {
   SavedSegmentPublic,
   SavedSegment,
   SegmentData,
-  SegmentDataFromApi
+  SegmentDataFromApi,
+  SEGMENT_TYPE_LABELS
 } from '../../filtering/segments'
-import { QueryFunction, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  QueryFunction,
+  useQuery,
+  useQueryClient,
+  UseQueryResult
+} from '@tanstack/react-query'
 import { cleanLabels } from '../../util/filters'
 import classNames from 'classnames'
 import { Tooltip } from '../../util/tooltip'
@@ -27,9 +33,13 @@ import { ErrorPanel } from '../../components/error-panel'
 import { get } from '../../api'
 import { Role, useUserContext } from '../../user-context'
 
-function useSegmentsListQuery<T extends boolean>(_isPublicRequest: T) {
+function useSegmentsListQuery(
+  _isPublicRequest: boolean
+): typeof _isPublicRequest extends true
+  ? UseQueryResult<SavedSegmentPublic[]>
+  : UseQueryResult<SavedSegment[]> {
   const site = useSiteContext()
-  return useQuery<T extends true ? SavedSegmentPublic[] : SavedSegment[]>({
+  return useQuery({
     queryKey: ['segments'],
     placeholderData: (previousData) => previousData,
     queryFn: async () => {
@@ -102,21 +112,16 @@ export const SearchableSegmentsSection = ({
             )}
           </div>
 
-          {showableSlice!.map((s) => {
+          {showableSlice!.map((segment) => {
             return (
               <Tooltip
                 className="group"
-                key={s.id}
+                key={segment.id}
                 info={
                   <div className="max-w-60">
-                    <div className="break-all">{s.name}</div>
+                    <div className="break-all">{segment.name}</div>
                     <div className="font-normal text-xs">
-                      {
-                        {
-                          personal: 'Personal segment',
-                          site: 'Site segment'
-                        }[s.type]
-                      }
+                      {SEGMENT_TYPE_LABELS[segment.type]}
                     </div>
 
                     <SegmentAuthorship
@@ -124,18 +129,18 @@ export const SearchableSegmentsSection = ({
                       {...(isPublicListQuery
                         ? {
                             showOnlyPublicData: true,
-                            segment: s as SavedSegmentPublic
+                            segment: segment as SavedSegmentPublic
                           }
                         : {
                             showOnlyPublicData: false,
-                            segment: s as SavedSegment
+                            segment: segment as SavedSegment
                           })}
                     />
                   </div>
                 }
               >
                 <SegmentLink
-                  {...s}
+                  {...segment}
                   appliedSegmentIds={appliedSegmentIds}
                   closeList={closeList}
                 />

--- a/assets/js/dashboard/segments/segment-authorship.test.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.test.tsx
@@ -1,0 +1,98 @@
+/** @format */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { SegmentAuthorship } from './segment-authorship'
+import { SegmentType } from '../filtering/segments'
+
+describe('public (no "by <user>" shown)', () => {
+  const showOnlyPublicData = true
+
+  test('shows only insert date if its the same as updated at', async () => {
+    render(
+      <SegmentAuthorship
+        showOnlyPublicData={showOnlyPublicData}
+        segment={{
+          type: SegmentType.site,
+          name: 'APAC region',
+          id: 100,
+          owner_id: null,
+          owner_name: null,
+          inserted_at: '2025-02-01 14:00:00',
+          updated_at: '2025-02-01 14:00:00'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Created at 1 Feb')).toBeVisible()
+    expect(screen.queryByText(/Last updated/)).toBeNull()
+    expect(screen.queryByText(/by /)).toBeNull()
+  })
+
+  test('shows both insert date and updated at', async () => {
+    render(
+      <SegmentAuthorship
+        showOnlyPublicData={showOnlyPublicData}
+        segment={{
+          type: SegmentType.site,
+          name: 'APAC region',
+          id: 100,
+          owner_id: null,
+          owner_name: null,
+          inserted_at: '2025-02-01 14:00:00',
+          updated_at: '2025-02-01 15:00:00'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Created at 1 Feb')).toBeVisible()
+    expect(screen.getByText('Last updated at 1 Feb')).toBeVisible()
+    expect(screen.queryByText(/by /)).toBeNull()
+  })
+})
+
+describe('shown to a site member ("by <user>" shown)', () => {
+  const showOnlyPublicData = false
+
+  test('shows only insert date if its the same as updated at', async () => {
+    render(
+      <SegmentAuthorship
+        showOnlyPublicData={showOnlyPublicData}
+        segment={{
+          type: SegmentType.site,
+          name: 'APAC region',
+          id: 100,
+          owner_id: null,
+          owner_name: null,
+          inserted_at: '2025-02-01 14:00:00',
+          updated_at: '2025-02-01 14:00:00'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Created at 1 Feb by (Removed User)')).toBeVisible()
+    expect(screen.queryByText(/Last updated/)).toBeNull()
+  })
+
+  test('shows both insert date and updated at', async () => {
+    render(
+      <SegmentAuthorship
+        showOnlyPublicData={showOnlyPublicData}
+        segment={{
+          type: SegmentType.site,
+          name: 'APAC region',
+          id: 100,
+          owner_id: 500,
+          owner_name: 'Jane Smith',
+          inserted_at: '2025-02-01 14:00:00',
+          updated_at: '2025-02-05 15:00:00'
+        }}
+      />
+    )
+
+    expect(screen.getByText('Created at 1 Feb')).toBeVisible()
+    expect(
+      screen.queryByText('Last updated at 5 Feb by Jane Smith')
+    ).toBeVisible()
+  })
+})

--- a/assets/js/dashboard/segments/segment-authorship.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.tsx
@@ -2,51 +2,29 @@
 
 import React from 'react'
 import { SavedSegment } from '../filtering/segments'
-import { PlausibleSite, useSiteContext } from '../site-context'
-import { dateForSite, formatDayShort } from '../util/date'
-
-const getAuthorLabel = (
-  site: Pick<PlausibleSite, 'members'>,
-  owner_id: number
-) => {
-  if (!site.members) {
-    return ''
-  }
-
-  if (!owner_id || !site.members[owner_id]) {
-    return '(Removed User)'
-  }
-
-  // if (owner_id === user.id) {
-  //   return 'You'
-  // }
-
-  return site.members[owner_id]
-}
+import { formatDayShort, parseNaiveDate } from '../util/date'
 
 export const SegmentAuthorship = ({
   className,
-  owner_id,
+  owner_name,
   inserted_at,
   updated_at
-}: Pick<SavedSegment, 'owner_id' | 'inserted_at' | 'updated_at'> & {
+}: Pick<SavedSegment, 'owner_name' | 'inserted_at' | 'updated_at'> & {
   className?: string
 }) => {
-  const site = useSiteContext()
-
-  const authorLabel = getAuthorLabel(site, owner_id)
+  const authorLabel = owner_name
 
   const showUpdatedAt = updated_at !== inserted_at
 
   return (
     <div className={className}>
       <div>
-        {`Created at ${formatDayShort(dateForSite(inserted_at, site))}`}
+        {`Created at ${formatDayShort(parseNaiveDate(inserted_at))}`}
         {!showUpdatedAt && !!authorLabel && ` by ${authorLabel}`}
       </div>
       {showUpdatedAt && (
         <div>
-          {`Last updated at ${formatDayShort(dateForSite(updated_at, site))}`}
+          {`Last updated at ${formatDayShort(parseNaiveDate(updated_at))}`}
           {!!authorLabel && ` by ${authorLabel}`}
         </div>
       )}

--- a/assets/js/dashboard/segments/segment-authorship.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.tsx
@@ -1,19 +1,25 @@
 /** @format */
 
 import React from 'react'
-import { SavedSegment } from '../filtering/segments'
+import { SavedSegmentPublic, SavedSegment } from '../filtering/segments'
 import { formatDayShort, parseNaiveDate } from '../util/date'
 
-export const SegmentAuthorship = ({
-  className,
-  owner_name,
-  inserted_at,
-  updated_at
-}: Pick<SavedSegment, 'owner_name' | 'inserted_at' | 'updated_at'> & {
-  className?: string
-}) => {
-  const authorLabel = owner_name
+type SegmentAuthorshipProps = { className?: string } & (
+  | { showOnlyPublicData: true; segment: SavedSegmentPublic }
+  | { showOnlyPublicData: false; segment: SavedSegment }
+)
 
+export function SegmentAuthorship({
+  className,
+  showOnlyPublicData,
+  segment
+}: SegmentAuthorshipProps) {
+  const authorLabel =
+    showOnlyPublicData === true
+      ? null
+      : (segment.owner_name ?? '(Removed User)')
+
+  const { updated_at, inserted_at } = segment
   const showUpdatedAt = updated_at !== inserted_at
 
   return (

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -466,7 +466,11 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
           <>
             <FiltersInSegment segment_data={data.segment_data} />
 
-            <SegmentAuthorship {...data} className="mt-4 text-sm" />
+            <SegmentAuthorship
+              segment={data}
+              showOnlyPublicData={false}
+              className="mt-4 text-sm"
+            />
             <div className="mt-4">
               <ButtonsRow>
                 <AppNavigationLink

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -5,6 +5,7 @@ import ModalWithRouting from '../stats/modals/modal'
 import {
   isSegmentFilter,
   SavedSegment,
+  SEGMENT_TYPE_LABELS,
   SegmentData,
   SegmentType
 } from '../filtering/segments'
@@ -162,11 +163,7 @@ export const DeleteSegmentModal = ({
   return (
     <SegmentActionModal onClose={onClose}>
       <FormTitle>
-        {
-          { personal: 'Delete personal segment', site: 'Delete site segment' }[
-            segment.type
-          ]
-        }
+        Delete {SEGMENT_TYPE_LABELS[segment.type].toLowerCase()}
         <span className="break-all">{` "${segment.name}"?`}</span>
       </FormTitle>
       {!!segment.segment_data && (
@@ -263,13 +260,13 @@ const SegmentTypeSelector = ({
   const options = [
     {
       type: SegmentType.personal,
-      name: 'Personal segment',
+      name: SEGMENT_TYPE_LABELS[SegmentType.personal],
       description: 'Visible only to you',
       disabled: false
     },
     {
       type: SegmentType.site,
-      name: 'Site segment',
+      name: SEGMENT_TYPE_LABELS[SegmentType.site],
       description: 'Visible to others on the site',
       disabled: !userCanSelectSiteSegment || !siteSegmentsAvailable,
       disabledReason: !userCanSelectSiteSegment ? (
@@ -453,12 +450,7 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
 
         <div className="mt-2 text-sm/5">
           <Placeholder placeholder={'Segment type'}>
-            {data?.segment_data
-              ? {
-                  [SegmentType.personal]: 'Personal segment',
-                  [SegmentType.site]: 'Site segment'
-                }[data.type]
-              : false}
+            {data?.segment_data ? SEGMENT_TYPE_LABELS[data.type] : false}
           </Placeholder>
         </div>
         <div className="my-4 border-b border-gray-300" />

--- a/assets/js/dashboard/site-context.test.tsx
+++ b/assets/js/dashboard/site-context.test.tsx
@@ -29,7 +29,6 @@ describe('parseSiteFromDataset', () => {
       data-is-dbip="false"
       data-current-user-role="owner"
       data-current-user-id="1"
-      data-members='{"1":"Test User"}'
       data-flags="{}"
       data-valid-intervals-by-period='{"12mo":["day","week","month"],"30d":["day","week"],"6mo":["day","week","month"],"7d":["hour","day"],"all":["week","month"],"custom":["day","week","month"],"day":["minute","hour"],"month":["day","week"],"realtime":["minute"],"year":["day","week","month"]}'
       {...attrs}
@@ -67,8 +66,7 @@ describe('parseSiteFromDataset', () => {
       realtime: ['minute'],
       year: ['day', 'week', 'month']
     },
-    shared: false,
-    members: { '1': 'Test User' }
+    shared: false
   }
 
   it('parses from dom string map correctly', () => {

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -23,8 +23,7 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
     isDbip: dataset.isDbip === 'true',
     flags: JSON.parse(dataset.flags!),
     validIntervalsByPeriod: JSON.parse(dataset.validIntervalsByPeriod!),
-    shared: !!dataset.sharedLinkAuth,
-    members: JSON.parse(dataset.members!)
+    shared: !!dataset.sharedLinkAuth
   }
 }
 
@@ -57,8 +56,7 @@ const siteContextDefaultValue = {
   isDbip: false,
   flags: {} as FeatureFlags,
   validIntervalsByPeriod: {} as Record<string, Array<string>>,
-  shared: false,
-  members: null as null | Record<number, string>
+  shared: false
 }
 
 export type PlausibleSite = typeof siteContextDefaultValue

--- a/assets/js/dashboard/util/date.test.ts
+++ b/assets/js/dashboard/util/date.test.ts
@@ -5,6 +5,7 @@ import {
   formatDayShort,
   formatISO,
   nowForSite,
+  parseNaiveDate,
   shiftMonths,
   yesterday
 } from './date'
@@ -117,5 +118,13 @@ describe('formatting UTC dates from database', () => {
         dateForSite('2025-01-01T14:00:00', { offset: 60 * 60 * 11 })
       )
     ).toEqual('2 Jan')
+  })
+})
+
+describe('formatting site-timezoned datetimes from database works flawlessly', () => {
+  it('is able to enrich UTC date string with site timezone, formatting the value correctly', () => {
+    expect(formatDayShort(parseNaiveDate('2025-01-01 14:00:00'))).toEqual(
+      '1 Jan'
+    )
   })
 })

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -43,8 +43,7 @@ export const TestContextProviders = ({
     isDbip: false,
     flags: {},
     validIntervalsByPeriod: {},
-    shared: false,
-    members: { 1: 'Test User' }
+    shared: false
   }
 
   const site = { ...defaultSite, ...siteOptions }

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -10,17 +10,6 @@ defmodule Plausible.Segments.Segment do
 
   @type t() :: %__MODULE__{}
 
-  @derive {Jason.Encoder,
-           only: [
-             :id,
-             :name,
-             :type,
-             :segment_data,
-             :owner_id,
-             :inserted_at,
-             :updated_at
-           ]}
-
   schema "segments" do
     field :name, :string
     field :type, Ecto.Enum, values: @segment_types
@@ -202,5 +191,27 @@ defmodule Plausible.Segments.Segment do
       [:has_not_done, _] -> true
       _ -> false
     end
+  end
+end
+
+defimpl Jason.Encoder, for: Plausible.Segments.Segment do
+  def encode(%Plausible.Segments.Segment{} = segment, opts) do
+    %{
+      id: segment.id,
+      name: segment.name,
+      type: segment.type,
+      segment_data: segment.segment_data,
+      owner_id: segment.owner_id,
+      owner_name: if(is_nil(segment.owner_id), do: "(Removed User)", else: segment.owner.name),
+      inserted_at:
+        segment.inserted_at
+        |> Plausible.Timezones.to_datetime_in_timezone(segment.site.timezone)
+        |> Calendar.strftime("%Y-%m-%d %H:%M:%S"),
+      updated_at:
+        segment.updated_at
+        |> Plausible.Timezones.to_datetime_in_timezone(segment.site.timezone)
+        |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+    }
+    |> Jason.Encode.map(opts)
   end
 end

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -202,7 +202,7 @@ defimpl Jason.Encoder, for: Plausible.Segments.Segment do
       type: segment.type,
       segment_data: segment.segment_data,
       owner_id: segment.owner_id,
-      owner_name: if(is_nil(segment.owner_id), do: "(Removed User)", else: segment.owner.name),
+      owner_name: if(is_nil(segment.owner_id), do: nil, else: segment.owner.name),
       inserted_at:
         segment.inserted_at
         |> Plausible.Timezones.to_datetime_in_timezone(segment.site.timezone)

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -87,7 +87,7 @@ defmodule Plausible.Segments do
            ),
          :ok <-
            Segment.validate_segment_data(site, params["segment_data"], true) do
-      {:ok, Repo.insert!(changeset) |> Repo.preload(:owner)}
+      {:ok, changeset |> Repo.insert!() |> Repo.preload(:owner)}
     else
       %{valid?: false, errors: errors} ->
         {:error, {:invalid_segment, errors}}
@@ -120,12 +120,9 @@ defmodule Plausible.Segments do
              params["segment_data"],
              true
            ) do
-      {:ok,
-       Repo.update!(
-         changeset,
-         preload: :owner,
-         returning: true
-       )}
+      Repo.update!(changeset)
+
+      {:ok, Repo.reload!(segment) |> Repo.preload(:owner)}
     else
       %{valid?: false, errors: errors} ->
         {:error, {:invalid_segment, errors}}

--- a/lib/plausible_web/controllers/api/internal/segments_controller.ex
+++ b/lib/plausible_web/controllers/api/internal/segments_controller.ex
@@ -24,7 +24,10 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         H.not_enough_permissions(conn, "Not enough permissions to get segments")
 
       {:ok, segments} ->
-        json(conn, segments)
+        json(
+          conn,
+          Enum.map(segments, fn segment -> Segments.enrich_with_site(segment, site) end)
+        )
     end
   end
 
@@ -54,7 +57,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         segment_not_found(conn, params["segment_id"])
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.enrich_with_site(segment, site))
     end
   end
 
@@ -80,7 +83,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         })
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.enrich_with_site(segment, site))
     end
   end
 
@@ -114,7 +117,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         })
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.enrich_with_site(segment, site))
     end
   end
 
@@ -141,7 +144,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         segment_not_found(conn, params["segment_id"])
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.enrich_with_site(segment, site))
     end
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -87,11 +87,6 @@ defmodule PlausibleWeb.StatsController do
           title: title(conn, site),
           demo: demo,
           flags: flags,
-          members:
-            if(flags.saved_segments,
-              do: get_members(conn.assigns[:site_role], site),
-              else: nil
-            ),
           is_dbip: is_dbip(),
           dogfood_page_path: dogfood_page_path,
           load_dashboard_js: true
@@ -381,11 +376,6 @@ defmodule PlausibleWeb.StatsController do
           background: conn.params["background"],
           theme: conn.params["theme"],
           flags: flags,
-          members:
-            if(flags.saved_segments,
-              do: get_members(conn.assigns[:site_role], shared_link.site),
-              else: nil
-            ),
           is_dbip: is_dbip(),
           load_dashboard_js: true
         )
@@ -410,30 +400,6 @@ defmodule PlausibleWeb.StatsController do
         {flag, FunWithFlags.enabled?(flag, for: user) || FunWithFlags.enabled?(flag, for: site)}
       end)
       |> Map.new()
-
-  defp get_members(site_role, %Plausible.Site{} = site)
-       when site_role in [:viewer, :editor, :owner, :admin, :super_admin] do
-    site =
-      site
-      |> Plausible.Repo.preload(
-        team: [team_memberships: [:user]],
-        guest_memberships: [team_membership: [:user]]
-      )
-
-    site.guest_memberships
-    |> Enum.map(fn i = %Plausible.Teams.GuestMembership{} ->
-      i.team_membership
-    end)
-    |> Enum.concat(site.team.team_memberships)
-    |> Enum.map(fn i = %Plausible.Teams.Membership{} ->
-      {i.user.id, i.user.name}
-    end)
-    |> Map.new()
-  end
-
-  defp get_members(_site_role, _site) do
-    nil
-  end
 
   defp is_dbip() do
     on_ee do

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -45,7 +45,6 @@
     data-current-user-id={
       if user = @conn.assigns[:current_user], do: user.id, else: Jason.encode!(nil)
     }
-    data-members={Jason.encode!(@members)}
     data-flags={Jason.encode!(@flags)}
     data-valid-intervals-by-period={
       Plausible.Stats.Interval.valid_by_period(site: @site) |> Jason.encode!()

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -41,10 +41,10 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                      "id" => s.id,
                      "name" => s.name,
                      "type" => Atom.to_string(s.type),
-                     "owner_id" => nil,
-                     "owner_name" => nil,
                      "inserted_at" => Calendar.strftime(s.inserted_at, "%Y-%m-%d %H:%M:%S"),
                      "updated_at" => Calendar.strftime(s.updated_at, "%Y-%m-%d %H:%M:%S"),
+                     "owner_id" => nil,
+                     "owner_name" => nil,
                      "segment_data" => nil
                    }
                  end)
@@ -125,7 +125,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
             type: :site,
             name: "Another region"
           )
-          |> Map.put(:owner_name, "(Removed User)")
+          |> Map.put(:owner_name, nil)
 
         conn =
           get(conn, "/api/#{site.domain}/segments")

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -27,7 +27,6 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-has-props") == "false"
       assert text_of_attr(resp, @react_container, "data-logged-in") == "false"
       assert text_of_attr(resp, @react_container, "data-embedded") == ""
-      assert text_of_attr(resp, @react_container, "data-members") == "null"
 
       [{"div", attrs, _}] = find(resp, @react_container)
       assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
@@ -117,14 +116,11 @@ defmodule PlausibleWeb.StatsControllerTest do
   describe "GET /:domain - as a logged in user" do
     setup [:create_user, :log_in, :create_site]
 
-    test "can view stats of a website I've created", %{conn: conn, site: site, user: user} do
+    test "can view stats of a website I've created", %{conn: conn, site: site} do
       populate_stats(site, [build(:pageview)])
       conn = get(conn, "/" <> site.domain)
       resp = html_response(conn, 200)
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
-
-      assert text_of_attr(resp, @react_container, "data-members") ==
-               "{\"#{user.id}\":\"#{user.name}\"}"
     end
 
     test "can view stats of a website I've created, enforcing pageviews check skip", %{


### PR DESCRIPTION
### Changes

* Removes workaround with segment owner names and dates. Keeps the date util just in case.
* Indicates clearly the different segments index payloads (one for public dashboards and one for site members).
* Adds tests about claiming ownership of dangling segment. 
* Centralizes segment type label

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
