### PR TITLE
Store `tracker_script_version` under `ingest_counters`

### DIFF
--- a/lib/plausible/ingestion/counters.ex
+++ b/lib/plausible/ingestion/counters.ex
@@ -70,12 +70,13 @@ defmodule Plausible.Ingestion.Counters do
 
       records ->
         records =
-          Enum.map(records, fn {bucket, metric, domain, value} ->
+          Enum.map(records, fn {bucket, metric, domain, tracker_script_version, value} ->
             %{
               event_timebucket: to_0_minute_datetime(bucket),
               metric: metric,
               site_id: Plausible.Site.Cache.get_site_id(domain),
               domain: domain,
+              tracker_script_version: tracker_script_version,
               value: value
             }
           end)

--- a/lib/plausible/ingestion/counters/record.ex
+++ b/lib/plausible/ingestion/counters/record.ex
@@ -13,5 +13,6 @@ defmodule Plausible.Ingestion.Counters.Record do
     field :domain, Ch, type: "LowCardinality(String)"
     field :metric, Ch, type: "LowCardinality(String)"
     field :value, Ch, type: "UInt64"
+    field :tracker_script_version, Ch, type: "UInt16"
   end
 end

--- a/lib/plausible/ingestion/counters/telemetry_handler.ex
+++ b/lib/plausible/ingestion/counters/telemetry_handler.ex
@@ -30,20 +30,36 @@ defmodule Plausible.Ingestion.Counters.TelemetryHandler do
   def handle_event(
         @event_dropped,
         _measurements,
-        %{domain: domain, reason: reason, request_timestamp: timestamp},
+        %{
+          domain: domain,
+          reason: reason,
+          request_timestamp: timestamp,
+          tracker_script_version: tracker_script_version
+        },
         buffer
       ) do
-    Counters.Buffer.aggregate(buffer, "dropped_#{reason}", domain, timestamp)
+    Counters.Buffer.aggregate(
+      buffer,
+      "dropped_#{reason}",
+      domain,
+      timestamp,
+      tracker_script_version
+    )
+
     :ok
   end
 
   def handle_event(
         @event_buffered,
         _measurements,
-        %{domain: domain, request_timestamp: timestamp},
+        %{
+          domain: domain,
+          request_timestamp: timestamp,
+          tracker_script_version: tracker_script_version
+        },
         buffer
       ) do
-    Counters.Buffer.aggregate(buffer, "buffered", domain, timestamp)
+    Counters.Buffer.aggregate(buffer, "buffered", domain, timestamp, tracker_script_version)
     :ok
   end
 end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -96,7 +96,8 @@ defmodule Plausible.Ingestion.Event do
   def emit_telemetry_buffered(event) do
     :telemetry.execute(telemetry_event_buffered(), %{}, %{
       domain: event.domain,
-      request_timestamp: event.request.timestamp
+      request_timestamp: event.request.timestamp,
+      tracker_script_version: event.request.tracker_script_version || 0
     })
   end
 
@@ -108,7 +109,8 @@ defmodule Plausible.Ingestion.Event do
       %{
         domain: event.domain,
         reason: reason,
-        request_timestamp: event.request.timestamp
+        request_timestamp: event.request.timestamp,
+        tracker_script_version: event.request.tracker_script_version || 0
       }
     )
   end

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -97,7 +97,7 @@ defmodule Plausible.Ingestion.Event do
     :telemetry.execute(telemetry_event_buffered(), %{}, %{
       domain: event.domain,
       request_timestamp: event.request.timestamp,
-      tracker_script_version: event.request.tracker_script_version || 0
+      tracker_script_version: event.request.tracker_script_version
     })
   end
 
@@ -110,7 +110,7 @@ defmodule Plausible.Ingestion.Event do
         domain: event.domain,
         reason: reason,
         request_timestamp: event.request.timestamp,
-        tracker_script_version: event.request.tracker_script_version || 0
+        tracker_script_version: event.request.tracker_script_version
       }
     )
   end

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -43,6 +43,7 @@ defmodule Plausible.Ingestion.Request do
     field :props, :map
     field :scroll_depth, :integer
     field :engagement_time, :integer
+    field :tracker_script_version, :integer
 
     on_ee do
       field :revenue_source, :map
@@ -84,6 +85,7 @@ defmodule Plausible.Ingestion.Request do
         |> put_pathname()
         |> put_query_params()
         |> put_revenue_source(request_body)
+        |> put_tracker_script_version(request_body)
         |> map_domains(request_body)
         |> Changeset.validate_required([
           :event_name,
@@ -267,6 +269,16 @@ defmodule Plausible.Ingestion.Request do
       Changeset.put_change(changeset, :engagement_time, engagement_time)
     else
       changeset
+    end
+  end
+
+  defp put_tracker_script_version(changeset, %{} = request_body) do
+    case request_body["v"] do
+      version when is_integer(version) ->
+        Changeset.put_change(changeset, :tracker_script_version, version)
+
+      _ ->
+        changeset
     end
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Ingestion.Request do
     field :props, :map
     field :scroll_depth, :integer
     field :engagement_time, :integer
-    field :tracker_script_version, :integer
+    field :tracker_script_version, :integer, default: 0
 
     on_ee do
       field :revenue_source, :map

--- a/priv/ingest_repo/migrations/20250316182725_ingest_counters_tracker_script_version.exs
+++ b/priv/ingest_repo/migrations/20250316182725_ingest_counters_tracker_script_version.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.IngestRepo.Migrations.IngestCountersTrackerScriptVersion do
+  use Ecto.Migration
+
+  def change do
+    on_cluster = Plausible.MigrationUtils.on_cluster_statement("ingest_counters")
+
+    execute """
+    ALTER TABLE ingest_counters
+    #{on_cluster}
+    ADD COLUMN IF NOT EXISTS tracker_script_version UInt16,
+    MODIFY ORDER BY (domain, toDate(event_timebucket), metric, toStartOfMinute(event_timebucket), tracker_script_version)
+    """
+  end
+end

--- a/test/plausible/ingestion/counters/telemetry_handler_test.exs
+++ b/test/plausible/ingestion/counters/telemetry_handler_test.exs
@@ -34,9 +34,20 @@ defmodule Plausible.Ingestion.Counters.TelemetryHandlerTest do
     buffer = Buffer.new(test)
     assert :ok = TelemetryHandler.install(buffer)
 
-    e1 = %{domain: "a.example.com", request: %{timestamp: NaiveDateTime.utc_now()}}
-    e2 = %{domain: "b.example.com", request: %{timestamp: NaiveDateTime.utc_now()}}
-    e3 = %{domain: "c.example.com", request: %{timestamp: NaiveDateTime.utc_now()}}
+    e1 = %{
+      domain: "a.example.com",
+      request: %{timestamp: NaiveDateTime.utc_now(), tracker_script_version: 137}
+    }
+
+    e2 = %{
+      domain: "b.example.com",
+      request: %{timestamp: NaiveDateTime.utc_now(), tracker_script_version: 137}
+    }
+
+    e3 = %{
+      domain: "c.example.com",
+      request: %{timestamp: NaiveDateTime.utc_now(), tracker_script_version: 137}
+    }
 
     :ok = Event.emit_telemetry_dropped(e1, :invalid)
     :ok = Event.emit_telemetry_dropped(e2, :not_found)
@@ -47,8 +58,8 @@ defmodule Plausible.Ingestion.Counters.TelemetryHandlerTest do
 
     assert aggregates = Buffer.flush(buffer, future)
 
-    assert Enum.find(aggregates, &match?({_, "dropped_invalid", "a.example.com", 1}, &1))
-    assert Enum.find(aggregates, &match?({_, "dropped_not_found", "b.example.com", 2}, &1))
-    assert Enum.find(aggregates, &match?({_, "buffered", "c.example.com", 1}, &1))
+    assert Enum.find(aggregates, &match?({_, "dropped_invalid", "a.example.com", 137, 1}, &1))
+    assert Enum.find(aggregates, &match?({_, "dropped_not_found", "b.example.com", 137, 2}, &1))
+    assert Enum.find(aggregates, &match?({_, "buffered", "c.example.com", 137, 1}, &1))
   end
 end

--- a/test/plausible/ingestion/counters_test.exs
+++ b/test/plausible/ingestion/counters_test.exs
@@ -116,7 +116,8 @@ defmodule Plausible.Ingestion.CountersTest do
 
     payload = %{
       name: "pageview",
-      url: "http://#{site.domain}"
+      url: "http://#{site.domain}",
+      v: 137
     }
 
     conn = build_conn(:post, "/api/event", payload)
@@ -133,7 +134,8 @@ defmodule Plausible.Ingestion.CountersTest do
 
     payload = %{
       name: "pageview",
-      url: "http://#{site.domain}"
+      url: "http://#{site.domain}",
+      v: 137
     }
 
     conn = build_conn(:post, "/api/event", payload)
@@ -152,8 +154,8 @@ defmodule Plausible.Ingestion.CountersTest do
   defp verify_record_written(domain, metric, value, site_id \\ nil) do
     query =
       from(r in Record,
-        group_by: [:site_id, :domain, :metric, :event_timebucket],
-        where: r.domain == ^domain and r.metric == ^metric,
+        group_by: [:site_id, :domain, :metric, :event_timebucket, :tracker_script_version],
+        where: r.domain == ^domain and r.metric == ^metric and r.tracker_script_version == 137,
         select: sum(r.value)
       )
 

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -494,7 +494,7 @@ defmodule Plausible.Ingestion.RequestTest do
              "ip_classification" => nil,
              "scroll_depth" => nil,
              "engagement_time" => nil,
-             "tracker_script_version" => nil
+             "tracker_script_version" => 0
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -159,7 +159,8 @@ defmodule Plausible.Ingestion.RequestTest do
       props: %{
         "custom1" => "property1",
         "custom2" => "property2"
-      }
+      },
+      v: 137
     }
 
     conn = build_conn(:post, "/api/events", payload)
@@ -169,6 +170,7 @@ defmodule Plausible.Ingestion.RequestTest do
     assert request.hash_mode == 1
     assert request.props["custom1"] == "property1"
     assert request.props["custom2"] == "property2"
+    assert request.tracker_script_version == 137
   end
 
   @tag :ee_only
@@ -491,7 +493,8 @@ defmodule Plausible.Ingestion.RequestTest do
              "user_agent" => "Mozilla",
              "ip_classification" => nil,
              "scroll_depth" => nil,
-             "engagement_time" => nil
+             "engagement_time" => nil,
+             "tracker_script_version" => nil
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])


### PR DESCRIPTION
### Changes

This will enable tracking how many events per tracker_script_version to track the rollout for any issues.

Migration PR: https://github.com/plausible/analytics/pull/5202 (to be deployed first)
Tracker PR: https://github.com/plausible/analytics/pull/5198