### PR TITLE
Tracker: Pause engagement_time when browser loses focus

### DIFF
--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -151,20 +151,24 @@
     }
   }
 
+  function onVisibilityChange() {
+    if (document.visibilityState === 'visible' && document.hasFocus() && runningEngagementStart === null) {
+      runningEngagementStart = Date.now()
+    } else if (document.visibilityState === 'hidden' || !document.hasFocus()) {
+      // Tab went back to background or lost focus. Save the engaged time so far
+      currentEngagementTime = getEngagementTime()
+      runningEngagementStart = null
+
+      triggerEngagement()
+    }
+  }
+
   function registerEngagementListener() {
     if (!listeningOnEngagement) {
       // Only register visibilitychange listener only after initial page load and pageview
-      document.addEventListener('visibilitychange', function() {
-        if (document.visibilityState === 'hidden') {
-          // Tab went back to background. Save the engaged time so far
-          currentEngagementTime = getEngagementTime()
-          runningEngagementStart = null
-
-          triggerEngagement()
-        } else if (document.visibilityState === 'visible' && runningEngagementStart === null) {
-          runningEngagementStart = Date.now()
-        }
-      })
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      window.addEventListener('blur', onVisibilityChange)
+      window.addEventListener('focus', onVisibilityChange)
       listeningOnEngagement = true
     }
   }

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -161,12 +161,37 @@ exports.showCurrentTab = async function(page) {
   return toggleTabVisibility(page, false)
 }
 
+async function setFocus(page, focus) {
+  await page.evaluate((focus) => {
+    Object.defineProperty(document, 'hasFocus', { value: () => focus, writable: true })
+
+    const eventName = focus ? 'focus' : 'blur'
+    window.dispatchEvent(new Event(eventName))
+  }, focus)
+}
+
+exports.focus = async function(page) {
+  return setFocus(page, true)
+}
+
+exports.blur = async function(page) {
+  return setFocus(page, false)
+}
+
 exports.hideAndShowCurrentTab = async function(page, options = {}) {
   await exports.hideCurrentTab(page)
   if (options.delay > 0) {
     await delay(options.delay)
   }
   await exports.showCurrentTab(page)
+}
+
+exports.blurAndFocusPage = async function(page, options = {}) {
+  await exports.blur(page)
+  if (options.delay > 0) {
+    await delay(options.delay)
+  }
+  await exports.focus(page)
 }
 
 function includesSubset(body, subset) {


### PR DESCRIPTION
Consider this scenario:
1. User opens page /blog
2. 3 seconds later, alt-tabs to another window
3. minute later, alt-tabs to the page and closes it

Previously, this would be reported as 1m03s engagement_time. Now this would be reported as 3s engagement_time.