### PR TITLE
time-on-page: Don't read/write active_visitors from GA4

### DIFF
--- a/lib/plausible/imported/google_analytics4.ex
+++ b/lib/plausible/imported/google_analytics4.ex
@@ -200,7 +200,6 @@ defmodule Plausible.Imported.GoogleAnalytics4 do
       hostname: row.dimensions |> Map.fetch!("hostName") |> String.replace_prefix("www.", ""),
       page: row.dimensions |> Map.fetch!("pagePath") |> URI.parse() |> Map.get(:path),
       visitors: row.metrics |> Map.fetch!("totalUsers") |> parse_number(),
-      active_visitors: row.metrics |> Map.fetch!("activeUsers") |> parse_number(),
       visits: row.metrics |> Map.fetch!("sessions") |> parse_number(),
       pageviews: row.metrics |> Map.fetch!("screenPageViews") |> parse_number(),
       # NOTE: no exits metric in GA4 API currently

--- a/lib/plausible/imported/page.ex
+++ b/lib/plausible/imported/page.ex
@@ -11,7 +11,6 @@ defmodule Plausible.Imported.Page do
     field :page, :string
     field :visits, Ch, type: "UInt64"
     field :visitors, Ch, type: "UInt64"
-    field :active_visitors, Ch, type: "UInt64"
     field :pageviews, Ch, type: "UInt64"
     field :exits, Ch, type: "UInt64"
     field :total_scroll_depth, Ch, type: "UInt64"

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -6,7 +6,6 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
   import Ecto.Query, only: [from: 2]
   import ExUnit.CaptureLog
 
-  alias Plausible.ClickhouseRepo
   alias Plausible.Repo
   alias Plausible.Imported.GoogleAnalytics4
 
@@ -150,9 +149,6 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
       assert_browsers(conn, breakdown_params)
       assert_os(conn, breakdown_params)
       assert_os_versions(conn, breakdown_params)
-
-      # Misc
-      assert_active_visitors(site_import)
     end
 
     test "handles empty response payload gracefully", %{user: user, site: site} do
@@ -461,34 +457,6 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
         end)
       end
     end
-  end
-
-  defp assert_active_visitors(site_import) do
-    result =
-      ClickhouseRepo.query!(
-        "SELECT date, sum(visitors) AS all_visitors, sum(active_visitors) AS all_active_visitors " <>
-          "FROM imported_pages WHERE site_id = #{site_import.site_id} AND import_id = #{site_import.id} GROUP BY date"
-      )
-      |> Map.fetch!(:rows)
-      |> Enum.map(fn [date, all_visitors, all_active_visitors] ->
-        %{date: date, visitors: all_visitors, active_visitors: all_active_visitors}
-      end)
-
-    assert length(result) == 31
-
-    Enum.each(result, fn row ->
-      assert row.visitors > 100 and row.active_visitors > 100
-      assert row.active_visitors <= row.visitors
-    end)
-
-    ClickhouseRepo.query!(
-      "SELECT time_on_page FROM imported_pages WHERE active_visitors = 0 AND " <>
-        "site_id = #{site_import.site_id} AND import_id = #{site_import.id}"
-    )
-    |> Map.fetch!(:rows)
-    |> Enum.each(fn [time_on_page] ->
-      assert time_on_page == 0
-    end)
   end
 
   defp assert_custom_events(conn, params) do


### PR DESCRIPTION
Ref: https://3.basecamp.com/5308029/buckets/41123095/card_tables/cards/8391930289

This column was speculatively added for time-on-page but we don't need it.