### PR TITLE
Increase Conversion Rate precision by one decimal place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Increase decimal precision of the "Conversion rate" metric from 1 to 2 (e.g. 16.7 -> 16.67)
 - The "Last 30 days" period is now "Last 28 days" on the dashboard and also the new default. Keyboard shortcut `T` still works for last 30 days.
 - Last `7d` and `30d` periods do not include today anymore
 - Filters appear in the search bar as ?f=is,page,/docs,/blog&f=... instead of ?filters=((is,page,(/docs,/blog)),...) for Plausible links sent on various platforms to work reliably.

--- a/lib/plausible/stats/sql/special_metrics.ex
+++ b/lib/plausible/stats/sql/special_metrics.ex
@@ -70,7 +70,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
       |> select_merge_as([e], %{
         conversion_rate:
           fragment(
-            "if(? > 0, round(? / ? * 100, 1), 0)",
+            "if(? > 0, round(? / ? * 100, 2), 0)",
             selected_as(:total_visitors),
             selected_as(:visitors),
             selected_as(:total_visitors)
@@ -114,7 +114,7 @@ defmodule Plausible.Stats.SQL.SpecialMetrics do
         total_visitors: c.visitors,
         group_conversion_rate:
           fragment(
-            "if(? > 0, round(? / ? * 100, 1), 0)",
+            "if(? > 0, round(? / ? * 100, 2), 0)",
             c.visitors,
             e.visitors,
             c.visitors

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -983,21 +983,21 @@ defmodule Plausible.Imported.CSVImporterTest do
         assert exported["events"] == imported["events"]
       end)
 
-      # NOTE: goal breakdown's conversion rate difference is up to 18%
+      # NOTE: goal breakdown's conversion rate difference is up to 19%
       assert summary(field(exported_goals, "conversion_rate")) == [
-               0.1,
-               0.55,
-               1.0,
-               3.3,
-               5.6
+               0.08,
+               0.515,
+               0.95,
+               3.255,
+               5.56
              ]
 
       assert summary(field(imported_goals, "conversion_rate")) == [
-               0.1,
-               0.5,
-               0.9,
-               3.8499999999999996,
-               6.8
+               0.08,
+               0.505,
+               0.93,
+               3.87,
+               6.81
              ]
 
       assert summary(
@@ -1006,10 +1006,10 @@ defmodule Plausible.Imported.CSVImporterTest do
                end)
              ) == [
                0.0,
-               0.05555555555555558,
-               0.11111111111111116,
-               0.14379084967320266,
-               0.17647058823529416
+               0.010752688172043001,
+               0.021505376344086002,
+               0.10252948699729997,
+               0.18355359765051393
              ]
 
       # url property breakdown
@@ -1024,15 +1024,28 @@ defmodule Plausible.Imported.CSVImporterTest do
         assert exported["events"] == imported["events"]
       end)
 
-      # NOTE: url property breakdown's conversion rate difference is up to 20%
-      assert summary(field(exported_url_props, "conversion_rate")) == [0.1, 0.1, 0.1, 0.1, 0.8]
-      assert summary(field(imported_url_props, "conversion_rate")) == [0.1, 0.1, 0.1, 0.1, 0.8]
+      # NOTE: url property breakdown's conversion rate difference is up to 7%
+      assert summary(field(exported_url_props, "conversion_rate")) == [
+               0.08,
+               0.08,
+               0.08,
+               0.08,
+               0.79
+             ]
+
+      assert summary(field(imported_url_props, "conversion_rate")) == [
+               0.08,
+               0.08,
+               0.08,
+               0.08,
+               0.77
+             ]
 
       assert summary(
                pairwise(exported_url_props, imported_url_props, fn exported, imported ->
                  abs(1 - exported["conversion_rate"] / imported["conversion_rate"])
                end)
-             ) == [0.0, 0.0, 0.0, 0.0, 0.19999999999999996]
+             ) == [0.0, 0.0, 0.0, 0.0, 0.06666666666666665]
 
       # path property breakdown
       exported_path_props = goal_breakdown.(exported_site, "event:props:path", "event:goal==404")
@@ -1041,7 +1054,7 @@ defmodule Plausible.Imported.CSVImporterTest do
       pairwise(exported_path_props, imported_path_props, fn exported, imported ->
         assert exported["visitors"] == imported["visitors"]
         assert exported["events"] == imported["events"]
-        assert exported["conversion_rate"] == imported["conversion_rate"]
+        assert abs(exported["conversion_rate"] - imported["conversion_rate"]) < 0.011
       end)
     end
 

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -473,19 +473,19 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
                "goal" => "scroll",
                "visitors" => 1513,
                "events" => 2130,
-               "conversion_rate" => 24.7
+               "conversion_rate" => 24.69
              },
              %{
                "goal" => "Outbound Link: Click",
                "visitors" => 17,
                "events" => 17,
-               "conversion_rate" => 0.3
+               "conversion_rate" => 0.28
              },
              %{
                "goal" => "view_search_results",
                "visitors" => 11,
                "events" => 30,
-               "conversion_rate" => 0.2
+               "conversion_rate" => 0.18
              }
            ]
   end
@@ -511,13 +511,14 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
                "events" => 6
              }
 
-    assert %{
-             "url" =>
-               "http://www.jamieoliver.com/recipes/pasta-recipes/spinach-ricotta-cannelloni/",
-             "visitors" => 1,
-             "conversion_rate" => 0.0,
-             "events" => 1
-           } in results
+    results
+    |> Enum.find(
+      &(&1["url"] ==
+          "http://www.jamieoliver.com/recipes/pasta-recipes/spinach-ricotta-cannelloni/")
+    )
+    |> then(fn page ->
+      assert %{"visitors" => 1, "conversion_rate" => 0.02, "events" => 1} = page
+    end)
   end
 
   defp assert_timeseries(conn, params) do

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/channels.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/channels.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-Direct,1,33.3
+Direct,1,33.33

--- a/test/plausible_web/controllers/CSVs/30d-filter-goal/sources.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-goal/sources.csv
@@ -1,2 +1,2 @@
 name,conversions,conversion_rate
-Direct / None,1,33.3
+Direct / None,1,33.33

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -444,7 +444,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
                "conversion_rate" => %{
                  "value" => 50.0,
                  "change" => 16.7,
-                 "comparison_value" => 33.3
+                 "comparison_value" => 33.33
                }
              }
     end

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -2848,7 +2848,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                    "page" => "/en/register",
                    "visitors" => 2,
                    "events" => 2,
-                   "conversion_rate" => 66.7
+                   "conversion_rate" => 66.67
                  },
                  %{
                    "page" => "/it/register",
@@ -2923,7 +2923,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
                    "device" => "Mobile",
                    "visitors" => 2,
                    "events" => 2,
-                   "conversion_rate" => 66.7
+                   "conversion_rate" => 66.67
                  },
                  %{
                    "device" => "Desktop",

--- a/test/plausible_web/controllers/api/external_stats_controller/query_special_metrics_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_special_metrics_test.exs
@@ -99,7 +99,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
       })
 
     assert json_response(conn, 200)["results"] == [
-             %{"dimensions" => ["/en/register"], "metrics" => [2, 2, 66.7]},
+             %{"dimensions" => ["/en/register"], "metrics" => [2, 2, 66.67]},
              %{"dimensions" => ["/it/register"], "metrics" => [1, 2, 50.0]}
            ]
   end
@@ -159,7 +159,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QuerySpecialMetricsTest do
     %{"results" => results} = json_response(conn, 200)
 
     assert results == [
-             %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.7]},
+             %{"dimensions" => ["Mobile"], "metrics" => [2, 2, 66.67]},
              %{"dimensions" => ["Desktop"], "metrics" => [1, 2, 50]}
            ]
   end

--- a/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/timeseries_test.exs
@@ -1248,7 +1248,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
       assert [first, second] == [
                %{
                  "date" => "2021-01-04",
-                 "conversion_rate" => 66.7
+                 "conversion_rate" => 66.67
                },
                %{
                  "date" => "2021-01-05",
@@ -1336,7 +1336,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
       assert first == %{
                "date" => "2021-01-04",
-               "conversion_rate" => 33.3
+               "conversion_rate" => 33.33
              }
     end
 
@@ -1375,7 +1375,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
 
       assert first == %{
                "date" => "2021-01-04",
-               "conversion_rate" => 33.3
+               "conversion_rate" => 33.33
              }
     end
 
@@ -1860,7 +1860,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                },
                %{
                  "date" => "2021-01-04",
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end
@@ -1980,7 +1980,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.TimeseriesTest do
                },
                %{
                  "date" => "2021-01-04",
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -307,7 +307,7 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       assert %{
                "name" => "Chrome 110",
                "browser" => "Chrome",
-               "conversion_rate" => 66.7,
+               "conversion_rate" => 66.67,
                "version" => "110",
                "total_visitors" => 3,
                "visitors" => 2

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -42,13 +42,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Signup",
                  "visitors" => 3,
                  "events" => 4,
-                 "conversion_rate" => 42.9
+                 "conversion_rate" => 42.86
                },
                %{
                  "name" => "Visit /register",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 28.6
+                 "conversion_rate" => 28.57
                }
              ]
     end
@@ -181,7 +181,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Payment",
                  "visitors" => 1,
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end
@@ -221,7 +221,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Payment",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 66.7
+                 "conversion_rate" => 66.67
                }
              ]
     end
@@ -259,7 +259,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Payment",
                  "visitors" => 2,
                  "events" => 3,
-                 "conversion_rate" => 66.7
+                 "conversion_rate" => 66.67
                }
              ]
     end
@@ -299,7 +299,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Payment",
                  "visitors" => 2,
                  "events" => 3,
-                 "conversion_rate" => 66.7
+                 "conversion_rate" => 66.67
                }
              ]
     end
@@ -353,13 +353,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Payment",
                  "visitors" => 1,
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "name" => "Visit /register",
                  "visitors" => 1,
                  "events" => 1,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end
@@ -494,7 +494,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                    "value" => 10.0,
                    "currency" => "EUR"
                  },
-                 "conversion_rate" => 16.7,
+                 "conversion_rate" => 16.67,
                  "name" => "Payment",
                  "events" => 1,
                  "total_revenue" => %{
@@ -507,7 +507,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                },
                %{
                  "average_revenue" => nil,
-                 "conversion_rate" => 33.3,
+                 "conversion_rate" => 33.33,
                  "name" => "Signup",
                  "events" => 2,
                  "total_revenue" => nil,
@@ -577,7 +577,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           "name" => "Signup",
           "visitors" => 1,
           "events" => 1,
-          "conversion_rate" => 33.3
+          "conversion_rate" => 33.33
         }
       ]
 
@@ -619,7 +619,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Visit /register",
                  "visitors" => 1,
                  "events" => 1,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end
@@ -650,13 +650,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Signup",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "name" => "Visit /register",
                  "visitors" => 1,
                  "events" => 1,
-                 "conversion_rate" => 16.7
+                 "conversion_rate" => 16.67
                }
              ]
     end
@@ -684,13 +684,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Visit /blog/**",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 66.7
+                 "conversion_rate" => 66.67
                },
                %{
                  "name" => "Visit /billing/upgrade",
                  "visitors" => 1,
                  "events" => 1,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ]
     end
@@ -722,13 +722,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Visit /blog**",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "name" => "Signup",
                  "visitors" => 1,
                  "events" => 1,
-                 "conversion_rate" => 16.7
+                 "conversion_rate" => 16.67
                }
              ]
     end
@@ -1023,13 +1023,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Purchase",
                  "visitors" => 5,
                  "events" => 7,
-                 "conversion_rate" => 55.6
+                 "conversion_rate" => 55.56
                },
                %{
                  "name" => "Activation",
                  "visitors" => 3,
                  "events" => 5,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                }
              ] = json_response(conn, 200)["results"]
     end
@@ -1144,13 +1144,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
                  "name" => "Visit /test",
                  "visitors" => 3,
                  "events" => 3,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "name" => "Visit /blog",
                  "visitors" => 2,
                  "events" => 2,
-                 "conversion_rate" => 22.2
+                 "conversion_rate" => 22.22
                }
              ] = json_response(conn, 200)["results"]
     end

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -179,13 +179,13 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 2,
                  "name" => "B",
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "visitors" => 1,
                  "name" => "A",
                  "events" => 1,
-                 "conversion_rate" => 16.7
+                 "conversion_rate" => 16.67
                }
              ]
     end
@@ -215,13 +215,13 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 2,
                  "name" => "(none)",
                  "events" => 2,
-                 "conversion_rate" => 33.3
+                 "conversion_rate" => 33.33
                },
                %{
                  "visitors" => 1,
                  "name" => "A",
                  "events" => 1,
-                 "conversion_rate" => 16.7
+                 "conversion_rate" => 16.67
                }
              ]
     end
@@ -809,7 +809,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 2,
                  "name" => "true",
                  "events" => 2,
-                 "conversion_rate" => 66.7,
+                 "conversion_rate" => 66.67,
                  "total_revenue" => %{
                    "long" => "€112.00",
                    "short" => "€112.0",
@@ -827,7 +827,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 1,
                  "name" => "false",
                  "events" => 1,
-                 "conversion_rate" => 33.3,
+                 "conversion_rate" => 33.33,
                  "total_revenue" => %{
                    "long" => "€8.00",
                    "short" => "€8.0",
@@ -893,7 +893,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 2,
                  "name" => "true",
                  "events" => 2,
-                 "conversion_rate" => 66.7,
+                 "conversion_rate" => 66.67,
                  "total_revenue" => %{
                    "long" => "€80.00",
                    "short" => "€80.0",
@@ -911,7 +911,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
                  "visitors" => 1,
                  "name" => "false",
                  "events" => 1,
-                 "conversion_rate" => 33.3,
+                 "conversion_rate" => 33.33,
                  "total_revenue" => %{
                    "long" => "€10.00",
                    "short" => "€10.0",

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -759,7 +759,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
       assert %{"plot" => plot} = json_response(conn, 200)
       assert Enum.count(plot) == 31
 
-      assert List.first(plot) == 33.3
+      assert List.first(plot) == 33.33
       assert Enum.at(plot, 10) == 0.0
       assert List.last(plot) == 50.0
     end
@@ -1511,7 +1511,7 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
                json_response(conn, 200)
 
       assert this_week_plot == [50.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      assert last_week_plot == [33.3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      assert last_week_plot == [33.33, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     end
   end
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -1490,7 +1490,12 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       conn = get(conn, "/api/stats/#{site.domain}/pages?period=day&filters=#{filters}")
 
       assert json_response(conn, 200)["results"] == [
-               %{"total_visitors" => 3, "visitors" => 1, "name" => "/", "conversion_rate" => 33.3}
+               %{
+                 "total_visitors" => 3,
+                 "visitors" => 1,
+                 "name" => "/",
+                 "conversion_rate" => 33.33
+               }
              ]
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -1415,7 +1415,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Conversion rate", "value" => 33.3, "graph_metric" => "conversion_rate"} in res[
+      assert %{"name" => "Conversion rate", "value" => 33.33, "graph_metric" => "conversion_rate"} in res[
                "top_stats"
              ]
     end
@@ -1442,7 +1442,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Conversion rate", "value" => 33.3, "graph_metric" => "conversion_rate"} in res[
+      assert %{"name" => "Conversion rate", "value" => 33.33, "graph_metric" => "conversion_rate"} in res[
                "top_stats"
              ]
     end
@@ -1863,7 +1863,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       assert %{"name" => "Unique conversions", "value" => 2} = unique_conversions
       assert %{"name" => "Total conversions", "value" => nil} = total_conversions
-      assert %{"name" => "Conversion rate", "value" => 66.7} = conversion_rate
+      assert %{"name" => "Conversion rate", "value" => 66.67} = conversion_rate
     end
   end
 
@@ -2022,13 +2022,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{
-               "change" => -33.4,
-               "comparison_value" => 66.7,
-               "name" => "Conversion rate",
-               "value" => 33.3,
-               "graph_metric" => "conversion_rate"
-             } in res["top_stats"]
+      cr = Enum.find(res["top_stats"], &(&1["name"] == "Conversion rate"))
+
+      assert %{"change" => -33.3, "comparison_value" => 66.67, "value" => 33.33} = cr
     end
   end
 end


### PR DESCRIPTION
### Changes

Change the ClickHouse select statement to round conversion rate to 2 decimal places.

Feedback: https://feedback.plausible.io/235

### Tests
- [x] Automated tests have been adjusted

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
