### PR TITLE
Add `team_id` relation to `api_keys`

### DIFF
--- a/priv/repo/migrations/20250324142615_add_api_keys_team_id.exs
+++ b/priv/repo/migrations/20250324142615_add_api_keys_team_id.exs
@@ -1,0 +1,11 @@
+defmodule Plausible.Repo.Migrations.AddApiKeysTeamId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:api_keys) do
+      add :team_id, references(:teams, on_delete: :delete_all), null: true
+    end
+
+    create unique_index(:api_keys, [:team_id, :user_id])
+  end
+end


### PR DESCRIPTION
### Changes

Adds a new relation to `api_keys` which will enable team-bound API keys later on.


