### PR TITLE
Bump elixir.yml cache version to fix a test

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_VERSION: v10
+  CACHE_VERSION: v11
   PERSISTENT_CACHE_DIR: cached
 
 jobs:

--- a/test/plausible_web/plugs/tracker_test.exs
+++ b/test/plausible_web/plugs/tracker_test.exs
@@ -42,7 +42,6 @@ defmodule PlausibleWeb.TrackerTest do
     assert response == get_script("plausible.outbound-links.file-downloads.compat.hash.js")
   end
 
-  @tag :skip
   test "pageleave extension" do
     # Some customers who have participated in the private preview of the
     # scroll depth feature, have updated their tracking scripts to


### PR DESCRIPTION
A test in test/plausible_web/plugs/tracker_test.exs was failing due to cached version of tracker script being used in other PRs.

The reason it didn't fail in the original PR adding the test was that changes in tracker script bypassed the cache **for that pr**. The old cached data was still used for other PRs, causing them to fail.