### PR TITLE
Improve verification diagnostics

### DIFF
--- a/lib/plausible/verification/checks/snippet.ex
+++ b/lib/plausible/verification/checks/snippet.ex
@@ -47,15 +47,21 @@ defmodule Plausible.Verification.Checks.Snippet do
     "defer",
     "data-api",
     "data-exclude",
-    "data-include"
+    "data-include",
+    "data-cfasync"
   ]
 
   defp unknown_attributes?(nodes) do
     Enum.any?(nodes, fn {_, attrs, _} ->
       Enum.any?(attrs, fn
-        {"type", "text/javascript"} -> false
-        {"event-" <> _, _} -> false
-        {key, _} -> key not in @known_attributes
+        {"type", "text/javascript"} ->
+          false
+
+        {"event-" <> _, _} ->
+          false
+
+        {key, _} ->
+          key not in @known_attributes
       end)
     end)
   end

--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -58,13 +58,21 @@ defmodule Plausible.Verification.Diagnostics do
   end
 
   def interpret(
-        %__MODULE__{plausible_installed?: false, gtm_likely?: true, cookie_banner_likely?: true},
+        %__MODULE__{
+          plausible_installed?: false,
+          gtm_likely?: true,
+          cookie_banner_likely?: true,
+          wordpress_plugin?: false
+        },
         _url
       ) do
     error(@errors.gtm_cookie_banner)
   end
 
-  def interpret(%__MODULE__{plausible_installed?: false, gtm_likely?: true}, _url) do
+  def interpret(
+        %__MODULE__{plausible_installed?: false, gtm_likely?: true, wordpress_plugin?: false},
+        _url
+      ) do
     error(@errors.gtm)
   end
 

--- a/test/plausible/site/verification/checks/snippet_test.exs
+++ b/test/plausible/site/verification/checks/snippet_test.exs
@@ -129,7 +129,7 @@ defmodule Plausible.Verification.Checks.SnippetTest do
 
   @valid_attributes """
   <head>
-  <script defer type="text/javascript" data-api="some" data-include="some" data-exclude="some" data-domain="example.com" src="http://my-domain.example.com/js/script.js"></script>
+  <script defer type="text/javascript" data-cfasync='false' data-api="some" data-include="some" data-exclude="some" data-domain="example.com" src="http://my-domain.example.com/js/script.js"></script>
   </head>
   """
 

--- a/test/plausible/site/verification/checks_test.exs
+++ b/test/plausible/site/verification/checks_test.exs
@@ -854,6 +854,29 @@ defmodule Plausible.Verification.ChecksTest do
       |> interpret_sentry_case()
       |> assert_error(@errors.no_snippet)
     end
+
+    test "gtm+wp detected, but likely script id attribute interfering" do
+      %Plausible.Verification.Diagnostics{
+        plausible_installed?: false,
+        snippets_found_in_head: 1,
+        snippets_found_in_body: 0,
+        snippet_found_after_busting_cache?: false,
+        snippet_unknown_attributes?: true,
+        disallowed_via_csp?: false,
+        service_error: nil,
+        body_fetched?: true,
+        wordpress_likely?: true,
+        cookie_banner_likely?: true,
+        gtm_likely?: true,
+        callback_status: 0,
+        proxy_likely?: true,
+        manual_script_extension?: false,
+        data_domain_mismatch?: false,
+        wordpress_plugin?: true
+      }
+      |> interpret_sentry_case()
+      |> assert_error(@errors.illegal_attrs_wp_plugin)
+    end
   end
 
   defp interpret_sentry_case(diagnostics) do


### PR DESCRIPTION
For when both GTM & WordPress Plugin are detected, give WP priority. Also, consider `data-cfasync`
a known attribute since it's the plugin that
adds that.


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
