### PR TITLE
Add site_segments feature to enterprise plans

### DIFF
--- a/priv/repo/migrations/20250306083000_add_site_segments_feature_to_enterprise_plans.exs
+++ b/priv/repo/migrations/20250306083000_add_site_segments_feature_to_enterprise_plans.exs
@@ -1,0 +1,20 @@
+defmodule Plausible.Repo.Migrations.AddSiteSegmentsFeatureToEnterprisePlans do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE enterprise_plans
+    SET features = array_append(features, 'site_segments')
+    WHERE features @> ARRAY['props', 'stats_api', 'funnels', 'revenue_goals']::varchar[]
+      AND NOT (features @> ARRAY['site_segments']::varchar[])
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE enterprise_plans
+    SET features = array_remove(features, 'site_segments')
+    WHERE features @> ARRAY['props', 'stats_api', 'funnels', 'revenue_goals', 'site_segments']::varchar[]
+    """
+  end
+end


### PR DESCRIPTION
### Changes

Adds :site_segments feature to some plans.

### Tests
Up
```
plausible_dev=# select id,features from enterprise_plans;
 id |                features                 
----+-----------------------------------------
  1 | {stats_api,props,funnels,revenue_goals}
  2 | {stats_api,props}
(2 rows)

plausible_dev=#     UPDATE enterprise_plans
    SET features = array_append(features, 'site_segments')
    WHERE features @> ARRAY['props', 'stats_api', 'funnels', 'revenue_goals']::varchar[]
      AND NOT (features @> ARRAY['site_segments']::varchar[]);
UPDATE 1
plausible_dev=# select id,features from enterprise_plans;
 id |                       features                        
----+-------------------------------------------------------
  2 | {stats_api,props}
  1 | {stats_api,props,funnels,revenue_goals,site_segments}
(2 rows)
```

Down
```
plausible_dev=#     UPDATE enterprise_plans
    SET features = array_remove(features, 'site_segments')
    WHERE features @> ARRAY['props', 'stats_api', 'funnels', 'revenue_goals', 'site_segments']::varchar[];
UPDATE 1
plausible_dev=# select id,features from enterprise_plans;
 id |                features                 
----+-----------------------------------------
  2 | {stats_api,props}
  1 | {stats_api,props,funnels,revenue_goals}
(2 rows)
```

### Changelog
Has separate PR

### Documentation
Part of Segments

### Dark mode
- [x] This PR does not change the UI
