### PR TITLE
Add final usage check before locking sites

### DIFF
--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -15,10 +15,11 @@ defmodule Plausible.Billing.SiteLocker do
           {:locked, lock_reason()} | :unlocked
   def update_sites_for(team, opts \\ []) do
     send_email? = Keyword.get(opts, :send_email?, true)
+    usage_mod = Keyword.get(opts, :usage_mod, Teams.Billing)
 
     team = Teams.with_subscription(team)
 
-    case Plausible.Teams.Billing.check_needs_to_upgrade(team) do
+    case Plausible.Teams.Billing.check_needs_to_upgrade(team, usage_mod) do
       {:needs_to_upgrade, :grace_period_ended} ->
         set_lock_status_for(team, true)
 

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -147,14 +147,14 @@ defmodule Plausible.Teams.Billing do
         {:needs_to_upgrade, :no_active_trial_or_subscription}
 
       Teams.GracePeriod.expired?(team) ->
-        check_usage_last_chance(team, usage_mod)
+        revise_pageview_usage(team, usage_mod)
 
       true ->
         :no_upgrade_needed
     end
   end
 
-  defp check_usage_last_chance(team, usage_mod) do
+  defp revise_pageview_usage(team, usage_mod) do
     case Plausible.Workers.CheckUsage.check_pageview_usage_two_cycles(team, usage_mod) do
       {:over_limit, _} ->
         {:needs_to_upgrade, :grace_period_ended}

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -55,7 +55,9 @@ defmodule PlausibleWeb.Live.Sites do
       class="container pt-6"
     >
       <PlausibleWeb.Live.Components.Visitors.gradient_defs />
-      <.upgrade_nag_screen :if={@needs_to_upgrade == {:needs_to_upgrade, :no_active_subscription}} />
+      <.upgrade_nag_screen :if={
+        @needs_to_upgrade == {:needs_to_upgrade, :no_active_trial_or_subscription}
+      } />
 
       <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
         <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -146,7 +146,7 @@ defmodule Plausible.Workers.CheckUsage do
     end
   end
 
-  defp check_pageview_usage_two_cycles(subscriber, usage_mod) do
+  def check_pageview_usage_two_cycles(subscriber, usage_mod) do
     usage = usage_mod.monthly_pageview_usage(subscriber)
     limit = Teams.Billing.monthly_pageview_limit(subscriber.subscription)
 

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -613,4 +613,30 @@ defmodule Plausible.BillingTest do
     refute Plausible.Teams.Billing.has_active_subscription?(paused_team)
     refute Plausible.Teams.Billing.has_active_subscription?(nil)
   end
+
+  def monthly_pageview_usage_stub(penultimate_usage, last_usage) do
+    last_bill_date = Date.utc_today() |> Date.shift(day: -1)
+
+    Plausible.Teams.Billing
+    |> Double.stub(:monthly_pageview_usage, fn _user ->
+      %{
+        last_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -1),
+              Date.shift(last_bill_date, day: -1)
+            ),
+          total: last_usage
+        },
+        penultimate_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -2),
+              Date.shift(last_bill_date, day: -1, month: -1)
+            ),
+          total: penultimate_usage
+        }
+      }
+    end)
+  end
 end

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -7,6 +7,8 @@ defmodule Plausible.BillingTest do
   alias Plausible.Billing.Subscription
 
   describe "check_needs_to_upgrade" do
+    @describetag :ee_only
+
     test "is false for a trial user" do
       team = new_user(trial_expiry_date: Date.utc_today()) |> team_of()
       assert Plausible.Teams.Billing.check_needs_to_upgrade(team) == :no_upgrade_needed

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -104,7 +104,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+      over_limits_usage_stub = Plausible.BillingTest.monthly_pageview_usage_stub(15_000, 15_000)
 
       assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}
@@ -136,7 +136,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       billing_member = new_user()
       add_member(team, user: billing_member, role: :billing)
 
-      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+      over_limits_usage_stub = Plausible.BillingTest.monthly_pageview_usage_stub(15_000, 15_000)
 
       assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}
@@ -164,7 +164,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       new_site(owner: user)
       team = team_of(user)
 
-      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+      over_limits_usage_stub = Plausible.BillingTest.monthly_pageview_usage_stub(15_000, 15_000)
 
       assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -5,6 +5,8 @@ defmodule Plausible.Billing.SiteLockerTest do
   require Plausible.Billing.Subscription.Status
   alias Plausible.Billing.{SiteLocker, Subscription}
 
+  @moduletag :ee_only
+
   @v4_growth_plan_id "857097"
 
   describe "update_sites_for/1" do

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -5,6 +5,8 @@ defmodule Plausible.Billing.SiteLockerTest do
   require Plausible.Billing.Subscription.Status
   alias Plausible.Billing.{SiteLocker, Subscription}
 
+  @v4_growth_plan_id "857097"
+
   describe "update_sites_for/1" do
     test "does not lock sites if user is on trial" do
       user = new_user(trial_expiry_date: Date.utc_today())
@@ -61,6 +63,24 @@ defmodule Plausible.Billing.SiteLockerTest do
       refute Repo.reload!(site).locked
     end
 
+    test "does not lock enterprise customers with (manual lock) graceperiod ended" do
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: Date.utc_today() |> Date.shift(day: -1),
+        manual_lock: true
+      }
+
+      user =
+        new_user(team: [grace_period: grace_period])
+        |> subscribe_to_enterprise_plan(monthly_pageview_limit: 10_000)
+
+      site = new_site(owner: user)
+      team = team_of(user)
+
+      assert SiteLocker.update_sites_for(team) == :unlocked
+
+      refute Repo.reload!(site).locked
+    end
+
     test "locks user who cancelled subscription and the cancelled subscription has expired" do
       user =
         new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: -1))
@@ -72,48 +92,54 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_subscription}
+      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site).locked
     end
 
-    test "locks all sites if team has active subscription but grace period has ended" do
+    test "locks all sites if team has an active subscription but grace period has ended (still over limits)" do
       grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
-      subscribe_to_plan(user, "123")
+      subscribe_to_plan(user, @v4_growth_plan_id)
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :grace_period_ended_now}
+      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+
+      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+               {:locked, :grace_period_ended_now}
 
       assert Repo.reload!(site).locked
     end
 
-    test "sends email if grace period has ended" do
+    test "does not lock sites (and removes grace period), when on active subscription and grace period ended, but usage now within limits" do
       grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
-      subscribe_to_plan(user, "123")
-      new_site(owner: user)
+      subscribe_to_plan(user, @v4_growth_plan_id)
+      site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :grace_period_ended_now}
+      assert SiteLocker.update_sites_for(team) == :unlocked
 
-      assert_email_delivered_with(
-        to: [user],
-        subject: "[Action required] Your Plausible dashboard is now locked"
-      )
+      refute Repo.reload!(site).locked
+
+      assert_no_emails_delivered()
     end
 
-    test "sends email to billing members if grace period has ended" do
+    test "sends email to all billing members if grace period has ended and still over limits" do
       grace_period = %Plausible.Teams.GracePeriod{end_date: Timex.shift(Timex.today(), days: -1)}
       user = new_user(team: [grace_period: grace_period])
-      subscribe_to_plan(user, "123")
+      subscribe_to_plan(user, @v4_growth_plan_id)
       new_site(owner: user)
       team = team_of(user)
+
       billing_member = new_user()
       add_member(team, user: billing_member, role: :billing)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :grace_period_ended_now}
+      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+
+      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+               {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
         to: [user],
@@ -134,11 +160,14 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       user = new_user(team: [grace_period: grace_period])
 
-      subscribe_to_plan(user, "123")
+      subscribe_to_plan(user, @v4_growth_plan_id)
       new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :grace_period_ended_now}
+      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+
+      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+               {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
         to: [user],
@@ -146,9 +175,29 @@ defmodule Plausible.Billing.SiteLockerTest do
       )
 
       team = Repo.reload!(team)
-      assert SiteLocker.update_sites_for(team) == {:locked, :grace_period_ended_already}
+
+      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+               {:locked, :grace_period_ended_already}
 
       assert_no_emails_delivered()
+    end
+
+    test "unlocks already ended grace periods when they still have an active subscription and went within limits again" do
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: Timex.shift(Timex.today(), days: -7),
+        is_over: true
+      }
+
+      user = new_user(team: [grace_period: grace_period])
+
+      subscribe_to_plan(user, @v4_growth_plan_id)
+      new_site(owner: user)
+      site = new_site(owner: user)
+      team = team_of(user)
+
+      assert SiteLocker.update_sites_for(team) == :unlocked
+
+      refute Repo.reload!(site).locked
     end
 
     test "locks all sites if user has no trial or active subscription" do
@@ -156,7 +205,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_subscription}
+      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site).locked
     end
@@ -166,7 +215,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = user |> team_of() |> Ecto.Changeset.change(trial_expiry_date: nil) |> Repo.update!()
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_trial}
+      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site).locked
     end
@@ -179,7 +228,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       add_guest(viewer_site, user: user, role: :viewer)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_subscription}
+      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
 
       owner_site = Repo.reload!(owner_site)
       viewer_site = Repo.reload!(viewer_site)

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -141,6 +141,7 @@ defmodule PlausibleWeb.SiteControllerTest do
              )
     end
 
+    @tag :ee_only
     test "shows upgrade nag message to expired trial user without subscription", %{
       conn: initial_conn,
       user: user

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -306,30 +306,4 @@ defmodule Plausible.TestUtils do
     |> Application.fetch_env!(PlausibleWeb.Endpoint)
     |> Keyword.fetch!(:secret_key_base)
   end
-
-  def monthly_pageview_usage_stub(penultimate_usage, last_usage) do
-    last_bill_date = Date.utc_today() |> Date.shift(day: -1)
-
-    Plausible.Teams.Billing
-    |> Double.stub(:monthly_pageview_usage, fn _user ->
-      %{
-        last_cycle: %{
-          date_range:
-            Date.range(
-              Date.shift(last_bill_date, month: -1),
-              Date.shift(last_bill_date, day: -1)
-            ),
-          total: last_usage
-        },
-        penultimate_cycle: %{
-          date_range:
-            Date.range(
-              Date.shift(last_bill_date, month: -2),
-              Date.shift(last_bill_date, day: -1, month: -1)
-            ),
-          total: penultimate_usage
-        }
-      }
-    end)
-  end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -306,4 +306,30 @@ defmodule Plausible.TestUtils do
     |> Application.fetch_env!(PlausibleWeb.Endpoint)
     |> Keyword.fetch!(:secret_key_base)
   end
+
+  def monthly_pageview_usage_stub(penultimate_usage, last_usage) do
+    last_bill_date = Date.utc_today() |> Date.shift(day: -1)
+
+    Plausible.Teams.Billing
+    |> Double.stub(:monthly_pageview_usage, fn _user ->
+      %{
+        last_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -1),
+              Date.shift(last_bill_date, day: -1)
+            ),
+          total: last_usage
+        },
+        penultimate_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -2),
+              Date.shift(last_bill_date, day: -1, month: -1)
+            ),
+          total: penultimate_usage
+        }
+      }
+    end)
+  end
 end

--- a/test/workers/lock_sites_test.exs
+++ b/test/workers/lock_sites_test.exs
@@ -5,6 +5,8 @@ defmodule Plausible.Workers.LockSitesTest do
   alias Plausible.Workers.LockSites
   alias Plausible.Billing.Subscription
 
+  @moduletag :ee_only
+
   test "does not lock enterprise site on grace period" do
     user = new_user()
     site = new_site(owner: user)


### PR DESCRIPTION
### Changes

This PR fixes a bug described below:

Our `CheckUsage` and `SiteLocker` jobs are two independent workers. The first is setting grace periods for users and the other one is acting upon them. The bug is that the `SiteLocker` doesn't look at the usage. It just blindly locks a team when their grace period is over.

Because of that, it's possible that when a user lowers their usage (e.g. deletes or transfers some sites) at the last moment (i.e. after the last CheckUsage job that runs daily at 2PM UTC **AND** before midnight UTC the next day) they might still get locked

This PR introduces a "final check" before we actually proceed with locking the team and sending the "Your stats are now locked" email. If they turn out to have lowered their usage. They'll remain unlocked and their grace period will be silently deleted.

NOTE: This also means that even when a team is locked for a month, the `SiteLocker` job will still automatically check their usage every midnight **IF they still have an active subscription**, and unlock them if their usage has dropped back within their limits.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
