### PR TITLE
time-on-page: dashboard + timeseries support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Add filter `is not` for goals in dashboard plausible/analytics#4983
 - Add Segments feature
 - Support `["is", "segment", [<segment ID>]]` filter in Stats API
+- Time on page metric is now sortable in reports
 
 ### Removed
 
@@ -41,7 +42,7 @@ All notable changes to this project will be documented in this file.
 - Breakdown modals now display correct comparison values instead of 0 after pagination
 - Fix database mismatch between event and session user_ids after rotating salts
 - `/api/v2/query` no longer returns a 500 when querying percentage metric without `visitors`
-- Fix current visitors loading when viewing a dashboard with a shared link  
+- Fix current visitors loading when viewing a dashboard with a shared link
 - Fix Conversion Rate graph being unselectable when "Goal is ..." filter is within a segment
 - Fix Channels filter input appearing when clicking Sources in filter menu or clicking an applied "Channel is..." filter
 

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -74,6 +74,12 @@ export function queryToSearchParams(
     queryObj.auth = sharedLinkParams.auth
   }
 
+  if (query.legacy_time_on_page_cutoff) {
+    queryObj.include = JSON.stringify({
+      legacy_time_on_page_cutoff: query.legacy_time_on_page_cutoff
+    })
+  }
+
   Object.assign(queryObj, ...extraQuery)
 
   return serializeUrlParams(queryObj)

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -74,7 +74,10 @@ export function queryToSearchParams(
     queryObj.auth = sharedLinkParams.auth
   }
 
-  if (query.legacy_time_on_page_cutoff && validDate(query.legacy_time_on_page_cutoff)) {
+  if (
+    query.legacy_time_on_page_cutoff &&
+    validDate(query.legacy_time_on_page_cutoff)
+  ) {
     queryObj.include = JSON.stringify({
       legacy_time_on_page_cutoff: query.legacy_time_on_page_cutoff
     })

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -74,7 +74,7 @@ export function queryToSearchParams(
     queryObj.auth = sharedLinkParams.auth
   }
 
-  if (query.legacy_time_on_page_cutoff) {
+  if (query.legacy_time_on_page_cutoff && validDate(query.legacy_time_on_page_cutoff)) {
     queryObj.include = JSON.stringify({
       legacy_time_on_page_cutoff: query.legacy_time_on_page_cutoff
     })
@@ -83,6 +83,11 @@ export function queryToSearchParams(
   Object.assign(queryObj, ...extraQuery)
 
   return serializeUrlParams(queryObj)
+}
+
+function validDate(dateString: string) {
+  const date = new Date(dateString)
+  return isFinite(date.getTime())
 }
 
 function getHeaders(): Record<string, string> {

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -122,6 +122,7 @@ export default function QueryContextProvider({
     period,
     to,
     with_imported,
+    legacy_time_on_page_cutoff,
     site,
     expandedSegment
   ])

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -107,7 +107,7 @@ export default function QueryContextProvider({
         ? postProcessFilters(filters as Filter[])
         : defaultValues.filters,
       labels: (labels as FilterClauseLabels) || defaultValues.labels,
-      legacy_time_on_page_cutoff: legacy_time_on_page_cutoff || site.legacyTimeOnPageCutoff
+      legacy_time_on_page_cutoff: (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
     }
   }, [
     compare_from,

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -60,6 +60,7 @@ export default function QueryContextProvider({
     period,
     to,
     with_imported,
+    legacy_time_on_page_cutoff,
     ...otherSearch
   } = useMemo(() => parseSearch(location.search), [location.search])
 
@@ -105,7 +106,8 @@ export default function QueryContextProvider({
       filters: Array.isArray(filters)
         ? postProcessFilters(filters as Filter[])
         : defaultValues.filters,
-      labels: (labels as FilterClauseLabels) || defaultValues.labels
+      labels: (labels as FilterClauseLabels) || defaultValues.labels,
+      legacy_time_on_page_cutoff: legacy_time_on_page_cutoff || site.legacyTimeOnPageCutoff
     }
   }, [
     compare_from,

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -107,7 +107,8 @@ export default function QueryContextProvider({
         ? postProcessFilters(filters as Filter[])
         : defaultValues.filters,
       labels: (labels as FilterClauseLabels) || defaultValues.labels,
-      legacy_time_on_page_cutoff: (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
+      legacy_time_on_page_cutoff:
+        (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
     }
   }, [
     compare_from,

--- a/assets/js/dashboard/query.ts
+++ b/assets/js/dashboard/query.ts
@@ -44,7 +44,8 @@ export const queryDefaultValue = {
   compare_to: null as Dayjs | null,
   filters: [] as Filter[],
   labels: {} as FilterClauseLabels,
-  with_imported: true
+  with_imported: true,
+  legacy_time_on_page_cutoff: undefined as string | undefined
 }
 
 export type DashboardQuery = typeof queryDefaultValue

--- a/assets/js/dashboard/site-context.test.tsx
+++ b/assets/js/dashboard/site-context.test.tsx
@@ -25,6 +25,7 @@ describe('parseSiteFromDataset', () => {
       data-logged-in="true"
       data-stats-begin="2021-09-07"
       data-native-stats-begin="2022-09-02"
+      data-legacy-time-on-page-cutoff="2022-01-01T00:00:00Z"
       data-embedded=""
       data-is-dbip="false"
       data-current-user-role="owner"
@@ -66,7 +67,8 @@ describe('parseSiteFromDataset', () => {
       realtime: ['minute'],
       year: ['day', 'week', 'month']
     },
-    shared: false
+    shared: false,
+    legacyTimeOnPageCutoff: '2022-01-01T00:00:00Z'
   }
 
   it('parses from dom string map correctly', () => {

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -14,6 +14,7 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
     conversionsOptedOut: dataset.conversionsOptedOut === 'true',
     funnelsOptedOut: dataset.funnelsOptedOut === 'true',
     propsOptedOut: dataset.propsOptedOut === 'true',
+    legacyTimeOnPageCutoff: dataset.legacyTimeOnPageCutoff,
     revenueGoals: JSON.parse(dataset.revenueGoals!),
     funnels: JSON.parse(dataset.funnels!),
     statsBegin: dataset.statsBegin!,
@@ -30,6 +31,7 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
 type FeatureFlags = {
   saved_segments?: boolean
   saved_segments_fe?: boolean
+  new_time_on_page?: boolean
 }
 
 const siteContextDefaultValue = {
@@ -56,7 +58,8 @@ const siteContextDefaultValue = {
   isDbip: false,
   flags: {} as FeatureFlags,
   validIntervalsByPeriod: {} as Record<string, Array<string>>,
-  shared: false
+  shared: false,
+  legacyTimeOnPageCutoff: undefined as string | undefined
 }
 
 export type PlausibleSite = typeof siteContextDefaultValue

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -11,6 +11,7 @@ export const METRIC_LABELS = {
   'average_revenue': 'Average Revenue',
   'total_revenue': 'Total Revenue',
   'scroll_depth': 'Scroll Depth',
+  'time_on_page': 'Time on Page',
 }
 
 function plottable(dataArray) {

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -39,7 +39,7 @@ export default function TopStats({
 
   function tooltip(stat) {
     let statName = stat.name.toLowerCase()
-    const warning = data.meta.metric_warnings?.[stat.graph_metric]
+    const warning = warningText(stat.graph_metric, data.meta.metric_warnings?.[stat.graph_metric], site)
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
     return (
@@ -72,19 +72,19 @@ export default function TopStats({
 
         {warning ? (
           <p className="font-normal text-xs whitespace-nowrap">
-            * {warningText(stat.graph_metric, warning)}
+            * {warning}
           </p>
         ) : null}
       </div>
     )
   }
 
-  function warningText(metric, warning) {
+  function warningText(metric, warning, site) {
     if (metric === 'scroll_depth' && warning.code === 'no_imported_scroll_depth') {
       return "Does not include imported data"
     }
 
-    if (metric === 'time_on_page') {
+    if (metric === 'time_on_page' && site.flags.new_time_on_page) {
       return warning.message
     }
 

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -39,7 +39,11 @@ export default function TopStats({
 
   function tooltip(stat) {
     let statName = stat.name.toLowerCase()
-    const warning = warningText(stat.graph_metric, data.meta.metric_warnings?.[stat.graph_metric], site)
+    const warning = warningText(
+      stat.graph_metric,
+      data.meta.metric_warnings?.[stat.graph_metric],
+      site
+    )
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
     return (
@@ -71,17 +75,18 @@ export default function TopStats({
         )}
 
         {warning ? (
-          <p className="font-normal text-xs whitespace-nowrap">
-            * {warning}
-          </p>
+          <p className="font-normal text-xs whitespace-nowrap">* {warning}</p>
         ) : null}
       </div>
     )
   }
 
   function warningText(metric, warning, site) {
-    if (metric === 'scroll_depth' && warning.code === 'no_imported_scroll_depth') {
-      return "Does not include imported data"
+    if (
+      metric === 'scroll_depth' &&
+      warning.code === 'no_imported_scroll_depth'
+    ) {
+      return 'Does not include imported data'
     }
 
     if (metric === 'time_on_page' && site.flags.new_time_on_page) {

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -82,6 +82,10 @@ export default function TopStats({
   }
 
   function warningText(metric, warning, site) {
+    if (!warning) {
+      return null
+    }
+
     if (
       metric === 'scroll_depth' &&
       warning.code === 'no_imported_scroll_depth'

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -39,6 +39,7 @@ export default function TopStats({
 
   function tooltip(stat) {
     let statName = stat.name.toLowerCase()
+    const warning = data.meta.metric_warnings?.[stat.graph_metric]
     statName = stat.value === 1 ? statName.slice(0, -1) : statName
 
     return (
@@ -69,15 +70,25 @@ export default function TopStats({
           </p>
         )}
 
-        {stat.name === 'Scroll depth' &&
-          data.meta.metric_warnings?.scroll_depth?.code ===
-            'no_imported_scroll_depth' && (
-            <p className="font-normal text-xs whitespace-nowrap">
-              * Does not include imported data
-            </p>
-          )}
+        {warning ? (
+          <p className="font-normal text-xs whitespace-nowrap">
+            * {warningText(stat.graph_metric, warning)}
+          </p>
+        ) : null}
       </div>
     )
+  }
+
+  function warningText(metric, warning) {
+    if (metric === 'scroll_depth' && warning.code === 'no_imported_scroll_depth') {
+      return "Does not include imported data"
+    }
+
+    if (metric === 'time_on_page') {
+      return warning.message
+    }
+
+    return null
   }
 
   function canMetricBeGraphed(stat) {

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -17,7 +17,7 @@ import { Metric } from '../reports/metrics'
 import { BreakdownResultMeta, DashboardQuery } from '../../query'
 import { ColumnConfiguraton } from '../../components/table'
 import { BreakdownTable } from './breakdown-table'
-import { useSiteContext } from '../../site-context'
+import { PlausibleSite, useSiteContext } from '../../site-context'
 
 export type ReportInfo = {
   /** Title of the report to render on the top left. */
@@ -152,7 +152,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
           key: m.key,
           width: m.width,
           align: 'right',
-          metricWarning: getMetricWarning(m, meta),
+          metricWarning: getMetricWarning(m, meta, site),
           renderValue: (item) => m.renderValue(item, meta),
           onSort: m.sortable ? () => toggleSortByMetric(m) : undefined,
           sortDirection: orderByDictionary[m.key]
@@ -235,7 +235,7 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
     </a>
   ) : null
 
-const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
+const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null, site: PlausibleSite) => {
   const warnings = meta?.metric_warnings
 
   if (warnings && warnings[metric.key]) {
@@ -245,7 +245,7 @@ const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
       return 'Does not include imported data'
     }
 
-    if (metric.key == 'time_on_page' && code) {
+    if (metric.key == 'time_on_page' && code && site.flags.new_time_on_page) {
       return message
     }
   }

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -235,7 +235,11 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
     </a>
   ) : null
 
-const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null, site: PlausibleSite) => {
+const getMetricWarning = (
+  metric: Metric,
+  meta: BreakdownResultMeta | null,
+  site: PlausibleSite
+) => {
   const warnings = meta?.metric_warnings
 
   if (warnings && warnings[metric.key]) {

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -238,11 +238,15 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
 const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
   const warnings = meta?.metric_warnings
 
-  if (warnings) {
-    const code = warnings[metric.key]?.code
+  if (warnings && warnings[metric.key]) {
+    const { code, message } = warnings[metric.key]
 
-    if (code == 'no_imported_scroll_depth') {
+    if (metric.key == 'scroll_depth' && code == 'no_imported_scroll_depth') {
       return 'Does not include imported data'
+    }
+
+    if (metric.key == 'time_on_page' && code) {
+      return message
     }
   }
 }

--- a/assets/js/dashboard/stats/reports/metrics.js
+++ b/assets/js/dashboard/stats/reports/metrics.js
@@ -198,7 +198,7 @@ export const createTimeOnPage = (props) => {
     ...props,
     key: 'time_on_page',
     renderLabel,
-    sortable: false
+    sortable: true
   })
 }
 

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -43,7 +43,8 @@ export const TestContextProviders = ({
     isDbip: false,
     flags: {},
     validIntervalsByPeriod: {},
-    shared: false
+    shared: false,
+    legacyTimeOnPageCutoff: undefined
   }
 
   const site = { ...defaultSite, ...siteOptions }

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -46,7 +46,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
            Plausible.Segments.Filters.resolve_segments(filters, preloaded_segments),
          {:ok, dimensions} <- parse_dimensions(Map.get(params, "dimensions", [])),
          {:ok, order_by} <- parse_order_by(Map.get(params, "order_by")),
-         {:ok, include} <- parse_include(site, Map.get(params, "include", %{})),
+         {:ok, include} <- parse_include(Map.get(params, "include", %{}), site),
          {:ok, pagination} <- parse_pagination(Map.get(params, "pagination", %{})),
          {preloaded_goals, revenue_warning, revenue_currencies} <-
            preload_goals_and_revenue(site, metrics, filters, dimensions),
@@ -310,12 +310,12 @@ defmodule Plausible.Stats.Filters.QueryParser do
     )
   end
 
-  defp parse_order_by(order_by) when is_list(order_by) do
+  def parse_order_by(order_by) when is_list(order_by) do
     parse_list(order_by, &parse_order_by_entry/1)
   end
 
-  defp parse_order_by(nil), do: {:ok, nil}
-  defp parse_order_by(order_by), do: {:error, "Invalid order_by '#{i(order_by)}'."}
+  def parse_order_by(nil), do: {:ok, nil}
+  def parse_order_by(order_by), do: {:error, "Invalid order_by '#{i(order_by)}'."}
 
   defp parse_order_by_entry(entry) do
     with {:ok, value} <- parse_metric_or_dimension(entry),
@@ -359,14 +359,22 @@ defmodule Plausible.Stats.Filters.QueryParser do
   defp parse_order_direction([_, "desc"]), do: {:ok, :desc}
   defp parse_order_direction(entry), do: {:error, "Invalid order_by entry '#{i(entry)}'."}
 
-  defp parse_include(site, include) when is_map(include) do
-    parsed =
-      include
-      |> atomize_keys()
-      |> update_comparisons_date_range(site)
-
-    with {:ok, include} <- parsed do
+  def parse_include(include, site) when is_map(include) do
+    with {:ok, include} <- atomize_include_keys(include),
+         {:ok, include} <- update_comparisons_date_range(include, site) do
       {:ok, Map.merge(@default_include, include)}
+    end
+  end
+
+  def parse_include(include, _site), do: {:error, "Invalid include '#{i(include)}'."}
+
+  defp atomize_include_keys(map) do
+    expected_keys = @default_include |> Map.keys() |> Enum.map(&Atom.to_string/1)
+
+    if Map.keys(map) |> Enum.all?(&(&1 in expected_keys)) do
+      {:ok, atomize_keys(map)}
+    else
+      {:error, "Invalid include '#{i(map)}'."}
     end
   end
 

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -156,6 +156,22 @@ defmodule Plausible.Stats.QueryResult do
     end
   end
 
+  defp metric_warning(:time_on_page, %Query{} = query) do
+    case query.time_on_page_data do
+      %{include_legacy_metric: true, cutoff: cutoff} ->
+        cutoff_time =
+          cutoff |> DateTime.shift_zone!(query.timezone) |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+
+        %{
+          code: :legacy_time_on_page_used,
+          message: "Contains less accurate legacy time-on-page data up to #{cutoff_time}"
+        }
+
+      _ ->
+        nil
+    end
+  end
+
   defp metric_warning(_metric, _query), do: nil
 
   defp to_iso8601(datetime, timezone) do

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -64,6 +64,7 @@ defmodule Plausible.Stats.QueryRunner do
       query
       |> Comparisons.get_comparison_query()
       |> Comparisons.add_comparison_filters(main_results)
+      |> QueryOptimizer.optimize()
 
     struct!(runner, comparison_query: comparison_query)
   end

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -255,8 +255,10 @@ defmodule Plausible.Stats.SQL.Expression do
           wrap_alias(
             [e],
             %{
-              __internal_total_time_on_page: 0,
-              __internal_total_time_on_page_visits: 0
+              # :KLUDGE: We would like to but can't use constant 0 here as it leads to cyclic aliases if there's no other
+              # metrics selected other than time_on_page.
+              __internal_total_time_on_page: fragment("count() * 0"),
+              __internal_total_time_on_page_visits: fragment("count() * 0")
             }
           )
 

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -257,8 +257,8 @@ defmodule Plausible.Stats.SQL.Expression do
             %{
               # :KLUDGE: We would like to but can't use constant 0 here as it leads to cyclic aliases if there's no other
               # metrics selected other than time_on_page.
-              __internal_total_time_on_page: fragment("count() * 0"),
-              __internal_total_time_on_page_visits: fragment("count() * 0")
+              __internal_total_time_on_page: fragment("sumArray([0])"),
+              __internal_total_time_on_page_visits: fragment("sumArray([0])")
             }
           )
 

--- a/lib/plausible/stats/time_on_page.ex
+++ b/lib/plausible/stats/time_on_page.ex
@@ -1,0 +1,16 @@
+defmodule Plausible.Stats.TimeOnPage do
+  @moduledoc """
+  Module to check whether the new time on page metric is available.
+  """
+
+  def new_time_on_page_enabled?(site, user) do
+    FunWithFlags.enabled?(:new_time_on_page, for: user) ||
+      FunWithFlags.enabled?(:new_time_on_page, for: site)
+  end
+
+  def legacy_time_on_page_cutoff() do
+    # Placeholder until we implement a more sophisticated way to determine the cutoff
+    # Only used when `new_time_on_page` flag is enabled
+    DateTime.utc_now() |> DateTime.shift(day: -4) |> DateTime.to_iso8601()
+  end
+end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Api.StatsController do
   use PlausibleWeb.Plugs.ErrorHandler
 
   alias Plausible.Stats
-  alias Plausible.Stats.{Query, Comparisons, Filters, Time, TableDecider}
+  alias Plausible.Stats.{Query, Comparisons, Filters, Time, TableDecider, TimeOnPage}
   alias PlausibleWeb.Api.Helpers, as: H
 
   require Logger
@@ -444,7 +444,11 @@ defmodule PlausibleWeb.Api.StatsController do
     %{
       top_stats: top_stats,
       meta: meta,
-      graphable_metrics: metrics -- [:time_on_page],
+      graphable_metrics:
+        if(TimeOnPage.new_time_on_page_enabled?(site, current_user),
+          do: metrics,
+          else: metrics -- [:time_on_page]
+        ),
       sample_percent: sample_percent
     }
   end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.StatsController do
   use Plausible.Repo
 
   alias Plausible.Sites
-  alias Plausible.Stats.{Filters, Query}
+  alias Plausible.Stats.{Filters, Query, TimeOnPage}
   alias PlausibleWeb.Api
 
   plug(PlausibleWeb.Plugs.AuthorizeSiteAccess when action in [:stats, :csv_export])
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.StatsController do
           scroll_depth_visible: scroll_depth_visible?,
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
-          legacy_time_on_page_cutoff: legacy_time_on_page_cutoff(),
+          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff(),
           title: title(conn, site),
           demo: demo,
           flags: flags,
@@ -362,7 +362,7 @@ defmodule PlausibleWeb.StatsController do
           scroll_depth_visible: scroll_depth_visible?,
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
-          legacy_time_on_page_cutoff: legacy_time_on_page_cutoff(),
+          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff(),
           title: title(conn, shared_link.site),
           demo: false,
           dogfood_page_path: "/share/:dashboard",
@@ -387,12 +387,6 @@ defmodule PlausibleWeb.StatsController do
   end
 
   defp shared_link_cookie_name(slug), do: "shared-link-" <> slug
-
-  defp legacy_time_on_page_cutoff() do
-    # Placeholder until we implement a more sophisticated way to determine the cutoff
-    # Only used when `new_time_on_page` flag is enabled
-    DateTime.utc_now() |> DateTime.shift(day: -4) |> DateTime.to_iso8601()
-  end
 
   defp get_flags(user, site),
     do:

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -77,6 +77,7 @@ defmodule PlausibleWeb.StatsController do
           scroll_depth_visible: scroll_depth_visible?,
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
+          legacy_time_on_page_cutoff: legacy_time_on_page_cutoff(),
           title: title(conn, site),
           demo: demo,
           flags: flags,
@@ -361,6 +362,7 @@ defmodule PlausibleWeb.StatsController do
           scroll_depth_visible: scroll_depth_visible?,
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
+          legacy_time_on_page_cutoff: legacy_time_on_page_cutoff(),
           title: title(conn, shared_link.site),
           demo: false,
           dogfood_page_path: "/share/:dashboard",
@@ -386,9 +388,15 @@ defmodule PlausibleWeb.StatsController do
 
   defp shared_link_cookie_name(slug), do: "shared-link-" <> slug
 
+  defp legacy_time_on_page_cutoff() do
+    # Placeholder until we implement a more sophisticated way to determine the cutoff
+    # Only used when `new_time_on_page` flag is enabled
+    DateTime.utc_now() |> DateTime.shift(day: -4) |> DateTime.to_iso8601()
+  end
+
   defp get_flags(user, site),
     do:
-      [:saved_segments, :saved_segments_fe, :scroll_depth]
+      [:saved_segments, :saved_segments_fe, :scroll_depth, :new_time_on_page]
       |> Enum.map(fn flag ->
         {flag, FunWithFlags.enabled?(flag, for: user) || FunWithFlags.enabled?(flag, for: site)}
       end)

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -37,6 +37,7 @@
     data-logged-in={to_string(!!@conn.assigns[:current_user])}
     data-stats-begin={@stats_start_date}
     data-native-stats-begin={@native_stats_start_date}
+    data-legacy-time-on-page-cutoff={@legacy_time_on_page_cutoff}
     data-shared-link-auth={assigns[:shared_link_auth]}
     data-embedded={to_string(@conn.assigns[:embedded])}
     data-background={@conn.assigns[:background]}

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -3,6 +3,7 @@ defmodule Plausible.Stats.QueryTest do
   use Plausible.Teams.Test
   alias Plausible.Stats.Query
   alias Plausible.Stats.Legacy.QueryBuilder
+  alias Plausible.Stats.Filters.QueryParser
   alias Plausible.Stats.DateTimeRange
 
   doctest Plausible.Stats.Legacy.QueryBuilder


### PR DESCRIPTION
### Changes

This PR adds support for new time-on-page metric to dashboard. The new functionality is behind a feature flag named `new_time_on_page`.

New functionality is (click on a header to see screenshots):

<details>
<summary><strong>1. time-on-page is now graphable</strong></summary>

![image](https://github.com/user-attachments/assets/17f624c7-96a8-457c-904b-6dadcfd84e46)
![image](https://github.com/user-attachments/assets/2df0ef3c-b9fc-4d70-b287-60e685f89e93)
</details>

<details>
<summary><strong>2. time-on-page is now sortable in modals</strong></summary>

![image](https://github.com/user-attachments/assets/86822c2f-8c67-4d75-8ab0-3d4858f3fd5d)
</details>

<details>
<summary><strong>3. metric warnings when legacy time-on-data is shown</strong></summary>

![image](https://github.com/user-attachments/assets/4c55e278-cce7-4f2f-b687-e7cfe4a9751c)
![image](https://github.com/user-attachments/assets/f73d1317-190f-4b3b-b0e9-1cbdbfdd8a14)
</details>

<strong>4. Improved query: comparisons & timeseries tests</strong>

### Legacy time-on-page compatibility

If feature flag is enabled, `include.legacy_time_on_page_cutoff` is sent with each query to the backend. This date determines when the new time-on-data metric is shown.

By default for now, the cutoff is 4 days ago, however for internal testing purposes we also allow setting `legacy_time_on_page` query parameter (e.g. `&legacy_time_on_page_cutoff=2021-01-01T00:00:00Z`) on the dashboard to allow overriding the default value. Invalid ISO8601 dates result in seeing legacy results only (e.g. `&legacy_time_on_page_cutoff=off`)
