### PR TITLE
Tracker: Remove redundant engagement cooldown

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -42,16 +42,10 @@
   // prevents registering multiple listeners in those cases.
   var listeningOnEngagement = false
 
-  // In SPA-s, multiple listeners that trigger the engagement event
-  // might fire nearly at the same time. E.g. when navigating back
-  // in browser history while using hash-based routing - a popstate
-  // and hashchange will be fired in a very quick succession. This
-  // flag prevents sending multiple engagement events in those cases.
-  var engagementCooldown = false
-
   // Timestamp indicating when this particular page last became visible.
   // Reset during pageviews, set to null when page is closed.
   var runningEngagementStart = null
+
   // When page is hidden, this 'engaged' time is saved to this variable
   var currentEngagementTime = 0
 
@@ -121,13 +115,10 @@
 
     The first engagement event is always sent due to containing at least the initial scroll depth.
 
-    We don't send engagements if:
-    - Less than 300ms have passed since the last engagement event
-    - The current pageview is ignored (onIgnoredEvent)
+    Also, we don't send engagements if the current pageview is ignored (onIgnoredEvent)
     */
-    if (!engagementCooldown && !currentEngagementIgnored && (currentEngagementMaxScrollDepth < maxScrollDepthPx || engagementTime >= 3000)) {
+    if (!currentEngagementIgnored && (currentEngagementMaxScrollDepth < maxScrollDepthPx || engagementTime >= 3000)) {
       currentEngagementMaxScrollDepth = maxScrollDepthPx
-      setTimeout(function () {engagementCooldown = false}, 300)
 
       var payload = {
         n: 'engagement',

--- a/tracker/test/engagement.spec.js
+++ b/tracker/test/engagement.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require("@playwright/test")
-const { expectPlausibleInAction, engagementCooldown, hideAndShowCurrentTab, focus, blur, blurAndFocusPage } = require('./support/test-utils')
+const { expectPlausibleInAction, hideAndShowCurrentTab, focus, blur, blurAndFocusPage } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 const { tracker_script_version } = require('../package.json')
@@ -100,8 +100,6 @@ test.describe('engagement events', () => {
       expectedRequests: [{n: 'engagement', u: pageBaseURL, h: 1}]
     })
 
-    await engagementCooldown(page)
-
     // Navigate from ignored page to a tracked page ->
     // no engagement from the current page, pageview on the next page
     await expectPlausibleInAction(page, {
@@ -109,8 +107,6 @@ test.describe('engagement events', () => {
       expectedRequests: [{n: 'pageview', u: `${pageBaseURL}#hash1`, h: 1}],
       refutedRequests: [{n: 'engagement'}]
     })
-
-    await engagementCooldown(page)
 
     // Navigate from a tracked page to another tracked page ->
     // engagement with the last page URL, pageview with the new URL
@@ -163,8 +159,6 @@ test.describe('engagement events', () => {
       ]
     })
 
-    await engagementCooldown(page)
-
     await expectPlausibleInAction(page, {
       action: () => page.click('#jane-post'),
       expectedRequests: [
@@ -172,8 +166,6 @@ test.describe('engagement events', () => {
         {n: 'pageview', p: {author: 'jane'}}
       ]
     })
-
-    await engagementCooldown(page)
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#home'),

--- a/tracker/test/scroll-depth.spec.js
+++ b/tracker/test/scroll-depth.spec.js
@@ -1,4 +1,4 @@
-const { engagementCooldown, expectPlausibleInAction, hideCurrentTab, hideAndShowCurrentTab } = require('./support/test-utils')
+const { expectPlausibleInAction, hideCurrentTab, hideAndShowCurrentTab } = require('./support/test-utils')
 const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
@@ -31,8 +31,6 @@ test.describe('scroll depth (engagement events)', () => {
         {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/scroll-depth-hash.html#about`}
       ]
     })
-
-    await engagementCooldown(page)
 
     await expectPlausibleInAction(page, {
       action: () => page.click('#home-link'),

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -1,11 +1,5 @@
 const { expect, Page } = require("@playwright/test");
 
-// Since engagement events in the Plausible script are throttled to 300ms, we
-// often need to wait for an artificial timeout before navigating in tests.
-exports.engagementCooldown = async function(page) {
-  return page.waitForTimeout(400)
-}
-
 // Mocks an HTTP request call with the given path. Returns a Promise that resolves to the request
 // data. If the request is not made, resolves to null after 3 seconds.
 const mockRequest = function (page, path) {


### PR DESCRIPTION
### Changes

Removes redundant engagement cooldown of 300ms (this was currently not even used and the comment about SPA navigation was wrong because our script adds a listener for either hashchange or pushstate/popstate - not both)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
