### PR TITLE
Refine team switching and switch from `my_team` to `current_team` 

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -145,7 +145,7 @@ defmodule Plausible.Billing do
         # this could result in assigning this new subscription to the newly owned team,
         # effectively "shadowing" any old one.
         #
-        # That's why we are always defaulting to creating a new "My Team" team regardless
+        # That's why we are always defaulting to creating a new "My Personal Sites" team regardless
         # if they were owner of one before or not.
         Auth.User
         |> Repo.get!(user_id)

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == Plausible.Teams.name() do
+          if site.team.name == Plausible.Teams.default_name() do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == "My Team" do
+          if site.team.name == "My Personal Sites" do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,7 +210,7 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == "My Personal Sites" do
+          if site.team.name == Plausible.Teams.name() do
             owner.name
           else
             site.team.name

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -210,10 +210,10 @@ defmodule Plausible.SiteAdmin do
     team_name =
       case site.owners do
         [owner] ->
-          if site.team.name == Plausible.Teams.default_name() do
-            owner.name
-          else
+          if site.team.setup_complete do
             site.team.name
+          else
+            owner.name
           end
 
         [_ | _] ->

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -190,8 +190,9 @@ defmodule Plausible.Sites do
           {:ok, Teams.with_subscription(team)}
 
         is_nil(team) ->
-          team = Teams.force_create_my_team(user)
-          {:ok, Teams.with_subscription(team)}
+          with {:ok, team} <- Teams.get_or_create(user) do
+            {:ok, Teams.with_subscription(team)}
+          end
 
         true ->
           {:error, :permission_denied}

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -190,9 +190,8 @@ defmodule Plausible.Sites do
           {:ok, Teams.with_subscription(team)}
 
         is_nil(team) ->
-          with {:ok, team} <- Teams.get_or_create(user) do
-            {:ok, Teams.with_subscription(team)}
-          end
+          team = Teams.force_create_my_team(user)
+          {:ok, Teams.with_subscription(team)}
 
         true ->
           {:error, :permission_denied}

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,11 +12,11 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
-  @spec name() :: String.t()
-  def name(), do: name(nil)
+  @spec default_name() :: String.t()
+  def default_name(), do: "My Personal Sites"
 
   @spec name(nil | Teams.Team.t()) :: String.t()
-  def name(nil), do: "My Personal Sites"
+  def name(nil), do: default_name()
   def name(team), do: team.name
 
   def enabled?(team) do
@@ -283,7 +283,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: name()})
+      |> Teams.Team.changeset(%{name: default_name()})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -180,6 +180,7 @@ defmodule Plausible.Teams do
       from(tm in Teams.Membership,
         inner_join: t in assoc(tm, :team),
         where: tm.user_id == ^user_id and tm.role == :owner,
+        where: t.setup_complete == false,
         select: t,
         order_by: t.id
       )

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -115,7 +115,7 @@ defmodule Plausible.Teams do
   @doc """
   Get or create user's team.
 
-  If the user has no non-guest membership yet, an implicit "My Team" team is
+  If the user has no non-guest membership yet, an implicit "My Personal Sites" team is
   created with them as an owner.
 
   If the user already has an owner membership in an existing team,
@@ -276,7 +276,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: "My Team"})
+      |> Teams.Team.changeset(%{name: "My Personal Sites"})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -12,6 +12,13 @@ defmodule Plausible.Teams do
 
   @accept_traffic_until_free ~D[2135-01-01]
 
+  @spec name() :: String.t()
+  def name(), do: name(nil)
+
+  @spec name(nil | Teams.Team.t()) :: String.t()
+  def name(nil), do: "My Personal Sites"
+  def name(team), do: team.name
+
   def enabled?(team) do
     not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
   end
@@ -276,7 +283,7 @@ defmodule Plausible.Teams do
   defp create_my_team(user) do
     team =
       %Teams.Team{}
-      |> Teams.Team.changeset(%{name: "My Personal Sites"})
+      |> Teams.Team.changeset(%{name: name()})
       |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
       |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -20,8 +20,17 @@ defmodule Plausible.Teams do
   def name(%{setup_complete: false}), do: default_name()
   def name(team), do: team.name
 
+  @spec setup?(nil | Teams.Team.t()) :: boolean()
+  def setup?(nil), do: false
+  def setup?(%{setup_complete: setup_complete}), do: setup_complete
+
+  @spec enabled?(nil | Teams.Team.t()) :: boolean()
+  def enabled?(nil) do
+    FunWithFlags.enabled?(:teams)
+  end
+
   def enabled?(team) do
-    not is_nil(team) and FunWithFlags.enabled?(:teams, for: team)
+    FunWithFlags.enabled?(:teams, for: team)
   end
 
   @spec get(pos_integer() | binary() | nil) :: Teams.Team.t() | nil

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -17,6 +17,7 @@ defmodule Plausible.Teams do
 
   @spec name(nil | Teams.Team.t()) :: String.t()
   def name(nil), do: default_name()
+  def name(%{setup_complete: false}), do: default_name()
   def name(team), do: team.name
 
   def enabled?(team) do

--- a/lib/plausible/teams/management/layout.ex
+++ b/lib/plausible/teams/management/layout.ex
@@ -107,16 +107,12 @@ defmodule Plausible.Teams.Management.Layout do
     end)
   end
 
-  @spec persist(t(), %{current_user: User.t(), my_team: Teams.Team.t()}) ::
+  @spec persist(t(), %{current_user: User.t(), current_team: Teams.Team.t()}) ::
           {:ok, integer()} | {:error, any()}
   def persist(layout, context) do
     result =
       Repo.transaction(fn ->
-        if not context.my_team.setup_complete do
-          context.my_team
-          |> Teams.Team.setup_changeset()
-          |> Repo.update!()
-        end
+        Teams.complete_setup(context.current_team)
 
         layout
         |> sorted_for_persistence()

--- a/lib/plausible/teams/management/layout/entry.ex
+++ b/lib/plausible/teams/management/layout/entry.ex
@@ -69,7 +69,7 @@ defmodule Plausible.Teams.Management.Layout.Entry do
         context
       )
       when op in [:update, :send] do
-    Teams.Invitations.InviteToTeam.invite(context.my_team, context.current_user, email, role,
+    Teams.Invitations.InviteToTeam.invite(context.current_team, context.current_user, email, role,
       send_email?: false
     )
   end
@@ -78,7 +78,7 @@ defmodule Plausible.Teams.Management.Layout.Entry do
         %__MODULE__{type: :invitation_sent, email: email, role: role, queued_op: :update},
         context
       ) do
-    Teams.Invitations.InviteToTeam.invite(context.my_team, context.current_user, email, role,
+    Teams.Invitations.InviteToTeam.invite(context.current_team, context.current_user, email, role,
       send_email?: false
     )
   end
@@ -88,7 +88,7 @@ defmodule Plausible.Teams.Management.Layout.Entry do
         context
       ) do
     Plausible.Teams.Invitations.Remove.remove(
-      context.my_team,
+      context.current_team,
       meta.invitation_id,
       context.current_user
     )
@@ -99,7 +99,7 @@ defmodule Plausible.Teams.Management.Layout.Entry do
         context
       ) do
     Plausible.Teams.Memberships.Remove.remove(
-      context.my_team,
+      context.current_team,
       meta.user.id,
       context.current_user,
       send_email?: false
@@ -111,7 +111,7 @@ defmodule Plausible.Teams.Management.Layout.Entry do
         context
       ) do
     Plausible.Teams.Memberships.UpdateRole.update(
-      context.my_team,
+      context.current_team,
       meta.user.id,
       "#{role}",
       context.current_user

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -73,6 +73,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
+    |> validate_exclusion(:name, ["My Personal Sites"])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -73,7 +73,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
-    |> validate_exclusion(:name, ["My Personal Sites"])
+    |> validate_exclusion(:name, [Plausible.Teams.name()])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -73,7 +73,7 @@ defmodule Plausible.Teams.Team do
     team
     |> cast(attrs, [:name])
     |> validate_required(:name)
-    |> validate_exclusion(:name, [Plausible.Teams.name()])
+    |> validate_exclusion(:name, [Plausible.Teams.default_name()])
   end
 
   def setup_changeset(team, now \\ NaiveDateTime.utc_now(:second)) do

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -170,7 +170,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == "My Personal Sites" do
+        if team.name == Plausible.Teams.name() do
           owner.name
         else
           team.name

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -170,7 +170,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == "My Team" do
+        if team.name == "My Personal Sites" do
           owner.name
         else
           team.name

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -170,10 +170,10 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == Plausible.Teams.default_name() do
-          owner.name
-        else
+        if team.setup_complete do
           team.name
+        else
+          owner.name
         end
 
       [_ | _] ->

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -170,7 +170,7 @@ defmodule Plausible.Teams.TeamAdmin do
   defp team_name(team) do
     case team.owners do
       [owner] ->
-        if team.name == Plausible.Teams.name() do
+        if team.name == Plausible.Teams.default_name() do
           owner.name
         else
           team.name

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -175,7 +175,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     change_plan_link_text = change_plan_link_text(assigns)
 
     subscription =
-      Plausible.Teams.Billing.get_subscription(assigns.my_team)
+      Plausible.Teams.Billing.get_subscription(assigns.current_team)
 
     billing_details_expired =
       Subscription.Status.in?(subscription, [
@@ -225,10 +225,14 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       |> assign(:confirm_message, losing_features_message(feature_usage_check))
 
     ~H"""
-    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@my_team.subscription) do %>
+    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_team.subscription) do %>
       <.change_plan_link {assigns} />
     <% else %>
-      <PlausibleWeb.Components.Billing.paddle_button user={@current_user} team={@my_team} {assigns}>
+      <PlausibleWeb.Components.Billing.paddle_button
+        user={@current_user}
+        team={@current_team}
+        {assigns}
+      >
         Upgrade
       </PlausibleWeb.Components.Billing.paddle_button>
     <% end %>
@@ -260,18 +264,18 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
   defp check_usage_within_plan_limits(%{
          available: true,
          usage: usage,
-         my_team: my_team,
+         current_team: current_team,
          plan_to_render: plan
        }) do
     # At this point, the user is *not guaranteed* to have a team,
     # with ongoing trial.
     trial_active_or_ended_recently? =
-      not is_nil(my_team) and not is_nil(my_team.trial_expiry_date) and
-        Plausible.Teams.trial_days_left(my_team) >= -10
+      not is_nil(current_team) and not is_nil(current_team.trial_expiry_date) and
+        Plausible.Teams.trial_days_left(current_team) >= -10
 
     limit_checking_opts =
       cond do
-        my_team && my_team.allow_next_upgrade_override ->
+        current_team && current_team.allow_next_upgrade_override ->
           [ignore_pageview_limit: true]
 
         trial_active_or_ended_recently? && plan.volume == "10k" ->

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -273,6 +273,7 @@ defmodule PlausibleWeb.Components.Generic do
   end
 
   attr(:href, :string)
+  attr(:method, :string, default: "get")
   attr(:class, :string, default: "")
   attr(:id, :string, default: nil)
   attr(:new_tab, :boolean, default: false)
@@ -299,6 +300,7 @@ defmodule PlausibleWeb.Components.Generic do
         class={@class}
         new_tab={@new_tab}
         href={@href}
+        method={@method}
         x-on:click="close()"
         data-ui-state={@state}
         {@rest}

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -273,7 +273,6 @@ defmodule PlausibleWeb.Components.Generic do
   end
 
   attr(:href, :string)
-  attr(:method, :string, default: "get")
   attr(:class, :string, default: "")
   attr(:id, :string, default: nil)
   attr(:new_tab, :boolean, default: false)
@@ -300,7 +299,6 @@ defmodule PlausibleWeb.Components.Generic do
         class={@class}
         new_tab={@new_tab}
         href={@href}
-        method={@method}
         x-on:click="close()"
         data-ui-state={@state}
         {@rest}

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              ^Plausible.Teams.name(),
+              ^Plausible.Teams.default_name(),
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  ^Plausible.Teams.name(),
+                  ^Plausible.Teams.default_name(),
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -99,14 +99,13 @@ defmodule PlausibleWeb.AdminController do
           select:
             fragment(
               """
-              case when ? = ? then 
+              case when ? = false then 
                 string_agg(concat(?, ' (', ?, ')'), ',') 
               else 
                 concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']') 
               end
               """,
-              t.name,
-              ^Plausible.Teams.default_name(),
+              t.setup_complete,
               o.name,
               o.email,
               t.name,
@@ -156,14 +155,13 @@ defmodule PlausibleWeb.AdminController do
               select: [
                 fragment(
                   """
-                  case when ? = ? then 
+                  case when ? = false then 
                     concat(string_agg(concat(?, ' (', ?, ')'), ','), ' - ', ?)
                   else 
                     concat(concat(?, ' [', string_agg(concat(?, ' (', ?, ')'), ','), ']'), ' - ', ?)
                   end
                   """,
-                  t.name,
-                  ^Plausible.Teams.default_name(),
+                  t.setup_complete,
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              "My Team",
+              "My Personal Sites",
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  "My Team",
+                  "My Personal Sites",
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -106,7 +106,7 @@ defmodule PlausibleWeb.AdminController do
               end
               """,
               t.name,
-              "My Personal Sites",
+              ^Plausible.Teams.name(),
               o.name,
               o.email,
               t.name,
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.AdminController do
                   end
                   """,
                   t.name,
-                  "My Personal Sites",
+                  ^Plausible.Teams.name(),
                   o.name,
                   o.email,
                   t.identifier,

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -57,6 +57,7 @@ defmodule PlausibleWeb.AuthController do
 
   def select_team(conn, _params) do
     current_user = conn.assigns.current_user
+    current_team = conn.assigns[:current_team]
 
     owner_name_fn = fn owner ->
       if owner.id == current_user.id do
@@ -71,7 +72,7 @@ defmodule PlausibleWeb.AuthController do
       |> Teams.Users.teams()
       |> Enum.filter(& &1.setup_complete)
       |> Enum.map(fn team ->
-        current_team? = team.id == conn.assigns.current_team.id
+        current_team? = current_team && team.id == current_team.id
 
         owners =
           Enum.map_join(team.owners, ", ", &owner_name_fn.(&1))

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -91,24 +91,32 @@ defmodule PlausibleWeb.AuthController do
 
   def switch_team(conn, params) do
     current_user = conn.assigns.current_user
-    team = Teams.get(params["team_id"])
+    team_id = params["team_id"]
+    team = if team_id != "none", do: Teams.get(params["team_id"])
 
-    if team do
-      case Teams.Memberships.team_role(team, current_user) do
-        {:ok, role} when role != :guest ->
-          conn
-          |> put_session("current_team_id", team.identifier)
-          |> redirect(to: Routes.site_path(conn, :index))
+    cond do
+      team ->
+        case Teams.Memberships.team_role(team, current_user) do
+          {:ok, role} when role != :guest ->
+            conn
+            |> put_session("current_team_id", team.identifier)
+            |> redirect(to: Routes.site_path(conn, :index))
 
-        _ ->
-          conn
-          |> put_flash(:error, "You have select an invalid team")
-          |> redirect(to: Routes.site_path(conn, :index))
-      end
-    else
-      conn
-      |> put_flash(:error, "You have select an invalid team")
-      |> redirect(to: Routes.site_path(conn, :index))
+          _ ->
+            conn
+            |> put_flash(:error, "You have select an invalid team")
+            |> redirect(to: Routes.site_path(conn, :index))
+        end
+
+      team_id == "none" ->
+        conn
+        |> delete_session("current_team_id")
+        |> redirect(to: Routes.site_path(conn, :index))
+
+      true ->
+        conn
+        |> put_flash(:error, "You have select an invalid team")
+        |> redirect(to: Routes.site_path(conn, :index))
     end
   end
 

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -86,7 +86,7 @@ defmodule PlausibleWeb.AuthController do
         }
       end)
 
-    render(conn, "select_team.html", teams: teams)
+    render(conn, "select_team.html", teams_selection: teams)
   end
 
   def switch_team(conn, params) do

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -9,15 +9,15 @@ defmodule PlausibleWeb.BillingController do
   plug PlausibleWeb.RequireAccountPlug
 
   def ping_subscription(%Plug.Conn{} = conn, _params) do
-    subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.my_team)
+    subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.current_team)
 
     json(conn, %{is_subscribed: subscribed?})
   end
 
   def choose_plan(conn, _params) do
-    my_team = conn.assigns.my_team
+    team = conn.assigns.current_team
 
-    if Plausible.Teams.Billing.enterprise_configured?(my_team) do
+    if Plausible.Teams.Billing.enterprise_configured?(team) do
       redirect(conn, to: Routes.billing_path(conn, :upgrade_to_enterprise_plan))
     else
       render(conn, "choose_plan.html",
@@ -28,12 +28,12 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def upgrade_to_enterprise_plan(conn, _params) do
-    my_team = conn.assigns.my_team
-    subscription = Plausible.Teams.Billing.get_subscription(my_team)
+    team = conn.assigns.current_team
+    subscription = Plausible.Teams.Billing.get_subscription(team)
 
     {latest_enterprise_plan, price} =
       Plausible.Teams.Billing.latest_enterprise_plan_with_price(
-        my_team,
+        team,
         PlausibleWeb.RemoteIP.get(conn)
       )
 
@@ -70,9 +70,9 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def change_plan_preview(conn, %{"plan_id" => new_plan_id}) do
-    my_team = conn.assigns.my_team
+    team = conn.assigns.current_team
     current_user = conn.assigns.current_user
-    subscription = Plausible.Teams.Billing.active_subscription_for(my_team)
+    subscription = Plausible.Teams.Billing.active_subscription_for(team)
 
     case preview_subscription(subscription, new_plan_id) do
       {:ok, {subscription, preview_info}} ->
@@ -91,7 +91,7 @@ defmodule PlausibleWeb.BillingController do
           extra: %{
             message: msg,
             new_plan_id: new_plan_id,
-            team_id: my_team.id,
+            team_id: team.id,
             user_id: current_user.id
           }
         )
@@ -103,9 +103,9 @@ defmodule PlausibleWeb.BillingController do
   end
 
   def change_plan(conn, %{"new_plan_id" => new_plan_id}) do
-    my_team = conn.assigns.my_team
+    team = conn.assigns.current_team
 
-    case Plausible.Teams.Billing.change_plan(my_team, new_plan_id) do
+    case Plausible.Teams.Billing.change_plan(team, new_plan_id) do
       {:ok, _subscription} ->
         conn
         |> put_flash(:success, "Plan changed successfully")
@@ -133,7 +133,7 @@ defmodule PlausibleWeb.BillingController do
             errors: inspect(e),
             message: msg,
             new_plan_id: new_plan_id,
-            team_id: my_team.id,
+            team_id: team.id,
             user_id: conn.assigns.current_user.id
           }
         )

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -104,7 +104,7 @@ defmodule PlausibleWeb.InvitationController do
   end
 
   def remove_team_invitation(conn, %{"invitation_id" => invitation_id}) do
-    %{my_team: team, current_user: current_user} = conn.assigns
+    %{current_team: team, current_user: current_user} = conn.assigns
 
     case Plausible.Teams.Invitations.Remove.remove(team, invitation_id, current_user) do
       {:ok, invitation} ->

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -31,18 +31,23 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   defp render_team_general(conn, opts \\ []) do
-    name_changeset =
-      Keyword.get(
-        opts,
-        :team_name_changeset,
-        Plausible.Teams.Team.name_changeset(conn.assigns.current_team)
-      )
+    if Plausible.Teams.setup?(conn.assigns.current_team) do
+      name_changeset =
+        Keyword.get(
+          opts,
+          :team_name_changeset,
+          Plausible.Teams.Team.name_changeset(conn.assigns.current_team)
+        )
 
-    render(conn, :team_general,
-      team_name_changeset: name_changeset,
-      layout: {PlausibleWeb.LayoutView, :settings},
-      connect_live_socket: true
-    )
+      render(conn, :team_general,
+        team_name_changeset: name_changeset,
+        layout: {PlausibleWeb.LayoutView, :settings},
+        connect_live_socket: true
+      )
+    else
+      conn
+      |> redirect(to: Routes.site_path(conn, :index))
+    end
   end
 
   def preferences(conn, _params) do

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   def update_team_name(conn, %{"team" => params}) do
-    changeset = Plausible.Teams.Team.name_changeset(conn.assigns.my_team, params)
+    changeset = Plausible.Teams.Team.name_changeset(conn.assigns.current_team, params)
 
     case Repo.update(changeset) do
       {:ok, _user} ->
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.SettingsController do
       Keyword.get(
         opts,
         :team_name_changeset,
-        Plausible.Teams.Team.name_changeset(conn.assigns.my_team)
+        Plausible.Teams.Team.name_changeset(conn.assigns.current_team)
       )
 
     render(conn, :team_general,
@@ -54,23 +54,23 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   def subscription(conn, _params) do
-    my_team = conn.assigns.my_team
-    subscription = Teams.Billing.get_subscription(my_team)
+    team = conn.assigns.current_team
+    subscription = Teams.Billing.get_subscription(team)
 
     render(conn, :subscription,
       layout: {PlausibleWeb.LayoutView, :settings},
       subscription: subscription,
       pageview_limit: Teams.Billing.monthly_pageview_limit(subscription),
-      pageview_usage: Teams.Billing.monthly_pageview_usage(my_team),
-      site_usage: Teams.Billing.site_usage(my_team),
-      site_limit: Teams.Billing.site_limit(my_team),
-      team_member_limit: Teams.Billing.team_member_limit(my_team),
-      team_member_usage: Teams.Billing.team_member_usage(my_team)
+      pageview_usage: Teams.Billing.monthly_pageview_usage(team),
+      site_usage: Teams.Billing.site_usage(team),
+      site_limit: Teams.Billing.site_limit(team),
+      team_member_limit: Teams.Billing.team_member_limit(team),
+      team_member_usage: Teams.Billing.team_member_usage(team)
     )
   end
 
   def invoices(conn, _params) do
-    subscription = Teams.Billing.get_subscription(conn.assigns.my_team)
+    subscription = Teams.Billing.get_subscription(conn.assigns.current_team)
 
     invoices = Plausible.Billing.paddle_api().get_invoices(subscription)
     render(conn, :invoices, layout: {PlausibleWeb.LayoutView, :settings}, invoices: invoices)

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -14,12 +14,12 @@ defmodule PlausibleWeb.SiteController do
 
   def new(conn, params) do
     flow = params["flow"] || PlausibleWeb.Flows.register()
-    my_team = conn.assigns.my_team
+    team = conn.assigns.current_team
 
     render(conn, "new.html",
       changeset: Plausible.Site.changeset(%Plausible.Site{}),
-      site_limit: Plausible.Teams.Billing.site_limit(my_team),
-      site_limit_exceeded?: Plausible.Teams.Billing.ensure_can_add_new_site(my_team) != :ok,
+      site_limit: Plausible.Teams.Billing.site_limit(team),
+      site_limit_exceeded?: Plausible.Teams.Billing.ensure_can_add_new_site(team) != :ok,
       form_submit_url: "/sites?flow=#{flow}",
       flow: flow
     )

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -26,8 +26,7 @@ defmodule PlausibleWeb.SiteController do
   end
 
   def create_site(conn, %{"site" => site_params}) do
-    current_team = conn.assigns.current_team
-    team = Plausible.Teams.get(site_params["team_id"]) || current_team
+    team = conn.assigns.current_team
     user = conn.assigns.current_user
     first_site? = Plausible.Teams.Billing.site_usage(team) == 0
     flow = conn.params["flow"]

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{current_user: user} ->
           if current_team_id = session["current_team_id"] do
             user.team_memberships
-            |> Enum.find(%{}, &(&1.team_id == current_team_id))
+            |> Enum.find(%{}, &(&1.team.identifier == current_team_id))
             |> Map.get(:team)
           end
       end)

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -68,6 +68,16 @@ defmodule PlausibleWeb.Live.AuthContext do
       |> assign_new(:current_team, fn context ->
         context.team_from_session || context.my_team
       end)
+      |> assign_new(:teams, fn
+        %{current_user: nil} ->
+          []
+
+        %{current_user: user} ->
+          user.team_memberships
+          |> Enum.sort_by(fn tm -> [tm.role != :owner, tm.team_id] end)
+          |> Enum.map(&Map.fetch!(&1, :team))
+          |> Enum.take(3)
+      end)
       |> assign_new(:teams_count, fn
         %{current_user: nil} -> 0
         %{current_user: user} -> length(user.team_memberships)

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -61,13 +61,8 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{my_team: %{} = my_team} ->
           my_team
 
-        %{current_user: user} ->
-          if not Plausible.Teams.enabled?(nil) do
-            user.team_memberships
-            |> Enum.sort_by(& &1.team_id)
-            |> List.first(%{})
-            |> Map.get(:team)
-          end
+        _ ->
+          nil
       end)
       |> assign_new(:teams, fn
         %{current_user: nil} ->

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -58,11 +58,16 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{team_from_session: %{} = team_from_session} ->
           team_from_session
 
+        %{my_team: %{} = my_team} ->
+          my_team
+
         %{current_user: user} ->
-          user.team_memberships
-          |> Enum.sort_by(& &1.team_id)
-          |> List.first(%{})
-          |> Map.get(:team)
+          if not Plausible.Teams.enabled?(nil) do
+            user.team_memberships
+            |> Enum.sort_by(& &1.team_id)
+            |> List.first(%{})
+            |> Map.get(:team)
+          end
       end)
       |> assign_new(:teams, fn
         %{current_user: nil} ->

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -82,8 +82,8 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{current_user: nil} -> 0
         %{current_user: user} -> length(user.team_memberships)
       end)
-      |> assign_new(:multiple_teams?, fn context ->
-        context.teams_count > 1
+      |> assign_new(:more_teams?, fn context ->
+        context.teams_count > 3
       end)
 
     {:cont, socket}

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -47,23 +47,9 @@ defmodule PlausibleWeb.Live.AuthContext do
           nil
 
         %{current_user: user} = context ->
-          current_team = context.team_from_session
-
-          current_team_owner? =
-            (current_team || %{})
-            |> Map.get(:owners, [])
-            |> Enum.any?(&(&1.id == user.id))
-
-          if current_team_owner? do
-            current_team
-          else
-            user.team_memberships
-            # NOTE: my_team should eventually only hold user's personal team. This requires
-            # additional adjustments, which will be done in follow-up work.
-            # |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
-            |> List.first(%{})
-            |> Map.get(:team)
-          end
+          user.team_memberships
+          |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
+          |> Map.get(:team)
       end)
       |> assign_new(:current_team, fn context ->
         context.team_from_session || context.my_team

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -46,13 +46,23 @@ defmodule PlausibleWeb.Live.AuthContext do
         %{current_user: nil} ->
           nil
 
-        %{current_user: user} = context ->
+        %{current_user: user} ->
           user.team_memberships
           |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
           |> Map.get(:team)
       end)
-      |> assign_new(:current_team, fn context ->
-        context.team_from_session || context.my_team
+      |> assign_new(:current_team, fn
+        %{current_user: nil} ->
+          nil
+
+        %{team_from_session: %{} = team_from_session} ->
+          team_from_session
+
+        %{current_user: user} ->
+          user.team_memberships
+          |> Enum.sort_by(& &1.team_id)
+          |> List.first(%{})
+          |> Map.get(:team)
       end)
       |> assign_new(:teams, fn
         %{current_user: nil} ->

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -19,16 +19,16 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         Plausible.Teams.Memberships.all_pending_site_transfers(current_user.email)
       end)
       |> assign_new(:usage, fn %{
-                                 my_team: my_team,
+                                 current_team: current_team,
                                  pending_ownership_site_ids: pending_ownership_site_ids
                                } ->
-        Plausible.Teams.Billing.quota_usage(my_team,
+        Plausible.Teams.Billing.quota_usage(current_team,
           with_features: true,
           pending_ownership_site_ids: pending_ownership_site_ids
         )
       end)
-      |> assign_new(:subscription, fn %{my_team: my_team} ->
-        Plausible.Teams.Billing.get_subscription(my_team)
+      |> assign_new(:subscription, fn %{current_team: current_team} ->
+        Plausible.Teams.Billing.get_subscription(current_team)
       end)
       |> assign_new(:owned_plan, fn %{subscription: subscription} ->
         Plans.get_regular_plan(subscription, only_non_expired: true)

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -37,10 +37,10 @@ defmodule PlausibleWeb.Live.Sites do
       end)
       |> assign_new(:needs_to_upgrade, fn %{
                                             current_user: current_user,
-                                            my_team: my_team
+                                            current_team: current_team
                                           } ->
         Teams.Users.owns_sites?(current_user, include_pending?: true) &&
-          Teams.Billing.check_needs_to_upgrade(my_team)
+          Teams.Billing.check_needs_to_upgrade(current_team)
       end)
 
     {:noreply, socket}

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.Sites do
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
           <span :if={Teams.enabled?(@current_team)}>
             {Teams.name(@current_team)}
-            <.unstyled_link href={Routes.settings_path(@socket, :team_general)}>
+            <.unstyled_link :if={@current_team} href={Routes.settings_path(@socket, :team_general)}>
               <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
             </.unstyled_link>
           </span>

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -57,9 +57,14 @@ defmodule PlausibleWeb.Live.Sites do
       <PlausibleWeb.Live.Components.Visitors.gradient_defs />
       <.upgrade_nag_screen :if={@needs_to_upgrade == {:needs_to_upgrade, :no_active_subscription}} />
 
-      <div class="mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
+      <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-          <span :if={Teams.enabled?(@current_team)}>{Teams.name(@current_team)}</span>
+          <span :if={Teams.enabled?(@current_team)}>
+            {Teams.name(@current_team)}
+            <.unstyled_link href={Routes.settings_path(@socket, :team_general)}>
+              <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
+            </.unstyled_link>
+          </span>
           <span :if={not Teams.enabled?(@current_team)}>My Sites</span>
         </h2>
       </div>

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -59,7 +59,8 @@ defmodule PlausibleWeb.Live.Sites do
 
       <div class="mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-          {Teams.name(@current_team)}
+          <span :if={Teams.enabled?(@current_team)}>{Teams.name(@current_team)}</span>
+          <span :if={not Teams.enabled?(@current_team)}>My Sites</span>
         </h2>
       </div>
 

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.Sites do
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
           <span :if={Teams.enabled?(@current_team)}>
             {Teams.name(@current_team)}
-            <.unstyled_link :if={@current_team} href={Routes.settings_path(@socket, :team_general)}>
+            <.unstyled_link data-test-id="team-settings-link" :if={Teams.setup?(@current_team)} href={Routes.settings_path(@socket, :team_general)}>
               <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
             </.unstyled_link>
           </span>

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -61,7 +61,11 @@ defmodule PlausibleWeb.Live.Sites do
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
           <span :if={Teams.enabled?(@current_team)}>
             {Teams.name(@current_team)}
-            <.unstyled_link data-test-id="team-settings-link" :if={Teams.setup?(@current_team)} href={Routes.settings_path(@socket, :team_general)}>
+            <.unstyled_link
+              :if={Teams.setup?(@current_team)}
+              data-test-id="team-settings-link"
+              href={Routes.settings_path(@socket, :team_general)}
+            >
               <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
             </.unstyled_link>
           </span>

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -21,14 +21,14 @@ defmodule PlausibleWeb.Live.TeamManagement do
     {:ok, socket |> assign(mode: mode) |> reset()}
   end
 
-  defp reset(%{assigns: %{current_user: current_user, my_team: my_team}} = socket) do
-    {:ok, my_role} = Teams.Memberships.team_role(my_team, current_user)
+  defp reset(%{assigns: %{current_user: current_user, current_team: current_team}} = socket) do
+    {:ok, my_role} = Teams.Memberships.team_role(current_team, current_user)
 
     if my_role not in [:owner, :admin] do
       redirect(socket, to: Routes.settings_path(socket, :team_general))
     else
-      layout = Layout.init(my_team)
-      team_members_limit = Plausible.Teams.Billing.team_member_limit(my_team)
+      layout = Layout.init(current_team)
+      team_members_limit = Plausible.Teams.Billing.team_member_limit(current_team)
 
       assign(socket,
         team_members_limit: team_members_limit,
@@ -49,7 +49,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
       :if={at_limit?(@layout, @team_members_limit)}
       current_user={@current_user}
       billable_user={@current_user}
-      current_team={@my_team}
+      current_team={@current_team}
       limit={@team_members_limit}
       resource="team members"
       class="mb-4"
@@ -282,9 +282,10 @@ defmodule PlausibleWeb.Live.TeamManagement do
   end
 
   defp save_team_layout(
-         %{assigns: %{layout: layout, my_team: my_team, current_user: current_user}} = socket
+         %{assigns: %{layout: layout, current_team: current_team, current_user: current_user}} =
+           socket
        ) do
-    result = Layout.persist(layout, %{current_user: current_user, my_team: my_team})
+    result = Layout.persist(layout, %{current_user: current_user, current_team: current_team})
 
     case {result, socket.assigns.mode} do
       {{:ok, _}, :team_setup} ->

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -291,7 +291,9 @@ defmodule PlausibleWeb.Live.TeamManagement do
       {{:ok, _}, :team_setup} ->
         socket
         |> put_flash(:success, "Your team is now setup")
-        |> redirect(to: Routes.settings_path(socket, :team_general))
+        |> redirect(
+          to: Routes.settings_path(socket, :team_general, team: current_team.identifier)
+        )
 
       {{:ok, _}, :team_management} ->
         reset(socket)

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -292,7 +292,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
         socket
         |> put_flash(:success, "Your team is now setup")
         |> redirect(
-          to: Routes.settings_path(socket, :team_general, team: current_team.identifier)
+          to: Routes.settings_path(socket, :team_general, __team: current_team.identifier)
         )
 
       {{:ok, _}, :team_management} ->

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -160,7 +160,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
         phx-click="save-team-layout"
         class="mt-8 w-full"
       >
-        Create Team
+        Setup Team
       </.button>
     </div>
     """

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
 
         {true, %Teams.Team{}, _} ->
           my_team =
-            if Teams.name(my_team) == Teams.name() do
+            if Teams.name(my_team) == Teams.default_name() do
               current_user = socket.assigns.current_user
 
               my_team

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,19 +23,13 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          my_team =
-            if Teams.name(my_team) == Teams.default_name() do
-              current_user = socket.assigns.current_user
-
-              my_team
-              |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
-              |> Repo.update!()
-            else
-              my_team
-            end
+          current_user = socket.assigns.current_user
 
           team_name_form =
-            Teams.Team.name_changeset(my_team, %{})
+            my_team
+            |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
+            |> Repo.update!()
+            |> Teams.Team.name_changeset(%{})
             |> to_form()
 
           layout = Layout.init(my_team)

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
   def render(assigns) do
     ~H"""
     <.focus_box>
-      <:title>Create a new team</:title>
+      <:title>Setup a new team</:title>
       <:subtitle>
         Add members and assign roles to manage different sites access efficiently
       </:subtitle>

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,7 +23,10 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          team_name_form = Teams.Team.name_changeset(my_team, %{name: ""}) |> to_form()
+          user = socket.assigns.current_user
+
+          team_name_form =
+            Teams.Team.name_changeset(my_team, %{name: "#{user.name}'s Team"}) |> to_form()
 
           layout = Layout.init(my_team)
 
@@ -68,6 +71,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
       >
         <.input
           type="text"
+          value={"#{@current_user.name}'s Team"}
           placeholder={"#{@current_user.name}'s Team"}
           autofocus
           field={f[:name]}
@@ -77,18 +81,16 @@ defmodule PlausibleWeb.Live.TeamSetup do
         />
       </.form>
 
-      <div :if={@team_name_form.source.valid?}>
-        <.label class="mb-2">
-          Team Members
-        </.label>
-        {live_render(@socket, PlausibleWeb.Live.TeamManagement,
-          id: "team-management-setup",
-          container: {:div, id: "team-setup"},
-          session: %{
-            "mode" => "team-setup"
-          }
-        )}
-      </div>
+      <.label class="mb-2">
+        Team Members
+      </.label>
+      {live_render(@socket, PlausibleWeb.Live.TeamManagement,
+        id: "team-management-setup",
+        container: {:div, id: "team-setup"},
+        session: %{
+          "mode" => "team-setup"
+        }
+      )}
     </.focus_box>
     """
   end

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -40,6 +40,11 @@ defmodule PlausibleWeb.Live.TeamSetup do
             my_team: my_team
           )
 
+        {true, nil, _} ->
+          socket
+          |> put_flash(:error, "You cannot set up any team just yet")
+          |> redirect(to: Routes.site_path(socket, :index))
+
         {false, _, _} ->
           socket
           |> put_flash(:error, "You cannot set up any team just yet")

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -23,7 +23,8 @@ defmodule PlausibleWeb.Live.TeamSetup do
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}, _} ->
-          team_name_changeset = Teams.Team.name_changeset(my_team)
+          user = socket.assigns.current_user
+          team_name_changeset = Teams.Team.name_changeset(my_team, %{name: "#{user.name}'s Team"})
 
           layout = Layout.init(my_team)
 

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -10,50 +10,44 @@ defmodule PlausibleWeb.Live.TeamSetup do
   alias Plausible.Teams.Management.Layout
   alias PlausibleWeb.Router.Helpers, as: Routes
 
-  def mount(params, _session, socket) do
-    my_team = socket.assigns.my_team
-    enabled? = Teams.enabled?(my_team)
+  def mount(_params, _session, socket) do
+    current_team = socket.assigns.current_team
+    enabled? = Teams.enabled?(current_team)
 
-    # XXX: remove dev param, once manual testing is considered done
     socket =
-      case {enabled?, my_team, params["dev"]} do
-        {true, %Teams.Team{setup_complete: true}, nil} ->
+      case {enabled?, current_team} do
+        {true, %Teams.Team{setup_complete: true}} ->
           socket
           |> put_flash(:success, "Your team is now setup")
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
-        {true, %Teams.Team{}, _} ->
+        {true, %Teams.Team{}} ->
           current_user = socket.assigns.current_user
 
           team_name_form =
-            my_team
+            current_team
             |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
             |> Repo.update!()
             |> Teams.Team.name_changeset(%{})
             |> to_form()
 
-          layout = Layout.init(my_team)
+          layout = Layout.init(current_team)
 
           assign(socket,
             team_name_form: team_name_form,
             team_layout: layout,
-            my_team: my_team
+            current_team: current_team
           )
 
-        {true, nil, _} ->
-          socket
-          |> put_flash(:error, "You cannot set up any team just yet")
-          |> redirect(to: Routes.site_path(socket, :index))
-
-        {false, _, _} ->
+        {_, _} ->
           socket
           |> put_flash(:error, "You cannot set up any team just yet")
           |> redirect(to: Routes.site_path(socket, :index))
       end
 
     socket =
-      if my_team do
-        {:ok, my_role} = Teams.Memberships.team_role(my_team, socket.assigns.current_user)
+      if current_team do
+        {:ok, my_role} = Teams.Memberships.team_role(current_team, socket.assigns.current_user)
         assign(socket, my_role: my_role)
       else
         socket
@@ -105,7 +99,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
   end
 
   def handle_event("update-team", %{"team" => %{"name" => name}}, socket) do
-    changeset = Teams.Team.name_changeset(socket.assigns.my_team, %{name: name})
+    changeset = Teams.Team.name_changeset(socket.assigns.current_team, %{name: name})
 
     socket =
       case Repo.update(changeset) do

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_team, current_team || my_team)
         |> assign(:teams_count, teams_count)
         |> assign(:teams, teams)
-        |> assign(:multiple_teams?, teams_count > 1)
+        |> assign(:more_teams?, teams_count > 3)
 
       _ ->
         conn

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -28,27 +28,16 @@ defmodule PlausibleWeb.AuthPlug do
             |> Map.get(:team)
           end
 
-        current_team_owner? =
-          (current_team || %{})
-          |> Map.get(:owners, [])
-          |> Enum.any?(&(&1.id == user.id))
-
         my_team =
-          if current_team_owner? do
-            current_team
-          else
-            user.team_memberships
-            # NOTE: my_team should eventually only hold user's personal team. This requires
-            # additional adjustments, which will be done in follow-up work.
-            # |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
-            |> List.first(%{})
-            |> Map.get(:team)
-          end
+          user.team_memberships
+          |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
+          |> Map.get(:team)
 
         teams_count = length(user.team_memberships)
 
         teams =
           user.team_memberships
+          |> Enum.filter(& &1.team.setup_complete)
           |> Enum.sort_by(fn tm -> [tm.role != :owner, tm.team_id] end)
           |> Enum.map(&Map.fetch!(&1, :team))
           |> Enum.take(3)

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.AuthPlug do
         current_team =
           if current_team_id do
             user.team_memberships
-            |> Enum.find(%{}, &(&1.team_id == current_team_id))
+            |> Enum.find(%{}, &(&1.team.identifier == current_team_id))
             |> Map.get(:team)
           end
 

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -33,6 +33,11 @@ defmodule PlausibleWeb.AuthPlug do
           |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
           |> Map.get(:team)
 
+        fallback_team =
+          user.team_memberships
+          |> List.first(%{})
+          |> Map.get(:team)
+
         teams_count = length(user.team_memberships)
 
         teams =
@@ -49,7 +54,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_user, user)
         |> assign(:current_user_session, user_session)
         |> assign(:my_team, my_team)
-        |> assign(:current_team, current_team || my_team)
+        |> assign(:current_team, current_team || fallback_team)
         |> assign(:teams_count, teams_count)
         |> assign(:teams, teams)
         |> assign(:more_teams?, teams_count > 3)

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -30,10 +30,15 @@ defmodule PlausibleWeb.AuthPlug do
           end
 
         conn =
-          if current_team && current_team_id != current_team_id_from_session do
-            Plug.Conn.put_session(conn, "current_team_id", current_team_id)
-          else
-            conn
+          cond do
+            current_team && current_team_id != current_team_id_from_session ->
+              Plug.Conn.put_session(conn, "current_team_id", current_team_id)
+
+            is_nil(current_team) && not is_nil(current_team_id_from_session) ->
+              Plug.Conn.delete_session(conn, "current_team_id")
+
+            true ->
+              conn
           end
 
         my_team =

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -20,7 +20,7 @@ defmodule PlausibleWeb.AuthPlug do
         user = user_session.user
 
         current_team_id_from_session = Plug.Conn.get_session(conn, "current_team_id")
-        current_team_id = conn.params["__team"] || current_team_id_from_session 
+        current_team_id = conn.params["__team"] || current_team_id_from_session
 
         current_team =
           if current_team_id do

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -19,7 +19,8 @@ defmodule PlausibleWeb.AuthPlug do
       {:ok, user_session} ->
         user = user_session.user
 
-        current_team_id = Plug.Conn.get_session(conn, "current_team_id")
+        current_team_id =
+          Plug.Conn.get_session(conn, "current_team_id")
 
         current_team =
           if current_team_id do
@@ -34,9 +35,11 @@ defmodule PlausibleWeb.AuthPlug do
           |> Map.get(:team)
 
         fallback_team =
-          user.team_memberships
-          |> List.first(%{})
-          |> Map.get(:team)
+          if not Plausible.Teams.enabled?(nil) do
+            user.team_memberships
+            |> List.first(%{})
+            |> Map.get(:team)
+          end
 
         teams_count = length(user.team_memberships)
 
@@ -54,7 +57,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_user, user)
         |> assign(:current_user_session, user_session)
         |> assign(:my_team, my_team)
-        |> assign(:current_team, current_team || fallback_team)
+        |> assign(:current_team, current_team || my_team || fallback_team)
         |> assign(:teams_count, teams_count)
         |> assign(:teams, teams)
         |> assign(:more_teams?, teams_count > 3)

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -47,6 +47,12 @@ defmodule PlausibleWeb.AuthPlug do
 
         teams_count = length(user.team_memberships)
 
+        teams =
+          user.team_memberships
+          |> Enum.sort_by(fn tm -> [tm.role != :owner, tm.team_id] end)
+          |> Enum.map(&Map.fetch!(&1, :team))
+          |> Enum.take(3)
+
         Plausible.OpenTelemetry.add_user_attributes(user)
         Sentry.Context.set_user_context(%{id: user.id, name: user.name, email: user.email})
 
@@ -56,6 +62,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:my_team, my_team)
         |> assign(:current_team, current_team || my_team)
         |> assign(:teams_count, teams_count)
+        |> assign(:teams, teams)
         |> assign(:multiple_teams?, teams_count > 1)
 
       _ ->

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -20,7 +20,7 @@ defmodule PlausibleWeb.AuthPlug do
         user = user_session.user
 
         current_team_id_from_session = Plug.Conn.get_session(conn, "current_team_id")
-        current_team_id = conn.params["team"] || current_team_id_from_session
+        current_team_id = conn.params["__team"] || current_team_id_from_session 
 
         current_team =
           if current_team_id do
@@ -46,13 +46,6 @@ defmodule PlausibleWeb.AuthPlug do
           |> Enum.find(%{}, &(&1.role == :owner and &1.team.setup_complete == false))
           |> Map.get(:team)
 
-        fallback_team =
-          if not Plausible.Teams.enabled?(nil) do
-            user.team_memberships
-            |> List.first(%{})
-            |> Map.get(:team)
-          end
-
         teams_count = length(user.team_memberships)
 
         teams =
@@ -69,7 +62,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_user, user)
         |> assign(:current_user_session, user_session)
         |> assign(:my_team, my_team)
-        |> assign(:current_team, current_team || my_team || fallback_team)
+        |> assign(:current_team, current_team || my_team)
         |> assign(:teams_count, teams_count)
         |> assign(:teams, teams)
         |> assign(:more_teams?, teams_count > 3)

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -19,14 +19,21 @@ defmodule PlausibleWeb.AuthPlug do
       {:ok, user_session} ->
         user = user_session.user
 
-        current_team_id =
-          Plug.Conn.get_session(conn, "current_team_id")
+        current_team_id_from_session = Plug.Conn.get_session(conn, "current_team_id")
+        current_team_id = conn.params["team"] || current_team_id_from_session
 
         current_team =
           if current_team_id do
             user.team_memberships
             |> Enum.find(%{}, &(&1.team.identifier == current_team_id))
             |> Map.get(:team)
+          end
+
+        conn =
+          if current_team && current_team_id != current_team_id_from_session do
+            Plug.Conn.put_session(conn, "current_team_id", current_team_id)
+          else
+            conn
           end
 
         my_team =

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -404,7 +404,6 @@ defmodule PlausibleWeb.Router do
     delete "/me", AuthController, :delete_me
 
     get "/team/select", AuthController, :select_team
-    post "/team/select/:team_id", AuthController, :switch_team
 
     get "/auth/google/callback", AuthController, :google_auth_callback
 

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -9,14 +9,11 @@
         :for={team <- @teams_selection}
         class={if team.current?, do: ["border-indigo-400 border-r-4 m-2"], else: ["m-2"]}
       >
-        <.unstyled_link
-          method={if team.current?, do: "get", else: "post"}
-          href={
-            if team.current?,
-              do: "#",
-              else: Routes.auth_path(@conn, :switch_team, team.identifier)
-          }
-        >
+        <.unstyled_link href={
+          if team.current?,
+            do: "#",
+            else: Routes.site_path(@conn, :index, team: team.identifier)
+        }>
           <div class="hover:bg-indigo-100 dark:hover:bg-gray-700 p-4">
             <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">
               {team.name}

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -6,7 +6,7 @@
   <div>
     <ul>
       <li
-        :for={team <- @teams}
+        :for={team <- @teams_selection}
         class={if team.current?, do: ["border-indigo-400 border-l-4 m-2"], else: ["m-2"]}
       >
         <.unstyled_link

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -12,7 +12,7 @@
         <.unstyled_link href={
           if team.current?,
             do: "#",
-            else: Routes.site_path(@conn, :index, team: team.identifier)
+            else: Routes.site_path(@conn, :index, __team: team.identifier)
         }>
           <div class="hover:bg-indigo-100 dark:hover:bg-gray-700 p-4">
             <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">

--- a/lib/plausible_web/templates/auth/select_team.html.heex
+++ b/lib/plausible_web/templates/auth/select_team.html.heex
@@ -7,7 +7,7 @@
     <ul>
       <li
         :for={team <- @teams_selection}
-        class={if team.current?, do: ["border-indigo-400 border-l-4 m-2"], else: ["m-2"]}
+        class={if team.current?, do: ["border-indigo-400 border-r-4 m-2"], else: ["m-2"]}
       >
         <.unstyled_link
           method={if team.current?, do: "get", else: "post"}

--- a/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
+++ b/lib/plausible_web/templates/billing/upgrade_to_enterprise_plan.html.heex
@@ -67,7 +67,7 @@
           id="paddle-button"
           paddle_product_id={@latest_enterprise_plan.paddle_plan_id}
           user={@current_user}
-          team={@my_team}
+          team={@current_team}
         >
           <svg fill="currentColor" viewBox="0 0 20 20" class="inline w-4 h-4 mr-2">
             <path

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -72,13 +72,14 @@
                         {@conn.assigns[:current_user].email}
                       </p>
                     </.dropdown_item>
-                    <.dropdown_item :if={@conn.assigns[:multiple_teams?]}>
-                      <div class="text-xs text-gray-500 dark:text-gray-400">Team</div>
-                      <p class="truncate font-medium text-gray-900 dark:text-gray-100" role="none">
-                        {@current_team.name}
-                      </p>
-                    </.dropdown_item>
-
+                    <.team_switcher
+                      :if={Plausible.Teams.enabled?(@my_team)}
+                      conn={@conn}
+                      teams={@teams}
+                      my_team={@my_team}
+                      current_team={@current_team}
+                      more_teams?={@more_teams?}
+                    />
                     <.dropdown_divider />
                     <.dropdown_item href={Routes.settings_path(@conn, :index)}>
                       Account Settings
@@ -108,12 +109,6 @@
                         <span class="flex-1">
                           Team Settings
                         </span>
-                      </.dropdown_item>
-                      <.dropdown_item
-                        :if={@conn.assigns[:multiple_teams?]}
-                        href={Routes.auth_path(@conn, :select_team)}
-                      >
-                        Switch Team
                       </.dropdown_item>
                       <.dropdown_divider />
                     </div>

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -84,7 +84,9 @@
                       Account Settings
                     </.dropdown_item>
 
-                    <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
+                    <div :if={
+                      Plausible.Teams.enabled?(@my_team) and not Plausible.Teams.setup?(@my_team)
+                    }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
                           Setup a Team
@@ -96,7 +98,9 @@
                       <.dropdown_divider />
                     </div>
 
-                    <div :if={Plausible.Teams.enabled?(@my_team) and @my_team.setup_complete}>
+                    <div :if={
+                      Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)
+                    }>
                       <.dropdown_item
                         class="flex"
                         href={Routes.settings_path(@conn, :team_general)}

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -86,8 +86,8 @@
                     </.dropdown_item>
 
                     <div :if={
-                      Plausible.Teams.enabled?(@current_team) and
-                        not Plausible.Teams.setup?(@current_team)
+                      @my_team && Plausible.Teams.enabled?(@current_team) &&
+                        @my_team.id == @current_team.id
                     }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -44,14 +44,14 @@
                 </.styled_link>
               </li>
               <li
-                :if={ee?() and Plausible.Teams.on_trial?(@conn.assigns[:my_team])}
+                :if={ee?() and Plausible.Teams.on_trial?(@conn.assigns[:current_team])}
                 class="hidden mr-6 sm:block"
               >
                 <.styled_link
                   class="text-sm text-yellow-900 dark:text-yellow-900 rounded px-3 py-2 rounded-md bg-yellow-100 dark:bg-yellow-100"
                   href={Routes.settings_path(@conn, :subscription)}
                 >
-                  {trial_notification(@conn.assigns[:my_team])}
+                  {trial_notification(@conn.assigns[:current_team])}
                 </.styled_link>
               </li>
               <li class="w-full sm:w-auto">
@@ -73,7 +73,7 @@
                       </p>
                     </.dropdown_item>
                     <.team_switcher
-                      :if={Plausible.Teams.enabled?(@my_team)}
+                      :if={Plausible.Teams.enabled?(@current_team)}
                       conn={@conn}
                       teams={@teams}
                       my_team={@my_team}
@@ -86,7 +86,8 @@
                     </.dropdown_item>
 
                     <div :if={
-                      Plausible.Teams.enabled?(@my_team) and not Plausible.Teams.setup?(@my_team)
+                      Plausible.Teams.enabled?(@current_team) and
+                        not Plausible.Teams.setup?(@current_team)
                     }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
@@ -100,7 +101,8 @@
                     </div>
 
                     <div :if={
-                      Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)
+                      Plausible.Teams.enabled?(@current_team) and
+                        Plausible.Teams.setup?(@current_team)
                     }>
                       <.dropdown_item
                         class="flex"

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -87,7 +87,7 @@
                     <div :if={Plausible.Teams.enabled?(@my_team) and not @my_team.setup_complete}>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
-                          Create a Team
+                          Setup a Team
                         </span>
                         <span class="ml-1 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
                           NEW

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -2,18 +2,18 @@
   {render("_flash.html", assigns)}
 <% end %>
 
-<div :if={assigns[:my_team]} class="flex flex-col gap-y-2">
+<div :if={assigns[:current_team]} class="flex flex-col gap-y-2">
   <Notice.active_grace_period
-    :if={Plausible.Teams.GracePeriod.active?(@my_team)}
-    enterprise?={Plausible.Teams.Billing.enterprise_configured?(@my_team)}
-    grace_period_end={grace_period_end(@my_team)}
+    :if={Plausible.Teams.GracePeriod.active?(@current_team)}
+    enterprise?={Plausible.Teams.Billing.enterprise_configured?(@current_team)}
+    grace_period_end={grace_period_end(@current_team)}
   />
 
-  <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@my_team)} />
+  <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@current_team)} />
 
-  <Notice.subscription_cancelled subscription={@my_team.subscription} />
+  <Notice.subscription_cancelled subscription={@current_team.subscription} />
 
-  <Notice.subscription_past_due subscription={@my_team.subscription} class="container" />
+  <Notice.subscription_past_due subscription={@current_team.subscription} class="container" />
 
-  <Notice.subscription_paused subscription={@my_team.subscription} class="container" />
+  <Notice.subscription_paused subscription={@current_team.subscription} class="container" />
 </div>

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -36,7 +36,7 @@
           <% end %>
         </div>
 
-        <div :if={Plausible.Teams.enabled?(@my_team) and @my_team.setup_complete}>
+        <div :if={Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)}>
           <div class="mb-4 mt-4 hidden lg:block">
             <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
             <p class="text-xs dark:text-gray-400 truncate">{@my_team.name}</p>

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -36,10 +36,14 @@
           <% end %>
         </div>
 
-        <div :if={Plausible.Teams.enabled?(@my_team) and Plausible.Teams.setup?(@my_team)}>
+        <div :if={
+          Plausible.Teams.enabled?(@current_team) and Plausible.Teams.setup?(@current_team)
+        }>
           <div class="mb-4 mt-4 hidden lg:block">
             <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>
-            <p class="text-xs dark:text-gray-400 truncate">{@my_team.name}</p>
+            <p class="text-xs dark:text-gray-400 truncate">
+              {Plausible.Teams.name(@current_team)}
+            </p>
           </div>
 
           <div class="hidden lg:block">

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -10,13 +10,13 @@
     <PlausibleWeb.Components.Billing.Notice.premium_feature
       billable_user={@current_user}
       current_user={@current_user}
-      current_team={@my_team}
+      current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.StatsAPI}
     />
 
     <.filter_bar filtering_enabled?={false}>
       <.button_link
-        :if={Plausible.Billing.Feature.StatsAPI.check_availability(@my_team) == :ok}
+        :if={Plausible.Billing.Feature.StatsAPI.check_availability(@current_team) == :ok}
         href={Routes.settings_path(@conn, :new_api_key)}
       >
         New API Key

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -7,7 +7,7 @@
     <:title>Delete Account</:title>
     <:subtitle>Deleting your account removes all sites and stats you've collected</:subtitle>
 
-    <%= if Plausible.Billing.Subscription.Status.active?(@my_team && @my_team.subscription) do %>
+    <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
       <.notice theme={:gray} title="Cannot delete account at this time">
         Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
       </.notice>

--- a/lib/plausible_web/templates/settings/subscription.html.heex
+++ b/lib/plausible_web/templates/settings/subscription.html.heex
@@ -33,7 +33,7 @@
 
     <div class="flex flex-col items-center justify-between sm:flex-row sm:items-start">
       <PlausibleWeb.Components.Billing.monthly_quota_box
-        team={@my_team}
+        team={@current_team}
         subscription={@subscription}
       />
       <div class="w-full md:w-1/3 h-32 px-2 py-4 my-4 text-center bg-gray-100 rounded dark:bg-gray-900">

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -12,12 +12,14 @@
       for={@team_name_changeset}
       method="post"
     >
-      <.input_with_clipboard
-        name="team-identifier"
-        id="team-identifier"
-        label="Team Identifier"
-        value={@current_team.identifier}
-      />
+      <div class="w-1/2">
+        <.input_with_clipboard
+          name="team-identifier"
+          id="team-identifier"
+          label="Team Identifier"
+          value={@current_team.identifier}
+        />
+      </div>
       <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
 
       <.button type="submit">

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -1,7 +1,7 @@
 <.settings_tiles>
   <.tile>
     <:title>
-      <a id="update-name">Team Name</a>
+      <a id="update-name">Team Information</a>
     </:title>
     <:subtitle>
       Change the name of your team
@@ -12,6 +12,12 @@
       for={@team_name_changeset}
       method="post"
     >
+      <.input_with_clipboard
+        name="team-identifier"
+        id="team-identifier"
+        label="Team Identifier"
+        value={@current_team.identifier}
+      />
       <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
 
       <.button type="submit">

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -9,13 +9,13 @@
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={@site_limit_exceeded?}
       current_user={@current_user}
-      current_team={@my_team}
+      current_team={@current_team}
       billable_user={@current_user}
       limit={@site_limit}
       resource="sites"
     />
 
-    <%= if is_nil(@my_team) or is_nil(@my_team.trial_expiry_date) do %>
+    <%= if is_nil(@current_team) or is_nil(@current_team.trial_expiry_date) do %>
       <div class="rounded-md bg-blue-50 dark:bg-transparent dark:border border-blue-200 p-4">
         <div class="flex">
           <div class="flex-shrink-0">

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -1,6 +1,6 @@
 <.settings_tiles>
   <PlausibleWeb.Team.Notice.inviting_banner :if={
-    @site_role in [:owner, :admin] and @my_team.setup_complete
+    @site_role in [:owner, :admin] and Plausible.Teams.setup?(@current_team)
   } />
 
   <.tile docs="users-roles">
@@ -17,7 +17,7 @@
     </.filter_bar>
 
     <PlausibleWeb.Team.Notice.team_members_notice :if={
-      @site_role in [:owner, :admin] and @my_team.setup_complete
+      @site_role in [:owner, :admin] and Plausible.Teams.setup?(@current_team)
     } />
 
     <div class="flow-root">

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -49,7 +49,7 @@
               unlock the stats.
             </p>
             <div
-              :if={not Plausible.Teams.enabled?(@conn.assigns[:my_team])}
+              :if={not Plausible.Teams.enabled?(@conn.assigns[:current_team])}
               class="mt-6 text-sm text-gray-500"
             >
               <p>Want to pay for this site with the account you're logged in with?</p>

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -134,10 +134,6 @@ defmodule PlausibleWeb.UserAuth do
         inner_join: u in assoc(us, :user),
         as: :user,
         left_join: tm in assoc(u, :team_memberships),
-        # NOTE: whenever my_team.subscription is used to prevent user action,
-        # we must check whether the team association is ownership.
-        # Otherwise regular members will be limited by team owner in cases
-        # like deleting their own account.
         on: tm.role != :guest,
         left_join: t in assoc(tm, :team),
         as: :team,

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -128,15 +128,10 @@ defmodule PlausibleWeb.LayoutView do
       current_is_my? = current_team && my_team && current_team.id == my_team.id
 
       teams =
-        cond do
-          current_included? ->
-            teams
-
-          !current_is_my? ->
-            [current_team | teams]
-
-          true ->
-            teams
+        if current_team && !current_included? && !current_is_my? do
+          [current_team | teams]
+        else
+          teams
         end
 
       teams =

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -118,6 +118,12 @@ defmodule PlausibleWeb.LayoutView do
     end
   end
 
+  attr :conn, :map, required: true
+  attr :teams, :list, required: true
+  attr :my_team, :any, default: nil
+  attr :current_team, :any, default: nil
+  attr :more_teams?, :boolean, required: true
+
   def team_switcher(assigns) do
     teams = assigns[:teams]
 

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -154,8 +154,7 @@ defmodule PlausibleWeb.LayoutView do
       </.dropdown_item>
       <.dropdown_item
         :for={team <- @teams}
-        href={Routes.auth_path(@conn, :switch_team, team.identifier)}
-        method="post"
+        href={Routes.site_path(@conn, :index, team: team.identifier)}
       >
         <p
           class={[

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -125,27 +125,25 @@ defmodule PlausibleWeb.LayoutView do
       current_team = assigns[:current_team]
       my_team = assigns[:my_team]
       current_included? = current_team && Enum.any?(teams, &(&1.id == current_team.id))
-      my_included? = my_team && Enum.any?(teams, &(&1.id == my_team.id))
+      current_is_my? = current_team && my_team && current_team.id == my_team.id
 
       teams =
-        if current_included? do
-          teams
-        else
-          [current_team | teams]
-        end
+        cond do
+          current_included? ->
+            teams
 
-      teams =
-        if my_included? do
-          teams
-        else
-          teams ++ [my_team]
+          !current_is_my? ->
+            [current_team | teams]
+
+          true ->
+            teams
         end
 
       teams =
         if my_team do
-          teams
+          teams ++ [my_team]
         else
-          teams ++ [%Teams.Team{name: Teams.default_name()}]
+          teams ++ [%Teams.Team{identifier: "none", name: Teams.default_name()}]
         end
 
       selected_id = current_team && current_team.id

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -107,9 +107,9 @@ defmodule PlausibleWeb.LayoutView do
       ]
     }
 
-    my_team = conn.assigns[:my_team]
+    current_team = conn.assigns[:current_team]
 
-    if Teams.enabled?(my_team) and Teams.setup?(my_team) do
+    if Teams.enabled?(current_team) and Teams.setup?(current_team) do
       Map.put(options, "Team Settings", [
         %{key: "General", value: "team/general", icon: :adjustments_horizontal}
       ])

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -1,6 +1,8 @@
 defmodule PlausibleWeb.LayoutView do
   use PlausibleWeb, :view
   use Plausible
+
+  alias Plausible.Teams
   alias PlausibleWeb.Components.Billing.Notice
 
   def plausible_url do
@@ -105,7 +107,9 @@ defmodule PlausibleWeb.LayoutView do
       ]
     }
 
-    if Plausible.Teams.enabled?(conn.assigns[:my_team]) do
+    my_team = conn.assigns[:my_team]
+
+    if Teams.enabled?(my_team) and Teams.setup?(my_team) do
       Map.put(options, "Team Settings", [
         %{key: "General", value: "team/general", icon: :adjustments_horizontal}
       ])
@@ -115,7 +119,7 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def trial_notification(team) do
-    case Plausible.Teams.trial_days_left(team) do
+    case Teams.trial_days_left(team) do
       days when days > 1 ->
         "#{days} trial days left"
 

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.LayoutView do
   def team_switcher(assigns) do
     teams = assigns[:teams]
 
-    if teams && length(teams) > 1 do
+    if teams && length(teams) > 0 do
       current_team = assigns[:current_team]
       my_team = assigns[:my_team]
       current_included? = current_team && Enum.any?(teams, &(&1.id == current_team.id))

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -154,7 +154,7 @@ defmodule PlausibleWeb.LayoutView do
       </.dropdown_item>
       <.dropdown_item
         :for={team <- @teams}
-        href={Routes.site_path(@conn, :index, team: team.identifier)}
+        href={Routes.site_path(@conn, :index, __team: team.identifier)}
       >
         <p
           class={[

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -164,8 +164,11 @@ defmodule PlausibleWeb.LayoutView do
       >
         <p
           class={[
-            if(team.id == @selected_id, do: "font-bold", else: "font-medium"),
-            "truncate text-gray-900 dark:text-gray-100"
+            if(team.id == @selected_id,
+              do: "border-r-4 border-indigo-400 font-bold",
+              else: "font-medium"
+            ),
+            "truncate text-gray-900 dark:text-gray-100 pr-4"
           ]}
           role="none"
         >

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -99,16 +99,21 @@ defmodule PlausibleWeb.LayoutView do
     current_team = conn.assigns[:current_team]
 
     options = %{
-      "Account Settings" => [
-        %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
-        %{key: "Security", value: "security", icon: :lock_closed},
-        if(not Teams.setup?(current_team), do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}),
-        if(not Teams.setup?(current_team), do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}),
-        %{key: "API Keys", value: "api-keys", icon: :key},
-        %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
-      ] |> Enum.reject(&is_nil/1)
+      "Account Settings" =>
+        [
+          %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
+          %{key: "Security", value: "security", icon: :lock_closed},
+          if(not Teams.setup?(current_team),
+            do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
+          ),
+          if(not Teams.setup?(current_team),
+            do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
+          ),
+          %{key: "API Keys", value: "api-keys", icon: :key},
+          %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
+        ]
+        |> Enum.reject(&is_nil/1)
     }
-
 
     if Teams.enabled?(current_team) and Teams.setup?(current_team) do
       Map.put(options, "Team Settings", [

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -96,22 +96,25 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def account_settings_sidebar(conn) do
+    current_team = conn.assigns[:current_team]
+
     options = %{
       "Account Settings" => [
         %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
         %{key: "Security", value: "security", icon: :lock_closed},
-        %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
-        %{key: "Invoices", value: "billing/invoices", icon: :banknotes},
+        if(not Teams.setup?(current_team), do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}),
+        if(not Teams.setup?(current_team), do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}),
         %{key: "API Keys", value: "api-keys", icon: :key},
         %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
-      ]
+      ] |> Enum.reject(&is_nil/1)
     }
 
-    current_team = conn.assigns[:current_team]
 
     if Teams.enabled?(current_team) and Teams.setup?(current_team) do
       Map.put(options, "Team Settings", [
-        %{key: "General", value: "team/general", icon: :adjustments_horizontal}
+        %{key: "General", value: "team/general", icon: :adjustments_horizontal},
+        %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
+        %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
       ])
     else
       options

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -62,6 +62,10 @@ site =
 add_guest(site, user: new_user(name: "Arnold Wallaby", password: "plausible"), role: :viewer)
 add_guest(site, user: new_user(name: "Lois Lane", password: "plausible"), role: :editor)
 
+user2 = new_user(name: "Mary Jane", email: "user2@plausible.test", password: "plausible")
+site2 = new_site(domain: "computer.example.com", owner: user2)
+invite_guest(site2, user, inviter: user2, role: :viewer)
+
 Plausible.Factory.insert_list(29, :ip_rule, site: site)
 Plausible.Factory.insert(:country_rule, site: site, country_code: "PL")
 Plausible.Factory.insert(:country_rule, site: site, country_code: "EE")

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -470,12 +470,12 @@ defmodule Plausible.SitesTest do
 
       invite_guest(site3, user1, role: :viewer, inviter: user3)
       invite_transfer(site2, user1, inviter: user2)
-      add_member(site4.team, user: user1, role: :editor)
+      team4 = Plausible.Teams.complete_setup(site4.team)
+      add_member(team4, user: user1, role: :editor)
 
       assert_matches %{
                        entries: [
-                         %{id: ^site1.id},
-                         %{id: ^site4.id}
+                         %{id: ^site1.id}
                        ]
                      } = Sites.list(user1, %{})
 
@@ -483,8 +483,7 @@ defmodule Plausible.SitesTest do
                        entries: [
                          %{id: ^site3.id},
                          %{id: ^site2.id},
-                         %{id: ^site1.id},
-                         %{id: ^site4.id}
+                         %{id: ^site1.id}
                        ]
                      } = Sites.list_with_invitations(user1, %{})
 
@@ -492,15 +491,14 @@ defmodule Plausible.SitesTest do
                        entries: [
                          %{id: ^site4.id}
                        ]
-                     } = Sites.list(user1, %{}, team: site4.team)
+                     } = Sites.list(user1, %{}, team: team4)
 
       assert_matches %{
                        entries: [
-                         %{id: ^site3.id},
                          %{id: ^site2.id},
                          %{id: ^site4.id}
                        ]
-                     } = Sites.list_with_invitations(user1, %{}, team: site4.team)
+                     } = Sites.list_with_invitations(user1, %{}, team: team4)
     end
 
     test "handles pagination correctly" do

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -224,6 +224,113 @@ defmodule Plausible.SitesTest do
              } = Plausible.Teams.Sites.list_with_invitations(user, %{})
     end
 
+    test "lists guest sites, site invitations and transfers when no current team set" do
+      user1 = new_user()
+      user2 = new_user()
+      user3 = new_user()
+      user4 = new_user()
+
+      # owned site on a setup team
+      site1 = new_site(owner: user1, domain: "own.example.com")
+      Plausible.Teams.complete_setup(site1.team)
+
+      # guest site access
+      site2 = new_site(owner: user2, domain: "guest.example.com")
+      add_guest(site2, user: user1, role: :editor)
+
+      # site invitation
+      site3 = new_site(owner: user3, domain: "invitation.example.com")
+      invite_guest(site3, user1, role: :viewer, inviter: user3)
+
+      # transfer
+      site4 = new_site(domain: "transfer.example.com", owner: user3)
+      invite_transfer(site4, user1, inviter: user2)
+
+      # other team site access
+      site5 = new_site(domain: "team.example.com", owner: user4)
+      add_member(site5.team, user: user1, role: :editor)
+
+      assert %{
+               entries: [
+                 %{domain: "invitation.example.com"},
+                 %{domain: "transfer.example.com"},
+                 %{domain: "guest.example.com"}
+               ]
+             } =
+               Sites.list_with_invitations(user1, %{})
+    end
+
+    test "lists guest sites, site invitations, transfers and team sites when current team set but not setup" do
+      user1 = new_user()
+      user2 = new_user()
+      user3 = new_user()
+      user4 = new_user()
+
+      # owned site on a personal team
+      site1 = new_site(owner: user1, domain: "own.example.com")
+
+      # guest site access
+      site2 = new_site(owner: user2, domain: "guest.example.com")
+      add_guest(site2, user: user1, role: :editor)
+
+      # site invitation
+      site3 = new_site(owner: user3, domain: "invitation.example.com")
+      invite_guest(site3, user1, role: :viewer, inviter: user3)
+
+      # transfer
+      site4 = new_site(domain: "transfer.example.com", owner: user3)
+      invite_transfer(site4, user1, inviter: user2)
+
+      # other team site access
+      site5 = new_site(domain: "team.example.com", owner: user4)
+      add_member(site5.team, user: user1, role: :editor)
+
+      assert %{
+               entries: [
+                 %{domain: "invitation.example.com"},
+                 %{domain: "transfer.example.com"},
+                 %{domain: "guest.example.com"},
+                 %{domain: "own.example.com"}
+               ]
+             } =
+               Sites.list_with_invitations(user1, %{}, team: site1.team)
+    end
+
+    test "lists team sites and transfers when current team set and setup" do
+      user1 = new_user()
+      user2 = new_user()
+      user3 = new_user()
+      user4 = new_user()
+
+      # owned site on a personal team
+      new_site(owner: user1, domain: "own.example.com")
+
+      # guest site access
+      site2 = new_site(owner: user2, domain: "guest.example.com")
+      add_guest(site2, user: user1, role: :editor)
+
+      # site invitation
+      site3 = new_site(owner: user3, domain: "invitation.example.com")
+      invite_guest(site3, user1, role: :viewer, inviter: user3)
+
+      # transfer
+      site4 = new_site(domain: "transfer.example.com", owner: user3)
+      invite_transfer(site4, user1, inviter: user2)
+
+      # other team site access
+      site5 = new_site(domain: "team.example.com", owner: user4)
+      team5 = Plausible.Teams.complete_setup(site5.team)
+      add_member(site5.team, user: user1, role: :editor)
+
+      assert %{
+               entries: [
+                 %{domain: "transfer.example.com"},
+                 %{domain: "team.example.com"}
+               ]
+             } =
+               Sites.list_with_invitations(user1, %{}, team: team5)
+    end
+
     test "prioritizes pending transfer over pinned site with guest membership" do
       owner = new_user()
       pending_owner = new_user()

--- a/test/plausible/teams/management/layout_test.exs
+++ b/test/plausible/teams/management/layout_test.exs
@@ -240,7 +240,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
       assert {:ok, 0} =
                team
                |> Layout.init()
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert_no_emails_delivered()
     end
@@ -249,7 +249,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
       refute team.setup_complete
       refute team.setup_at
 
-      team |> Layout.init() |> Layout.persist(%{current_user: user, my_team: team})
+      team |> Layout.init() |> Layout.persist(%{current_user: user, current_team: team})
 
       team = Repo.reload!(team)
 
@@ -268,7 +268,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
       assert setup_at = team.setup_at
 
-      team |> Layout.init() |> Layout.persist(%{current_user: user, my_team: team})
+      team |> Layout.init() |> Layout.persist(%{current_user: user, current_team: team})
 
       team = Repo.reload!(team)
 
@@ -280,7 +280,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                team
                |> Layout.init()
                |> Layout.schedule_send("test@example.com", :admin)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert_email_delivered_with(
         to: [nil: "test@example.com"],
@@ -298,7 +298,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                team
                |> Layout.init()
                |> Layout.schedule_delete("test@example.com")
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert_email_delivered_with(
         to: [nil: "test@example.com"],
@@ -314,7 +314,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.schedule_send("test2@example.com", :admin)
                |> Layout.schedule_send("test3@example.com", :admin)
                |> Layout.schedule_send("test4@example.com", :admin)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert {:error, :only_one_owner} =
                team
@@ -322,19 +322,19 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.schedule_delete(user.email)
                |> put(invitation_pending("00-invitation-pending@example.com", role: :owner))
                |> put(invitation_sent("00-invitation-sent@example.com", role: :owner))
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert {:error, :only_one_owner} =
                team
                |> Layout.init()
                |> Layout.update_role(user.email, :viewer)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert {:error, :already_a_member} =
                team
                |> Layout.init()
                |> Layout.schedule_send(user.email, :admin)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert_no_emails_delivered()
     end
@@ -350,7 +350,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.schedule_send("new@example.com", :admin)
                |> Layout.schedule_delete("test1@example.com")
                |> Layout.schedule_delete("test2@example.com")
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
     end
 
     test "multiple ops queue", %{user: user, team: team} do
@@ -363,7 +363,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.schedule_send("new@example.com", :admin)
                |> Layout.schedule_delete("test1@example.com")
                |> Layout.update_role("test2@example.com", :viewer)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert {:error, :not_a_member} = Teams.Memberships.team_role(team, member1)
       assert {:ok, :viewer} = Teams.Memberships.team_role(team, member2)
@@ -388,7 +388,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.init()
                |> Layout.schedule_send("new@example.com", :admin)
                |> Layout.schedule_delete("new@example.com")
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
     end
 
     test "idempotence", %{user: user, team: team} do
@@ -404,7 +404,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
                |> Layout.update_role("test2@example.com", :viewer)
                |> Layout.schedule_delete("test1@example.com")
                |> Layout.update_role("test2@example.com", :viewer)
-               |> Layout.persist(%{current_user: user, my_team: team})
+               |> Layout.persist(%{current_user: user, current_team: team})
 
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
@@ -431,7 +431,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
       layout
       |> Layout.update_role(u2.email, :viewer)
-      |> Layout.persist(%{current_user: user, my_team: team})
+      |> Layout.persist(%{current_user: user, current_team: team})
 
       refute team |> Layout.init() |> Layout.has_guests?()
 

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -7,14 +7,14 @@ defmodule Plausible.TeamsTest do
   alias Plausible.Repo
 
   describe "get_or_create/1" do
-    test "creates 'My Team' if user is a member of none" do
+    test "creates 'My Personal Sites' if user is a member of no teams" do
       today = Date.utc_today()
       user = new_user()
       user_id = user.id
 
       assert {:ok, team} = Teams.get_or_create(user)
 
-      assert team.name == "My Team"
+      assert team.name == "My Personal Sites"
       assert Date.compare(team.trial_expiry_date, today) == :gt
 
       assert [
@@ -22,7 +22,7 @@ defmodule Plausible.TeamsTest do
              ] = Repo.preload(team, :team_memberships).team_memberships
     end
 
-    test "returns existing 'My Team' if user already owns one" do
+    test "returns existing team if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id
       existing_team = team_of(user)
@@ -31,6 +31,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+      assert team.name == "My Personal Sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}
@@ -58,7 +59,7 @@ defmodule Plausible.TeamsTest do
                |> Enum.sort_by(& &1.id)
     end
 
-    test "creates 'My Team' if user is a guest on another team" do
+    test "creates 'My Personal Sites' if user is a guest on another team" do
       user = new_user()
       user_id = user.id
       site = new_site()
@@ -68,6 +69,7 @@ defmodule Plausible.TeamsTest do
       assert {:ok, team} = Teams.get_or_create(user)
 
       assert team.id != existing_team.id
+      assert team.name == "My Personal Sites"
 
       assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
                team
@@ -146,7 +148,7 @@ defmodule Plausible.TeamsTest do
       assert {:error, :no_team} = Teams.get_by_owner(user)
     end
 
-    test "returns existing 'My Team' if user already owns one" do
+    test "returns existing 'My Personal Sites' if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id
       existing_team = team_of(user)
@@ -155,6 +157,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
+      assert team.name == "My Personal Sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -77,7 +77,7 @@ defmodule Plausible.TeamsTest do
                |> Map.fetch!(:team_memberships)
     end
 
-    test "creates 'My Team' if user is a non-owner member on existing teams" do
+    test "creates 'My Personal Sites' if user is a non-owner member on existing teams" do
       user = new_user()
       user_id = user.id
       site1 = new_site()

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -6,6 +6,26 @@ defmodule Plausible.TeamsTest do
   alias Plausible.Teams
   alias Plausible.Repo
 
+  describe "name/1" do
+    test "returns default name when there's no team" do
+      assert Teams.name(nil) == "My Personal Sites"
+    end
+
+    test "returns default name when team setup is not completed yet" do
+      user = new_user(team: [setup_complete: false, name: "Foo"])
+      team = team_of(user)
+
+      assert Teams.name(team) == "My Personal Sites"
+    end
+
+    test "returns team name for a setup team" do
+      user = new_user(team: [setup_complete: true, name: "Foo"])
+      team = team_of(user)
+
+      assert Teams.name(team) == "Foo"
+    end
+  end
+
   describe "get_or_create/1" do
     test "creates 'My Personal Sites' if user is a member of no teams" do
       today = Date.utc_today()

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -74,8 +74,10 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
     for role <- [:viewer, :owner] do
       test "returns list with personal and site segments for #{role}, avoiding segments from other site",
            %{conn: conn, user: user, site: site} do
+        team = team_of(user)
         other_user = new_user(name: "Other User")
-        other_site = new_site(owner: other_user, team: team_of(user))
+        other_site = new_site(team: team)
+        add_member(team, user: other_user, role: :owner)
 
         insert_list(2, :segment,
           site: other_site,

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -616,9 +616,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       user: user,
       site: site
     } do
-      site.team
-      |> Plausible.Teams.Team.setup_changeset()
-      |> Repo.update!()
+      Plausible.Teams.complete_setup(site.team)
 
       conn = delete(conn, "/me")
 
@@ -635,9 +633,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       user: user,
       site: site
     } do
-      site.team
-      |> Plausible.Teams.Team.setup_changeset()
-      |> Repo.update!()
+      Plausible.Teams.complete_setup(site.team)
 
       another_owner = new_user()
       another_site = new_site(owner: another_owner)

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -98,6 +98,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       other_owner = new_user() |> subscribe_to_growth_plan()
       new_team = team_of(other_owner)
       add_member(new_team, user: user, role: :viewer)
+      conn = set_current_team(conn, new_team)
 
       transfer = invite_transfer(site, user, inviter: old_owner)
 
@@ -284,6 +285,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
         _site = new_site(owner: owner)
         team = team_of(owner)
         add_member(team, user: user, role: unquote(role))
+        conn = set_current_team(conn, team)
 
         invitation =
           invite_member(team, "jane@example.com", inviter: owner, role: unquote(invitee_role))
@@ -354,6 +356,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       _site = new_site(owner: owner)
       team = team_of(owner)
       add_member(team, user: user, role: :editor)
+      conn = set_current_team(conn, team)
 
       remove_invitation_path =
         Routes.invitation_path(

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1136,6 +1136,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
     test "GET /settings/team/general", %{conn: conn, user: user} do
       {:ok, team} = Plausible.Teams.get_or_create(user)
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
       conn = get(conn, Routes.settings_path(conn, :team_general))
       html = html_response(conn, 200)
       assert html =~ "Team Information"
@@ -1159,7 +1161,9 @@ defmodule PlausibleWeb.SettingsControllerTest do
     end
 
     test "POST /settings/team/general/name - changeset error", %{conn: conn, user: user} do
-      {:ok, _team} = Plausible.Teams.get_or_create(user)
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
 
       conn =
         post(conn, Routes.settings_path(conn, :update_team_name), %{

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1137,9 +1137,10 @@ defmodule PlausibleWeb.SettingsControllerTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       conn = get(conn, Routes.settings_path(conn, :team_general))
       html = html_response(conn, 200)
-      assert html =~ "Team Name"
+      assert html =~ "Team Information"
       assert html =~ "Change the name of your team"
       assert text_of_attr(html, "input#team_name", "value") == team.name
+      assert text_of_attr(html, "input#team-identifier", "value") == team.identifier
     end
 
     test "POST /settings/team/general/name", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1129,7 +1129,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      assert html =~ "Team Settings"
+      refute html =~ "Team Settings"
       refute html =~ team.name
     end
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1118,7 +1118,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
     test "renders team settings, when team assigned and set up", %{conn: conn, user: user} do
       {:ok, team} = Plausible.Teams.get_or_create(user)
-      team |> Plausible.Teams.Team.setup_changeset() |> Repo.update!()
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
       assert html =~ "Team Settings"

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -259,6 +259,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     test "fails to create site when not allowed to in selected team", %{conn: conn, user: user} do
       site = new_site()
       add_member(site.team, user: user, role: :viewer)
+      conn = set_current_team(conn, site.team)
 
       conn =
         post(conn, "/sites", %{
@@ -591,7 +592,9 @@ defmodule PlausibleWeb.SiteControllerTest do
       refute resp =~ "You can also invite people to your team"
       refute resp =~ "Team members automatically have access to this site."
 
-      user |> team_of() |> Teams.Team.setup_changeset() |> Repo.update!()
+      team = team_of(user)
+      Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
 
       resp = conn |> get("/#{site.domain}/settings/people") |> html_response(200)
       assert resp =~ "You can also invite people to your team"

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -25,6 +25,7 @@ defmodule PlausibleWeb.Live.SitesTest do
 
       new_site(owner: user)
       team = team_of(user)
+      team = Plausible.Teams.complete_setup(team)
 
       conn = set_current_team(conn, team)
 

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -13,6 +13,8 @@ defmodule PlausibleWeb.Live.SitesTest do
     test "renders empty sites page", %{conn: conn} do
       {:ok, _lv, html} = live(conn, "/sites")
 
+      assert text(html) =~ "My Personal Sites"
+
       assert text(html) =~ "You don't have any sites yet"
     end
 

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -18,6 +18,21 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert text(html) =~ "You don't have any sites yet"
     end
 
+    test "renders settings link when current team is set", %{user: user, conn: conn} do
+      {:ok, _lv, html} = live(conn, "/sites")
+
+      refute element_exists?(html, ~s|a[data-test-id="team-settings-link"]|)
+
+      new_site(owner: user)
+      team = team_of(user)
+
+      conn = set_current_team(conn, team)
+
+      {:ok, _lv, html} = live(conn, "/sites")
+
+      assert element_exists?(html, ~s|a[data-test-id="team-settings-link"]|)
+    end
+
     test "renders team invitations", %{user: user, conn: conn} do
       owner1 = new_user(name: "G.I. Joe")
       new_site(owner: owner1)

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -31,10 +31,10 @@ defmodule PlausibleWeb.Live.SitesTest do
       {:ok, _lv, html} = live(conn, "/sites")
 
       assert text_of_element(html, "#invitation-#{invitation1.invitation_id}") =~
-               "G.I. Joe has invited you to join the \"My Team\" as viewer member."
+               "G.I. Joe has invited you to join the \"My Personal Sites\" as viewer member."
 
       assert text_of_element(html, "#invitation-#{invitation2.invitation_id}") =~
-               "G.I. Jane has invited you to join the \"My Team\" as editor member."
+               "G.I. Jane has invited you to join the \"My Personal Sites\" as editor member."
 
       assert find(
                html,

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -24,8 +24,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       refute element_exists?(resp, ~s|button[phx-click="save-team-layout"]|)
     end
 
-    test "renders existing guests under Guest divider", %{conn: conn, user: user} do
-      site = new_site(owner: user)
+    test "renders existing guests under Guest divider", %{conn: conn, team: team, user: user} do
+      site = new_site(team: team)
       add_guest(site, role: :viewer, user: new_user(name: "Mr Guest", email: "guest@example.com"))
 
       resp =
@@ -102,11 +102,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :viewer)
     end
 
-    test "allows updating guest membership so it moves sections", %{
-      conn: conn,
-      user: user
-    } do
-      site = new_site(owner: user)
+    test "allows updating guest membership so it moves sections", %{conn: conn, team: team} do
+      site = new_site(team: team)
       add_guest(site, role: :viewer, user: new_user(name: "Mr Guest", email: "guest@example.com"))
 
       lv = get_liveview(conn)
@@ -154,7 +151,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       member2 = add_member(team, role: :admin)
       _invitation = invite_member(team, "sent@example.com", inviter: user, role: :viewer)
 
-      site = new_site(owner: user)
+      site = new_site(team: team)
 
       guest =
         add_guest(site,
@@ -223,7 +220,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
            user: user,
            team: team
          } do
-      site = new_site(owner: user)
+      site = new_site(team: team)
 
       member2 =
         add_guest(site,

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -22,6 +22,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
     test "redirects to /team/general if team is already set up", %{conn: conn, user: user} do
       {:ok, team} = Teams.get_or_create(user)
       Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
       assert {:error, {:redirect, %{to: "/settings/team/general"}}} = live(conn, @url)
     end
   end

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -110,7 +110,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       save_layout(lv)
 
-      assert_redirect(lv, "/settings/team/general")
+      assert_redirect(lv, "/settings/team/general?team=" <> team.identifier)
 
       team = Repo.reload!(team)
 

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -51,6 +51,23 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       _ = render(lv)
     end
+
+    test "setting team name to 'My Personal Sites' is reserved", %{
+      conn: conn,
+      team: team,
+      user: user
+    } do
+      {:ok, lv, html} = live(conn, @url)
+
+      assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
+               "#{user.name}'s Teamk"
+
+      type_into_input(lv, "team[name]", "Team Name 1")
+      _ = render(lv)
+      type_into_input(lv, "team[name]", "My Personal Sites")
+      _ = render(lv)
+      assert Repo.reload!(team).name == "Team Name 1"
+    end
   end
 
   describe "/team/setup - full integration" do

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -21,15 +21,8 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
     test "redirects to /team/general if team is already set up", %{conn: conn, user: user} do
       {:ok, team} = Teams.get_or_create(user)
-      team |> Teams.Team.setup_changeset() |> Repo.update!()
+      Teams.complete_setup(team)
       assert {:error, {:redirect, %{to: "/settings/team/general"}}} = live(conn, @url)
-    end
-
-    test "does not redirect to /team/general if dev mode", %{conn: conn, user: user} do
-      {:ok, team} = Teams.get_or_create(user)
-      team |> Teams.Team.setup_changeset() |> Repo.update!()
-      assert {:ok, lv, _} = live(conn, @url <> "?dev=1")
-      _ = render(lv)
     end
   end
 

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -60,7 +60,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       {:ok, lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "#{user.name}'s Teamk"
+               "#{user.name}'s Team"
 
       type_into_input(lv, "team[name]", "Team Name 1")
       _ = render(lv)

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -46,15 +46,15 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       assert Repo.reload!(team).name == "Jane Smith's Team"
     end
 
-    test "does not rename the team if different than stock name", %{conn: conn, team: team} do
+    test "renames even if team already has non-default name", %{conn: conn, team: team} do
       assert team.name == "My Personal Sites"
       Repo.update!(Teams.Team.name_changeset(team, %{name: "Foo"}))
       {:ok, _lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "Foo"
+               "Jane Smith's Team"
 
-      assert Repo.reload!(team).name == "Foo"
+      assert Repo.reload!(team).name == "Jane Smith's Team"
     end
 
     test "renders form", %{conn: conn} do

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -110,7 +110,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       save_layout(lv)
 
-      assert_redirect(lv, "/settings/team/general?team=" <> team.identifier)
+      assert_redirect(lv, "/settings/team/general?__team=" <> team.identifier)
 
       team = Repo.reload!(team)
 

--- a/test/plausible_web/plugs/auth_plug_test.exs
+++ b/test/plausible_web/plugs/auth_plug_test.exs
@@ -56,7 +56,7 @@ defmodule PlausibleWeb.AuthPlugTest do
 
     conn =
       conn
-      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{team: team.identifier})
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{__team: team.identifier})
       |> AuthPlug.call(%{})
 
     assert conn.assigns[:current_team].id == team.id

--- a/test/plausible_web/plugs/auth_plug_test.exs
+++ b/test/plausible_web/plugs/auth_plug_test.exs
@@ -49,4 +49,46 @@ defmodule PlausibleWeb.AuthPlugTest do
     assert conn.assigns[:current_user].id == user.id
     assert conn.assigns[:my_team].subscription.paddle_plan_id == "456"
   end
+
+  test "switches current team when `team` parameter provided", %{conn: conn, user: user} do
+    subscribe_to_plan(user, "123", inserted_at: NaiveDateTime.utc_now())
+    team = team_of(user)
+
+    conn =
+      conn
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{team: team.identifier})
+      |> AuthPlug.call(%{})
+
+    assert conn.assigns[:current_team].id == team.id
+    assert get_session(conn, "current_team_id") == team.identifier
+  end
+
+  test "does not switch to team provided via `team` the user doesn't belong to", %{conn: conn} do
+    other_user = new_user()
+    subscribe_to_plan(other_user, "123", inserted_at: NaiveDateTime.utc_now())
+    team = team_of(other_user)
+
+    conn =
+      conn
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{team: team.identifier})
+      |> AuthPlug.call(%{})
+
+    refute conn.assigns[:current_team]
+    refute get_session(conn, "current_team_id")
+  end
+
+  test "does not switch to a team from session when the user doesn't belong to it", %{conn: conn} do
+    other_user = new_user()
+    subscribe_to_plan(other_user, "123", inserted_at: NaiveDateTime.utc_now())
+    team = team_of(other_user)
+
+    conn =
+      conn
+      |> put_session("current_team_id", team.identifier)
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{})
+      |> AuthPlug.call(%{})
+
+    refute conn.assigns[:current_team]
+    refute get_session(conn, "current_team_id")
+  end
 end

--- a/test/plausible_web/plugs/auth_plug_test.exs
+++ b/test/plausible_web/plugs/auth_plug_test.exs
@@ -91,4 +91,17 @@ defmodule PlausibleWeb.AuthPlugTest do
     refute conn.assigns[:current_team]
     refute get_session(conn, "current_team_id")
   end
+
+  test "falls back to my_team when there's no current team picked", %{conn: conn, user: user} do
+    subscribe_to_plan(user, "123", inserted_at: NaiveDateTime.utc_now())
+    team = team_of(user)
+
+    conn =
+      conn
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{})
+      |> AuthPlug.call(%{})
+
+    assert conn.assigns[:current_team].id == team.id
+    refute get_session(conn, "current_team_id")
+  end
 end

--- a/test/plausible_web/plugs/user_session_touch_test.exs
+++ b/test/plausible_web/plugs/user_session_touch_test.exs
@@ -18,6 +18,7 @@ defmodule PlausibleWeb.Plugs.UserSessionTouchTest do
 
     assert %{assigns: %{current_user_session: user_session}} =
              conn
+             |> Plug.Conn.fetch_query_params()
              |> AuthPlug.call([])
              |> UserSessionTouch.call([])
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: "My Personal Sites",
+      name: Plausible.Teams.name(),
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: Plausible.Teams.name(),
+      name: Plausible.Teams.default_name(),
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Factory do
 
   def team_factory do
     %Plausible.Teams.Team{
-      name: "My Team",
+      name: "My Personal Sites",
       trial_expiry_date: Timex.today() |> Timex.shift(days: 30),
       setup_complete: true,
       setup_at: NaiveDateTime.utc_now()

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -19,19 +19,24 @@ defmodule Plausible.Teams.Test do
 
   def new_site(args \\ []) do
     args =
-      if user = args[:owner] do
-        {owner, args} = Keyword.pop(args, :owner)
-        {:ok, team} = Teams.get_or_create(user)
+      cond do
+        args[:team] ->
+          args
 
-        args
-        |> Keyword.put(:owners, [owner])
-        |> Keyword.put(:team, team)
-      else
-        user = new_user()
-        {:ok, team} = Teams.get_or_create(user)
+        user = args[:owner] ->
+          {owner, args} = Keyword.pop(args, :owner)
+          {:ok, team} = Teams.get_or_create(user)
 
-        args
-        |> Keyword.put(:team, team)
+          args
+          |> Keyword.put(:owners, [owner])
+          |> Keyword.put(:team, team)
+
+        true ->
+          user = new_user()
+          {:ok, team} = Teams.get_or_create(user)
+
+          args
+          |> Keyword.put(:team, team)
       end
 
     :site

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -17,12 +17,13 @@ defmodule Plausible.Teams.Test do
     end
   end
 
+  def set_current_team(conn, team) do
+    Plug.Conn.put_session(conn, :current_team_id, team.identifier)
+  end
+
   def new_site(args \\ []) do
     args =
       cond do
-        args[:team] ->
-          args
-
         user = args[:owner] ->
           {owner, args} = Keyword.pop(args, :owner)
           {:ok, team} = Teams.get_or_create(user)
@@ -30,6 +31,9 @@ defmodule Plausible.Teams.Test do
           args
           |> Keyword.put(:owners, [owner])
           |> Keyword.put(:team, team)
+
+        args[:team] ->
+          args
 
         true ->
           user = new_user()

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -48,10 +48,7 @@ defmodule Plausible.TestUtils do
   end
 
   def setup_team(%{team: team}) do
-    team =
-      team
-      |> Plausible.Teams.Team.setup_changeset()
-      |> Repo.update!()
+    team = Plausible.Teams.complete_setup(team)
 
     {:ok, team: team}
   end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -47,10 +47,14 @@ defmodule Plausible.TestUtils do
     {:ok, team: team}
   end
 
-  def setup_team(%{team: team}) do
+  def setup_team(%{conn: conn, team: team}) do
     team = Plausible.Teams.complete_setup(team)
 
-    {:ok, team: team}
+    conn =
+      conn
+      |> Plug.Conn.put_session(:current_team_id, team.identifier)
+
+    {:ok, conn: conn, team: team}
   end
 
   def create_legacy_site_import(%{site: site}) do


### PR DESCRIPTION
### Changes

This PR renames "My Team" to "My Personal Sites" when team's setup is not complete yet.

It also enforces team name change during setup, treating "My Personal Sites" as reserved name. There's a default generated on the basis of user's name.

The CTA is also rephrased to "Setup Team" instead of "Create Team" to express the intent better.

The team name is now used in place of "My Sites" heading in sites list view to clearly identify which team the user is switched to. The "My Personal Sites" heading is also the default for a case where user is not a member of any team yet.

The heading change is hidden behind a flag for now.

Other changes done as a part of this PR:

- sites listing behavior is changed depending on the team state
  - if there's no team passed or the passed team is not setup yet, site invitations, sites transfers, guest sites and owned sites (if personal team exists) are listed
  - if the team is setup already, only transfers and sites for that particular team are listed
- when a personal team is setup, it's now possible to create another personal team by add another site under "My Personal Sites"
- once the team is setup if stops being treated as user's personal team
- an embedded team switcher is introduced, showing up to 3 teams the user can switch between directly from navbar; if user is a member of more teams, a "Switch to Another Team" option is presented
- basically all controller actions using team from context are now always using `current_team`
- `current_team` does fall back to `my_team`, if present but otherwise, remains unset if not picked explicitly

### Tests
- [x] Automated tests have been added

