### PR TITLE
Provide top stats graphable metrics from BE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Fix database mismatch between event and session user_ids after rotating salts
 - `/api/v2/query` no longer returns a 500 when querying percentage metric without `visitors`
 - Fix current visitors loading when viewing a dashboard with a shared link  
+- Fix Conversion Rate graph being unselectable when "Goal is ..." filter is within a segment
 
 ## v2.1.5-rc.1 - 2025-01-17
 

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -1,27 +1,3 @@
-import { getFiltersByKeyPrefix, hasConversionGoalFilter } from '../../util/filters'
-import { revenueAvailable } from '../../query'
-
-export function getGraphableMetrics(query, site) {
-  const isRealtime = query.period === 'realtime'
-  const isGoalFilter = hasConversionGoalFilter(query)
-  const isPageFilter = getFiltersByKeyPrefix(query, "page").length > 0
-
-  if (isRealtime && isGoalFilter) {
-    return ["visitors"]
-  } else if (isRealtime) {
-    return ["visitors", "pageviews"]
-  } else if (isGoalFilter && revenueAvailable(query, site)) {
-    return ["visitors", "events", "average_revenue", "total_revenue", "conversion_rate"]
-  } else if (isGoalFilter) {
-    return ["visitors", "events", "conversion_rate"]
-  } else if (isPageFilter) {
-    const pageFilterMetrics = ["visitors", "visits", "pageviews", "bounce_rate"]
-    return site.scrollDepthVisible ? [...pageFilterMetrics, "scroll_depth"] : pageFilterMetrics
-  } else {
-    return ["visitors", "visits", "pageviews", "views_per_visit", "bounce_rate", "visit_duration"]
-  }
-}
-
 export const METRIC_LABELS = {
   'visitors': 'Visitors',
   'pageviews': 'Pageviews',

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -6,7 +6,6 @@ import { SecondsSinceLastLoad } from '../../util/seconds-since-last-load'
 import classNames from 'classnames'
 import * as storage from '../../util/storage'
 import { formatDateRange } from '../../util/date'
-import { getGraphableMetrics } from './graph-util'
 import { useQueryContext } from '../../query-context'
 import { useSiteContext } from '../../site-context'
 import { useLastLoadContext } from '../../last-load-context'
@@ -26,7 +25,12 @@ function topStatNumberLong(metric, value) {
   return formatter(value)
 }
 
-export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
+export default function TopStats({
+  data,
+  onMetricUpdate,
+  tooltipBoundary,
+  graphableMetrics
+}) {
   const { query } = useQueryContext()
   const lastLoadTimestamp = useLastLoadContext()
   const site = useSiteContext()
@@ -77,7 +81,6 @@ export default function TopStats({ data, onMetricUpdate, tooltipBoundary }) {
   }
 
   function canMetricBeGraphed(stat) {
-    const graphableMetrics = getGraphableMetrics(query, site)
     return graphableMetrics.includes(stat.graph_metric)
   }
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -194,7 +194,8 @@ defmodule PlausibleWeb.Api.StatsController do
     %{
       top_stats: top_stats,
       meta: meta,
-      sample_percent: sample_percent
+      sample_percent: sample_percent,
+      graphable_metrics: graphable_metrics
     } = fetch_top_stats(site, query, current_user)
 
     comparison_query = comparison_query(query)
@@ -202,6 +203,7 @@ defmodule PlausibleWeb.Api.StatsController do
     json(conn, %{
       top_stats: top_stats,
       meta: meta,
+      graphable_metrics: graphable_metrics,
       interval: query.interval,
       sample_percent: sample_percent,
       with_imported_switch: with_imported_switch_info(meta),
@@ -276,7 +278,8 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp fetch_top_stats(site, query, current_user) do
-    goal_filter? = toplevel_goal_filter?(query)
+    goal_filter? =
+      toplevel_goal_filter?(query)
 
     cond do
       query.period == "30m" && goal_filter? ->
@@ -322,7 +325,12 @@ defmodule PlausibleWeb.Api.StatsController do
       }
     ]
 
-    %{top_stats: top_stats, meta: meta, sample_percent: 100}
+    %{
+      top_stats: top_stats,
+      meta: meta,
+      graphable_metrics: [:visitors, :events],
+      sample_percent: 100
+    }
   end
 
   defp fetch_realtime_top_stats(site, query) do
@@ -354,7 +362,12 @@ defmodule PlausibleWeb.Api.StatsController do
       }
     ]
 
-    %{top_stats: top_stats, meta: meta, sample_percent: 100}
+    %{
+      top_stats: top_stats,
+      meta: meta,
+      sample_percent: 100,
+      graphable_metrics: [:visitors, :pageviews]
+    }
   end
 
   defp fetch_goal_top_stats(site, query) do
@@ -377,7 +390,7 @@ defmodule PlausibleWeb.Api.StatsController do
       ]
       |> Enum.reject(&is_nil/1)
 
-    %{top_stats: top_stats, meta: meta, sample_percent: 100}
+    %{top_stats: top_stats, meta: meta, graphable_metrics: metrics, sample_percent: 100}
   end
 
   defp fetch_other_top_stats(site, query, current_user) do
@@ -428,7 +441,12 @@ defmodule PlausibleWeb.Api.StatsController do
 
     sample_percent = results[:sample_percent][:value]
 
-    %{top_stats: top_stats, meta: meta, sample_percent: sample_percent}
+    %{
+      top_stats: top_stats,
+      meta: meta,
+      graphable_metrics: metrics -- [:time_on_page],
+      sample_percent: sample_percent
+    }
   end
 
   defp top_stats_entry(current_results, name, key, opts \\ []) do
@@ -1656,6 +1674,9 @@ defmodule PlausibleWeb.Api.StatsController do
   defp realtime_period_to_30m(params), do: params
 
   defp toplevel_goal_filter?(query) do
-    Filters.filtering_on_dimension?(query, "event:goal", max_depth: 0)
+    Filters.filtering_on_dimension?(query, "event:goal",
+      max_depth: 0,
+      behavioral_filters: :ignore
+    )
   end
 end


### PR DESCRIPTION
### Changes

Fixes the issue with filters inside segments not being counted properly for top stats.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
