### PR TITLE
Change site team

### DIFF
--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -37,7 +37,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
           | :multiple_teams
           | :permission_denied
 
-  @type membership :: %Teams.Membership{}
+  @type membership() :: %Teams.Membership{}
 
   @spec bulk_transfer_ownership_direct([Site.t()], Auth.User.t(), Teams.Team.t() | nil) ::
           {:ok, [membership]} | {:error, transfer_error()}
@@ -53,6 +53,14 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
         end
       end
     end)
+  end
+
+  @spec change_team(Site.t(), Auth.User.t(), Teams.Team.t()) ::
+          :ok | {:error, transfer_error()}
+  def change_team(site, user, new_team) do
+    with {:ok, _} <- transfer_ownership(site, user, new_team) do
+      :ok
+    end
   end
 
   @spec accept_invitation(String.t(), Auth.User.t(), Teams.Team.t() | nil) ::

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -15,7 +15,12 @@ defmodule PlausibleWeb.Site.MembershipController do
   use Plausible
   alias Plausible.Site.Memberships
 
-  @only_owner_and_admin_is_allowed_to [:transfer_ownership_form, :transfer_ownership]
+  @only_owner_and_admin_is_allowed_to [
+    :transfer_ownership_form,
+    :transfer_ownership,
+    :change_team,
+    :change_team_form
+  ]
 
   plug PlausibleWeb.RequireAccountPlug
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -507,6 +507,9 @@ defmodule PlausibleWeb.Router do
     get "/sites/:domain/transfer-ownership", Site.MembershipController, :transfer_ownership_form
     post "/sites/:domain/transfer-ownership", Site.MembershipController, :transfer_ownership
 
+    get "/sites/:domain/change-team", Site.MembershipController, :change_team_form
+    post "/sites/:domain/change-team", Site.MembershipController, :change_team
+
     put "/sites/:domain/memberships/u/:id/role/:new_role",
         Site.MembershipController,
         :update_role_by_user

--- a/lib/plausible_web/templates/site/membership/change_team_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/change_team_form.html.heex
@@ -1,0 +1,24 @@
+<.focus_box>
+  <:title>
+    Change the team of {@site.domain}
+  </:title>
+  <:subtitle>
+    Choose the team you'd like to move the site to. The new team must have a sufficient subscription plan.
+  </:subtitle>
+  <.form :let={f} for={@conn} action={Routes.membership_path(@conn, :change_team, @site.domain)}>
+    <div class="my-6">
+      <.input
+        type="select"
+        options={@transferable_teams}
+        field={f[:team_identifier]}
+        label="Destination Team"
+        required="true"
+      />
+      <%= if @conn.assigns[:error] do %>
+        <div class="text-red-500 mt-4">{@conn.assigns[:error]}</div>
+      <% end %>
+    </div>
+
+    <.button type="submit" class="w-full" mt?={false}>Change team</.button>
+  </.form>
+</.focus_box>

--- a/lib/plausible_web/templates/site/settings_danger_zone.html.heex
+++ b/lib/plausible_web/templates/site/settings_danger_zone.html.heex
@@ -14,6 +14,17 @@
     </.button_link>
   </.tile>
 
+  <.tile :if={Enum.count(Plausible.Teams.Users.teams(@current_user, roles: [:owner, :admin])) > 1}>
+    <:title>Change Teams</:title>
+    <:subtitle>Move the site to another team that you are a member of</:subtitle>
+    <.button_link
+      href={Routes.membership_path(@conn, :change_team_form, @site.domain)}
+      theme="danger"
+    >
+      Change {@site.domain} team
+    </.button_link>
+  </.tile>
+
   <.tile>
     <:title>Reset Stats</:title>
     <:subtitle>Reset all stats but keep the site configuration intact</:subtitle>

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -26,6 +26,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       subscribe_to_growth_plan(another)
 
       assert :ok = AcceptInvitation.change_team(site, user, team2)
+      assert Repo.reload!(site).team_id == team2.id
+      assert_team_membership(user, team2, :owner)
     end
 
     test "changes the team if admin in second team" do
@@ -41,6 +43,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       add_member(team2, user: user, role: :admin)
 
       assert :ok = AcceptInvitation.change_team(site, user, team2)
+      assert Repo.reload!(site).team_id == team2.id
+      assert_team_membership(user, team2, :admin)
     end
 
     for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do
@@ -57,6 +61,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
         add_member(team2, user: user, role: unquote(role))
 
         assert {:error, :permission_denied} = AcceptInvitation.change_team(site, user, team2)
+        refute Repo.reload!(site).team_id == team2.id
       end
     end
   end

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -9,6 +9,58 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
 
   @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
+  describe "change_team/3" do
+    test "changes the team if owner in both teams" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :owner)
+
+      assert {:error, :no_plan} = AcceptInvitation.change_team(site, user, team2)
+
+      subscribe_to_growth_plan(another)
+
+      assert :ok = AcceptInvitation.change_team(site, user, team2)
+    end
+
+    test "changes the team if admin in second team" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      subscribe_to_growth_plan(another)
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :admin)
+
+      assert :ok = AcceptInvitation.change_team(site, user, team2)
+    end
+
+    for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do
+      test "refuses to change the team if #{role} in second team" do
+        user = new_user()
+        site = new_site(owner: user)
+
+        another = new_user()
+        subscribe_to_growth_plan(another)
+        new_site(owner: another)
+
+        team2 = team_of(another)
+
+        add_member(team2, user: user, role: unquote(role))
+
+        assert {:error, :permission_denied} = AcceptInvitation.change_team(site, user, team2)
+      end
+    end
+  end
+
   describe "bulk_transfer_ownership_direct/2" do
     test "transfers ownership for multiple sites in one action" do
       current_owner = new_user()

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -28,6 +28,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert :ok = AcceptInvitation.change_team(site, user, team2)
       assert Repo.reload!(site).team_id == team2.id
       assert_team_membership(user, team2, :owner)
+      assert_no_emails_delivered()
     end
 
     test "changes the team if admin in second team" do
@@ -45,6 +46,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert :ok = AcceptInvitation.change_team(site, user, team2)
       assert Repo.reload!(site).team_id == team2.id
       assert_team_membership(user, team2, :admin)
+      assert_no_emails_delivered()
     end
 
     for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -10,7 +10,23 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
   @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
   describe "change_team/3" do
-    test "changes the team if owner in both teams" do
+    @tag :ce_build_only
+    test "changes the team if owner in both teams (CE)" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :owner)
+
+      assert :ok = AcceptInvitation.change_team(site, user, team2)
+    end
+
+    @tag :ee_only
+    test "changes the team if owner in both teams (EE)" do
       user = new_user()
       site = new_site(owner: user)
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1850,6 +1850,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert element_exists?(html, ~s|button[type=submit]|)
     end
 
+    @tag :ee_only
     test "change team form error: destination team has no subscription", %{
       user: user,
       conn: conn,
@@ -1869,6 +1870,7 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert html =~ "This team has no subscription"
     end
 
+    @tag :ee_only
     test "change team form error: subscription insufficient", %{
       user: user,
       conn: conn,

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1813,4 +1813,128 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert Repo.reload(site).stats_start_date == nil
     end
   end
+
+  describe "change team" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "no change team section appears when <1 team", %{conn: conn, site: site} do
+      conn = get(conn, Routes.site_path(conn, :settings_danger_zone, site.domain))
+      html = html_response(conn, 200)
+      assert html =~ "Danger Zone"
+      assert html =~ "Delete #{site.domain}"
+      refute html =~ "Change #{site.domain} team"
+    end
+
+    test "change team section appears when >1 team", %{user: user, conn: conn, site: site} do
+      join_2nd_team(user)
+
+      conn = get(conn, Routes.site_path(conn, :settings_danger_zone, site.domain))
+      html = html_response(conn, 200)
+      assert html =~ "Danger Zone"
+      assert html =~ "Delete #{site.domain}"
+      assert html =~ "Change #{site.domain} team"
+    end
+
+    test "change team form renders", %{user: user, conn: conn, site: site} do
+      join_2nd_team(user)
+
+      conn = get(conn, Routes.membership_path(conn, :change_team_form, site.domain))
+      html = html_response(conn, 200)
+      assert html =~ "Change the team of #{site.domain}"
+
+      assert element_exists?(
+               html,
+               ~s|form[action="#{Routes.membership_path(conn, :change_team, site.domain)}"]|
+             )
+
+      assert element_exists?(html, ~s|button[type=submit]|)
+    end
+
+    test "change team form error: destination team has no subscription", %{
+      user: user,
+      conn: conn,
+      site: site
+    } do
+      team2 = join_2nd_team(user)
+
+      conn =
+        post(
+          conn,
+          Routes.membership_path(conn, :change_team, site.domain,
+            team_identifier: team2.identifier
+          )
+        )
+
+      html = html_response(conn, 200)
+      assert html =~ "This team has no subscription"
+    end
+
+    test "change team form error: subscription insufficient", %{
+      user: user,
+      conn: conn,
+      site: site
+    } do
+      team2 = join_2nd_team(user, subscribe?: true)
+
+      generate_usage_for(site, 11_000, NaiveDateTime.utc_now() |> NaiveDateTime.shift(day: -5))
+      generate_usage_for(site, 11_000, NaiveDateTime.utc_now() |> NaiveDateTime.shift(day: -35))
+
+      conn =
+        post(
+          conn,
+          Routes.membership_path(conn, :change_team, site.domain,
+            team_identifier: team2.identifier
+          )
+        )
+
+      html = html_response(conn, 200)
+      assert text(html) =~ "This team's subscription outgrows site usage"
+    end
+
+    test "change team form error: unknown team identifier", %{
+      conn: conn,
+      site: site
+    } do
+      assert_raise Ecto.NoResultsError, fn ->
+        post(
+          conn,
+          Routes.membership_path(conn, :change_team, site.domain,
+            team_identifier: Ecto.UUID.generate()
+          )
+        )
+      end
+    end
+
+    test "successfully changes team", %{
+      user: user,
+      conn: conn,
+      site: site
+    } do
+      team2 = join_2nd_team(user, subscribe?: true)
+
+      conn =
+        post(
+          conn,
+          Routes.membership_path(conn, :change_team, site.domain,
+            team_identifier: team2.identifier
+          )
+        )
+
+      assert redirected_to(conn) == "/sites?__team=#{team2.identifier}"
+      assert Phoenix.Flash.get(conn.assigns.flash, :success) =~ "Site team was changed"
+    end
+
+    defp join_2nd_team(user, opts \\ []) do
+      another = new_user()
+      new_site(owner: another)
+      team2 = team_of(another)
+      add_member(team2, user: user, role: :admin)
+
+      if opts[:subscribe?] do
+        subscribe_to_growth_plan(another)
+      end
+
+      team2
+    end
+  end
 end


### PR DESCRIPTION
### Changes

In case the user belongs to more than 1 team, in either admin or owner roles, Site's Danger Zone section allows changing the team. Team change is effectively identical to inviting user's own e-mail to site transfer, except bypasses the invitation flow.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
