### PR TITLE
Revert "Limit rate of requests for Stats/Sites API via Team directly (#5231)

### DIFF
--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -6,13 +6,14 @@ defmodule Plausible.Auth.ApiKey do
   @type t() :: %__MODULE__{}
 
   @required [:user_id, :name]
-  @optional [:key, :scopes]
+  @optional [:key, :scopes, :hourly_request_limit]
 
   @hourly_request_limit on_ee(do: 600, else: 1_000_000)
 
   schema "api_keys" do
     field :name, :string
     field :scopes, {:array, :string}, default: ["stats:read:*"]
+    field :hourly_request_limit, :integer, default: @hourly_request_limit
 
     field :key, :string, virtual: true
     field :key_hash, :string
@@ -36,7 +37,7 @@ defmodule Plausible.Auth.ApiKey do
 
   def update(schema, attrs \\ %{}) do
     schema
-    |> cast(attrs, [:name, :user_id, :scopes])
+    |> cast(attrs, [:name, :user_id, :scopes, :hourly_request_limit])
     |> validate_required([:user_id, :name])
   end
 

--- a/lib/plausible/auth/api_key_admin.ex
+++ b/lib/plausible/auth/api_key_admin.ex
@@ -29,6 +29,7 @@ defmodule Plausible.Auth.ApiKeyAdmin do
       name: nil,
       key: %{create: :readonly, update: :hidden, help_text: @plaintext_key_help},
       key_prefix: %{create: :hidden, update: :readonly},
+      hourly_request_limit: %{default: 1000},
       scope: %{choices: [{"Stats API", ["stats:read:*"]}, {"Sites API", ["sites:provision:*"]}]},
       user_id: nil
     ]

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -175,16 +175,8 @@ defmodule Plausible.Auth do
     end
   end
 
-  @spec find_api_key(String.t(), Keyword.t()) ::
-          {:ok, Auth.ApiKey.t() | %{api_key: Auth.ApiKey.t(), team: Teams.Team.t() | nil}}
-          | {:error, :invalid_api_key | :missing_site_id}
-  def find_api_key(raw_key, opts \\ []) do
-    {team_scope, id} = Keyword.get(opts, :team_by, {nil, nil})
-
-    find_api_key(raw_key, team_scope, id)
-  end
-
-  defp find_api_key(raw_key, nil, _) do
+  @spec find_api_key(String.t()) :: {:ok, Auth.ApiKey.t()} | {:error, :invalid_api_key}
+  def find_api_key(raw_key) do
     hashed_key = Auth.ApiKey.do_hash(raw_key)
 
     query =
@@ -199,28 +191,6 @@ defmodule Plausible.Auth do
     else
       {:error, :invalid_api_key}
     end
-  end
-
-  defp find_api_key(raw_key, :site, nil) do
-    with {:ok, api_key} <- find_api_key(raw_key, nil, nil) do
-      {:ok, %{api_key: api_key, team: nil}}
-    end
-  end
-
-  defp find_api_key(raw_key, :site, domain) do
-    with {:ok, api_key} <- find_api_key(raw_key, nil, nil) do
-      team = find_team_by_site(domain)
-      {:ok, %{api_key: api_key, team: team}}
-    end
-  end
-
-  defp find_team_by_site(domain) do
-    Repo.one(
-      from s in Plausible.Site,
-        inner_join: t in assoc(s, :team),
-        where: s.domain == ^domain or s.domain_changed_from == ^domain,
-        select: t
-    )
   end
 
   defp check_stats_api_available(user) do

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -245,6 +245,10 @@ defmodule Plausible.Billing do
       )
 
     if plan do
+      owner_ids = Enum.map(team.owners, & &1.id)
+      api_keys = from(key in Plausible.Auth.ApiKey, where: key.user_id in ^owner_ids)
+      Repo.update_all(api_keys, set: [hourly_request_limit: plan.hourly_api_request_limit])
+
       Repo.update_all(
         from(t in Teams.Team, where: t.id == ^team.id),
         set: [hourly_api_request_limit: plan.hourly_api_request_limit]

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -34,8 +34,6 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   alias Plausible.Sites
   alias PlausibleWeb.Api.Helpers, as: H
 
-  require Logger
-
   # Scopes permitted implicitly for every API key. Existing API keys
   # have _either_ `["stats:read:*"]` (the default) or `["sites:provision:*"]`
   # set as their valid scopes. We always consider implicit scopes as
@@ -49,11 +47,10 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   def call(conn, _opts) do
     requested_scope = Map.fetch!(conn.assigns, :api_scope)
-    context = conn.assigns[:api_context]
 
     with {:ok, token} <- get_bearer_token(conn),
-         {:ok, api_key, limit_key, hourly_limit} <- find_api_key(conn, token, context),
-         :ok <- check_api_key_rate_limit(limit_key, hourly_limit),
+         {:ok, api_key} <- Auth.find_api_key(token),
+         :ok <- check_api_key_rate_limit(api_key),
          {:ok, conn} <- verify_by_scope(conn, api_key, requested_scope) do
       assign(conn, :current_user, api_key.user)
     else
@@ -62,53 +59,6 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
   end
 
   ### Verification dispatched by scope
-
-  defp find_api_key(conn, token, :site) do
-    case Auth.find_api_key(token, team_by: {:site, conn.params["site_id"]}) do
-      {:ok, %{api_key: api_key, team: nil}} ->
-        {:ok, api_key, limit_key(api_key, nil), Auth.ApiKey.hourly_request_limit()}
-
-      {:ok, %{api_key: api_key, team: team}} ->
-        team_role_result = Plausible.Teams.Memberships.team_role(team, api_key.user)
-
-        cond do
-          Auth.is_super_admin?(api_key.user) ->
-            :pass
-
-          team_role_result == {:ok, :guest} ->
-            Logger.warning(
-              "[#{inspect(__MODULE__)}] API key #{api_key.id} user accessing #{conn.params["site_id"]} as a guest"
-            )
-
-          team_role_result == {:error, :not_a_member} ->
-            Logger.warning(
-              "[#{inspect(__MODULE__)}] API key #{api_key.id} user trying to access #{conn.params["site_id"]} as a non-member"
-            )
-
-          true ->
-            :pass
-        end
-
-        {:ok, api_key, limit_key(api_key, team.identifier), team.hourly_api_request_limit}
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp find_api_key(_conn, token, _) do
-    with {:ok, api_key} <- Auth.find_api_key(token) do
-      {:ok, api_key, limit_key(api_key, nil), Auth.ApiKey.hourly_request_limit()}
-    end
-  end
-
-  defp limit_key(api_key, nil) do
-    "api_request:#{api_key.id}"
-  end
-
-  defp limit_key(api_key, team_id) do
-    "api_request:#{api_key.id}:#{team_id}"
-  end
 
   defp verify_by_scope(conn, api_key, "stats:read:" <> _ = scope) do
     with :ok <- check_scope(api_key, scope),
@@ -157,10 +107,14 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
     end
   end
 
-  defp check_api_key_rate_limit(limit_key, hourly_limit) do
-    case RateLimit.check_rate(limit_key, to_timeout(hour: 1), hourly_limit) do
+  defp check_api_key_rate_limit(api_key) do
+    case RateLimit.check_rate(
+           "api_request:#{api_key.id}",
+           to_timeout(hour: 1),
+           api_key.hourly_request_limit
+         ) do
       {:allow, _} -> :ok
-      {:deny, _} -> {:error, :rate_limit, hourly_limit}
+      {:deny, _} -> {:error, :rate_limit, api_key.hourly_request_limit}
     end
   end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -227,8 +227,7 @@ defmodule PlausibleWeb.Router do
     end
   end
 
-  scope "/api/v1/stats", PlausibleWeb.Api,
-    assigns: %{api_scope: "stats:read:*", api_context: :site} do
+  scope "/api/v1/stats", PlausibleWeb.Api, assigns: %{api_scope: "stats:read:*"} do
     pipe_through [:public_api, PlausibleWeb.Plugs.AuthorizePublicAPI]
 
     get "/realtime/visitors", ExternalStatsController, :realtime_visitors
@@ -237,8 +236,7 @@ defmodule PlausibleWeb.Router do
     get "/timeseries", ExternalStatsController, :timeseries
   end
 
-  scope "/api/v2", PlausibleWeb.Api,
-    assigns: %{api_scope: "stats:read:*", api_context: :site, schema_type: :public} do
+  scope "/api/v2", PlausibleWeb.Api, assigns: %{api_scope: "stats:read:*", schema_type: :public} do
     pipe_through [:public_api, PlausibleWeb.Plugs.AuthorizePublicAPI]
 
     post "/query", ExternalQueryApiController, :query
@@ -269,31 +267,25 @@ defmodule PlausibleWeb.Router do
 
         get "/", ExternalSitesController, :index
         get "/teams", ExternalSitesController, :teams_index
-
-        scope assigns: %{api_context: :site} do
-          get "/goals", ExternalSitesController, :goals_index
-          get "/guests", ExternalSitesController, :guests_index
-          get "/:site_id", ExternalSitesController, :get_site
-        end
+        get "/goals", ExternalSitesController, :goals_index
+        get "/guests", ExternalSitesController, :guests_index
+        get "/:site_id", ExternalSitesController, :get_site
       end
 
       scope assigns: %{api_scope: "sites:provision:*"} do
         pipe_through PlausibleWeb.Plugs.AuthorizePublicAPI
 
         post "/", ExternalSitesController, :create_site
+        put "/shared-links", ExternalSitesController, :find_or_create_shared_link
 
-        scope assigns: %{api_context: :site} do
-          put "/shared-links", ExternalSitesController, :find_or_create_shared_link
+        put "/goals", ExternalSitesController, :find_or_create_goal
+        delete "/goals/:goal_id", ExternalSitesController, :delete_goal
 
-          put "/goals", ExternalSitesController, :find_or_create_goal
-          delete "/goals/:goal_id", ExternalSitesController, :delete_goal
+        put "/guests", ExternalSitesController, :find_or_create_guest
+        delete "/guests/:email", ExternalSitesController, :delete_guest
 
-          put "/guests", ExternalSitesController, :find_or_create_guest
-          delete "/guests/:email", ExternalSitesController, :delete_guest
-
-          put "/:site_id", ExternalSitesController, :update_site
-          delete "/:site_id", ExternalSitesController, :delete_site
-        end
+        put "/:site_id", ExternalSitesController, :update_site
+        delete "/:site_id", ExternalSitesController, :delete_site
       end
     end
   end

--- a/test/plausible/auth/auth_test.exs
+++ b/test/plausible/auth/auth_test.exs
@@ -25,6 +25,26 @@ defmodule Plausible.AuthTest do
       assert {:ok, %Auth.ApiKey{}} = Auth.create_api_key(user, "my new key", key)
     end
 
+    @tag :ee_only
+    test "defaults to 600 requests per hour limit in EE" do
+      user = new_user(trial_expiry_date: Date.utc_today())
+
+      {:ok, %Auth.ApiKey{hourly_request_limit: hourly_request_limit}} =
+        Auth.create_api_key(user, "my new EE key", Ecto.UUID.generate())
+
+      assert hourly_request_limit == 600
+    end
+
+    @tag :ce_build_only
+    test "defaults to 1000000 requests per hour limit in CE" do
+      user = new_user(trial_expiry_date: Date.utc_today())
+
+      {:ok, %Auth.ApiKey{hourly_request_limit: hourly_request_limit}} =
+        Auth.create_api_key(user, "my new CE key", Ecto.UUID.generate())
+
+      assert hourly_request_limit == 1_000_000
+    end
+
     test "errors when key already exists" do
       u1 = new_user(trial_expiry_date: Date.utc_today())
       u2 = new_user(trial_expiry_date: Date.utc_today())

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -289,13 +289,14 @@ defmodule Plausible.BillingTest do
 
       team = team_of(user)
 
-      _api_key = insert(:api_key, user: user)
+      api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
       assert team.hourly_api_request_limit != 10_000
 
       %{@subscription_created_params | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"}
       |> Billing.subscription_created()
 
+      assert Repo.reload!(api_key).hourly_request_limit == 10_000
       assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
   end
@@ -419,7 +420,7 @@ defmodule Plausible.BillingTest do
 
       team = team_of(user)
 
-      _api_key = insert(:api_key, user: user)
+      api_key = insert(:api_key, user: user, hourly_request_limit: 1)
 
       assert team.hourly_api_request_limit != 10_000
 
@@ -431,6 +432,7 @@ defmodule Plausible.BillingTest do
       })
       |> Billing.subscription_updated()
 
+      assert Repo.reload!(api_key).hourly_request_limit == 10_000
       assert Repo.reload!(team).hourly_api_request_limit == 10_000
     end
 

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -235,7 +235,6 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert json_response(conn, 404) == %{"error" => "Site could not be found"}
       end
 
-      @tag :capture_log
       test "cannot delete a site that the user does not own", %{conn: conn, user: user} do
         site = new_site()
         add_guest(site, user: user, role: :editor)
@@ -333,7 +332,6 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert res["error"] == "Site could not be found"
       end
 
-      @tag :capture_log
       test "returns 404 when api key owner does not have permissions to create a shared link", %{
         conn: conn,
         user: user
@@ -482,7 +480,6 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert res["error"] == "Site could not be found"
       end
 
-      @tag :capture_log
       test "returns 404 when api key owner does not have permissions to create a goal", %{
         conn: conn,
         user: user
@@ -589,7 +586,6 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
         assert json_response(conn, 404) == %{"error" => "Goal could not be found"}
       end
 
-      @tag :capture_log
       test "cannot delete a goal belongs to a site that the user does not own", %{
         conn: conn,
         user: user
@@ -1101,7 +1097,6 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                }
       end
 
-      @tag :capture_log
       test "returns goals for site where user is viewer", %{site: site} do
         viewer = new_user()
         add_guest(site, user: viewer, role: :viewer)

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -100,30 +100,23 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   end
 
   test "limits the rate of API requests", %{user: user} do
-    site = new_site(owner: user)
-
-    user
-    |> team_of()
-    |> Ecto.Changeset.change(hourly_api_request_limit: 3)
-    |> Plausible.Repo.update!()
-
-    api_key = insert(:api_key, user_id: user.id)
+    api_key = insert(:api_key, user_id: user.id, hourly_request_limit: 3)
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
+    |> get("/api/v1/stats/aggregate")
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
+    |> get("/api/v1/stats/aggregate")
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
+    |> get("/api/v1/stats/aggregate")
 
     build_conn()
     |> with_api_key(api_key.key)
-    |> get("/api/v1/stats/aggregate", %{"site_id" => site.domain})
+    |> get("/api/v1/stats/aggregate")
     |> assert_error(
       429,
       "Too many API requests. Your API key is limited to 3 requests per hour."

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1805,7 +1805,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       assert %{"error_code" => "unsupported_filters"} = json_response(conn, 422)
     end
 
-    @tag :capture_log
+    @tag :capure_log
     test "returns 502 when Google API responds with an unexpected error", %{
       conn: conn,
       site: site


### PR DESCRIPTION
…(#5231)"

This reverts commit e07300e0c0c1d075ff298486fc71c28bdc87868a.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
