### PR TITLE
time-on-page: Mark unreasonably high engagement_time values as 0-s

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -352,7 +352,14 @@ defmodule Plausible.Ingestion.Request do
     end
   end
 
-  defp parse_engagement_time(et) when is_integer(et) and et >= 0, do: et
+  # :KLUDGE: Old version of tracker script sent huge values for engagement time. Ignore
+  # these while users might still have the old script cached.
+  @too_large_engagement_time :timer.hours(30 * 24)
+
+  defp parse_engagement_time(et)
+       when is_integer(et) and et >= 0 and et < @too_large_engagement_time,
+       do: et
+
   defp parse_engagement_time(_), do: @missing_engagement_time
 end
 

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1339,6 +1339,26 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       assert engagement.engagement_time == 0
     end
 
+    test "ingests engagement_time as 0 when tracker is sending invalid high values", %{
+      conn: conn,
+      site: site
+    } do
+      post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
+
+      post(conn, "/api/event", %{
+        n: "engagement",
+        u: "https://test.com",
+        d: site.domain,
+        sd: 50,
+        e: 1_741_850_224_785
+      })
+
+      engagement = get_events(site) |> Enum.find(&(&1.name == "engagement"))
+
+      assert engagement.engagement_time == 0
+      assert engagement.scroll_depth == 50
+    end
+
     test "sd and e fields are ignored if name is not engagement", %{conn: conn, site: site} do
       post(conn, "/api/event", %{
         n: "pageview",


### PR DESCRIPTION
Follow-up to https://github.com/plausible/analytics/pull/5181

Users might have the old version of the script cached for a while yet so avoid ingesting invalid data while that's the case