### PR TITLE
time-on-page: Remove flag, CHANGELOG.md, time_on_page in APIv2, update old tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Introduce "billing" team role for users
 - Introduce "editor" role with permissions greater than "viewer" but lesser than "admin"
 - Support behavioral filters `has_done` and `has_not_done` on the Stats API to allow filtering sessions by other events that have been completed.
+- `time_on_page` metric is now graphable, sortable on the dashboard, and available in the Stats API and CSV and GA4 exports/imports
 
 ### Removed
 
@@ -44,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Main graph now shows `-` instead of `0` for visit duration, scroll depth when hovering a data point with no visit data
 - Make Stats and Sites API keys scoped to teams they are created in
 - Remove permissions to manage sites guests and run destructive actions from team editor and guest editor roles in favour of team admin role
+- Time-on-page metric has been reworked. It now uses `engagement` events sent by plausible tracker script. We still use the old calculation methods for periods before the self-hosted instance was upgraded. Warnings are shown in the dashboard and API when legacy calculation methods are used.
 
 ### Fixed
 

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -25,8 +25,8 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
   }
 }
 
-type FeatureFlags = {
-}
+// Update this object when new feature flags are added to the frontend.
+type FeatureFlags = Record<never, boolean>
 
 const siteContextDefaultValue = {
   domain: '',

--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -26,7 +26,6 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
 }
 
 type FeatureFlags = {
-  new_time_on_page?: boolean
 }
 
 const siteContextDefaultValue = {

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -75,7 +75,7 @@ export default function TopStats({
     )
   }
 
-  function warningText(metric, site) {
+  function warningText(metric) {
     const warning = data.meta.metric_warnings?.[metric]
     if (!warning) {
       return null
@@ -141,7 +141,7 @@ export default function TopStats({
         {statExtraName && (
           <span className="hidden sm:inline-block ml-1">{statExtraName}</span>
         )}
-        {warningText(stat.graph_metric, site) && (
+        {warningText(stat.graph_metric) && (
           <span className="inline-block ml-1">*</span>
         )}
       </div>

--- a/assets/js/dashboard/stats/graph/top-stats.js
+++ b/assets/js/dashboard/stats/graph/top-stats.js
@@ -88,7 +88,7 @@ export default function TopStats({
       return 'Does not include imported data'
     }
 
-    if (metric === 'time_on_page' && site.flags.new_time_on_page) {
+    if (metric === 'time_on_page') {
       return warning.message
     }
 

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -14,7 +14,7 @@ import { Metric } from '../reports/metrics'
 import { BreakdownResultMeta, DashboardQuery } from '../../query'
 import { ColumnConfiguraton } from '../../components/table'
 import { BreakdownTable } from './breakdown-table'
-import { PlausibleSite, useSiteContext } from '../../site-context'
+import { useSiteContext } from '../../site-context'
 import { DrilldownLink, FilterInfo } from '../../components/drilldown-link'
 import { SharedReportProps } from '../reports/list'
 
@@ -142,7 +142,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
           key: m.key,
           width: m.width,
           align: 'right',
-          metricWarning: getMetricWarning(m, meta, site),
+          metricWarning: getMetricWarning(m, meta),
           renderValue: (item) => m.renderValue(item, meta),
           onSort: m.sortable ? () => toggleSortByMetric(m) : undefined,
           sortDirection: orderByDictionary[m.key]
@@ -158,8 +158,7 @@ export default function BreakdownModal<TListItem extends { name: string }>({
       toggleSortByMetric,
       renderIcon,
       getExternalLinkUrl,
-      meta,
-      site
+      meta
     ]
   )
 
@@ -226,11 +225,7 @@ const ExternalLinkIcon = ({ url }: { url?: string }) =>
     </a>
   ) : null
 
-const getMetricWarning = (
-  metric: Metric,
-  meta: BreakdownResultMeta | null,
-  site: PlausibleSite
-) => {
+const getMetricWarning = (metric: Metric, meta: BreakdownResultMeta | null) => {
   const warnings = meta?.metric_warnings
 
   if (warnings && warnings[metric.key]) {

--- a/assets/js/dashboard/stats/modals/breakdown-modal.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-modal.tsx
@@ -240,7 +240,7 @@ const getMetricWarning = (
       return 'Does not include imported data'
     }
 
-    if (metric.key == 'time_on_page' && code && site.flags.new_time_on_page) {
+    if (metric.key == 'time_on_page' && code) {
       return message
     }
   }

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -642,6 +642,19 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
+  defp validate_metric(:time_on_page = metric, query) do
+    cond do
+      Enum.member?(query.dimensions, "event:page") ->
+        :ok
+
+      Filters.filtering_on_dimension?(query, "event:page", behavioral_filters: :ignore) ->
+        :ok
+
+      true ->
+        {:error, "Metric `#{metric}` can only be queried with event:page filters or dimensions."}
+    end
+  end
+
   defp validate_metric(_, _), do: :ok
 
   defp validate_include(query) do

--- a/lib/plausible/stats/time_on_page.ex
+++ b/lib/plausible/stats/time_on_page.ex
@@ -4,7 +4,7 @@ defmodule Plausible.Stats.TimeOnPage do
   """
 
   def new_time_on_page_visible?(site) do
-    new_time_on_page_enabled?(site) && not is_nil(site.legacy_time_on_page_cutoff)
+    not is_nil(site.legacy_time_on_page_cutoff)
   end
 
   def legacy_time_on_page_cutoff(site) do
@@ -23,9 +23,5 @@ defmodule Plausible.Stats.TimeOnPage do
       {:gap, just_before, _just_after} -> just_before
       {:ambiguous, first_datetime, _second_datetime} -> first_datetime
     end
-  end
-
-  defp new_time_on_page_enabled?(site) do
-    FunWithFlags.enabled?(:new_time_on_page, for: site)
   end
 end

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -392,7 +392,7 @@ defmodule PlausibleWeb.StatsController do
 
   defp get_flags(user, site),
     do:
-      [:new_time_on_page]
+      []
       |> Enum.map(fn flag ->
         {flag, FunWithFlags.enabled?(flag, for: user) || FunWithFlags.enabled?(flag, for: site)}
       end)

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -266,7 +266,7 @@
         },
         {
           "const": "time_on_page",
-          "$comment": "only :internal"
+          "markdownDescription": "Average time spent on a given page in a visit in seconds. Requires: `event:page` filter or dimension."
         },
         {
           "const": "total_revenue",

--- a/test/plausible/imported/csv_importer_test.exs
+++ b/test/plausible/imported/csv_importer_test.exs
@@ -734,9 +734,6 @@ defmodule Plausible.Imported.CSVImporterTest do
         assert exported["pageviews"] == imported["pageviews"]
         assert exported["visit_duration"] == imported["visit_duration"]
         assert exported["bounce_rate"] == imported["bounce_rate"]
-
-        # time on page is not being exported/imported right now
-        assert imported["time_on_page"] == 0
       end)
 
       # NOTE: page breakdown's visitors difference is up to 28%

--- a/test/plausible/imported/google_analytics4_test.exs
+++ b/test/plausible/imported/google_analytics4_test.exs
@@ -779,7 +779,7 @@ defmodule Plausible.Imported.GoogleAnalytics4Test do
     # it will allow us to assert on the session metrics as well.
     assert Enum.at(results, 2) == %{
              "page" => "/",
-             "time_on_page" => 18,
+             "time_on_page" => 462,
              "visitors" => 371,
              "visits" => 212,
              "bounce_rate" => 54.0,

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/pages.csv
@@ -1,2 +1,2 @@
 name,visitors,pageviews,bounce_rate,time_on_page,scroll_depth
-/some-other-page,1,1,0,60,
+/some-other-page,1,1,0,60,30

--- a/test/plausible_web/controllers/CSVs/30d-filter-path/visitors.csv
+++ b/test/plausible_web/controllers/CSVs/30d-filter-path/visitors.csv
@@ -29,4 +29,4 @@ date,visitors,pageviews,visits,views_per_visit,bounce_rate,visit_duration,scroll
 2021-10-17,0,0,0,0.0,0.0,,
 2021-10-18,0,0,0,0.0,0.0,,
 2021-10-19,0,0,0,0.0,0.0,,
-2021-10-20,1,1,1,2.0,0,60,
+2021-10-20,1,1,1,2.0,0,60,30

--- a/test/plausible_web/controllers/CSVs/30d/pages.csv
+++ b/test/plausible_web/controllers/CSVs/30d/pages.csv
@@ -1,4 +1,4 @@
 name,visitors,pageviews,bounce_rate,time_on_page,scroll_depth
-/,4,3,67,,
-/signup,1,1,0,60,
-/some-other-page,1,1,0,60,
+/,4,3,67,30,27
+/signup,1,1,0,60,20
+/some-other-page,1,1,0,60,30

--- a/test/plausible_web/controllers/CSVs/6m/pages.csv
+++ b/test/plausible_web/controllers/CSVs/6m/pages.csv
@@ -1,4 +1,4 @@
 name,visitors,pageviews,bounce_rate,time_on_page,scroll_depth
-/,5,4,75,,
-/signup,1,1,0,60,
-/some-other-page,1,1,0,60,
+/,5,4,75,30,25
+/signup,1,1,0,60,20
+/some-other-page,1,1,0,60,30

--- a/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/aggregate_test.exs
@@ -452,8 +452,20 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
     test "can compare time_on_page with previous period", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, pathname: "/A", user_id: 111, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:engagement,
+          pathname: "/A",
+          user_id: 111,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview, pathname: "/B", user_id: 111, timestamp: ~N[2021-01-01 00:01:00]),
         build(:pageview, pathname: "/A", user_id: 999, timestamp: ~N[2021-01-02 00:00:00]),
+        build(:engagement,
+          pathname: "/A",
+          user_id: 999,
+          timestamp: ~N[2021-01-02 00:01:30],
+          engagement_time: 90_000
+        ),
         build(:pageview, pathname: "/B", user_id: 999, timestamp: ~N[2021-01-02 00:01:30])
       ])
 
@@ -478,6 +490,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
          %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, pathname: "/A", user_id: 123, timestamp: ~N[2021-01-01 00:00:00]),
+        build(:engagement,
+          pathname: "/A",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview, pathname: "/B", user_id: 123, timestamp: ~N[2021-01-01 00:01:00]),
         build(:pageview, pathname: "/A", timestamp: ~N[2021-01-02 00:00:00])
       ])
@@ -1597,6 +1615,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/A",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/another",
           user_id: 123,
@@ -1606,6 +1630,12 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
           pathname: "/A",
           user_id: 321,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/A",
+          user_id: 321,
+          timestamp: ~N[2021-01-01 00:01:20],
+          engagement_time: 80_000
         ),
         build(:pageview,
           pathname: "/another",
@@ -1640,27 +1670,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AggregateTest do
         })
 
       assert json_response(conn, 200)["results"] == %{"time_on_page" => %{"value" => nil}}
-    end
-
-    test "engagement events are ignored when querying time on page", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:00], pathname: "/1"),
-        build(:pageview, user_id: 1234, timestamp: ~N[2021-01-01 12:00:05], pathname: "/2"),
-        build(:engagement, user_id: 1234, timestamp: ~N[2021-01-01 12:01:00], pathname: "/1")
-      ])
-
-      conn =
-        get(conn, "/api/v1/stats/aggregate", %{
-          "site_id" => site.domain,
-          "metrics" => "time_on_page",
-          "filters" => "event:page==/2",
-          "period" => "day",
-          "date" => "2021-01-01"
-        })
-
-      assert json_response(conn, 200)["results"] == %{
-               "time_on_page" => %{"value" => nil}
-             }
     end
 
     test "conversion_rate when goal filter is applied", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_time_on_page_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_time_on_page_test.exs
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal-test", %{
+      post(conn, "/api/v2/query", %{
         "site_id" => site.domain,
         "metrics" => ["time_on_page"],
         "date_range" => "all",
@@ -79,7 +79,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal-test", %{
+      post(conn, "/api/v2/query", %{
         "site_id" => site.domain,
         "metrics" => ["time_on_page"],
         "date_range" => "all",
@@ -145,7 +145,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
     ])
 
     conn =
-      post(conn, "/api/v2/query-internal-test", %{
+      post(conn, "/api/v2/query", %{
         "site_id" => site.domain,
         "metrics" => ["time_on_page"],
         "date_range" => ["2021-01-01", "2021-01-04"],
@@ -232,7 +232,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[1970-01-01])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -260,7 +260,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-05])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -294,7 +294,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-02])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -331,7 +331,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-02])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -361,7 +361,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-05])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -393,7 +393,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-02])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -428,7 +428,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-02])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => "all",
@@ -468,7 +468,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "time_on_page"],
           "date_range" => "all",
@@ -497,7 +497,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "time_on_page"],
           "date_range" => "all",
@@ -525,7 +525,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "time_on_page"],
           "date_range" => "all",
@@ -583,7 +583,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
 
     test "reports average new time-on-page per day", %{conn: conn, site: site} do
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => ["2021-01-01", "2021-01-04"],
@@ -603,7 +603,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2100-01-01])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => ["2021-01-01", "2021-01-04"],
@@ -623,7 +623,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTimeOnPageTest do
       site = Plausible.Sites.update_legacy_time_on_page_cutoff!(site, ~D[2021-01-03])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["time_on_page"],
           "date_range" => ["2021-01-01", "2021-01-04"],

--- a/test/plausible_web/controllers/api/stats_controller/imported_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/imported_test.exs
@@ -879,7 +879,7 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
         assert json_response(conn, 200)["results"] == [
                  %{
                    "bounce_rate" => 0,
-                   "time_on_page" => 40,
+                   "time_on_page" => 60,
                    "visitors" => 3,
                    "pageviews" => 4,
                    "scroll_depth" => nil,
@@ -887,7 +887,7 @@ defmodule PlausibleWeb.Api.StatsController.ImportedTest do
                  },
                  %{
                    "bounce_rate" => 25.0,
-                   "time_on_page" => 800.0,
+                   "time_on_page" => 700,
                    "visitors" => 2,
                    "pageviews" => 2,
                    "scroll_depth" => nil,

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -243,10 +243,24 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/john-1",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/blog/john-2",
@@ -255,6 +269,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/blog/john-2",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/blog/john-2",
           "meta.key": ["author"],
@@ -262,10 +284,24 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: 456,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/john-2",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:10:00],
+          engagement_time: 600_000
+        ),
         build(:pageview,
           pathname: "/blog",
           user_id: 456,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -283,8 +319,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 0,
-                 "time_on_page" => 600,
-                 "scroll_depth" => nil
+                 "time_on_page" => 315,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/john-1",
@@ -292,7 +328,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 1,
                  "bounce_rate" => 0,
                  "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -305,12 +341,26 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog/john-1",
           user_id: @user_id,
           "meta.key": ["author"],
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/blog/john-1",
+          user_id: @user_id,
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/blog/other-post",
@@ -319,10 +369,24 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           "meta.value": ["other"],
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/blog/other-post",
+          user_id: @user_id,
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/blog",
           user_id: 456,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:03:00],
+          engagement_time: 180_000
         ),
         build(:pageview,
           pathname: "/blog/john-1",
@@ -330,6 +394,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           "meta.value": ["John Doe"],
           user_id: 456,
           timestamp: ~N[2021-01-01 00:03:00]
+        ),
+        build(:engagement,
+          pathname: "/blog/john-1",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:03:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -347,16 +419,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 0,
-                 "time_on_page" => 120.0,
-                 "scroll_depth" => nil
+                 "time_on_page" => 120,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -369,6 +441,12 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog/john-1",
           user_id: @user_id,
@@ -376,14 +454,35 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/blog/john-1",
+          user_id: @user_id,
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog/other-post",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/blog/other-post",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/blog",
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:00:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -401,16 +500,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "time_on_page" => 45,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/other-post",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -425,10 +524,24 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           "meta.value": ["John Doe"],
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/john-1",
+          user_id: @user_id,
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/blog",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/blog/other-post",
@@ -437,11 +550,28 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/blog/other-post",
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/blog/other-post",
           "meta.key": ["author"],
           "meta.value": [""],
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/blog/other-post",
+          "meta.key": ["author"],
+          "meta.value": [""],
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:00:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -459,8 +589,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/john-1",
@@ -468,7 +598,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 1,
                  "bounce_rate" => 0,
                  "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -569,15 +699,33 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/about",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
         ),
         build(:pageview,
           pathname: "/",
@@ -585,7 +733,14 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
         ),
         build(:pageview,
           pathname: "/about",
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -603,8 +758,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "time_on_page" => 90,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -615,17 +770,53 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement,
+          user_id: 12,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 20,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement,
+          user_id: 12,
+          pathname: "/another",
+          timestamp: t2,
+          scroll_depth: 24,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 17,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/another",
+          timestamp: t2,
+          scroll_depth: 26,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/blog",
+          timestamp: t3,
+          scroll_depth: 60,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement,
+          user_id: 56,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 100,
+          engagement_time: 60_000
+        )
       ])
 
       conn =
@@ -648,7 +839,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 3,
                  "pageviews" => 4,
                  "bounce_rate" => 33,
-                 "time_on_page" => 60,
+                 "time_on_page" => 80,
                  "scroll_depth" => 60
                }
              ]
@@ -664,7 +855,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           pathname: "/blog",
           timestamp: ~N[2020-01-01 00:00:00],
-          scroll_depth: 80
+          scroll_depth: 80,
+          engagement_time: 20_000
         ),
         build(:imported_pages,
           date: ~D[2020-01-01],
@@ -690,7 +882,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 4,
                  "pageviews" => 4,
                  "bounce_rate" => 100,
-                 "time_on_page" => 30.0,
+                 "time_on_page" => 28,
                  "scroll_depth" => 50
                }
              ]
@@ -710,7 +902,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           pathname: "/native-and-imported",
           timestamp: ~N[2020-01-01 00:01:00],
-          scroll_depth: 80
+          scroll_depth: 80,
+          engagement_time: 60_000
         ),
         build(:pageview,
           user_id: @user_id,
@@ -721,7 +914,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           pathname: "/native-only",
           timestamp: ~N[2020-01-01 00:02:00],
-          scroll_depth: 40
+          scroll_depth: 40,
+          engagement_time: 60_000
         ),
         build(:imported_pages,
           date: ~D[2020-01-01],
@@ -765,7 +959,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
+                 "time_on_page" => 60,
                  "scroll_depth" => 40
                },
                %{
@@ -773,13 +967,13 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 20,
                  "pageviews" => 30,
                  "bounce_rate" => 0,
-                 "time_on_page" => 10.0,
+                 "time_on_page" => 30,
                  "scroll_depth" => 10
                }
              ]
     end
 
-    test "can query scroll depth only from imported data, ignoring rows where scroll depth doesn't exist",
+    test "can query scroll depth and time-on-page only from imported data, ignoring rows where scroll depth doesn't exist",
          %{
            conn: conn,
            site: site
@@ -791,14 +985,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           pageviews: 10,
           page: "/blog",
           total_scroll_depth: 100,
-          total_scroll_depth_visits: 10
+          total_scroll_depth_visits: 10,
+          total_time_on_page: 300,
+          total_time_on_page_visits: 5
         ),
         build(:imported_pages,
           date: ~D[2020-01-01],
           visitors: 100,
           pageviews: 150,
           page: "/blog",
-          total_scroll_depth: 0
+          total_scroll_depth: 0,
+          total_scroll_depth_visits: 0,
+          total_time_on_page: 0,
+          total_time_on_page_visits: 0
         )
       ])
 
@@ -814,7 +1013,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 110,
                  "pageviews" => 160,
                  "bounce_rate" => 0,
-                 "time_on_page" => 0,
+                 "time_on_page" => 60,
                  "scroll_depth" => 10
                }
              ]
@@ -828,23 +1027,55 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/irrelevant",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/irrelevant",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/about",
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -862,16 +1093,16 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "time_on_page" => 75,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/about",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -884,23 +1115,55 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/irrelevant",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/irrelevant",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:02:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:02:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 123,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
         ),
         build(:pageview,
           pathname: "/about",
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -918,8 +1181,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 3,
                  "bounce_rate" => 50,
-                 "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "time_on_page" => 75,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -932,22 +1195,55 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog/post-2",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/blog/post-2",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 100,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
-        build(:pageview,
-          pathname: "/articles/post-1",
-          timestamp: ~N[2021-01-01 00:10:00]
+        build(:engagement,
+          pathname: "/",
+          user_id: 100,
+          timestamp: ~N[2021-01-01 00:00:30],
+          engagement_time: 30_000
         ),
         build(:pageview,
           pathname: "/articles/post-1",
+          user_id: 200,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/articles/post-1",
+          user_id: 200,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
+        ),
+        build(:pageview,
+          pathname: "/articles/post-1",
+          user_id: 300,
+          timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/articles/post-1",
+          user_id: 300,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -965,8 +1261,8 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "visitors" => 2,
                  "pageviews" => 2,
                  "bounce_rate" => 100,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/post-1",
@@ -974,15 +1270,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 1,
                  "bounce_rate" => 0,
                  "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/post-2",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -995,14 +1291,33 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/(/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview,
           pathname: "/blog/(/post-2",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/blog/(/post-2",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:01:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 456,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 456,
+          timestamp: ~N[2021-01-01 00:00:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -1021,15 +1336,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 1,
                  "bounce_rate" => 0,
                  "time_on_page" => 60,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/blog/(/post-2",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1039,25 +1354,58 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/blog/post-1",
+          user_id: 100,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/blog/post-1",
+          user_id: 100,
+          timestamp: ~N[2021-01-01 00:00:30],
+          engagement_time: 30_000
         ),
         build(:pageview,
           pathname: "/",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:10:00],
+          engagement_time: 600_000
         ),
         build(:pageview,
           pathname: "/about",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:10:00]
         ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 200,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 200,
+          timestamp: ~N[2021-01-01 00:10:00],
+          engagement_time: 600_000
         ),
         build(:pageview,
           pathname: "/articles/post-1",
+          user_id: 300,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/articles/post-1",
+          user_id: 300,
+          timestamp: ~N[2021-01-01 00:10:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -1076,15 +1424,15 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 2,
                  "bounce_rate" => 50,
                  "time_on_page" => 600,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "name" => "/about",
                  "visitors" => 1,
                  "pageviews" => 1,
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
-                 "scroll_depth" => nil
+                 "time_on_page" => 30,
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1165,14 +1513,33 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 900_000
+        ),
         build(:pageview,
           pathname: "/some-other-page",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
+        build(:engagement,
+          pathname: "/some-other-page",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 123,
           timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:15:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -1185,19 +1552,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "bounce_rate" => 50.0,
-                 "time_on_page" => 900.0,
+                 "time_on_page" => 465.0,
                  "visitors" => 2,
                  "pageviews" => 2,
                  "name" => "/",
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 0,
-                 "time_on_page" => nil,
+                 "time_on_page" => 30,
                  "visitors" => 1,
                  "pageviews" => 1,
                  "name" => "/some-other-page",
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1255,6 +1622,13 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id + 1,
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/about-blog",
+          hostname: "blog.example.com",
+          user_id: @user_id + 1,
+          timestamp: ~N[2021-01-01 00:01:30],
+          engagement_time: 30_000
+        ),
 
         # session 2
         build(:pageview,
@@ -1263,11 +1637,25 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:01:00]
         ),
+        build(:engagement,
+          pathname: "/about-blog",
+          hostname: "blog.example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:10:00],
+          engagement_time: 540_000
+        ),
         build(:pageview,
           pathname: "/about",
           hostname: "example.com",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:10:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          hostname: "example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 300_000
         ),
         build(:pageview,
           pathname: "/about-blog",
@@ -1275,23 +1663,51 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
+        build(:engagement,
+          pathname: "/about-blog",
+          hostname: "blog.example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:20:00],
+          engagement_time: 300_000
+        ),
         build(:pageview,
           pathname: "/exit-blog",
           hostname: "blog.example.com",
-          timestamp: ~N[2021-01-01 00:20:00],
-          user_id: @user_id
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:20:00]
+        ),
+        build(:engagement,
+          pathname: "/exit-blog",
+          hostname: "blog.example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:22:00],
+          engagement_time: 120_000
         ),
         build(:pageview,
           pathname: "/about",
           hostname: "example.com",
-          timestamp: ~N[2021-01-01 00:22:00],
-          user_id: @user_id
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:22:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          hostname: "example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:25:00],
+          engagement_time: 180_000
         ),
         build(:pageview,
           pathname: "/exit",
           hostname: "example.com",
-          timestamp: ~N[2021-01-01 00:25:00],
-          user_id: @user_id
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:25:00]
+        ),
+        build(:engagement,
+          pathname: "/exit",
+          hostname: "example.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:25:30],
+          engagement_time: 30_000
         ),
 
         # session 3
@@ -1300,6 +1716,13 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           hostname: "example.com",
           user_id: @user_id + 2,
           timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:engagement,
+          pathname: "/about",
+          hostname: "example.com",
+          user_id: @user_id + 2,
+          timestamp: ~N[2021-01-01 00:01:30],
+          engagement_time: 30_000
         )
       ])
 
@@ -1316,84 +1739,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "bounce_rate" => 50,
                  "name" => "/about-blog",
                  "pageviews" => 3,
-                 "time_on_page" => 1140.0,
+                 "time_on_page" => 435,
                  "visitors" => 2,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 0,
                  "name" => "/exit-blog",
                  "pageviews" => 1,
-                 "time_on_page" => nil,
+                 "time_on_page" => 120,
                  "visitors" => 1,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                }
              ]
-    end
-
-    test "doesn't calculate time on page with only single page visits", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/", user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/", user_id: @user_id, timestamp: ~N[2021-01-01 00:10:00])
-      ])
-
-      assert [%{"name" => "/", "time_on_page" => nil}] =
-               conn
-               |> get("/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&detailed=true")
-               |> json_response(200)
-               |> Map.get("results")
-    end
-
-    test "ignores page refresh when calculating time on page", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:01:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:02:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:03:00], pathname: "/exit")
-      ])
-
-      assert [
-               %{"name" => "/", "time_on_page" => _three_minutes = 180},
-               %{"name" => "/exit", "time_on_page" => nil}
-             ] =
-               conn
-               |> get("/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&detailed=true")
-               |> json_response(200)
-               |> Map.get("results")
-    end
-
-    test "calculates time on page per unique transition within session", %{conn: conn, site: site} do
-      # ┌─p──┬─p2─┬─minus(t2, t)─┬──s─┐
-      # │ /a │ /b │          100 │ s1 │
-      # │ /a │ /d │          100 │ s2 │ <- these two get treated
-      # │ /a │ /d │            0 │ s2 │ <- as single page transition
-      # └────┴────┴──────────────┴────┘
-      # so that time_on_page(a)=(100+100)/uniq(transition)=200/2=100
-
-      s1 = @user_id
-      s2 = @user_id + 1
-
-      now = ~N[2021-01-01 00:00:00]
-      later = fn seconds -> NaiveDateTime.add(now, seconds) end
-
-      populate_stats(site, [
-        build(:pageview, user_id: s1, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s1, timestamp: later.(100), pathname: "/b"),
-        build(:pageview, user_id: s2, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d")
-      ])
-
-      assert [
-               %{"name" => "/a", "time_on_page" => 100},
-               %{"name" => "/b", "time_on_page" => nil},
-               %{"name" => "/d", "time_on_page" => 0}
-             ] =
-               conn
-               |> get("/api/stats/#{site.domain}/pages?period=day&date=2021-01-01&detailed=true")
-               |> json_response(200)
-               |> Map.get("results")
     end
 
     test "calculates bounce rate and time on page for pages with imported data", %{
@@ -1406,14 +1764,33 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 900_000
+        ),
         build(:pageview,
           pathname: "/some-other-page",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
+        build(:engagement,
+          pathname: "/some-other-page",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:30],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/",
+          user_id: 123,
           timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:30:00],
+          engagement_time: 900_000
         ),
         build(:imported_pages,
           page: "/",
@@ -1444,18 +1821,18 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       assert json_response(conn, 200)["results"] == [
                %{
                  "bounce_rate" => 40.0,
-                 "time_on_page" => 800.0,
+                 "time_on_page" => 500,
                  "visitors" => 3,
                  "pageviews" => 3,
-                 "scroll_depth" => nil,
+                 "scroll_depth" => 0,
                  "name" => "/"
                },
                %{
                  "bounce_rate" => 0,
-                 "time_on_page" => 60,
+                 "time_on_page" => 45,
                  "visitors" => 2,
                  "pageviews" => 2,
-                 "scroll_depth" => nil,
+                 "scroll_depth" => 0,
                  "name" => "/some-other-page"
                }
              ]
@@ -1504,7 +1881,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       populate_stats(site, site_import.id, [
         build(:pageview, user_id: 1, pathname: "/", timestamp: ~N[2021-01-01 12:00:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 12:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 1, pathname: "/ignored", timestamp: ~N[2021-01-01 12:01:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/ignored",
+          timestamp: ~N[2021-01-01 12:02:00],
+          engagement_time: 60_000
+        ),
         build(:imported_entry_pages,
           entry_page: "/",
           visitors: 1,
@@ -1534,7 +1923,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 4,
                  "time_on_page" => 90.0,
                  "visitors" => 4,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                }
              ]
     end
@@ -1544,7 +1933,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       populate_stats(site, site_import.id, [
         build(:pageview, user_id: 1, pathname: "/", timestamp: ~N[2021-01-01 12:00:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/",
+          timestamp: ~N[2021-01-01 12:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 1, pathname: "/ignored", timestamp: ~N[2021-01-01 12:01:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/ignored",
+          timestamp: ~N[2021-01-01 12:02:00],
+          engagement_time: 60_000
+        ),
         build(:imported_entry_pages,
           entry_page: "/",
           visitors: 1,
@@ -1585,7 +1986,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 4,
                  "time_on_page" => 90.0,
                  "visitors" => 4,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 100,
@@ -1603,7 +2004,19 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
 
       populate_stats(site, site_import.id, [
         build(:pageview, user_id: 1, pathname: "/aaa", timestamp: ~N[2021-01-01 12:00:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/aaa",
+          timestamp: ~N[2021-01-01 12:01:00],
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 1, pathname: "/ignored", timestamp: ~N[2021-01-01 12:01:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/ignored",
+          timestamp: ~N[2021-01-01 12:02:00],
+          engagement_time: 60_000
+        ),
         build(:imported_entry_pages,
           entry_page: "/aaa",
           visitors: 1,
@@ -1644,7 +2057,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                  "pageviews" => 4,
                  "time_on_page" => 90.0,
                  "visitors" => 4,
-                 "scroll_depth" => nil
+                 "scroll_depth" => 0
                },
                %{
                  "bounce_rate" => 100,

--- a/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/top_stats_test.exs
@@ -169,6 +169,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 199_000
+        ),
         build(:pageview,
           pathname: "/pageB",
           user_id: @user_id,
@@ -177,6 +183,12 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
         build(:pageview,
           pathname: "/pageA",
           timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 1_000
         )
       ])
 
@@ -190,7 +202,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Time on page", "value" => 900, "graph_metric" => "time_on_page"} in res[
+      assert %{"name" => "Time on page", "value" => 200, "graph_metric" => "time_on_page"} in res[
                "top_stats"
              ]
     end
@@ -205,19 +217,43 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 199_000
+        ),
         build(:pageview,
           pathname: "/pageB",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:engagement,
+          pathname: "/pageB",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 20_000
         ),
         build(:pageview,
           pathname: "/pageC",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:16:00]
         ),
+        build(:engagement,
+          pathname: "/pageC",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:16:00],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/pageA",
-          timestamp: ~N[2021-01-01 00:15:00]
+          timestamp: ~N[2021-01-01 00:17:00]
+        ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:00],
+          engagement_time: 1_000
         )
       ])
 
@@ -231,7 +267,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Time on page", "value" => 480, "graph_metric" => "time_on_page"} in res[
+      assert %{"name" => "Time on page", "value" => 220, "graph_metric" => "time_on_page"} in res[
                "top_stats"
              ]
     end
@@ -246,19 +282,43 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 199_000
+        ),
         build(:pageview,
           pathname: "/pageB",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:engagement,
+          pathname: "/pageB",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 20_000
         ),
         build(:pageview,
           pathname: "/pageC",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:16:00]
         ),
+        build(:engagement,
+          pathname: "/pageC",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:16:00],
+          engagement_time: 30_000
+        ),
         build(:pageview,
           pathname: "/pageA",
-          timestamp: ~N[2021-01-01 00:15:00]
+          timestamp: ~N[2021-01-01 00:17:00]
+        ),
+        build(:engagement,
+          pathname: "/pageA",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:00],
+          engagement_time: 1_000
         )
       ])
 
@@ -272,7 +332,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Time on page", "value" => 60, "graph_metric" => "time_on_page"} in res[
+      assert %{"name" => "Time on page", "value" => 20, "graph_metric" => "time_on_page"} in res[
                "top_stats"
              ]
     end
@@ -287,20 +347,44 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
         ),
+        build(:engagement,
+          pathname: "/blog/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 100_000
+        ),
         build(:pageview,
           pathname: "/about",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:15:00]
         ),
+        build(:engagement,
+          pathname: "/about",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:16:00],
+          engagement_time: 20_000
+        ),
         build(:pageview,
           pathname: "/articles/post-1",
           user_id: 321,
-          timestamp: ~N[2021-01-01 00:15:00]
+          timestamp: ~N[2021-01-01 00:16:00]
+        ),
+        build(:engagement,
+          pathname: "/articles/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:00],
+          engagement_time: 30_000
         ),
         build(:pageview,
           pathname: "/",
           user_id: 321,
-          timestamp: ~N[2021-01-01 00:16:00]
+          timestamp: ~N[2021-01-01 00:17:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:30],
+          engagement_time: 3_000
         )
       ])
 
@@ -314,7 +398,7 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Time on page", "value" => 480, "graph_metric" => "time_on_page"} in res[
+      assert %{"name" => "Time on page", "value" => 130, "graph_metric" => "time_on_page"} in res[
                "top_stats"
              ]
     end
@@ -326,25 +410,47 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       populate_stats(site, [
         build(:pageview,
           pathname: "/blog/post-1",
-          timestamp: ~N[2021-01-01 00:00:00]
-        ),
-        build(:pageview,
-          pathname: "/",
           user_id: @user_id,
           timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:engagement,
+          pathname: "/blog/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00],
+          engagement_time: 100_000
         ),
         build(:pageview,
           pathname: "/about",
           user_id: @user_id,
-          timestamp: ~N[2021-01-01 00:10:00]
+          timestamp: ~N[2021-01-01 00:15:00]
         ),
-        build(:pageview,
-          pathname: "/",
-          timestamp: ~N[2021-01-01 00:00:00]
+        build(:engagement,
+          pathname: "/about",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:16:00],
+          engagement_time: 20_000
         ),
         build(:pageview,
           pathname: "/articles/post-1",
-          timestamp: ~N[2021-01-01 00:10:00]
+          user_id: 321,
+          timestamp: ~N[2021-01-01 00:16:00]
+        ),
+        build(:engagement,
+          pathname: "/articles/post-1",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:00],
+          engagement_time: 30_000
+        ),
+        build(:pageview,
+          pathname: "/",
+          user_id: 321,
+          timestamp: ~N[2021-01-01 00:17:00]
+        ),
+        build(:engagement,
+          pathname: "/",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:17:30],
+          engagement_time: 3_000
         )
       ])
 
@@ -358,26 +464,9 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
 
       res = json_response(conn, 200)
 
-      assert %{"name" => "Time on page", "value" => 600, "graph_metric" => "time_on_page"} in res[
+      assert %{"name" => "Time on page", "value" => 23, "graph_metric" => "time_on_page"} in res[
                "top_stats"
              ]
-    end
-
-    test "doesn't calculate time on page with only single page visits", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/", user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/", user_id: @user_id, timestamp: ~N[2021-01-01 00:10:00])
-      ])
-
-      filters = Jason.encode!([[:is, "event:page", ["/"]]])
-      path = "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}"
-
-      assert %{"name" => "Time on page", "value" => 0, "graph_metric" => "time_on_page"} ==
-               conn
-               |> get(path)
-               |> json_response(200)
-               |> Map.fetch!("top_stats")
-               |> Enum.find(&(&1["name"] == "Time on page"))
     end
 
     test "bounce_rate is 0 when the page in filter was never a landing page", %{
@@ -409,66 +498,6 @@ defmodule PlausibleWeb.Api.StatsController.TopStatsTest do
       path = "/api/stats/#{site.domain}/top-stats?&filters=#{filters}"
 
       assert %{"name" => "Time on page", "value" => 0, "graph_metric" => "time_on_page"} ==
-               conn
-               |> get(path)
-               |> json_response(200)
-               |> Map.fetch!("top_stats")
-               |> Enum.find(&(&1["name"] == "Time on page"))
-    end
-
-    test "ignores page refresh when calculating time on page", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:00:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:01:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:02:00], pathname: "/"),
-        build(:pageview, user_id: @user_id, timestamp: ~N[2021-01-01 00:03:00], pathname: "/exit")
-      ])
-
-      filters = Jason.encode!([[:is, "event:page", ["/"]]])
-      path = "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}"
-
-      assert %{
-               "name" => "Time on page",
-               "value" => _three_minutes = 180,
-               "graph_metric" => "time_on_page"
-             } ==
-               conn
-               |> get(path)
-               |> json_response(200)
-               |> Map.fetch!("top_stats")
-               |> Enum.find(&(&1["name"] == "Time on page"))
-    end
-
-    test "averages time on page over unique transitions across sessions", %{
-      conn: conn,
-      site: site
-    } do
-      # ┌─p──┬─p2─┬─minus(t2, t)─┬──s─┐
-      # │ /a │ /b │          100 │ s1 │
-      # │ /a │ /d │          100 │ s2 ��� <- these two get treated
-      # │ /a │ /d │            0 │ s2 │ <- as single page transition
-      # └────┴────┴──────────────┴────┘
-      # so that time_on_page(a)=(100+100)/uniq(transition)=200/2=100
-
-      s1 = @user_id
-      s2 = @user_id + 1
-
-      now = ~N[2021-01-01 00:00:00]
-      later = fn seconds -> NaiveDateTime.add(now, seconds) end
-
-      populate_stats(site, [
-        build(:pageview, user_id: s1, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s1, timestamp: later.(100), pathname: "/b"),
-        build(:pageview, user_id: s2, timestamp: now, pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/a"),
-        build(:pageview, user_id: s2, timestamp: later.(100), pathname: "/d")
-      ])
-
-      filters = Jason.encode!([[:is, "event:page", ["/a"]]])
-      path = "/api/stats/#{site.domain}/top-stats?period=day&date=2021-01-01&filters=#{filters}"
-
-      assert %{"name" => "Time on page", "value" => 100, "graph_metric" => "time_on_page"} ==
                conn
                |> get(path)
                |> json_response(200)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -334,17 +334,53 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       populate_stats(site, [
         build(:pageview, user_id: 12, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 12, pathname: "/blog", timestamp: t1, scroll_depth: 20),
+        build(:engagement,
+          user_id: 12,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 20,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 12, pathname: "/another", timestamp: t1),
-        build(:engagement, user_id: 12, pathname: "/another", timestamp: t2, scroll_depth: 24),
+        build(:engagement,
+          user_id: 12,
+          pathname: "/another",
+          timestamp: t2,
+          scroll_depth: 24,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t1, scroll_depth: 17),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 17,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/another", timestamp: t1),
-        build(:engagement, user_id: 34, pathname: "/another", timestamp: t2, scroll_depth: 26),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/another",
+          timestamp: t2,
+          scroll_depth: 26,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 34, pathname: "/blog", timestamp: t2),
-        build(:engagement, user_id: 34, pathname: "/blog", timestamp: t3, scroll_depth: 60),
+        build(:engagement,
+          user_id: 34,
+          pathname: "/blog",
+          timestamp: t3,
+          scroll_depth: 60,
+          engagement_time: 60_000
+        ),
         build(:pageview, user_id: 56, pathname: "/blog", timestamp: t0),
-        build(:engagement, user_id: 56, pathname: "/blog", timestamp: t1, scroll_depth: 100)
+        build(:engagement,
+          user_id: 56,
+          pathname: "/blog",
+          timestamp: t1,
+          scroll_depth: 100,
+          engagement_time: 60_000
+        )
       ])
 
       pages =
@@ -355,7 +391,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert pages == [
                ["name", "visitors", "pageviews", "bounce_rate", "time_on_page", "scroll_depth"],
-               ["/blog", "3", "4", "33", "60", "60"],
+               ["/blog", "3", "4", "33", "80", "60"],
                ["/another", "2", "2", "0", "60", "25"],
                [""]
              ]
@@ -927,6 +963,17 @@ defmodule PlausibleWeb.StatsControllerTest do
         city_geoname_id: 588_409,
         referrer_source: "Google"
       ),
+      build(:engagement,
+        user_id: 123,
+        pathname: "/",
+        timestamp: ~N[2021-10-20 12:00:00] |> NaiveDateTime.truncate(:second),
+        engagement_time: 30_000,
+        scroll_depth: 30,
+        country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
+        referrer_source: "Google"
+      ),
       build(:pageview,
         user_id: 123,
         pathname: "/some-other-page",
@@ -937,7 +984,20 @@ defmodule PlausibleWeb.StatsControllerTest do
         city_geoname_id: 588_409,
         referrer_source: "Google"
       ),
+      build(:engagement,
+        user_id: 123,
+        pathname: "/some-other-page",
+        timestamp:
+          Timex.shift(~N[2021-10-20 12:00:00], minutes: -1) |> NaiveDateTime.truncate(:second),
+        engagement_time: 60_000,
+        scroll_depth: 30,
+        country_code: "EE",
+        subdivision1_code: "EE-37",
+        city_geoname_id: 588_409,
+        referrer_source: "Google"
+      ),
       build(:pageview,
+        user_id: 100,
         pathname: "/",
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], days: -1) |> NaiveDateTime.truncate(:second),
@@ -951,7 +1011,26 @@ defmodule PlausibleWeb.StatsControllerTest do
         operating_system: "Mac",
         operating_system_version: "14"
       ),
+      build(:engagement,
+        user_id: 100,
+        pathname: "/",
+        timestamp:
+          Timex.shift(~N[2021-10-20 12:00:00], days: -1, minutes: 1)
+          |> NaiveDateTime.truncate(:second),
+        engagement_time: 30_000,
+        scroll_depth: 30,
+        utm_medium: "search",
+        utm_campaign: "ads",
+        utm_source: "google",
+        utm_content: "content",
+        utm_term: "term",
+        browser: "Firefox",
+        browser_version: "120",
+        operating_system: "Mac",
+        operating_system_version: "14"
+      ),
       build(:pageview,
+        user_id: 200,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -1) |> NaiveDateTime.truncate(:second),
         country_code: "EE",
@@ -960,9 +1039,37 @@ defmodule PlausibleWeb.StatsControllerTest do
         operating_system: "Mac",
         operating_system_version: "14"
       ),
+      build(:engagement,
+        user_id: 200,
+        timestamp:
+          Timex.shift(~N[2021-10-20 12:00:00], months: -1, minutes: 1)
+          |> NaiveDateTime.truncate(:second),
+        engagement_time: 30_000,
+        scroll_depth: 20,
+        country_code: "EE",
+        browser: "Firefox",
+        browser_version: "120",
+        operating_system: "Mac",
+        operating_system_version: "14"
+      ),
       build(:pageview,
+        user_id: 300,
         timestamp:
           Timex.shift(~N[2021-10-20 12:00:00], months: -5) |> NaiveDateTime.truncate(:second),
+        utm_campaign: "ads",
+        country_code: "EE",
+        referrer_source: "Google",
+        click_id_param: "gclid",
+        browser: "FirefoxNoVersion",
+        operating_system: "MacNoVersion"
+      ),
+      build(:engagement,
+        user_id: 300,
+        timestamp:
+          Timex.shift(~N[2021-10-20 12:00:00], months: -5, minutes: 1)
+          |> NaiveDateTime.truncate(:second),
+        engagement_time: 30_000,
+        scroll_depth: 20,
         utm_campaign: "ads",
         country_code: "EE",
         referrer_source: "Google",
@@ -976,6 +1083,16 @@ defmodule PlausibleWeb.StatsControllerTest do
           Timex.shift(~N[2021-10-20 12:00:00], days: -1, minutes: -1)
           |> NaiveDateTime.truncate(:second),
         pathname: "/signup",
+        "meta.key": ["variant"],
+        "meta.value": ["A"]
+      ),
+      build(:engagement,
+        user_id: 456,
+        timestamp:
+          Timex.shift(~N[2021-10-20 12:00:00], days: -1) |> NaiveDateTime.truncate(:second),
+        pathname: "/signup",
+        engagement_time: 60_000,
+        scroll_depth: 20,
         "meta.key": ["variant"],
         "meta.value": ["A"]
       ),


### PR DESCRIPTION
### Changes

This PR:
1. Removes `new_time_on_page` feature flga
2. Updates CHANGELOG.md for the new feature
3. Enables time_on_page metric in APIv2
4. Updates tests still relying on legacy time-on-page calculation methods

Depends on https://github.com/plausible/analytics/pull/5274