### PR TITLE
Hide footer when viewing stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 - Remove permissions to manage sites guests and run destructive actions from team editor and guest editor roles in favour of team admin role
 - Time-on-page metric has been reworked. It now uses `engagement` events sent by plausible tracker script. We still use the old calculation methods for periods before the self-hosted instance was upgraded. Warnings are shown in the dashboard and API when legacy calculation methods are used.
 - Always set site and team member limits to unlimited for Community Edition
+- Stop showing Plausible footer when viewing stats, except when viewing a public dashboard or unembedded shared link dashboard
 
 ### Fixed
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -83,7 +83,8 @@ defmodule PlausibleWeb.StatsController do
           is_dbip: is_dbip(),
           dogfood_page_path: dogfood_page_path,
           segments: segments,
-          load_dashboard_js: true
+          load_dashboard_js: true,
+          hide_footer?: if(ce?() || demo, do: false, else: site_role != :public)
         )
 
       !stats_start_date && can_see_stats? ->
@@ -349,6 +350,8 @@ defmodule PlausibleWeb.StatsController do
 
         {:ok, segments} = Plausible.Segments.get_all_for_site(shared_link.site, site_role)
 
+        embedded? = conn.params["embed"] == "true"
+
         conn
         |> put_resp_header("x-robots-tag", "noindex, nofollow")
         |> delete_resp_header("x-frame-options")
@@ -365,13 +368,14 @@ defmodule PlausibleWeb.StatsController do
           demo: false,
           dogfood_page_path: "/share/:dashboard",
           shared_link_auth: shared_link.slug,
-          embedded: conn.params["embed"] == "true",
+          embedded: embedded?,
           background: conn.params["background"],
           theme: conn.params["theme"],
           flags: flags,
           is_dbip: is_dbip(),
           segments: segments,
-          load_dashboard_js: true
+          load_dashboard_js: true,
+          hide_footer?: if(ce?(), do: embedded?, else: embedded? || site_role != :public)
         )
 
       Sites.locked?(shared_link.site) ->

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -49,7 +49,8 @@
       <div data-iframe-height></div>
       <script type="text/javascript" src={Routes.static_path(@conn, "/js/embed.content.js")}>
       </script>
-    <% else %>
+    <% end %>
+    <%= if !assigns[:hide_footer?] do %>
       {render("_footer.html", assigns)}
     <% end %>
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -22,7 +22,7 @@
           selected_fn={&is_current_tab(@conn, &1)}
         />
 
-        <div class="hidden lg:block py-4 sticky top-0">
+        <div class="hidden lg:block py-4 sticky top-0" data-testid="site_settings_sidebar">
           <%= for %{key: key, value: value, icon: icon} <- site_settings_sidebar(@conn) do %>
             <%= if is_binary(value) do %>
               {render("_site_settings_tab.html",

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -493,82 +493,6 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
-  describe "GET /:domain/settings" do
-    setup [:create_user, :log_in]
-
-    @tag :ee_only
-    test "all menu options are shown with links, header and footer are shown", %{
-      conn: conn,
-      user: user
-    } do
-      site = new_site(owner: user, domain: "example.com")
-      conn = get(conn, "/#{site.domain}/settings/general")
-      resp = html_response(conn, 200)
-
-      items = resp |> find("[data-testid=site_settings_sidebar] a") |> Enum.map(fn a -> {text(a), text_of_attr(a, "href")} end)
-
-      assert items == [
-        {"General", "/#{site.domain}/settings/general"},
-        {"People", "/#{site.domain}/settings/people"},
-        {"Visibility", "/#{site.domain}/settings/visibility"},
-        {"Goals", "/#{site.domain}/settings/goals"},
-        {"Funnels", "/#{site.domain}/settings/funnels"},
-        {"Custom Properties", "/#{site.domain}/settings/properties"},
-        {"Integrations", "/#{site.domain}/settings/integrations"},
-        {"Visibility", "/#{site.domain}/settings/visibility"},
-        {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
-
-        {"Shields", ""},
-        {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
-        {"Countries", "/#{site.domain}/settings/shields/countries"},
-        {"Pages", "/#{site.domain}/settings/shields/pages"},
-        {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
-
-        {"Email Reports", "/#{site.domain}/settings/email-reports"},
-        {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
-      ]
-    end
-
-    @tag :ce_only
-    test "all menu options are shown with links, header and footer are shown on CE", %{
-      conn: conn,
-      user: user
-    } do
-      site = new_site(owner: user, domain: "example.com")
-      conn = get(conn, "/#{site.domain}/settings/general")
-      resp = html_response(conn, 200)
-
-      items = resp |> find("[data-testid=site_settings_sidebar] a") |> Enum.map(fn a -> {text(a), text_of_attr(a, "href")} end)
-
-      assert items == [
-        {"General", "/#{site.domain}/settings/general"},
-        {"People", "/#{site.domain}/settings/people"},
-        {"Visibility", "/#{site.domain}/settings/visibility"},
-        {"Goals", "/#{site.domain}/settings/goals"},
-        {"Custom Properties", "/#{site.domain}/settings/properties"},
-        {"Integrations", "/#{site.domain}/settings/integrations"},
-        {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
-
-        {"Shields", ""},
-        {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
-        {"Countries", "/#{site.domain}/settings/shields/countries"},
-        {"Pages", "/#{site.domain}/settings/shields/pages"},
-        {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
-
-        {"Email Reports", "/#{site.domain}/settings/email-reports"},
-        {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
-      ]
-    end
-
-    test "header and footer are shown", %{conn: conn, site: site, user: user} do
-      conn = get(conn, "/#{site.domain}/settings/general")
-      resp = html_response(conn, 200)
-      assert resp =~ user.name
-      assert resp =~ "Getting started"
-    end
-
-  end
-
   describe "GET /:domain/settings/general" do
     setup [:create_user, :log_in, :create_site]
 
@@ -581,6 +505,78 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert resp =~ "Site Timezone"
       assert resp =~ "Site Domain"
       assert resp =~ "Site Installation"
+    end
+
+    @tag :ee_only
+    test "all site settings sidebar items are working links", %{
+      conn: conn,
+      user: user
+    } do
+      site = new_site(owner: user, domain: "example.com")
+      conn = get(conn, "/#{site.domain}/settings/general")
+      resp = html_response(conn, 200)
+
+      items =
+        resp
+        |> find("[data-testid=site_settings_sidebar] a")
+        |> Enum.map(fn a -> {text(a), text_of_attr(a, "href")} end)
+
+      assert items == [
+               {"General", "/#{site.domain}/settings/general"},
+               {"People", "/#{site.domain}/settings/people"},
+               {"Visibility", "/#{site.domain}/settings/visibility"},
+               {"Goals", "/#{site.domain}/settings/goals"},
+               {"Funnels", "/#{site.domain}/settings/funnels"},
+               {"Custom Properties", "/#{site.domain}/settings/properties"},
+               {"Integrations", "/#{site.domain}/settings/integrations"},
+               {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
+               {"Shields", ""},
+               {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
+               {"Countries", "/#{site.domain}/settings/shields/countries"},
+               {"Pages", "/#{site.domain}/settings/shields/pages"},
+               {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
+               {"Email Reports", "/#{site.domain}/settings/email-reports"},
+               {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
+             ]
+    end
+
+    @tag :ce_build_only
+    test "all site settings sidebar items are working links on CE", %{
+      conn: conn,
+      user: user
+    } do
+      site = new_site(owner: user, domain: "example.com")
+      conn = get(conn, "/#{site.domain}/settings/general")
+      resp = html_response(conn, 200)
+
+      items =
+        resp
+        |> find("[data-testid=site_settings_sidebar] a")
+        |> Enum.map(fn a -> {text(a), text_of_attr(a, "href")} end)
+
+      assert items == [
+               {"General", "/#{site.domain}/settings/general"},
+               {"People", "/#{site.domain}/settings/people"},
+               {"Visibility", "/#{site.domain}/settings/visibility"},
+               {"Goals", "/#{site.domain}/settings/goals"},
+               {"Custom Properties", "/#{site.domain}/settings/properties"},
+               {"Integrations", "/#{site.domain}/settings/integrations"},
+               {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
+               {"Shields", ""},
+               {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
+               {"Countries", "/#{site.domain}/settings/shields/countries"},
+               {"Pages", "/#{site.domain}/settings/shields/pages"},
+               {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
+               {"Email Reports", "/#{site.domain}/settings/email-reports"},
+               {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
+             ]
+    end
+
+    test "header and footer are shown", %{conn: conn, site: site, user: user} do
+      conn = get(conn, "/#{site.domain}/settings/general")
+      resp = html_response(conn, 200)
+      assert resp =~ user.name
+      assert resp =~ "Getting started"
     end
   end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -498,6 +498,45 @@ defmodule PlausibleWeb.SiteControllerTest do
 
     setup_patch_env(:google, client_id: "some", api_url: "https://www.googleapis.com")
 
+    test "all menu options are shown with links, header and footer are shown", %{
+      conn: conn,
+      site: site
+    } do
+      conn = get(conn, "/#{site.domain}/settings/general")
+      resp = html_response(conn, 200)
+      site_domain = URI.encode_www_form(site.domain)
+
+      for {link_text, href} <- [
+            {"General", "#{site_domain}/settings/general"},
+            {"People", "#{site_domain}/settings/people"},
+            {"Visibility", "#{site_domain}/settings/visibility"},
+            {"Goals", "#{site_domain}/settings/goals"},
+            {"Funnels", "#{site_domain}/settings/funnels"},
+            {"Custom Properties", "#{site_domain}/settings/properties"},
+            {"Integrations", "#{site_domain}/settings/integrations"},
+            {"Visibility", "#{site_domain}/settings/visibility"},
+
+            # {"Imports & Exports", "#{site_domain}/settings/imports-exports"},
+
+            # Shields
+            {"IP Addresses", "#{site_domain}/settings/shields/ip_addresses"},
+            {"Countries", "#{site_domain}/settings/shields/countries"},
+            {"Pages", "#{site_domain}/settings/shields/pages"},
+            {"Hostnames", "#{site_domain}/settings/shields/hostnames"},
+            {"Email Reports", "#{site_domain}/settings/email-reports"}
+          ] do
+        assert resp =~ link_text
+        assert resp =~ href
+      end
+    end
+
+    test "header and footer are shown", %{conn: conn, site: site, user: user} do
+      conn = get(conn, "/#{site.domain}/settings/general")
+      resp = html_response(conn, 200)
+      assert resp =~ user.name
+      assert resp =~ "Getting started"
+    end
+
     test "shows settings form", %{conn: conn, site: site} do
       conn = get(conn, "/#{site.domain}/settings/general")
       resp = html_response(conn, 200)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -158,7 +158,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       refute resp =~ "Getting started"
     end
 
-    @tag :ce_only
+    @tag :ce_build_only
     test "header, stats, footer are shown", %{conn: conn, site: site, user: user} do
       populate_stats(site, [build(:pageview)])
       conn = get(conn, "/" <> site.domain)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -148,6 +148,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
+    @tag :ee_only
     test "header, stats are shown; footer is not shown", %{conn: conn, site: site, user: user} do
       populate_stats(site, [build(:pageview)])
       conn = get(conn, "/" <> site.domain)
@@ -155,6 +156,16 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert resp =~ user.name
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
       refute resp =~ "Getting started"
+    end
+
+    @tag :ce_only
+    test "header, stats, footer are shown", %{conn: conn, site: site, user: user} do
+      populate_stats(site, [build(:pageview)])
+      conn = get(conn, "/" <> site.domain)
+      resp = html_response(conn, 200)
+      assert resp =~ user.name
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+      assert resp =~ "Getting started"
     end
 
     test "shows locked page if site is locked", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -76,7 +76,7 @@ defmodule PlausibleWeb.StatsControllerTest do
                Jason.encode!([foo_personal_segment, emea_site_segment])
     end
 
-    test "plausible.io live demo - shows site stats", %{conn: conn} do
+    test "plausible.io live demo - shows site stats, header and footer", %{conn: conn} do
       site = new_site(domain: "plausible.io", public: true)
       populate_stats(site, [build(:pageview)])
 
@@ -90,6 +90,8 @@ defmodule PlausibleWeb.StatsControllerTest do
                |> Floki.attribute("content")
 
       assert text_of_element(resp, "title") == "Plausible Analytics: Live Demo"
+      assert resp =~ "Login"
+      assert resp =~ "Getting started"
     end
 
     test "public site - redirect to /login when no stats because verification requires it", %{
@@ -146,6 +148,15 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
+    test "header, stats are shown; footer is not shown", %{conn: conn, site: site, user: user} do
+      populate_stats(site, [build(:pageview)])
+      conn = get(conn, "/" <> site.domain)
+      resp = html_response(conn, 200)
+      assert resp =~ user.name
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+      refute resp =~ "Getting started"
+    end
+
     test "shows locked page if site is locked", %{conn: conn, user: user} do
       locked_site = new_site(locked: true, owner: user)
       conn = get(conn, "/" <> locked_site.domain)
@@ -196,7 +207,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       refute html_response(conn, 200) =~ "/crm/sites/site/#{site.id}"
     end
 
-    test "all segments (personal or site) are stuffed into dataset, with associated their owner_id and owner_name",
+    test "all segments (personal or site) are stuffed into dataset, with their associated owner_id and owner_name",
          %{conn: conn, site: site, user: user} do
       populate_stats(site, [build(:pageview)])
 
@@ -1238,6 +1249,22 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-current-user-role") == "public"
     end
 
+    test "footer and header are shown when accessing public dashboard", %{
+      conn: conn
+    } do
+      site = new_site(domain: "test-site.com")
+      link = insert(:shared_link, site: site)
+
+      conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
+      resp = html_response(conn, 200)
+      assert resp =~ "stats-react-container"
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "false"
+      assert text_of_attr(resp, @react_container, "data-current-user-id") == "null"
+      assert text_of_attr(resp, @react_container, "data-current-user-role") == "public"
+      assert resp =~ "Login"
+      assert resp =~ "Getting started"
+    end
+
     test "returns page with X-Frame-Options disabled so it can be embedded in an iframe", %{
       conn: conn
     } do
@@ -1266,6 +1293,17 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       [{"div", attrs, _}] = find(resp, @react_container)
       assert Enum.all?(attrs, fn {k, v} -> is_binary(k) and is_binary(v) end)
+    end
+
+    test "does not show header, does not show footer on embedded pages", %{conn: conn} do
+      site = new_site(domain: "test-site.com")
+      link = insert(:shared_link, site: site)
+
+      conn = get(conn, "/share/test-site.com/?auth=#{link.slug}&embed=true")
+      resp = html_response(conn, 200)
+      assert text_of_attr(resp, @react_container, "data-embedded") == "true"
+      refute resp =~ "Login"
+      refute resp =~ "Getting started"
     end
 
     test "shows locked page if page is locked", %{conn: conn} do


### PR DESCRIPTION
### Changes

Conditionally hides footer. Bolded logic was already present.

#### User has opened a page containing a dashboard...
- **Dashboard is embedded -> no show footer**
- **Dashboard is from a CE install -> show footer**
- **User viewing public dashboard or accessing a dashboard with a shared link -> show footer**
- User is logged in to Plausible and has a role related to the site (role~"viewer" or above) -> no show footer
- **Special plausible.io/plausible.io case, regardless of login state or role -> show footer**

#### User opened Settings or Sites view... 
**-> show footer**

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
