### PR TITLE
Upgrade page fixes

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -253,4 +253,12 @@ defmodule Plausible.Billing do
 
     team
   end
+
+  def dashboard_locked_notice_title(), do: "Dashboard locked"
+  def active_grace_period_notice_title(), do: "You have outgrown your Plausible subscription tier"
+  def subscription_cancelled_notice_title(), do: "Subscription cancelled"
+  def subscription_past_due_notice_title(), do: "Payment failed"
+  def subscription_paused_notice_title(), do: "Subscription paused"
+  def upgrade_ineligible_notice_title(), do: "No sites owned"
+  def pending_site_ownerships_notice_title(), do: "Pending ownership transfers"
 end

--- a/lib/plausible/billing/qouta/quota.ex
+++ b/lib/plausible/billing/qouta/quota.ex
@@ -46,15 +46,17 @@ defmodule Plausible.Billing.Quota do
   `:custom` is returned. This means that this kind of usage should get on
   a custom plan.
 
+  To avoid confusion, we do not recommend Growth tiers for customers that
+  are already on a Business tier (even if their usage would fit Growth).
+
   `nil` is returned if the usage is not eligible for upgrade.
   """
-  def suggest_tier(usage, highest_growth_plan, highest_business_plan) do
-    if eligible_for_upgrade?(usage) do
-      cond do
-        usage_fits_plan?(usage, highest_growth_plan) -> :growth
-        usage_fits_plan?(usage, highest_business_plan) -> :business
-        true -> :custom
-      end
+  def suggest_tier(usage, highest_growth, highest_business, owned_tier) do
+    cond do
+      not eligible_for_upgrade?(usage) -> nil
+      usage_fits_plan?(usage, highest_growth) and owned_tier != :business -> :growth
+      usage_fits_plan?(usage, highest_business) -> :business
+      true -> :custom
     end
   end
 

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -11,7 +11,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       ~H"""
       <aside class="container">
         <.notice
-          title="You have outgrown your Plausible subscription tier"
+          title={Plausible.Billing.active_grace_period_notice_title()}
           class="shadow-md dark:shadow-none"
         >
           To keep your stats running smoothly, it’s time to upgrade your subscription to match your growing usage.
@@ -28,7 +28,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       ~H"""
       <aside class="container">
         <.notice
-          title="You have outgrown your Plausible subscription tier"
+          title={Plausible.Billing.active_grace_period_notice_title()}
           class="shadow-md dark:shadow-none"
         >
           To keep your stats running smoothly, it’s time to upgrade your subscription to match your growing usage.
@@ -47,7 +47,10 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   def dashboard_locked(assigns) do
     ~H"""
     <aside class="container">
-      <.notice title="Dashboard locked" class="shadow-md dark:shadow-none">
+      <.notice
+        title={Plausible.Billing.dashboard_locked_notice_title()}
+        class="shadow-md dark:shadow-none"
+      >
         Since you’ve outgrown your current subscription tier, it’s time to upgrade to match your growing usage.
         <.link
           href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
@@ -123,7 +126,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     <aside id="global-subscription-cancelled-notice" class="container">
       <.notice
         dismissable_id={Plausible.Billing.cancelled_subscription_notice_dismiss_id(@subscription.id)}
-        title="Subscription cancelled"
+        title={Plausible.Billing.subscription_cancelled_notice_title()}
         theme={:red}
         class="shadow-md dark:shadow-none"
       >
@@ -143,7 +146,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
     ~H"""
     <aside id={@container_id} class="hidden">
-      <.notice title="Subscription cancelled" theme={:red} class="shadow-md dark:shadow-none">
+      <.notice
+        title={Plausible.Billing.subscription_cancelled_notice_title()}
+        theme={:red}
+        class="shadow-md dark:shadow-none"
+      >
         <.subscription_cancelled_notice_body subscription={@subscription} />
       </.notice>
     </aside>
@@ -170,7 +177,10 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       ) do
     ~H"""
     <aside class={@class}>
-      <.notice title="Payment failed" class="shadow-md dark:shadow-none">
+      <.notice
+        title={Plausible.Billing.subscription_past_due_notice_title()}
+        class="shadow-md dark:shadow-none"
+      >
         There was a problem with your latest payment. Please update your payment information to keep using Plausible.<.link
           href={@subscription.update_url}
           class="whitespace-nowrap font-semibold"
@@ -190,7 +200,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       ) do
     ~H"""
     <aside class={@class}>
-      <.notice title="Subscription paused" theme={:red} class="shadow-md dark:shadow-none">
+      <.notice
+        title={Plausible.Billing.subscription_paused_notice_title()}
+        theme={:red}
+        class="shadow-md dark:shadow-none"
+      >
         Your subscription is paused due to failed payments. Please provide valid payment details to keep using Plausible.<.link
           href={@subscription.update_url}
           class="whitespace-nowrap font-semibold"
@@ -205,7 +219,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   def upgrade_ineligible(assigns) do
     ~H"""
     <aside id="upgrade-eligible-notice" class="pb-6">
-      <.notice title="No sites owned" theme={:yellow} class="shadow-md dark:shadow-none">
+      <.notice
+        title={Plausible.Billing.upgrade_ineligible_notice_title()}
+        theme={:yellow}
+        class="shadow-md dark:shadow-none"
+      >
         You cannot start a subscription as your account doesn't own any sites. The account that owns the sites is responsible for the billing. Please either
         <.styled_link href="https://plausible.io/docs/transfer-ownership">
           transfer the sites
@@ -227,7 +245,10 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
       ~H"""
       <aside class={@class}>
-        <.notice title="Pending ownership transfers" class="shadow-md dark:shadow-none mt-4">
+        <.notice
+          title={Plausible.Billing.pending_site_ownerships_notice_title()}
+          class="shadow-md dark:shadow-none mt-4"
+        >
           {@message} To exclude pending sites from your usage, please go to
           <.link href="https://plausible.io/sites" class="whitespace-nowrap font-semibold">
             plausible.io/sites

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -23,6 +23,7 @@ defmodule PlausibleWeb.BillingController do
       redirect(conn, to: Routes.billing_path(conn, :upgrade_to_enterprise_plan))
     else
       render(conn, "choose_plan.html",
+        disable_global_notices?: true,
         skip_plausible_tracking: true,
         connect_live_socket: true
       )

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -42,10 +42,14 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       |> assign_new(:available_plans, fn %{subscription: subscription} ->
         Plans.available_plans_for(subscription, with_prices: true, customer_ip: remote_ip)
       end)
-      |> assign_new(:recommended_tier, fn %{usage: usage, available_plans: available_plans} ->
+      |> assign_new(:recommended_tier, fn %{
+                                            usage: usage,
+                                            available_plans: available_plans,
+                                            owned_tier: owned_tier
+                                          } ->
         highest_growth_plan = List.last(available_plans.growth)
         highest_business_plan = List.last(available_plans.business)
-        Quota.suggest_tier(usage, highest_growth_plan, highest_business_plan)
+        Quota.suggest_tier(usage, highest_growth_plan, highest_business_plan, owned_tier)
       end)
       |> assign_new(:available_volumes, fn %{available_plans: available_plans} ->
         get_available_volumes(available_plans)

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -35,7 +35,10 @@
   >
     <%= if !assigns[:embedded] do %>
       {render("_header.html", assigns)}
-      {render("_notice.html", assigns)}
+
+      <%= if !assigns[:disable_global_notices?] do %>
+        {render("_notice.html", assigns)}
+      <% end %>
     <% end %>
 
     <main class="flex-1">

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -577,7 +577,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert text_of_element(doc, @slider_value) == "10k"
     end
 
-    test "highlights Business box as the 'Current' tier if it's suitable for their usage", %{
+    test "highlights Business box as the 'Current' tier", %{
       conn: conn,
       site: site
     } do
@@ -592,20 +592,6 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert text_of_element(doc, @business_highlight_pill) == "Current"
 
       refute element_exists?(doc, @growth_highlight_pill)
-    end
-
-    test "highlights Growth box as the 'Recommended' tier if it would accommodate their usage", %{
-      conn: conn
-    } do
-      {:ok, _lv, doc} = get_liveview(conn)
-
-      class = class_of_element(doc, @growth_plan_box)
-
-      assert class =~ "ring-2"
-      assert class =~ "ring-indigo-600"
-      assert text_of_element(doc, @growth_highlight_pill) == "Recommended"
-
-      refute element_exists?(doc, @business_highlight_pill)
     end
 
     test "recommends Enterprise when site limit exceeds Business tier due to pending ownerships",

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -6,7 +6,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   import Phoenix.LiveViewTest
   import Plausible.Test.Support.HTML
   require Plausible.Billing.Subscription.Status
-  alias Plausible.{Repo, Billing.Subscription}
+  alias Plausible.{Repo, Billing, Billing.Subscription}
 
   @v1_10k_yearly_plan_id "572810"
   @v1_50m_yearly_plan_id "650653"
@@ -54,6 +54,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert doc =~ "What happens if I go over my page views limit?"
       assert doc =~ "Enterprise"
       assert doc =~ "+ VAT if applicable"
+    end
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
     end
 
     test "displays plan benefits", %{conn: conn} do
@@ -371,7 +376,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
   end
 
-  describe "for a user with a v4 growth subscription plan" do
+  describe "for a user with an active v4 growth subscription plan" do
     setup [:create_user, :create_site, :log_in, :subscribe_v4_growth]
 
     test "displays basic page content", %{conn: conn} do
@@ -380,6 +385,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert doc =~ "Change subscription plan"
       assert doc =~ "Questions?"
       refute doc =~ "What happens if I go over my page views limit?"
+    end
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
     end
 
     test "displays plan benefits", %{conn: conn} do
@@ -462,6 +472,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       {:ok, _lv, doc} = get_liveview(conn)
 
+      check_notice_titles(doc, [Billing.pending_site_ownerships_notice_title()])
       assert doc =~ "Your account has been invited to become the owner of a site"
 
       assert text_of_element(doc, @growth_plan_tooltip) ==
@@ -569,12 +580,17 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
   end
 
-  describe "for a user with a v4 business subscription plan" do
+  describe "for a user with an active v4 business subscription plan" do
     setup [:create_user, :create_site, :log_in, :subscribe_v4_business]
 
     test "sets pageview slider according to last cycle usage", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @slider_value) == "10k"
+    end
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
     end
 
     test "highlights Business box as the 'Current' tier", %{
@@ -733,6 +749,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, context}
     end
 
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
+
     test "displays plan benefits", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
@@ -777,6 +798,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
     test "renders failed payment notice and link to update billing details", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [Billing.subscription_past_due_notice_title()])
       assert doc =~ "There was a problem with your latest payment"
       assert doc =~ "https://update.billing.details"
     end
@@ -810,6 +832,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
     test "renders subscription paused notice and link to update billing details", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [Billing.subscription_paused_notice_title()])
       assert doc =~ "Your subscription is paused due to failed payments"
       assert doc =~ "https://update.billing.details"
     end
@@ -838,8 +861,13 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     end
   end
 
-  describe "for a user with a cancelled subscription" do
+  describe "for a user with a cancelled, but still active subscription" do
     setup [:create_user, :create_site, :log_in, :create_cancelled_subscription]
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
 
     test "checkout buttons are paddle buttons", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
@@ -849,7 +877,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                "Paddle.Checkout.open"
     end
 
-    test "currently owned tier is highlighted if stats are still unlocked", %{conn: conn} do
+    test "currently owned tier is highlighted", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @growth_highlight_pill) == "Current"
     end
@@ -858,9 +886,12 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, _lv, doc} = get_liveview(conn)
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
     end
+  end
 
-    test "highlights recommended tier if subscription expired and no days are paid for anymore",
-         %{conn: conn, user: user} do
+  describe "for a user with a cancelled and expired subscription" do
+    setup [:create_user, :create_site, :log_in, :create_cancelled_subscription]
+
+    setup %{user: user} do
       user
       |> team_of()
       |> Repo.preload(:subscription)
@@ -868,6 +899,15 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       |> Subscription.changeset(%{next_bill_date: Timex.shift(Timex.now(), months: -2)})
       |> Repo.update!()
 
+      :ok
+    end
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
+
+    test "highlights recommended tier", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @growth_highlight_pill) == "Recommended"
       refute text_of_element(doc, @business_highlight_pill) == "Recommended"
@@ -876,6 +916,12 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
   describe "for a grandfathered user with a high volume plan" do
     setup [:create_user, :create_site, :log_in]
+
+    test "does not render any global notices", %{conn: conn, user: user} do
+      create_subscription_for(user, paddle_plan_id: @v1_50m_yearly_plan_id)
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
 
     test "on a 50M v1 plan, Growth tiers are available at 20M, 50M, 50M+, but Business tiers are not",
          %{conn: conn, user: user} do
@@ -933,6 +979,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, context}
     end
 
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
+
     test "v1 20M and 50M Growth plans are not available",
          %{conn: conn} do
       {:ok, lv, _doc} = get_liveview(conn)
@@ -979,16 +1030,26 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       refute enterprise_box =~ "10+ team members"
       refute enterprise_box =~ "Unlimited team members"
     end
+  end
 
-    test "allows to upgrade without a trial_expiry_date when the user owns a site", %{
-      conn: conn,
-      user: user
-    } do
+  describe "for a user without a trial_expiry_date (invited user) who owns a site (transferred)" do
+    setup [:create_user, :create_site, :log_in]
+
+    setup %{user: user} do
       user
       |> team_of()
       |> Ecto.Changeset.change(trial_expiry_date: nil)
       |> Repo.update!()
 
+      :ok
+    end
+
+    test "does not render any global notices", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [])
+    end
+
+    test "allows to upgrade", %{conn: conn} do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "100k")
 
@@ -1039,6 +1100,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "does not allow to subscribe and renders notice", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      check_notice_titles(doc, [Billing.upgrade_ineligible_notice_title()])
+
       assert text_of_element(doc, "#upgrade-eligible-notice") =~ "You cannot start a subscription"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
@@ -1048,21 +1111,48 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   describe "for a user with no sites but pending ownership transfer" do
     setup [:create_user, :log_in]
 
-    test "allows to subscribe and does not render the 'upgrade ineligible' notice", %{
-      conn: conn,
-      user: user
-    } do
+    setup %{user: user} do
       old_owner = new_user()
       site = new_site(owner: old_owner)
       invite_transfer(site, user, inviter: old_owner)
 
+      :ok
+    end
+
+    test "renders only the pending ownership transfer notice", %{conn: conn} do
+      {:ok, _lv, doc} = get_liveview(conn)
+      check_notice_titles(doc, [Billing.pending_site_ownerships_notice_title()])
+    end
+
+    test "allows to subscribe", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
-      refute text_of_element(doc, "#upgrade-eligible-notice") =~ "You cannot start a subscription"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
       assert text_of_element(doc, @growth_plan_box) =~ "Recommended"
     end
+  end
+
+  # Checks the given HTML document for the presence of all possible billing
+  # notices. For those expected, we assert that only one is present. Others
+  # should not appear in the document.
+  defp check_notice_titles(doc, expected) do
+    [
+      Billing.dashboard_locked_notice_title(),
+      Billing.active_grace_period_notice_title(),
+      Billing.subscription_cancelled_notice_title(),
+      Billing.subscription_past_due_notice_title(),
+      Billing.subscription_paused_notice_title(),
+      Billing.upgrade_ineligible_notice_title(),
+      Billing.pending_site_ownerships_notice_title()
+    ]
+    |> Enum.each(fn title ->
+      if title in expected do
+        assert length(String.split(doc, title)) == 2
+      else
+        refute doc =~ title
+      end
+    end)
   end
 
   defp subscribe_v4_growth(%{user: user}) do


### PR DESCRIPTION
### Changes

### 1. Do not recommend Growth tier for Business customers

https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8237275669

Stop highlighting the Growth box on the upgrade page for Business subscribers, even if their usage would allow downgrading to Growth. This only creates confusion as the email asks users to upgrade, but on the upgrade page, the Growth plan says "Downgrade to Growth".

Instead we will highlight the Business box as the "Current" tier, and do not "Recommend" any tier at all.

### 2. Stop rendering global billing notices on the upgrade page.

https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7881526960

Notices like "Dashboard locked" or "You've outgrown your subscription tier" were never intended to show up on that page. The only notices that this page should display are:

* Pending ownerships - just to let the user know that these are counted towards their usage on the upgrade page.
* No sites owned - e.g. the user is an invited user and hasn't added any sites for their own team yet. The upgrade page renders in an error state, not allowing the user to click the upgrade buttons.
* Subscription past due or paused - also looks like an error state, the user is not allowed to click the upgrade links. Instead they have to either 1) click the link in the notice to upgrade their billing details or 2) cancel their current subscription and subscribe again, providing new details from scratch

This PR fixes it so that only the intended messages are rendered, and also adds tests to refute any other notices showing up.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
