### PR TITLE
Add teams hourly api request limit backfill to CE-only migration

### DIFF
--- a/priv/repo/migrations/20250403093826_backfill_teams_hourly_api_request_limit.exs
+++ b/priv/repo/migrations/20250403093826_backfill_teams_hourly_api_request_limit.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Repo.Migrations.BackfillTeamsHourlyApiRequestLimit do
+  use Plausible
+  use Ecto.Migration
+
+  def up do
+    if ce?() do
+      Plausible.DataMigration.BackfillTeamsHourlyRequestLimit.run(dry_run?: false)
+    end
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end


### PR DESCRIPTION
### Changes

Wrap existing backfill data script in a migration to run only against CE instances.
