### PR TITLE
time-on-page: csv import/export support, preparation for release

### DIFF
--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -72,15 +72,6 @@ export function queryToSearchParams(
     queryObj.auth = sharedLinkParams.auth
   }
 
-  if (
-    query.legacy_time_on_page_cutoff &&
-    validDate(query.legacy_time_on_page_cutoff)
-  ) {
-    queryObj.include = JSON.stringify({
-      legacy_time_on_page_cutoff: query.legacy_time_on_page_cutoff
-    })
-  }
-
   Object.assign(queryObj, ...extraQuery)
 
   return serializeUrlParams(queryObj)

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -77,11 +77,6 @@ export function queryToSearchParams(
   return serializeUrlParams(queryObj)
 }
 
-function validDate(dateString: string) {
-  const date = new Date(dateString)
-  return isFinite(date.getTime())
-}
-
 function getHeaders(): Record<string, string> {
   return SHARED_LINK_AUTH ? { 'X-Shared-Link-Auth': SHARED_LINK_AUTH } : {}
 }

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -61,7 +61,6 @@ export default function QueryContextProvider({
     period,
     to,
     with_imported,
-    legacy_time_on_page_cutoff,
     ...otherSearch
   } = useMemo(() => parseSearch(location.search), [location.search])
 
@@ -112,10 +111,7 @@ export default function QueryContextProvider({
         : defaultValues.with_imported,
       filters,
       resolvedFilters,
-      labels: (labels as FilterClauseLabels) || defaultValues.labels,
-      legacy_time_on_page_cutoff: site.flags.new_time_on_page
-        ? (legacy_time_on_page_cutoff as string) || site.legacyTimeOnPageCutoff
-        : defaultValues.legacy_time_on_page_cutoff
+      labels: (labels as FilterClauseLabels) || defaultValues.labels
     }
   }, [
     compare_from,
@@ -129,7 +125,6 @@ export default function QueryContextProvider({
     period,
     to,
     with_imported,
-    legacy_time_on_page_cutoff,
     site,
     expandedSegment,
     segmentsContext.segments

--- a/assets/js/dashboard/query.ts
+++ b/assets/js/dashboard/query.ts
@@ -50,7 +50,6 @@ export type DashboardQuery = {
   resolvedFilters: Filter[]
   labels: FilterClauseLabels
   with_imported: boolean
-  legacy_time_on_page_cutoff: string | undefined
 }
 
 export const queryDefaultValue: DashboardQuery = {
@@ -65,8 +64,7 @@ export const queryDefaultValue: DashboardQuery = {
   filters: [],
   resolvedFilters: [],
   labels: {},
-  with_imported: true,
-  legacy_time_on_page_cutoff: undefined
+  with_imported: true
 }
 
 export type BreakdownResultMeta = {

--- a/assets/js/dashboard/site-context.test.tsx
+++ b/assets/js/dashboard/site-context.test.tsx
@@ -67,8 +67,7 @@ describe('parseSiteFromDataset', () => {
       realtime: ['minute'],
       year: ['day', 'week', 'month']
     },
-    shared: false,
-    legacyTimeOnPageCutoff: '2022-01-01T00:00:00Z'
+    shared: false
   }
 
   it('parses from dom string map correctly', () => {

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -12,7 +12,6 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
     conversionsOptedOut: dataset.conversionsOptedOut === 'true',
     funnelsOptedOut: dataset.funnelsOptedOut === 'true',
     propsOptedOut: dataset.propsOptedOut === 'true',
-    legacyTimeOnPageCutoff: dataset.legacyTimeOnPageCutoff,
     revenueGoals: JSON.parse(dataset.revenueGoals!),
     funnels: JSON.parse(dataset.funnels!),
     statsBegin: dataset.statsBegin!,
@@ -53,8 +52,7 @@ const siteContextDefaultValue = {
   isDbip: false,
   flags: {} as FeatureFlags,
   validIntervalsByPeriod: {} as Record<string, Array<string>>,
-  shared: false,
-  legacyTimeOnPageCutoff: undefined as string | undefined
+  shared: false
 }
 
 export type PlausibleSite = typeof siteContextDefaultValue

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -208,7 +208,6 @@ export interface QueryApiSchema {
            */
           date_range: [string, string];
         };
-    legacy_time_on_page_cutoff?: string;
   };
   pagination?: {
     /**

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -49,8 +49,7 @@ export const TestContextProviders = ({
     isDbip: false,
     flags: {},
     validIntervalsByPeriod: {},
-    shared: false,
-    legacyTimeOnPageCutoff: undefined
+    shared: false
   }
 
   const site = { ...defaultSite, ...siteOptions }

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -8,15 +8,14 @@ defmodule Plausible.Exports do
   import Ecto.Query
 
   @doc "Schedules CSV export job to S3 storage"
-  @spec schedule_s3_export(pos_integer, pos_integer | nil, String.t()) ::
+  @spec schedule_s3_export(pos_integer, String.t()) ::
           {:ok, Oban.Job.t()} | {:error, :no_data}
-  def schedule_s3_export(site_id, current_user_id, email_to) do
+  def schedule_s3_export(site_id, email_to) do
     with :ok <- ensure_has_data(site_id) do
       args = %{
         "storage" => "s3",
         "site_id" => site_id,
         "email_to" => email_to,
-        "current_user_id" => current_user_id,
         "s3_bucket" => Plausible.S3.exports_bucket(),
         "s3_path" => s3_export_key(site_id)
       }

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -372,6 +372,13 @@ defmodule Plausible.Sites do
     |> Repo.update!()
   end
 
+  def update_legacy_time_on_page_cutoff!(site, cutoff) do
+    site
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_change(:legacy_time_on_page_cutoff, cutoff)
+    |> Repo.update!()
+  end
+
   def has_goals?(site) do
     Repo.exists?(
       from(g in Plausible.Goal,

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -30,6 +30,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_include(site, params)
       |> Query.put_comparison_utc_time_range()
       |> Query.put_imported_opts(site)
+      |> Query.set_time_on_page_data(site)
 
     on_ee do
       query = Plausible.Stats.Sampling.put_threshold(query, site, params)

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -158,7 +158,7 @@ defmodule Plausible.Stats.QueryResult do
 
   defp metric_warning(:time_on_page, %Query{} = query) do
     case query.time_on_page_data do
-      %{include_legacy_metric: true, cutoff: cutoff} ->
+      %{new_metric_visible: true, include_legacy_metric: true, cutoff: cutoff} ->
         cutoff_date =
           cutoff |> DateTime.shift_zone!(query.timezone) |> Calendar.strftime("%Y-%m-%d")
 

--- a/lib/plausible/stats/time_on_page.ex
+++ b/lib/plausible/stats/time_on_page.ex
@@ -8,11 +8,26 @@ defmodule Plausible.Stats.TimeOnPage do
       FunWithFlags.enabled?(:new_time_on_page, for: site)
   end
 
+  def new_time_on_page_visible?(site, user) do
+    new_time_on_page_enabled?(site, user) && not is_nil(site.legacy_time_on_page_cutoff)
+  end
+
+  def legacy_time_on_page_cutoff_iso8601(site) do
+    case cutoff(site.legacy_time_on_page_cutoff, site.timezone) do
+      nil -> ""
+      datetime -> DateTime.to_iso8601(datetime)
+    end
+  end
+
   def legacy_time_on_page_cutoff(site) do
     cutoff(site.legacy_time_on_page_cutoff, site.timezone)
   end
 
-  defp cutoff(nil, _timezone), do: ""
+  defp cutoff(nil, _timezone), do: nil
+
+  # Workaround for a case where casting unix epoch to DateTime fails for sites that should
+  # always have the new time-on-page only. Affects CSV imports.
+  defp cutoff(~D[1970-01-01], _timezone), do: ~U[2000-01-01 00:00:00Z]
 
   defp cutoff(date, timezone) do
     case DateTime.new(date, ~T[00:00:00], timezone) do
@@ -20,6 +35,5 @@ defmodule Plausible.Stats.TimeOnPage do
       {:gap, just_before, _just_after} -> just_before
       {:ambiguous, first_datetime, _second_datetime} -> first_datetime
     end
-    |> DateTime.to_iso8601()
   end
 end

--- a/lib/plausible/stats/time_on_page.ex
+++ b/lib/plausible/stats/time_on_page.ex
@@ -3,37 +3,29 @@ defmodule Plausible.Stats.TimeOnPage do
   Module to check whether the new time on page metric is available.
   """
 
-  def new_time_on_page_enabled?(site, user) do
-    FunWithFlags.enabled?(:new_time_on_page, for: user) ||
-      FunWithFlags.enabled?(:new_time_on_page, for: site)
-  end
-
-  def new_time_on_page_visible?(site, user) do
-    new_time_on_page_enabled?(site, user) && not is_nil(site.legacy_time_on_page_cutoff)
-  end
-
-  def legacy_time_on_page_cutoff_iso8601(site) do
-    case cutoff(site.legacy_time_on_page_cutoff, site.timezone) do
-      nil -> ""
-      datetime -> DateTime.to_iso8601(datetime)
-    end
+  def new_time_on_page_visible?(site) do
+    new_time_on_page_enabled?(site) && not is_nil(site.legacy_time_on_page_cutoff)
   end
 
   def legacy_time_on_page_cutoff(site) do
-    cutoff(site.legacy_time_on_page_cutoff, site.timezone)
+    cutoff_datetime(site.legacy_time_on_page_cutoff, site.timezone)
   end
 
-  defp cutoff(nil, _timezone), do: nil
+  def cutoff_datetime(nil, _timezone), do: nil
 
   # Workaround for a case where casting unix epoch to DateTime fails for sites that should
   # always have the new time-on-page only. Affects CSV imports.
-  defp cutoff(~D[1970-01-01], _timezone), do: ~U[2000-01-01 00:00:00Z]
+  def cutoff_datetime(~D[1970-01-01], _timezone), do: ~U[2000-01-01 00:00:00Z]
 
-  defp cutoff(date, timezone) do
+  def cutoff_datetime(date, timezone) do
     case DateTime.new(date, ~T[00:00:00], timezone) do
       {:ok, datetime} -> datetime
       {:gap, just_before, _just_after} -> just_before
       {:ambiguous, first_datetime, _second_datetime} -> first_datetime
     end
+  end
+
+  defp new_time_on_page_enabled?(site) do
+    FunWithFlags.enabled?(:new_time_on_page, for: site)
   end
 end

--- a/lib/plausible_web/controllers/api/external_query_api_controller.ex
+++ b/lib/plausible_web/controllers/api/external_query_api_controller.ex
@@ -11,8 +11,6 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
 
     case Query.build(site, conn.assigns.schema_type, params, debug_metadata(conn)) do
       {:ok, query} ->
-        query = update_time_on_page_query_data(query)
-
         results = Plausible.Stats.query(site, query)
         json(conn, results)
 
@@ -25,19 +23,5 @@ defmodule PlausibleWeb.Api.ExternalQueryApiController do
 
   def schema(conn, _params) do
     json(conn, Plausible.Stats.JSONSchema.raw_public_schema())
-  end
-
-  defp update_time_on_page_query_data(query) do
-    if is_nil(query.include.legacy_time_on_page_cutoff) do
-      Query.set(query,
-        time_on_page_data: %{
-          include_new_metric: true,
-          include_legacy_metric: false,
-          cutoff: nil
-        }
-      )
-    else
-      query
-    end
   end
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -437,7 +437,7 @@ defmodule PlausibleWeb.Api.StatsController do
       top_stats: top_stats,
       meta: meta,
       graphable_metrics:
-        if(TimeOnPage.new_time_on_page_enabled?(site, current_user),
+        if(TimeOnPage.new_time_on_page_visible?(site, current_user),
           do: metrics,
           else: metrics -- [:time_on_page]
         ),

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -182,7 +182,6 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def top_stats(conn, params) do
     site = conn.assigns[:site]
-    current_user = conn.assigns[:current_user]
 
     params = realtime_period_to_30m(params)
 
@@ -196,7 +195,7 @@ defmodule PlausibleWeb.Api.StatsController do
       meta: meta,
       sample_percent: sample_percent,
       graphable_metrics: graphable_metrics
-    } = fetch_top_stats(site, query, current_user)
+    } = fetch_top_stats(site, query)
 
     comparison_query = comparison_query(query)
 
@@ -277,7 +276,7 @@ defmodule PlausibleWeb.Api.StatsController do
     end
   end
 
-  defp fetch_top_stats(site, query, current_user) do
+  defp fetch_top_stats(site, query) do
     goal_filter? =
       toplevel_goal_filter?(query)
 
@@ -292,7 +291,7 @@ defmodule PlausibleWeb.Api.StatsController do
         fetch_goal_top_stats(site, query)
 
       true ->
-        fetch_other_top_stats(site, query, current_user)
+        fetch_other_top_stats(site, query)
     end
   end
 
@@ -393,7 +392,7 @@ defmodule PlausibleWeb.Api.StatsController do
     %{top_stats: top_stats, meta: meta, graphable_metrics: metrics, sample_percent: 100}
   end
 
-  defp fetch_other_top_stats(site, query, current_user) do
+  defp fetch_other_top_stats(site, query) do
     page_filter? =
       Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore)
 
@@ -437,7 +436,7 @@ defmodule PlausibleWeb.Api.StatsController do
       top_stats: top_stats,
       meta: meta,
       graphable_metrics:
-        if(TimeOnPage.new_time_on_page_visible?(site, current_user),
+        if(TimeOnPage.new_time_on_page_visible?(site),
           do: metrics,
           else: metrics -- [:time_on_page]
         ),

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.StatsController do
           has_props: Plausible.Props.configured?(site),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
-          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff(site),
+          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff_iso8601(site),
           title: title(conn, site),
           demo: demo,
           flags: flags,
@@ -362,7 +362,8 @@ defmodule PlausibleWeb.StatsController do
           has_props: Plausible.Props.configured?(shared_link.site),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
-          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff(shared_link.site),
+          legacy_time_on_page_cutoff:
+            TimeOnPage.legacy_time_on_page_cutoff_iso8601(shared_link.site),
           title: title(conn, shared_link.site),
           demo: false,
           dogfood_page_path: "/share/:dashboard",

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.StatsController do
   use Plausible.Repo
 
   alias Plausible.Sites
-  alias Plausible.Stats.{Filters, Query, TimeOnPage}
+  alias Plausible.Stats.{Filters, Query}
   alias PlausibleWeb.Api
 
   plug(PlausibleWeb.Plugs.AuthorizeSiteAccess when action in [:stats, :csv_export])

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -77,7 +77,6 @@ defmodule PlausibleWeb.StatsController do
           has_props: Plausible.Props.configured?(site),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(site.native_stats_start_at),
-          legacy_time_on_page_cutoff: TimeOnPage.legacy_time_on_page_cutoff_iso8601(site),
           title: title(conn, site),
           demo: demo,
           flags: flags,
@@ -362,8 +361,6 @@ defmodule PlausibleWeb.StatsController do
           has_props: Plausible.Props.configured?(shared_link.site),
           stats_start_date: stats_start_date,
           native_stats_start_date: NaiveDateTime.to_date(shared_link.site.native_stats_start_at),
-          legacy_time_on_page_cutoff:
-            TimeOnPage.legacy_time_on_page_cutoff_iso8601(shared_link.site),
           title: title(conn, shared_link.site),
           demo: false,
           dogfood_page_path: "/share/:dashboard",

--- a/lib/plausible_web/live/csv_export.ex
+++ b/lib/plausible_web/live/csv_export.ex
@@ -210,12 +210,12 @@ defmodule PlausibleWeb.Live.CSVExport do
 
   @impl true
   def handle_event("export", _params, socket) do
-    %{storage: storage, site_id: site_id, email_to: email_to, current_user: current_user} =
+    %{storage: storage, site_id: site_id, email_to: email_to} =
       socket.assigns
 
     schedule_result =
       case storage do
-        "s3" -> Exports.schedule_s3_export(site_id, current_user.id, email_to)
+        "s3" -> Exports.schedule_s3_export(site_id, email_to)
         "local" -> Exports.schedule_local_export(site_id, email_to)
       end
 

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -36,7 +36,6 @@
     data-logged-in={to_string(!!@conn.assigns[:current_user])}
     data-stats-begin={@stats_start_date}
     data-native-stats-begin={@native_stats_start_date}
-    data-legacy-time-on-page-cutoff={@legacy_time_on_page_cutoff}
     data-shared-link-auth={assigns[:shared_link_auth]}
     data-embedded={to_string(@conn.assigns[:embedded])}
     data-background={@conn.assigns[:background]}

--- a/lib/workers/export_analytics.ex
+++ b/lib/workers/export_analytics.ex
@@ -29,13 +29,11 @@ defmodule Plausible.Workers.ExportAnalytics do
       "site_id" => site_id
     } = args
 
-    current_user_id = args["current_user_id"]
-
     site = Plausible.Repo.get!(Plausible.Site, site_id)
     %Date.Range{} = date_range = Exports.date_range(site.id, site.timezone)
 
     queries =
-      Exports.export_queries(site_id, current_user_id,
+      Exports.export_queries(site_id,
         date_range: date_range,
         timezone: site.timezone,
         extname: ".csv"

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -109,11 +109,6 @@
               "additionalProperties": false
             }
           ]
-        },
-        "legacy_time_on_page_cutoff": {
-          "$comment": "only :internal",
-          "type": "string",
-          "format": "datetime"
         }
       }
     },

--- a/test/plausible/exports_test.exs
+++ b/test/plausible/exports_test.exs
@@ -9,7 +9,7 @@ defmodule Plausible.ExportsTest do
     setup [:create_user, :create_site]
 
     test "returns named ecto queries", %{site: site} do
-      queries = Plausible.Exports.export_queries(site.id, nil)
+      queries = Plausible.Exports.export_queries(site.id)
       assert queries |> Map.values() |> Enum.all?(&match?(%Ecto.Query{}, &1))
 
       assert Map.keys(queries) == [
@@ -28,7 +28,7 @@ defmodule Plausible.ExportsTest do
 
     test "with date range", %{site: site} do
       queries =
-        Plausible.Exports.export_queries(site.id, nil,
+        Plausible.Exports.export_queries(site.id,
           date_range: Date.range(~D[2023-01-01], ~D[2024-03-12])
         )
 
@@ -47,7 +47,7 @@ defmodule Plausible.ExportsTest do
     end
 
     test "with custom extension", %{site: site} do
-      queries = Plausible.Exports.export_queries(site.id, nil, extname: ".ch")
+      queries = Plausible.Exports.export_queries(site.id, extname: ".ch")
 
       assert Map.keys(queries) == [
                "imported_browsers.ch",

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -1248,7 +1248,7 @@ defmodule Plausible.Imported.CSVImporterTest do
     context =
       on_ee do
         assert {:ok, _job} =
-                 Plausible.Exports.schedule_s3_export(exported_site.id, nil, user.email)
+                 Plausible.Exports.schedule_s3_export(exported_site.id, user.email)
 
         context
       else

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -1059,9 +1059,10 @@ defmodule Plausible.Imported.CSVImporterTest do
     end
 
     @tag :tmp_dir
-    test "scroll_depth", %{conn: conn, user: user, tmp_dir: tmp_dir} do
+    test "scroll_depth and time_on_page", %{conn: conn, user: user, tmp_dir: tmp_dir} do
       exported_site = new_site(owner: user)
       imported_site = new_site(owner: user)
+      FunWithFlags.enable(:new_time_on_page, for_actor: exported_site)
 
       t0 =
         NaiveDateTime.utc_now(:second)
@@ -1073,19 +1074,61 @@ defmodule Plausible.Imported.CSVImporterTest do
       stats =
         [
           build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-          build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+          build(:engagement,
+            user_id: 12,
+            pathname: "/blog",
+            timestamp: t1,
+            scroll_depth: 20,
+            engagement_time: 50_000
+          ),
           build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-          build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+          build(:engagement,
+            user_id: 12,
+            pathname: "/another",
+            timestamp: t2,
+            scroll_depth: 24,
+            engagement_time: 30_000
+          ),
           build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-          build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+          build(:engagement,
+            user_id: 34,
+            pathname: "/blog",
+            timestamp: t1,
+            scroll_depth: 17,
+            engagement_time: 10_000
+          ),
           build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-          build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+          build(:engagement,
+            user_id: 34,
+            pathname: "/another",
+            timestamp: t2,
+            scroll_depth: 26,
+            engagement_time: 20_000
+          ),
           build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-          build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+          build(:engagement,
+            user_id: 34,
+            pathname: "/blog",
+            timestamp: t3,
+            scroll_depth: 60,
+            engagement_time: 30_000
+          ),
           build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-          build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100),
+          build(:engagement,
+            user_id: 56,
+            pathname: "/blog",
+            timestamp: t1,
+            scroll_depth: 100,
+            engagement_time: 40_000
+          ),
           build(:pageview, user_id: 78, pathname: "/", timestamp: t0),
-          build(:engagement, user_id: 78, pathname: "/", timestamp: t1, scroll_depth: 20),
+          build(:engagement,
+            user_id: 78,
+            pathname: "/",
+            timestamp: t1,
+            scroll_depth: 20,
+            engagement_time: 10_000
+          ),
           build(:pageview, pathname: "/", timestamp: t1),
           build(:pageview, pathname: "/blog", timestamp: NaiveDateTime.add(t0, 1, :day))
         ]
@@ -1132,7 +1175,9 @@ defmodule Plausible.Imported.CSVImporterTest do
             date: i.date,
             page: i.page,
             total_scroll_depth: i.total_scroll_depth,
-            total_scroll_depth_visits: i.total_scroll_depth_visits
+            total_scroll_depth_visits: i.total_scroll_depth_visits,
+            total_time_on_page: i.total_time_on_page,
+            total_time_on_page_visits: i.total_time_on_page_visits
           }
         )
         |> Plausible.IngestRepo.all()
@@ -1141,28 +1186,36 @@ defmodule Plausible.Imported.CSVImporterTest do
                date: expected_start_date,
                page: "/",
                total_scroll_depth: 20,
-               total_scroll_depth_visits: 1
+               total_scroll_depth_visits: 1,
+               total_time_on_page: 10,
+               total_time_on_page_visits: 1
              } in imported_data
 
       assert %{
                date: expected_start_date,
                page: "/another",
                total_scroll_depth: 50,
-               total_scroll_depth_visits: 2
+               total_scroll_depth_visits: 2,
+               total_time_on_page: 50,
+               total_time_on_page_visits: 2
              } in imported_data
 
       assert %{
                date: expected_start_date,
                page: "/blog",
                total_scroll_depth: 180,
-               total_scroll_depth_visits: 3
+               total_scroll_depth_visits: 3,
+               total_time_on_page: 130,
+               total_time_on_page_visits: 3
              } in imported_data
 
       assert %{
                date: expected_end_date,
                page: "/blog",
                total_scroll_depth: 0,
-               total_scroll_depth_visits: 0
+               total_scroll_depth_visits: 0,
+               total_time_on_page: 0,
+               total_time_on_page_visits: 0
              } in imported_data
 
       # assert via stats queries that scroll_depth from imported


### PR DESCRIPTION
### Changes

This PR:
1. Adds CSV import/export support for time-on-page
2. Removes previous code handling time-on-page via frontend include flag. Now the behavior is determined by site.legacy_time_on_page_cutoff and feature flag state.

After this PR (assuming documentation is updated) the feature can be released.