### PR TITLE
Don't show new time-on-page metric for customers without flag

### DIFF
--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -107,8 +107,9 @@ export default function QueryContextProvider({
         ? postProcessFilters(filters as Filter[])
         : defaultValues.filters,
       labels: (labels as FilterClauseLabels) || defaultValues.labels,
-      legacy_time_on_page_cutoff:
-        (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
+      legacy_time_on_page_cutoff: site.flags.new_time_on_page
+        ? (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
+        : undefined
     }
   }, [
     compare_from,

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -109,7 +109,7 @@ export default function QueryContextProvider({
       labels: (labels as FilterClauseLabels) || defaultValues.labels,
       legacy_time_on_page_cutoff: site.flags.new_time_on_page
         ? (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
-        : undefined
+        : defaultValues.legacy_time_on_page_cutoff
     }
   }, [
     compare_from,


### PR DESCRIPTION
This broke in a refactor - originally api.ts also checked for the feature flag before sending include.legacy_time_on_page_cutoff but this was incorrectly removed due to conflicting changes.
