### PR TITLE
Change "My Team" to "My Personal Sites" and expose it in sites list

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -145,7 +145,7 @@ defmodule Plausible.Billing do
         # this could result in assigning this new subscription to the newly owned team,
         # effectively "shadowing" any old one.
         #
-        # That's why we are always defaulting to creating a new "My Team" team regardless
+        # That's why we are always defaulting to creating a new "My Personal Sites" team regardless
         # if they were owner of one before or not.
         Auth.User
         |> Repo.get!(user_id)

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == Plausible.Teams.name() do
+          if site.team.name == Plausible.Teams.default_name() do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == "My Team" do
+          if site.team.name == "My Personal Sites" do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == "My Personal Sites" do
+          if site.team.name == Plausible.Teams.name() do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,10 +210,10 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == Plausible.Teams.default_name() do
-            owner.name
-          else
+          if site.team.setup_complete do
             site.team.name
+          else
+            owner.name
           end
 
         [_ | _] ->

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,11 +12,11 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
-  @spec name() :: String.t()
-  def name(), do: name(nil)
+  @spec default_name() :: String.t()
+  def default_name(), do: "My Personal Sites"
 
   @spec name(nil | Teams.Team.t()) :: String.t()
-  def name(nil), do: "My Personal Sites"
+  def name(nil), do: default_name()
   def name(team), do: team.name
 
   def enabled?(team) do
@@ -283,7 +283,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: name()})
+      |> Teams.Team.changeset(%{name: default_name()})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -115,7 +115,7 @@ defmodule Plausible.Teams do
   @doc """
   Get or create user's team.
 
-  If the user has no non-guest membership yet, an implicit "My Team" team is
+  If the user has no non-guest membership yet, an implicit "My Personal Sites" team is
   created with them as an owner.
 
   If the user already has an owner membership in an existing team,
@@ -276,7 +276,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: "My Team"})
+      |> Teams.Team.changeset(%{name: "My Personal Sites"})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,6 +12,13 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
+  @spec name() :: String.t()
+  def name(), do: name(nil)
+
+  @spec name(nil | Teams.Team.t()) :: String.t()
+  def name(nil), do: "My Personal Sites"
+  def name(team), do: team.name
+
   def enabled?(team) do
     not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
   end
@@ -276,7 +283,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: "My Personal Sites"})
+      |> Teams.Team.changeset(%{name: name()})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -20,8 +20,17 @@ defmodule Plausible.Teams do
   def name(%{setup_complete: false}), do: default_name()
   def name(team), do: team.name
 
+  @spec setup?(nil | Teams.Team.t()) :: boolean()
+  def setup?(nil), do: false
+  def setup?(%{setup_complete: setup_complete}), do: setup_complete
+
+  @spec enabled?(nil | Teams.Team.t()) :: boolean()
+  def enabled?(nil) do
+    FunWithFlags.enabled?(:teams)
+  end
+
   def enabled?(team) do
-    not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
+    FunWithFlags.enabled?(:teams, for: team)
   end
 
   @spec get(pos_integer() | binary() | nil) :: Teams.Team.t() | nil

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -17,6 +17,7 @@ defmodule Plausible.Teams do
 
   @spec name(nil | Teams.Team.t()) :: String.t()
   def name(nil), do: default_name()
+  def name(%{setup_complete: false}), do: default_name()
   def name(team), do: team.name
 
   def enabled?(team) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -69,6 +69,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
+    |> validate_exclusion(:name, ["My Personal Sites"])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
-    |> validate_exclusion(:name, ["My Personal Sites"])
+    |> validate_exclusion(:name, [Plausible.Teams.name()])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
-    |> validate_exclusion(:name, [Plausible.Teams.name()])
+    |> validate_exclusion(:name, [Plausible.Teams.default_name()])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -169,10 +169,10 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == Plausible.Teams.default_name() do
-          owner.name
-        else
+        if team.setup_complete do
           team.name
+        else
+          owner.name
         end
 
       [_ | _] ->

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -169,7 +169,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == "My Team" do
+        if team.name == "My Personal Sites" do
           owner.name
         else
           team.name

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -169,7 +169,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == Plausible.Teams.name() do
+        if team.name == Plausible.Teams.default_name() do
           owner.name
         else
           team.name

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -169,7 +169,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == "My Personal Sites" do
+        if team.name == Plausible.Teams.name() do
           owner.name
         else
           team.name

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              ^Plausible.Teams.name(),
+              ^Plausible.Teams.default_name(),
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  ^Plausible.Teams.name(),
+                  ^Plausible.Teams.default_name(),
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -99,14 +99,13 @@ defmodule PlausibleWeb.AdminController do
           select:
             fragment(
               """
-              case when ? = ? then 
+              case when ? = false then 
                 string_agg(concat(?, ' (', ?, ')'), ',') 
               else 
                 concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']') 
               end
               """,
-              t.name,
-              ^Plausible.Teams.default_name(),
+              t.setup_complete,
               o.name,
               o.email,
               t.name,
@@ -156,14 +155,13 @@ defmodule PlausibleWeb.AdminController do
               select: [
                 fragment(
                   """
-                  case when ? = ? then 
+                  case when ? = false then 
                     concat(string_agg(concat(?, ' (', ?, ')'), ','), ' - ', ?)
                   else 
                     concat(concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']'), ' - ', ?)
                   end
                   """,
-                  t.name,
-                  ^Plausible.Teams.default_name(),
+                  t.setup_complete,
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              "My Team",
+              "My Personal Sites",
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  "My Team",
+                  "My Personal Sites",
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              "My Personal Sites",
+              ^Plausible.Teams.name(),
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  "My Personal Sites",
+                  ^Plausible.Teams.name(),
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{current_user: user} ->
           if current_team_id = session["current_team_id"] do
             user.team_memberships
-            |> Enum.find(%{}, &(&1.team_id == current_team_id))
+            |> Enum.find(%{}, &(&1.team.identifier == current_team_id))
             |> Map.get(:team)
           end
       end)

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -58,7 +58,8 @@ defmodule PlausibleWeb.Live.Sites do
 
       <div class="mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-          {Teams.name(@current_team)}
+          <span :if={Teams.enabled?(@current_team)}>{Teams.name(@current_team)}</span>
+          <span :if={not Teams.enabled?(@current_team)}>My Sites</span>
         </h2>
       </div>
 

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -7,6 +7,7 @@ defmodule PlausibleWeb.Live.Sites do
   import PlausibleWeb.Live.Components.Pagination
 
   alias Plausible.Sites
+  alias Plausible.Teams
 
   def mount(params, _session, socket) do
     uri =
@@ -18,7 +19,7 @@ defmodule PlausibleWeb.Live.Sites do
       |> assign(:uri, uri)
       |> assign(
         :team_invitations,
-        Plausible.Teams.Invitations.all(socket.assigns.current_user)
+        Teams.Invitations.all(socket.assigns.current_user)
       )
       |> assign(:filter_text, params["filter_text"] || "")
 
@@ -31,14 +32,14 @@ defmodule PlausibleWeb.Live.Sites do
       |> assign(:params, params)
       |> load_sites()
       |> assign_new(:has_sites?, fn %{current_user: current_user} ->
-        Plausible.Teams.Users.has_sites?(current_user, include_pending?: true)
+        Teams.Users.has_sites?(current_user, include_pending?: true)
       end)
       |> assign_new(:needs_to_upgrade, fn %{
                                             current_user: current_user,
                                             my_team: my_team
                                           } ->
-        Plausible.Teams.Users.owns_sites?(current_user, include_pending?: true) &&
-          Plausible.Teams.Billing.check_needs_to_upgrade(my_team)
+        Teams.Users.owns_sites?(current_user, include_pending?: true) &&
+          Teams.Billing.check_needs_to_upgrade(my_team)
       end)
 
     {:noreply, socket}
@@ -57,7 +58,7 @@ defmodule PlausibleWeb.Live.Sites do
 
       <div class="mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-          My Sites
+          {Teams.name(@current_team)}
         </h2>
       </div>
 
@@ -698,7 +699,7 @@ defmodule PlausibleWeb.Live.Sites do
 
   defp check_limits(invitation, _), do: %{invitation: invitation}
 
-  defdelegate ensure_can_take_ownership(site, team), to: Plausible.Teams.Invitations
+  defdelegate ensure_can_take_ownership(site, team), to: Teams.Invitations
 
   def check_features(%{role: :owner, site: site} = invitation, team) do
     case check_feature_access(site, team) do
@@ -718,7 +719,7 @@ defmodule PlausibleWeb.Live.Sites do
   on_ee do
     defp check_feature_access(site, new_team) do
       missing_features =
-        Plausible.Teams.Billing.features_usage(nil, [site.id])
+        Teams.Billing.features_usage(nil, [site.id])
         |> Enum.filter(&(&1.check_availability(new_team) != :ok))
 
       if missing_features == [] do

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -161,7 +161,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
         phx-click="save-team-layout"
         class="mt-8 w-full"
       >
-        Create Team
+        Setup Team
       </.button>
     </div>
     """

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
 
         {true, %Teams.Team{}, _} ->
           my_team =
-            if Teams.name(my_team) == Teams.name() do
+            if Teams.name(my_team) == Teams.default_name() do
               current_user = socket.assigns.current_user
 
               my_team

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,19 +23,13 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          my_team =
-            if Teams.name(my_team) == Teams.default_name() do
-              current_user = socket.assigns.current_user
-
-              my_team
-              |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
-              |> Repo.update!()
-            else
-              my_team
-            end
+          current_user = socket.assigns.current_user
 
           team_name_form =
-            Teams.Team.name_changeset(my_team, %{})
+            my_team
+            |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
+            |> Repo.update!()
+            |> Teams.Team.name_changeset(%{})
             |> to_form()
 
           layout = Layout.init(my_team)

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
   def render(assigns) do
     ~H"""
     <.focus_box>
-      <:title>Create a new team</:title>
+      <:title>Setup a new team</:title>
       <:subtitle>
         Add members and assign roles to manage different sites access efficiently
       </:subtitle>

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,7 +23,10 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          team_name_form = Teams.Team.name_changeset(my_team, %{name: ""}) |> to_form()
+          user = socket.assigns.current_user
+
+          team_name_form =
+            Teams.Team.name_changeset(my_team, %{name: "#{user.name}'s Team"}) |> to_form()
 
           layout = Layout.init(my_team)
 
@@ -68,6 +71,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
       >
         <.input
           type="text"
+          value={"#{@current_user.name}'s Team"}
           placeholder={"#{@current_user.name}'s Team"}
           autofocus
           field={f[:name]}
@@ -77,18 +81,16 @@ defmodule PlausibleWeb.Live.TeamSetup do
         />
       </.form>
 
-      <div :if={@team_name_form.source.valid?}>
-        <.label class="mb-2">
-          Team Members
-        </.label>
-        {live_render(@socket, PlausibleWeb.Live.TeamManagement,
-          id: "team-management-setup",
-          container: {:div, id: "team-setup"},
-          session: %{
-            "mode" => "team-setup"
-          }
-        )}
-      </div>
+      <.label class="mb-2">
+        Team Members
+      </.label>
+      {live_render(@socket, PlausibleWeb.Live.TeamManagement,
+        id: "team-management-setup",
+        container: {:div, id: "team-setup"},
+        session: %{
+          "mode" => "team-setup"
+        }
+      )}
     </.focus_box>
     """
   end

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -40,6 +40,11 @@ defmodule PlausibleWeb.Live.TeamSetup do
             my_team: my_team
           )
 
+        {true, nil, _} ->
+          socket
+          |> put_flash(:error, "You cannot set up any team just yet")
+          |> redirect(to: Routes.site_path(socket, :index))
+
         {false, _, _} ->
           socket
           |> put_flash(:error, "You cannot set up any team just yet")

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,7 +23,8 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          team_name_changeset = Teams.Team.name_changeset(my_team)
+          user = socket.assigns.current_user
+          team_name_changeset = Teams.Team.name_changeset(my_team, %{name: "#{user.name}'s Team"})
 
           layout = Layout.init(my_team)
 

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.AuthPlug do
         current_team =
           if current_team_id do
             user.team_memberships
-            |> Enum.find(%{}, &(&1.team_id == current_team_id))
+            |> Enum.find(%{}, &(&1.team.identifier == current_team_id))
             |> Map.get(:team)
           end
 

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -84,7 +84,9 @@
                       Account Settings
                     </.dropdown_item>
 
-                    <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
+                    <div :if={
+                      Plausible.Teams.enabled?(@my_team) and not Plausible.Teams.setup?(@my_team)
+                    }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
                           Setup a Team
@@ -96,7 +98,9 @@
                       <.dropdown_divider />
                     </div>
 
-                    <div :if={Plausible.Teams.enabled?(@my_team) and @my_team.setup_complete}>
+                    <div :if={
+                      Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)
+                    }>
                       <.dropdown_item
                         class="flex"
                         href={Routes.settings_path(@conn, :team_general)}

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -87,7 +87,7 @@
                     <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
-                          Create a Team
+                          Setup a Team
                         </span>
                         <span class="ml-1 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
                           NEW

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -36,7 +36,7 @@
           <% end %>
         </div>
 
-        <div :if={Plausible.Teams.enabled?(@my_team) and @my_team.setup_complete}>
+        <div :if={Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)}>
           <div class="mb-4 mt-4 hidden lg:block">
             <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
             <p class="text-xs dark:text-gray-400 truncate">{@my_team.name}</p>

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -12,12 +12,14 @@
       for={@team_name_changeset}
       method="post"
     >
-      <.input_with_clipboard
-        name="team-identifier"
-        id="team-identifier"
-        label="Team Identifier"
-        value={@current_team.identifier}
-      />
+      <div class="w-1/2">
+        <.input_with_clipboard
+          name="team-identifier"
+          id="team-identifier"
+          label="Team Identifier"
+          value={@current_team.identifier}
+        />
+      </div>
       <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
 
       <.button type="submit">

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -1,7 +1,7 @@
 <.settings_tiles>
   <.tile>
     <:title>
-      <a id="update-name">Team Name</a>
+      <a id="update-name">Team Information</a>
     </:title>
     <:subtitle>
       Change the name of your team
@@ -12,6 +12,12 @@
       for={@team_name_changeset}
       method="post"
     >
+      <.input_with_clipboard
+        name="team-identifier"
+        id="team-identifier"
+        label="Team Identifier"
+        value={@current_team.identifier}
+      />
       <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
 
       <.button type="submit">

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -1,6 +1,8 @@
 defmodule PlausibleWeb.LayoutView do
   use PlausibleWeb, :view
   use Plausible
+
+  alias Plausible.Teams
   alias PlausibleWeb.Components.Billing.Notice
 
   def plausible_url do
@@ -105,7 +107,9 @@ defmodule PlausibleWeb.LayoutView do
       ]
     }
 
-    if Plausible.Teams.enabled?(conn.assigns[:my_team]) do
+    my_team = conn.assigns[:my_team]
+
+    if Teams.enabled?(my_team) and Teams.setup?(my_team) do
       Map.put(options, "Team Settings", [
         %{key: "General", value: "team/general", icon: :adjustments_horizontal}
       ])
@@ -115,7 +119,7 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def trial_notification(team) do
-    case Plausible.Teams.trial_days_left(team) do
+    case Teams.trial_days_left(team) do
       days when days > 1 ->
         "#{days} trial days left"
 

--- a/priv/repo/migrations/20250224074807_rename_my_team.exs
+++ b/priv/repo/migrations/20250224074807_rename_my_team.exs
@@ -1,0 +1,15 @@
+defmodule Plausible.Repo.Migrations.RenameMyTeam do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE teams SET name = 'My Personal Sites' WHERE name = 'My Team'
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE teams SET name = 'My Team' WHERE name = 'My Personal Sites'
+    """
+  end
+end

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -7,14 +7,14 @@ defmodule Plausible.TeamsTest do
   alias Plausible.Repo
 
   describe "get_or_create/1" do
-    test "creates 'My Team' if user is a member of none" do
+    test "creates 'My Personal Sites' if user is a member of no teams" do
       today = Date.utc_today()
       user = new_user()
       user_id = user.id
 
       assert {:ok, team} = Teams.get_or_create(user)
 
-      assert team.name == "My Team"
+      assert team.name == "My Personal Sites"
       assert Date.compare(team.trial_expiry_date, today) == :gt
 
       assert [
@@ -22,7 +22,7 @@ defmodule Plausible.TeamsTest do
              ] = Repo.preload(team, :team_memberships).team_memberships
     end
 
-    test "returns existing 'My Team' if user already owns one" do
+    test "returns existing team if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id
       existing_team = team_of(user)
@@ -31,6 +31,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+      assert team.name == "My Personal Sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}
@@ -58,7 +59,7 @@ defmodule Plausible.TeamsTest do
                |> Enum.sort_by(& &1.id)
     end
 
-    test "creates 'My Team' if user is a guest on another team" do
+    test "creates 'My Personal Sites' if user is a guest on another team" do
       user = new_user()
       user_id = user.id
       site = new_site()
@@ -68,6 +69,7 @@ defmodule Plausible.TeamsTest do
       assert {:ok, team} = Teams.get_or_create(user)
 
       assert team.id != existing_team.id
+      assert team.name == "My Personal Sites"
 
       assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
                team
@@ -146,7 +148,7 @@ defmodule Plausible.TeamsTest do
       assert {:error, :no_team} = Teams.get_by_owner(user)
     end
 
-    test "returns existing 'My Team' if user already owns one" do
+    test "returns existing 'My Personal Sites' if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id
       existing_team = team_of(user)
@@ -155,6 +157,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+      assert team.name == "My Personal Sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -77,7 +77,7 @@ defmodule Plausible.TeamsTest do
                |> Map.fetch!(:team_memberships)
     end
 
-    test "creates 'My Team' if user is a non-owner member on existing teams" do
+    test "creates 'My Personal Sites' if user is a non-owner member on existing teams" do
       user = new_user()
       user_id = user.id
       site1 = new_site()

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -6,6 +6,26 @@ defmodule Plausible.TeamsTest do
   alias Plausible.Teams
   alias Plausible.Repo
 
+  describe "name/1" do
+    test "returns default name when there's no team" do
+      assert Teams.name(nil) == "My Personal Sites"
+    end
+
+    test "returns default name when team setup is not completed yet" do
+      user = new_user(team: [setup_complete: false, name: "Foo"])
+      team = team_of(user)
+
+      assert Teams.name(team) == "My Personal Sites"
+    end
+
+    test "returns team name for a setup team" do
+      user = new_user(team: [setup_complete: true, name: "Foo"])
+      team = team_of(user)
+
+      assert Teams.name(team) == "Foo"
+    end
+  end
+
   describe "get_or_create/1" do
     test "creates 'My Personal Sites' if user is a member of no teams" do
       today = Date.utc_today()

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1137,9 +1137,10 @@ defmodule PlausibleWeb.SettingsControllerTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       conn = get(conn, Routes.settings_path(conn, :team_general))
       html = html_response(conn, 200)
-      assert html =~ "Team Name"
+      assert html =~ "Team Information"
       assert html =~ "Change the name of your team"
       assert text_of_attr(html, "input#team_name", "value") == team.name
+      assert text_of_attr(html, "input#team-identifier", "value") == team.identifier
     end
 
     test "POST /settings/team/general/name", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1129,7 +1129,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      assert html =~ "Team Settings"
+      refute html =~ "Team Settings"
       refute html =~ team.name
     end
 

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -13,6 +13,8 @@ defmodule PlausibleWeb.Live.SitesTest do
     test "renders empty sites page", %{conn: conn} do
       {:ok, _lv, html} = live(conn, "/sites")
 
+      assert text(html) =~ "My Personal Sites"
+
       assert text(html) =~ "You don't have any sites yet"
     end
 

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -31,10 +31,10 @@ defmodule PlausibleWeb.Live.SitesTest do
       {:ok, _lv, html} = live(conn, "/sites")
 
       assert text_of_element(html, "#invitation-#{invitation1.invitation_id}") =~
-               "G.I. Joe has invited you to join the \"My Team\" as viewer member."
+               "G.I. Joe has invited you to join the \"My Personal Sites\" as viewer member."
 
       assert text_of_element(html, "#invitation-#{invitation2.invitation_id}") =~
-               "G.I. Jane has invited you to join the \"My Team\" as editor member."
+               "G.I. Jane has invited you to join the \"My Personal Sites\" as editor member."
 
       assert find(
                html,

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -51,6 +51,23 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       _ = render(lv)
     end
+
+    test "setting team name to 'My Personal Sites' is reserved", %{
+      conn: conn,
+      team: team,
+      user: user
+    } do
+      {:ok, lv, html} = live(conn, @url)
+
+      assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
+               "#{user.name}'s Teamk"
+
+      type_into_input(lv, "team[name]", "Team Name 1")
+      _ = render(lv)
+      type_into_input(lv, "team[name]", "My Personal Sites")
+      _ = render(lv)
+      assert Repo.reload!(team).name == "Team Name 1"
+    end
   end
 
   describe "/team/setup - full integration" do

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -60,7 +60,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       {:ok, lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "#{user.name}'s Teamk"
+               "#{user.name}'s Team"
 
       type_into_input(lv, "team[name]", "Team Name 1")
       _ = render(lv)

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -46,15 +46,15 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       assert Repo.reload!(team).name == "Jane Smith's Team"
     end
 
-    test "does not rename the team if different than stock name", %{conn: conn, team: team} do
+    test "renames even if team already has non-default name", %{conn: conn, team: team} do
       assert team.name == "My Personal Sites"
       Repo.update!(Teams.Team.name_changeset(team, %{name: "Foo"}))
       {:ok, _lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "Foo"
+               "Jane Smith's Team"
 
-      assert Repo.reload!(team).name == "Foo"
+      assert Repo.reload!(team).name == "Jane Smith's Team"
     end
 
     test "renders form", %{conn: conn} do

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -36,6 +36,27 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
   describe "/team/setup - main differences from team management" do
     setup [:create_user, :log_in, :create_team]
 
+    test "renames the team on first render", %{conn: conn, team: team} do
+      assert team.name == "My Personal Sites"
+      {:ok, _lv, html} = live(conn, @url)
+
+      assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
+               "Jane Smith's Team"
+
+      assert Repo.reload!(team).name == "Jane Smith's Team"
+    end
+
+    test "does not rename the team if different than stock name", %{conn: conn, team: team} do
+      assert team.name == "My Personal Sites"
+      Repo.update!(Teams.Team.name_changeset(team, %{name: "Foo"}))
+      {:ok, _lv, html} = live(conn, @url)
+
+      assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
+               "Foo"
+
+      assert Repo.reload!(team).name == "Foo"
+    end
+
     test "renders form", %{conn: conn} do
       {:ok, lv, html} = live(conn, @url)
       assert element_exists?(html, ~s|input#update-team-form_name[name="team[name]"]|)
@@ -97,6 +118,8 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       assert_redirect(lv, "/settings/team/general")
 
+      team = Repo.reload!(team)
+
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
         subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
@@ -118,6 +141,8 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       assert text_of_element(html, "#{member_el()}:nth-of-type(1) button") == "Viewer"
 
       save_layout(lv)
+
+      team = Repo.reload!(team)
 
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
@@ -264,6 +289,8 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       refute html =~ "Guest"
 
       save_layout(lv)
+
+      team = Repo.reload!(team)
 
       assert_email_delivered_with(
         to: [nil: guest.email],

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: "My Personal Sites",
+      name: Plausible.Teams.name(),
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: Plausible.Teams.name(),
+      name: Plausible.Teams.default_name(),
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: "My Team",
+      name: "My Personal Sites",
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()


### PR DESCRIPTION
### Changes

This PR renames "My Team" to "My Personal Sites" when team's setup is not complete yet.

It also enforces team name change during setup, treating "My Personal Sites" as reserved name. There's a default generated on the basis of user's name.

The CTA is also rephrased to "Setup Team" instead of "Create Team" to express the intent better.

The team name is now used in place of "My Sites" heading in sites list view to clearly identify which team the user is switched to. The "My Personal Sites" heading is also the default for a case where user is not a member of any team yet.

The heading change is hidden behind a flag for now.

The migration renaming the teams will be extracted and deployed independently after the PR is approved.

### Tests
- [x] Automated tests have been added

