### PR TITLE
Fix favicons for domains including a subfolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix fetching favicons from DuckDuckGo when the domain includes a pathname
 - Fix `visitors.csv` (in dashboard CSV export) vs dashboard main graph reporting different results for `visitors` and `visits` with a `time:minute` interval.
 - The tracker script now sends pageviews when a page gets loaded from bfcache
 - Fix returning filter suggestions for multiple custom property values in the dashboard Filter modal

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -94,11 +94,11 @@ defmodule PlausibleWeb.Favicon do
       "/favicon/sources/placeholder" ->
         send_placeholder(conn)
 
-      "/favicon/sources/" <> source ->
-        clean_source = URI.decode_www_form(source)
+      "/favicon/sources/" <> domain ->
+        domain = URI.decode_www_form(domain)
 
         domain =
-          Map.get(favicon_domains, clean_source, clean_source)
+          Map.get(favicon_domains, domain, domain)
           |> String.split("/", parts: 2)
           |> hd()
 

--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -96,7 +96,11 @@ defmodule PlausibleWeb.Favicon do
 
       "/favicon/sources/" <> source ->
         clean_source = URI.decode_www_form(source)
-        domain = Map.get(favicon_domains, clean_source, clean_source)
+
+        domain =
+          Map.get(favicon_domains, clean_source, clean_source)
+          |> String.split("/", parts: 2)
+          |> hd()
 
         case HTTPClient.impl().get("https://icons.duckduckgo.com/ip3/#{domain}.ico") do
           {:ok, %Finch.Response{status: 200, body: body, headers: headers}}

--- a/test/plausible_web/plugs/favicon_test.exs
+++ b/test/plausible_web/plugs/favicon_test.exs
@@ -38,11 +38,11 @@ defmodule PlausibleWeb.FaviconTest do
     assert conn.resp_body == "favicon response body"
   end
 
-  test "requests favicon from DDG when domain contains a forward slash", %{plug_opts: plug_opts} do
+  test "requests favicon from DDG by hostname only (strips pathname)", %{plug_opts: plug_opts} do
     expect(
       Plausible.HTTPClient.Mock,
       :get,
-      fn "https://icons.duckduckgo.com/ip3/site.com/subfolder.ico" ->
+      fn "https://icons.duckduckgo.com/ip3/site.com.ico" ->
         {:ok, %Finch.Response{status: 200, body: "favicon response body"}}
       end
     )


### PR DESCRIPTION
### Changes

https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8360831680

Fixes fetching favicons from DuckDuckGo if there's a subfolder provided with the domain name. DuckDuckGo only resolves favicons at a domain level, so we need to strip the pathname before we send the request to DDG.

For example, in our [referer_favicon_domains.json](https://github.com/plausible/analytics/blob/master/priv/referer_favicon_domains.json) we have a few sources that include forward slashes:

```json
{
  "Orange Webmail": "orange.fr/webmail",
  "Bing Images": "bing.com/images/search",
  "Google Product Search": "google.ac/products",
}
```

* https://icons.duckduckgo.com/ip3/orange.fr/webmail.ico -> returns placeholder
* https://icons.duckduckgo.com/ip3/orange.fr.ico -> returns the favicon

Stripping the pathname in the `favicon.ex` plug also fixes fetching favicons on the "/sites" page.

### Tests
- [x] Automated tests have been adjusted

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
