### PR TITLE
Fix user and team deletion from CRM

### DIFF
--- a/lib/plausible/auth/user_admin.ex
+++ b/lib/plausible/auth/user_admin.ex
@@ -22,10 +22,13 @@ defmodule Plausible.Auth.UserAdmin do
   def delete(_conn, %{data: user}) do
     case Plausible.Auth.delete_user(user) do
       {:ok, :deleted} ->
-        :ok
+        {:ok, user}
+
+      {:error, :active_subscription} ->
+        {user, "User's personal team has an active subscription which must be canceled first."}
 
       {:error, :is_only_team_owner} ->
-        "The user is the only public team owner on one or more teams."
+        {user, "The user is the only public team owner on one or more teams."}
     end
   end
 

--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -87,9 +87,14 @@ defmodule Plausible.Teams.TeamAdmin do
     ]
   end
 
-  def delete(_conn, %{data: _team}) do
-    # TODO: Implement custom team removal
-    "Cannot remove the team for now"
+  def delete(_conn, %{data: team}) do
+    case Teams.delete(team) do
+      {:ok, :deleted} ->
+        {:ok, team}
+
+      {:error, :active_subscription} ->
+        {team, "The team has an active subscription which must be canceled first."}
+    end
   end
 
   def grace_period_status(team) do

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -74,6 +74,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       :ok
     end
 
+    @tag :ee_only
     test "deletes a user without a team", %{conn: conn} do
       another_user = new_user()
 
@@ -83,6 +84,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       refute Repo.reload(another_user)
     end
 
+    @tag :ee_only
     test "deletes a user with a personal team without subscription", %{conn: conn} do
       another_user = new_user()
       site = new_site(owner: another_user)
@@ -96,6 +98,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       refute Repo.reload(team)
     end
 
+    @tag :ee_only
     test "fails to delete a user with a personal team with active subscription", %{conn: conn} do
       another_user = new_user() |> subscribe_to_growth_plan()
       site = new_site(owner: another_user)
@@ -112,6 +115,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       assert Repo.reload(team)
     end
 
+    @tag :ee_only
     test "fails to delete a user who is the only owner on a public team", %{conn: conn} do
       another_user = new_user()
       site = new_site(owner: another_user)
@@ -138,6 +142,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       :ok
     end
 
+    @tag :ee_only
     test "deletes a team", %{conn: conn} do
       another_user = new_user()
       site = new_site(owner: another_user)
@@ -151,6 +156,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       assert Repo.reload(another_user)
     end
 
+    @tag :ee_only
     test "fails to delete a team with an active subscription", %{conn: conn} do
       another_user = new_user() |> subscribe_to_growth_plan()
       site = new_site(owner: another_user)

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -65,6 +65,109 @@ defmodule PlausibleWeb.AdminControllerTest do
     end
   end
 
+  describe "DELETE /crm/auth/user/:user_id" do
+    setup [:create_user, :log_in]
+
+    setup %{user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      :ok
+    end
+
+    test "deletes a user without a team", %{conn: conn} do
+      another_user = new_user()
+
+      conn = delete(conn, "/crm/auth/user/#{another_user.id}")
+      assert redirected_to(conn, 302) == "/crm/auth/user"
+
+      refute Repo.reload(another_user)
+    end
+
+    test "deletes a user with a personal team without subscription", %{conn: conn} do
+      another_user = new_user()
+      site = new_site(owner: another_user)
+      team = team_of(another_user)
+
+      conn = delete(conn, "/crm/auth/user/#{another_user.id}")
+      assert redirected_to(conn, 302) == "/crm/auth/user"
+
+      refute Repo.reload(another_user)
+      refute Repo.reload(site)
+      refute Repo.reload(team)
+    end
+
+    test "fails to delete a user with a personal team with active subscription", %{conn: conn} do
+      another_user = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: another_user)
+      team = team_of(another_user)
+
+      conn = delete(conn, "/crm/auth/user/#{another_user.id}")
+      assert redirected_to(conn, 302) == "/crm/auth/user/#{another_user.id}"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "User's personal team has an active subscription"
+
+      assert Repo.reload(another_user)
+      assert Repo.reload(site)
+      assert Repo.reload(team)
+    end
+
+    test "fails to delete a user who is the only owner on a public team", %{conn: conn} do
+      another_user = new_user()
+      site = new_site(owner: another_user)
+      team = another_user |> team_of() |> Plausible.Teams.complete_setup()
+
+      conn = delete(conn, "/crm/auth/user/#{another_user.id}")
+      assert redirected_to(conn, 302) == "/crm/auth/user/#{another_user.id}"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "The user is the only public team owner"
+
+      assert Repo.reload(another_user)
+      assert Repo.reload(site)
+      assert Repo.reload(team)
+    end
+  end
+
+  describe "DELETE /crm/teams/team/:team_id" do
+    setup [:create_user, :log_in]
+
+    setup %{user: user} do
+      patch_env(:super_admin_user_ids, [user.id])
+
+      :ok
+    end
+
+    test "deletes a team", %{conn: conn} do
+      another_user = new_user()
+      site = new_site(owner: another_user)
+      team = team_of(another_user)
+
+      conn = delete(conn, "/crm/teams/team/#{team.id}")
+      assert redirected_to(conn, 302) == "/crm/teams/team"
+
+      refute Repo.reload(team)
+      refute Repo.reload(site)
+      assert Repo.reload(another_user)
+    end
+
+    test "fails to delete a team with an active subscription", %{conn: conn} do
+      another_user = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: another_user)
+      team = team_of(another_user)
+
+      conn = delete(conn, "/crm/teams/team/#{team.id}")
+      assert redirected_to(conn, 302) == "/crm/teams/team/#{team.id}"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "The team has an active subscription"
+
+      assert Repo.reload(team)
+      assert Repo.reload(site)
+      assert Repo.reload(another_user)
+    end
+  end
+
   describe "POST /crm/sites/site/:site_id" do
     setup [:create_user, :log_in]
 


### PR DESCRIPTION
### Changes

The user delete action wasn't properly tested and was returning wrong result format. The error format turned out wrong too. Team delete action was missing. This PR fixes both CRM actions and adds tests against them.

### Tests
- [x] Automated tests have been added

