### PR TITLE
Set current_team when user has team membership in viewed site 

### DIFF
--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -461,19 +461,16 @@ defmodule Plausible.Teams.Invitations do
   end
 
   def send_transfer_accepted_email(site_transfer, team) do
-    initiator_as_editor? =
-      Teams.Memberships.site_role(site_transfer.site, site_transfer.initiator) == {:ok, :editor}
-
-    initiator_as_guest? =
-      Teams.Memberships.team_role(team, site_transfer.initiator) == {:ok, :guest}
+    initiator_as_guest_editor? =
+      Teams.Memberships.site_role(site_transfer.site, site_transfer.initiator) ==
+        {:ok, {:guest_member, :editor}}
 
     PlausibleWeb.Email.ownership_transfer_accepted(
       site_transfer.email,
       site_transfer.initiator.email,
       team,
       site_transfer.site,
-      initiator_as_editor?,
-      initiator_as_guest?
+      initiator_as_guest_editor?
     )
     |> Plausible.Mailer.send()
   end
@@ -508,16 +505,12 @@ defmodule Plausible.Teams.Invitations do
     end
   end
 
-  def check_invitation_permissions(%Plausible.Site{} = site, inviter, invitation_role, opts) do
+  def check_invitation_permissions(%Plausible.Site{} = site, inviter, _invitation_role, opts) do
     check_permissions? = Keyword.get(opts, :check_permissions, true)
 
     if check_permissions? do
       case Teams.Memberships.site_role(site, inviter) do
-        {:ok, inviter_role} when inviter_role in [:owner, :admin] and invitation_role == :owner ->
-          :ok
-
-        {:ok, inviter_role}
-        when inviter_role in [:owner, :admin, :editor] and invitation_role != :owner ->
+        {:ok, {:team_member, inviter_role}} when inviter_role in [:owner, :admin] ->
           :ok
 
         _ ->

--- a/lib/plausible/teams/membership.ex
+++ b/lib/plausible/teams/membership.ex
@@ -11,6 +11,8 @@ defmodule Plausible.Teams.Membership do
 
   @type t() :: %__MODULE__{}
 
+  @type role() :: unquote(Enum.reduce(@roles, &{:|, [], [&1, &2]}))
+
   schema "team_memberships" do
     field :role, Ecto.Enum, values: @roles
     field :is_autocreated, :boolean, default: false

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -66,6 +66,9 @@ defmodule Plausible.Teams.Memberships do
     end
   end
 
+  @spec site_role(Plausible.Site.t(), Auth.User.t() | nil) ::
+          {:ok, {:team_member | :guest_member, Teams.Membership.role()}} | {:error, :not_a_member}
+
   def site_role(_site, nil), do: {:error, :not_a_member}
 
   def site_role(site, user) do
@@ -80,8 +83,8 @@ defmodule Plausible.Teams.Memberships do
       |> Repo.one()
 
     case result do
-      {:guest, role} -> {:ok, role}
-      {role, _} -> {:ok, role}
+      {:guest, role} -> {:ok, {:guest_member, role}}
+      {role, _} -> {:ok, {:team_member, role}}
       _ -> {:error, :not_a_member}
     end
   end
@@ -95,7 +98,7 @@ defmodule Plausible.Teams.Memberships do
 
   def has_admin_access?(site, user) do
     case site_role(site, user) do
-      {:ok, role} when role in [:editor, :admin, :owner] ->
+      {:ok, {_, role}} when role in [:editor, :admin, :owner] ->
         true
 
       _ ->

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -96,7 +96,8 @@ defmodule Plausible.Teams.Memberships do
     end
   end
 
-  def has_admin_access?(site, user) do
+  @spec has_editor_access?(Plausible.Site.t(), Auth.User.t() | nil) :: boolean()
+  def has_editor_access?(site, user) do
     case site_role(site, user) do
       {:ok, {_, role}} when role in [:editor, :admin, :owner] ->
         true

--- a/lib/plausible_web/controllers/api/internal_controller.ex
+++ b/lib/plausible_web/controllers/api/internal_controller.ex
@@ -29,7 +29,7 @@ defmodule PlausibleWeb.Api.InternalController do
     with %User{id: user_id} = user <- conn.assigns[:current_user],
          site <- Sites.get_by_domain(domain),
          true <-
-           Plausible.Teams.Memberships.has_admin_access?(site, user) ||
+           Plausible.Teams.Memberships.has_editor_access?(site, user) ||
              Auth.is_super_admin?(user_id),
          {:ok, mod} <- Map.fetch(@features, feature),
          {:ok, _site} <- mod.toggle(site, user, override: false) do

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -777,7 +777,7 @@ defmodule PlausibleWeb.Api.StatsController do
 
     is_admin =
       if current_user = conn.assigns[:current_user] do
-        Plausible.Teams.Memberships.has_admin_access?(site, current_user)
+        Plausible.Teams.Memberships.has_editor_access?(site, current_user)
       else
         false
       end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -365,8 +365,7 @@ defmodule PlausibleWeb.Email do
         inviter_email,
         team,
         site,
-        initiator_as_editor?,
-        initiator_as_guest?
+        initiator_as_guest_editor?
       ) do
     priority_email()
     |> to(inviter_email)
@@ -378,8 +377,7 @@ defmodule PlausibleWeb.Email do
       new_owner_email: new_owner_email,
       team: team,
       site: site,
-      initiator_as_editor?: initiator_as_editor?,
-      initiator_as_guest?: initiator_as_guest?
+      initiator_as_guest_editor?: initiator_as_guest_editor?
     )
   end
 

--- a/lib/plausible_web/live/goal_settings.ex
+++ b/lib/plausible_web/live/goal_settings.ex
@@ -19,7 +19,7 @@ defmodule PlausibleWeb.Live.GoalSettings do
         |> Plausible.Sites.get_for_user!(domain, [:owner, :admin, :editor, :super_admin])
       end)
       |> assign_new(:site_role, fn %{site: site, current_user: current_user} ->
-        {:ok, role} = Plausible.Teams.Memberships.site_role(site, current_user)
+        {:ok, {_, role}} = Plausible.Teams.Memberships.site_role(site, current_user)
         role
       end)
       |> assign_new(:all_goals, fn %{site: site} ->

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -38,6 +38,8 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
   import Plug.Conn
   import Phoenix.Controller, only: [get_format: 1]
 
+  alias Plausible.Teams
+
   @all_roles [:public, :viewer, :admin, :editor, :super_admin, :owner, :billing]
 
   def init([]), do: {@all_roles, nil}
@@ -112,7 +114,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
           |> Repo.preload([
             :owners,
             :completed_imports,
-            team: [subscription: Plausible.Teams.last_subscription_query()]
+            team: [subscription: Teams.last_subscription_query()]
           ])
 
         conn = merge_assigns(conn, site: site, site_role: role)
@@ -155,8 +157,8 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
 
     if site do
       site_role =
-        case Plausible.Teams.Memberships.site_role(site, current_user) do
-          {:ok, role} -> role
+        case Teams.Memberships.site_role(site, current_user) do
+          {:ok, {_, role}} -> role
           _ -> nil
         end
 

--- a/lib/plausible_web/templates/email/ownership_transfer_accepted.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_accepted.html.heex
@@ -1,8 +1,6 @@
 {@new_owner_email} has accepted the ownership transfer of {@site.domain}. They will be responsible for billing of it going
-forward<%= if @initiator_as_guest? and @initiator_as_editor? do %>
-  and your role has been changed to <b>guest editor</b>
-<% end %>.
-<%= if @initiator_as_guest? do %>
+forward<%= if @initiator_as_guest_editor? do %>
+  and your role has been changed to <b>guest editor</b>.
   <a href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @site.domain) <> "?__team=none"}>
     Click here
   </a>

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -70,7 +70,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       [owner, inviter, invitee] = for _ <- 1..3, do: new_user()
 
       site = new_site(owner: owner)
-      inviter = add_guest(site, user: inviter, role: :editor)
+      inviter = add_member(site.team, user: inviter, role: :admin)
       for _ <- 1..4, do: add_guest(site, role: :viewer)
 
       assert {:error, {:over_limit, 3}} =
@@ -130,7 +130,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       )
     end
 
-    test "admin initiate ownership transfer too" do
+    test "admin can initiate ownership transfer too" do
       inviter = new_user()
       site = new_site()
       add_member(site.team, user: inviter, role: :admin)
@@ -182,16 +182,16 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       inviter = new_user()
       owner = new_user()
       site = new_site(owner: owner)
-      add_guest(site, user: inviter, role: :viewer)
+      add_member(site.team, user: inviter, role: :viewer)
 
       assert {:error, :forbidden} =
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :viewer)
     end
 
-    test "allows admins to invite other admins" do
+    test "allows admins to invite editors" do
       inviter = new_user()
       site = new_site()
-      add_guest(site, user: inviter, role: :editor)
+      add_member(site.team, user: inviter, role: :admin)
 
       assert {:ok, %Plausible.Teams.GuestInvitation{}} =
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :editor)

--- a/test/plausible_web/plugs/authorize_site_access_test.exs
+++ b/test/plausible_web/plugs/authorize_site_access_test.exs
@@ -247,7 +247,7 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
   end
 
   for role <- [:viewer, :editor] do
-    test "allows user based on their #{role} membership", %{conn: conn, user: user} do
+    test "allows user based on their #{role} guest membership", %{conn: conn, user: user} do
       site = new_site()
       add_guest(site, user: user, role: unquote(role))
 
@@ -258,6 +258,33 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccessTest do
         |> bypass_through(PlausibleWeb.Router)
         |> get("/plug-tests/#{site.domain}/with-domain")
         |> AuthorizeSiteAccess.call(opts)
+
+      # Does not set current team for guest membership
+      refute get_session(conn, "current_team_id") == site.team.identifier
+      refute conn.assigns.current_team.id == site.team.id
+
+      refute conn.halted
+      assert conn.assigns.site.id == site.id
+      assert conn.assigns.site_role == unquote(role)
+    end
+  end
+
+  for role <- [:viewer, :editor, :admin, :billing] do
+    test "allows user based on their #{role} team membership", %{conn: conn, user: user} do
+      site = new_site()
+      add_member(site.team, user: user, role: unquote(role))
+
+      opts = AuthorizeSiteAccess.init([unquote(role)])
+
+      conn =
+        conn
+        |> bypass_through(PlausibleWeb.Router)
+        |> get("/plug-tests/#{site.domain}/with-domain")
+        |> AuthorizeSiteAccess.call(opts)
+
+      # Sets current team for team membership
+      assert get_session(conn, "current_team_id") == site.team.identifier
+      assert conn.assigns.current_team.id == site.team.id
 
       refute conn.halted
       assert conn.assigns.site.id == site.id


### PR DESCRIPTION
### Changes

This PR enforces setting `current_team` to authorized site's team if it's different but only when user has a team membership in it.

Also, service-level checks for invitations were fixed to exclude editor role from managing invitations (it's currently enforced on plug level anyway but this change makes the service consistent with plug behavior).

### Tests
- [x] Automated tests have been added
