### PR TITLE
Migration: Drop `site.scroll_depth_visible_at`

### DIFF
--- a/priv/repo/migrations/20250313132408_drop_site_scroll_depth_visible_at.exs
+++ b/priv/repo/migrations/20250313132408_drop_site_scroll_depth_visible_at.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.DropSiteScrollDepthVisibleAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites) do
+      remove :scroll_depth_visible_at
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Migration to drop the `site.scroll_depth_visible_at` column which is no longer needed.
