### PR TITLE
Stop counting engagement events into current visitors

### DIFF
--- a/lib/plausible/stats/current_visitors.ex
+++ b/lib/plausible/stats/current_visitors.ex
@@ -13,6 +13,7 @@ defmodule Plausible.Stats.CurrentVisitors do
       from e in "events_v2",
         where: e.site_id == ^site.id,
         where: e.timestamp >= ^first_datetime,
+        where: e.name != "engagement",
         select: uniq(e.user_id)
     )
   end

--- a/test/plausible_web/controllers/api/stats_controller/current_visitors_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/current_visitors_test.exs
@@ -5,9 +5,14 @@ defmodule PlausibleWeb.Api.StatsController.CurrentVisitorsTest do
     setup [:create_user, :log_in, :create_site]
 
     test "returns unique users in the last 5 minutes", %{conn: conn, site: site} do
+      now = DateTime.utc_now()
+
       populate_stats(site, [
-        build(:pageview, user_id: 123),
-        build(:pageview, user_id: 456)
+        build(:pageview, user_id: 123, timestamp: now |> DateTime.shift(minute: -3)),
+        build(:pageview, user_id: 456, timestamp: now |> DateTime.shift(minute: -3)),
+        build(:pageview, user_id: 123, timestamp: now |> DateTime.shift(minute: -1)),
+        build(:pageview, user_id: 789, timestamp: now |> DateTime.shift(minute: -7)),
+        build(:engagement, user_id: 789, timestamp: now |> DateTime.shift(minute: -3))
       ])
 
       conn = get(conn, "/api/stats/#{site.domain}/current-visitors")


### PR DESCRIPTION
This was unexpected breakage from releasing new tracker script with engagement tracking to the world. Users are seeing inflated current visitors counts compared to top sources report.

[Helpscout link](https://secure.helpscout.net/conversation/2869053683/23571?viewId=6980900)