### PR TITLE
Add `Team.hourly_api_request_limit` and update it on plan change

### DIFF
--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -7,10 +7,13 @@ defmodule Plausible.Auth.ApiKey do
 
   @required [:user_id, :name]
   @optional [:key, :scopes, :hourly_request_limit]
+
+  @hourly_request_limit on_ee(do: 600, else: 1_000_000)
+
   schema "api_keys" do
     field :name, :string
     field :scopes, {:array, :string}, default: ["stats:read:*"]
-    field :hourly_request_limit, :integer, default: on_ee(do: 600, else: 1_000_000)
+    field :hourly_request_limit, :integer, default: @hourly_request_limit
 
     field :key, :string, virtual: true
     field :key_hash, :string
@@ -20,6 +23,8 @@ defmodule Plausible.Auth.ApiKey do
 
     timestamps()
   end
+
+  def hourly_request_limit(), do: @hourly_request_limit
 
   def changeset(schema, attrs \\ %{}) do
     schema

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -248,6 +248,11 @@ defmodule Plausible.Billing do
       owner_ids = Enum.map(team.owners, & &1.id)
       api_keys = from(key in Plausible.Auth.ApiKey, where: key.user_id in ^owner_ids)
       Repo.update_all(api_keys, set: [hourly_request_limit: plan.hourly_api_request_limit])
+
+      Repo.update_all(
+        from(t in Teams.Team, where: t.id == ^team.id),
+        set: [hourly_api_request_limit: plan.hourly_api_request_limit]
+      )
     end
 
     team

--- a/lib/plausible/data_migration/backfill_teams_hourly_api_request_limit.ex
+++ b/lib/plausible/data_migration/backfill_teams_hourly_api_request_limit.ex
@@ -1,0 +1,54 @@
+defmodule Plausible.DataMigration.BackfillTeamsHourlyRequestLimit do
+  @moduledoc """
+  !!!WARNING!!!: This script is used in migrations. Please take special care
+  when altering it.
+
+  Backfill `Team.hourly_api_request_limit`.
+  """
+
+  import Ecto.Query
+
+  alias Plausible.Billing
+  alias Plausible.Repo
+  alias Plausible.Teams
+
+  def run(opts \\ []) do
+    dry_run? = Keyword.get(opts, :dry_run?, true)
+
+    log("DRY RUN: #{dry_run?}")
+
+    active_enterprise_plans_query =
+      from t in Teams.Team,
+        as: :team,
+        inner_lateral_join: s in subquery(Teams.last_subscription_join_query()),
+        on: true,
+        inner_join: ep in Billing.EnterprisePlan,
+        on: ep.team_id == t.id and ep.paddle_plan_id == s.paddle_plan_id,
+        select: ep
+
+    active_enterprise_plans_query
+    |> Repo.all()
+    |> tap(fn enterprise_plans ->
+      log("About to update #{length(enterprise_plans)} teams with active enterprise plans...")
+    end)
+    |> Enum.each(fn enterprise_plan ->
+      log(
+        "Updating team ##{enterprise_plan.team_id} to hourly API request limit " <>
+          "of #{enterprise_plan.hourly_api_request_limit} rps"
+      )
+
+      if not dry_run? do
+        Repo.update_all(
+          from(t in Teams.Team, where: t.id == ^enterprise_plan.team_id),
+          set: [hourly_api_request_limit: enterprise_plan.hourly_api_request_limit]
+        )
+      end
+    end)
+
+    log("Done!")
+  end
+
+  def log(msg) do
+    IO.puts("[#{inspect(__MODULE__)}] #{msg}")
+  end
+end

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -12,6 +12,8 @@ defmodule Plausible.Teams.Team do
   use Ecto.Schema
   use Plausible
 
+  alias Plausible.Auth
+
   import Ecto.Changeset
 
   @type t() :: %__MODULE__{}
@@ -28,6 +30,9 @@ defmodule Plausible.Teams.Team do
 
     field :setup_complete, :boolean, default: false
     field :setup_at, :naive_datetime
+
+    # Field kept in sync with current subscription plan, if any
+    field :hourly_api_request_limit, :integer, default: Auth.ApiKey.hourly_request_limit()
 
     # Field for purely informational purposes in CRM context
     field :notes, :string

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -273,10 +273,13 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
+      assert team.hourly_api_request_limit == 600
+
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
       |> Billing.subscription_created()
 
       assert Repo.reload!(api_key).hourly_request_limit == 10_000
+      assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
   end
 
@@ -401,6 +404,8 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
+      assert team.hourly_api_request_limit == 600
+
       @subscription_updated_params
       |> Map.merge(%{
         "subscription_id" => subscription_of(user).paddle_subscription_id,
@@ -410,6 +415,7 @@ defmodule Plausible.BillingTest do
       |> Billing.subscription_updated()
 
       assert Repo.reload!(api_key).hourly_request_limit == 10_000
+      assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
 
     test "if teams's grace period has ended, upgrading will unlock sites and remove grace period" do

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -273,7 +273,7 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
-      assert team.hourly_api_request_limit == 600
+      assert team.hourly_api_request_limit < 10_000
 
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
       |> Billing.subscription_created()
@@ -404,7 +404,7 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
-      assert team.hourly_api_request_limit == 600
+      assert team.hourly_api_request_limit < 10_000
 
       @subscription_updated_params
       |> Map.merge(%{

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -273,7 +273,7 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
-      assert team.hourly_api_request_limit < 10_000
+      assert team.hourly_api_request_limit != 10_000
 
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
       |> Billing.subscription_created()
@@ -404,7 +404,7 @@ defmodule Plausible.BillingTest do
 
       api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
-      assert team.hourly_api_request_limit < 10_000
+      assert team.hourly_api_request_limit != 10_000
 
       @subscription_updated_params
       |> Map.merge(%{

--- a/test/plausible/data_migration/backfill_teams_hourly_request_limit_test.exs
+++ b/test/plausible/data_migration/backfill_teams_hourly_request_limit_test.exs
@@ -1,0 +1,67 @@
+defmodule Plausible.DataMigration.BackfillTeamsHourlyRequestLimitTest do
+  use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
+
+  import ExUnit.CaptureIO
+
+  alias Plausible.DataMigration.BackfillTeamsHourlyRequestLimit
+
+  alias Plausible.Repo
+
+  describe "run/1" do
+    test "runs for empty dataset" do
+      dry_run_output =
+        capture_io(fn ->
+          assert :ok = BackfillTeamsHourlyRequestLimit.run()
+        end)
+
+      assert dry_run_output =~ "DRY RUN: true"
+      assert dry_run_output =~ "About to update 0 teams with active enterprise plans"
+      assert dry_run_output =~ "Done!"
+
+      real_run_output =
+        capture_io(fn ->
+          assert :ok = BackfillTeamsHourlyRequestLimit.run(dry_run?: false)
+        end)
+
+      assert real_run_output =~ "DRY RUN: false"
+      assert real_run_output =~ "About to update 0 teams with active enterprise plans"
+      assert real_run_output =~ "Done!"
+    end
+
+    test "updates teams with active subscriptions and matching enterprise plans" do
+      user1 =
+        new_user() |> subscribe_to_enterprise_plan(hourly_api_request_limit: 5000)
+
+      team1 = team_of(user1)
+
+      user2 =
+        new_user()
+        |> subscribe_to_enterprise_plan(hourly_api_request_limit: 5000, subscription?: false)
+
+      team2 = team_of(user2)
+
+      user3 = new_user() |> subscribe_to_growth_plan()
+
+      team3 = team_of(user3)
+
+      user4 = new_user(trial_expiry_date: Date.add(Date.utc_today(), 30))
+
+      team4 = team_of(user4)
+
+      real_run_output =
+        capture_io(fn ->
+          assert :ok = BackfillTeamsHourlyRequestLimit.run(dry_run?: false)
+        end)
+
+      assert real_run_output =~ "DRY RUN: false"
+      assert real_run_output =~ "About to update 1 teams with active enterprise plans"
+      assert real_run_output =~ "Done!"
+
+      assert Repo.reload(team1).hourly_api_request_limit == 5000
+      assert Repo.reload(team2).hourly_api_request_limit == 600
+      assert Repo.reload(team3).hourly_api_request_limit == 600
+      assert Repo.reload(team4).hourly_api_request_limit == 600
+    end
+  end
+end

--- a/test/plausible/data_migration/backfill_teams_hourly_request_limit_test.exs
+++ b/test/plausible/data_migration/backfill_teams_hourly_request_limit_test.exs
@@ -4,8 +4,8 @@ defmodule Plausible.DataMigration.BackfillTeamsHourlyRequestLimitTest do
 
   import ExUnit.CaptureIO
 
+  alias Plausible.Auth
   alias Plausible.DataMigration.BackfillTeamsHourlyRequestLimit
-
   alias Plausible.Repo
 
   describe "run/1" do
@@ -59,9 +59,10 @@ defmodule Plausible.DataMigration.BackfillTeamsHourlyRequestLimitTest do
       assert real_run_output =~ "Done!"
 
       assert Repo.reload(team1).hourly_api_request_limit == 5000
-      assert Repo.reload(team2).hourly_api_request_limit == 600
-      assert Repo.reload(team3).hourly_api_request_limit == 600
-      assert Repo.reload(team4).hourly_api_request_limit == 600
+
+      assert Repo.reload(team2).hourly_api_request_limit == Auth.ApiKey.hourly_request_limit()
+      assert Repo.reload(team3).hourly_api_request_limit == Auth.ApiKey.hourly_request_limit()
+      assert Repo.reload(team4).hourly_api_request_limit == Auth.ApiKey.hourly_request_limit()
     end
   end
 end

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -45,6 +45,22 @@ defmodule Plausible.TeamsTest do
              ] = Repo.preload(team, :team_memberships).team_memberships
     end
 
+    @tag :ee_only
+    test "sets hourly API request limit to 600 in EE" do
+      user = new_user()
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.hourly_api_request_limit == 600
+    end
+
+    @tag :ce_build_only
+    test "sets hourly API request limit to 1000000 in CE" do
+      user = new_user()
+      assert {:ok, team} = Teams.get_or_create(user)
+
+      assert team.hourly_api_request_limit == 1_000_000
+    end
+
     test "returns existing team if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id


### PR DESCRIPTION
### Changes

This PR is a follow-up to #5225. It adds `Team.hourly_api_request_limit` schema field and starts updating it along with `ApiKey` on plan change via Paddle webhook.

Extracted from https://github.com/plausible/analytics/pull/5224/commits/ea3438fc11066268ebb4b4a0764300798a1d7a0f

### Tests
- [x] Automated tests have been added
