### PR TITLE
Indicate extra filters count on triple dot menu hover

### DIFF
--- a/assets/js/dashboard/nav-menu/filters-bar.test.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.test.tsx
@@ -78,7 +78,7 @@ test('user can see expected filters and clear them one by one or all together', 
   await userEvent.click(
     screen.getByRole('button', {
       hidden: false,
-      name: 'See more'
+      name: 'See 3 more filters and actions'
     })
   )
 


### PR DESCRIPTION
### Changes

Bare minimum in response to https://feedback.plausible.io/582 while we think of something better.

**Now:** 
<img width="719" alt="Screenshot 2025-03-19 at 12 30 39" src="https://github.com/user-attachments/assets/fbb1dcd0-ab08-42d5-b66f-223071f993e3" />

**Before:** 
showed "See more" always

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
