### PR TITLE
Fix links to users under "Other Members" in Site CRM

### DIFF
--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -251,7 +251,7 @@ defmodule Plausible.SiteAdmin do
       role = html_escape(m.role)
 
       """
-      <a href="/auth/user/#{id}">#{email} (#{role})</a>
+      <a href="/crm/auth/user/#{id}">#{email} (#{role})</a>
       """
     end)
     |> Phoenix.HTML.raw()


### PR DESCRIPTION
### Changes

Fix the links in CRM as they now lead to 404 instead of user CRM form.


