### PR TITLE
Improve dashboard main graph - revenue metrics, nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
 - Plausible script now uses `fetch` with keepalive flag as default over `XMLHttpRequest`. This will ensure more reliable tracking. Reminder to use `compat` script variant if tracking Internet Explorer is required.
 - The old `/api/health` healtcheck is soft-deprecated in favour of separate `/api/system/health/live` and `/api/system/health/ready` checks
 - Changed top bar filter menu and how applied filters wrap
+- Main graph now shows revenue with relevant currency symbol when hovering a data point
+- Main graph now shows `-` instead of `0` for visit duration, scroll depth when hovering a data point with no visit data
 
 ### Fixed
 

--- a/assets/js/dashboard/stats/graph/graph-tooltip.js
+++ b/assets/js/dashboard/stats/graph/graph-tooltip.js
@@ -44,13 +44,14 @@ const buildTooltipData = function(query, graphData, metric, tooltipModel) {
   const label = data && renderBucketLabel(query, graphData, graphData.labels[data.dataIndex])
   const comparisonLabel = comparisonData && renderBucketLabel(query, graphData, graphData.comparison_labels[comparisonData.dataIndex], true)
 
-  const value = data?.raw || 0
-  const comparisonValue = comparisonData?.raw || 0
-  const comparisonDifference = label && comparisonLabel && calculatePercentageDifference(comparisonValue, value)
+  const value = graphData.plot[data.dataIndex]
 
-  const metricFormatter = MetricFormatterShort[metric]
-  const formattedValue = metricFormatter(value)
-  const formattedComparisonValue = comparisonData && metricFormatter(comparisonValue)
+  const formatter = MetricFormatterShort[metric]
+  const comparisonValue = graphData.comparison_plot?.[comparisonData.dataIndex]
+  const comparisonDifference = label && comparisonData && calculatePercentageDifference(comparisonValue, value)
+
+  const formattedValue = formatter(value)
+  const formattedComparisonValue = comparisonData && formatter(comparisonValue)
 
   return { label, formattedValue, comparisonLabel, formattedComparisonValue, comparisonDifference }
 }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -34,13 +34,25 @@ export const METRIC_LABELS = {
   'conversion_rate': 'Conversion Rate',
   'average_revenue': 'Average Revenue',
   'total_revenue': 'Total Revenue',
+  'scroll_depth': 'Scroll Depth',
+}
+
+function plottable(dataArray) {
+  return dataArray?.map((value) => {
+    if (typeof value === 'object' && value !== null) {
+      // Revenue metrics are returned as objects with a `value` property
+      return value.value
+    }
+
+    return value || 0
+  })
 }
 
 const buildComparisonDataset = function(comparisonPlot) {
   if (!comparisonPlot) return []
 
   return [{
-    data: comparisonPlot,
+    data: plottable(comparisonPlot),
     borderColor: 'rgba(60,70,110,0.2)',
     pointBackgroundColor: 'rgba(60,70,110,0.2)',
     pointHoverBackgroundColor: 'rgba(60, 70, 110)',
@@ -55,7 +67,7 @@ const buildDashedDataset = function(plot, presentIndex) {
   const dashedPlot = (new Array(presentIndex - 1)).concat(dashedPart)
 
   return [{
-    data: dashedPlot,
+    data: plottable(dashedPlot),
     borderDash: [3, 3],
     borderColor: 'rgba(101,116,205)',
     pointHoverBackgroundColor: 'rgba(71, 87, 193)',
@@ -67,7 +79,7 @@ const buildMainPlotDataset = function(plot, presentIndex) {
   const data = presentIndex ? plot.slice(0, presentIndex) : plot
 
   return [{
-    data: data,
+    data: plottable(data),
     borderColor: 'rgba(101,116,205)',
     pointBackgroundColor: 'rgba(101,116,205)',
     pointHoverBackgroundColor: 'rgba(71, 87, 193)',

--- a/assets/js/dashboard/stats/reports/metric-formatter.ts
+++ b/assets/js/dashboard/stats/reports/metric-formatter.ts
@@ -34,8 +34,8 @@ export const MetricFormatterShort: Record<
 
   conversions: numberShortFormatter,
 
-  time_on_page: durationFormatter,
-  visit_duration: durationFormatter,
+  time_on_page: nullable(durationFormatter),
+  visit_duration: nullable(durationFormatter),
 
   bounce_rate: percentageFormatter,
   conversion_rate: percentageFormatter,
@@ -62,8 +62,8 @@ export const MetricFormatterLong: Record<
 
   conversions: numberLongFormatter,
 
-  time_on_page: durationFormatter,
-  visit_duration: durationFormatter,
+  time_on_page: nullable(durationFormatter),
+  visit_duration: nullable(durationFormatter),
 
   bounce_rate: percentageFormatter,
   conversion_rate: percentageFormatter,

--- a/lib/plausible/stats/metrics.ex
+++ b/lib/plausible/stats/metrics.ex
@@ -26,6 +26,25 @@ defmodule Plausible.Stats.Metrics do
 
   def metric?(value), do: Enum.member?(@all_metrics, value)
 
+  on_ee do
+    def default_value(metric, query, dimensions)
+        when metric in [:average_revenue, :total_revenue],
+        do: Plausible.Stats.Goal.Revenue.format_revenue_metric(nil, query, dimensions)
+  end
+
+  def default_value(:visit_duration, _query, _dimensions), do: nil
+  def default_value(:scroll_depth, _query, _dimensions), do: nil
+
+  @float_metrics [
+    :views_per_visit,
+    :bounce_rate,
+    :percentage,
+    :conversion_rate,
+    :group_conversion_rate
+  ]
+  def default_value(metric, _query, _dimensions) when metric in @float_metrics, do: 0.0
+  def default_value(_metric, _query, _dimensions), do: 0
+
   def from_string!(str) do
     Map.fetch!(@metric_mappings, str)
   end

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -18,6 +18,7 @@ defmodule Plausible.Stats.QueryRunner do
     QueryOptimizer,
     QueryResult,
     Legacy,
+    Metrics,
     SQL,
     Util,
     Time
@@ -265,17 +266,8 @@ defmodule Plausible.Stats.QueryRunner do
 
   defp empty_metrics(query, dimensions) do
     query.metrics
-    |> Enum.map(fn metric -> empty_metric_value(metric, query, dimensions) end)
+    |> Enum.map(fn metric -> Metrics.default_value(metric, query, dimensions) end)
   end
-
-  on_ee do
-    defp empty_metric_value(metric, query, dimensions)
-         when metric in [:total_revenue, :average_revenue],
-         do: Plausible.Stats.Goal.Revenue.format_revenue_metric(nil, query, dimensions)
-  end
-
-  defp empty_metric_value(:scroll_depth, _query, _dimensions), do: nil
-  defp empty_metric_value(_metric, _query, _dimensions), do: 0
 
   defp total_rows([]), do: 0
   defp total_rows([first_row | _rest]), do: first_row.total_rows

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -203,7 +203,7 @@ defmodule Plausible.Stats.QueryRunner do
       |> Enum.reject(fn dimension_value -> Map.has_key?(indexed_results, [dimension_value]) end)
       |> Enum.map(fn dimension_value ->
         %{
-          metrics: empty_metrics(query),
+          metrics: empty_metrics(query, [dimension_value]),
           dimensions: [dimension_value]
         }
       end)
@@ -260,22 +260,22 @@ defmodule Plausible.Stats.QueryRunner do
   end
 
   defp get_comparison_metrics(comparison_map, dimensions, query) do
-    Map.get_lazy(comparison_map, dimensions, fn -> empty_metrics(query) end)
+    Map.get_lazy(comparison_map, dimensions, fn -> empty_metrics(query, dimensions) end)
   end
 
-  defp empty_metrics(query) do
+  defp empty_metrics(query, dimensions) do
     query.metrics
-    |> Enum.map(fn metric -> empty_metric_value(metric) end)
+    |> Enum.map(fn metric -> empty_metric_value(metric, query, dimensions) end)
   end
 
   on_ee do
-    defp empty_metric_value(metric)
+    defp empty_metric_value(metric, query, dimensions)
          when metric in [:total_revenue, :average_revenue],
-         do: nil
+         do: Plausible.Stats.Goal.Revenue.format_revenue_metric(nil, query, dimensions)
   end
 
-  defp empty_metric_value(:scroll_depth), do: nil
-  defp empty_metric_value(_), do: 0
+  defp empty_metric_value(:scroll_depth, _query, _dimensions), do: nil
+  defp empty_metric_value(_metric, _query, _dimensions), do: 0
 
   defp total_rows([]), do: 0
   defp total_rows([first_row | _rest]), do: first_row.total_rows

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -7,7 +7,7 @@ defmodule Plausible.Stats.Timeseries do
 
   use Plausible
   use Plausible.ClickhouseRepo
-  alias Plausible.Stats.{Comparisons, Query, QueryRunner, QueryOptimizer, Time}
+  alias Plausible.Stats.{Comparisons, Query, QueryRunner, QueryOptimizer, Metrics, Time}
 
   @time_dimension %{
     "month" => "time:month",
@@ -79,46 +79,9 @@ defmodule Plausible.Stats.Timeseries do
   end
 
   defp empty_row(date, metrics, query) do
-    Enum.reduce(metrics, %{date: date}, fn metric, row ->
-      case metric do
-        :pageviews ->
-          Map.merge(row, %{pageviews: 0})
-
-        :events ->
-          Map.merge(row, %{events: 0})
-
-        :visitors ->
-          Map.merge(row, %{visitors: 0})
-
-        :visits ->
-          Map.merge(row, %{visits: 0})
-
-        :views_per_visit ->
-          Map.merge(row, %{views_per_visit: 0.0})
-
-        :conversion_rate ->
-          Map.merge(row, %{conversion_rate: 0.0})
-
-        :group_conversion_rate ->
-          Map.merge(row, %{group_conversion_rate: 0.0})
-
-        :scroll_depth ->
-          Map.merge(row, %{scroll_depth: nil})
-
-        :bounce_rate ->
-          Map.merge(row, %{bounce_rate: 0.0})
-
-        :visit_duration ->
-          Map.merge(row, %{visit_duration: nil})
-
-        metric when metric in [:average_revenue, :total_revenue] ->
-          on_ee do
-            value = Plausible.Stats.Goal.Revenue.format_revenue_metric(nil, query, [date])
-
-            Map.merge(row, %{metric => value})
-          end
-      end
-    end)
+    metrics
+    |> Map.new(fn metric -> {metric, Metrics.default_value(metric, query, [date])} end)
+    |> Map.put(:date, date)
   end
 
   defp transform_metrics(metrics, to_replace) do

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -90,8 +90,8 @@ defmodule Plausible.Stats.Timeseries do
         :scroll_depth -> Map.merge(row, %{scroll_depth: nil})
         :bounce_rate -> Map.merge(row, %{bounce_rate: 0.0})
         :visit_duration -> Map.merge(row, %{visit_duration: nil})
-        :average_revenue -> Map.merge(row, %{average_revenue: nil})
-        :total_revenue -> Map.merge(row, %{total_revenue: nil})
+        :average_revenue -> Map.merge(row, %{average_revenue: 0.0})
+        :total_revenue -> Map.merge(row, %{total_revenue: 0.0})
       end
     end)
   end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -123,13 +123,7 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp plot_timeseries(timeseries, metric) do
-    Enum.map(timeseries, fn row ->
-      case row[metric] do
-        nil -> 0
-        %{value: value} -> value
-        value -> value
-      end
-    end)
+    Enum.map(timeseries, & &1[metric])
   end
 
   defp label_timeseries(main_result, nil) do

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -631,7 +631,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       assert %{"plot" => plot} = json_response(conn, 200)
 
-      assert plot == [40, 20, 0, 0, 0, 0, 0]
+      assert plot == [40, 20, nil, nil, nil, nil, nil]
     end
 
     test "returns scroll depth per day with imported data", %{conn: conn, site: site} do
@@ -676,7 +676,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       assert %{"plot" => plot} = json_response(conn, 200)
 
-      assert plot == [40, 30, 90, 0, 0, 0, 0]
+      assert plot == [40, 30, 90, nil, nil, nil, nil]
     end
   end
 
@@ -922,7 +922,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"plot" => plot} = json_response(conn, 200)
 
       assert Enum.count(plot) == 31
-      assert List.first(plot) == 0
+      assert List.first(plot) == nil
       assert List.last(plot) == 300
     end
 
@@ -1431,37 +1431,37 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"plot" => plot} = json_response(conn, 200)
 
       assert plot == [
-               13.29,
-               0.0,
-               0.0,
-               0.0,
-               19.9,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               30.31
+               %{"currency" => "USD", "long" => "$13.29", "short" => "$13.3", "value" => 13.29},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$19.90", "short" => "$19.9", "value" => 19.9},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$30.31", "short" => "$30.3", "value" => 30.31}
              ]
     end
 
@@ -1516,8 +1516,25 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       assert %{"plot" => plot, "comparison_plot" => prev} = json_response(conn, 200)
 
-      assert plot == [0.0, 0.0, 10.31, 0.0, 30.0, 0.0, 0.0]
-      assert prev == [13.29, 0.0, 0.0, 0.0, 19.9, 0.0, 0.0]
+      assert plot == [
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$10.31", "short" => "$10.3", "value" => 10.31},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$30.00", "short" => "$30.0", "value" => 30.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0}
+             ]
+
+      assert prev == [
+               %{"currency" => "USD", "long" => "$13.29", "short" => "$13.3", "value" => 13.29},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$19.90", "short" => "$19.9", "value" => 19.9},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0}
+             ]
     end
   end
 
@@ -1572,37 +1589,37 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"plot" => plot} = json_response(conn, 200)
 
       assert plot == [
-               31.895,
-               0.0,
-               0.0,
-               0.0,
-               19.9,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               0.0,
-               15.155
+               %{"currency" => "USD", "long" => "$31.90", "short" => "$31.9", "value" => 31.895},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$19.90", "short" => "$19.9", "value" => 19.9},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$15.16", "short" => "$15.2", "value" => 15.155}
              ]
     end
 
@@ -1657,8 +1674,25 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
 
       assert %{"plot" => plot, "comparison_plot" => prev} = json_response(conn, 200)
 
-      assert plot == [0.0, 0.0, 10.31, 0.0, 15.0, 0.0, 0.0]
-      assert prev == [13.29, 0.0, 0.0, 0.0, 19.9, 0.0, 0.0]
+      assert plot == [
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$10.31", "short" => "$10.3", "value" => 10.31},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$15.00", "short" => "$15.0", "value" => 15.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0}
+             ]
+
+      assert prev == [
+               %{"currency" => "USD", "long" => "$13.29", "short" => "$13.3", "value" => 13.29},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$19.90", "short" => "$19.9", "value" => 19.9},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0},
+               %{"currency" => "USD", "long" => "$0.00", "short" => "$0.0", "value" => 0.0}
+             ]
     end
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -650,8 +650,8 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
                  "comparison" => %{
                    "visitors" => 0,
                    "bounce_rate" => 0,
-                   "visit_duration" => 0,
-                   "change" => %{"visitors" => 100, "bounce_rate" => nil, "visit_duration" => 0}
+                   "visit_duration" => nil,
+                   "change" => %{"visitors" => 100, "bounce_rate" => nil, "visit_duration" => nil}
                  }
                },
                %{


### PR DESCRIPTION
### Changes

This PR improves main graph by:
- showing revenue with relevant currency symbol when hovering a data point
- showing `-` instead of `0` for visit duration, scroll depth when hovering a data point with no visit data

![image](https://github.com/user-attachments/assets/289cfeb2-b85d-4065-ba7c-4f7d175a99ae)
![image](https://github.com/user-attachments/assets/efc1462c-c08f-4e1c-b1db-54ca2060c96f)

This is preparatory work for new time-on-page metric (which will be graphable). 