### PR TITLE
time-on-page: Dashboard tweaks

### DIFF
--- a/assets/js/dashboard/components/table.tsx
+++ b/assets/js/dashboard/components/table.tsx
@@ -121,7 +121,7 @@ export const Table = <T extends Record<string, string | number | ReactNode>>({
   const warningSpan = (warning: string) => {
     return (
       <span className="text-xs font-normal whitespace-nowrap">
-        {'*' + warning}
+        {'* ' + warning}
       </span>
     )
   }

--- a/assets/js/dashboard/stats/reports/metrics.js
+++ b/assets/js/dashboard/stats/reports/metrics.js
@@ -194,7 +194,7 @@ export const createPageviews = (props) => {
 export const createTimeOnPage = (props) => {
   const renderLabel = (_query) => 'Time on Page'
   return new Metric({
-    width: 'w-28',
+    width: 'w-32',
     ...props,
     key: 'time_on_page',
     renderLabel,

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -159,12 +159,13 @@ defmodule Plausible.Stats.QueryResult do
   defp metric_warning(:time_on_page, %Query{} = query) do
     case query.time_on_page_data do
       %{include_legacy_metric: true, cutoff: cutoff} ->
-        cutoff_time =
-          cutoff |> DateTime.shift_zone!(query.timezone) |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+        cutoff_date =
+          cutoff |> DateTime.shift_zone!(query.timezone) |> Calendar.strftime("%Y-%m-%d")
 
         %{
           code: :legacy_time_on_page_used,
-          message: "Contains less accurate legacy time-on-page data up to #{cutoff_time}"
+          message:
+            "This period includes data calculated with the legacy time on page method up to #{cutoff_date}"
         }
 
       _ ->

--- a/test/plausible_web/controllers/api/external_stats_controller/query_time_on_page_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_time_on_page_test.exs
@@ -275,7 +275,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-05 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-05"
                              }
                            }
                          })
@@ -308,7 +308,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-02 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-02"
                              }
                            }
                          })
@@ -342,7 +342,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-02 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-02"
                              }
                            }
                          })
@@ -373,7 +373,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-05 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-05"
                              }
                            }
                          })
@@ -404,7 +404,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-02 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-02"
                              }
                            }
                          })
@@ -436,7 +436,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
                              "time_on_page" => %{
                                "code" => "legacy_time_on_page_used",
                                "message" =>
-                                 "Contains less accurate legacy time-on-page data up to 2021-01-02 00:00:00"
+                                 "This period includes data calculated with the legacy time on page method up to 2021-01-02"
                              }
                            }
                          })


### PR DESCRIPTION
### Changes

Minor tweaks to the dashboard:

- Don't overflow to second row when showing time-on-page in a modal:
- Update metric warning wording
- Add space between * and warning in tooltip

![image](https://github.com/user-attachments/assets/ac72d7a0-f6a9-4dab-aabe-d6e4e6772914)
