### PR TITLE
Allow any email in CE

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -92,7 +92,7 @@ config :peep, :bucket_calculator, Plausible.PromEx.Buckets
 
 # https://github.com/plausible/community-edition/issues/210
 # this regex is more permissive than the original one
-# and allows the users use whatever they want
+# and allows users to use whatever they want
 config :mail, email_regex: ~r/\S+@\S+/
 
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
closes https://github.com/plausible/community-edition/issues/210

Right now `Mail` library that is used by default with `Bamboo.Mua` in CE [requires](https://github.com/DockYard/elixir-mail/blob/a369dc340f557503dcb58a2ffde6d1fd94495bce/lib/mail/renderers/rfc_2822.ex#L24-L29) `MAILER_EMAIL` hostname to be a FQDN.

This PR allows users to use whatever they want.