### PR TITLE
Fix shared links export

### DIFF
--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -103,7 +103,7 @@ export async function get(
 ) {
   const queryString = query
     ? queryToSearchParams(query, [...extraQueryParams])
-    : null
+    : serializeUrlParams(getSharedLinkSearchParams())
 
   const response = await fetch(queryString ? `${url}?${queryString}` : url, {
     signal: abortController.signal,

--- a/assets/js/dashboard/stats/graph/stats-export.js
+++ b/assets/js/dashboard/stats/graph/stats-export.js
@@ -34,7 +34,7 @@ export default function StatsExport() {
 
   function renderExportLink() {
     const interval = getCurrentInterval(site, query)
-    const queryParams = api.serializeUrlParams(api.queryToSearchParams(query, [{ interval, comparison: undefined }]))
+    const queryParams = api.queryToSearchParams(query, [{ interval, comparison: undefined }])
     const endpoint = `/${encodeURIComponent(site.domain)}/export?${queryParams}`
 
     return (


### PR DESCRIPTION
This fixes a bug with doing csv exports on shared links.

How to reproduce (on master):
1. Open http://localhost:8000/dummy.site/settings/visibility
2. Make sure stats are _not_ publicly accessible
3. Create a shared link
4. Visit shared link in incognito
5. Click to export

Expected result:
1. Export succeeds

Actual result:
1. Export fails with 404

This bug was introduced by a refactor that removed the `auth` search param from link in https://github.com/plausible/analytics/pull/5154