### PR TITLE
Implement team deletion and refactor user deletion

### DIFF
--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -116,8 +116,12 @@ defmodule Plausible.Auth do
   end
 
   defp delete_user!(user) do
-    Plausible.Segments.user_removed(user)
-    Repo.delete!(user)
+    Repo.transaction(fn ->
+      Plausible.Segments.user_removed(user)
+      Repo.delete!(user)
+    end)
+
+    :ok
   end
 
   defp check_can_leave_teams(teams) do

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -87,7 +87,7 @@ defmodule Plausible.Auth do
         teams = Teams.Users.owned_teams(user)
 
         with :ok <- check_can_leave_teams(teams) do
-          personal_team = Enum.find(teams, & &1.setup_complete)
+          personal_team = Enum.find(teams, &(not Teams.setup?(&1)))
           delete_team_and_user(personal_team, user)
         end
 

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -70,52 +70,72 @@ defmodule Plausible.Auth do
     end
   end
 
+  @spec delete_user(Auth.User.t()) ::
+          {:ok, :deleted} | {:error, :is_only_team_owner | :active_subscription}
   def delete_user(user) do
+    case Teams.get_by_owner(user) do
+      {:ok, %{setup_complete: false} = team} ->
+        delete_team_and_user(team, user)
+
+      {:ok, team} ->
+        with :ok <- check_can_leave_team(team) do
+          delete_user!(user)
+          {:ok, :deleted}
+        end
+
+      {:error, :multiple_teams} ->
+        teams = Teams.Users.owned_teams(user)
+
+        with :ok <- check_can_leave_teams(teams) do
+          personal_team = Enum.find(teams, & &1.setup_complete)
+          delete_team_and_user(personal_team, user)
+        end
+
+      {:error, :no_team} ->
+        delete_user!(user)
+        {:ok, :deleted}
+    end
+  end
+
+  defp delete_team_and_user(nil, user) do
+    delete_user!(user)
+    {:ok, :deleted}
+  end
+
+  defp delete_team_and_user(team, user) do
     Repo.transaction(fn ->
-      case Teams.get_by_owner(user) do
-        {:ok, %{setup_complete: false} = team} ->
-          for site <- Teams.owned_sites(team) do
-            Plausible.Site.Removal.run(site)
-          end
+      case Teams.delete(team) do
+        {:ok, :deleted} ->
+          delete_user!(user)
+          :deleted
 
-          Repo.delete_all(from s in Plausible.Billing.Subscription, where: s.team_id == ^team.id)
-
-          Repo.delete_all(
-            from ep in Plausible.Billing.EnterprisePlan, where: ep.team_id == ^team.id
-          )
-
-          Plausible.Segments.user_removed(user)
-          Repo.delete!(team)
-          Repo.delete!(user)
-
-        {:ok, team} ->
-          check_can_leave_team!(team)
-          Repo.delete!(user)
-
-        {:error, :multiple_teams} ->
-          check_can_leave_teams!(user)
-          Repo.delete!(user)
-
-        {:error, :no_team} ->
-          Repo.delete!(user)
+        {:error, error} ->
+          Repo.rollback(error)
       end
-
-      :deleted
     end)
   end
 
-  defp check_can_leave_teams!(user) do
-    user
-    |> Teams.Users.owned_teams()
-    |> Enum.reject(&(&1.setup_complete == false))
-    |> Enum.map(fn team ->
-      check_can_leave_team!(team)
+  defp delete_user!(user) do
+    Plausible.Segments.user_removed(user)
+    Repo.delete!(user)
+  end
+
+  defp check_can_leave_teams(teams) do
+    teams
+    |> Enum.filter(& &1.setup_complete)
+    |> Enum.reduce_while(:ok, fn team, :ok ->
+      case check_can_leave_team(team) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
     end)
   end
 
-  defp check_can_leave_team!(team) do
-    if Teams.Memberships.owners_count(team) <= 1 do
-      Repo.rollback(:is_only_team_owner)
+  defp check_can_leave_team(team) do
+    if Teams.Memberships.owners_count(team) > 1 do
+      :ok
+    else
+      {:error, :is_only_team_owner}
     end
   end
 

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -7,6 +7,7 @@ defmodule Plausible.Teams do
 
   alias __MODULE__
   alias Plausible.Auth
+  alias Plausible.Billing
   alias Plausible.Repo
   use Plausible
 
@@ -182,6 +183,29 @@ defmodule Plausible.Teams do
       team
     else
       team
+    end
+  end
+
+  @spec delete(Teams.Team.t()) :: {:ok, :deleted} | {:error, :active_subscription}
+  def delete(team) do
+    team = Teams.with_subscription(team)
+
+    if Billing.Subscription.Status.active?(team.subscription) do
+      {:error, :active_subscription}
+    else
+      Repo.transaction(fn ->
+        for site <- Teams.owned_sites(team) do
+          Plausible.Site.Removal.run(site)
+        end
+
+        Repo.delete_all(from s in Billing.Subscription, where: s.team_id == ^team.id)
+
+        Repo.delete_all(from ep in Billing.EnterprisePlan, where: ep.team_id == ^team.id)
+
+        Repo.delete!(team)
+
+        :deleted
+      end)
     end
   end
 

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -476,6 +476,14 @@ defmodule PlausibleWeb.AuthController do
       {:ok, :deleted} ->
         logout(conn, params)
 
+      {:error, :active_subscription} ->
+        conn
+        |> put_flash(
+          :error,
+          "You have an active subscription which must be canceled first."
+        )
+        |> redirect(to: Routes.settings_path(conn, :danger_zone))
+
       {:error, :is_only_team_owner} ->
         conn
         |> put_flash(

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -132,6 +132,29 @@ defmodule PlausibleWeb.SettingsController do
     render(conn, :danger_zone, layout: {PlausibleWeb.LayoutView, :settings})
   end
 
+  def team_danger_zone(conn, _params) do
+    render(conn, :team_danger_zone, layout: {PlausibleWeb.LayoutView, :settings})
+  end
+
+  def delete_team(conn, _params) do
+    team = conn.assigns.current_team
+
+    case Plausible.Teams.delete(team) do
+      {:ok, :deleted} ->
+        conn
+        |> put_flash(:success, ~s|Team "#{Plausible.Teams.name(team)}" deleted|)
+        |> redirect(to: Routes.site_path(conn, :index, __team: "none"))
+
+      {:error, :active_subscription} ->
+        conn
+        |> put_flash(
+          :error,
+          "Team has an active subscription. You must cancel it first."
+        )
+        |> redirect(to: Routes.settings_path(conn, :team_danger_zone))
+    end
+  end
+
   # Preferences actions
 
   def update_name(conn, %{"user" => params}) do

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -132,7 +132,18 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   def danger_zone(conn, _params) do
-    render(conn, :danger_zone, layout: {PlausibleWeb.LayoutView, :settings})
+    solely_owned_teams =
+      conn.assigns.current_user
+      |> Teams.Users.owned_teams()
+      |> Enum.filter(& &1.setup_complete)
+      |> Enum.reject(fn team ->
+        Teams.Memberships.owners_count(team) > 1
+      end)
+
+    render(conn, :danger_zone,
+      solely_owned_teams: solely_owned_teams,
+      layout: {PlausibleWeb.LayoutView, :settings}
+    )
   end
 
   def team_danger_zone(conn, _params) do

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -14,6 +14,9 @@ defmodule PlausibleWeb.SettingsController do
   plug Plausible.Plugs.AuthorizeTeamAccess,
        [:owner, :admin, :billing] when action in [:invoices]
 
+  plug Plausible.Plugs.AuthorizeTeamAccess,
+       [:owner] when action in [:team_danger_zone, :delete_team]
+
   def index(conn, _params) do
     redirect(conn, to: Routes.settings_path(conn, :preferences))
   end

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -57,7 +57,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
               name="input-email"
               type="email"
               value={@input_email}
-              placeholder="Enter e-mail to send invitation to"
+              placeholder="Enter e-mail"
               phx-debounce={200}
               readonly={at_limit?(@layout, @team_members_limit) or @my_role not in [:admin, :owner]}
               mt?={false}

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -158,7 +158,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
         phx-click="save-team-layout"
         class="mt-8 w-full"
       >
-        Setup Team
+        Create Team
       </.button>
     </div>
     """
@@ -288,7 +288,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
     case {result, socket.assigns.mode} do
       {{:ok, _}, :team_setup} ->
         socket
-        |> put_flash(:success, "Your team is now setup")
+        |> put_flash(:success, "Your team is now created")
         |> redirect(
           to: Routes.settings_path(socket, :team_general, __team: current_team.identifier)
         )

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
       case {enabled?, current_team} do
         {true, %Teams.Team{setup_complete: true}} ->
           socket
-          |> put_flash(:success, "Your team is now setup")
+          |> put_flash(:success, "Your team is now created")
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         {true, %Teams.Team{}} ->
@@ -41,7 +41,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
 
         {_, _} ->
           socket
-          |> put_flash(:error, "You cannot set up any team just yet")
+          |> put_flash(:error, "You cannot create any team just yet")
           |> redirect(to: Routes.site_path(socket, :index))
       end
 
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
   def render(assigns) do
     ~H"""
     <.focus_box>
-      <:title>Setup a new team</:title>
+      <:title>Create a new team</:title>
       <:subtitle>
         Add members and assign roles to manage different sites access efficiently
       </:subtitle>

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
     <.focus_box>
       <:title>Create a new team</:title>
       <:subtitle>
-        Add members and assign roles to manage different sites access efficiently
+        Add your team members and assign their roles
       </:subtitle>
 
       <.form

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -393,6 +393,8 @@ defmodule PlausibleWeb.Router do
     post "/team/invitations/:invitation_id/accept", InvitationController, :accept_invitation
     post "/team/invitations/:invitation_id/reject", InvitationController, :reject_invitation
     delete "/team/invitations/:invitation_id", InvitationController, :remove_team_invitation
+    get "/team/delete", SettingsController, :team_danger_zone
+    delete "/team/delete", SettingsController, :delete_team
   end
 
   scope "/", PlausibleWeb do

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -91,7 +91,7 @@
                     }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span class="flex-1">
-                          Setup a Team
+                          Create a Team
                         </span>
                         <span class="ml-1 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
                           NEW

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -7,19 +7,33 @@
     <:title>Delete Account</:title>
     <:subtitle>Deleting your account removes all sites and stats you've collected</:subtitle>
 
-    <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
-      <.notice theme={:gray} title="Cannot delete account at this time">
-        Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
-      </.notice>
-    <% else %>
-      <.button_link
-        data-confirm="Deleting your account will also delete all the sites and data that you own. This action cannot be reversed. Are you sure?"
-        href="/me"
-        method="delete"
-        theme="danger"
-      >
-        Delete my account
-      </.button_link>
+    <%= cond do %>
+      <% length(@solely_owned_teams) > 0 -> %>
+        <.notice theme={:gray} title="Cannot delete account at this time">
+          Your are the sole owner of one or more teams. If you want to delete your account, please either add another owner or delete each of the following teams:
+          <ul class="w-full py-4">
+            <li :for={team <- @solely_owned_teams} class="pt-1">
+              <.styled_link href={
+                Routes.settings_path(@conn, :team_general, __team: team.identifier)
+              }>
+                {Plausible.Teams.name(team)}
+              </.styled_link>
+            </li>
+          </ul>
+        </.notice>
+      <% Plausible.Billing.Subscription.Status.active?(@my_team && @my_team.subscription) -> %>
+        <.notice theme={:gray} title="Cannot delete account at this time">
+          Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
+        </.notice>
+      <% true -> %>
+        <.button_link
+          data-confirm="Deleting your account will also delete all the sites and data that you own. This action cannot be reversed. Are you sure?"
+          href="/me"
+          method="delete"
+          theme="danger"
+        >
+          Delete my account
+        </.button_link>
     <% end %>
   </.tile>
 </.settings_tiles>

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -10,7 +10,7 @@
     <%= cond do %>
       <% length(@solely_owned_teams) > 0 -> %>
         <.notice theme={:gray} title="Cannot delete account at this time">
-          Your are the sole owner of one or more teams. If you want to delete your account, please either add another owner or delete each of the following teams:
+          You are the sole owner of one or more teams. If you want to delete your account, please either add another owner or delete each of the following teams:
           <ul class="w-full py-4">
             <li :for={team <- @solely_owned_teams} class="pt-1">
               <.styled_link href={

--- a/lib/plausible_web/templates/settings/team_danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/team_danger_zone.html.heex
@@ -1,0 +1,25 @@
+<.notice title="Danger Zone" theme={:red}>
+  Destructive actions below can result in irrecoverable data loss. Be careful.
+</.notice>
+
+<.settings_tiles>
+  <.tile docs="delete-team">
+    <:title>Delete Team</:title>
+    <:subtitle>Deleting the team removes all associated sites and collected stats</:subtitle>
+
+    <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
+      <.notice theme={:gray} title="Cannot delete the team at this time">
+        The team cannot be deleted because it has an active subscription. Please cancel the subscription first.
+      </.notice>
+    <% else %>
+      <.button_link
+        data-confirm="Deleting the team will also delete all the associated sites and data. This action cannot be reversed. Are you sure?"
+        href={Routes.settings_path(@conn, :delete_team)}
+        method="delete"
+        theme="danger"
+      >
+        Delete "{Plausible.Teams.name(@current_team)}"
+      </.button_link>
+    <% end %>
+  </.tile>
+</.settings_tiles>

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -38,7 +38,7 @@
       <a id="team-members">Team Members</a>
     </:title>
     <:subtitle>
-      Add, remove or change your team memberships
+      Add or remove team members and adjust their roles
     </:subtitle>
     {live_render(@conn, PlausibleWeb.Live.TeamManagement,
       id: "team-setup",

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -125,6 +125,9 @@ defmodule PlausibleWeb.LayoutView do
           %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
           if(current_team_role in [:owner, :admin, :billing],
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
+          ),
+          if(current_team_role == :owner,
+            do: %{key: "Danger Zone", value: "team/delete", icon: :exclamation_triangle}
           )
         ]
         |> Enum.reject(&is_nil/1)

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -749,11 +749,31 @@ defmodule PlausibleWeb.AuthControllerTest do
     } do
       another_owner = new_user()
       another_site = new_site(owner: another_owner)
+      team = team_of(another_owner)
       add_member(another_site.team, user: user, role: :owner)
 
       delete(conn, "/me")
 
       refute Repo.reload(user)
+      assert Repo.reload(team)
+    end
+
+    test "deletes personal team in multiple teams case as well", %{
+      conn: conn,
+      user: user
+    } do
+      new_site(owner: user)
+      personal_team = team_of(user)
+      another_owner = new_user()
+      _another_site = new_site(owner: another_owner)
+      another_team = team_of(another_owner)
+      add_member(another_team, user: user, role: :owner)
+
+      delete(conn, "/me")
+
+      refute Repo.reload(user)
+      assert Repo.reload(another_team)
+      refute Repo.reload(personal_team)
     end
   end
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1107,6 +1107,29 @@ defmodule PlausibleWeb.SettingsControllerTest do
     end
   end
 
+  describe "GET /settings/danger-zone" do
+    setup [:create_user, :log_in, :create_team]
+
+    test "without active subscription", %{conn: conn} do
+      conn = get(conn, Routes.settings_path(conn, :danger_zone))
+
+      assert html = html_response(conn, 200)
+
+      refute html =~ "Your account cannot be deleted because you have an active subscription"
+      assert html =~ "Delete my account"
+    end
+
+    test "with active subscription", %{conn: conn, user: user} do
+      subscribe_to_growth_plan(user)
+      conn = get(conn, Routes.settings_path(conn, :danger_zone))
+
+      assert html = html_response(conn, 200)
+
+      assert html =~ "Your account cannot be deleted because you have an active subscription"
+      refute html =~ "Delete my account"
+    end
+  end
+
   describe "Team Settings" do
     setup [:create_user, :log_in]
 
@@ -1171,6 +1194,101 @@ defmodule PlausibleWeb.SettingsControllerTest do
         })
 
       assert text(html_response(conn, 200)) =~ "can't be blank"
+    end
+
+    test "GET /settings/team/delete - without active subscription", %{conn: conn, user: user} do
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      team =
+        team
+        |> Plausible.Teams.complete_setup()
+        |> Ecto.Changeset.change(name: "Foo Crew")
+        |> Repo.update!()
+
+      conn = set_current_team(conn, team)
+      conn = get(conn, Routes.settings_path(conn, :team_danger_zone))
+
+      assert html = html_response(conn, 200)
+
+      refute html =~ "The team cannot be deleted because it has an active subscription"
+      assert html =~ "Delete \"Foo Crew\""
+    end
+
+    test "GET /settings/team/delete - with active subscription", %{conn: conn, user: user} do
+      user = subscribe_to_growth_plan(user)
+      team = team_of(user)
+
+      team =
+        team
+        |> Plausible.Teams.complete_setup()
+        |> Ecto.Changeset.change(name: "Foo Crew")
+        |> Repo.update!()
+
+      conn = set_current_team(conn, team)
+      conn = get(conn, Routes.settings_path(conn, :team_danger_zone))
+
+      assert html = html_response(conn, 200)
+
+      assert html =~ "The team cannot be deleted because it has an active subscription"
+      refute html =~ "Delete \"Foo Crew\""
+    end
+
+    test "GET /settings/team/delete - permission denied", %{conn: conn, user: user} do
+      another_user = new_user() |> subscribe_to_growth_plan()
+      team = team_of(another_user)
+      add_member(team, user: user, role: :admin)
+      conn = set_current_team(conn, team)
+      conn = get(conn, Routes.settings_path(conn, :team_danger_zone))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+    end
+
+    test "DELETE /settings/team/delete - deletes a team", %{conn: conn, user: user} do
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      team =
+        team
+        |> Plausible.Teams.complete_setup()
+        |> Ecto.Changeset.change(name: "Foo Crew")
+        |> Repo.update!()
+
+      conn = set_current_team(conn, team)
+      conn = delete(conn, Routes.settings_path(conn, :delete_team))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index, __team: "none")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) == "Team \"Foo Crew\" deleted"
+    end
+
+    test "DELETE /settings/team/delete - fails when there's an active subscription", %{
+      conn: conn,
+      user: user
+    } do
+      subscribe_to_growth_plan(user)
+      team = team_of(user)
+
+      team =
+        team
+        |> Plausible.Teams.complete_setup()
+        |> Ecto.Changeset.change(name: "Foo Crew")
+        |> Repo.update!()
+
+      conn = set_current_team(conn, team)
+      conn = delete(conn, Routes.settings_path(conn, :delete_team))
+
+      assert redirected_to(conn, 302) == Routes.settings_path(conn, :team_danger_zone)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Team has an active subscription"
+    end
+
+    test "DELETE /settings/team/delete - permission denied", %{conn: conn, user: user} do
+      another_user = new_user() |> subscribe_to_growth_plan()
+      team = team_of(another_user)
+      add_member(team, user: user, role: :admin)
+      conn = set_current_team(conn, team)
+      conn = delete(conn, Routes.settings_path(conn, :delete_team))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
     end
   end
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1128,6 +1128,22 @@ defmodule PlausibleWeb.SettingsControllerTest do
       assert html =~ "Your account cannot be deleted because you have an active subscription"
       refute html =~ "Delete my account"
     end
+
+    test "with a setup team", %{conn: conn, user: user} do
+      new_site(owner: user)
+
+      _team =
+        user
+        |> team_of()
+        |> Plausible.Teams.complete_setup()
+
+      conn = get(conn, Routes.settings_path(conn, :danger_zone))
+
+      assert html = html_response(conn, 200)
+
+      assert html =~ "You are the sole owner of one or more teams"
+      refute html =~ "Delete my account"
+    end
   end
 
   describe "Team Settings" do

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -19,7 +19,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
         |> html_response(200)
         |> text()
 
-      assert resp =~ "Add, remove or change your team memberships"
+      assert resp =~ "Add or remove team members and adjust their roles"
 
       refute element_exists?(resp, ~s|button[phx-click="save-team-layout"]|)
     end

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -340,6 +340,13 @@ defmodule Plausible.Teams.Test do
            )
   end
 
+  def refute_team_invitation(team, email) do
+    refute Repo.get_by(Plausible.Teams.Invitation,
+             email: email,
+             team_id: team.id
+           )
+  end
+
   def assert_site_transfer(site, %Plausible.Auth.User{} = user) do
     assert_site_transfer(site, user.email)
   end


### PR DESCRIPTION
### Changes

This PR adds capability to delete current team from a dedicated section under "Team Settings > Danger Zone". 

User deletion procedure was refactored as well to explicitly prevent deletion if associated personal team has an active subscription. The user deletion routine will be further extended in a follow-up with more explicit messaging for cases of setup teams with the user for sole owner. 

The team deletion procedure also accounts for ensuring the subscription is canceled first before allowing to delete the team.

Team deletion can be carried out only by one of the team owners.

### Tests
- [x] Automated tests have been added

