### PR TITLE
Add top 3 pages to traffic spike email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- Add top 3 pages into the traffic spike email
 - Two new shorthand time periods `28d` and `90d` available on both dashboard and in public API
 - Average scroll depth metric
 - Scroll Depth goals

--- a/lib/plausible/site/traffic_change_notification.ex
+++ b/lib/plausible/site/traffic_change_notification.ex
@@ -34,8 +34,7 @@ defmodule Plausible.Site.TrafficChangeNotification do
     |> change(recipients: List.delete(schema.recipients, recipient))
   end
 
-  def was_sent(schema) do
-    schema
-    |> change(last_sent: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second))
+  def was_sent(schema, now) do
+    schema |> change(last_sent: now)
   end
 end

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -75,34 +75,6 @@ defmodule Plausible.Stats.Clickhouse do
 
   def usage_breakdown([], _date_range), do: {0, 0}
 
-  def top_sources_for_spike(site, query, limit, page) do
-    offset = (page - 1) * limit
-
-    {first_datetime, last_datetime} = Plausible.Stats.Time.utc_boundaries(query)
-
-    referrers =
-      from(s in "sessions_v2",
-        select: %{
-          name: s.referrer_source,
-          count: uniq(s.user_id)
-        },
-        where: s.site_id == ^site.id,
-        # Note: This query intentionally uses session end timestamp to get currently active users
-        where: s.timestamp >= ^first_datetime and s.start < ^last_datetime,
-        where: s.referrer_source != "",
-        group_by: s.referrer_source,
-        order_by: [desc: uniq(s.user_id), asc: s.referrer_source],
-        limit: ^limit,
-        offset: ^offset
-      )
-
-    on_ee do
-      referrers = Plausible.Stats.Sampling.add_query_hint(referrers, 10_000_000)
-    end
-
-    ClickhouseRepo.all(referrers)
-  end
-
   def current_visitors(site) do
     Plausible.Stats.current_visitors(site)
   end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -127,15 +127,16 @@ defmodule PlausibleWeb.Email do
     |> html_body(PlausibleWeb.MJML.StatsReport.render(assigns))
   end
 
-  def spike_notification(email, site, current_visitors, sources, dashboard_link) do
+  def spike_notification(email, site, stats, dashboard_link) do
     base_email()
     |> to(email)
     |> tag("spike-notification")
     |> subject("Traffic Spike on #{site.domain}")
     |> render("spike_notification.html", %{
       site: site,
-      current_visitors: current_visitors,
-      sources: sources,
+      current_visitors: stats.current_visitors,
+      sources: stats.sources,
+      pages: stats.pages,
       link: dashboard_link
     })
   end

--- a/lib/plausible_web/templates/email/spike_notification.html.heex
+++ b/lib/plausible_web/templates/email/spike_notification.html.heex
@@ -3,9 +3,15 @@ There are currently {@current_visitors} visitors on
 <%= if Enum.count(@sources) > 0 do %>
   <br />
   <br /> The top sources for current visitors:<br />
-  <%= for %{name: source, count: visitors} <- @sources do %>
+  <%= for %{dimensions: [source], metrics: [visitors]} <- @sources do %>
     {source} - {visitors} visitor{if visitors > 1, do: "s"}<br />
   <% end %>
+<% end %>
+
+<br />
+<br /> The top pages visited:<br />
+<%= for %{dimensions: [page], metrics: [visitors]} <- @pages do %>
+  {page} - {visitors} visitor{if visitors > 1, do: "s"}<br />
 <% end %>
 
 <%= if @link do %>

--- a/lib/plausible_web/templates/email/spike_notification.html.heex
+++ b/lib/plausible_web/templates/email/spike_notification.html.heex
@@ -1,21 +1,27 @@
-There are currently {@current_visitors} visitors on
-<a href={"https://" <> @site.domain}><%= @site.domain %></a>.
+There are currently <b>{@current_visitors}</b>
+visitors on <a href={"https://" <> @site.domain}><%= @site.domain %></a>. <br />
 <%= if Enum.count(@sources) > 0 do %>
-  <br />
   <br /> The top sources for current visitors:<br />
-  <%= for %{dimensions: [source], metrics: [visitors]} <- @sources do %>
-    {source} - {visitors} visitor{if visitors > 1, do: "s"}<br />
-  <% end %>
+  <ul>
+    <%= for %{dimensions: [source], metrics: [visitors]} <- @sources do %>
+      <li>
+        <b>{visitors}</b> visitor{if visitors > 1, do: "s"} from <b>{source}</b>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 
-<br />
-<br /> The top pages visited:<br />
-<%= for %{dimensions: [page], metrics: [visitors]} <- @pages do %>
-  {page} - {visitors} visitor{if visitors > 1, do: "s"}<br />
-<% end %>
+<br /> Your top pages being visited:<br />
+<ul>
+  <%= for %{dimensions: [page], metrics: [visitors]} <- @pages do %>
+    <li>
+      <b>{visitors}</b> visitor{if visitors > 1, do: "s"} on <b>{page}</b>
+    </li>
+  <% end %>
+</ul>
 
 <%= if @link do %>
-  <br /><br /> View dashboard: <a href={@link}>{@link}</a>
+  <br /> View dashboard: <a href={@link}>{@link}</a>
 <% end %>
 <br /><br /> Congrats on the spike in traffic!
 <%= if Plausible.ce? do %>

--- a/test/plausible/stats/clickhouse_test.exs
+++ b/test/plausible/stats/clickhouse_test.exs
@@ -307,41 +307,6 @@ defmodule Plausible.Stats.ClickhouseTest do
     end
   end
 
-  describe "top_sources_for_spike/4" do
-    test "gets named sources" do
-      site = insert(:site)
-      query = Plausible.Stats.Query.from(site, %{"period" => "all"})
-
-      populate_stats(site, [
-        build(:pageview,
-          pathname: "/",
-          referrer_source: "Twitter"
-        ),
-        build(:pageview,
-          pathname: "/plausible.io"
-        ),
-        build(:pageview,
-          pathname: "/plausible.io",
-          referrer_source: "Google"
-        ),
-        build(:pageview,
-          pathname: "/plausible.io",
-          referrer_source: "Google"
-        ),
-        build(:pageview,
-          pathname: "/plausible.io",
-          referrer_source: "Bing"
-        )
-      ])
-
-      assert [
-               %{count: 2, name: "Google"},
-               %{count: 1, name: "Bing"},
-               %{count: 1, name: "Twitter"}
-             ] = Clickhouse.top_sources_for_spike(site, query, 5, 1)
-    end
-  end
-
   describe "imported_pageview_counts/1" do
     test "gets pageview counts for each of sites' imports" do
       site = insert(:site)

--- a/test/workers/traffic_change_notifier_test.exs
+++ b/test/workers/traffic_change_notifier_test.exs
@@ -198,10 +198,10 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
       })
 
       assert html_body =~ "The top sources for current visitors:"
-      assert html_body =~ "A - 3 visitors<br>"
-      assert html_body =~ "B - 2 visitors<br>"
-      assert html_body =~ "C - 1 visitor<br>"
-      assert html_body =~ "There are currently 8 visitors"
+      assert html_body =~ "<b>3</b> visitors from <b>A</b>"
+      assert html_body =~ "<b>2</b> visitors from <b>B</b>"
+      assert html_body =~ "<b>1</b> visitor from <b>C</b>"
+      assert html_body =~ "There are currently <b>8</b>"
     end
 
     test "does not list sources at all when everything is 'Direct / None'" do
@@ -226,7 +226,7 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
       })
 
       refute html_body =~ "The top sources for current visitors:"
-      assert html_body =~ "There are currently 2 visitors"
+      assert html_body =~ "There are currently <b>2</b>"
     end
 
     test "includes top 3 pages" do
@@ -258,12 +258,12 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
         html_body: html_body
       })
 
-      assert html_body =~ "There are currently 10 visitors"
+      assert html_body =~ "There are currently <b>10</b>"
 
-      assert html_body =~ "The top pages visited:"
-      assert html_body =~ "/one - 4 visitors<br>"
-      assert html_body =~ "/two - 3 visitors<br>"
-      assert html_body =~ "/ - 2 visitors<br>"
+      assert html_body =~ "Your top pages being visited:"
+      assert html_body =~ "<b>4</b> visitors on <b>/one</b>"
+      assert html_body =~ "<b>3</b> visitors on <b>/two</b>"
+      assert html_body =~ "<b>2</b> visitors on <b>/</b>"
 
       refute html_body =~ "/not-this-one"
     end


### PR DESCRIPTION
### Changes

Slight doc adjustment when this goes live: https://github.com/plausible/docs/pull/597

* Improve `TrafficChangeNotifierTest` and add a few missing tests
* Leverage `Stats.query` instead of building the `Ecto.Query` for top 3 sources from scratch
* Add the top 3 pages below the sources in the email (see screenshots below)

Before (multiple sources exist):

![image](https://github.com/user-attachments/assets/81a52858-6e2b-4db6-8e65-4a900b6700f5)

After (multiple source exist):

![image](https://github.com/user-attachments/assets/c83faa08-d3c1-4bf1-91b9-f5bc1e00c384)

Before (all traffic is "Direct / None"; _NOTE: we don't display sources at all in this case_):

![image](https://github.com/user-attachments/assets/941ee6c8-991d-4df9-bb91-e6029b6c1b73)

After (all traffic is "Direct / None"):

![image](https://github.com/user-attachments/assets/835cbe2a-4495-4ce6-b4e0-99e930507c0f)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] PR is waiting

### Dark mode
- [x] This PR does not change the UI
