### PR TITLE
Guest Memberships via Sites API

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
     with {:ok, site_id} <- expect_param_key(params, "site_id"),
          {:ok, site} <- get_site(user, site_id, [:owner, :admin, :editor, :viewer]) do
-      opts = [cursor_fields: [id: :desc, inserted_at: :desc], limit: 100, maximum_limit: 1000]
+      opts = [cursor_fields: [inserted_at: :desc, id: :desc], limit: 100, maximum_limit: 1000]
       page = site |> Sites.list_guests_query() |> paginate(params, opts)
 
       json(conn, %{

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -162,6 +162,49 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     end
   end
 
+  def find_or_create_guest(conn, params) do
+    with {:ok, site_id} <- expect_param_key(params, "site_id"),
+         {:ok, email} <- expect_param_key(params, "email"),
+         {:ok, role} <- expect_param_key(params, "role", ["viewer", "editor"]),
+         {:ok, site} <- get_site(conn.assigns.current_user, site_id, [:owner, :admin]) do
+      existing = Repo.one(Sites.list_guests_query(site, email: email))
+
+      if existing do
+        json(conn, %{
+          role: existing.role,
+          email: existing.email,
+          accepted: existing.accepted
+        })
+      else
+        case Plausible.Site.Memberships.CreateInvitation.create_invitation(
+               site,
+               conn.assigns.current_user,
+               email,
+               role
+             ) do
+          {:ok, invitation} ->
+            json(conn, %{
+              role: invitation.role,
+              email: invitation.team_invitation.email,
+              accepted: false
+            })
+        end
+      end
+    else
+      {:error, :site_not_found} ->
+        H.not_found(conn, "Site could not be found")
+
+      {:missing, "role"} ->
+        H.bad_request(
+          conn,
+          "Parameter `role` is required to create guest. Possible values: `viewer` or `editor`"
+        )
+
+      {:missing, param} ->
+        H.bad_request(conn, "Parameter `#{param}` is required to create guest")
+    end
+  end
+
   def find_or_create_shared_link(conn, params) do
     with {:ok, site_id} <- expect_param_key(params, "site_id"),
          {:ok, link_name} <- expect_param_key(params, "name"),
@@ -259,10 +302,21 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     %{"error" => error_msg}
   end
 
-  defp expect_param_key(params, key) do
-    case Map.fetch(params, key) do
-      :error -> {:missing, key}
-      res -> res
+  defp expect_param_key(params, key, inclusion \\ []) do
+    case Map.get(params, key) do
+      nil ->
+        {:missing, key}
+
+      res ->
+        if Enum.empty?(inclusion) do
+          {:ok, res}
+        else
+          if res in inclusion do
+            {:ok, res}
+          else
+            {:missing, key}
+          end
+        end
     end
   end
 end

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -219,7 +219,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
           end
 
         %{accepted: true, email: email} ->
-          with user when not is_nil(user) <- Repo.get_by(Plausible.Auth.User, email: email) do
+          with %{} = user <- Repo.get_by(Plausible.Auth.User, email: email) do
             Teams.Memberships.remove(site, user)
           end
 

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -334,21 +334,22 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     %{"error" => error_msg}
   end
 
-  defp expect_param_key(params, key, inclusion \\ []) do
-    case Map.get(params, key) do
-      nil ->
-        {:missing, key}
+  defp expect_param_key(params, key, inclusion \\ [])
 
-      res ->
-        if Enum.empty?(inclusion) do
-          {:ok, res}
-        else
-          if res in inclusion do
-            {:ok, res}
-          else
-            {:missing, key}
-          end
-        end
+  defp expect_param_key(params, key, []) do
+    case Map.fetch(params, key) do
+      :error -> {:missing, key}
+      res -> res
+    end
+  end
+
+  defp expect_param_key(params, key, inclusion) do
+    case expect_param_key(params, key, []) do
+      {:ok, value} = ok ->
+        if value in inclusion, do: ok, else: {:missing, key}
+
+      _ ->
+        {:missing, key}
     end
   end
 end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -161,7 +161,7 @@ defmodule Plausible.Sites do
         as: :user,
         where: gm.site_id == ^site.id,
         select: %{
-          id: tm.id,
+          id: gm.id,
           inserted_at: gm.inserted_at,
           email: u.email,
           role: gm.role,

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -151,8 +151,8 @@ defmodule Plausible.Sites do
     %{memberships: memberships, invitations: site_transfers ++ invitations}
   end
 
-  @spec list_guests_query(Site.t()) :: Ecto.Query.t()
-  def list_guests_query(site) do
+  @spec list_guests_query(Site.t(), Keyword.t()) :: Ecto.Query.t()
+  def list_guests_query(site, opts \\ []) do
     guest_memberships =
       from(
         gm in Teams.GuestMembership,
@@ -168,6 +168,13 @@ defmodule Plausible.Sites do
         }
       )
 
+    guest_memberships =
+      if email = opts[:email] do
+        guest_memberships |> where([..., u], u.email == ^email)
+      else
+        guest_memberships
+      end
+
     guest_invitations =
       from(
         gi in Teams.GuestInvitation,
@@ -181,6 +188,13 @@ defmodule Plausible.Sites do
           accepted: false
         }
       )
+
+    guest_invitations =
+      if email = opts[:email] do
+        guest_invitations |> where([..., ti], ti.email == ^email)
+      else
+        guest_invitations
+      end
 
     guests = union_all(guest_memberships, ^guest_invitations)
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -158,6 +158,7 @@ defmodule Plausible.Sites do
         gm in Teams.GuestMembership,
         inner_join: tm in assoc(gm, :team_membership),
         inner_join: u in assoc(tm, :user),
+        as: :user,
         where: gm.site_id == ^site.id,
         select: %{
           id: tm.id,
@@ -179,6 +180,7 @@ defmodule Plausible.Sites do
       from(
         gi in Teams.GuestInvitation,
         inner_join: ti in assoc(gi, :team_invitation),
+        as: :team_invitation,
         where: gi.site_id == ^site.id,
         select: %{
           id: gi.id,
@@ -191,7 +193,7 @@ defmodule Plausible.Sites do
 
     guest_invitations =
       if email = opts[:email] do
-        guest_invitations |> where([..., ti], ti.email == ^email)
+        guest_invitations |> where([team_invitation: ti], ti.email == ^email)
       else
         guest_invitations
       end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -170,7 +170,7 @@ defmodule Plausible.Sites do
 
     guest_memberships =
       if email = opts[:email] do
-        guest_memberships |> where([..., u], u.email == ^email)
+        guest_memberships |> where([user: u], u.email == ^email)
       else
         guest_memberships
       end

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -151,6 +151,51 @@ defmodule Plausible.Sites do
     %{memberships: memberships, invitations: site_transfers ++ invitations}
   end
 
+  @spec list_guests_query(Site.t()) :: Ecto.Query.t()
+  def list_guests_query(site) do
+    guest_memberships =
+      from(
+        gm in Teams.GuestMembership,
+        inner_join: tm in assoc(gm, :team_membership),
+        inner_join: u in assoc(tm, :user),
+        where: gm.site_id == ^site.id,
+        select: %{
+          id: tm.id,
+          inserted_at: gm.inserted_at,
+          email: u.email,
+          role: gm.role,
+          accepted: true
+        }
+      )
+
+    guest_invitations =
+      from(
+        gi in Teams.GuestInvitation,
+        inner_join: ti in assoc(gi, :team_invitation),
+        where: gi.site_id == ^site.id,
+        select: %{
+          id: gi.id,
+          inserted_at: gi.inserted_at,
+          email: ti.email,
+          role: gi.role,
+          accepted: false
+        }
+      )
+
+    guests = union_all(guest_memberships, ^guest_invitations)
+
+    from(g in subquery(guests),
+      select: %{
+        id: g.id,
+        inserted_at: g.inserted_at,
+        email: g.email,
+        role: g.role,
+        accepted: g.accepted
+      },
+      order_by: [desc: g.id]
+    )
+  end
+
   @spec for_user_query(Auth.User.t(), Teams.Team.t() | nil) :: Ecto.Query.t()
   def for_user_query(user, team \\ nil) do
     query =

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -208,7 +208,7 @@ defmodule Plausible.Sites do
         role: g.role,
         accepted: g.accepted
       },
-      order_by: [desc: g.id]
+      order_by: [desc: g.inserted_at, desc: g.id]
     )
   end
 

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -165,7 +165,7 @@ defmodule Plausible.Sites do
           inserted_at: gm.inserted_at,
           email: u.email,
           role: gm.role,
-          accepted: true
+          status: "accepted"
         }
       )
 
@@ -187,7 +187,7 @@ defmodule Plausible.Sites do
           inserted_at: gi.inserted_at,
           email: ti.email,
           role: gi.role,
-          accepted: false
+          status: "invited"
         }
       )
 
@@ -206,7 +206,7 @@ defmodule Plausible.Sites do
         inserted_at: g.inserted_at,
         email: g.email,
         role: g.role,
-        accepted: g.accepted
+        status: g.status
       },
       order_by: [desc: g.inserted_at, desc: g.id]
     )

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -276,9 +276,13 @@ defmodule PlausibleWeb.Router do
 
         post "/", ExternalSitesController, :create_site
         put "/shared-links", ExternalSitesController, :find_or_create_shared_link
+
         put "/goals", ExternalSitesController, :find_or_create_goal
-        put "/guests", ExternalSitesController, :find_or_create_guest
         delete "/goals/:goal_id", ExternalSitesController, :delete_goal
+
+        put "/guests", ExternalSitesController, :find_or_create_guest
+        delete "/guests/:email", ExternalSitesController, :delete_guest
+
         put "/:site_id", ExternalSitesController, :update_site
         delete "/:site_id", ExternalSitesController, :delete_site
       end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -267,6 +267,7 @@ defmodule PlausibleWeb.Router do
 
         get "/", ExternalSitesController, :index
         get "/goals", ExternalSitesController, :goals_index
+        get "/guests", ExternalSitesController, :guests_index
         get "/:site_id", ExternalSitesController, :get_site
       end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -277,6 +277,7 @@ defmodule PlausibleWeb.Router do
         post "/", ExternalSitesController, :create_site
         put "/shared-links", ExternalSitesController, :find_or_create_shared_link
         put "/goals", ExternalSitesController, :find_or_create_goal
+        put "/guests", ExternalSitesController, :find_or_create_guest
         delete "/goals/:goal_id", ExternalSitesController, :delete_goal
         put "/:site_id", ExternalSitesController, :update_site
         delete "/:site_id", ExternalSitesController, :delete_site

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -741,7 +741,10 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                  "role" => "viewer"
                }
 
-        assert_email_delivered_with(to: [nil: "test@example.com"], subject: ~r/You've been invited to #{site.domain}/)
+        assert_email_delivered_with(
+          to: [nil: "test@example.com"],
+          subject: ~r/You've been invited to #{site.domain}/
+        )
       end
 
       test "is idempotent", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -662,11 +662,11 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
 
         assert json_response(conn, 200) == %{
                  "guests" => [
-                   %{"email" => guest2.email, "accepted" => true, "role" => "viewer"},
-                   %{"email" => guest1.email, "accepted" => true, "role" => "editor"},
+                   %{"email" => guest2.email, "status" => "accepted", "role" => "viewer"},
+                   %{"email" => guest1.email, "status" => "accepted", "role" => "editor"},
                    %{
                      "email" => guest3.team_invitation.email,
-                     "accepted" => false,
+                     "status" => "invited",
                      "role" => "viewer"
                    }
                  ],
@@ -689,8 +689,8 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
 
         assert %{
                  "guests" => [
-                   %{"email" => ^guest2_email, "accepted" => true, "role" => "viewer"},
-                   %{"email" => ^guest1_email, "accepted" => true, "role" => "editor"}
+                   %{"email" => ^guest2_email, "status" => "accepted", "role" => "viewer"},
+                   %{"email" => ^guest1_email, "status" => "accepted", "role" => "editor"}
                  ],
                  "meta" => %{
                    "before" => nil,
@@ -709,7 +709,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                  "guests" => [
                    %{
                      "email" => "third@example.com",
-                     "accepted" => false,
+                     "status" => "invited",
                      "role" => "viewer"
                    }
                  ],
@@ -736,7 +736,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
           })
 
         assert json_response(conn, 200) == %{
-                 "accepted" => false,
+                 "status" => "invited",
                  "email" => "test@example.com",
                  "role" => "viewer"
                }
@@ -765,7 +765,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
             "email" => "test@example.com"
           })
 
-        assert %{"role" => "viewer", "accepted" => false} = json_response(conn2, 200)
+        assert %{"role" => "viewer", "status" => "invited"} = json_response(conn2, 200)
 
         assert %{memberships: [_], invitations: [%{role: "viewer"}]} =
                  Plausible.Sites.list_people(site)
@@ -785,7 +785,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
             "email" => "guest@example.com"
           })
 
-        assert %{"role" => "viewer", "accepted" => true} = json_response(conn, 200)
+        assert %{"role" => "viewer", "status" => "accepted"} = json_response(conn, 200)
 
         assert %{
                  memberships: [%{user: _}, %{user: %{email: "guest@example.com"}}],


### PR DESCRIPTION
### Changes

This PR adds Create/List/Delete operations for "guests" via the Sites API.
Implementation follows existing conventions. 
`accepted` boolean payload attribute indicates difference between invitation and a membership. `email` is used as a universal identifier for either guest invitation or a guest membership.

Docs: https://github.com/plausible/docs/pull/591

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated: https://github.com/plausible/docs/pull/591
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
