### PR TITLE
Only show team CTA banner to owner when site team is not set up

### DIFF
--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -1,6 +1,6 @@
 <.settings_tiles>
   <PlausibleWeb.Team.Notice.owner_cta_banner :if={
-    @site_role == :owner and not Plausible.Teams.setup?(@current_team)
+    @site_role == :owner and not Plausible.Teams.setup?(@site.team)
   } />
 
   <PlausibleWeb.Team.Notice.guest_cta_banner :if={


### PR DESCRIPTION
### Changes

Minor fix to CTA banner rendering condition.
