### PR TITLE
Limit to 500 segments per site

### DIFF
--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -11,6 +11,11 @@ defmodule Plausible.Segments do
 
   @type error_not_enough_permissions() :: {:error, :not_enough_permissions}
   @type error_segment_not_found() :: {:error, :segment_not_found}
+  @type error_segment_limit_reached() :: {:error, :segment_limit_reached}
+  @type error_invalid_segment() :: {:error, {:invalid_segment, Keyword.t()}}
+  @type unknown_error() :: {:error, any()}
+
+  @max_segments 500
 
   @spec index(pos_integer() | nil, Plausible.Site.t(), atom()) ::
           {:ok, [Segment.t()]} | error_not_enough_permissions()
@@ -73,6 +78,13 @@ defmodule Plausible.Segments do
     end
   end
 
+  @spec insert_one(pos_integer(), Plausible.Site.t(), atom(), map()) ::
+          {:ok, Segment.t()}
+          | error_not_enough_permissions()
+          | error_invalid_segment()
+          | error_segment_limit_reached()
+          | unknown_error()
+
   def insert_one(
         user_id,
         %Plausible.Site{} = site,
@@ -99,6 +111,12 @@ defmodule Plausible.Segments do
         error
     end
   end
+
+  @spec update_one(pos_integer(), Plausible.Site.t(), atom(), pos_integer(), map()) ::
+          {:ok, Segment.t()}
+          | error_not_enough_permissions()
+          | error_invalid_segment()
+          | unknown_error()
 
   def update_one(
         user_id,
@@ -301,6 +319,9 @@ defmodule Plausible.Segments do
 
   defp can_insert_one?(%Plausible.Site{} = site, site_role, params) do
     cond do
+      count_segments(site.id) >= @max_segments ->
+        {:error, :segment_limit_reached}
+
       params["type"] == "site" and site_role in roles_with_maybe_site_segments() and
           site_segments_available?(site) ->
         :ok
@@ -312,6 +333,13 @@ defmodule Plausible.Segments do
       true ->
         {:error, :not_enough_permissions}
     end
+  end
+
+  defp count_segments(site_id) do
+    from(segment in Segment,
+      where: segment.site_id == ^site_id
+    )
+    |> Repo.aggregate(:count, :id)
   end
 
   def roles_with_personal_segments(), do: [:viewer, :editor, :admin, :owner, :super_admin]
@@ -375,13 +403,14 @@ defmodule Plausible.Segments do
   This function enriches the segment with site, without actually querying the database for the site again.
   Needed for Plausible.Segments.Segment custom JSON serialization.
   """
+  @spec enrich_with_site(Segment.t(), Plausible.Site.t()) :: Segment.t()
   def enrich_with_site(%Segment{} = segment, %Plausible.Site{} = site) do
     Map.put(segment, :site, site)
   end
 
   @spec get_site_segments_usage_query(list(pos_integer())) :: Ecto.Query.t()
   def get_site_segments_usage_query(site_ids) do
-    from(segment in Plausible.Segments.Segment,
+    from(segment in Segment,
       as: :segment,
       where: segment.type == :site,
       where: segment.site_id in ^site_ids

--- a/lib/plausible_web/controllers/api/internal/segments_controller.ex
+++ b/lib/plausible_web/controllers/api/internal/segments_controller.ex
@@ -75,6 +75,9 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
       {:error, :not_enough_permissions} ->
         H.not_enough_permissions(conn, "Not enough permissions to create segment")
 
+      {:error, :segment_limit_reached} ->
+        H.not_enough_permissions(conn, "Segment limit reached")
+
       {:error, {:invalid_segment, errors}} when is_list(errors) ->
         conn
         |> put_status(400)


### PR DESCRIPTION
### Changes

Limits the possible count of segments to 500 per site to prevent system abuse.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
