### PR TITLE
Add `GET /api/v1/sites/teams` endpoint and make related adjustments

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -52,6 +52,30 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     end
   end
 
+  def teams_index(conn, params) do
+    user = conn.assigns.current_user
+
+    page =
+      user
+      |> Teams.Users.teams_query(order_by: :id_desc)
+      |> paginate(params, @pagination_opts)
+
+    json(conn, %{
+      teams:
+        Enum.map(page.entries, fn team ->
+          api_available? =
+            Plausible.Billing.Feature.StatsAPI in Teams.Billing.allowed_features_for(team)
+
+          %{
+            id: team.identifier,
+            name: Teams.name(team),
+            api_available: api_available?
+          }
+        end),
+      meta: pagination_meta(page.metadata)
+    })
+  end
+
   def goals_index(conn, params) do
     user = conn.assigns.current_user
 

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -64,7 +64,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
       teams:
         Enum.map(page.entries, fn team ->
           api_available? =
-            Plausible.Billing.Feature.StatsAPI in Teams.Billing.allowed_features_for(team)
+            Plausible.Billing.Feature.StatsAPI.check_availability(team) == :ok
 
           %{
             id: team.identifier,

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -231,7 +231,7 @@ defmodule Plausible.Sites do
       where(
         query,
         [team_memberships: tm, guest_memberships: gm, site: s],
-        (tm.role != :guest and tm.team_id == ^team.id) or gm.site_id == s.id
+        tm.role != :guest and tm.team_id == ^team.id
       )
     else
       where(

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -266,6 +266,7 @@ defmodule PlausibleWeb.Router do
         pipe_through PlausibleWeb.Plugs.AuthorizePublicAPI
 
         get "/", ExternalSitesController, :index
+        get "/teams", ExternalSitesController, :teams_index
         get "/goals", ExternalSitesController, :goals_index
         get "/guests", ExternalSitesController, :guests_index
         get "/:site_id", ExternalSitesController, :get_site

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -12,14 +12,6 @@
       for={@team_name_changeset}
       method="post"
     >
-      <div class="w-1/2">
-        <.input_with_clipboard
-          name="team-identifier"
-          id="team-identifier"
-          label="Team Identifier"
-          value={@current_team.identifier}
-        />
-      </div>
       <.input
         readonly={@current_team_role not in [:owner, :admin]}
         type="text"

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -14,6 +14,68 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
       {:ok, api_key: api_key, conn: conn}
     end
 
+    describe "GET /api/v1/sites/teams" do
+      test "shows empty list when user is not a member of any team", %{conn: conn} do
+        conn = get(conn, "/api/v1/sites/teams")
+
+        assert json_response(conn, 200) == %{
+                 "teams" => [],
+                 "meta" => %{
+                   "before" => nil,
+                   "after" => nil,
+                   "limit" => 100
+                 }
+               }
+      end
+
+      test "shows list of teams user is a member of with api availability reflecting team state",
+           %{conn: conn, user: user} do
+        user |> subscribe_to_growth_plan()
+
+        personal_team = team_of(user)
+
+        owner1 =
+          new_user(
+            trial_expiry_date: Date.add(Date.utc_today(), -1),
+            team: [name: "Team Without Stats API"]
+          )
+          |> subscribe_to_enterprise_plan(features: [])
+
+        team_without_stats = owner1 |> team_of() |> Plausible.Teams.complete_setup()
+        add_member(team_without_stats, user: user, role: :editor)
+        owner2 = new_user(team: [name: "Team With Stats API"])
+        team_with_stats = owner2 |> team_of() |> Plausible.Teams.complete_setup()
+        add_member(team_with_stats, user: user, role: :owner)
+
+        conn = get(conn, "/api/v1/sites/teams")
+
+        assert json_response(conn, 200) == %{
+                 "teams" => [
+                   %{
+                     "id" => team_with_stats.identifier,
+                     "name" => "Team With Stats API",
+                     "api_available" => true
+                   },
+                   %{
+                     "id" => team_without_stats.identifier,
+                     "name" => "Team Without Stats API",
+                     "api_available" => false
+                   },
+                   %{
+                     "id" => personal_team.identifier,
+                     "name" => "My Personal Sites",
+                     "api_available" => false
+                   }
+                 ],
+                 "meta" => %{
+                   "before" => nil,
+                   "after" => nil,
+                   "limit" => 100
+                 }
+               }
+      end
+    end
+
     describe "POST /api/v1/sites" do
       test "can create a site", %{conn: conn} do
         conn =

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -580,8 +580,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
 
         assert_matches %{
                          "sites" => [
-                           %{"domain" => ^other_team_site.domain},
-                           %{"domain" => ^other_site.domain}
+                           %{"domain" => ^other_team_site.domain}
                          ]
                        } = json_response(conn, 200)
       end

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -707,7 +707,8 @@ defmodule PlausibleWeb.AuthControllerTest do
     } do
       another_owner = new_user()
       another_site = new_site(owner: another_owner)
-      add_member(another_site.team, user: user, role: :admin)
+      another_team = another_owner |> team_of() |> Plausible.Teams.complete_setup()
+      add_member(another_team, user: user, role: :admin)
 
       segment =
         insert(:segment,
@@ -728,7 +729,8 @@ defmodule PlausibleWeb.AuthControllerTest do
     } do
       another_owner = new_user()
       another_site = new_site(owner: another_owner)
-      add_member(another_site.team, user: user, role: :admin)
+      another_team = another_owner |> team_of() |> Plausible.Teams.complete_setup()
+      add_member(another_team, user: user, role: :admin)
 
       segment =
         insert(:segment,
@@ -749,7 +751,7 @@ defmodule PlausibleWeb.AuthControllerTest do
     } do
       another_owner = new_user()
       another_site = new_site(owner: another_owner)
-      team = team_of(another_owner)
+      team = another_owner |> team_of() |> Plausible.Teams.complete_setup()
       add_member(another_site.team, user: user, role: :owner)
 
       delete(conn, "/me")
@@ -766,7 +768,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       personal_team = team_of(user)
       another_owner = new_user()
       _another_site = new_site(owner: another_owner)
-      another_team = team_of(another_owner)
+      another_team = another_owner |> team_of() |> Plausible.Teams.complete_setup()
       add_member(another_team, user: user, role: :owner)
 
       delete(conn, "/me")

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1182,7 +1182,6 @@ defmodule PlausibleWeb.SettingsControllerTest do
       assert html =~ "Team Information"
       assert html =~ "Change the name of your team"
       assert text_of_attr(html, "input#team_name", "value") == team.name
-      assert text_of_attr(html, "input#team-identifier", "value") == team.identifier
     end
 
     test "POST /settings/team/general/name", %{conn: conn, user: user} do


### PR DESCRIPTION
### Changes

This PR adds a Sites API endpoint for listing teams the user is a member in. The team identifier from that endpoint can be used when either creating sites via `POST /api/v1/sites` to create a site under a particular team or scope the list of sites  to a particular team with `GET /api/v1/sites?team_id=...`.

The team identifier input was removed from Team Settings to avoid confusing users who don't actively use the API, which is the only place where identifier is explicitly used so far.

The endpoint is under scope which is implicitly available to all API keys. The `api_available` field on team entry determines if the team has Stats API feature enabled. If it's disabled, it's not possible to create sites under it (or, for that matter, run other API queries against its sites).

The `GET /api/v1/sites` endpoint was adjusted to scope sites to a team exclusively, if an identifier is provided.

### TODO

- [x] ~make updates to API docs after https://github.com/plausible/docs/pull/591 is in~ extended docs in https://github.com/plausible/docs/pull/591

### Tests
- [x] Automated tests have been added

