### PR TITLE
Fix Team Admin permissions

### DIFF
--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -158,6 +158,8 @@ defmodule Plausible.Teams.Memberships do
   defp can_grant_role_to_other?(:owner, :editor), do: true
   defp can_grant_role_to_other?(:owner, :admin), do: true
   defp can_grant_role_to_other?(:owner, :viewer), do: true
+  defp can_grant_role_to_other?(:admin, :editor), do: true
+  defp can_grant_role_to_other?(:admin, :viewer), do: true
   defp can_grant_role_to_other?(:editor, :editor), do: true
   defp can_grant_role_to_other?(:editor, :viewer), do: true
   defp can_grant_role_to_other?(_, _), do: false

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -65,7 +65,7 @@
                     </.dropdown_item>
                     <.dropdown_divider />
                     <.dropdown_item
-                      :if={@conn.assigns[:site_role] == :owner}
+                      :if={@site_role in [:owner, :admin]}
                       class="text-red-600 dark:text-red-500 hover:text-red-600"
                       href={
                         Routes.membership_path(

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -300,6 +300,20 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
       assert_guest_membership(site.team, site, collaborator, :viewer)
     end
 
+    test "team admin can update a site member's role by user id", %{conn: conn, user: user} do
+      site = new_site()
+      team = Plausible.Teams.complete_setup(site.team)
+      add_member(team, user: user, role: :admin)
+      collaborator = add_guest(site, role: :editor)
+      assert_guest_membership(team, site, collaborator, :editor)
+
+      conn = set_current_team(conn, team)
+
+      put(conn, "/sites/#{site.domain}/memberships/u/#{collaborator.id}/role/viewer")
+
+      assert_guest_membership(team, site, collaborator, :viewer)
+    end
+
     test "can downgrade yourself from admin to viewer, redirects to stats", %{
       conn: conn,
       user: user


### PR DESCRIPTION
### Changes

Extracted from https://github.com/plausible/analytics/pull/5210 which is blocked until teams feature is released.

Fixes:

- allow admin to update site role (permission check was missing relevant clauses)
- display ownership transfer option under Site Settings > People to admin as well

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests
