### PR TITLE
Allow site transfer between different teams of the same user

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -144,9 +144,6 @@ defmodule Plausible.SiteAdmin do
     else
       {:error, :user_not_found} ->
         {:error, "User could not be found"}
-
-      {:error, :transfer_to_self} ->
-        {:error, "User is already an owner of one of the sites"}
     end
   end
 
@@ -169,7 +166,7 @@ defmodule Plausible.SiteAdmin do
         {:error, "User could not be found"}
 
       {:error, :transfer_to_self} ->
-        {:error, "User is already an owner of one of the sites"}
+        {:error, "The site is already in the picked team"}
 
       {:error, :no_plan} ->
         {:error, "The new owner does not have a subscription"}

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -144,6 +144,9 @@ defmodule Plausible.SiteAdmin do
     else
       {:error, :user_not_found} ->
         {:error, "User could not be found"}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:error, "Site transfer request has failed for one of the sites"}
     end
   end
 

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -75,8 +75,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   defp transfer_ownership(site, new_owner, team) do
     site = Repo.preload(site, :team)
 
-    with :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_owner, :owner),
-         {:ok, new_team} <- maybe_get_team(new_owner, team),
+    with {:ok, new_team} <- maybe_get_team(new_owner, team),
+         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
          :ok <- check_can_transfer_site(new_team, new_owner),
          :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
          :ok <- Teams.Invitations.transfer_site(site, new_team) do
@@ -89,8 +89,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
   defp do_accept_ownership_transfer(site_transfer, new_owner, team) do
     site = Repo.preload(site_transfer.site, :team)
 
-    with :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_owner, :owner),
-         {:ok, new_team} <- maybe_get_team(new_owner, team),
+    with {:ok, new_team} <- maybe_get_team(new_owner, team),
+         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
          :ok <- check_can_transfer_site(new_team, new_owner),
          :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
          :ok <- Teams.Invitations.accept_site_transfer(site_transfer, new_team) do

--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -33,6 +33,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
           | Billing.Quota.Limits.over_limits_error()
           | Ecto.Changeset.t()
           | :no_plan
+          | :transfer_to_self
           | :multiple_teams
           | :permission_denied
 

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -13,7 +13,6 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   @type invite_error() ::
           Ecto.Changeset.t()
           | :already_a_member
-          | :transfer_to_self
           | :no_plan
           | {:over_limit, non_neg_integer()}
           | :forbidden
@@ -65,12 +64,6 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
              invitee_email
            ),
          invitee = Plausible.Auth.find_user_by(email: invitee_email),
-         :ok <-
-           Teams.Invitations.ensure_transfer_valid(
-             site.team,
-             invitee,
-             role
-           ),
          :ok <-
            Teams.Invitations.ensure_new_membership(
              site,

--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -13,7 +13,6 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   @type invite_error() ::
           Ecto.Changeset.t()
           | :already_a_member
-          | :no_plan
           | {:over_limit, non_neg_integer()}
           | :forbidden
 

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -494,11 +494,11 @@ defmodule Plausible.Teams.Invitations do
 
     if check_permissions? do
       case Teams.Memberships.site_role(site, inviter) do
-        {:ok, :owner} when invitation_role == :owner ->
+        {:ok, inviter_role} when inviter_role in [:owner, :admin] and invitation_role == :owner ->
           :ok
 
         {:ok, inviter_role}
-        when inviter_role in [:owner, :editor, :admin] and invitation_role != :owner ->
+        when inviter_role in [:owner, :admin, :editor] and invitation_role != :owner ->
           :ok
 
         _ ->

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -233,10 +233,11 @@ defmodule Plausible.Teams.Invitations do
   @doc false
   def ensure_transfer_valid(_team, nil, :owner), do: :ok
 
-  def ensure_transfer_valid(team, new_owner, :owner) do
-    case Teams.Memberships.team_role(team, new_owner) do
-      {:ok, :owner} -> {:error, :transfer_to_self}
-      _ -> :ok
+  def ensure_transfer_valid(team, new_team, :owner) do
+    if team.id == new_team.id do
+      {:error, :transfer_to_self}
+    else
+      :ok
     end
   end
 

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -87,155 +87,11 @@ defmodule Plausible.Teams.Sites do
     domain_filter = Keyword.get(opts, :filter_by_domain)
     team = Keyword.get(opts, :team)
 
-    guest_membership_query =
-      from(tm in Teams.Membership,
-        inner_join: u in assoc(tm, :user),
-        as: :user,
-        inner_join: gm in assoc(tm, :guest_memberships),
-        inner_join: s in assoc(gm, :site),
-        as: :site,
-        where: tm.user_id == ^user.id and tm.role == :guest,
-        where:
-          not exists(
-            from st in Teams.SiteTransfer,
-              where: st.email == parent_as(:user).email,
-              where: st.site_id == parent_as(:site).id
-          ),
-        select: %{
-          site_id: s.id,
-          entry_type: "site",
-          guest_invitation_id: 0,
-          team_invitation_id: 0,
-          role:
-            fragment(
-              """
-              CASE
-                WHEN ? = 'editor' THEN 'admin'
-                ELSE ?
-              END
-              """,
-              gm.role,
-              gm.role
-            ),
-          transfer_id: 0
-        }
-      )
-
-    guest_invitation_query =
-      from ti in Teams.Invitation,
-        as: :team_invitation,
-        inner_join: gi in assoc(ti, :guest_invitations),
-        inner_join: s in assoc(gi, :site),
-        as: :site,
-        where:
-          not exists(
-            from tm in Teams.Membership,
-              inner_join: u in assoc(tm, :user),
-              left_join: gm in assoc(tm, :guest_memberships),
-              on: gm.site_id == parent_as(:site).id,
-              where: tm.team_id == parent_as(:team_invitation).team_id,
-              where: u.email == parent_as(:team_invitation).email,
-              where: not is_nil(gm.id) or tm.role != :guest,
-              select: 1
-          ),
-        where: ti.email == ^user.email and ti.role == :guest,
-        select: %{
-          site_id: s.id,
-          entry_type: "invitation",
-          guest_invitation_id: gi.id,
-          team_invitation_id: ti.id,
-          role:
-            fragment(
-              """
-              CASE
-                WHEN ? = 'editor' THEN 'admin'
-                ELSE ?
-              END
-              """,
-              gi.role,
-              gi.role
-            ),
-          transfer_id: 0
-        }
-
-    site_transfer_query =
-      from st in Teams.SiteTransfer,
-        as: :site_transfer,
-        inner_join: s in assoc(st, :site),
-        as: :site,
-        where: st.email == ^user.email,
-        where:
-          not exists(
-            from tm in Teams.Membership,
-              inner_join: u in assoc(tm, :user),
-              where: tm.team_id == parent_as(:site).team_id,
-              where: u.email == parent_as(:site_transfer).email,
-              where: tm.role == :owner,
-              select: 1
-          ),
-        select: %{
-          site_id: s.id,
-          entry_type: "invitation",
-          guest_invitation_id: 0,
-          team_invitation_id: 0,
-          role: "owner",
-          transfer_id: st.id
-        }
-
     union_query =
       if Teams.setup?(team) do
-        team_membership_query =
-          from(tm in Teams.Membership,
-            inner_join: t in assoc(tm, :team),
-            inner_join: u in assoc(tm, :user),
-            as: :user,
-            inner_join: s in assoc(t, :sites),
-            as: :site,
-            where: tm.user_id == ^user.id and tm.role != :guest,
-            where: tm.team_id == ^team.id,
-            where:
-              not exists(
-                from st in Teams.SiteTransfer,
-                  where: st.email == parent_as(:user).email,
-                  where: st.site_id == parent_as(:site).id
-              ),
-            select: %{
-              site_id: s.id,
-              entry_type: "site",
-              guest_invitation_id: 0,
-              team_invitation_id: 0,
-              role: tm.role,
-              transfer_id: 0
-            }
-          )
-
-        from s in team_membership_query,
-          union_all: ^site_transfer_query
+        list_with_invitations_setup_query(team, user)
       else
-        my_team_query =
-          from(tm in Teams.Membership,
-            inner_join: t in assoc(tm, :team),
-            inner_join: u in assoc(tm, :user),
-            as: :user,
-            inner_join: s in assoc(t, :sites),
-            as: :site,
-            where: tm.user_id == ^user.id and tm.role != :guest,
-            where: tm.is_autocreated == true,
-            where: t.setup_complete == false,
-            select: %{
-              site_id: s.id,
-              entry_type: "site",
-              guest_invitation_id: 0,
-              team_invitation_id: 0,
-              role: tm.role,
-              transfer_id: 0
-            }
-          )
-
-        from s in my_team_query,
-          union_all: ^guest_membership_query,
-          union_all: ^guest_invitation_query,
-          union_all: ^site_transfer_query
+        list_with_invitations_personal_query(team, user)
       end
 
     from(u in subquery(union_query),
@@ -305,6 +161,168 @@ defmodule Plausible.Teams.Sites do
           entry
       end)
     end)
+  end
+
+  defp list_with_invitations_setup_query(team, user) do
+    team_membership_query =
+      from(tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        inner_join: u in assoc(tm, :user),
+        as: :user,
+        inner_join: s in assoc(t, :sites),
+        as: :site,
+        where: tm.user_id == ^user.id and tm.role != :guest,
+        where: tm.team_id == ^team.id,
+        select: %{
+          site_id: s.id,
+          entry_type: "site",
+          guest_invitation_id: 0,
+          team_invitation_id: 0,
+          role: tm.role,
+          transfer_id: 0
+        }
+      )
+
+    site_transfer_query =
+      from st in Teams.SiteTransfer,
+        as: :site_transfer,
+        inner_join: s in assoc(st, :site),
+        as: :site,
+        where: s.team_id != ^team.id,
+        where: st.email == ^user.email,
+        where:
+          exists(
+            from tm in Teams.Membership,
+              inner_join: u in assoc(tm, :user),
+              where: tm.team_id == ^team.id,
+              where: u.email == parent_as(:site_transfer).email,
+              where: tm.role in [:owner, :admin],
+              select: 1
+          ),
+        select: %{
+          site_id: s.id,
+          entry_type: "invitation",
+          guest_invitation_id: 0,
+          team_invitation_id: 0,
+          role: "owner",
+          transfer_id: st.id
+        }
+
+    from s in team_membership_query,
+      union_all: ^site_transfer_query
+  end
+
+  defp list_with_invitations_personal_query(team, user) do
+    my_team_query =
+      from(tm in Teams.Membership,
+        inner_join: t in assoc(tm, :team),
+        inner_join: u in assoc(tm, :user),
+        as: :user,
+        inner_join: s in assoc(t, :sites),
+        as: :site,
+        where: tm.user_id == ^user.id and tm.role == :owner,
+        where: t.setup_complete == false,
+        select: %{
+          site_id: s.id,
+          entry_type: "site",
+          guest_invitation_id: 0,
+          team_invitation_id: 0,
+          role: tm.role,
+          transfer_id: 0
+        }
+      )
+
+    guest_membership_query =
+      from(tm in Teams.Membership,
+        inner_join: u in assoc(tm, :user),
+        as: :user,
+        inner_join: gm in assoc(tm, :guest_memberships),
+        inner_join: s in assoc(gm, :site),
+        as: :site,
+        where: tm.user_id == ^user.id and tm.role == :guest,
+        select: %{
+          site_id: s.id,
+          entry_type: "site",
+          guest_invitation_id: 0,
+          team_invitation_id: 0,
+          role:
+            fragment(
+              """
+              CASE
+                WHEN ? = 'editor' THEN 'admin'
+                ELSE ?
+              END
+              """,
+              gm.role,
+              gm.role
+            ),
+          transfer_id: 0
+        }
+      )
+
+    guest_invitation_query =
+      from ti in Teams.Invitation,
+        as: :team_invitation,
+        inner_join: gi in assoc(ti, :guest_invitations),
+        inner_join: s in assoc(gi, :site),
+        as: :site,
+        where:
+          not exists(
+            from tm in Teams.Membership,
+              inner_join: u in assoc(tm, :user),
+              left_join: gm in assoc(tm, :guest_memberships),
+              on: gm.site_id == parent_as(:site).id,
+              where: tm.team_id == parent_as(:team_invitation).team_id,
+              where: u.email == parent_as(:team_invitation).email,
+              where: not is_nil(gm.id) or tm.role != :guest,
+              select: 1
+          ),
+        where: ti.email == ^user.email and ti.role == :guest,
+        select: %{
+          site_id: s.id,
+          entry_type: "invitation",
+          guest_invitation_id: gi.id,
+          team_invitation_id: ti.id,
+          role:
+            fragment(
+              """
+              CASE
+                WHEN ? = 'editor' THEN 'admin'
+                ELSE ?
+              END
+              """,
+              gi.role,
+              gi.role
+            ),
+          transfer_id: 0
+        }
+
+    site_transfer_query =
+      from st in Teams.SiteTransfer,
+        as: :site_transfer,
+        inner_join: s in assoc(st, :site),
+        as: :site,
+        where: st.email == ^user.email,
+        select: %{
+          site_id: s.id,
+          entry_type: "invitation",
+          guest_invitation_id: 0,
+          team_invitation_id: 0,
+          role: "owner",
+          transfer_id: st.id
+        }
+
+    site_transfer_query =
+      if team do
+        where(site_transfer_query, [site: s], s.team_id != ^team.id)
+      else
+        site_transfer_query
+      end
+
+    from s in my_team_query,
+      union_all: ^guest_membership_query,
+      union_all: ^guest_invitation_query,
+      union_all: ^site_transfer_query
   end
 
   defp maybe_filter_by_domain(query, domain)

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -41,6 +41,11 @@ defmodule PlausibleWeb.InvitationController do
         |> put_flash(:error, "Invitation missing or already accepted")
         |> redirect(to: "/sites")
 
+      {:error, :transfer_to_self} ->
+        conn
+        |> put_flash(:error, "The site is already in the current team")
+        |> redirect(to: "/sites")
+
       {:error, :permission_denied} ->
         conn
         |> put_flash(:error, "You can't add sites in the current team")

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -118,13 +118,6 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> put_flash(:success, "Site transfer request has been sent to #{email}")
         |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
 
-      {:error, :transfer_to_self} ->
-        conn
-        |> put_flash(:ttl, :timer.seconds(5))
-        |> put_flash(:error_title, "Transfer error")
-        |> put_flash(:error, "Can't transfer ownership to existing owner")
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
-
       {:error, changeset} ->
         errors = Plausible.ChangesetHelpers.traverse_errors(changeset)
 

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -15,13 +15,15 @@ defmodule PlausibleWeb.Site.MembershipController do
   use Plausible
   alias Plausible.Site.Memberships
 
-  @only_owner_is_allowed_to [:transfer_ownership_form, :transfer_ownership]
+  @only_owner_and_admin_is_allowed_to [:transfer_ownership_form, :transfer_ownership]
 
   plug PlausibleWeb.RequireAccountPlug
-  plug PlausibleWeb.Plugs.AuthorizeSiteAccess, [:owner] when action in @only_owner_is_allowed_to
 
   plug PlausibleWeb.Plugs.AuthorizeSiteAccess,
-       [:owner, :editor, :admin] when action not in @only_owner_is_allowed_to
+       [:owner, :admin] when action in @only_owner_and_admin_is_allowed_to
+
+  plug PlausibleWeb.Plugs.AuthorizeSiteAccess,
+       [:owner, :admin, :editor] when action not in @only_owner_and_admin_is_allowed_to
 
   def invite_member_form(conn, _params) do
     site =

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -73,7 +73,7 @@ defmodule PlausibleWeb.LayoutView do
         ]
       },
       %{key: "Email Reports", value: "email-reports", icon: :envelope},
-      if conn.assigns[:site_role] == :owner do
+      if conn.assigns[:site_role] in [:owner, :admin] do
         %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
       end
     ]

--- a/test/plausible/site/admin_test.exs
+++ b/test/plausible/site/admin_test.exs
@@ -38,14 +38,6 @@ defmodule Plausible.Site.AdminTest do
                {:error, "User could not be found"}
     end
 
-    test "new owner can't be the same as old owner", %{conn: conn, transfer_action: action} do
-      current_owner = new_user()
-      site = new_site(owner: current_owner)
-
-      assert {:error, "User is already an owner of one of the sites"} =
-               action.(conn, [site], %{"email" => current_owner.email})
-    end
-
     test "initiates ownership transfer for multiple sites in one action", %{
       conn: conn,
       transfer_action: action
@@ -81,11 +73,14 @@ defmodule Plausible.Site.AdminTest do
                {:error, "User could not be found"}
     end
 
-    test "new owner can't be the same as old owner", %{conn: conn, transfer_direct_action: action} do
+    test "new team (via owner) can't be the same as old team", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
       current_owner = new_user()
       site = new_site(owner: current_owner)
 
-      assert {:error, "User is already an owner of one of the sites"} =
+      assert {:error, "The site is already in the picked team"} =
                action.(conn, [site], %{"email" => current_owner.email})
     end
 
@@ -143,6 +138,29 @@ defmodule Plausible.Site.AdminTest do
       assert {:error, "The new owner can't add sites in the selected team"} =
                action.(conn, [site], %{
                  "email" => new_owner.email,
+                 "team_id" => new_team.identifier
+               })
+    end
+
+    test "the new owner can be the same as old owner given selected team is different", %{
+      conn: conn,
+      transfer_direct_action: action
+    } do
+      today = Date.utc_today()
+      current_owner = new_user()
+      site = new_site(owner: current_owner)
+
+      another_owner =
+        new_user()
+        |> subscribe_to_growth_plan(last_bill_date: Date.shift(today, day: -5))
+
+      another_site = new_site(owner: another_owner)
+      new_team = another_site.team
+      add_member(new_team, user: current_owner, role: :owner)
+
+      assert :ok =
+               action.(conn, [site], %{
+                 "email" => current_owner.email,
                  "team_id" => new_team.identifier
                })
     end

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -150,14 +150,6 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
                CreateInvitation.create_invitation(site, inviter, invitee.email, :owner)
     end
 
-    test "does not allow transferring ownership to existing owner" do
-      inviter = new_user(email: "vini@plausible.test")
-      site = new_site(owner: inviter)
-
-      assert {:error, :transfer_to_self} =
-               CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :owner)
-    end
-
     test "allows creating an ownership transfer even when at team member limit" do
       inviter = new_user()
       site = new_site(owner: inviter)

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -130,7 +130,21 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       )
     end
 
-    test "only allows owners to transfer ownership" do
+    test "admin initiate ownership transfer too" do
+      inviter = new_user()
+      site = new_site()
+      add_member(site.team, user: inviter, role: :admin)
+
+      assert {:ok, %Plausible.Teams.SiteTransfer{}} =
+               CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :owner)
+
+      assert_email_delivered_with(
+        to: [nil: "vini@plausible.test"],
+        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
+      )
+    end
+
+    test "only allows owners and admins to transfer ownership" do
       inviter = new_user()
 
       site = new_site()


### PR DESCRIPTION
### Changes

This PR adjusts site transfer logic to allow transferring sites between different teams of the same user.

### Tests
- [x] Automated tests have been added

