### PR TITLE
Fix pageviews slider

### DIFF
--- a/lib/plausible_web/components/billing/pageview_slider.ex
+++ b/lib/plausible_web/components/billing/pageview_slider.ex
@@ -16,7 +16,7 @@ defmodule PlausibleWeb.Components.Billing.PageviewSlider do
 
   defp slider_output(assigns) do
     ~H"""
-    <output class="lg:w-1/4 lg:order-1 font-medium text-lg text-gray-600 dark:text-gray-200">
+    <output class="lg:w-1/4 lg:order-1 font-medium text-md text-gray-600 dark:text-gray-200">
       <span :if={@volume != :enterprise}>Up to</span>
       <strong id="slider-value" class="text-gray-900 dark:text-gray-100">
         {format_volume(@volume, @available_volumes)}

--- a/lib/plausible_web/components/billing/pageview_slider.ex
+++ b/lib/plausible_web/components/billing/pageview_slider.ex
@@ -46,7 +46,7 @@ defmodule PlausibleWeb.Components.Billing.PageviewSlider do
             phx-change="slide"
             id="slider"
             name="slider"
-            class="shadow mt-8 dark:bg-gray-600 dark:border-none"
+            class="shadow dark:bg-gray-600 dark:border-none"
             type="range"
             min="0"
             max={length(@available_volumes)}
@@ -101,13 +101,15 @@ defmodule PlausibleWeb.Components.Billing.PageviewSlider do
     ~H"""
     <style>
       input[type="range"] {
+        vertical-align: middle;
         -moz-appearance: none;
         -webkit-appearance: none;
         background: white;
         border-radius: 3px;
         height: 6px;
         width: 100%;
-        margin-bottom: 9px;
+        margin-top: 15px;
+        margin-bottom: 15px;
         outline: none;
       }
 

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -115,7 +115,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
 
     ~H"""
     <div class="pt-1 pb-12 sm:pb-16 text-gray-900 dark:text-gray-100">
-      <div class="mx-auto max-w-7xl px-6 lg:px-20">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
         <Notice.pending_site_ownerships_notice
           class="pb-6"
           pending_ownership_count={length(@pending_ownership_site_ids)}


### PR DESCRIPTION
### Changes

* Fixes the pageviews slider on Firefox by aligning the base of the range input with the base of various texts that appear next to it. 
  * For that, it needs to have same top and bottom margin and vertical-align: middle, which I opted to give using style not TW classes, just to keep it the same as in website #pricing section. 
* Stops slider output text from wrapping around the 1024px screen width mark by changing the font size and removing custom large screen horizontal padding from choose plan page. 

See comment for before / after images.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
