### PR TITLE
Make setting sites limit slightly more convenient

### DIFF
--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -142,13 +142,14 @@ defmodule Plausible.CrmExtensions do
         Phoenix.HTML.raw("""
         <script type="text/javascript">
           (() => {
-            const monthlyPageviewLimitField = document.getElementById("enterprise_plan_monthly_pageview_limit")
+            const fields = ["monthly_pageview_limit", "site_limit"].map(p => document.getElementById(`enterprise_plan_${p}`))
+            fields.forEach(field => {
+              field.type = "input"
+              field.addEventListener("keyup", numberFormatCallback)
+              field.addEventListener("change", numberFormatCallback)
 
-            monthlyPageviewLimitField.type = "input"
-            monthlyPageviewLimitField.addEventListener("keyup", numberFormatCallback)
-            monthlyPageviewLimitField.addEventListener("change", numberFormatCallback)
-
-            monthlyPageviewLimitField.dispatchEvent(new Event("change"))
+              field.dispatchEvent(new Event("change"))
+            })
 
             function numberFormatCallback(e) {
               const numeric = Number(e.target.value.replace(/[^0-9]/g, ''))


### PR DESCRIPTION
### Changes

Adds the en-GB number format to Enterprise Plan :site_limit field as well.

### Tests
- [x] Manually tested

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the FE UI
