### PR TITLE
Ingest scroll depth and engagment time from string + drop blanks

### DIFF
--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -58,6 +58,7 @@ defmodule Plausible.Ingestion.Event do
         for domain <- domains, do: drop(new(domain, request), :spam_referrer)
       else
         Enum.reduce(domains, [], fn domain, acc ->
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           case GateKeeper.check(domain) do
             {:allow, site} ->
               processed =

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -58,15 +58,15 @@ defmodule Plausible.Ingestion.Event do
         for domain <- domains, do: drop(new(domain, request), :spam_referrer)
       else
         Enum.reduce(domains, [], fn domain, acc ->
-          with {:allow, site} <- GateKeeper.check(domain),
-               :ok <- maybe_drop_blank_engagement(request) do
-            processed =
-              domain
-              |> new(site, request)
-              |> process_unless_dropped(pipeline(), context)
+          case GateKeeper.check(domain) do
+            {:allow, site} ->
+              processed =
+                domain
+                |> new(site, request)
+                |> process_unless_dropped(pipeline(), context)
 
-            [processed | acc]
-          else
+              [processed | acc]
+
             {:deny, reason} ->
               [drop(new(domain, request), reason) | acc]
           end
@@ -76,16 +76,6 @@ defmodule Plausible.Ingestion.Event do
     {dropped, buffered} = Enum.split_with(processed_events, & &1.dropped?)
     {:ok, %{dropped: dropped, buffered: buffered}}
   end
-
-  defp maybe_drop_blank_engagement(%{
-         event_name: "engagement",
-         scroll_depth: 255,
-         engagement_time: 0
-       }) do
-    {:deny, :blank_engagement}
-  end
-
-  defp maybe_drop_blank_engagement(_), do: :ok
 
   @spec telemetry_event_buffered() :: [atom()]
   def telemetry_event_buffered() do
@@ -124,6 +114,7 @@ defmodule Plausible.Ingestion.Event do
 
   defp pipeline() do
     [
+      drop_blank_engagement: &drop_blank_engagement/2,
       drop_verification_agent: &drop_verification_agent/2,
       drop_datacenter_ip: &drop_datacenter_ip/2,
       drop_shield_rule_hostname: &drop_shield_rule_hostname/2,
@@ -186,6 +177,16 @@ defmodule Plausible.Ingestion.Event do
 
   defp update_session_attrs(%__MODULE__{} = event, %{} = attrs) do
     struct!(event, clickhouse_session_attrs: Map.merge(event.clickhouse_session_attrs, attrs))
+  end
+
+  defp drop_blank_engagement(%__MODULE__{} = event, _context) do
+    case event.request do
+      %{event_name: "engagement", scroll_depth: 255, engagement_time: 0} ->
+        drop(event, :blank_engagement)
+
+      _ ->
+        event
+    end
   end
 
   defp drop_verification_agent(%__MODULE__{} = event, _context) do

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -262,11 +262,7 @@ defmodule Plausible.Ingestion.Request do
 
   defp put_engagement_time(changeset, %{} = request_body) do
     if Changeset.get_field(changeset, :event_name) == "engagement" do
-      engagement_time =
-        case request_body["e"] do
-          e when is_integer(e) and e >= 0 -> e
-          _ -> 0
-        end
+      engagement_time = parse_engagement_time(request_body["e"])
 
       Changeset.put_change(changeset, :engagement_time, engagement_time)
     else
@@ -346,6 +342,18 @@ defmodule Plausible.Ingestion.Request do
   defp parse_scroll_depth(sd) when is_integer(sd) and sd >= 0 and sd <= 100, do: sd
   defp parse_scroll_depth(sd) when is_integer(sd) and sd > 100, do: 100
   defp parse_scroll_depth(_), do: @missing_scroll_depth
+
+  @missing_engagement_time 0
+
+  defp parse_engagement_time(et) when is_binary(et) do
+    case Integer.parse(et) do
+      {et_int, ""} -> parse_engagement_time(et_int)
+      _ -> @missing_engagement_time
+    end
+  end
+
+  defp parse_engagement_time(et) when is_integer(et) and et >= 0, do: et
+  defp parse_engagement_time(_), do: @missing_engagement_time
 end
 
 defimpl Jason.Encoder, for: URI do

--- a/test/plausible/ingestion/event_test.exs
+++ b/test/plausible/ingestion/event_test.exs
@@ -329,7 +329,9 @@ defmodule Plausible.Ingestion.EventTest do
     payload = %{
       name: "engagement",
       url: "https://#{site.domain}/123",
-      d: "#{site.domain}"
+      d: "#{site.domain}",
+      sd: 25,
+      et: 1000
     }
 
     conn = build_conn(:post, "/api/events", payload)
@@ -339,10 +341,8 @@ defmodule Plausible.Ingestion.EventTest do
     assert dropped.drop_reason == :no_session_for_engagement
   end
 
-  test "TEMPORARY: drops engagement if FF not enabled for site" do
+  test "blank engagements (i.e. both 'sd' and 'e' missing) get dropped" do
     site = new_site()
-
-    FunWithFlags.disable(:engagements, for_actor: "site:#{site.domain}")
 
     payload = %{
       name: "engagement",
@@ -354,7 +354,7 @@ defmodule Plausible.Ingestion.EventTest do
 
     assert {:ok, request} = Request.build(conn)
     assert {:ok, %{buffered: [], dropped: [dropped]}} = Event.build_and_buffer(request)
-    assert dropped.drop_reason == :engagement_ff_throttle
+    assert dropped.drop_reason == :blank_engagement
   end
 
   @tag :ee_only

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -167,7 +167,10 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   test "defaults to 30 days format", %{site: site} do
-    assert Query.from(site, %{}) == Query.from(site, %{"period" => "30d"})
+    query_default = Query.from(site, %{}) |> Map.delete(:now)
+    query_30d = Query.from(site, %{"period" => "30d"}) |> Map.delete(:now)
+
+    assert query_default == query_30d
   end
 
   test "parses custom format", %{site: site} do

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1414,6 +1414,22 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert engagement.scroll_depth == 255
     end
 
+    test "ingests scroll_depth as 255 when sd is a non-number string", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
+
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        sd: "12asd",
+        e: 100
+      })
+
+      engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
+      assert engagement.scroll_depth == 255
+    end
+
     test "ingests engagement_time from a string", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1379,13 +1379,13 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert engagement.scroll_depth == 100
     end
 
-    test "ingests scroll_depth as 255 when sd is a string", %{conn: conn, site: site} do
+    test "parses scroll_depth from a string", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
       post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: "1"})
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
-      assert engagement.scroll_depth == 255
+      assert engagement.scroll_depth == 1
     end
 
     test "ingests scroll_depth as 255 when sd is a negative integer", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -660,6 +660,8 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
         name: "engagement",
         url: "http://ab.cd/",
         domain: site.domain,
+        sd: 50,
+        e: 1000,
         props: %{
           bool_test: true,
           number_test: 12
@@ -1319,13 +1321,21 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       {:ok, site: site}
     end
 
-    test "ingests scroll_depth and engagement_time when not in params", %{conn: conn, site: site} do
+    test "ingests scroll_depth as 255 when not in params", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain})
+      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, e: 200})
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
       assert engagement.scroll_depth == 255
+    end
+
+    test "ingests engagement_time as 0 when not in params", %{conn: conn, site: site} do
+      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
+      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: 50})
+
+      engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
       assert engagement.engagement_time == 0
     end
 
@@ -1390,7 +1400,14 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
     test "ingests scroll_depth as 255 when sd is a negative integer", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, sd: -1})
+
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        sd: -1,
+        e: 100
+      })
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
@@ -1400,7 +1417,13 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
     test "ingests engagement_time as 0 when e is a string", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
 
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, e: "789"})
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        e: "789",
+        sd: 40
+      })
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
@@ -1409,7 +1432,14 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
     test "ingests engagement_time as 0 when e is a negative integer", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
-      post(conn, "/api/event", %{n: "engagement", u: "https://test.com", d: site.domain, e: -100})
+
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        e: -100,
+        sd: 50
+      })
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1414,7 +1414,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert engagement.scroll_depth == 255
     end
 
-    test "ingests engagement_time as 0 when e is a string", %{conn: conn, site: site} do
+    test "ingests engagement_time from a string", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
 
       post(conn, "/api/event", %{
@@ -1427,7 +1427,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
 
       engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
 
-      assert engagement.engagement_time == 0
+      assert engagement.engagement_time == 789
     end
 
     test "ingests engagement_time as 0 when e is a negative integer", %{conn: conn, site: site} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,7 +8,6 @@ Application.ensure_all_started(:double)
 
 FunWithFlags.enable(:channels)
 FunWithFlags.enable(:scroll_depth)
-FunWithFlags.enable(:engagements)
 FunWithFlags.enable(:teams)
 FunWithFlags.enable(:saved_segments)
 


### PR DESCRIPTION
### Changes

* Accept strings for scroll depth and engagement time (parsing them to integers)
* Remove the `ff_throttle` engagement dropping and replace it with dropping blank engagments instead
* Fix a flaky test

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
