### PR TITLE
Get rid of `billable_user` in favour of `current_team_role` (or `site_role` if need be)

### DIFF
--- a/lib/plausible_web/live/auth_context.ex
+++ b/lib/plausible_web/live/auth_context.ex
@@ -65,7 +65,7 @@ defmodule PlausibleWeb.Live.AuthContext do
           nil
       end)
       |> assign_new(
-        :current_role,
+        :current_team_role,
         fn
           %{current_user: user = %{}, current_team: current_team = %{}} ->
             Enum.find_value(user.team_memberships, fn team_membership ->

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -60,6 +60,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
           domain={@domain}
           site={@site}
           current_user={@current_user}
+          current_role={@current_role}
           site_team={@site_team}
           existing_goals={@all_goals}
           goal={@form_goal}

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -18,6 +18,10 @@ defmodule PlausibleWeb.Live.GoalSettings do
         current_user
         |> Plausible.Sites.get_for_user!(domain, [:owner, :admin, :editor, :super_admin])
       end)
+      |> assign_new(:site_role, fn %{site: site, current_user: current_user} ->
+        {:ok, role} = Plausible.Teams.Memberships.site_role(site, current_user)
+        role
+      end)
       |> assign_new(:all_goals, fn %{site: site} ->
         Goals.for_site(site, preload_funnels?: true)
       end)
@@ -60,7 +64,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
           domain={@domain}
           site={@site}
           current_user={@current_user}
-          current_role={@current_role}
+          site_role={@site_role}
           site_team={@site_team}
           existing_goals={@all_goals}
           goal={@form_goal}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -35,6 +35,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         event_name_options_count: length(assigns.event_name_options),
         event_name_options: Enum.map(assigns.event_name_options, &{&1, &1}),
         current_user: assigns.current_user,
+        current_role: assigns.current_role,
         site_team: assigns.site_team,
         domain: assigns.domain,
         selected_tab: selected_tab,
@@ -71,7 +72,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         :if={@selected_tab == "custom_events"}
         f={f}
         suffix={@context_unique_id}
-        current_user={@current_user}
+        current_role={@current_role}
         site_team={@site_team}
         site={@site}
         goal={@goal}
@@ -121,7 +122,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         x-show="!tabSelectionInProgress"
         f={f}
         suffix={suffix(@context_unique_id, @tab_sequence_id)}
-        current_user={@current_user}
+        current_role={@current_role}
         site_team={@site_team}
         site={@site}
         existing_goals={@existing_goals}
@@ -314,7 +315,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
   attr(:f, Phoenix.HTML.Form)
   attr(:site, Plausible.Site)
-  attr(:current_user, Plausible.Auth.User)
+  attr(:current_role, :atom)
   attr(:site_team, Plausible.Teams.Team)
   attr(:suffix, :string)
   attr(:existing_goals, :list)
@@ -375,7 +376,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           :if={ee?()}
           f={@f}
           site={@site}
-          current_user={@current_user}
+          current_role={@current_role}
           site_team={@site_team}
           has_access_to_revenue_goals?={@has_access_to_revenue_goals?}
           goal={@goal}
@@ -398,8 +399,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     ~H"""
     <div class="mt-6 space-y-3" x-data={@js_data}>
       <PlausibleWeb.Components.Billing.Notice.premium_feature
-        billable_user={List.first(@site.owners)}
-        current_user={@current_user}
+        current_role={@current_role}
         current_team={@site_team}
         feature_mod={Plausible.Billing.Feature.RevenueGoals}
         class="rounded-b-md"

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         event_name_options_count: length(assigns.event_name_options),
         event_name_options: Enum.map(assigns.event_name_options, &{&1, &1}),
         current_user: assigns.current_user,
-        current_role: assigns.current_role,
+        site_role: assigns.site_role,
         site_team: assigns.site_team,
         domain: assigns.domain,
         selected_tab: selected_tab,
@@ -72,7 +72,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         :if={@selected_tab == "custom_events"}
         f={f}
         suffix={@context_unique_id}
-        current_role={@current_role}
+        site_role={@site_role}
         site_team={@site_team}
         site={@site}
         goal={@goal}
@@ -122,7 +122,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         x-show="!tabSelectionInProgress"
         f={f}
         suffix={suffix(@context_unique_id, @tab_sequence_id)}
-        current_role={@current_role}
+        site_role={@site_role}
         site_team={@site_team}
         site={@site}
         existing_goals={@existing_goals}
@@ -315,7 +315,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
 
   attr(:f, Phoenix.HTML.Form)
   attr(:site, Plausible.Site)
-  attr(:current_role, :atom)
+  attr(:site_role, :atom)
   attr(:site_team, Plausible.Teams.Team)
   attr(:suffix, :string)
   attr(:existing_goals, :list)
@@ -376,7 +376,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
           :if={ee?()}
           f={@f}
           site={@site}
-          current_role={@current_role}
+          site_role={@site_role}
           site_team={@site_team}
           has_access_to_revenue_goals?={@has_access_to_revenue_goals?}
           goal={@goal}
@@ -399,7 +399,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     ~H"""
     <div class="mt-6 space-y-3" x-data={@js_data}>
       <PlausibleWeb.Components.Billing.Notice.premium_feature
-        current_role={@current_role}
+        current_role={@site_role}
         current_team={@site_team}
         feature_mod={Plausible.Billing.Feature.RevenueGoals}
         class="rounded-b-md"

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -43,7 +43,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={at_limit?(@layout, @team_members_limit)}
-      current_role={@current_role}
+      current_role={@current_team_role}
       current_team={@current_team}
       limit={@team_members_limit}
       resource="team members"

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -43,8 +43,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={at_limit?(@layout, @team_members_limit)}
-      current_user={@current_user}
-      billable_user={@current_user}
+      current_role={@current_role}
       current_team={@current_team}
       limit={@team_members_limit}
       resource="team members"

--- a/lib/plausible_web/plugs/auth_plug.ex
+++ b/lib/plausible_web/plugs/auth_plug.ex
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.AuthPlug do
         current_team_id_from_session = Plug.Conn.get_session(conn, "current_team_id")
         current_team_id = conn.params["__team"] || current_team_id_from_session
 
-        {current_team, current_role} =
+        {current_team, current_team_role} =
           if current_team_id do
             team_membership =
               Enum.find(user.team_memberships, %{}, &(&1.team.identifier == current_team_id))
@@ -66,7 +66,7 @@ defmodule PlausibleWeb.AuthPlug do
         |> assign(:current_user_session, user_session)
         |> assign(:my_team, my_team)
         |> assign(:current_team, current_team || my_team)
-        |> assign(:current_role, current_role || (my_team && :owner))
+        |> assign(:current_team_role, current_team_role || (my_team && :owner))
         |> assign(:teams_count, teams_count)
         |> assign(:teams, teams)
         |> assign(:more_teams?, teams_count > 3)

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -38,7 +38,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   import Plug.Conn
   import Phoenix.Controller, only: [get_format: 1]
 
-  @all_roles [:public, :viewer, :admin, :editor, :super_admin, :owner]
+  @all_roles [:public, :viewer, :admin, :editor, :super_admin, :owner, :billing]
 
   def init([]), do: {@all_roles, nil}
 

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -1,7 +1,7 @@
 defmodule Plausible.Plugs.AuthorizeTeamAccess do
   @moduledoc """
   Enforce team role to be within the declared set.
-  `:current_role` is assumed to be populated by `PlausibleWeb.AuthPlug`.
+  `:current_team_role` is assumed to be populated by `PlausibleWeb.AuthPlug`.
 
   For cases where no `:current_team` exists, the plug is permissive,
   so that existing notices can be displayed still.
@@ -24,9 +24,9 @@ defmodule Plausible.Plugs.AuthorizeTeamAccess do
     current_team = conn.assigns[:current_team]
 
     if current_team && Plausible.Teams.enabled?(current_team) do
-      current_role = conn.assigns[:current_role]
+      current_team_role = conn.assigns[:current_team_role]
 
-      if current_role in roles do
+      if current_team_role in roles do
         conn
       else
         conn

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -8,7 +8,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      current_role={@current_role}
+      current_role={@current_team_role}
       current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.StatsAPI}
     />

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -8,8 +8,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      billable_user={@current_user}
-      current_user={@current_user}
+      current_role={@current_role}
       current_team={@current_team}
       feature_mod={Plausible.Billing.Feature.StatsAPI}
     />

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -21,14 +21,14 @@
         />
       </div>
       <.input
-        readonly={@current_role not in [:owner, :admin]}
+        readonly={@current_team_role not in [:owner, :admin]}
         type="text"
         field={f[:name]}
         label="Name"
         width="w-1/2"
       />
 
-      <.button type="submit" disabled={@current_role not in [:owner, :admin]}>
+      <.button type="submit" disabled={@current_team_role not in [:owner, :admin]}>
         Change Name
       </.button>
     </.form>

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -11,7 +11,7 @@
   <.form :let={f} for={@conn} action={Routes.membership_path(@conn, :invite_member, @site.domain)}>
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={Map.get(assigns, :is_at_limit, false)}
-      current_role={@current_role}
+      current_role={@current_team_role}
       current_team={@site_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
       resource="team members"

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -11,8 +11,7 @@
   <.form :let={f} for={@conn} action={Routes.membership_path(@conn, :invite_member, @site.domain)}>
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={Map.get(assigns, :is_at_limit, false)}
-      current_user={@current_user}
-      billable_user={List.first(@site.owners)}
+      current_role={@current_role}
       current_team={@site_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
       resource="team members"

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -8,7 +8,7 @@
   <.form :let={f} for={@changeset} action={@form_submit_url}>
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={@site_limit_exceeded?}
-      current_role={@current_role}
+      current_role={@current_team_role}
       current_team={@current_team}
       limit={@site_limit}
       resource="sites"

--- a/lib/plausible_web/templates/site/new.html.heex
+++ b/lib/plausible_web/templates/site/new.html.heex
@@ -8,9 +8,8 @@
   <.form :let={f} for={@changeset} action={@form_submit_url}>
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
       :if={@site_limit_exceeded?}
-      current_user={@current_user}
+      current_role={@current_role}
       current_team={@current_team}
-      billable_user={@current_user}
       limit={@site_limit}
       resource="sites"
     />

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -13,8 +13,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      billable_user={List.first(@site.owners)}
-      current_user={@current_user}
+      current_role={@current_role}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Funnels}
     />

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -13,7 +13,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      current_role={@current_role}
+      current_role={@site_role}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Funnels}
     />

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -14,8 +14,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      billable_user={List.first(@site.owners)}
-      current_user={@current_user}
+      current_role={@current_role}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Props}
       grandfathered?

--- a/lib/plausible_web/templates/site/settings_props.html.heex
+++ b/lib/plausible_web/templates/site/settings_props.html.heex
@@ -14,7 +14,7 @@
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature
-      current_role={@current_role}
+      current_role={@site_role}
       current_team={@site_team}
       feature_mod={Plausible.Billing.Feature.Props}
       grandfathered?

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -21,7 +21,7 @@
       </h3>
 
       <%= case @conn.assigns[:site_role] do %>
-        <% :owner -> %>
+        <% role when role in [:owner, :billing] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
               This dashboard is locked because you don't have a valid subscription.
@@ -43,24 +43,8 @@
         <% role when role in [:admin, :viewer, :editor] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
-              This dashboard is currently locked and cannot be accessed. The site owner
-              <b>{List.first(@site.owners).email}</b>
-              must upgrade their subscription plan in order to
-              unlock the stats.
+              Owner of this site must upgrade their subscription plan in order to unlock the stats.
             </p>
-            <div
-              :if={not Plausible.Teams.enabled?(@conn.assigns[:current_team])}
-              class="mt-6 text-sm text-gray-500"
-            >
-              <p>Want to pay for this site with the account you're logged in with?</p>
-              <p class="mt-1">
-                Contact {List.first(@site.owners).email} and ask them to
-                <.styled_link href="https://plausible.io/docs/transfer-ownership" new_tab={true}>
-                  transfer the ownership
-                </.styled_link>
-                of the site over to you.
-              </p>
-            </div>
           </div>
           <div class="mt-6 w-full text-center">
             <.button_link href={Routes.site_path(@conn, :index)}>Back to my sites</.button_link>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -97,7 +97,7 @@ defmodule PlausibleWeb.LayoutView do
 
   def account_settings_sidebar(conn) do
     current_team = conn.assigns[:current_team]
-    current_role = conn.assigns[:current_role]
+    current_team_role = conn.assigns[:current_team_role]
 
     options = %{
       "Account Settings" =>
@@ -123,7 +123,7 @@ defmodule PlausibleWeb.LayoutView do
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
           %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
-          if(current_role in [:owner, :admin, :billing],
+          if(current_team_role in [:owner, :admin, :billing],
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           )
         ]

--- a/lib/workers/notify_annual_renewal.ex
+++ b/lib/workers/notify_annual_renewal.ex
@@ -57,8 +57,7 @@ defmodule Plausible.Workers.NotifyAnnualRenewal do
 
         _ ->
           Sentry.capture_message("Invalid subscription for renewal",
-            team: team,
-            user: List.first(team.owner)
+            team: team
           )
       end
 

--- a/test/plausible_web/plugs/auth_plug_test.exs
+++ b/test/plausible_web/plugs/auth_plug_test.exs
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.AuthPlugTest do
 
     assert conn.assigns[:current_user].id == user.id
     assert conn.assigns[:my_team].subscription.paddle_plan_id == "123"
-    assert conn.assigns[:current_role] == :owner
+    assert conn.assigns[:current_team_role] == :owner
   end
 
   test "looks up the latest subscription", %{conn: conn, user: user} do
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.AuthPlugTest do
       |> AuthPlug.call(%{})
 
     assert conn.assigns[:current_team].id == team.id
-    assert conn.assigns[:current_role] == :owner
+    assert conn.assigns[:current_team_role] == :owner
     assert get_session(conn, "current_team_id") == team.identifier
   end
 
@@ -121,6 +121,6 @@ defmodule PlausibleWeb.AuthPlugTest do
       |> AuthPlug.call(%{})
 
     assert conn.assigns[:current_team].id == team.id
-    assert conn.assigns[:current_role] == :editor
+    assert conn.assigns[:current_team_role] == :editor
   end
 end

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -15,10 +15,10 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
         [],
         :all_roles,
         {:all_roles, nil},
-        {[:public, :viewer, :admin, :editor, :super_admin, :owner], nil}
+        {[:public, :viewer, :admin, :editor, :super_admin, :owner, :billing], nil}
       ] do
     test "init resolves to expected options with argument #{inspect(init_argument)}" do
-      assert {[:public, :viewer, :admin, :editor, :super_admin, :owner], nil} ==
+      assert {[:public, :viewer, :admin, :editor, :super_admin, :owner, :billing], nil} ==
                AuthorizeSiteAccess.init(unquote(init_argument))
     end
   end

--- a/test/plausible_web/plugs/authorize_team_access_test.exs
+++ b/test/plausible_web/plugs/authorize_team_access_test.exs
@@ -9,7 +9,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
     test "passes when valid current role: #{role}" do
       conn =
         build_conn()
-        |> assign(:current_role, unquote(role))
+        |> assign(:current_team_role, unquote(role))
         |> AuthorizeTeamAccess.call()
 
       refute conn.halted
@@ -36,7 +36,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
     conn =
       build_conn()
       |> assign(:current_team, :some)
-      |> assign(:current_role, :admin)
+      |> assign(:current_team_role, :admin)
       |> AuthorizeTeamAccess.call([:owner])
 
     assert conn.halted
@@ -47,7 +47,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeTeamAccessTest do
     conn =
       build_conn()
       |> assign(:current_team, nil)
-      |> assign(:current_role, :admin)
+      |> assign(:current_team_role, :admin)
       |> AuthorizeTeamAccess.call([:owner])
 
     refute conn.halted


### PR DESCRIPTION
### Changes

As of #5171 we have `current_role` in assigns.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
