### PR TITLE
Fix visitors.csv vs main graph discrepancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix `visitors.csv` (in dashboard CSV export) vs dashboard main graph reporting different results for `visitors` and `visits` with a `time:minute` interval.
 - The tracker script now sends pageviews when a page gets loaded from bfcache
 - Fix returning filter suggestions for multiple custom property values in the dashboard Filter modal
 - Fix typo on login screen

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -62,7 +62,7 @@ export type SimpleFilterDimensions =
   | "visit:exit_page_hostname";
 export type CustomPropertyFilterDimensions = string;
 export type GoalDimension = "event:goal";
-export type TimeDimensions = "time" | "time:month" | "time:week" | "time:day" | "time:hour";
+export type TimeDimensions = ("time" | "time:month" | "time:week" | "time:day" | "time:hour") | "time:minute";
 export type FilterTree = FilterEntry | FilterAndOr | FilterNot | FilterHasDone;
 export type FilterEntry = FilterWithoutGoals | FilterWithGoals | FilterWithPattern | FilterForSegment;
 /**

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -349,6 +349,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_time("time"), do: {:ok, "time"}
+  defp parse_time("time:minute"), do: {:ok, "time:minute"}
   defp parse_time("time:hour"), do: {:ok, "time:hour"}
   defp parse_time("time:day"), do: {:ok, "time:day"}
   defp parse_time("time:week"), do: {:ok, "time:week"}

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -182,12 +182,14 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     do: sessions_q |> build_order_by(events_query)
 
   defp join_query_results({events_q, events_query}, {sessions_q, sessions_query}) do
-    join(subquery(events_q), :left, [e], s in subquery(sessions_q),
+    {join_type, events_q_fields, sessions_q_fields} =
+      TableDecider.join_options(events_query, sessions_query)
+
+    join(subquery(events_q), join_type, [e], s in subquery(sessions_q),
       on: ^build_group_by_join(events_query)
     )
-    |> select_join_fields(events_query, events_query.dimensions, e)
-    |> select_join_fields(events_query, events_query.metrics, e)
-    |> select_join_fields(sessions_query, List.delete(sessions_query.metrics, :sample_percent), s)
+    |> select_join_fields(events_query, events_q_fields, e)
+    |> select_join_fields(sessions_query, sessions_q_fields, s)
     |> build_order_by(events_query)
   end
 

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -54,6 +54,39 @@ defmodule Plausible.Stats.TableDecider do
     end
   end
 
+  @doc """
+  Returns a three-element tuple with instructions on how to join two Ecto
+  queries. The arguments (`events_query` and `sessions_query`) are `%Query{}`
+  structs that have been split by TableDecider already.
+
+  Normally we can always LEFT JOIN sessions to events, selecting `dimensions`
+  only from the events subquery. That's because:
+
+  1) session dimensions (e.g. entry_page) cannot be queried alongside event
+     metrics/dimensions, or
+
+  2) session dimensions (e.g. operating_system) are also available in the
+     events table.
+
+  The only exception is using the "time:minute" dimension where the sessions
+  subquery might return more rows than the events one. That's because we're
+  counting sessions in all time buckets they were active in.
+  """
+  def join_options(events_query, sessions_query) do
+    events_q_select_fields = events_query.metrics ++ events_query.dimensions
+    sessions_q_select_fields = sessions_query.metrics -- [:sample_percent]
+
+    if "time:minute" in events_query.dimensions do
+      {
+        :full,
+        events_q_select_fields -- ["time:minute"],
+        sessions_q_select_fields ++ ["time:minute"]
+      }
+    else
+      {:left, events_q_select_fields, sessions_q_select_fields}
+    end
+  end
+
   def partition_metrics(metrics, query) do
     %{
       event: event_only_metrics,
@@ -99,10 +132,12 @@ defmodule Plausible.Stats.TableDecider do
   defp metric_partitioner(%Query{legacy_breakdown: true}, :pageviews), do: :either
   defp metric_partitioner(%Query{legacy_breakdown: true}, :events), do: :either
 
+  defp metric_partitioner(query, metric) when metric in [:visitors, :visits] do
+    if "time:minute" in query.dimensions, do: :session, else: :either
+  end
+
   defp metric_partitioner(_, :conversion_rate), do: :either
   defp metric_partitioner(_, :group_conversion_rate), do: :either
-  defp metric_partitioner(_, :visitors), do: :either
-  defp metric_partitioner(_, :visits), do: :either
   defp metric_partitioner(_, :percentage), do: :either
 
   defp metric_partitioner(_, :average_revenue), do: :event

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -324,8 +324,16 @@
       "markdownDescription": "Goal dimension"
     },
     "time_dimensions": {
-      "type": "string",
-      "enum": ["time", "time:month", "time:week", "time:day", "time:hour"]
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["time", "time:month", "time:week", "time:day", "time:hour"]
+        },
+        {
+          "const": "time:minute",
+          "$comment": "only :internal"
+        }
+      ]
     },
     "dimensions": {
       "oneOf": [

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1490,6 +1490,39 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       end
     end
 
+    test "time:minute dimension fails public schema validation", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["time:minute"]
+      }
+      |> check_error(site, "#/dimensions/0: Invalid dimension \"time:minute\"")
+    end
+
+    test "time:minute dimension passes internal schema validation", %{site: site} do
+      %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors"],
+        "date_range" => "all",
+        "dimensions" => ["time:minute"]
+      }
+      |> check_success(
+        site,
+        %{
+          metrics: [:visitors],
+          utc_time_range: @date_range_day,
+          filters: [],
+          dimensions: ["time:minute"],
+          order_by: nil,
+          timezone: site.timezone,
+          include: @default_include,
+          pagination: %{limit: 10_000, offset: 0}
+        },
+        :internal
+      )
+    end
+
     test "custom properties dimension", %{site: site} do
       %{
         "site_id" => site.domain,

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1805,7 +1805,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert %{"error_code" => "unsupported_filters"} = json_response(conn, 422)
     end
 
-    @tag :capure_log
+    @tag :capture_log
     test "returns 502 when Google API responds with an unexpected error", %{
       conn: conn,
       site: site


### PR DESCRIPTION
### Changes

This PR fixes a bug: `visitors.csv` in the CSV export are reporting different `visitors` and `visits` numbers than the main graph (while they should be equivalent reports).

There are two reasons for why those numbers are different:

1. A query optimization (`TableDecider` reducing joins) selecting a different table from which to query

* For the main graph, both `visitors` and `visits` are queried from the sessions table
* For the csv export, both `visitors` and `visits` are queried from the events table

The difference comes from the fact that the CSV export is querying all metrics at once, while main graph is asking for a single graph metric at a time.

2. We count sessions in all time buckets they were active in

Let’s say user A sent us a pageview at 12:00 and another pageview at 12:10. If we now focus on a specific minute like 12:05, there were 0 pageviews but 1 session active. Similarly, if we take visitors from the events table, it's 0, but from the sessions table it's 1.

This PR fixes that by always counting `visitors` and `visits` from the sessions table IF there's a `time:minute` dimension at play.

Among that, this PR also adds `time:minute` dimension into the internal API schema to be able to test it with the new API structure.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
