### PR TITLE
Fix invalid default `order_by` in conversions report

### DIFF
--- a/assets/js/dashboard/stats/modals/conversions.js
+++ b/assets/js/dashboard/stats/modals/conversions.js
@@ -16,8 +16,7 @@ function ConversionsModal() {
     title: 'Goal Conversions',
     dimension: 'goal',
     endpoint: url.apiPath(site, '/conversions'),
-    dimensionLabel: "Goal",
-    defaultOrder: []
+    dimensionLabel: "Goal"
   }
 
   const getFilterInfo = useCallback((listItem) => {


### PR DESCRIPTION
Sentry error: https://sentry.plausible.io/organizations/plausible/issues/1038/?environment=prod&project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true

The frontend was passing invalid order_by values to the backend that a refactor started unaccepting.

This PR makes it so we don't pass an invalid order_by anymore. LocalStorage isn't an issue since there's already an internal validations system this value would fail.

Follow-up to https://github.com/plausible/analytics/pull/5174