### PR TITLE
Prefix site roles with "Guest " in UI

### DIFF
--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -55,7 +55,7 @@
               class="text-gray-900 dark:text-gray-100 block text-sm font-medium"
               x-class="{'text-indigo-900 dark:text-white': selectedOption === 'admin', 'text-gray-900 dark:text-gray-100': selectedOption !== 'admin'}"
             >
-              Admin
+              Guest Admin
             </span>
             <span
               class="text-gray-500 dark:text-gray-400 text-sm block"
@@ -85,7 +85,7 @@
               class="text-gray-900 dark:text-gray-100 text-sm block font-medium"
               x-class="{'text-indigo-900 dark:text-white': selectedOption === 'viewer', 'text-gray-900 dark:text-gray-100': selectedOption !== 'viewer'}"
             >
-              Viewer
+              Guest Viewer
             </span>
             <span
               class="text-gray-500 dark:text-gray-400 text-sm block"

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -52,7 +52,7 @@
 
               <.dropdown>
                 <:button class="bg-transparent text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 focus-visible:outline-gray-100 whitespace-nowrap truncate inline-flex items-center gap-x-2 font-medium rounded-md px-3.5 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:bg-gray-400 dark:disabled:text-white dark:disabled:text-gray-400 dark:disabled:bg-gray-700">
-                  {membership.role |> to_string() |> String.capitalize()}
+                  {site_role(membership)}
                   <Heroicons.chevron_down mini class="size-4 mt-0.5" />
                 </:button>
                 <:menu class="max-w-60">
@@ -91,7 +91,7 @@
                       method="put"
                       disabled={membership.role == "admin"}
                     >
-                      <div>Admin</div>
+                      <div>Guest Admin</div>
                       <div class="text-gray-500 dark:text-gray-400 text-xs/5">
                         View stats and edit site settings
                       </div>
@@ -109,7 +109,7 @@
                       method="put"
                       disabled={membership.role == "viewer"}
                     >
-                      <div>Viewer</div>
+                      <div>Guest Viewer</div>
                       <div class="text-gray-500 dark:text-gray-400 text-xs/5">
                         View stats only
                       </div>

--- a/lib/plausible_web/views/site_view.ex
+++ b/lib/plausible_web/views/site_view.ex
@@ -25,4 +25,16 @@ defmodule PlausibleWeb.SiteView do
       "a " <> word
     end
   end
+
+  def site_role(%{role: "viewer"}) do
+    "Guest Viewer"
+  end
+
+  def site_role(%{role: "admin"}) do
+    "Guest Admin"
+  end
+
+  def site_role(%{role: role}) do
+    role |> to_string() |> String.capitalize()
+  end
 end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -552,11 +552,11 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert owner_row =~ "Owner"
 
       assert editor_row =~ editor.email
-      assert editor_row_button == "Admin"
+      assert editor_row_button == "Guest Admin"
       refute editor_row =~ "Owner"
 
       assert viewer_row =~ viewer.email
-      assert viewer_row_button == "Viewer"
+      assert viewer_row_button == "Guest Viewer"
       refute viewer_row =~ "Owner"
     end
 


### PR DESCRIPTION
### Changes

Make a strictly visual change, prefixing site roles with "Guest " in order to reduce confusion between site and team roles. Notifications toasts and notification email still use phrasing without the prefix.

![image](https://github.com/user-attachments/assets/99bc2e9c-ac35-4659-972e-ea77791fdb5e)

![image](https://github.com/user-attachments/assets/6e7dc4c7-4eae-4f9e-8b87-b8d052ba83f6)

![image](https://github.com/user-attachments/assets/6437aca4-f905-47db-905c-3c37abaca199)

