### PR TITLE
Send e-mail to new owners when site team is changed

### DIFF
--- a/lib/plausible/site/memberships/accept_invitation.ex
+++ b/lib/plausible/site/memberships/accept_invitation.ex
@@ -59,6 +59,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitation do
           :ok | {:error, transfer_error()}
   def change_team(site, user, new_team) do
     with {:ok, _} <- transfer_ownership(site, user, new_team) do
+      Teams.Invitations.send_team_changed_email(site, user, new_team)
       :ok
     end
   end

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -478,6 +478,15 @@ defmodule Plausible.Teams.Invitations do
     |> Plausible.Mailer.send()
   end
 
+  def send_team_changed_email(site, user, team) do
+    owners = Repo.preload(team, :owners).owners
+
+    for owner <- owners do
+      PlausibleWeb.Email.team_changed(owner.email, user, team, site)
+      |> Plausible.Mailer.send()
+    end
+  end
+
   @doc false
   def check_invitation_permissions(%Teams.Team{} = team, inviter, invitation_role, opts) do
     check_permissions? = Keyword.get(opts, :check_permissions, true)

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -383,6 +383,20 @@ defmodule PlausibleWeb.Email do
     )
   end
 
+  def team_changed(owner_email, user, team, site) do
+    priority_email()
+    |> to(owner_email)
+    |> tag("team-changed")
+    |> subject(
+      "[#{Plausible.product_name()}] #{user.email} has transferred #{site.domain} to \"#{team.name}\""
+    )
+    |> render("team_changed.html",
+      user: user,
+      team: team,
+      site: site
+    )
+  end
+
   def ownership_transfer_rejected(site_transfer) do
     priority_email()
     |> to(site_transfer.initiator.email)

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -388,7 +388,7 @@ defmodule PlausibleWeb.Email do
     |> to(owner_email)
     |> tag("team-changed")
     |> subject(
-      "[#{Plausible.product_name()}] #{user.email} has transferred #{site.domain} to \"#{team.name}\""
+      "[#{Plausible.product_name()}] #{user.email} has transferred #{site.domain} to \"#{team.name}\" team"
     )
     |> render("team_changed.html",
       user: user,

--- a/lib/plausible_web/templates/email/team_changed.html.heex
+++ b/lib/plausible_web/templates/email/team_changed.html.heex
@@ -1,0 +1,2 @@
+{@user.email} has transferred {@site.domain} to the "{@team.name}" team on Plausible Analytics.
+<a href={Routes.stats_url(PlausibleWeb.Endpoint, :stats, @site.domain, []) <> "?__team=#{@team.identifier}"}>Click here</a> to view the stats.

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -44,7 +44,20 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert :ok = AcceptInvitation.change_team(site, user, team2)
       assert Repo.reload!(site).team_id == team2.id
       assert_team_membership(user, team2, :owner)
-      assert_no_emails_delivered()
+
+      assert_email_delivered_with(
+        to: [nil: another.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+      )
+
+      assert_email_delivered_with(
+        to: [nil: user.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+      )
     end
 
     test "changes the team if admin in second team" do
@@ -62,7 +75,13 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
       assert :ok = AcceptInvitation.change_team(site, user, team2)
       assert Repo.reload!(site).team_id == team2.id
       assert_team_membership(user, team2, :admin)
-      assert_no_emails_delivered()
+
+      assert_email_delivered_with(
+        to: [nil: another.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+      )
     end
 
     for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -49,14 +49,14 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
         to: [nil: another.email],
         subject:
           @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
       )
 
       assert_email_delivered_with(
         to: [nil: user.email],
         subject:
           @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
       )
     end
 
@@ -80,7 +80,7 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
         to: [nil: another.email],
         subject:
           @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\""
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
       )
     end
 


### PR DESCRIPTION
### Changes

This PR implements sending email notifications on changing team of the site via "Change Team" operation. The notification is sent to all owners of the new team.

### Tests
- [x] Automated tests have been added

