### PR TITLE
Email notification on guest->team member promotion

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -278,6 +278,14 @@ defmodule PlausibleWeb.Email do
     )
   end
 
+  def guest_to_team_member_promotion(email, team, inviter) do
+    priority_email()
+    |> to(email)
+    |> tag("guest-to-team-member-promotion")
+    |> subject("[#{Plausible.product_name()}] Welcome to \"#{team.name}\" team")
+    |> render("guest_to_team_member_promotion.html", inviter: inviter, team: team)
+  end
+
   def ownership_transfer_request(email, invitation_id, site, inviter, new_owner_account) do
     priority_email()
     |> to(email)

--- a/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
+++ b/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
@@ -1,1 +1,1 @@
-{@inviter.email} has promoted you to team member in the "{@team.name}" team on {Plausible.product_name()}.
+{@inviter.email} has promoted you to a team member in the "{@team.name}" team on {Plausible.product_name()}.

--- a/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
+++ b/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
@@ -1,0 +1,1 @@
+{@inviter.email} has promoted you to team member in the "{@team.name}" team on {Plausible.product_name()}.

--- a/test/plausible/teams/memberships/update_role_test.exs
+++ b/test/plausible/teams/memberships/update_role_test.exs
@@ -3,8 +3,11 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
   use Plausible.Repo
   use Plausible.Teams.Test
   use Bamboo.Test
+  use Plausible
 
   alias Plausible.Teams.Memberships.UpdateRole
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   test "updates a team member's role by user id" do
     user = new_user()
@@ -28,6 +31,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
     assert {:ok, _} = UpdateRole.update(team, collaborator.id, "owner", user)
 
     assert_team_membership(collaborator, team, :owner)
+    assert_no_emails_delivered()
   end
 
   test "can demote self when an owner" do
@@ -39,6 +43,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
     assert {:ok, _} = UpdateRole.update(team, user.id, "viewer", user)
 
     assert_team_membership(user, team, :viewer)
+    assert_no_emails_delivered()
   end
 
   test "can't demote self when the only owner" do
@@ -49,6 +54,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
     assert {:error, :only_one_owner} = UpdateRole.update(team, user.id, "viewer", user)
 
     assert_team_membership(user, team, :owner)
+    assert_no_emails_delivered()
   end
 
   test "can demote self when an admin" do
@@ -61,6 +67,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
     assert {:ok, _} = UpdateRole.update(team, user.id, "viewer", user)
 
     assert_team_membership(user, team, :viewer)
+    assert_no_emails_delivered()
   end
 
   test "admin can't update role of an owner" do
@@ -74,6 +81,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
     assert {:error, :permission_denied} = UpdateRole.update(team, owner.id, "viewer", user)
 
     assert_team_membership(owner, team, :owner)
+    assert_no_emails_delivered()
   end
 
   for role <- Plausible.Teams.Membership.roles() -- [:owner, :admin] do
@@ -89,6 +97,23 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
                UpdateRole.update(team, another_member.id, "editor", user)
 
       assert_team_membership(another_member, team, :viewer)
+      assert_no_emails_delivered()
     end
+  end
+
+  test "guest->member promotion sends out an e-mail" do
+    user = new_user()
+    owner = new_user()
+    site = new_site(owner: owner)
+    team = team_of(owner)
+
+    add_guest(site, role: :viewer, user: user)
+
+    assert {:ok, _} = UpdateRole.update(team, user.id, "editor", owner)
+
+    assert_email_delivered_with(
+      to: [nil: user.email],
+      subject: @subject_prefix <> "Welcome to \"#{team.name}\" team"
+    )
   end
 end

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -237,6 +237,11 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       assert_team_membership(user, team, :owner)
       assert_team_membership(member2, team, :owner)
+
+      assert_email_delivered_with(
+        to: [nil: member2.email],
+        subject: @subject_prefix <> "Welcome to \"#{team.name}\" team"
+      )
     end
 
     test "multiple-owners",


### PR DESCRIPTION
### Changes

Send out an e-mail indicating team member promotion for users previously being site guests.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
