### PR TITLE
APIv2: More tolerant shorthands for date ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - Make Stats and Sites API keys scoped to teams they are created in
 - Remove permissions to manage sites guests and run destructive actions from team editor and guest editor roles in favour of team admin role
 - Time-on-page metric has been reworked. It now uses `engagement` events sent by plausible tracker script. We still use the old calculation methods for periods before the self-hosted instance was upgraded. Warnings are shown in the dashboard and API when legacy calculation methods are used.
+- Stats API now supports more `date_range` shorthand options like `30d`, `3mo`.
 
 ### Fixed
 

--- a/assets/js/types/query-api.d.ts
+++ b/assets/js/types/query-api.d.ts
@@ -27,7 +27,8 @@ export type DateRangeShorthand =
   | "month"
   | "6mo"
   | "12mo"
-  | "year";
+  | "year"
+  | string;
 /**
  * @minItems 2
  * @maxItems 2

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -256,7 +256,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
         {:ok, DateTimeRange.new!(first, last, site.timezone)}
 
       _ ->
-        {:error, "Invalid date_range '#{i(shorthand)}'."}
+        {:error, "Invalid date_range #{i(shorthand)}"}
     end
   end
 
@@ -268,7 +268,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   end
 
   defp parse_time_range(_site, unknown, _date, _now),
-    do: {:error, "Invalid date_range '#{i(unknown)}'."}
+    do: {:error, "Invalid date_range #{i(unknown)}"}
 
   defp date_range_from_date_strings(site, from, to) do
     with {:ok, from_date} <- Date.from_iso8601(from),

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -171,7 +171,7 @@
       ]
     },
     "date_range_shorthand": {
-      "oneOf": [
+      "anyOf": [
         {
           "const": "30m",
           "$comment": "only :internal"
@@ -219,6 +219,16 @@
         {
           "const": "year",
           "description": "Since the start of this year"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+d$",
+          "description": "Last n days relative to today"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+mo$",
+          "description": "Last n months relative to this month"
         }
       ]
     },

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -27,12 +27,20 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     first: DateTime.new!(~D[2021-04-28], ~T[00:00:00], "Etc/UTC"),
     last: DateTime.new!(~D[2021-05-04], ~T[23:59:59], "Etc/UTC")
   }
+  @date_range_10d %DateTimeRange{
+    first: DateTime.new!(~D[2021-04-25], ~T[00:00:00], "Etc/UTC"),
+    last: DateTime.new!(~D[2021-05-04], ~T[23:59:59], "Etc/UTC")
+  }
   @date_range_30d %DateTimeRange{
     first: DateTime.new!(~D[2021-04-05], ~T[00:00:00], "Etc/UTC"),
     last: DateTime.new!(~D[2021-05-04], ~T[23:59:59], "Etc/UTC")
   }
   @date_range_month %DateTimeRange{
     first: DateTime.new!(~D[2021-05-01], ~T[00:00:00], "Etc/UTC"),
+    last: DateTime.new!(~D[2021-05-31], ~T[23:59:59], "Etc/UTC")
+  }
+  @date_range_3mo %DateTimeRange{
+    first: DateTime.new!(~D[2020-03-01], ~T[00:00:00], "Etc/UTC"),
     last: DateTime.new!(~D[2021-05-31], ~T[23:59:59], "Etc/UTC")
   }
   @date_range_6mo %DateTimeRange{
@@ -1255,8 +1263,10 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     test "parsing shortcut options", %{site: site} do
       check_date_range(%{"date_range" => "day"}, site, @date_range_day)
       check_date_range(%{"date_range" => "7d"}, site, @date_range_7d)
+      check_date_range(%{"date_range" => "10d"}, site, @date_range_10d)
       check_date_range(%{"date_range" => "30d"}, site, @date_range_30d)
       check_date_range(%{"date_range" => "month"}, site, @date_range_month)
+      check_date_range(%{"date_range" => "3mo"}, site, @date_range_3mo)
       check_date_range(%{"date_range" => "6mo"}, site, @date_range_6mo)
       check_date_range(%{"date_range" => "12mo"}, site, @date_range_12mo)
       check_date_range(%{"date_range" => "year"}, site, @date_range_year)
@@ -1374,8 +1384,10 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       for {date_range_shortcut, expected_date_range} <- [
             {"day", @date_range_day},
             {"7d", @date_range_7d},
+            {"10d", @date_range_10d},
             {"30d", @date_range_30d},
             {"month", @date_range_month},
+            {"3mo", @date_range_3mo},
             {"6mo", @date_range_6mo},
             {"12mo", @date_range_12mo},
             {"year", @date_range_year}

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -40,7 +40,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     last: DateTime.new!(~D[2021-05-31], ~T[23:59:59], "Etc/UTC")
   }
   @date_range_3mo %DateTimeRange{
-    first: DateTime.new!(~D[2020-03-01], ~T[00:00:00], "Etc/UTC"),
+    first: DateTime.new!(~D[2021-03-01], ~T[00:00:00], "Etc/UTC"),
     last: DateTime.new!(~D[2021-05-31], ~T[23:59:59], "Etc/UTC")
   }
   @date_range_6mo %DateTimeRange{

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -1333,11 +1333,17 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
 
     test "parsing invalid custom date range with invalid dates", %{site: site} do
+      %{"site_id" => site.domain, "date_range" => "-1d", "metrics" => ["visitors"]}
+      |> check_error(site, "#/date_range: Invalid date range \"-1d\"")
+
       %{"site_id" => site.domain, "date_range" => "foo", "metrics" => ["visitors"]}
       |> check_error(site, "#/date_range: Invalid date range \"foo\"")
 
       %{"site_id" => site.domain, "date_range" => ["21415-00", "eee"], "metrics" => ["visitors"]}
       |> check_error(site, "#/date_range: Invalid date range [\"21415-00\", \"eee\"]")
+
+      %{"site_id" => site.domain, "date_range" => "999999999mo", "metrics" => ["visitors"]}
+      |> check_error(site, "Invalid date_range \"999999999mo\"")
     end
 
     test "custom date range is invalid when timestamps do not include timezone info", %{


### PR DESCRIPTION
I was using APIv2 today and got pissed off that I couldn't do `"date_range": "3d"`. So I went ahead and fixed this issue...