### PR TITLE
Drop old (unused) time-on-page columns from imported_pages

### DIFF
--- a/priv/ingest_repo/migrations/20250312063938_imported_pages_remove_old_time_on_page_columns.exs
+++ b/priv/ingest_repo/migrations/20250312063938_imported_pages_remove_old_time_on_page_columns.exs
@@ -1,0 +1,23 @@
+defmodule Plausible.IngestRepo.Migrations.ImportedPagesRemoveOldTimeOnPageColumns do
+  use Ecto.Migration
+
+  def up do
+    on_cluster = Plausible.MigrationUtils.on_cluster_statement("imported_pages")
+
+    execute """
+    ALTER TABLE imported_pages
+    #{on_cluster}
+    DROP COLUMN IF EXISTS time_on_page
+    """
+
+    execute """
+    ALTER TABLE imported_pages
+    #{on_cluster}
+    DROP COLUMN IF EXISTS active_visitors
+    """
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end


### PR DESCRIPTION
Ref: https://3.basecamp.com/5308029/buckets/41123095/card_tables/cards/8391930289

Another PR since despite giving myself explicit instructions, https://github.com/plausible/analytics/pull/5179 was merged into the wrong branch. :facepalm: 