### PR TITLE
Prepare FE feature flag for launching smoothly

### DIFF
--- a/assets/js/dashboard/nav-menu/top-bar.test.tsx
+++ b/assets/js/dashboard/nav-menu/top-bar.test.tsx
@@ -14,7 +14,8 @@ import { TopBar } from './top-bar'
 import { MockAPI } from '../../../test-utils/mock-api'
 
 const flags = {
-  saved_segments: true
+  saved_segments: true,
+  saved_segments_fe: true
 }
 const domain = 'dummy.site'
 const domains = [domain, 'example.com', 'blog.example.com']

--- a/assets/js/dashboard/nav-menu/top-bar.tsx
+++ b/assets/js/dashboard/nav-menu/top-bar.tsx
@@ -49,12 +49,12 @@ function TopBarStickyWrapper({ children }: { children: ReactNode }) {
 function TopBarInner({ showCurrentVisitors }: TopBarProps) {
   const site = useSiteContext()
   const user = useUserContext()
-  const { saved_segments } = site.flags
+  const { saved_segments, saved_segments_fe } = site.flags
   const leftActionsRef = useRef<HTMLDivElement>(null)
 
   return (
     <div className="flex items-center w-full">
-      {saved_segments ? (
+      {!!saved_segments && !!saved_segments_fe ? (
         <>
           <div
             className="flex items-center gap-x-4 shrink-0"

--- a/assets/js/dashboard/segments/routeless-segment-modals.tsx
+++ b/assets/js/dashboard/segments/routeless-segment-modals.tsx
@@ -140,7 +140,11 @@ export const RoutelessSegmentModals = () => {
     }
   })
 
-  if (!user.loggedIn || !site.flags.saved_segments) {
+  if (
+    !user.loggedIn ||
+    !site.flags.saved_segments ||
+    !site.flags.saved_segments_fe
+  ) {
     return null
   }
 

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -30,6 +30,7 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
 type FeatureFlags = {
   channels?: boolean
   saved_segments?: boolean
+  saved_segments_fe?: boolean
 }
 
 const siteContextDefaultValue = {

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -22,7 +22,8 @@ export function getAvailableFilterModals(site) {
   return {
     ...rest,
     ...(site.propsAvailable && { props }),
-    ...(site.flags.saved_segments && { segment })
+    ...(site.flags.saved_segments &&
+      site.flags.saved_segments_fe && { segment })
   }
 }
 

--- a/assets/js/dashboard/util/filters.test.ts
+++ b/assets/js/dashboard/util/filters.test.ts
@@ -7,7 +7,7 @@ describe(`${getAvailableFilterModals.name}`, () => {
     expect(
       getAvailableFilterModals({
         propsAvailable: false,
-        flags: { saved_segments: null }
+        flags: { saved_segments: null, saved_segments_fe: null }
       })
     ).toEqual({
       browser: ['browser', 'browser_version'],
@@ -32,7 +32,7 @@ describe(`${getAvailableFilterModals.name}`, () => {
     expect(
       getAvailableFilterModals({
         propsAvailable: true,
-        flags: { saved_segments: true }
+        flags: { saved_segments: true, saved_segments_fe: true }
       })
     ).toEqual({
       browser: ['browser', 'browser_version'],

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -395,7 +395,7 @@ defmodule PlausibleWeb.StatsController do
 
   defp get_flags(user, site),
     do:
-      [:saved_segments, :scroll_depth]
+      [:saved_segments, :saved_segments_fe, :scroll_depth]
       |> Enum.map(fn flag ->
         {flag, FunWithFlags.enabled?(flag, for: user) || FunWithFlags.enabled?(flag, for: site)}
       end)

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -83,7 +83,8 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       assigns.selected_business_plan || List.last(assigns.available_plans.business)
 
     saved_segments_enabled? =
-      FunWithFlags.enabled?(:saved_segments, for: assigns.current_user)
+      FunWithFlags.enabled?(:saved_segments_fe, for: assigns.current_user) and
+        FunWithFlags.enabled?(:saved_segments, for: assigns.current_user)
 
     growth_benefits =
       PlanBenefits.for_growth(growth_plan_to_render) ++


### PR DESCRIPTION
### Changes

Needed to prevent unexpected 404s when `saved_segments` feature flag has propagated to the node that serves the dashboard, but not to *all* app nodes.

To use successfully, we'd first enable `saved_segments` feature flag, ensure it is propagated, then enable `saved_segments_fe` flag. That signals dashboards to start making segment related requests.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
