### PR TITLE
Switch Teams feature flag to scope by user instead of a team

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -25,13 +25,13 @@ defmodule Plausible.Teams do
   def setup?(nil), do: false
   def setup?(%{setup_complete: setup_complete}), do: setup_complete
 
-  @spec enabled?(nil | Teams.Team.t()) :: boolean()
+  @spec enabled?(nil | Auth.User.t()) :: boolean()
   def enabled?(nil) do
     FunWithFlags.enabled?(:teams)
   end
 
-  def enabled?(team) do
-    FunWithFlags.enabled?(:teams, for: team)
+  def enabled?(user) do
+    FunWithFlags.enabled?(:teams, for: user)
   end
 
   @spec get(pos_integer() | binary() | nil) :: Teams.Team.t() | nil

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.Live.Sites do
 
       <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-          <span :if={Teams.enabled?(@current_team)}>
+          <span :if={Teams.enabled?(@current_user)}>
             {Teams.name(@current_team)}
             <.unstyled_link
               :if={Teams.setup?(@current_team)}
@@ -69,7 +69,7 @@ defmodule PlausibleWeb.Live.Sites do
               <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
             </.unstyled_link>
           </span>
-          <span :if={not Teams.enabled?(@current_team)}>My Sites</span>
+          <span :if={not Teams.enabled?(@current_user)}>My Sites</span>
         </h2>
       </div>
 

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -11,8 +11,9 @@ defmodule PlausibleWeb.Live.TeamSetup do
   alias PlausibleWeb.Router.Helpers, as: Routes
 
   def mount(_params, _session, socket) do
+    current_user = socket.assigns.current_user
     current_team = socket.assigns.current_team
-    enabled? = Teams.enabled?(current_team)
+    enabled? = Teams.enabled?(current_user)
 
     socket =
       case {enabled?, current_team} do

--- a/lib/plausible_web/plugs/authorize_team_access.ex
+++ b/lib/plausible_web/plugs/authorize_team_access.ex
@@ -21,9 +21,10 @@ defmodule Plausible.Plugs.AuthorizeTeamAccess do
   end
 
   def call(conn, roles \\ @all_roles) do
+    current_user = conn.assigns[:current_user]
     current_team = conn.assigns[:current_team]
 
-    if current_team && Plausible.Teams.enabled?(current_team) do
+    if current_team && Plausible.Teams.enabled?(current_user) do
       current_team_role = conn.assigns[:current_team_role]
 
       if current_team_role in roles do

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -73,7 +73,7 @@
                       </p>
                     </.dropdown_item>
                     <.team_switcher
-                      :if={Plausible.Teams.enabled?(@current_team)}
+                      :if={Plausible.Teams.enabled?(@current_user)}
                       conn={@conn}
                       teams={@teams}
                       my_team={@my_team}
@@ -86,7 +86,7 @@
                     </.dropdown_item>
 
                     <div :if={
-                      @my_team && Plausible.Teams.enabled?(@current_team) &&
+                      @my_team && Plausible.Teams.enabled?(@current_user) &&
                         @my_team.id == @current_team.id
                     }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
@@ -101,7 +101,7 @@
                     </div>
 
                     <div :if={
-                      Plausible.Teams.enabled?(@current_team) and
+                      Plausible.Teams.enabled?(@current_user) and
                         Plausible.Teams.setup?(@current_team)
                     }>
                       <.dropdown_item

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -37,7 +37,7 @@
         </div>
 
         <div :if={
-          Plausible.Teams.enabled?(@current_team) and Plausible.Teams.setup?(@current_team)
+          Plausible.Teams.enabled?(@current_user) and Plausible.Teams.setup?(@current_team)
         }>
           <div class="mb-4 mt-4 hidden lg:block">
             <h3 class="uppercase text-sm text-indigo-600 font-semibold">Team Settings</h3>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -96,6 +96,7 @@ defmodule PlausibleWeb.LayoutView do
   end
 
   def account_settings_sidebar(conn) do
+    current_user = conn.assigns[:current_user]
     current_team = conn.assigns[:current_team]
     current_team_role = conn.assigns[:current_team_role]
 
@@ -116,7 +117,7 @@ defmodule PlausibleWeb.LayoutView do
         |> Enum.reject(&is_nil/1)
     }
 
-    if Teams.enabled?(current_team) and Teams.setup?(current_team) do
+    if Teams.enabled?(current_user) and Teams.setup?(current_team) do
       Map.put(
         options,
         "Team Settings",


### PR DESCRIPTION
### Changes

Teams feature flag scoped to a team is not very practical for limited roll-out. Switching on user makes more sense as we can enable that for a limited set of users to run some final tests in production.

