### PR TITLE
Adjust `api_keys.team_id` index, making it non-unique

### DIFF
--- a/priv/repo/migrations/20250325144254_alter_api_keys_team_id_index.exs
+++ b/priv/repo/migrations/20250325144254_alter_api_keys_team_id_index.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AlterApiKeysTeamIdIndex do
+  use Ecto.Migration
+
+  def change do
+    drop unique_index(:api_keys, [:team_id, :user_id])
+
+    create index(:api_keys, [:team_id])
+  end
+end


### PR DESCRIPTION
### Changes

I have hastily assumed that team_id/user_id combination should be unique for API keys, while it obviously shouldn't, as a single user might very well have more than one key per team.


