### PR TITLE
Add `hourly_api_request_limit` column to `teams`

### DIFF
--- a/priv/repo/migrations/20250319201227_add_teams_hourly_api_request_limit.exs
+++ b/priv/repo/migrations/20250319201227_add_teams_hourly_api_request_limit.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddTeamsHourlyApiRequestLimit do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :hourly_api_request_limit, :integer, null: false, default: 600
+    end
+  end
+end


### PR DESCRIPTION
### Changes

First step towards implementing more consistent API rate limit checking. Extracted from https://github.com/plausible/analytics/pull/5224

