### PR TITLE
Populate `team_id` when provisioning API key

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -102,7 +102,7 @@ jobs:
 
       - run: make minio
         if: env.MIX_ENV == 'test'
-      - run: mix test --include slow --include minio --include migrations --max-failures 1 --warnings-as-errors
+      - run: mix test --include slow --include minio --include migrations --include kaffy_quirks --max-failures 1 --warnings-as-errors
         if: env.MIX_ENV == 'test'
         env:
           MINIO_HOST_FOR_CLICKHOUSE: "172.17.0.1"

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -391,15 +391,10 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
       site ->
         site = Repo.preload(site, :team)
 
-        cond do
-          team && team.id != site.team_id ->
-            {:error, :site_not_found}
-
-          !team && site.team.setup_complete ->
-            {:error, :site_not_found}
-
-          true ->
-            {:ok, site}
+        if team && team.id != site.team_id do
+          {:error, :site_not_found}
+        else
+          {:ok, site}
         end
     end
   end

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -14,14 +14,8 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
   @pagination_opts [cursor_fields: [{:id, :desc}], limit: 100, maximum_limit: 1000]
 
   def index(conn, params) do
-    team =
-      if conn.assigns.current_team do
-        conn.assigns.current_team
-      else
-        Teams.get(params["team_id"])
-      end
-
     user = conn.assigns.current_user
+    team = conn.assigns.current_team || Teams.get(params["team_id"])
 
     page =
       user
@@ -119,13 +113,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
   def create_site(conn, params) do
     user = conn.assigns.current_user
-
-    team =
-      if conn.assigns.current_team do
-        conn.assigns.current_team
-      else
-        Plausible.Teams.get(params["team_id"])
-      end
+    team = conn.assigns.current_team || Teams.get(params["team_id"])
 
     case Sites.create(user, params, team) do
       {:ok, %{site: site}} ->

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -61,10 +61,11 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
   def teams_index(conn, params) do
     user = conn.assigns.current_user
+    team = conn.assigns.current_team
 
     page =
       user
-      |> Teams.Users.teams_query(order_by: :id_desc)
+      |> Teams.Users.teams_query(identifier: team && team.identifier, order_by: :id_desc)
       |> paginate(params, @pagination_opts)
 
     json(conn, %{

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -26,15 +26,20 @@ defmodule Plausible.Auth.ApiKey do
 
   def hourly_request_limit(), do: @hourly_request_limit
 
-  def changeset(schema, team, attrs \\ %{}) do
+  def changeset(schema, team, attrs) do
     schema
     |> cast(attrs, @required ++ @optional)
     |> validate_required(@required)
     |> maybe_put_key()
     |> process_key()
-    |> put_assoc(:team, team)
+    |> maybe_put_team(team)
     |> unique_constraint(:key_hash, error_key: :key)
     |> unique_constraint([:team_id, :user_id], error_key: :team)
+  end
+
+  # NOTE: needed only because of lacking introspection in Kaffy
+  def changeset(schema, attrs) do
+    changeset(schema, nil, attrs)
   end
 
   def update(schema, attrs \\ %{}) do
@@ -59,6 +64,12 @@ defmodule Plausible.Auth.ApiKey do
   end
 
   def process_key(changeset), do: changeset
+
+  defp maybe_put_team(changeset, nil), do: changeset
+
+  defp maybe_put_team(changeset, team) do
+    put_assoc(changeset, :team, team)
+  end
 
   defp maybe_put_key(changeset) do
     if get_change(changeset, :key) do

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -26,8 +26,8 @@ defmodule Plausible.Auth.ApiKey do
 
   def hourly_request_limit(), do: @hourly_request_limit
 
-  def changeset(schema, team, attrs) do
-    schema
+  def changeset(struct, team, attrs) do
+    struct
     |> cast(attrs, @required ++ @optional)
     |> validate_required(@required)
     |> maybe_put_key()
@@ -38,12 +38,12 @@ defmodule Plausible.Auth.ApiKey do
   end
 
   # NOTE: needed only because of lacking introspection in Kaffy
-  def changeset(schema, attrs) do
-    changeset(schema, nil, attrs)
+  def changeset(struct, attrs) do
+    changeset(struct, nil, attrs)
   end
 
-  def update(schema, attrs \\ %{}) do
-    schema
+  def update(struct, attrs \\ %{}) do
+    struct
     |> cast(attrs, [:name, :user_id, :scopes])
     |> validate_required([:user_id, :name])
   end

--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -18,6 +18,7 @@ defmodule Plausible.Auth.ApiKey do
     field :key_hash, :string
     field :key_prefix, :string
 
+    belongs_to :team, Plausible.Teams.Team
     belongs_to :user, Plausible.Auth.User
 
     timestamps()
@@ -25,13 +26,15 @@ defmodule Plausible.Auth.ApiKey do
 
   def hourly_request_limit(), do: @hourly_request_limit
 
-  def changeset(schema, attrs \\ %{}) do
+  def changeset(schema, team, attrs \\ %{}) do
     schema
     |> cast(attrs, @required ++ @optional)
     |> validate_required(@required)
     |> maybe_put_key()
     |> process_key()
+    |> put_assoc(:team, team)
     |> unique_constraint(:key_hash, error_key: :key)
+    |> unique_constraint([:team_id, :user_id], error_key: :team)
   end
 
   def update(schema, attrs \\ %{}) do

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -93,7 +93,7 @@ defmodule Plausible.Auth.ApiKeyAdmin do
 
   defp get_team(api_key) do
     team_name =
-      case api_key.team.owners do
+      case api_key.team && api_key.team.owners do
         [owner] ->
           if api_key.team.setup_complete do
             api_key.team.name
@@ -103,13 +103,19 @@ defmodule Plausible.Auth.ApiKeyAdmin do
 
         [_ | _] ->
           api_key.team.name
+
+        nil ->
+          "(none)"
       end
       |> html_escape()
 
-    """
-    <a href="/crm/teams/team/#{api_key.team.id}">#{team_name}</a>
-    """
-    |> Phoenix.HTML.raw()
+    if api_key.team do
+      Phoenix.HTML.raw("""
+      <a href="/crm/teams/team/#{api_key.team.id}">#{team_name}</a>
+      """)
+    else
+      team_name
+    end
   end
 
   defp get_owner(api_key) do

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -1,4 +1,7 @@
 defmodule Plausible.Auth.ApiKeyAdmin do
+  @moduledoc """
+  Stats and Sites API key logic for CRM.
+  """
   use Plausible.Repo
 
   alias Plausible.Auth
@@ -16,7 +19,7 @@ defmodule Plausible.Auth.ApiKeyAdmin do
     from(r in query, preload: [:user, team: :owners])
   end
 
-  def create_changeset(schema, attrs) do
+  def create_changeset(_schema, attrs) do
     team = Teams.get(attrs["team_identifier"])
 
     user_id =
@@ -33,24 +36,15 @@ defmodule Plausible.Auth.ApiKeyAdmin do
           team
 
         {nil, %{} = user} ->
-          case Teams.get_or_create(user) do
-            {:ok, team} ->
-              team
+          {:ok, team} = Teams.get_or_create(user)
 
-            {:error, _} ->
-              nil
-          end
+          team
 
         _ ->
           nil
       end
 
-    if team do
-      Auth.ApiKey.changeset(struct(schema, %{}), team, attrs)
-    else
-      Auth.ApiKey.changeset(struct(schema, %{}), nil, attrs)
-      |> Ecto.Changeset.add_error(:team, "is required")
-    end
+    Auth.ApiKey.changeset(%Auth.ApiKey{}, team, attrs)
   end
 
   def update_changeset(entry, attrs) do

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -1,35 +1,82 @@
 defmodule Plausible.Auth.ApiKeyAdmin do
   use Plausible.Repo
 
+  alias Plausible.Auth
+  alias Plausible.Teams
+
   def search_fields(_schema) do
     [
       :name,
-      user: [:name, :email]
+      user: [:name, :email],
+      team: [:name, :identifier]
     ]
   end
 
   def custom_index_query(_conn, _schema, query) do
-    from(r in query, preload: [:user])
+    from(r in query, preload: [:user, team: :owners])
   end
 
   def create_changeset(schema, attrs) do
-    scopes = [attrs["scope"]]
-    Plausible.Auth.ApiKey.changeset(struct(schema, %{}), Map.merge(%{"scopes" => scopes}, attrs))
+    team = Teams.get(attrs["team_identifier"])
+
+    user_id =
+      case Integer.parse(Map.get(attrs, "user_id", "")) do
+        {user_id, ""} -> user_id
+        _ -> nil
+      end
+
+    user = user_id && Auth.find_user_by(id: user_id)
+
+    team =
+      case {team, user} do
+        {%{} = team, _} ->
+          team
+
+        {nil, %{} = user} ->
+          case Teams.get_or_create(user) do
+            {:ok, team} ->
+              team
+
+            {:error, _} ->
+              nil
+          end
+
+        _ ->
+          nil
+      end
+
+    if team do
+      Auth.ApiKey.changeset(struct(schema, %{}), team, attrs)
+    else
+      Auth.ApiKey.changeset(struct(schema, %{}), nil, attrs)
+      |> Ecto.Changeset.add_error(:team, "is required")
+    end
   end
 
-  def update_changeset(schema, attrs) do
-    Plausible.Auth.ApiKey.update(schema, attrs)
+  def update_changeset(entry, attrs) do
+    Auth.ApiKey.update(entry, attrs)
   end
 
   @plaintext_key_help """
   The value of the API key is sensitive data like a password. Once created, the value of they will never be revealed again. Make sure to copy/paste this into a secure place before hitting 'save'. When sending the key to a customer, use a secure E2EE system that destructs the message after a certain period like https://bitwarden.com/products/send
   """
+
+  @team_identifier_help """
+  Team under which the key is to be created. Defaults to user's personal team when left empty.
+  """
+
   def form_fields(_) do
     [
       name: nil,
       key: %{create: :readonly, update: :hidden, help_text: @plaintext_key_help},
       key_prefix: %{create: :hidden, update: :readonly},
-      scope: %{choices: [{"Stats API", ["stats:read:*"]}, {"Sites API", ["sites:provision:*"]}]},
+      scopes: %{
+        choices: [
+          {"Stats API", Jason.encode!(["stats:read:*"])},
+          {"Sites API", Jason.encode!(["sites:provision:*"])}
+        ]
+      },
+      team_identifier: %{update: :hidden, help_text: @team_identifier_help},
       user_id: nil
     ]
   end
@@ -39,7 +86,49 @@ defmodule Plausible.Auth.ApiKeyAdmin do
       key_prefix: nil,
       name: nil,
       scopes: nil,
-      owner: %{value: & &1.user.email}
+      owner: %{value: &get_owner/1},
+      team: %{value: &get_team/1}
     ]
+  end
+
+  defp get_team(api_key) do
+    team_name =
+      case api_key.team.owners do
+        [owner] ->
+          if api_key.team.setup_complete do
+            api_key.team.name
+          else
+            owner.name
+          end
+
+        [_ | _] ->
+          api_key.team.name
+      end
+      |> html_escape()
+
+    """
+    <a href="/crm/teams/team/#{api_key.team.id}">#{team_name}</a>
+    """
+    |> Phoenix.HTML.raw()
+  end
+
+  defp get_owner(api_key) do
+    escaped_name = html_escape(api_key.user.name)
+    escaped_email = html_escape(api_key.user.email)
+
+    owner_html =
+      """
+       <a href="/crm/auth/user/#{api_key.user.id}">#{escaped_name}</a>
+       <br/>
+       #{escaped_email}
+      """
+
+    {:safe, owner_html}
+  end
+
+  defp html_escape(string) do
+    string
+    |> Phoenix.HTML.html_escape()
+    |> Phoenix.HTML.safe_to_string()
   end
 end

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -19,7 +19,7 @@ defmodule Plausible.Auth.ApiKeyAdmin do
     from(r in query, preload: [:user, team: :owners])
   end
 
-  def create_changeset(_schema, attrs) do
+  def create_changeset(schema, attrs) do
     team = Teams.get(attrs["team_identifier"])
 
     user_id =
@@ -44,7 +44,7 @@ defmodule Plausible.Auth.ApiKeyAdmin do
           nil
       end
 
-    Auth.ApiKey.changeset(%Auth.ApiKey{}, team, attrs)
+    Auth.ApiKey.changeset(schema, team, attrs)
   end
 
   def update_changeset(entry, attrs) do

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -154,11 +154,11 @@ defmodule Plausible.Auth do
     def is_super_admin?(_), do: false
   end
 
-  @spec create_api_key(Auth.User.t(), String.t(), String.t()) ::
+  @spec create_api_key(Auth.User.t(), Teams.Team.t(), String.t(), String.t()) ::
           {:ok, Auth.ApiKey.t()} | {:error, Ecto.Changeset.t() | :upgrade_required}
-  def create_api_key(user, name, key) do
+  def create_api_key(user, team, name, key) do
     params = %{name: name, user_id: user.id, key: key}
-    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, params)
+    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, team, params)
 
     with :ok <- check_stats_api_available(user) do
       Repo.insert(changeset)

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -204,12 +204,8 @@ defmodule Plausible.Auth do
     query
   end
 
-  defp scope_api_keys_by_team(query, %{setup_complete: false} = team) do
-    where(query, [a], is_nil(a.team_id) or a.team_id == ^team.id)
-  end
-
   defp scope_api_keys_by_team(query, team) do
-    where(query, [a], a.team_id == ^team.id)
+    where(query, [a], is_nil(a.team_id) or a.team_id == ^team.id)
   end
 
   defp find_api_key(raw_key, nil, _) do

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -184,8 +184,6 @@ defmodule Plausible.Teams do
 
       [owner] = team.owners
 
-      scope_api_keys(owner, team)
-
       clear_autocreated(owner)
 
       team
@@ -352,15 +350,6 @@ defmodule Plausible.Teams do
         where: tm.is_autocreated == true
       ),
       set: [is_autocreated: false]
-    )
-
-    :ok
-  end
-
-  defp scope_api_keys(user, team) do
-    Repo.update_all(
-      from(a in Auth.ApiKey, where: a.user_id == ^user.id),
-      set: [team_id: team.id]
     )
 
     :ok

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -297,12 +297,14 @@ defmodule Plausible.Teams do
     end
   end
 
+  @spec last_subscription_join_query() :: Ecto.Query.t()
   def last_subscription_join_query() do
     from(subscription in last_subscription_query(),
       where: subscription.team_id == parent_as(:team).id
     )
   end
 
+  @spec last_subscription_query() :: Ecto.Query.t()
   def last_subscription_query() do
     from(subscription in Plausible.Billing.Subscription,
       order_by: [desc: subscription.inserted_at, desc: subscription.id],
@@ -310,7 +312,9 @@ defmodule Plausible.Teams do
     )
   end
 
-  defp get_owned_team(user, opts \\ []) do
+  # Exposed for use in tests
+  @doc false
+  def get_owned_team(user, opts \\ []) do
     only_not_setup? = Keyword.get(opts, :only_not_setup?, false)
 
     query =

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -184,6 +184,8 @@ defmodule Plausible.Teams do
 
       [owner] = team.owners
 
+      scope_api_keys(owner, team)
+
       clear_autocreated(owner)
 
       team
@@ -350,6 +352,15 @@ defmodule Plausible.Teams do
         where: tm.is_autocreated == true
       ),
       set: [is_autocreated: false]
+    )
+
+    :ok
+  end
+
+  defp scope_api_keys(user, team) do
+    Repo.update_all(
+      from(a in Auth.ApiKey, where: a.user_id == ^user.id),
+      set: [team_id: team.id]
     )
 
     :ok

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -42,7 +42,13 @@ defmodule Plausible.Teams do
   end
 
   def get(team_identifier) when is_binary(team_identifier) do
-    Repo.get_by(Teams.Team, identifier: team_identifier)
+    case Ecto.UUID.cast(team_identifier) do
+      {:ok, uuid} ->
+        Repo.get_by(Teams.Team, identifier: uuid)
+
+      :error ->
+        nil
+    end
   end
 
   @spec get!(pos_integer() | binary()) :: Teams.Team.t()

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -92,9 +92,9 @@ defmodule PlausibleWeb.SettingsController do
 
   def api_keys(conn, _params) do
     current_user = conn.assigns.current_user
+    current_team = conn.assigns[:current_team]
 
-    api_keys =
-      Repo.preload(current_user, :api_keys).api_keys
+    api_keys = Auth.list_api_keys(current_user, current_team)
 
     render(conn, :api_keys, layout: {PlausibleWeb.LayoutView, :settings}, api_keys: api_keys)
   end

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -102,7 +102,7 @@ defmodule PlausibleWeb.SettingsController do
   def new_api_key(conn, _params) do
     current_team = conn.assigns[:current_team]
 
-    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, current_team)
+    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, current_team, %{})
 
     render(conn, "new_api_key.html", changeset: changeset)
   end

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -100,13 +100,18 @@ defmodule PlausibleWeb.SettingsController do
   end
 
   def new_api_key(conn, _params) do
-    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{})
+    current_team = conn.assigns[:current_team]
+
+    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, current_team)
 
     render(conn, "new_api_key.html", changeset: changeset)
   end
 
   def create_api_key(conn, %{"api_key" => %{"name" => name, "key" => key}}) do
-    case Auth.create_api_key(conn.assigns.current_user, name, key) do
+    current_user = conn.assigns.current_user
+    current_team = conn.assigns.current_team
+
+    case Auth.create_api_key(current_user, current_team, name, key) do
       {:ok, _api_key} ->
         conn
         |> put_flash(:success, "API key created successfully")

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -201,9 +201,6 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
       api_key.team_id && api_key.team_id != site.team_id ->
         {:error, :invalid_api_key}
 
-      !api_key.team_id && team.setup_complete ->
-        {:error, :invalid_api_key}
-
       Sites.locked?(site) ->
         {:error, :site_locked}
 

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -199,6 +199,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
       api_key.team_id && api_key.team_id != site.team_id ->
         {:error, :invalid_api_key}
 
+      !api_key.team_id && team.setup_complete ->
+        {:error, :invalid_api_key}
+
       Sites.locked?(site) ->
         {:error, :site_locked}
 

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -55,7 +55,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
          {:ok, api_key, limit_key, hourly_limit} <- find_api_key(conn, token, context),
          :ok <- check_api_key_rate_limit(limit_key, hourly_limit),
          {:ok, conn} <- verify_by_scope(conn, api_key, requested_scope) do
-      assign(conn, :current_user, api_key.user)
+      conn
+      |> assign(:current_user, api_key.user)
+      |> assign(:current_team, api_key.team)
     else
       error -> send_error(conn, requested_scope, error)
     end

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -196,6 +196,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
       is_super_admin? ->
         :ok
 
+      api_key.team_id && api_key.team_id != site.team_id ->
+        {:error, :invalid_api_key}
+
       Sites.locked?(site) ->
         {:error, :site_locked}
 

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -111,7 +111,9 @@ defmodule PlausibleWeb.LayoutView do
           if(not Teams.setup?(current_team),
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
-          %{key: "API Keys", value: "api-keys", icon: :key},
+          if(not Teams.setup?(current_team),
+            do: %{key: "API Keys", value: "api-keys", icon: :key}
+          ),
           %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
         ]
         |> Enum.reject(&is_nil/1)
@@ -127,6 +129,7 @@ defmodule PlausibleWeb.LayoutView do
           if(current_team_role in [:owner, :admin, :billing],
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
+          %{key: "API Keys", value: "api-keys", icon: :key},
           if(current_team_role == :owner,
             do: %{key: "Danger Zone", value: "team/delete", icon: :exclamation_triangle}
           )

--- a/test/plausible/auth/auth_test.exs
+++ b/test/plausible/auth/auth_test.exs
@@ -21,16 +21,21 @@ defmodule Plausible.AuthTest do
   describe "create_api_key/3" do
     test "creates a new api key" do
       user = new_user(trial_expiry_date: Date.utc_today())
+      team = team_of(user)
       key = Ecto.UUID.generate()
-      assert {:ok, %Auth.ApiKey{}} = Auth.create_api_key(user, "my new key", key)
+      assert {:ok, %Auth.ApiKey{} = api_key} = Auth.create_api_key(user, team, "my new key", key)
+      assert api_key.team_id == team.id
+      assert api_key.user_id == user.id
     end
 
     test "errors when key already exists" do
       u1 = new_user(trial_expiry_date: Date.utc_today())
+      t1 = team_of(u1)
       u2 = new_user(trial_expiry_date: Date.utc_today())
+      t2 = team_of(u2)
       key = Ecto.UUID.generate()
-      assert {:ok, %Auth.ApiKey{}} = Auth.create_api_key(u1, "my new key", key)
-      assert {:error, changeset} = Auth.create_api_key(u2, "my other key", key)
+      assert {:ok, %Auth.ApiKey{}} = Auth.create_api_key(u1, t1, "my new key", key)
+      assert {:error, changeset} = Auth.create_api_key(u2, t2, "my other key", key)
 
       assert changeset.errors[:key] ==
                {"has already been taken",
@@ -38,27 +43,30 @@ defmodule Plausible.AuthTest do
     end
 
     @tag :ee_only
-    test "returns error when user is on a growth plan" do
+    test "returns error when team is on a growth plan" do
       user = new_user() |> subscribe_to_growth_plan()
+      team = team_of(user)
 
       assert {:error, :upgrade_required} =
-               Auth.create_api_key(user, "my new key", Ecto.UUID.generate())
+               Auth.create_api_key(user, team, "my new key", Ecto.UUID.generate())
     end
 
-    test "creates a key for user on a growth plan when they are an owner of more than one team" do
-      user = new_user() |> subscribe_to_growth_plan()
+    test "creates a key for user in a team with a bunsiness plan" do
+      user = new_user() |> subscribe_to_business_plan()
+      team = team_of(user)
       another_site = new_site()
       add_member(another_site.team, user: user, role: :owner)
 
       assert {:ok, %Auth.ApiKey{}} =
-               Auth.create_api_key(user, "my new key", Ecto.UUID.generate())
+               Auth.create_api_key(user, team, "my new key", Ecto.UUID.generate())
     end
   end
 
   describe "delete_api_key/2" do
     test "deletes the record" do
       user = new_user(trial_expiry_date: Date.utc_today())
-      assert {:ok, api_key} = Auth.create_api_key(user, "my new key", Ecto.UUID.generate())
+      team = team_of(user)
+      assert {:ok, api_key} = Auth.create_api_key(user, team, "my new key", Ecto.UUID.generate())
       assert :ok = Auth.delete_api_key(user, api_key.id)
       refute Plausible.Repo.reload(api_key)
     end
@@ -67,7 +75,10 @@ defmodule Plausible.AuthTest do
       me = new_user(trial_expiry_date: Date.utc_today())
 
       other_user = new_user(trial_expiry_date: Date.utc_today())
-      {:ok, other_api_key} = Auth.create_api_key(other_user, "my new key", Ecto.UUID.generate())
+      other_team = team_of(other_user)
+
+      {:ok, other_api_key} =
+        Auth.create_api_key(other_user, other_team, "my new key", Ecto.UUID.generate())
 
       assert {:error, :not_found} = Auth.delete_api_key(me, other_api_key.id)
       assert {:error, :not_found} = Auth.delete_api_key(me, -1)

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -3,6 +3,7 @@ defmodule PlausibleWeb.AdminControllerTest do
   use Plausible.Teams.Test
 
   alias Plausible.Repo
+  alias Plausible.Teams
 
   describe "GET /crm/teams/team/:team_id/usage" do
     setup [:create_user, :log_in, :create_team]
@@ -267,6 +268,160 @@ defmodule PlausibleWeb.AdminControllerTest do
                "site_limit" => 10,
                "team_member_limit" => 3
              }
+    end
+  end
+
+  describe "POST /crm/auth/api_key" do
+    setup [:create_user, :log_in]
+
+    @tag :ee_only
+    test "creates a team-bound API key", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      another_user = new_user()
+      team = another_user |> subscribe_to_business_plan() |> team_of()
+
+      params = %{
+        "api_key" => %{
+          "name" => "Some key",
+          "key" => Ecto.UUID.generate(),
+          "scope" => "stats:read:*",
+          "user_id" => "#{another_user.id}"
+        }
+      }
+
+      conn = post(conn, "/crm/auth/api_key", params)
+
+      assert api_key = Repo.get_by(Plausible.Auth.ApiKey, user_id: another_user.id)
+
+      assert redirected_to(conn, 302) == "/crm/auth/api_key"
+
+      assert api_key.team_id == team.id
+      assert api_key.user_id == another_user.id
+    end
+
+    @tag :ee_only
+    test "Creates personal team when creating the api key if there's none", %{
+      conn: conn,
+      user: user
+    } do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      another_user = new_user()
+
+      another_team = new_site().team |> Teams.complete_setup()
+      add_member(another_team, user: another_user, role: :owner)
+
+      params = %{
+        "api_key" => %{
+          "name" => "Some key",
+          "key" => Ecto.UUID.generate(),
+          "scopes" => Jason.encode!(["stats:read:*"]),
+          "user_id" => "#{another_user.id}"
+        }
+      }
+
+      conn = post(conn, "/crm/auth/api_key", params)
+
+      assert api_key = Repo.get_by(Plausible.Auth.ApiKey, user_id: another_user.id)
+
+      assert {:ok, personal_team} = Teams.get_owned_team(another_user, only_not_setup?: true)
+
+      assert redirected_to(conn, 302) == "/crm/auth/api_key"
+
+      assert api_key.team_id == personal_team.id
+    end
+
+    @tag :ee_only
+    test "Creates team for a particular team if provided", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      another_user = new_user() |> subscribe_to_business_plan()
+
+      another_team = new_site().team |> Teams.complete_setup()
+      add_member(another_team, user: another_user, role: :owner)
+
+      params = %{
+        "api_key" => %{
+          "team_identifier" => another_team.identifier,
+          "name" => "Some key",
+          "key" => Ecto.UUID.generate(),
+          "scopes" => Jason.encode!(["stats:read:*"]),
+          "user_id" => "#{another_user.id}"
+        }
+      }
+
+      conn = post(conn, "/crm/auth/api_key", params)
+
+      assert api_key = Repo.get_by(Plausible.Auth.ApiKey, user_id: another_user.id)
+
+      assert redirected_to(conn, 302) == "/crm/auth/api_key"
+
+      assert api_key.team_id == another_team.id
+    end
+  end
+
+  describe "PUT /crm/auth/api_key/:id" do
+    setup [:create_user, :log_in]
+
+    @tag :ee_only
+    test "updates an API key", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      another_user = new_user()
+      team = another_user |> subscribe_to_business_plan() |> team_of()
+
+      api_key = insert(:api_key, user: user, team: team)
+
+      assert api_key.scopes == ["stats:read:*"]
+
+      params = %{
+        "api_key" => %{
+          "name" => "Some key",
+          "key" => Ecto.UUID.generate(),
+          "scopes" => Jason.encode!(["sites:provision:*"]),
+          "user_id" => "#{another_user.id}"
+        }
+      }
+
+      conn = put(conn, "/crm/auth/api_key/#{api_key.id}", params)
+
+      assert api_key = Repo.get_by(Plausible.Auth.ApiKey, user_id: another_user.id)
+
+      assert redirected_to(conn, 302) == "/crm/auth/api_key"
+
+      assert api_key.team_id == team.id
+      assert api_key.scopes == ["sites:provision:*"]
+    end
+
+    @tag :ee_only
+    test "leaves legacy API key without a team on update", %{conn: conn, user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      another_user = new_user()
+      _team = another_user |> subscribe_to_business_plan() |> team_of()
+
+      api_key = insert(:api_key, user: user)
+
+      assert api_key.scopes == ["stats:read:*"]
+
+      params = %{
+        "api_key" => %{
+          "name" => "Some key",
+          "key" => Ecto.UUID.generate(),
+          "scopes" => Jason.encode!(["sites:provision:*"]),
+          "user_id" => "#{another_user.id}"
+        }
+      }
+
+      conn = put(conn, "/crm/auth/api_key/#{api_key.id}", params)
+
+      assert api_key = Repo.get_by(Plausible.Auth.ApiKey, user_id: another_user.id)
+
+      assert redirected_to(conn, 302) == "/crm/auth/api_key"
+
+      refute api_key.team_id
+      assert api_key.scopes == ["sites:provision:*"]
     end
   end
 end

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -274,8 +274,7 @@ defmodule PlausibleWeb.AdminControllerTest do
   describe "POST /crm/auth/api_key" do
     setup [:create_user, :log_in]
 
-    @tag :ee_only
-    @tag :slow
+    @tag :kaffy_quirks
     test "creates a team-bound API key", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 
@@ -301,8 +300,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       assert api_key.user_id == another_user.id
     end
 
-    @tag :ee_only
-    @tag :slow
+    @tag :kaffy_quirks
     test "Creates personal team when creating the api key if there's none", %{
       conn: conn,
       user: user
@@ -334,8 +332,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       assert api_key.team_id == personal_team.id
     end
 
-    @tag :ee_only
-    @tag :slow
+    @tag :kaffy_quirks
     test "Creates team for a particular team if provided", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -275,6 +275,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     setup [:create_user, :log_in]
 
     @tag :ee_only
+    @tag :slow
     test "creates a team-bound API key", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 
@@ -301,6 +302,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     end
 
     @tag :ee_only
+    @tag :slow
     test "Creates personal team when creating the api key if there's none", %{
       conn: conn,
       user: user
@@ -333,6 +335,7 @@ defmodule PlausibleWeb.AdminControllerTest do
     end
 
     @tag :ee_only
+    @tag :slow
     test "Creates team for a particular team if provided", %{conn: conn, user: user} do
       patch_env(:super_admin_user_ids, [user.id])
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1095,10 +1095,11 @@ defmodule PlausibleWeb.SettingsControllerTest do
     test "can't delete api key that doesn't belong to me", %{conn: conn} do
       other_user = new_user()
       new_site(owner: other_user)
+      team = team_of(other_user)
 
       assert {:ok, %ApiKey{} = api_key} =
                %ApiKey{user_id: other_user.id}
-               |> ApiKey.changeset(%{"name" => "other user's key"})
+               |> ApiKey.changeset(team, %{"name" => "other user's key"})
                |> Repo.insert()
 
       conn = delete(conn, Routes.settings_path(conn, :delete_api_key, api_key.id))

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -75,7 +75,8 @@ defmodule Plausible.TestUtils do
   end
 
   def create_api_key(%{user: user}) do
-    api_key = Factory.insert(:api_key, user: user)
+    team = Plausible.Teams.Test.team_of(user)
+    api_key = Factory.insert(:api_key, user: user, team: team)
 
     {:ok, api_key: api_key.key}
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,7 +17,7 @@ if :minio in Keyword.fetch!(ExUnit.configuration(), :include) do
   Plausible.TestUtils.ensure_minio()
 end
 
-default_exclude = [:slow, :minio, :migrations]
+default_exclude = [:slow, :minio, :migrations, :kaffy_quirks]
 
 # avoid slowdowns contacting the code server https://github.com/sasa1977/con_cache/pull/79
 :code.ensure_loaded(ConCache.Lock.Resource)


### PR DESCRIPTION
### Changes

This PR starts populating `team_id` relation in ApiKey on creation. When created by user, `current_team` is used. From CRM, when left empty, it defaults to user's personal team. When explicit team identifier is provided, the API key is bound to that key.

When creating the key from "Account Settings" the new key is always bound to the current team.

All existing keys are left intact and still allow querying sites from all teams where user has access - either via guest or full membership, provided the site's team has Stats API capability enabled.

NOTE: The test suite will now throw a following warning even on a clean run:

```elixir
warning: using map.field notation (without parentheses) to invoke function Plausible.Auth.ApiKey.__struct__() is deprecated, you must add parenthes
es instead: remote.function()                                                                                                                                                                                                                                                               
  (kaffy 0.10.3) lib/kaffy/resource_admin.ex:224: Kaffy.ResourceAdmin.create_changeset/2                                                                                                                                                                                                    
  (kaffy 0.10.3) lib/kaffy/resource_callbacks.ex:7: Kaffy.ResourceCallbacks.create_callbacks/3                                                                                                                                                                                              
  (kaffy 0.10.3) lib/kaffy_web/controllers/resource_controller.ex:252: KaffyWeb.ResourceController.create/2                                                                                                                                                                                 
  (kaffy 0.10.3) lib/kaffy_web/controllers/resource_controller.ex:1: KaffyWeb.ResourceController.action/2                                                                                                                                                                                   
  (kaffy 0.10.3) lib/kaffy_web/controllers/resource_controller.ex:1: KaffyWeb.ResourceController.phoenix_controller_pipeline/2                                                                                                                                                              
  (phoenix 1.7.20) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5                                                                                                                                                                                                                     
  (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint.plug_builder_call/2                                                                                                                                                                                              
  (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint."call (overridable 3)"/2                                                                                                                                                                                         
  (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint.call/2                                                                                                                                                                                                           
  (phoenix 1.7.20) lib/phoenix/test/conn_test.ex:225: Phoenix.ConnTest.dispatch/5                                                                                                                                                                                                           
  test/plausible_web/controllers/admin_controller_test.exs:293: PlausibleWeb.AdminControllerTest."test POST /crm/auth/api_key creates a team-bound API key"/1                                                                                                                               
  (ex_unit 1.17.3) lib/ex_unit/runner.ex:485: ExUnit.Runner.exec_test/2                                                                                                                                                                                                                     
  (stdlib 6.2) timer.erl:595: :timer.tc/2                                                                                                                                                                                                                                                   
  (ex_unit 1.17.3) lib/ex_unit/runner.ex:407: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4  
```

The issue is on Kaffy's end and will be addressed separately, either upstream or in a fork (unless we decide to rework CRM entirely, but that's another matter).

### Tests
- [x] Automated tests have been added
