### PR TITLE
Add billing role

### DIFF
--- a/assets/js/dashboard/user-context.tsx
+++ b/assets/js/dashboard/user-context.tsx
@@ -6,7 +6,8 @@ export enum Role {
   admin = 'admin',
   viewer = 'viewer',
   editor = 'editor',
-  public = 'public'
+  public = 'public',
+  billing = 'billing'
 }
 
 const userContextDefaultValue = {

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -89,7 +89,7 @@ defmodule Plausible.Billing do
     subscription =
       Subscription
       |> Repo.get_by(paddle_subscription_id: params["subscription_id"])
-      |> Repo.preload(team: :owners)
+      |> Repo.preload(team: [:owners, :billing_members])
 
     if subscription do
       changeset =
@@ -99,8 +99,8 @@ defmodule Plausible.Billing do
 
       updated = Repo.update!(changeset)
 
-      for owner <- subscription.team.owners do
-        owner
+      for recipient <- subscription.team.owners ++ subscription.team.billing_members do
+        recipient
         |> PlausibleWeb.Email.cancellation_email()
         |> Plausible.Mailer.send()
       end

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Billing.SiteLocker do
           Plausible.Teams.end_grace_period(team)
 
           if send_email? do
-            team = Repo.preload(team, :owners)
+            team = Repo.preload(team, [:owners, :billing_members])
             send_grace_period_end_email(team)
           end
 
@@ -64,8 +64,8 @@ defmodule Plausible.Billing.SiteLocker do
     usage = Teams.Billing.monthly_pageview_usage(team)
     suggested_plan = Plausible.Billing.Plans.suggest(team, usage.last_cycle.total)
 
-    for owner <- team.owners do
-      owner
+    for recipient <- team.owners ++ team.billing_members do
+      recipient
       |> PlausibleWeb.Email.dashboard_locked(usage, suggested_plan)
       |> Plausible.Mailer.send()
     end

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -6,7 +6,7 @@ defmodule Plausible.Segments do
   alias Plausible.Repo
   import Ecto.Query
 
-  @roles_with_personal_segments [:viewer, :editor, :admin, :owner, :super_admin]
+  @roles_with_personal_segments [:billing, :viewer, :editor, :admin, :owner, :super_admin]
   @roles_with_maybe_site_segments [:editor, :admin, :owner, :super_admin]
 
   @type error_not_enough_permissions() :: {:error, :not_enough_permissions}

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -7,7 +7,7 @@ defmodule Plausible.Teams.Membership do
 
   import Ecto.Changeset
 
-  @roles [:guest, :viewer, :editor, :admin, :owner]
+  @roles [:guest, :viewer, :editor, :admin, :owner, :billing]
 
   @type t() :: %__MODULE__{}
 

--- a/lib/plausible/teams/memberships/update_role.ex
+++ b/lib/plausible/teams/memberships/update_role.ex
@@ -73,20 +73,26 @@ defmodule Plausible.Teams.Memberships.UpdateRole do
   defp can_grant_role_to_self?(:owner, :admin), do: true
   defp can_grant_role_to_self?(:owner, :editor), do: true
   defp can_grant_role_to_self?(:owner, :viewer), do: true
+  defp can_grant_role_to_self?(:owner, :billing), do: true
   defp can_grant_role_to_self?(:admin, :editor), do: true
   defp can_grant_role_to_self?(:admin, :viewer), do: true
+  defp can_grant_role_to_self?(:admin, :billing), do: true
   defp can_grant_role_to_self?(_, _), do: false
 
   defp can_grant_role_to_other?(:owner, _, _), do: true
   defp can_grant_role_to_other?(:admin, :admin, :admin), do: true
   defp can_grant_role_to_other?(:admin, :admin, :editor), do: true
   defp can_grant_role_to_other?(:admin, :admin, :viewer), do: true
+  defp can_grant_role_to_other?(:admin, :admin, :billing), do: true
   defp can_grant_role_to_other?(:admin, :editor, :admin), do: true
   defp can_grant_role_to_other?(:admin, :editor, :editor), do: true
   defp can_grant_role_to_other?(:admin, :editor, :viewer), do: true
+  defp can_grant_role_to_other?(:admin, :editor, :billing), do: true
   defp can_grant_role_to_other?(:admin, :viewer, :admin), do: true
   defp can_grant_role_to_other?(:admin, :viewer, :editor), do: true
   defp can_grant_role_to_other?(:admin, :viewer, :viewer), do: true
+  defp can_grant_role_to_other?(:admin, :viewer, :billing), do: true
+  defp can_grant_role_to_other?(:admin, :billing, :billing), do: true
   defp can_grant_role_to_other?(_, _, _), do: false
 
   defp maybe_prune_guest_memberships(%Teams.Membership{role: :guest}),

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -44,7 +44,12 @@ defmodule Plausible.Teams.Team do
       where: [role: :owner],
       preload_order: [asc: :id]
 
+    has_many :billing_memberships, Plausible.Teams.Membership,
+      where: [role: :billing],
+      preload_order: [asc: :id]
+
     has_many :owners, through: [:ownerships, :user]
+    has_many :billing_members, through: [:billing_memberships, :user]
 
     timestamps()
   end

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -8,6 +8,8 @@ defmodule PlausibleWeb.BillingController do
 
   plug PlausibleWeb.RequireAccountPlug
 
+  plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :admin, :billing]
+
   def ping_subscription(%Plug.Conn{} = conn, _params) do
     subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.current_team)
 

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -8,6 +8,10 @@ defmodule PlausibleWeb.SettingsController do
 
   require Logger
 
+  # XXX carry on
+  plug Plausible.Plugs.AuthorizeTeamAccess,
+       [:owner, :admin] when action in [:update_team_name]
+
   def index(conn, _params) do
     redirect(conn, to: Routes.settings_path(conn, :preferences))
   end
@@ -32,12 +36,6 @@ defmodule PlausibleWeb.SettingsController do
 
   defp render_team_general(conn, opts \\ []) do
     if Plausible.Teams.setup?(conn.assigns.current_team) do
-      my_role =
-        Plausible.Teams.Memberships.team_role(
-          conn.assigns.current_team,
-          conn.assigns.current_user
-        )
-
       name_changeset =
         Keyword.get(
           opts,
@@ -48,8 +46,7 @@ defmodule PlausibleWeb.SettingsController do
       render(conn, :team_general,
         team_name_changeset: name_changeset,
         layout: {PlausibleWeb.LayoutView, :settings},
-        connect_live_socket: true,
-        my_role: my_role
+        connect_live_socket: true
       )
     else
       conn

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -32,6 +32,12 @@ defmodule PlausibleWeb.SettingsController do
 
   defp render_team_general(conn, opts \\ []) do
     if Plausible.Teams.setup?(conn.assigns.current_team) do
+      my_role =
+        Plausible.Teams.Memberships.team_role(
+          conn.assigns.current_team,
+          conn.assigns.current_user
+        )
+
       name_changeset =
         Keyword.get(
           opts,
@@ -42,7 +48,8 @@ defmodule PlausibleWeb.SettingsController do
       render(conn, :team_general,
         team_name_changeset: name_changeset,
         layout: {PlausibleWeb.LayoutView, :settings},
-        connect_live_socket: true
+        connect_live_socket: true,
+        my_role: my_role
       )
     else
       conn

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -8,9 +8,11 @@ defmodule PlausibleWeb.SettingsController do
 
   require Logger
 
-  # XXX carry on
   plug Plausible.Plugs.AuthorizeTeamAccess,
        [:owner, :admin] when action in [:update_team_name]
+
+  plug Plausible.Plugs.AuthorizeTeamAccess,
+       [:owner, :admin, :billing] when action in [:invoices]
 
   def index(conn, _params) do
     redirect(conn, to: Routes.settings_path(conn, :preferences))

--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -64,6 +64,23 @@ defmodule PlausibleWeb.Live.AuthContext do
         _ ->
           nil
       end)
+      |> assign_new(
+        :current_role,
+        fn
+          %{current_user: user = %{}, current_team: current_team = %{}} ->
+            Enum.find_value(user.team_memberships, fn team_membership ->
+              if team_membership.team_id == current_team.id do
+                team_membership.role
+              end
+            end)
+
+          %{my_team: %{}} ->
+            :owner
+
+          _ ->
+            nil
+        end
+      )
       |> assign_new(:teams, fn
         %{current_user: nil} ->
           []

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -22,9 +22,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
   end
 
   defp reset(%{assigns: %{current_user: current_user, current_team: current_team}} = socket) do
-    {:ok, my_role} =
-      Teams.Memberships.team_role(current_team, current_user)
-      |> IO.inspect(label: :my_role)
+    {:ok, my_role} = Teams.Memberships.team_role(current_team, current_user)
 
     layout = Layout.init(current_team)
     team_members_limit = Plausible.Teams.Billing.team_member_limit(current_team)

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -22,23 +22,21 @@ defmodule PlausibleWeb.Live.TeamManagement do
   end
 
   defp reset(%{assigns: %{current_user: current_user, current_team: current_team}} = socket) do
-    {:ok, my_role} = Teams.Memberships.team_role(current_team, current_user)
+    {:ok, my_role} =
+      Teams.Memberships.team_role(current_team, current_user)
+      |> IO.inspect(label: :my_role)
 
-    if my_role not in [:owner, :admin] do
-      redirect(socket, to: Routes.settings_path(socket, :team_general))
-    else
-      layout = Layout.init(current_team)
-      team_members_limit = Plausible.Teams.Billing.team_member_limit(current_team)
+    layout = Layout.init(current_team)
+    team_members_limit = Plausible.Teams.Billing.team_member_limit(current_team)
 
-      assign(socket,
-        team_members_limit: team_members_limit,
-        layout: layout,
-        my_role: my_role,
-        team_layout_changed?: false,
-        input_role: :viewer,
-        input_email: ""
-      )
-    end
+    assign(socket,
+      team_members_limit: team_members_limit,
+      layout: layout,
+      my_role: my_role,
+      team_layout_changed?: false,
+      input_role: :viewer,
+      input_email: ""
+    )
   end
 
   def render(assigns) do
@@ -64,7 +62,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
               value={@input_email}
               placeholder="Enter e-mail to send invitation to"
               phx-debounce={200}
-              readonly={at_limit?(@layout, @team_members_limit)}
+              readonly={at_limit?(@layout, @team_members_limit) or @my_role not in [:admin, :owner]}
               mt?={false}
             />
           </div>
@@ -113,7 +111,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
             id="invite-member"
             type="submit"
             mt?={false}
-            disabled={at_limit?(@layout, @team_members_limit)}
+            disabled={at_limit?(@layout, @team_members_limit) or @my_role not in [:admin, :owner]}
           >
             Invite
           </.button>
@@ -129,7 +127,10 @@ defmodule PlausibleWeb.Live.TeamManagement do
           label={entry_label(entry, @current_user)}
           my_role={@my_role}
           remove_disabled={not Layout.removable?(@layout, email)}
-          disabled={entry.role == :owner && Layout.owners_count(@layout) == 1}
+          disabled={
+            (entry.role == :owner && Layout.owners_count(@layout) == 1) or
+              @my_role not in [:owner, :admin]
+          }
         />
       </div>
 
@@ -297,6 +298,13 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
       {{:ok, _}, :team_management} ->
         reset(socket)
+
+      {{:error, :permission_denied}, _} ->
+        socket
+        |> put_live_flash(
+          :error,
+          "Permission denied"
+        )
 
       {{:error, :only_one_owner}, _} ->
         socket

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -13,7 +13,9 @@ defmodule Plausible.Plugs.AuthorizeTeamAccess do
   end
 
   def call(conn, roles \\ @all_roles) do
-    if Plausible.Teams.enabled?(conn.assigns[:current_team]) do
+    current_team = conn.assigns[:current_team]
+
+    if current_team && Plausible.Teams.enabled?(current_team) do
       current_role = conn.assigns[:current_role]
 
       if current_role in roles do

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -1,4 +1,12 @@
 defmodule Plausible.Plugs.AuthorizeTeamAccess do
+  @moduledoc """
+  Enforce team role to be within the declared set.
+  `:current_role` is assumed to be populated by `PlausibleWeb.AuthPlug`.
+
+  For cases where no `:current_team` exists, the plug is permissive,
+  so that existing notices can be displayed still.
+  """
+
   alias PlausibleWeb.Router.Helpers, as: Routes
 
   import Plug.Conn

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -1,0 +1,26 @@
+defmodule Plausible.Plugs.AuthorizeTeamAccess do
+  alias PlausibleWeb.Router.Helpers, as: Routes
+
+  import Plug.Conn
+
+  @all_roles Plausible.Teams.Membership.roles()
+
+  def init([]), do: @all_roles
+
+  def init(roles) when is_list(roles) do
+    true = Enum.all?(roles, &(&1 in @all_roles))
+    roles
+  end
+
+  def call(conn, roles \\ @all_roles) do
+    current_role = conn.assigns[:current_role]
+
+    if current_role in roles do
+      conn
+    else
+      conn
+      |> Phoenix.Controller.redirect(to: Routes.site_path(conn, :index))
+      |> halt()
+    end
+  end
+end

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -13,14 +13,18 @@ defmodule Plausible.Plugs.AuthorizeTeamAccess do
   end
 
   def call(conn, roles \\ @all_roles) do
-    current_role = conn.assigns[:current_role]
+    if Plausible.Teams.enabled?(conn.assigns[:current_team]) do
+      current_role = conn.assigns[:current_role]
 
-    if current_role in roles do
-      conn
+      if current_role in roles do
+        conn
+      else
+        conn
+        |> Phoenix.Controller.redirect(to: Routes.site_path(conn, :index))
+        |> halt()
+      end
     else
       conn
-      |> Phoenix.Controller.redirect(to: Routes.site_path(conn, :index))
-      |> halt()
     end
   end
 end

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -11,7 +11,7 @@ defmodule Plausible.Plugs.AuthorizeTeamAccess do
 
   import Plug.Conn
 
-  @all_roles Plausible.Teams.Membership.roles()
+  @all_roles Plausible.Teams.Membership.roles() -- [:guest]
 
   def init([]), do: @all_roles
 

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -20,9 +20,15 @@
           value={@current_team.identifier}
         />
       </div>
-      <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
+      <.input
+        readonly={@my_role not in [:owner, :admin]}
+        type="text"
+        field={f[:name]}
+        label="Name"
+        width="w-1/2"
+      />
 
-      <.button type="submit">
+      <.button type="submit" disabled={@my_role not in [:owner, :admin]}>
         Change Name
       </.button>
     </.form>

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -21,14 +21,14 @@
         />
       </div>
       <.input
-        readonly={@my_role not in [:owner, :admin]}
+        readonly={@current_role not in [:owner, :admin]}
         type="text"
         field={f[:name]}
         label="Name"
         width="w-1/2"
       />
 
-      <.button type="submit" disabled={@my_role not in [:owner, :admin]}>
+      <.button type="submit" disabled={@current_role not in [:owner, :admin]}>
         Change Name
       </.button>
     </.form>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -97,6 +97,7 @@ defmodule PlausibleWeb.LayoutView do
 
   def account_settings_sidebar(conn) do
     current_team = conn.assigns[:current_team]
+    current_role = conn.assigns[:current_role]
 
     options = %{
       "Account Settings" =>
@@ -116,11 +117,18 @@ defmodule PlausibleWeb.LayoutView do
     }
 
     if Teams.enabled?(current_team) and Teams.setup?(current_team) do
-      Map.put(options, "Team Settings", [
-        %{key: "General", value: "team/general", icon: :adjustments_horizontal},
-        %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
-        %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
-      ])
+      Map.put(
+        options,
+        "Team Settings",
+        [
+          %{key: "General", value: "team/general", icon: :adjustments_horizontal},
+          %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
+          if(current_role in [:owner, :admin, :billing],
+            do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
+          )
+        ]
+        |> Enum.reject(&is_nil/1)
+      )
     else
       options
     end

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -41,6 +41,7 @@ defmodule Plausible.Workers.CheckUsage do
         from(t in Teams.Team,
           as: :team,
           inner_join: o in assoc(t, :owners),
+          left_join: bm in assoc(t, :billing_members),
           inner_lateral_join: s in subquery(Teams.last_subscription_join_query()),
           on: true,
           left_join: ep in Plausible.Billing.EnterprisePlan,
@@ -58,7 +59,7 @@ defmodule Plausible.Workers.CheckUsage do
             least(day_of_month(s.last_bill_date), day_of_month(last_day_of_month(^yesterday))) ==
               day_of_month(^yesterday),
           order_by: t.id,
-          preload: [subscription: s, enterprise_plan: ep, owners: o]
+          preload: [subscription: s, enterprise_plan: ep, owners: o, billing_members: bm]
         )
       )
 
@@ -110,7 +111,7 @@ defmodule Plausible.Workers.CheckUsage do
         suggested_plan =
           Plausible.Billing.Plans.suggest(subscriber, pageview_usage.last_cycle.total)
 
-        for owner <- subscriber.owners do
+        for owner <- subscriber.owners ++ subscriber.billing_members do
           PlausibleWeb.Email.over_limit_email(owner, pageview_usage, suggested_plan)
           |> Plausible.Mailer.send()
         end
@@ -131,7 +132,7 @@ defmodule Plausible.Workers.CheckUsage do
         nil
 
       {{_, pageview_usage}, {_, {site_usage, site_allowance}}} ->
-        for owner <- subscriber.owners do
+        for owner <- subscriber.owners ++ subscriber.billing_members do
           PlausibleWeb.Email.enterprise_over_limit_internal_email(
             owner,
             pageview_usage,

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -489,13 +489,25 @@ defmodule Plausible.BillingTest do
       user = new_user()
       subscribe_to_growth_plan(user, status: Subscription.Status.active())
 
+      team = team_of(user)
+      billing_member = new_user()
+      add_member(team, user: billing_member, role: :billing)
+
       Billing.subscription_cancelled(%{
         "alert_name" => "subscription_cancelled",
         "subscription_id" => subscription_of(user).paddle_subscription_id,
         "status" => "deleted"
       })
 
-      assert_email_delivered_with(subject: "Mind sharing your thoughts on Plausible?")
+      assert_email_delivered_with(
+        to: [nil: user.email],
+        subject: "Mind sharing your thoughts on Plausible?"
+      )
+
+      assert_email_delivered_with(
+        to: [nil: billing_member.email],
+        subject: "Mind sharing your thoughts on Plausible?"
+      )
     end
   end
 

--- a/test/plausible_web/controllers/billing_controller_test.exs
+++ b/test/plausible_web/controllers/billing_controller_test.exs
@@ -108,7 +108,7 @@ defmodule PlausibleWeb.BillingControllerTest do
   end
 
   describe "GET /billing/upgrade-success" do
-    setup [:create_user, :log_in]
+    setup [:create_user, :create_team, :log_in]
 
     test "shows success page after user subscribes", %{conn: conn} do
       conn = get(conn, Routes.billing_path(conn, :upgrade_success))

--- a/test/plausible_web/plugs/auth_plug_test.exs
+++ b/test/plausible_web/plugs/auth_plug_test.exs
@@ -25,6 +25,7 @@ defmodule PlausibleWeb.AuthPlugTest do
 
     assert conn.assigns[:current_user].id == user.id
     assert conn.assigns[:my_team].subscription.paddle_plan_id == "123"
+    assert conn.assigns[:current_role] == :owner
   end
 
   test "looks up the latest subscription", %{conn: conn, user: user} do
@@ -60,6 +61,7 @@ defmodule PlausibleWeb.AuthPlugTest do
       |> AuthPlug.call(%{})
 
     assert conn.assigns[:current_team].id == team.id
+    assert conn.assigns[:current_role] == :owner
     assert get_session(conn, "current_team_id") == team.identifier
   end
 
@@ -103,5 +105,22 @@ defmodule PlausibleWeb.AuthPlugTest do
 
     assert conn.assigns[:current_team].id == team.id
     refute get_session(conn, "current_team_id")
+  end
+
+  test "tracks current team role", %{conn: conn, user: user} do
+    other_user = new_user()
+    subscribe_to_plan(other_user, "123", inserted_at: NaiveDateTime.utc_now())
+    team = team_of(other_user)
+
+    add_member(team, user: user, role: :editor)
+    conn = set_current_team(conn, team)
+
+    conn =
+      conn
+      |> Plug.Adapters.Test.Conn.conn(:get, "/", %{})
+      |> AuthPlug.call(%{})
+
+    assert conn.assigns[:current_team].id == team.id
+    assert conn.assigns[:current_role] == :editor
   end
 end

--- a/test/plausible_web/plugs/authorize_team_access_test.exs
+++ b/test/plausible_web/plugs/authorize_team_access_test.exs
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
   alias Plausible.Plugs.AuthorizeTeamAccess
   import Plug.Conn
 
-  for role <- Plausible.Teams.Membership.roles() do
+  for role <- Plausible.Teams.Membership.roles() -- [:guest] do
     test "passes when valid current role: #{role}" do
       conn =
         build_conn()
@@ -16,15 +16,19 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
     end
   end
 
-  for role <- Plausible.Teams.Membership.roles() do
+  for role <- Plausible.Teams.Membership.roles() -- [:guest] do
     test "inits with role: #{role}" do
       assert AuthorizeTeamAccess.init([unquote(role)])
     end
   end
 
-  test "fails to init with unknown role" do
+  test "fails to init with invalid role" do
     assert_raise MatchError, fn ->
-      AuthorizeTeamAccess.init([:unknown_role])
+      AuthorizeTeamAccess.init([:guest])
+    end
+
+    assert_raise MatchError, fn ->
+      AuthorizeTeamAccess.init([:unknown])
     end
   end
 

--- a/test/plausible_web/plugs/authorize_team_access_test.exs
+++ b/test/plausible_web/plugs/authorize_team_access_test.exs
@@ -31,10 +31,21 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
   test "redirects to /sites on mismatch" do
     conn =
       build_conn()
+      |> assign(:current_team, :some)
       |> assign(:current_role, :admin)
       |> AuthorizeTeamAccess.call([:owner])
 
     assert conn.halted
     assert redirected_to(conn, 302) == "/sites"
+  end
+
+  test "is permissive when no :current_team assigned" do
+    conn =
+      build_conn()
+      |> assign(:current_team, nil)
+      |> assign(:current_role, :admin)
+      |> AuthorizeTeamAccess.call([:owner])
+
+    refute conn.halted
   end
 end

--- a/test/plausible_web/plugs/authorize_team_access_test.exs
+++ b/test/plausible_web/plugs/authorize_team_access_test.exs
@@ -1,0 +1,40 @@
+defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
+  use PlausibleWeb.ConnCase, async: true
+  use Plausible.Teams.Test
+
+  alias Plausible.Plugs.AuthorizeTeamAccess
+  import Plug.Conn
+
+  for role <- Plausible.Teams.Membership.roles() do
+    test "passes when valid current role: #{role}" do
+      conn =
+        build_conn()
+        |> assign(:current_role, unquote(role))
+        |> AuthorizeTeamAccess.call()
+
+      refute conn.halted
+    end
+  end
+
+  for role <- Plausible.Teams.Membership.roles() do
+    test "inits with role: #{role}" do
+      assert AuthorizeTeamAccess.init([unquote(role)])
+    end
+  end
+
+  test "fails to init with unknown role" do
+    assert_raise MatchError, fn ->
+      AuthorizeTeamAccess.init([:unknown_role])
+    end
+  end
+
+  test "redirects to /sites on mismatch" do
+    conn =
+      build_conn()
+      |> assign(:current_role, :admin)
+      |> AuthorizeTeamAccess.call([:owner])
+
+    assert conn.halted
+    assert redirected_to(conn, 302) == "/sites"
+  end
+end

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -96,6 +96,50 @@ defmodule Plausible.Workers.CheckUsageTest do
     )
   end
 
+  test "sends emails to billing members if available", %{user: user} do
+    usage_stub =
+      Plausible.Teams.Billing
+      |> stub(:monthly_pageview_usage, fn _user ->
+        %{
+          penultimate_cycle: %{date_range: @date_range, total: 11_000},
+          last_cycle: %{date_range: @date_range, total: 11_000}
+        }
+      end)
+
+    user2 = new_user()
+    user3 = new_user()
+    new_site(owner: user)
+    team = team_of(user)
+
+    add_member(team, user: user2, role: :billing)
+    add_member(team, user: user3, role: :viewer)
+
+    subscribe_to_plan(
+      user,
+      @paddle_id_10k,
+      last_bill_date: Date.shift(Date.utc_today(), day: -1),
+      next_bill_date: Date.shift(Date.utc_today(), day: +5),
+      status: :active
+    )
+
+    CheckUsage.perform(nil, usage_stub)
+
+    assert_email_delivered_with(
+      to: [user],
+      subject: "[Action required] You have outgrown your Plausible subscription tier"
+    )
+
+    assert_email_delivered_with(
+      to: [user2],
+      subject: "[Action required] You have outgrown your Plausible subscription tier"
+    )
+
+    refute_email_delivered_with(
+      to: [user3],
+      subject: "[Action required] You have outgrown your Plausible subscription tier"
+    )
+  end
+
   test "ignores user with paused subscription", %{user: user} do
     subscribe_to_plan(
       user,

--- a/test/workers/notify_annual_renewal_test.exs
+++ b/test/workers/notify_annual_renewal_test.exs
@@ -64,10 +64,19 @@ defmodule Plausible.Workers.NotifyAnnualRenewalTest do
       next_bill_date: Date.shift(Date.utc_today(), day: 7)
     )
 
+    team = team_of(user)
+    billing_member = new_user()
+    add_member(team, user: billing_member, role: :billing)
+
     NotifyAnnualRenewal.perform(nil)
 
     assert_email_delivered_with(
       to: [{user.name, user.email}],
+      subject: "Your Plausible subscription is up for renewal"
+    )
+
+    assert_email_delivered_with(
+      to: [{billing_member.name, billing_member.email}],
       subject: "Your Plausible subscription is up for renewal"
     )
   end

--- a/test/workers/send_trial_notifications_test.exs
+++ b/test/workers/send_trial_notifications_test.exs
@@ -58,6 +58,21 @@ defmodule Plausible.Workers.SendTrialNotificationsTest do
       assert_delivered_email(PlausibleWeb.Email.trial_one_week_reminder(user))
     end
 
+    test "includes billing member in recipients" do
+      user = new_user(trial_expiry_date: Date.utc_today() |> Date.shift(day: 7))
+      site = new_site(owner: user)
+      team = team_of(user)
+      billing_member = new_user()
+      add_member(team, user: billing_member, role: :billing)
+
+      populate_stats(site, [build(:pageview)])
+
+      perform_job(SendTrialNotifications, %{})
+
+      assert_delivered_email(PlausibleWeb.Email.trial_one_week_reminder(user))
+      assert_delivered_email(PlausibleWeb.Email.trial_one_week_reminder(billing_member))
+    end
+
     test "sends an upgrade email the day before the trial ends" do
       user = new_user(trial_expiry_date: Date.utc_today() |> Date.shift(day: 1))
       site = new_site(owner: user)


### PR DESCRIPTION
This PR introduces `:billing` team role; billing members receive all the subscription related notifications and can manage subscriptions. 