### PR TITLE
Make 'Remove filter' / 'Clear all filters' buttons less threatening & other tweaks

### DIFF
--- a/assets/js/dashboard/components/popover.tsx
+++ b/assets/js/dashboard/components/popover.tsx
@@ -55,6 +55,7 @@ const items = {
       'first-of-type:rounded-t-md',
       'last-of-type:rounded-b-md'
     ),
+    roundedEnd: classNames('last-of-type:rounded-b-md'),
     groupRoundedStartEnd: classNames(
       'group-first-of-type:rounded-t-md',
       'group-last-of-type:rounded-b-md'

--- a/assets/js/dashboard/components/remove-filter-button.tsx
+++ b/assets/js/dashboard/components/remove-filter-button.tsx
@@ -1,0 +1,8 @@
+/** @format */
+
+import classNames from 'classnames'
+
+export const removeFilterButtonClassname = classNames(
+  'flex items-center',
+  'text-sm font-medium whitespace-nowrap text-indigo-600 dark:text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-600'
+)

--- a/assets/js/dashboard/components/remove-filter-button.tsx
+++ b/assets/js/dashboard/components/remove-filter-button.tsx
@@ -3,6 +3,7 @@
 import classNames from 'classnames'
 
 export const removeFilterButtonClassname = classNames(
-  'flex items-center',
-  'text-sm font-medium whitespace-nowrap text-indigo-600 dark:text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-600'
+  'flex items-center py-1',
+  'text-sm font-medium whitespace-nowrap',
+  'text-gray-700 hover:text-gray-800 dark:text-gray-100 dark:hover:text-gray-200'
 )

--- a/assets/js/dashboard/components/remove-filter-button.tsx
+++ b/assets/js/dashboard/components/remove-filter-button.tsx
@@ -5,5 +5,5 @@ import classNames from 'classnames'
 export const removeFilterButtonClassname = classNames(
   'flex items-center py-1',
   'text-sm font-medium whitespace-nowrap',
-  'text-gray-700 hover:text-gray-800 dark:text-gray-100 dark:hover:text-gray-200'
+  'text-indigo-600 dark:text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-600'
 )

--- a/assets/js/dashboard/keybinding.tsx
+++ b/assets/js/dashboard/keybinding.tsx
@@ -3,6 +3,7 @@ import {
   AppNavigationTarget,
   useAppNavigate
 } from './navigation/use-app-navigate'
+import classNames from 'classnames'
 
 /**
  * Returns whether a keydown or keyup event should be ignored or not.
@@ -134,9 +135,20 @@ export function NavigateKeybind({
   )
 }
 
-export function KeybindHint({ children }: { children: ReactNode }) {
+export function KeybindHint({
+  children,
+  className
+}: {
+  children: ReactNode
+  className?: string
+}) {
   return (
-    <kbd className="rounded border border-gray-200 dark:border-gray-600 px-2 font-mono font-normal text-xs text-gray-400">
+    <kbd
+      className={classNames(
+        'rounded border border-gray-200 dark:border-gray-600 px-2 font-mono font-normal text-xs text-gray-400',
+        className
+      )}
+    >
       {children}
     </kbd>
   )

--- a/assets/js/dashboard/nav-menu/filter-pills-list.tsx
+++ b/assets/js/dashboard/nav-menu/filter-pills-list.tsx
@@ -32,7 +32,10 @@ type NoRenderOutsideSlice = {
 type AppliedFilterPillsListProps = Omit<
   FilterPillsListProps,
   'slice' | 'pillProps' | 'pills'
-> & { slice?: InvisibleOutsideSlice | NoRenderOutsideSlice }
+> & {
+  slice?: InvisibleOutsideSlice | NoRenderOutsideSlice
+  pillClassName?: string
+}
 
 type FilterPillsListProps = {
   direction: 'horizontal' | 'vertical'
@@ -43,7 +46,7 @@ type FilterPillsListProps = {
 export const AppliedFilterPillsList = React.forwardRef<
   HTMLDivElement,
   AppliedFilterPillsListProps
->(({ className, style, slice, direction }, ref) => {
+>(({ className, style, slice, direction, pillClassName }, ref) => {
   const { query } = useQueryContext()
   const navigate = useAppNavigate()
 
@@ -65,7 +68,7 @@ export const AppliedFilterPillsList = React.forwardRef<
   return (
     <FilterPillsList
       pills={renderableFilters.map((filter, index) => ({
-        className: classNames(isInvisible(index) && 'invisible'),
+        className: classNames(isInvisible(index) && 'invisible', pillClassName),
         plainText: plainFilterText(query, filter),
         children: styledFilterText(query, filter),
         interactive: {

--- a/assets/js/dashboard/nav-menu/filters-bar.test.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.test.tsx
@@ -99,7 +99,10 @@ test('user can see expected filters and clear them one by one or all together', 
   ])
 
   await userEvent.click(
-    screen.getByRole('link', { hidden: false, name: 'Clear all filters' })
+    screen.getByRole('link', {
+      hidden: false,
+      name: ['Clear all filters', 'Esc'].join(' ')
+    })
   )
 
   expect(queryFilterPills().map((m) => m.textContent)).toEqual([])

--- a/assets/js/dashboard/nav-menu/filters-bar.test.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.test.tsx
@@ -101,7 +101,7 @@ test('user can see expected filters and clear them one by one or all together', 
   await userEvent.click(
     screen.getByRole('link', {
       hidden: false,
-      name: ['Clear all filters', 'Esc'].join(' ')
+      name: 'Clear all filters'
     })
   )
 

--- a/assets/js/dashboard/nav-menu/filters-bar.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.tsx
@@ -346,8 +346,8 @@ const ClearAction = ({ className }: { className?: string }) => (
       labels: null
     })}
   >
-    <span className="ml-1">Clear all filters</span>
-    <KeybindHint>Esc</KeybindHint>
+    <span className="#ml-1">Clear all filters</span>
+    <KeybindHint className="ml-4">Esc</KeybindHint>
   </AppNavigationLink>
 )
 
@@ -361,7 +361,7 @@ const SaveAsSegmentAction = ({ className }: { className?: string }) => {
       onClick={() => setModal('create')}
       state={{ expandedSegment: null }}
     >
-      <span className="ml-1">Save as segment</span>
+      <span className="#ml-1">Save as segment</span>
     </AppNavigationLink>
   )
 }

--- a/assets/js/dashboard/nav-menu/filters-bar.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.tsx
@@ -6,7 +6,7 @@ import { useQueryContext } from '../query-context'
 import { AppNavigationLink } from '../navigation/use-app-navigate'
 import { Popover, Transition } from '@headlessui/react'
 import { popover } from '../components/popover'
-import { BlurMenuButtonOnEscape, KeybindHint } from '../keybinding'
+import { BlurMenuButtonOnEscape } from '../keybinding'
 import { isSegmentFilter } from '../filtering/segments'
 import { useRoutelessModalsContext } from '../navigation/routeless-modals-context'
 import { DashboardQuery } from '../query'
@@ -264,10 +264,10 @@ const SeeMoreMenu = ({
         {showMoreFilters && (
           <div
             aria-hidden="true"
-            className="right-0 top-0 absolute p-1 flex items-center rounded opacity-50 group-hover:opacity-100 group-focus:opacity-100 transition-opacity"
+            className="absolute flex justify-end left-0 right-0 bottom-0 translate-y-1/4 pr-[3px]"
           >
-            <div style={{ fontSize: 6, lineHeight: 1 }}>
-              {filtersInMenuCount}
+            <div className="text-[10px] leading-[10px] min-w-[10px] font-medium shadow px-[3px] py-[1px] flex items-center rounded-sm bg-gray-100 dark:bg-gray-850">
+              +{filtersInMenuCount}
             </div>
           </div>
         )}
@@ -288,16 +288,19 @@ const SeeMoreMenu = ({
         >
           {showMoreFilters && (
             <>
-              <div className="pt-4 px-4">
+              <div className="py-4 px-4">
                 <AppliedFilterPillsList
                   direction="vertical"
+                  pillClassName="dark:!shadow-gray-950/60"
                   slice={{
                     type: 'no-render-outside',
                     start: visibleFiltersCount
                   }}
                 />
               </div>
-              <div className="mt-4 mb-1 border-gray-200 dark:border-gray-500 border-b"></div>
+              {showSomeActions && (
+                <div className="mb-1 border-gray-200 dark:border-gray-500 border-b"></div>
+              )}
             </>
           )}
           {showSomeActions && (
@@ -346,8 +349,7 @@ const ClearAction = ({ className }: { className?: string }) => (
       labels: null
     })}
   >
-    <span className="#ml-1">Clear all filters</span>
-    <KeybindHint className="ml-4">Esc</KeybindHint>
+    Clear all filters
   </AppNavigationLink>
 )
 
@@ -361,7 +363,7 @@ const SaveAsSegmentAction = ({ className }: { className?: string }) => {
       onClick={() => setModal('create')}
       state={{ expandedSegment: null }}
     >
-      <span className="#ml-1">Save as segment</span>
+      Save as segment
     </AppNavigationLink>
   )
 }

--- a/assets/js/dashboard/nav-menu/filters-bar.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.tsx
@@ -10,6 +10,7 @@ import { BlurMenuButtonOnEscape } from '../keybinding'
 import { isSegmentFilter } from '../filtering/segments'
 import { useRoutelessModalsContext } from '../navigation/routeless-modals-context'
 import { DashboardQuery } from '../query'
+import { removeFilterButtonClassname } from '../components/remove-filter-button'
 
 // Component structure is
 // `..[ filter (x) ]..[ filter (x) ]..[ three dot menu ]..`
@@ -206,8 +207,8 @@ export const FiltersBar = ({ accessors }: FiltersBarProps) => {
             filtersCount={query.filters.length}
             visibleFiltersCount={visibility.visibleCount}
           >
-            {showingClearAll && <ClearAction />}
             {showingSaveAsSegment && <SaveAsSegmentAction />}
+            {showingClearAll && <ClearAction />}
           </SeeMoreMenu>
         )}
     </div>
@@ -287,9 +288,7 @@ const SeeMoreMenu = ({
 
 const ClearAction = () => (
   <AppNavigationLink
-    className={classNames(
-      'button flex self-start h-9 !px-3 !bg-red-500 dark:!bg-red-500 hover:!bg-red-600 dark:hover:!bg-red-700 whitespace-nowrap'
-    )}
+    className={classNames(removeFilterButtonClassname, 'self-start')}
     search={(search) => ({
       ...search,
       filters: null,

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -17,13 +17,14 @@ import { rootRoute } from '../router'
 import { FilterPillsList } from '../nav-menu/filter-pills-list'
 import classNames from 'classnames'
 import { SegmentAuthorship } from './segment-authorship'
-import { ExclamationTriangleIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { MutationStatus } from '@tanstack/react-query'
 import { ApiError } from '../api'
 import { ErrorPanel } from '../components/error-panel'
 import { useSegmentsContext } from '../filtering/segments-context'
 import { useSiteContext } from '../site-context'
 import { useUserContext } from '../user-context'
+import { removeFilterButtonClassname } from '../components/remove-filter-button'
 
 interface ApiRequestProps {
   status: MutationStatus
@@ -496,7 +497,7 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
                 </AppNavigationLink>
 
                 <AppNavigationLink
-                  className={primaryNegativeButtonClassName}
+                  className={removeFilterButtonClassname}
                   path={rootRoute.path}
                   search={(s) => {
                     const nonSegmentFilters = query.filters.filter(
@@ -514,7 +515,6 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
                     }
                   }}
                 >
-                  <TrashIcon className="w-4 h-4 mr-2" />
                   Remove filter
                 </AppNavigationLink>
               </ButtonsRow>

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -401,6 +401,7 @@ const FiltersInSegment = ({ segment_data }: { segment_data: SegmentData }) => {
           className="flex-wrap"
           direction="horizontal"
           pills={segment_data.filters.map((filter) => ({
+            className: 'dark:!shadow-gray-950/60',
             plainText: plainFilterText({ labels: segment_data.labels }, filter),
             children: styledFilterText({ labels: segment_data.labels }, filter),
             interactive: false

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -42,15 +42,15 @@ interface SharedSegmentModalProps {
   namePlaceholder: string
 }
 
-const primaryNeutralButtonClassName = 'button'
+const primaryNeutralButtonClassName = 'button !px-3'
 
 const primaryNegativeButtonClassName = classNames(
-  'button',
+  'button !px-3',
   'items-center !bg-red-500 dark:!bg-red-500 hover:!bg-red-600 dark:hover:!bg-red-700 whitespace-nowrap'
 )
 
 const secondaryButtonClassName = classNames(
-  'button',
+  'button !px-3',
   'border !border-gray-300 dark:!border-gray-500 !text-gray-700 dark:!text-gray-300 !bg-transparent hover:!bg-gray-100 dark:hover:!bg-gray-850'
 )
 

--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -19,8 +19,8 @@ import FilterModalGroup from './filter-modal-group'
 import { rootRoute } from '../../router'
 import { useAppNavigate } from '../../navigation/use-app-navigate'
 import { SegmentModal } from '../../segments/segment-modals'
-import { TrashIcon } from '@heroicons/react/24/outline'
 import { findAppliedSegmentFilter } from '../../filtering/segments'
+import { removeFilterButtonClassname } from '../../components/remove-filter-button'
 
 function partitionFilters(modalType, filters) {
   const otherFilters = []
@@ -192,10 +192,10 @@ class FilterModal extends React.Component {
               />
             ))}
 
-            <div className="mt-6 flex items-center justify-start">
+            <div className="mt-6 flex gap-x-4 items-center justify-start">
               <button
                 type="submit"
-                className="button"
+                className="button !px-3"
                 disabled={this.isDisabled()}
               >
                 Apply filter
@@ -204,16 +204,14 @@ class FilterModal extends React.Component {
               {this.state.hasRelevantFilters && (
                 <button
                   type="button"
-                  className="ml-4 button px-4 flex bg-red-500 dark:bg-red-500 hover:bg-red-600 dark:hover:bg-red-700 items-center"
+                  className={removeFilterButtonClassname}
                   onClick={() => {
                     this.selectFiltersAndCloseModal(this.state.otherFilters)
                   }}
                 >
-                  <TrashIcon className="w-4 h-4 mr-2" />
-                  Remove filter
                   {FILTER_MODAL_TO_FILTER_GROUP[this.props.modalType].length > 1
-                    ? 's'
-                    : ''}
+                    ? 'Remove filters'
+                    : 'Remove filter'}
                 </button>
               )}
             </div>


### PR DESCRIPTION
### Changes

UI tweaks omnibus / buffet. 

- [ ] Adds indicator for how many additional filters are hiding in triple dot menu, if any (addresses https://feedback.plausible.io/582)
- [ ] Makes 'Remove filter(s)' buttons in modals less threatening by changing them to an indigo link in the modals.
- [ ] Makes 'Clear all filters' in triple dot menu / see more menu less threatening by changing it to a dropdown link.
- [ ] Makes 'Save as segment' button stand out less by changing it to a dropdown link.
- [ ] Makes filter pills stand out better in dark theme when rendered in dropdowns and modals with a darker heavier shadow.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
