### PR TITLE
time-on-page: Fix bug causing massive `engagement_time` values

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -51,7 +51,7 @@
 
   // Timestamp indicating when this particular page last became visible.
   // Reset during pageviews, set to null when page is closed.
-  var runningEnagementStart = null
+  var runningEngagementStart = null
   // When page is hidden, this 'engaged' time is saved to this variable
   var currentEngagementTime = 0
 
@@ -78,8 +78,8 @@
   }
 
   function getEngagementTime() {
-    if (runningEnagementStart) {
-      return currentEngagementTime + (Date.now() - runningEnagementStart)
+    if (runningEngagementStart) {
+      return currentEngagementTime + (Date.now() - runningEngagementStart)
     } else {
       return currentEngagementTime
     }
@@ -139,7 +139,7 @@
       }
 
       // Reset current engagement time metrics. They will restart upon when page becomes visible or the next SPA pageview
-      runningEnagementStart = null
+      runningEngagementStart = null
       currentEngagementTime = 0
 
       {{#if hash}}
@@ -157,11 +157,11 @@
         if (document.visibilityState === 'hidden') {
           // Tab went back to background. Save the engaged time so far
           currentEngagementTime = getEngagementTime()
-          runningEnagementStart = null
+          runningEngagementStart = null
 
           triggerEngagement()
-        } else if (document.visibilityState === 'visible' && runningEnagementStart === null) {
-          runningEnagementStart = Date.now()
+        } else if (document.visibilityState === 'visible' && runningEngagementStart === null) {
+          runningEngagementStart = Date.now()
         }
       })
       listeningOnEngagement = true
@@ -259,7 +259,7 @@
       currentEngagementProps = payload.p
       currentEngagementMaxScrollDepth = -1
       currentEngagementTime = 0
-      runningEnagementStart = Date.now()
+      runningEngagementStart = Date.now()
       registerEngagementListener()
     }
 

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -51,9 +51,9 @@
 
   // Timestamp indicating when this particular page last became visible.
   // Reset during pageviews, set to null when page is closed.
-  var runningEnagementStart
+  var runningEnagementStart = null
   // When page is hidden, this 'engaged' time is saved to this variable
-  var currentEngagementTime
+  var currentEngagementTime = 0
 
   function getDocumentHeight() {
     var body = document.body || {}
@@ -156,11 +156,11 @@
       document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'hidden') {
           // Tab went back to background. Save the engaged time so far
-          currentEngagementTime += (Date.now() - runningEnagementStart)
+          currentEngagementTime = getEngagementTime()
           runningEnagementStart = null
 
           triggerEngagement()
-        } else {
+        } else if (document.visibilityState === 'visible' && runningEnagementStart === null) {
           runningEnagementStart = Date.now()
         }
       })


### PR DESCRIPTION
The bug was:
1. Site sends an `engagement` event, which resets runningEnagementStart to null
2. Page visibility state changes to `hidden` before next pageview (and without visibilityState being changed to visible).
3. `currentEngagementTime = Date.now() - null` which reports Date.now() as engagement_time

I didn't find a way to test this as it relies heavily on timing we can't easily reproduce.

One scenario would be:
1. User clicks SPA link to exit page
2. `engagement` is sent, runningEngagementStart is reset 3.a. page is closed, triggering bug
3.b. pageview is sent, doing a correct reset

Usually, 3.b would happen before 3.a but there's no way to re-create this scenario in tests.

Along the way added some more defensive code.