### PR TITLE
Fix dashboard report behavior when goals are in segments - variant C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Fix current visitors loading when viewing a dashboard with a shared link
 - Fix Conversion Rate graph being unselectable when "Goal is ..." filter is within a segment
 - Fix Channels filter input appearing when clicking Sources in filter menu or clicking an applied "Channel is..." filter
+- Fix Conversion Rate metrics column disappearing from reports when "Goal is ..." filter is within a segment
 
 ## v2.1.5-rc.1 - 2025-01-17
 

--- a/assets/js/dashboard.tsx
+++ b/assets/js/dashboard.tsx
@@ -20,6 +20,10 @@ import {
   GoToSites,
   SomethingWentWrongMessage
 } from './dashboard/error/something-went-wrong'
+import {
+  parsePreloadedSegments,
+  SegmentsContextProvider
+} from './dashboard/filtering/segments-context'
 
 timer.start()
 
@@ -71,7 +75,11 @@ if (container && container.dataset) {
                     }
               }
             >
-              <RouterProvider router={router} />
+              <SegmentsContextProvider
+                preloadedSegments={parsePreloadedSegments(container.dataset)}
+              >
+                <RouterProvider router={router} />
+              </SegmentsContextProvider>
             </UserContextProvider>
           </SiteContextProvider>
         </ThemeContextProvider>

--- a/assets/js/dashboard/filtering/segments-context.test.tsx
+++ b/assets/js/dashboard/filtering/segments-context.test.tsx
@@ -1,0 +1,120 @@
+/** @format */
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SegmentsContextProvider, useSegmentsContext } from './segments-context'
+import { SavedSegment, SegmentData, SegmentType } from './segments'
+
+function TestComponent() {
+  const { segments, addOne, removeOne, updateOne } = useSegmentsContext()
+
+  return (
+    <div>
+      <button onClick={() => addOne(segmentOpenSource)}>Add Segment</button>
+      {segments.map((segment) => (
+        <div key={segment.id}>
+          <span data-testid="name">{segment.name}</span>
+          <button onClick={() => removeOne(segment)}>
+            Delete {segment.name}
+          </button>
+          <button
+            onClick={() =>
+              updateOne({ ...segment, name: `${segment.name} (Updated)` })
+            }
+          >
+            Update {segment.name}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const getRenderedSegmentNames = () =>
+  screen.queryAllByTestId('name').map((e) => e.textContent)
+
+describe('SegmentsContext functions', () => {
+  test('deleteOne works', () => {
+    render(
+      <SegmentsContextProvider
+        preloadedSegments={[segmentOpenSource, segmentAPAC]}
+      >
+        <TestComponent />
+      </SegmentsContextProvider>
+    )
+
+    expect(getRenderedSegmentNames()).toEqual([
+      segmentOpenSource.name,
+      segmentAPAC.name
+    ])
+    fireEvent.click(screen.getByText(`Delete ${segmentOpenSource.name}`))
+    expect(getRenderedSegmentNames()).toEqual([segmentAPAC.name])
+  })
+
+  test('addOne adds to head of list', async () => {
+    render(
+      <SegmentsContextProvider preloadedSegments={[segmentAPAC]}>
+        <TestComponent />
+      </SegmentsContextProvider>
+    )
+
+    expect(getRenderedSegmentNames()).toEqual([segmentAPAC.name])
+
+    fireEvent.click(screen.getByText('Add Segment'))
+    expect(screen.queryAllByTestId('name').map((e) => e.textContent)).toEqual([
+      segmentOpenSource.name,
+      segmentAPAC.name
+    ])
+  })
+
+  test('updateOne works: updated segment is at head of list', () => {
+    render(
+      <SegmentsContextProvider
+        preloadedSegments={[segmentOpenSource, segmentAPAC]}
+      >
+        <TestComponent />
+      </SegmentsContextProvider>
+    )
+
+    expect(getRenderedSegmentNames()).toEqual([
+      segmentOpenSource.name,
+      segmentAPAC.name
+    ])
+    fireEvent.click(screen.getByText(`Update ${segmentAPAC.name}`))
+    expect(getRenderedSegmentNames()).toEqual([
+      `${segmentAPAC.name} (Updated)`,
+      segmentOpenSource.name
+    ])
+  })
+})
+
+const segmentAPAC: SavedSegment & { segment_data: SegmentData } = {
+  id: 1,
+  name: 'APAC region',
+  type: SegmentType.personal,
+  owner_id: 100,
+  owner_name: 'Test User',
+  inserted_at: '2025-03-10T10:00:00',
+  updated_at: '2025-03-11T10:00:00',
+  segment_data: {
+    filters: [['is', 'country', ['JP', 'NZ']]],
+    labels: { JP: 'Japan', NZ: 'New Zealand' }
+  }
+}
+
+const segmentOpenSource: SavedSegment & { segment_data: SegmentData } = {
+  id: 2,
+  name: 'Open source fans',
+  type: SegmentType.site,
+  owner_id: 200,
+  owner_name: 'Other User',
+  inserted_at: '2025-03-11T10:00:00',
+  updated_at: '2025-03-12T10:00:00',
+  segment_data: {
+    filters: [
+      ['is', 'browser', ['Firefox']],
+      ['is', 'os', ['Linux']]
+    ],
+    labels: {}
+  }
+}

--- a/assets/js/dashboard/filtering/segments-context.tsx
+++ b/assets/js/dashboard/filtering/segments-context.tsx
@@ -1,0 +1,87 @@
+/** @format */
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState
+} from 'react'
+import {
+  handleSegmentResponse,
+  SavedSegment,
+  SavedSegmentPublic,
+  SegmentData
+} from './segments'
+
+export function parsePreloadedSegments(dataset: DOMStringMap): Segments {
+  return JSON.parse(dataset.segments!).map(handleSegmentResponse)
+}
+
+type Segments = Array<
+  (SavedSegment | SavedSegmentPublic) & {
+    segment_data: SegmentData
+  }
+>
+
+type ChangeSegmentState = (
+  segment: SavedSegment & { segment_data: SegmentData }
+) => void
+
+const initialValue: {
+  segments: Segments
+  updateOne: ChangeSegmentState
+  addOne: ChangeSegmentState
+  removeOne: ChangeSegmentState
+} = {
+  segments: [],
+  updateOne: () => {},
+  addOne: () => {},
+  removeOne: () => {}
+}
+
+const SegmentsContext = createContext(initialValue)
+
+export const useSegmentsContext = () => {
+  return useContext(SegmentsContext)
+}
+
+export const SegmentsContextProvider = ({
+  preloadedSegments,
+  children
+}: {
+  preloadedSegments: Segments
+  children: ReactNode
+}) => {
+  const [segments, setSegments] = useState(preloadedSegments)
+
+  const removeOne: ChangeSegmentState = useCallback(
+    ({ id }) =>
+      setSegments((currentSegments) =>
+        currentSegments.filter((s) => s.id !== id)
+      ),
+    []
+  )
+
+  const updateOne: ChangeSegmentState = useCallback(
+    (segment) =>
+      setSegments((currentSegments) => [
+        segment,
+        ...currentSegments.filter((s) => s.id !== segment.id)
+      ]),
+    []
+  )
+
+  const addOne: ChangeSegmentState = useCallback(
+    (segment) =>
+      setSegments((currentSegments) => [segment, ...currentSegments]),
+    []
+  )
+
+  return (
+    <SegmentsContext.Provider
+      value={{ segments, removeOne, updateOne, addOne }}
+    >
+      {children}
+    </SegmentsContext.Provider>
+  )
+}

--- a/assets/js/dashboard/filtering/segments-context.tsx
+++ b/assets/js/dashboard/filtering/segments-context.tsx
@@ -10,25 +10,20 @@ import {
   handleSegmentResponse,
   SavedSegment,
   SavedSegmentPublic,
+  SavedSegments,
   SegmentData
 } from './segments'
 
-export function parsePreloadedSegments(dataset: DOMStringMap): Segments {
+export function parsePreloadedSegments(dataset: DOMStringMap): SavedSegments {
   return JSON.parse(dataset.segments!).map(handleSegmentResponse)
 }
 
-type Segments = Array<
-  (SavedSegment | SavedSegmentPublic) & {
-    segment_data: SegmentData
-  }
->
-
 type ChangeSegmentState = (
-  segment: SavedSegment & { segment_data: SegmentData }
+  segment: (SavedSegment | SavedSegmentPublic) & { segment_data: SegmentData }
 ) => void
 
 const initialValue: {
-  segments: Segments
+  segments: SavedSegments
   updateOne: ChangeSegmentState
   addOne: ChangeSegmentState
   removeOne: ChangeSegmentState
@@ -49,7 +44,7 @@ export const SegmentsContextProvider = ({
   preloadedSegments,
   children
 }: {
-  preloadedSegments: Segments
+  preloadedSegments: SavedSegments
   children: ReactNode
 }) => {
   const [segments, setSegments] = useState(preloadedSegments)

--- a/assets/js/dashboard/filtering/segments.test.ts
+++ b/assets/js/dashboard/filtering/segments.test.ts
@@ -186,13 +186,21 @@ describe(`${resolveFilters.name}`, () => {
     expect(resolvedFilters).toEqual(filters)
   })
 
-  it('should throw an error if more than one segment filter is applied', () => {
-    const filters: Filter[] = [
-      ['is', 'segment', [1]],
-      ['is', 'segment', [2]]
-    ]
-    expect(() => resolveFilters(filters, segments)).toThrow(
-      'Only one segment filter can be applied'
-    )
-  })
+  const cases: Array<{ filters: Filter[] }> = [
+    {
+      filters: [
+        ['is', 'segment', [1]],
+        ['is', 'segment', [2]]
+      ]
+    },
+    { filters: [['is', 'segment', [1, 2]]] }
+  ]
+  it.each(cases)(
+    'should throw an error if more than one segment filter is applied, as in %p',
+    ({ filters }) => {
+      expect(() => resolveFilters(filters, segments)).toThrow(
+        'Dashboard can be filtered by only one segment'
+      )
+    }
+  )
 })

--- a/assets/js/dashboard/filtering/segments.test.ts
+++ b/assets/js/dashboard/filtering/segments.test.ts
@@ -12,7 +12,8 @@ import {
   resolveFilters,
   SegmentType,
   SavedSegment,
-  SegmentData
+  SegmentData,
+  canSeeSegmentDetails
 } from './segments'
 import { Filter } from '../query'
 import { PlausibleSite } from '../site-context'
@@ -203,4 +204,25 @@ describe(`${resolveFilters.name}`, () => {
       )
     }
   )
+})
+
+describe(`${canSeeSegmentDetails.name}`, () => {
+  it('should return true if the user is logged in and not a public role', () => {
+    const user: UserContextValue = { loggedIn: true, role: Role.admin, id: 1 }
+    expect(canSeeSegmentDetails({ user })).toBe(true)
+  })
+
+  it('should return false if the user is not logged in', () => {
+    const user: UserContextValue = {
+      loggedIn: false,
+      role: Role.editor,
+      id: null
+    }
+    expect(canSeeSegmentDetails({ user })).toBe(false)
+  })
+
+  it('should return false if the user has a public role', () => {
+    const user: UserContextValue = { loggedIn: true, role: Role.public, id: 1 }
+    expect(canSeeSegmentDetails({ user })).toBe(false)
+  })
 })

--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -49,6 +49,12 @@ export type SegmentData = {
   labels: Record<string, string>
 }
 
+export type SavedSegments = Array<
+  (SavedSegment | SavedSegmentPublic) & {
+    segment_data: SegmentData
+  }
+>
+
 const SEGMENT_LABEL_KEY_PREFIX = 'segment-'
 
 export function handleSegmentResponse(
@@ -176,6 +182,10 @@ export function isListableSegment({
   }
 
   return false
+}
+
+export function canSeeSegmentDetails({ user }: { user: UserContextValue }) {
+  return user.loggedIn && user.role !== Role.public
 }
 
 export function findAppliedSegmentFilter({ filters }: { filters: Filter[] }) {

--- a/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
+++ b/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
@@ -41,9 +41,7 @@ export const SearchableSegmentsSection = ({
   const site = useSiteContext()
   const segmentsContext = useSegmentsContext()
 
-  const { query, expandedSegment } = useQueryContext()
-  const segmentFilter = query.filters.find(isSegmentFilter)
-  const appliedSegmentIds = (segmentFilter ? segmentFilter[2] : []) as number[]
+  const { expandedSegment } = useQueryContext()
   const user = useUserContext()
 
   const isPublicListQuery = !user.loggedIn || user.role === Role.public
@@ -118,11 +116,7 @@ export const SearchableSegmentsSection = ({
                   </div>
                 }
               >
-                <SegmentLink
-                  {...segment}
-                  appliedSegmentIds={appliedSegmentIds}
-                  closeList={closeList}
-                />
+                <SegmentLink {...segment} closeList={closeList} />
               </Tooltip>
             )
           })}
@@ -160,10 +154,8 @@ export const SearchableSegmentsSection = ({
 const SegmentLink = ({
   id,
   name,
-  appliedSegmentIds,
   closeList
 }: Pick<SavedSegment, 'id' | 'name'> & {
-  appliedSegmentIds: number[]
   closeList: () => void
 }) => {
   const { query } = useQueryContext()
@@ -175,19 +167,8 @@ const SegmentLink = ({
       onClick={closeList}
       search={(search) => {
         const otherFilters = query.filters.filter((f) => !isSegmentFilter(f))
-        const updatedSegmentIds = appliedSegmentIds.includes(id) ? [] : [id]
-        if (!updatedSegmentIds.length) {
-          return {
-            ...search,
-            filters: otherFilters,
-            labels: cleanLabels(otherFilters, query.labels)
-          }
-        }
 
-        const updatedFilters = [
-          ['is', 'segment', updatedSegmentIds],
-          ...otherFilters
-        ]
+        const updatedFilters = [['is', 'segment', [id]], ...otherFilters]
 
         return {
           ...search,

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -19,9 +19,10 @@ import {
   queryDefaultValue,
   postProcessFilters
 } from './query'
-import { SavedSegment, SegmentData } from './filtering/segments'
+import { resolveFilters, SavedSegment, SegmentData } from './filtering/segments'
 import { useDefiniteLocationState } from './navigation/use-definite-location-state'
 import { useClearExpandedSegmentModeOnFilterClear } from './nav-menu/segments/segment-menu'
+import { useSegmentsContext } from './filtering/segments-context'
 
 const queryContextDefaultValue = {
   query: queryDefaultValue,
@@ -42,6 +43,7 @@ export default function QueryContextProvider({
 }: {
   children: ReactNode
 }) {
+  const segmentsContext = useSegmentsContext()
   const location = useLocation()
   const { definiteValue: expandedSegment } = useDefiniteLocationState<
     SavedSegment & { segment_data: SegmentData }
@@ -53,7 +55,7 @@ export default function QueryContextProvider({
     compare_to,
     comparison,
     date,
-    filters,
+    filters: rawFilters,
     from,
     labels,
     match_day_of_week,
@@ -73,6 +75,12 @@ export default function QueryContextProvider({
       defaultValues,
       segmentIsExpanded: !!expandedSegment
     })
+
+    const filters = Array.isArray(rawFilters)
+      ? postProcessFilters(rawFilters as Filter[])
+      : defaultValues.filters
+
+    const resolvedFilters = resolveFilters(filters, segmentsContext.segments)
 
     return {
       ...timeQuery,
@@ -103,9 +111,8 @@ export default function QueryContextProvider({
       with_imported: [true, false].includes(with_imported as boolean)
         ? (with_imported as boolean)
         : defaultValues.with_imported,
-      filters: Array.isArray(filters)
-        ? postProcessFilters(filters as Filter[])
-        : defaultValues.filters,
+      filters,
+      resolvedFilters,
       labels: (labels as FilterClauseLabels) || defaultValues.labels,
       legacy_time_on_page_cutoff:
         (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
@@ -115,7 +122,7 @@ export default function QueryContextProvider({
     compare_to,
     comparison,
     date,
-    filters,
+    rawFilters,
     from,
     labels,
     match_day_of_week,
@@ -124,7 +131,8 @@ export default function QueryContextProvider({
     with_imported,
     legacy_time_on_page_cutoff,
     site,
-    expandedSegment
+    expandedSegment,
+    segmentsContext.segments
   ])
 
   useClearExpandedSegmentModeOnFilterClear({ expandedSegment, query })

--- a/assets/js/dashboard/query.ts
+++ b/assets/js/dashboard/query.ts
@@ -33,22 +33,43 @@ export type Filter = [FilterOperator, FilterKey, FilterClause[]]
  * */
 export type FilterClauseLabels = Record<string, string>
 
-export const queryDefaultValue = {
-  period: '30d' as QueryPeriod,
-  comparison: null as ComparisonMode | null,
-  match_day_of_week: true,
-  date: null as Dayjs | null,
-  from: null as Dayjs | null,
-  to: null as Dayjs | null,
-  compare_from: null as Dayjs | null,
-  compare_to: null as Dayjs | null,
-  filters: [] as Filter[],
-  labels: {} as FilterClauseLabels,
-  with_imported: true,
-  legacy_time_on_page_cutoff: undefined as string | undefined
+export type DashboardQuery = {
+  period: QueryPeriod
+  comparison: ComparisonMode | null
+  match_day_of_week: boolean
+  date: Dayjs | null
+  from: Dayjs | null
+  to: Dayjs | null
+  compare_from: Dayjs | null
+  compare_to: Dayjs | null
+  filters: Filter[]
+  /**
+   * This property is the same as `filters` always, except when
+   * `filters` contains a "Segment is {segment ID}" filter. In this case,
+   * `resolvedFilters` has the segment filter replaced with its constituent filters,
+   * so the FE could be aware of what filters are applied.
+   */
+  resolvedFilters: Filter[]
+  labels: FilterClauseLabels
+  with_imported: boolean
+  legacy_time_on_page_cutoff: string | undefined
 }
 
-export type DashboardQuery = typeof queryDefaultValue
+export const queryDefaultValue: DashboardQuery = {
+  period: '30d' as QueryPeriod,
+  comparison: null,
+  match_day_of_week: true,
+  date: null,
+  from: null,
+  to: null,
+  compare_from: null,
+  compare_to: null,
+  filters: [],
+  resolvedFilters: [],
+  labels: {},
+  with_imported: true,
+  legacy_time_on_page_cutoff: undefined
+}
 
 export type BreakdownResultMeta = {
   date_range_label: string

--- a/assets/js/dashboard/segments/routeless-segment-modals.tsx
+++ b/assets/js/dashboard/segments/routeless-segment-modals.tsx
@@ -22,10 +22,12 @@ import { useQueryContext } from '../query-context'
 import { Role, useUserContext } from '../user-context'
 import { mutation } from '../api'
 import { useRoutelessModalsContext } from '../navigation/routeless-modals-context'
+import { useSegmentsContext } from '../filtering/segments-context'
 
 export type RoutelessSegmentModal = 'create' | 'update' | 'delete'
 
 export const RoutelessSegmentModals = () => {
+  const { updateOne, addOne, removeOne } = useSegmentsContext()
   const navigate = useAppNavigate()
   const queryClient = useQueryClient()
   const site = useSiteContext()
@@ -64,6 +66,7 @@ export const RoutelessSegmentModals = () => {
       return handleSegmentResponse(response)
     },
     onSuccess: async (segment) => {
+      updateOne(segment)
       queryClient.invalidateQueries({ queryKey: ['segments'] })
       navigate({
         search: getSearchToApplySingleSegmentFilter(segment),
@@ -100,6 +103,7 @@ export const RoutelessSegmentModals = () => {
       return handleSegmentResponse(response)
     },
     onSuccess: async (segment) => {
+      addOne(segment)
       queryClient.invalidateQueries({ queryKey: ['segments'] })
       navigate({
         search: getSearchToApplySingleSegmentFilter(segment),
@@ -122,7 +126,8 @@ export const RoutelessSegmentModals = () => {
         )
       return handleSegmentResponse(response)
     },
-    onSuccess: (_segment): void => {
+    onSuccess: (segment): void => {
+      removeOne(segment)
       queryClient.invalidateQueries({ queryKey: ['segments'] })
       navigate({
         search: (s) => {

--- a/assets/js/dashboard/segments/segment-authorship.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { SavedSegmentPublic, SavedSegment } from '../filtering/segments'
-import { formatDayShort, parseNaiveDate } from '../util/date'
+import { dateForSite, formatDayShort } from '../util/date'
+import { useSiteContext } from '../site-context'
 
 type SegmentAuthorshipProps = { className?: string } & (
   | { showOnlyPublicData: true; segment: SavedSegmentPublic }
@@ -14,6 +15,7 @@ export function SegmentAuthorship({
   showOnlyPublicData,
   segment
 }: SegmentAuthorshipProps) {
+  const site = useSiteContext()
   const authorLabel =
     showOnlyPublicData === true
       ? null
@@ -25,12 +27,12 @@ export function SegmentAuthorship({
   return (
     <div className={className}>
       <div>
-        {`Created at ${formatDayShort(parseNaiveDate(inserted_at))}`}
+        {`Created at ${formatDayShort(dateForSite(inserted_at, site))}`}
         {!showUpdatedAt && !!authorLabel && ` by ${authorLabel}`}
       </div>
       {showUpdatedAt && (
         <div>
-          {`Last updated at ${formatDayShort(parseNaiveDate(updated_at))}`}
+          {`Last updated at ${formatDayShort(dateForSite(updated_at, site))}`}
           {!!authorLabel && ` by ${authorLabel}`}
         </div>
       )}

--- a/assets/js/dashboard/segments/segment-modals.test.tsx
+++ b/assets/js/dashboard/segments/segment-modals.test.tsx
@@ -1,0 +1,148 @@
+/** @format */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { SegmentModal } from './segment-modals'
+import { TestContextProviders } from '../../../test-utils/app-context-providers'
+import {
+  SavedSegment,
+  SavedSegments,
+  SegmentData,
+  SegmentType
+} from '../filtering/segments'
+import { Role, UserContextValue } from '../user-context'
+import { PlausibleSite } from '../site-context'
+
+beforeEach(() => {
+  const modalRoot = document.createElement('div')
+  modalRoot.id = 'modal_root'
+  document.body.appendChild(modalRoot)
+})
+
+const flags = { saved_segments: true, saved_segments_fe: true }
+
+describe('Segment details modal - errors', () => {
+  const anySiteSegment: SavedSegment & { segment_data: SegmentData } = {
+    id: 1,
+    type: SegmentType.site,
+    owner_id: 1,
+    owner_name: 'Test User',
+    name: 'Blog or About',
+    segment_data: {
+      filters: [['is', 'page', ['/blog', '/about']]],
+      labels: {}
+    },
+    inserted_at: '2025-03-13T13:00:00',
+    updated_at: '2025-03-13T16:00:00'
+  }
+
+  const anyPersonalSegment: SavedSegment & { segment_data: SegmentData } = {
+    ...anySiteSegment,
+    id: 2,
+    type: SegmentType.personal
+  }
+
+  const cases: {
+    case: string
+    segments: SavedSegments
+    segmentId: number
+    user: UserContextValue
+    message: string
+    siteOptions: Partial<PlausibleSite>
+  }[] = [
+    {
+      case: 'segment is not in list',
+      segments: [anyPersonalSegment, anySiteSegment],
+      segmentId: 202020,
+      user: { loggedIn: true, id: 1, role: Role.owner },
+      message: `Segment not found with with ID "202020"`,
+      siteOptions: { flags, siteSegmentsAvailable: true }
+    },
+    {
+      case: 'site segment is in list but not listable because site segments are not available',
+      segments: [anyPersonalSegment, anySiteSegment],
+      segmentId: anySiteSegment.id,
+      user: { loggedIn: true, id: 1, role: Role.owner },
+      message: `Segment not found with with ID "${anySiteSegment.id}"`,
+      siteOptions: { flags, siteSegmentsAvailable: false }
+    },
+    {
+      case: 'personal segment is in list but not listable because it is a public dashboard',
+      segments: [{ ...anyPersonalSegment, owner_id: null, owner_name: null }],
+      segmentId: anyPersonalSegment.id,
+      user: { loggedIn: false, id: null, role: Role.public },
+      message: `Segment not found with with ID "${anyPersonalSegment.id}"`,
+      siteOptions: { flags, siteSegmentsAvailable: true }
+    },
+    {
+      case: 'segment is in list and listable, but detailed view is not available because user is not logged in',
+      segments: [{ ...anySiteSegment, owner_id: null, owner_name: null }],
+      segmentId: anySiteSegment.id,
+      user: { loggedIn: false, id: null, role: Role.public },
+      message: 'Not enough permissions to see segment details',
+      siteOptions: { flags, siteSegmentsAvailable: true }
+    }
+  ]
+  it.each(cases)(
+    'shows error `$message` when $case',
+    ({ user, segments, segmentId, message, siteOptions }) => {
+      render(<SegmentModal id={segmentId} />, {
+        wrapper: (props) => (
+          <TestContextProviders
+            user={user}
+            preloaded={{ segments }}
+            siteOptions={siteOptions}
+            {...props}
+          />
+        )
+      })
+
+      expect(screen.getByText(message)).toBeVisible()
+      expect(screen.queryByText(`Edit segment`)).not.toBeInTheDocument()
+    }
+  )
+})
+
+describe('Segment details modal - other cases', () => {
+  it('displays site segment correctly', () => {
+    const anySiteSegment: SavedSegment & { segment_data: SegmentData } = {
+      id: 100,
+      type: SegmentType.site,
+      owner_id: 100100,
+      owner_name: 'Test User',
+      name: 'Blog or About',
+      segment_data: {
+        filters: [['is', 'page', ['/blog', '/about']]],
+        labels: {}
+      },
+      inserted_at: '2025-03-13T13:00:00',
+      updated_at: '2025-03-13T16:00:00'
+    }
+
+    render(<SegmentModal id={anySiteSegment.id} />, {
+      wrapper: (props) => (
+        <TestContextProviders
+          user={{ loggedIn: true, role: Role.editor, id: 1 }}
+          preloaded={{
+            segments: [anySiteSegment]
+          }}
+          siteOptions={{ flags, siteSegmentsAvailable: true }}
+          {...props}
+        />
+      )
+    })
+    expect(screen.getByText(anySiteSegment.name)).toBeVisible()
+    expect(screen.getByText('Site segment')).toBeVisible()
+
+    expect(screen.getByText('Filters in segment')).toBeVisible()
+    expect(screen.getByTitle('Page is /blog or /about')).toBeVisible()
+
+    expect(
+      screen.getByText(`Last updated at 13 Mar by ${anySiteSegment.owner_name}`)
+    ).toBeVisible()
+    expect(screen.getByText(`Created at 13 Mar`)).toBeVisible()
+
+    expect(screen.getByText('Edit segment')).toBeVisible()
+    expect(screen.getByText('Remove filter')).toBeVisible()
+  })
+})

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -3,6 +3,7 @@
 import React, { ReactNode, useState } from 'react'
 import ModalWithRouting from '../stats/modals/modal'
 import {
+  canSeeSegmentDetails,
   isListableSegment,
   isSegmentFilter,
   SavedSegment,
@@ -434,14 +435,24 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
   const user = useUserContext()
   const { query } = useQueryContext()
   const { segments } = useSegmentsContext()
-  const data = segments
-    .filter((segment) => isListableSegment({ segment, site, user }))
+
+  const segment = segments
+    .filter((s) => isListableSegment({ segment: s, site, user }))
     .find((s) => String(s.id) === String(id))
-  const error = !data
-    ? new ApiError('Error loading segment', {
-        error: `Segment not found with with ID "${id}"`
-      })
-    : null
+
+  let error: ApiError | null = null
+
+  if (!segment) {
+    error = new ApiError(`Segment not found with with ID "${id}"`, {
+      error: `Segment not found with with ID "${id}"`
+    })
+  } else if (!canSeeSegmentDetails({ user })) {
+    error = new ApiError('Not enough permissions to see segment details', {
+      error: `Not enough permissions to see segment details`
+    })
+  }
+
+  const data = !error ? segment : null
 
   return (
     <ModalWithRouting maxWidth="460px">

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -1,15 +1,15 @@
 /** @format */
 
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 import ModalWithRouting from '../stats/modals/modal'
 import {
+  isListableSegment,
   isSegmentFilter,
   SavedSegment,
   SEGMENT_TYPE_LABELS,
   SegmentData,
   SegmentType
 } from '../filtering/segments'
-import { useSegmentPrefetch } from '../nav-menu/segments/searchable-segments-section'
 import { useQueryContext } from '../query-context'
 import { AppNavigationLink } from '../navigation/use-app-navigate'
 import { cleanLabels } from '../util/filters'
@@ -22,6 +22,9 @@ import { ExclamationTriangleIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { MutationStatus } from '@tanstack/react-query'
 import { ApiError } from '../api'
 import { ErrorPanel } from '../components/error-panel'
+import { useSegmentsContext } from '../filtering/segments-context'
+import { useSiteContext } from '../site-context'
+import { useUserContext } from '../user-context'
 
 interface ApiRequestProps {
   status: MutationStatus
@@ -427,15 +430,18 @@ const Placeholder = ({
 )
 
 export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
+  const site = useSiteContext()
+  const user = useUserContext()
   const { query } = useQueryContext()
-
-  const { data, fetchSegment, status, error } = useSegmentPrefetch({
-    id: String(id)
-  })
-
-  useEffect(() => {
-    fetchSegment()
-  }, [fetchSegment])
+  const { segments } = useSegmentsContext()
+  const data = segments
+    .filter((segment) => isListableSegment({ segment, site, user }))
+    .find((s) => String(s.id) === String(id))
+  const error = !data
+    ? new ApiError('Error loading segment', {
+        error: `Segment not found with with ID "${id}"`
+      })
+    : null
 
   return (
     <ModalWithRouting maxWidth="460px">
@@ -506,13 +512,6 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
             </div>
           </>
         )}
-        {status === 'pending' && (
-          <div className="flex items-center justify-center">
-            <div className="loading">
-              <div />
-            </div>
-          </div>
-        )}
         {error !== null && (
           <ErrorPanel
             className="mt-4"
@@ -521,7 +520,7 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
                 ? error.message
                 : 'Something went wrong loading segment'
             }
-            onRetry={() => fetchSegment()}
+            onRetry={() => window.location.reload()}
           />
         )}
       </div>

--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -11,7 +11,7 @@ import { rootRoute } from '../../router';
 import { useAppNavigate } from '../../navigation/use-app-navigate';
 import { SegmentModal } from '../../segments/segment-modals';
 import { TrashIcon } from '@heroicons/react/24/outline';
-import { isSegmentFilter } from '../../filtering/segments';
+import { findAppliedSegmentFilter } from '../../filtering/segments';
 
 function partitionFilters(modalType, filters) {
   const otherFilters = []
@@ -202,10 +202,13 @@ export default function FilterModalWithRouter(props) {
   if (!Object.keys(getAvailableFilterModals(site)).includes(field)) {
     return null
   }
-  const firstSegmentFilter = field === 'segment' ? query.filters?.find(isSegmentFilter) : null
-  if (firstSegmentFilter) {
-    const firstSegmentId = firstSegmentFilter[2][0]
-    return <SegmentModal id={firstSegmentId} />
+  const appliedSegmentFilter =
+    field === 'segment'
+      ? findAppliedSegmentFilter({ filters: query.filters })
+      : null
+  if (appliedSegmentFilter) {
+    const [_operation, _dimension, [segmentId]] = appliedSegmentFilter
+    return <SegmentModal id={segmentId} />
   }
   return (
     <FilterModal

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -90,11 +90,15 @@ export function getPropertyKeyFromFilterKey(filterKey) {
   return filterKey.slice(EVENT_PROPS_PREFIX.length)
 }
 
+/** WIP: investigate all occurrences */
 export function getFiltersByKeyPrefix(query, prefix) {
-  return query.filters.filter(([_operation, filterKey, _clauses]) =>
-    filterKey.startsWith(prefix)
-  )
+  return query.filters.filter(hasDimensionPrefix(prefix))
 }
+
+const hasDimensionPrefix =
+  (prefix) =>
+  ([_operation, dimension, _clauses]) =>
+    dimension.startsWith(prefix)
 
 function omitFiltersByKeyPrefix(query, prefix) {
   return query.filters.filter(
@@ -102,10 +106,12 @@ function omitFiltersByKeyPrefix(query, prefix) {
   )
 }
 
+/** WIP: investigate all occurrences */
 export function replaceFilterByPrefix(query, prefix, filter) {
   return omitFiltersByKeyPrefix(query, prefix).concat([filter])
 }
 
+/** WIP: investigate all occurrences */
 export function isFilteringOnFixedValue(query, filterKey, expectedValue) {
   const filters = query.filters.filter(([_operation, key]) => filterKey == key)
   if (filters.length == 1) {
@@ -119,10 +125,13 @@ export function isFilteringOnFixedValue(query, filterKey, expectedValue) {
   return false
 }
 
+/** WIP: investigate all occurrences */
 export function hasConversionGoalFilter(query) {
-  const goalFilters = getFiltersByKeyPrefix(query, 'goal')
+  const resolvedGoalFilters = query.resolvedFilters.filter(
+    hasDimensionPrefix('goal')
+  )
 
-  return goalFilters.some(([operation, _filterKey, _clauses]) => {
+  return resolvedGoalFilters.some(([operation, _filterKey, _clauses]) => {
     return operation !== FILTER_OPERATIONS.has_not_done
   })
 }
@@ -131,6 +140,7 @@ export function isRealTimeDashboard(query) {
   return query?.period === 'realtime'
 }
 
+/** WIP: investigate all occurrences */
 // Note: Currently only a single goal filter can be applied at a time.
 export function getGoalFilter(query) {
   return getFiltersByKeyPrefix(query, 'goal')[0] || null
@@ -264,6 +274,7 @@ export function fetchSuggestions(apiPath, query, input, additionalFilter) {
   return api.get(apiPath, updatedQuery, { q: input.trim() })
 }
 
+/** WIP: how well does it work with segments actually */
 function queryForSuggestions(query, additionalFilter) {
   let filters = query.filters
   if (additionalFilter) {

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -90,7 +90,6 @@ export function getPropertyKeyFromFilterKey(filterKey) {
   return filterKey.slice(EVENT_PROPS_PREFIX.length)
 }
 
-/** WIP: investigate all occurrences */
 export function getFiltersByKeyPrefix(query, prefix) {
   return query.filters.filter(hasDimensionPrefix(prefix))
 }
@@ -106,12 +105,10 @@ function omitFiltersByKeyPrefix(query, prefix) {
   )
 }
 
-/** WIP: investigate all occurrences */
 export function replaceFilterByPrefix(query, prefix, filter) {
   return omitFiltersByKeyPrefix(query, prefix).concat([filter])
 }
 
-/** WIP: investigate all occurrences */
 export function isFilteringOnFixedValue(query, filterKey, expectedValue) {
   const filters = query.filters.filter(([_operation, key]) => filterKey == key)
   if (filters.length == 1) {
@@ -125,7 +122,6 @@ export function isFilteringOnFixedValue(query, filterKey, expectedValue) {
   return false
 }
 
-/** WIP: investigate all occurrences */
 export function hasConversionGoalFilter(query) {
   const resolvedGoalFilters = query.resolvedFilters.filter(
     hasDimensionPrefix('goal')
@@ -140,7 +136,6 @@ export function isRealTimeDashboard(query) {
   return query?.period === 'realtime'
 }
 
-/** WIP: investigate all occurrences */
 // Note: Currently only a single goal filter can be applied at a time.
 export function getGoalFilter(query) {
   return getFiltersByKeyPrefix(query, 'goal')[0] || null
@@ -274,7 +269,6 @@ export function fetchSuggestions(apiPath, query, input, additionalFilter) {
   return api.get(apiPath, updatedQuery, { q: input.trim() })
 }
 
-/** WIP: how well does it work with segments actually */
 function queryForSuggestions(query, additionalFilter) {
   let filters = query.filters
   if (additionalFilter) {

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import QueryContextProvider from '../js/dashboard/query-context'
 import { getRouterBasepath } from '../js/dashboard/router'
 import { RoutelessModalsContextProvider } from '../js/dashboard/navigation/routeless-modals-context'
+import { SegmentsContextProvider } from '../js/dashboard/filtering/segments-context'
 
 type TestContextProvidersProps = {
   children: ReactNode
@@ -62,18 +63,20 @@ export const TestContextProviders = ({
   return (
     // <ThemeContextProvider> not interactive component, default value is suitable
     <SiteContextProvider site={site}>
-      <UserContextProvider user={{ role: Role.admin, loggedIn: true, id: 1 }}>
-        <MemoryRouter
-          basename={getRouterBasepath(site)}
-          initialEntries={defaultInitialEntries}
-          {...routerProps}
-        >
-          <QueryClientProvider client={queryClient}>
-            <RoutelessModalsContextProvider>
-              <QueryContextProvider>{children}</QueryContextProvider>
-            </RoutelessModalsContextProvider>
-          </QueryClientProvider>
-        </MemoryRouter>
+      <UserContextProvider user={{ role: Role.editor, loggedIn: true, id: 1 }}>
+        <SegmentsContextProvider preloadedSegments={[]}>
+          <MemoryRouter
+            basename={getRouterBasepath(site)}
+            initialEntries={defaultInitialEntries}
+            {...routerProps}
+          >
+            <QueryClientProvider client={queryClient}>
+              <RoutelessModalsContextProvider>
+                <QueryContextProvider>{children}</QueryContextProvider>
+              </RoutelessModalsContextProvider>
+            </QueryClientProvider>
+          </MemoryRouter>
+        </SegmentsContextProvider>
       </UserContextProvider>
     </SiteContextProvider>
     // </ThemeContextProvider>

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -4,24 +4,32 @@ import React, { ReactNode } from 'react'
 import SiteContextProvider, {
   PlausibleSite
 } from '../js/dashboard/site-context'
-import UserContextProvider, { Role } from '../js/dashboard/user-context'
+import UserContextProvider, {
+  Role,
+  UserContextValue
+} from '../js/dashboard/user-context'
 import { MemoryRouter, MemoryRouterProps } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import QueryContextProvider from '../js/dashboard/query-context'
 import { getRouterBasepath } from '../js/dashboard/router'
 import { RoutelessModalsContextProvider } from '../js/dashboard/navigation/routeless-modals-context'
 import { SegmentsContextProvider } from '../js/dashboard/filtering/segments-context'
+import { SavedSegments } from '../js/dashboard/filtering/segments'
 
 type TestContextProvidersProps = {
   children: ReactNode
   routerProps?: Pick<MemoryRouterProps, 'initialEntries'>
   siteOptions?: Partial<PlausibleSite>
+  user?: UserContextValue
+  preloaded?: { segments?: SavedSegments }
 }
 
 export const TestContextProviders = ({
   children,
   routerProps,
-  siteOptions
+  siteOptions,
+  preloaded,
+  user
 }: TestContextProvidersProps) => {
   const defaultSite: PlausibleSite = {
     domain: 'plausible.io/unit',
@@ -63,8 +71,10 @@ export const TestContextProviders = ({
   return (
     // <ThemeContextProvider> not interactive component, default value is suitable
     <SiteContextProvider site={site}>
-      <UserContextProvider user={{ role: Role.editor, loggedIn: true, id: 1 }}>
-        <SegmentsContextProvider preloadedSegments={[]}>
+      <UserContextProvider
+        user={user ?? { role: Role.editor, loggedIn: true, id: 1 }}
+      >
+        <SegmentsContextProvider preloadedSegments={preloaded?.segments ?? []}>
           <MemoryRouter
             basename={getRouterBasepath(site)}
             initialEntries={defaultInitialEntries}

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -203,14 +203,8 @@ defimpl Jason.Encoder, for: Plausible.Segments.Segment do
       segment_data: segment.segment_data,
       owner_id: segment.owner_id,
       owner_name: if(is_nil(segment.owner_id), do: nil, else: segment.owner.name),
-      inserted_at:
-        segment.inserted_at
-        |> Plausible.Timezones.to_datetime_in_timezone(segment.site.timezone)
-        |> Calendar.strftime("%Y-%m-%d %H:%M:%S"),
-      updated_at:
-        segment.updated_at
-        |> Plausible.Timezones.to_datetime_in_timezone(segment.site.timezone)
-        |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+      inserted_at: segment.inserted_at,
+      updated_at: segment.updated_at
     }
     |> Jason.Encode.map(opts)
   end

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -17,25 +17,32 @@ defmodule Plausible.Segments do
 
   @max_segments 500
 
-  @spec index(pos_integer() | nil, Plausible.Site.t(), atom()) ::
-          {:ok, [Segment.t()]} | error_not_enough_permissions()
-  def index(user_id, %Plausible.Site{} = site, site_role) do
-    fields = [:id, :name, :type, :inserted_at, :updated_at, :owner_id]
-
-    site_segments_available? =
-      site_segments_available?(site)
+  def get_all_for_site(%Plausible.Site{} = site, site_role) do
+    fields = [:id, :name, :type, :inserted_at, :updated_at, :segment_data]
 
     cond do
-      site_role in [:public] and
-          site_segments_available? ->
-        {:ok, get_public_site_segments(site.id, fields -- [:owner_id])}
+      site_role in [:public] ->
+        {:ok,
+         Repo.all(
+           from(segment in Segment,
+             select: ^fields,
+             where: segment.site_id == ^site.id,
+             order_by: [desc: segment.updated_at, desc: segment.id]
+           )
+         )}
 
-      site_role in @roles_with_maybe_site_segments and
-          site_segments_available? ->
-        {:ok, get_segments(user_id, site.id, fields)}
+      site_role in @roles_with_personal_segments or site_role in @roles_with_maybe_site_segments ->
+        fields = fields ++ [:owner_id]
 
-      site_role in @roles_with_personal_segments ->
-        {:ok, get_segments(user_id, site.id, fields, only: :personal)}
+        {:ok,
+         Repo.all(
+           from(segment in Segment,
+             select: ^fields,
+             where: segment.site_id == ^site.id,
+             order_by: [desc: segment.updated_at, desc: segment.id],
+             preload: [:owner]
+           )
+         )}
 
       true ->
         {:error, :not_enough_permissions}
@@ -348,42 +355,6 @@ defmodule Plausible.Segments do
   def site_segments_available?(%Plausible.Site{} = site),
     do: Plausible.Billing.Feature.SiteSegments.check_availability(site.team) == :ok
 
-  @spec get_public_site_segments(pos_integer(), list(atom())) :: [Segment.t()]
-  defp get_public_site_segments(site_id, fields) do
-    Repo.all(
-      from(segment in Segment,
-        select: ^fields,
-        where: segment.site_id == ^site_id,
-        where: segment.type == :site,
-        order_by: [desc: segment.updated_at, desc: segment.id]
-      )
-    )
-  end
-
-  @spec get_segments(pos_integer(), pos_integer(), list(atom()), Keyword.t()) :: [Segment.t()]
-  defp get_segments(user_id, site_id, fields, opts \\ []) do
-    query =
-      from(segment in Segment,
-        select: ^fields,
-        where: segment.site_id == ^site_id,
-        order_by: [desc: segment.updated_at, desc: segment.id],
-        preload: [:owner]
-      )
-
-    query =
-      if Keyword.get(opts, :only) == :personal do
-        where(query, [segment], segment.type == :personal and segment.owner_id == ^user_id)
-      else
-        where(
-          query,
-          [segment],
-          segment.type == :site or (segment.type == :personal and segment.owner_id == ^user_id)
-        )
-      end
-
-    Repo.all(query)
-  end
-
   @doc """
   iex> serialize_first_error([{"name", {"should be at most %{count} byte(s)", [count: 255]}}])
   "name should be at most 255 byte(s)"
@@ -397,15 +368,6 @@ defmodule Plausible.Segments do
       end)
 
     "#{field} #{formatted_message}"
-  end
-
-  @doc """
-  This function enriches the segment with site, without actually querying the database for the site again.
-  Needed for Plausible.Segments.Segment custom JSON serialization.
-  """
-  @spec enrich_with_site(Segment.t(), Plausible.Site.t()) :: Segment.t()
-  def enrich_with_site(%Segment{} = segment, %Plausible.Site{} = site) do
-    Map.put(segment, :site, site)
   end
 
   @spec get_site_segments_usage_query(list(pos_integer())) :: Ecto.Query.t()

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -221,9 +221,7 @@ defmodule PlausibleWeb.Router do
     end
 
     scope "/:domain/segments", PlausibleWeb.Api.Internal do
-      get "/", SegmentsController, :index
       post "/", SegmentsController, :create
-      get "/:segment_id", SegmentsController, :get
       patch "/:segment_id", SegmentsController, :update
       delete "/:segment_id", SegmentsController, :delete
     end

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -42,13 +42,12 @@
     data-embedded={to_string(@conn.assigns[:embedded])}
     data-background={@conn.assigns[:background]}
     data-is-dbip={to_string(@is_dbip)}
-    data-current-user-role={
-      if site_role = @conn.assigns[:site_role], do: site_role, else: :public
-    }
+    data-current-user-role={@site_role}
     data-current-user-id={
       if user = @conn.assigns[:current_user], do: user.id, else: Jason.encode!(nil)
     }
     data-flags={Jason.encode!(@flags)}
+    data-segments={Jason.encode!(@segments)}
     data-valid-intervals-by-period={
       Plausible.Stats.Interval.valid_by_period(site: @site) |> Jason.encode!()
     }

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -3,304 +3,6 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
   use Plausible.Repo
   use Plausible.Teams.Test
 
-  describe "GET /api/:domain/segments" do
-    setup [:create_user, :log_in, :create_site]
-
-    test "returns empty list when no segments", %{conn: conn, site: site} do
-      conn =
-        get(conn, "/api/#{site.domain}/segments")
-
-      assert json_response(conn, 200) == []
-    end
-
-    test "returns site segments list when looking at a public dashboard", %{conn: conn} do
-      other_user = new_user()
-      site = new_site(owner: other_user, public: true)
-
-      site_segments =
-        insert_list(2, :segment,
-          site: site,
-          owner: other_user,
-          type: :site,
-          name: "other site segment"
-        )
-
-      insert_list(10, :segment,
-        site: site,
-        owner: other_user,
-        type: :personal,
-        name: "other user personal segment"
-      )
-
-      conn = get(conn, "/api/#{site.domain}/segments")
-
-      assert json_response(conn, 200) ==
-               Enum.reverse(
-                 Enum.map(site_segments, fn s ->
-                   %{
-                     "id" => s.id,
-                     "name" => s.name,
-                     "type" => Atom.to_string(s.type),
-                     "inserted_at" => Calendar.strftime(s.inserted_at, "%Y-%m-%d %H:%M:%S"),
-                     "updated_at" => Calendar.strftime(s.updated_at, "%Y-%m-%d %H:%M:%S"),
-                     "owner_id" => nil,
-                     "owner_name" => nil,
-                     "segment_data" => nil
-                   }
-                 end)
-               )
-    end
-
-    test "forbids owners on growth plan from seeing site segments", %{
-      conn: conn,
-      user: user,
-      site: site
-    } do
-      user |> subscribe_to_growth_plan()
-
-      insert_list(2, :segment,
-        site: site,
-        owner: user,
-        type: :site,
-        name: "site segment"
-      )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments")
-
-      assert json_response(conn, 200) == []
-    end
-
-    for role <- [:viewer, :owner] do
-      test "returns list with personal and site segments for #{role}, avoiding segments from other site",
-           %{conn: conn, user: user, site: site} do
-        team = team_of(user)
-        other_user = new_user(name: "Other User")
-        other_site = new_site(team: team)
-        add_member(team, user: other_user, role: :owner)
-
-        insert_list(2, :segment,
-          site: other_site,
-          owner: user,
-          type: :site,
-          name: "other site segment"
-        )
-
-        insert_list(10, :segment,
-          site: site,
-          owner: other_user,
-          type: :personal,
-          name: "other user personal segment"
-        )
-
-        personal_segment =
-          insert(:segment,
-            site: site,
-            owner: user,
-            type: :personal,
-            name: "a personal segment"
-          )
-          |> Map.put(:owner_name, user.name)
-
-        emea_site_segment =
-          insert(:segment,
-            site: site,
-            owner: other_user,
-            type: :site,
-            name: "EMEA region"
-          )
-          |> Map.put(:owner_name, other_user.name)
-
-        apac_site_segment =
-          insert(:segment,
-            site: site,
-            owner: user,
-            type: :site,
-            name: "APAC region"
-          )
-          |> Map.put(:owner_name, user.name)
-
-        dangling_site_segment =
-          insert(:segment,
-            site: site,
-            owner: nil,
-            type: :site,
-            name: "Another region"
-          )
-          |> Map.put(:owner_name, nil)
-
-        conn =
-          get(conn, "/api/#{site.domain}/segments")
-
-        assert json_response(conn, 200) ==
-                 Enum.map(
-                   [
-                     dangling_site_segment,
-                     apac_site_segment,
-                     emea_site_segment,
-                     personal_segment
-                   ],
-                   fn s ->
-                     %{
-                       "id" => s.id,
-                       "name" => s.name,
-                       "type" => Atom.to_string(s.type),
-                       "owner_id" => s.owner_id,
-                       "owner_name" => s.owner_name,
-                       "inserted_at" => Calendar.strftime(s.inserted_at, "%Y-%m-%d %H:%M:%S"),
-                       "updated_at" => Calendar.strftime(s.updated_at, "%Y-%m-%d %H:%M:%S"),
-                       "segment_data" => nil
-                     }
-                   end
-                 )
-      end
-    end
-  end
-
-  describe "GET /api/:domain/segments/:segment_id" do
-    setup [:create_user, :create_site, :log_in]
-
-    test "serves 404 when invalid segment key used", %{conn: conn, site: site} do
-      conn =
-        get(conn, "/api/#{site.domain}/segments/any-id")
-
-      assert json_response(conn, 404) == %{"error" => "Segment not found with ID \"any-id\""}
-    end
-
-    test "serves 404 when no segment found", %{conn: conn, site: site} do
-      conn =
-        get(conn, "/api/#{site.domain}/segments/100100")
-
-      assert json_response(conn, 404) == %{"error" => "Segment not found with ID \"100100\""}
-    end
-
-    test "serves 404 when segment is for another site", %{conn: conn, site: site, user: user} do
-      other_site = new_site(owner: user)
-
-      segment =
-        insert(:segment,
-          site: other_site,
-          owner: user,
-          type: :site,
-          name: "any"
-        )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments/#{segment.id}")
-
-      assert json_response(conn, 404) == %{
-               "error" => "Segment not found with ID \"#{segment.id}\""
-             }
-    end
-
-    test "serves 404 for viewing contents of site segments for viewers of public dashboards",
-         %{
-           conn: conn
-         } do
-      site = new_site(public: true)
-      other_user = add_guest(site, user: new_user(), role: :editor)
-
-      segment =
-        insert(:segment,
-          type: :site,
-          owner: other_user,
-          site: site,
-          name: "any"
-        )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments/#{segment.id}")
-
-      assert json_response(conn, 403) == %{
-               "error" => "Not enough permissions to get segment data"
-             }
-    end
-
-    test "serves 404 when user is not the segment owner and segment is personal",
-         %{
-           conn: conn,
-           site: site
-         } do
-      other_user = add_guest(site, role: :editor)
-
-      segment =
-        insert(:segment,
-          type: :personal,
-          owner: other_user,
-          site: site,
-          name: "any"
-        )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments/#{segment.id}")
-
-      assert json_response(conn, 404) == %{
-               "error" => "Segment not found with ID \"#{segment.id}\""
-             }
-    end
-
-    test "serves 200 with segment when user is not the segment owner and segment is not personal",
-         %{
-           conn: conn,
-           user: user
-         } do
-      site = new_site(owner: user, timezone: "Asia/Tokyo")
-      other_user = add_guest(site, role: :editor)
-
-      segment =
-        insert(:segment,
-          type: :site,
-          owner: other_user,
-          site: site,
-          name: "any",
-          inserted_at: "2024-09-01T22:00:00.000Z",
-          updated_at: "2024-09-01T23:00:00.000Z"
-        )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments/#{segment.id}")
-
-      assert json_response(conn, 200) == %{
-               "id" => segment.id,
-               "owner_id" => other_user.id,
-               "owner_name" => other_user.name,
-               "name" => segment.name,
-               "type" => Atom.to_string(segment.type),
-               "segment_data" => segment.segment_data,
-               "inserted_at" => "2024-09-02 07:00:00",
-               "updated_at" => "2024-09-02 08:00:00"
-             }
-    end
-
-    test "serves 200 with segment when user is segment owner", %{
-      conn: conn,
-      site: site,
-      user: user
-    } do
-      segment =
-        insert(:segment,
-          site: site,
-          name: "any",
-          owner: user,
-          type: :personal
-        )
-
-      conn =
-        get(conn, "/api/#{site.domain}/segments/#{segment.id}")
-
-      assert json_response(conn, 200) == %{
-               "id" => segment.id,
-               "owner_id" => user.id,
-               "owner_name" => user.name,
-               "name" => segment.name,
-               "type" => Atom.to_string(segment.type),
-               "segment_data" => segment.segment_data,
-               "inserted_at" => Calendar.strftime(segment.inserted_at, "%Y-%m-%d %H:%M:%S"),
-               "updated_at" => Calendar.strftime(segment.updated_at, "%Y-%m-%d %H:%M:%S")
-             }
-    end
-  end
-
   describe "POST /api/:domain/segments" do
     setup [:create_user, :log_in, :create_site]
 
@@ -638,7 +340,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                        "inserted_at" =>
                          ^any(
                            :string,
-                           ~r/#{Calendar.strftime(segment.inserted_at, "%Y-%m-%d %H:%M:%S")}/
+                           ~r/#{Calendar.strftime(segment.inserted_at, "%Y-%m-%dT%H:%M:%S")}/
                          ),
                        "updated_at" => ^any(:iso8601_naive_datetime)
                      }) = response
@@ -678,7 +380,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                        "inserted_at" =>
                          ^any(
                            :string,
-                           ~r/#{Calendar.strftime(segment.inserted_at, "%Y-%m-%d %H:%M:%S")}/
+                           ~r/#{Calendar.strftime(segment.inserted_at, "%Y-%m-%dT%H:%M:%S")}/
                          ),
                        "updated_at" => ^any(:iso8601_naive_datetime)
                      }) = response
@@ -760,8 +462,8 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                  "name" => segment.name,
                  "segment_data" => segment.segment_data,
                  "type" => "#{unquote(type)}",
-                 "inserted_at" => Calendar.strftime(segment.inserted_at, "%Y-%m-%d %H:%M:%S"),
-                 "updated_at" => Calendar.strftime(segment.updated_at, "%Y-%m-%d %H:%M:%S")
+                 "inserted_at" => Calendar.strftime(segment.inserted_at, "%Y-%m-%dT%H:%M:%S"),
+                 "updated_at" => Calendar.strftime(segment.updated_at, "%Y-%m-%dT%H:%M:%S")
                } == response
 
         verify_no_segment_in_db(segment)
@@ -792,8 +494,8 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
                "name" => segment.name,
                "segment_data" => segment.segment_data,
                "type" => "site",
-               "inserted_at" => Calendar.strftime(segment.inserted_at, "%Y-%m-%d %H:%M:%S"),
-               "updated_at" => Calendar.strftime(segment.updated_at, "%Y-%m-%d %H:%M:%S")
+               "inserted_at" => Calendar.strftime(segment.inserted_at, "%Y-%m-%dT%H:%M:%S"),
+               "updated_at" => Calendar.strftime(segment.updated_at, "%Y-%m-%dT%H:%M:%S")
              } == response
 
       verify_no_segment_in_db(segment)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -41,6 +41,41 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_element(resp, "title") == "Plausible · #{site.domain}"
     end
 
+    test "public site - all segments (personal or site) are stuffed into dataset, without their owner_id and owner_name",
+         %{conn: conn} do
+      user = new_user()
+      site = new_site(owner: user, public: true)
+
+      populate_stats(site, [build(:pageview)])
+
+      emea_site_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :site,
+          name: "EMEA region"
+        )
+        |> Map.put(:owner_name, nil)
+        |> Map.put(:owner_id, nil)
+
+      foo_personal_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :personal,
+          name: "FOO"
+        )
+        |> Map.put(:owner_name, nil)
+        |> Map.put(:owner_id, nil)
+
+      conn = get(conn, "/#{site.domain}")
+      resp = html_response(conn, 200)
+      assert element_exists?(resp, @react_container)
+
+      assert text_of_attr(resp, @react_container, "data-segments") ==
+               Jason.encode!([foo_personal_segment, emea_site_segment])
+    end
+
     test "plausible.io live demo - shows site stats", %{conn: conn} do
       site = new_site(domain: "plausible.io", public: true)
       populate_stats(site, [build(:pageview)])
@@ -153,6 +188,36 @@ defmodule PlausibleWeb.StatsControllerTest do
     test "does not show CRM link to the site", %{conn: conn, site: site} do
       conn = get(conn, conn |> get("/" <> site.domain) |> redirected_to())
       refute html_response(conn, 200) =~ "/crm/sites/site/#{site.id}"
+    end
+
+    test "all segments (personal or site) are stuffed into dataset, with associated their owner_id and owner_name",
+         %{conn: conn, site: site, user: user} do
+      populate_stats(site, [build(:pageview)])
+
+      emea_site_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :site,
+          name: "EMEA region"
+        )
+        |> Map.put(:owner_name, user.name)
+
+      foo_personal_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :personal,
+          name: "FOO"
+        )
+        |> Map.put(:owner_name, user.name)
+
+      conn = get(conn, "/#{site.domain}")
+      resp = html_response(conn, 200)
+      assert element_exists?(resp, @react_container)
+
+      assert text_of_attr(resp, @react_container, "data-segments") ==
+               Jason.encode!([foo_personal_segment, emea_site_segment])
     end
   end
 
@@ -1138,6 +1203,39 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert text_of_attr(html, @react_container, "data-scroll-depth-visible") == "true"
       assert not is_nil(Repo.reload!(site).scroll_depth_visible_at)
+    end
+
+    test "all segments (personal or site) are stuffed into dataset, without their owner_id and owner_name",
+         %{conn: conn} do
+      user = new_user()
+      site = new_site(domain: "test-site.com", owner: user)
+      link = insert(:shared_link, site: site)
+
+      emea_site_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :site,
+          name: "EMEA region"
+        )
+        |> Map.put(:owner_name, nil)
+        |> Map.put(:owner_id, nil)
+
+      foo_personal_segment =
+        insert(:segment,
+          site: site,
+          owner: user,
+          type: :personal,
+          name: "FOO"
+        )
+        |> Map.put(:owner_name, nil)
+        |> Map.put(:owner_id, nil)
+
+      conn = get(conn, "/share/#{site.domain}/?auth=#{link.slug}")
+      resp = html_response(conn, 200)
+
+      assert text_of_attr(resp, @react_container, "data-segments") ==
+               Jason.encode!([foo_personal_segment, emea_site_segment])
     end
   end
 


### PR DESCRIPTION
### Changes

* Replaces `GET /api/:domain/segments` and `GET /api/:domain/segments/:segment_id` requests by stuffing all segments into the server rendered HTML
  * This list is updated in the FE on successful segment add, update, delete actions, and a new fresh list is provided any time the user refreshes the dashboard
* Adds calculated `resolvedFilters` to query context, for filters related utilities not to lose track of the metrics the FE should request 
  * makes use of `resolvedFilters` in `hasConversionGoalFilter` utility, which is called in most metrics reports

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
