### PR TITLE
Show year (if multi-year graph) in graph tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
 - Fix Conversion Rate graph being unselectable when "Goal is ..." filter is within a segment
 - Fix Channels filter input appearing when clicking Sources in filter menu or clicking an applied "Channel is..." filter
 - Fix Conversion Rate metrics column disappearing from reports when "Goal is ..." filter is within a segment
+- Graph tooltip now shows year when graph has data from multiple years
 
 ## v2.1.5-rc.1 - 2025-01-17
 

--- a/assets/js/dashboard/stats/graph/graph-tooltip.js
+++ b/assets/js/dashboard/stats/graph/graph-tooltip.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import dateFormatter from './date-formatter'
-import { METRIC_LABELS } from './graph-util'
+import { METRIC_LABELS, hasMultipleYears } from './graph-util'
 import { MetricFormatterShort } from '../reports/metric-formatter'
 import { ChangeArrow } from '../reports/change-arrow'
 
@@ -14,18 +14,22 @@ const renderBucketLabel = function (
   let isPeriodFull = graphData.full_intervals?.[label]
   if (comparison) isPeriodFull = true
 
+  const shouldShowYear = hasMultipleYears(graphData)
+
   const formattedLabel = dateFormatter({
     interval: graphData.interval,
     longForm: true,
     period: query.period,
-    isPeriodFull
+    isPeriodFull,
+    shouldShowYear
   })(label)
 
   if (query.period === 'realtime') {
     return dateFormatter({
       interval: graphData.interval,
       longForm: true,
-      period: query.period
+      period: query.period,
+      shouldShowYear
     })(label)
   }
 
@@ -33,7 +37,8 @@ const renderBucketLabel = function (
     const date = dateFormatter({
       interval: 'day',
       longForm: true,
-      period: query.period
+      period: query.period,
+      shouldShowYear
     })(label)
     return `${date}, ${formattedLabel}`
   }

--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -101,3 +101,12 @@ export const buildDataSet = (
 
   return dataset.map((item) => Object.assign(item, defaultOptions))
 }
+
+export function hasMultipleYears(graphData) {
+  return (
+    graphData.labels
+      .filter((date) => typeof date === 'string')
+      .map((date) => date.split('-')[0])
+      .filter((value, index, list) => list.indexOf(value) === index).length > 1
+  )
+}

--- a/assets/js/dashboard/stats/graph/line-graph.js
+++ b/assets/js/dashboard/stats/graph/line-graph.js
@@ -3,7 +3,7 @@ import { useAppNavigate } from '../../navigation/use-app-navigate'
 import { useQueryContext } from '../../query-context'
 import Chart from 'chart.js/auto'
 import GraphTooltip from './graph-tooltip'
-import { buildDataSet, METRIC_LABELS } from './graph-util'
+import { buildDataSet, METRIC_LABELS, hasMultipleYears } from './graph-util'
 import dateFormatter from './date-formatter'
 import FadeIn from '../../fade-in'
 import classNames from 'classnames'
@@ -103,27 +103,21 @@ class LineGraph extends React.Component {
               callback: function (val, _index, _ticks) {
                 if (this.getLabelForValue(val) == '__blank__') return ''
 
-                const hasMultipleYears =
-                  graphData.labels
-                    .filter((date) => typeof date === 'string')
-                    .map((date) => date.split('-')[0])
-                    .filter(
-                      (value, index, list) => list.indexOf(value) === index
-                    ).length > 1
+                const shouldShowYear = hasMultipleYears(graphData)
 
                 if (graphData.interval === 'hour' && query.period !== 'day') {
                   const date = dateFormatter({
                     interval: 'day',
                     longForm: false,
                     period: query.period,
-                    shouldShowYear: hasMultipleYears
+                    shouldShowYear
                   })(this.getLabelForValue(val))
 
                   const hour = dateFormatter({
                     interval: graphData.interval,
                     longForm: false,
                     period: query.period,
-                    shouldShowYear: hasMultipleYears
+                    shouldShowYear
                   })(this.getLabelForValue(val))
 
                   // Returns a combination of date and hour. This is because
@@ -147,7 +141,7 @@ class LineGraph extends React.Component {
                   interval: graphData.interval,
                   longForm: false,
                   period: query.period,
-                  shouldShowYear: hasMultipleYears
+                  shouldShowYear
                 })(this.getLabelForValue(val))
               },
               color: this.props.darkTheme ? 'rgb(243, 244, 246)' : undefined


### PR DESCRIPTION
The graph ticks already had this feature, but this was missing from tooltips. Hope this sparks some joy.

Basecamp ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/7630914606

Screenshot before:
![image](https://github.com/user-attachments/assets/3eb5f97c-b21e-44a1-9636-360c3972b1f9)

Screenshot after:
![image](https://github.com/user-attachments/assets/b42c2284-1989-495f-b7fd-2f12a37256e5)
