### PR TITLE
time-on-page: `imported_pages` new columns

### DIFF
--- a/priv/ingest_repo/migrations/20250221124625_imported_pages_total_time_on_page.exs
+++ b/priv/ingest_repo/migrations/20250221124625_imported_pages_total_time_on_page.exs
@@ -1,0 +1,10 @@
+defmodule Plausible.IngestRepo.Migrations.ImportedPagesTotalTimeOnPage do
+  use Ecto.Migration
+
+  def change do
+    alter table(:imported_pages) do
+      add :total_time_on_page, :UInt64
+      add :total_time_on_page_visits, :UInt64
+    end
+  end
+end

--- a/priv/ingest_repo/migrations/20250304074501_populate_imported_pages_total_time_on_page.exs
+++ b/priv/ingest_repo/migrations/20250304074501_populate_imported_pages_total_time_on_page.exs
@@ -1,0 +1,19 @@
+defmodule Plausible.IngestRepo.Migrations.PopulateImportedPagesTotalTimeOnPage do
+  use Ecto.Migration
+
+  def up do
+    # Note: This only populates the new column for old GA4 imports.
+    # Other imports didn't populate the `time_on_page` column.
+    execute """
+    ALTER TABLE imported_pages
+    UPDATE
+      total_time_on_page = time_on_page,
+      total_time_on_page_visits = visits
+    WHERE time_on_page > 0
+    """
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end


### PR DESCRIPTION
### Changes

This PR adds 2 migrations:
- Adding new columns to `imported_pages`
- Updating the columns to be populated for old GA4 imports