### PR TITLE
Only show nag screen when the current team has any sites

### DIFF
--- a/lib/plausible/teams/users.ex
+++ b/lib/plausible/teams/users.ex
@@ -130,6 +130,7 @@ defmodule Plausible.Teams.Users do
 
   def owns_sites?(user, opts \\ []) do
     include_pending? = Keyword.get(opts, :include_pending?, false)
+    only_team = Keyword.get(opts, :only_team)
 
     sites_query =
       from(
@@ -147,6 +148,13 @@ defmodule Plausible.Teams.Users do
         where: tm.role == :owner,
         select: 1
       )
+
+    owner_query =
+      if only_team do
+        where(owner_query, [tm], tm.team_id == ^only_team.id)
+      else
+        owner_query
+      end
 
     query =
       if include_pending? do

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -39,7 +39,8 @@ defmodule PlausibleWeb.Live.Sites do
                                             current_user: current_user,
                                             current_team: current_team
                                           } ->
-        Teams.Users.owns_sites?(current_user, include_pending?: true) &&
+        current_team &&
+          Teams.Users.owns_sites?(current_user, include_pending?: true, only_team: current_team) &&
           Teams.Billing.check_needs_to_upgrade(current_team)
       end)
 


### PR DESCRIPTION
### Changes

Upgrade nag notice fix to not show it when it shouldn't be visible. Currently it's shown when user has no current team set but they have another team setup (but are not switched to it). This is going to be a pretty common scenario for users setting up teams for the first team and switching back to "Personal Sites" again. While at it, a case of a current team having no sites (much less common) is handled properly as well.