### PR TITLE
use 100 sessions partitions

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -977,4 +977,6 @@ unless s3_disabled? do
     imports_bucket: s3_env_value.("S3_IMPORTS_BUCKET")
 end
 
+config :plausible, Plausible.Cache.Adapter, sessions: [partitions: 100]
+
 config :phoenix_storybook, enabled: env !== "prod"


### PR DESCRIPTION
Even with the new queues (https://github.com/plausible/analytics/pull/5113), ConCache _might_ be overloaded by `set_ttl` casts.
Bumping the number of partitions seems to help in that scenario.