### PR TITLE
Reveal segment filters in v2 Stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ All notable changes to this project will be documented in this file.
 - Add text version to emails plausible/analytics#4674
 - Add acquisition channels report
 - Add filter `is not` for goals in dashboard plausible/analytics#4983
-- Add Segments feature
-- Support `["is", "segment", [<segment ID>]]` filter in Stats API
 
 ### Removed
 
@@ -25,7 +23,6 @@ All notable changes to this project will be documented in this file.
 - Improved report performance in cases where site has a lot of unique pathnames
 - Plausible script now uses `fetch` with keepalive flag as default over `XMLHttpRequest`. This will ensure more reliable tracking. Reminder to use `compat` script variant if tracking Internet Explorer is required.
 - The old `/api/health` healtcheck is soft-deprecated in favour of separate `/api/system/health/live` and `/api/system/health/ready` checks
-- Changed top bar filter menu and how applied filters wrap
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Add text version to emails plausible/analytics#4674
 - Add acquisition channels report
 - Add filter `is not` for goals in dashboard plausible/analytics#4983
+- Add Segments feature
+- Support `["is", "segment", [<segment ID>]]` filter in Stats API
 
 ### Removed
 
@@ -23,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Improved report performance in cases where site has a lot of unique pathnames
 - Plausible script now uses `fetch` with keepalive flag as default over `XMLHttpRequest`. This will ensure more reliable tracking. Reminder to use `compat` script variant if tracking Internet Explorer is required.
 - The old `/api/health` healtcheck is soft-deprecated in favour of separate `/api/system/health/live` and `/api/system/health/ready` checks
+- Changed top bar filter menu and how applied filters wrap
 
 ### Fixed
 

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -462,10 +462,7 @@
         { "$ref": "#/definitions/filter_without_goals" },
         { "$ref": "#/definitions/filter_with_goals" },
         { "$ref": "#/definitions/filter_with_pattern" },
-        {
-          "$ref": "#/definitions/filter_for_segment",
-          "$comment": "only :internal"
-        }
+        { "$ref": "#/definitions/filter_for_segment" }
       ]
     },
     "filter_tree": {

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4900,20 +4900,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
   describe "segment filters" do
     setup [:create_user, :create_site, :create_api_key, :use_api_key]
 
-    test "segment filters are (not yet) available in public API", %{conn: conn, site: site} do
-      conn =
-        post(conn, "/api/v2/query", %{
-          "site_id" => site.domain,
-          "filters" => [["is", "segment", [1]]],
-          "date_range" => "all",
-          "metrics" => ["visitors"]
-        })
-
-      assert json_response(conn, 400) == %{
-               "error" => "#/filters/0: Invalid filter [\"is\", \"segment\", [1]]"
-             }
-    end
-
     test "site segments of other sites don't resolve", %{
       conn: conn,
       site: site
@@ -4933,7 +4919,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
         )
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "filters" => [["is", "segment", [segment.id]]],
           "date_range" => "all",
@@ -4987,7 +4973,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "filters" => [["is", "segment", [segment.id]]],
           "date_range" => "all",


### PR DESCRIPTION
### Changes

Reveals segment filter in v2 Stats API. 

docs: https://github.com/plausible/docs/pull/586

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
