### PR TITLE
Limit rate of requests for Stats/Sites API via Team directly

### DIFF
--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -6,14 +6,13 @@ defmodule Plausible.Auth.ApiKey do
   @type t() :: %__MODULE__{}
 
   @required [:user_id, :name]
-  @optional [:key, :scopes, :hourly_request_limit]
+  @optional [:key, :scopes]
 
   @hourly_request_limit on_ee(do: 600, else: 1_000_000)
 
   schema "api_keys" do
     field :name, :string
     field :scopes, {:array, :string}, default: ["stats:read:*"]
-    field :hourly_request_limit, :integer, default: @hourly_request_limit
 
     field :key, :string, virtual: true
     field :key_hash, :string
@@ -37,7 +36,7 @@ defmodule Plausible.Auth.ApiKey do
 
   def update(schema, attrs \\ %{}) do
     schema
-    |> cast(attrs, [:name, :user_id, :scopes, :hourly_request_limit])
+    |> cast(attrs, [:name, :user_id, :scopes])
     |> validate_required([:user_id, :name])
   end
 

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -29,7 +29,6 @@ defmodule Plausible.Auth.ApiKeyAdmin do
       name: nil,
       key: %{create: :readonly, update: :hidden, help_text: @plaintext_key_help},
       key_prefix: %{create: :hidden, update: :readonly},
-      hourly_request_limit: %{default: 1000},
       scope: %{choices: [{"Stats API", ["stats:read:*"]}, {"Sites API", ["sites:provision:*"]}]},
       user_id: nil
     ]

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -245,10 +245,6 @@ defmodule Plausible.Billing do
       )
 
     if plan do
-      owner_ids = Enum.map(team.owners, & &1.id)
-      api_keys = from(key in Plausible.Auth.ApiKey, where: key.user_id in ^owner_ids)
-      Repo.update_all(api_keys, set: [hourly_request_limit: plan.hourly_api_request_limit])
-
       Repo.update_all(
         from(t in Teams.Team, where: t.id == ^team.id),
         set: [hourly_api_request_limit: plan.hourly_api_request_limit]

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -47,10 +47,11 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   def call(conn, _opts) do
     requested_scope = Map.fetch!(conn.assigns, :api_scope)
+    context = conn.assigns[:api_context]
 
     with {:ok, token} <- get_bearer_token(conn),
-         {:ok, api_key} <- Auth.find_api_key(token),
-         :ok <- check_api_key_rate_limit(api_key),
+         {:ok, api_key, limit_key, hourly_limit} <- find_api_key(conn, token, context),
+         :ok <- check_api_key_rate_limit(limit_key, hourly_limit),
          {:ok, conn} <- verify_by_scope(conn, api_key, requested_scope) do
       assign(conn, :current_user, api_key.user)
     else
@@ -59,6 +60,33 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   end
 
   ### Verification dispatched by scope
+
+  defp find_api_key(conn, token, :site) do
+    case Auth.find_api_key(token, team_by: {:site, conn.params["site_id"]}) do
+      {:ok, %{api_key: api_key, team: nil}} ->
+        {:ok, api_key, limit_key(api_key, nil), Auth.ApiKey.hourly_request_limit()}
+
+      {:ok, %{api_key: api_key, team: team}} ->
+        {:ok, api_key, limit_key(api_key, team.identifier), team.hourly_api_request_limit}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp find_api_key(_conn, token, _) do
+    with {:ok, api_key} <- Auth.find_api_key(token) do
+      {:ok, api_key, limit_key(api_key, nil), Auth.ApiKey.hourly_request_limit()}
+    end
+  end
+
+  defp limit_key(api_key, nil) do
+    "api_request:#{api_key.id}"
+  end
+
+  defp limit_key(api_key, team_id) do
+    "api_request:#{api_key.id}:#{team_id}"
+  end
 
   defp verify_by_scope(conn, api_key, "stats:read:" <> _ = scope) do
     with :ok <- check_scope(api_key, scope),
@@ -107,14 +135,10 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
     end
   end
 
-  defp check_api_key_rate_limit(api_key) do
-    case RateLimit.check_rate(
-           "api_request:#{api_key.id}",
-           to_timeout(hour: 1),
-           api_key.hourly_request_limit
-         ) do
+  defp check_api_key_rate_limit(limit_key, hourly_limit) do
+    case RateLimit.check_rate(limit_key, to_timeout(hour: 1), hourly_limit) do
       {:allow, _} -> :ok
-      {:deny, _} -> {:error, :rate_limit, api_key.hourly_request_limit}
+      {:deny, _} -> {:error, :rate_limit, hourly_limit}
     end
   end
 

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -34,6 +34,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   alias Plausible.Sites
   alias PlausibleWeb.Api.Helpers, as: H
 
+  require Logger
+
   # Scopes permitted implicitly for every API key. Existing API keys
   # have _either_ `["stats:read:*"]` (the default) or `["sites:provision:*"]`
   # set as their valid scopes. We always consider implicit scopes as
@@ -67,6 +69,21 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
         {:ok, api_key, limit_key(api_key, nil), Auth.ApiKey.hourly_request_limit()}
 
       {:ok, %{api_key: api_key, team: team}} ->
+        case Plausible.Teams.Memberships.team_role(team, api_key.user) do
+          {:ok, :guest} ->
+            Logger.warning(
+              "[#{inspect(__MODULE__)}] API key #{api_key.id} user accessing #{conn.params["site_id"]} as a guest"
+            )
+
+          {:error, :not_a_member} ->
+            Logger.warning(
+              "[#{inspect(__MODULE__)}] API key #{api_key.id} user trying to access #{conn.params["site_id"]} as a non-member"
+            )
+
+          _ ->
+            :pass
+        end
+
         {:ok, api_key, limit_key(api_key, team.identifier), team.hourly_api_request_limit}
 
       {:error, _} = error ->

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -227,7 +227,8 @@ defmodule PlausibleWeb.Router do
     end
   end
 
-  scope "/api/v1/stats", PlausibleWeb.Api, assigns: %{api_scope: "stats:read:*"} do
+  scope "/api/v1/stats", PlausibleWeb.Api,
+    assigns: %{api_scope: "stats:read:*", api_context: :site} do
     pipe_through [:public_api, PlausibleWeb.Plugs.AuthorizePublicAPI]
 
     get "/realtime/visitors", ExternalStatsController, :realtime_visitors
@@ -236,7 +237,8 @@ defmodule PlausibleWeb.Router do
     get "/timeseries", ExternalStatsController, :timeseries
   end
 
-  scope "/api/v2", PlausibleWeb.Api, assigns: %{api_scope: "stats:read:*", schema_type: :public} do
+  scope "/api/v2", PlausibleWeb.Api,
+    assigns: %{api_scope: "stats:read:*", api_context: :site, schema_type: :public} do
     pipe_through [:public_api, PlausibleWeb.Plugs.AuthorizePublicAPI]
 
     post "/query", ExternalQueryApiController, :query
@@ -267,25 +269,31 @@ defmodule PlausibleWeb.Router do
 
         get "/", ExternalSitesController, :index
         get "/teams", ExternalSitesController, :teams_index
-        get "/goals", ExternalSitesController, :goals_index
-        get "/guests", ExternalSitesController, :guests_index
-        get "/:site_id", ExternalSitesController, :get_site
+
+        scope assigns: %{api_context: :site} do
+          get "/goals", ExternalSitesController, :goals_index
+          get "/guests", ExternalSitesController, :guests_index
+          get "/:site_id", ExternalSitesController, :get_site
+        end
       end
 
       scope assigns: %{api_scope: "sites:provision:*"} do
         pipe_through PlausibleWeb.Plugs.AuthorizePublicAPI
 
         post "/", ExternalSitesController, :create_site
-        put "/shared-links", ExternalSitesController, :find_or_create_shared_link
 
-        put "/goals", ExternalSitesController, :find_or_create_goal
-        delete "/goals/:goal_id", ExternalSitesController, :delete_goal
+        scope assigns: %{api_context: :site} do
+          put "/shared-links", ExternalSitesController, :find_or_create_shared_link
 
-        put "/guests", ExternalSitesController, :find_or_create_guest
-        delete "/guests/:email", ExternalSitesController, :delete_guest
+          put "/goals", ExternalSitesController, :find_or_create_goal
+          delete "/goals/:goal_id", ExternalSitesController, :delete_goal
 
-        put "/:site_id", ExternalSitesController, :update_site
-        delete "/:site_id", ExternalSitesController, :delete_site
+          put "/guests", ExternalSitesController, :find_or_create_guest
+          delete "/guests/:email", ExternalSitesController, :delete_guest
+
+          put "/:site_id", ExternalSitesController, :update_site
+          delete "/:site_id", ExternalSitesController, :delete_site
+        end
       end
     end
   end

--- a/test/plausible/auth/auth_test.exs
+++ b/test/plausible/auth/auth_test.exs
@@ -25,26 +25,6 @@ defmodule Plausible.AuthTest do
       assert {:ok, %Auth.ApiKey{}} = Auth.create_api_key(user, "my new key", key)
     end
 
-    @tag :ee_only
-    test "defaults to 600 requests per hour limit in EE" do
-      user = new_user(trial_expiry_date: Date.utc_today())
-
-      {:ok, %Auth.ApiKey{hourly_request_limit: hourly_request_limit}} =
-        Auth.create_api_key(user, "my new EE key", Ecto.UUID.generate())
-
-      assert hourly_request_limit == 600
-    end
-
-    @tag :ce_build_only
-    test "defaults to 1000000 requests per hour limit in CE" do
-      user = new_user(trial_expiry_date: Date.utc_today())
-
-      {:ok, %Auth.ApiKey{hourly_request_limit: hourly_request_limit}} =
-        Auth.create_api_key(user, "my new CE key", Ecto.UUID.generate())
-
-      assert hourly_request_limit == 1_000_000
-    end
-
     test "errors when key already exists" do
       u1 = new_user(trial_expiry_date: Date.utc_today())
       u2 = new_user(trial_expiry_date: Date.utc_today())

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -271,14 +271,13 @@ defmodule Plausible.BillingTest do
 
       team = team_of(user)
 
-      api_key = insert(:api_key, user: user, hourly_request_limit: 1)
+      _api_key = insert(:api_key, user: user)
 
       assert team.hourly_api_request_limit != 10_000
 
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
       |> Billing.subscription_created()
 
-      assert Repo.reload!(api_key).hourly_request_limit == 10_000
       assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
   end
@@ -402,7 +401,7 @@ defmodule Plausible.BillingTest do
 
       team = team_of(user)
 
-      api_key = insert(:api_key, user: user, hourly_request_limit: 1)
+      _api_key = insert(:api_key, user: user)
 
       assert team.hourly_api_request_limit != 10_000
 
@@ -414,7 +413,6 @@ defmodule Plausible.BillingTest do
       })
       |> Billing.subscription_updated()
 
-      assert Repo.reload!(api_key).hourly_request_limit == 10_000
       assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
 

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -235,6 +235,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert json_response(conn, 404) == %{"error" => "Site could not be found"}
       end
 
+      @tag :capture_log
       test "cannot delete a site that the user does not own", %{conn: conn, user: user} do
         site = new_site()
         add_guest(site, user: user, role: :editor)
@@ -332,6 +333,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert res["error"] == "Site could not be found"
       end
 
+      @tag :capture_log
       test "returns 404 when api key owner does not have permissions to create a shared link", %{
         conn: conn,
         user: user
@@ -480,6 +482,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert res["error"] == "Site could not be found"
       end
 
+      @tag :capture_log
       test "returns 404 when api key owner does not have permissions to create a goal", %{
         conn: conn,
         user: user
@@ -586,6 +589,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert json_response(conn, 404) == %{"error" => "Goal could not be found"}
       end
 
+      @tag :capture_log
       test "cannot delete a goal belongs to a site that the user does not own", %{
         conn: conn,
         user: user
@@ -1097,6 +1101,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                }
       end
 
+      @tag :capture_log
       test "returns goals for site where user is viewer", %{site: site} do
         viewer = new_user()
         add_guest(site, user: viewer, role: :viewer)

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -100,23 +100,30 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   end
 
   test "limits the rate of API requests", %{user: user} do
-    api_key = insert(:api_key, user_id: user.id, hourly_request_limit: 3)
+    site = new_site(owner: user)
+
+    user
+    |> team_of()
+    |> Ecto.Changeset.change(hourly_api_request_limit: 3)
+    |> Plausible.Repo.update!()
+
+    api_key = insert(:api_key, user_id: user.id)
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate")
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate")
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate")
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate")
+    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
     |> assert_error(
       429,
       "Too many API requests. Your API key is limited to 3 requests per hour."

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1805,7 +1805,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert %{"error_code" => "unsupported_filters"} = json_response(conn, 422)
     end
 
-    @tag :capure_log
+    @tag :capture_log
     test "returns 502 when Google API responds with an unexpected error", %{
       conn: conn,
       site: site

--- a/test/plausible_web/plugs/authorize_public_api_test.exs
+++ b/test/plausible_web/plugs/authorize_public_api_test.exs
@@ -171,14 +171,17 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   end
 
   test "halts with error when API rate limit hit", %{conn: conn} do
-    user = insert(:user)
-    api_key = insert(:api_key, user: user, hourly_request_limit: 1)
+    user = new_user(team: [hourly_api_request_limit: 1])
+    site = new_site(owner: user)
+
+    api_key = insert(:api_key, user: user)
 
     conn =
       conn
       |> put_req_header("authorization", "Bearer #{api_key.key}")
-      |> get("/")
+      |> get("/?site_id=#{site.domain}")
       |> assign(:api_scope, "sites:read:*")
+      |> assign(:api_context, :site)
 
     first_resp = AuthorizePublicAPI.call(conn, nil)
     second_resp = AuthorizePublicAPI.call(conn, nil)

--- a/test/plausible_web/plugs/authorize_public_api_test.exs
+++ b/test/plausible_web/plugs/authorize_public_api_test.exs
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   use PlausibleWeb.ConnCase, async: false
   use Plausible.Teams.Test
 
+  import ExUnit.CaptureLog
+
   alias PlausibleWeb.Plugs.AuthorizePublicAPI
 
   setup %{conn: conn} do
@@ -189,6 +191,64 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
     refute first_resp.halted
     assert second_resp.halted
     assert json_response(second_resp, 429)["error"] =~ "Too many API requests."
+  end
+
+  test "does not rate limit when not in applicable context", %{conn: conn} do
+    user = new_user(team: [hourly_api_request_limit: 1])
+    site = new_site(owner: user)
+
+    api_key = insert(:api_key, user: user)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{api_key.key}")
+      |> get("/?site_id=#{site.domain}")
+      |> assign(:api_scope, "sites:read:*")
+
+    first_resp = AuthorizePublicAPI.call(conn, nil)
+    second_resp = AuthorizePublicAPI.call(conn, nil)
+
+    refute first_resp.halted
+    refute second_resp.halted
+  end
+
+  test "logs a warning on using API key against site with guest access", %{conn: conn} do
+    user = new_user(team: [hourly_api_request_limit: 1])
+    site = new_site()
+    add_guest(site, user: user, role: :editor)
+
+    api_key = insert(:api_key, user: user)
+
+    capture_log(fn ->
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/?site_id=#{site.domain}")
+        |> assign(:api_scope, "sites:read:*")
+        |> assign(:api_context, :site)
+        |> AuthorizePublicAPI.call(nil)
+
+      refute conn.halted
+    end) =~ "API key #{api_key.id} user accessing #{site.domain} as a guest"
+  end
+
+  test "logs a warning on using API key against site with no access", %{conn: conn} do
+    user = new_user(team: [hourly_api_request_limit: 1])
+    site = new_site()
+
+    api_key = insert(:api_key, user: user)
+
+    capture_log(fn ->
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{api_key.key}")
+        |> get("/?site_id=#{site.domain}")
+        |> assign(:api_scope, "stats:read:*")
+        |> assign(:api_context, :site)
+        |> AuthorizePublicAPI.call(nil)
+
+      assert conn.halted
+    end) =~ "API key #{api_key.id} user trying to access #{site.domain} as a non-member"
   end
 
   test "passes and sets current user when valid API key with required scope provided", %{


### PR DESCRIPTION
### Changes

This PR switches Sites and Stats API rate limiting to use `Team.hourly_api_request_limit` for checking, with fallback to hardcoded default. The limit is no longer stored and read from `ApiKey.hourly_request_limit`. This change makes rate limit enforcement more consistent and prepares groundwork for team-bound API keys support.

### Tests
- [x] Automated tests have been added

