### PR TITLE
APIv2: Release `has_done`/`has_not_done`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Add support for creating and managing teams owning multiple sites
 - Introduce "billing" team role for users
 - Introduce "editor" role with permissions greater than "viewer" but lesser than "admin"
+- Support behavioral filters `has_done` and `has_not_done` on the Stats API to allow filtering sessions by other events that have been completed.
 
 ### Removed
 

--- a/priv/json-schemas/query-api-schema.json
+++ b/priv/json-schemas/query-api-schema.json
@@ -491,10 +491,7 @@
         { "$ref": "#/definitions/filter_entry" },
         { "$ref": "#/definitions/filter_and_or" },
         { "$ref": "#/definitions/filter_not" },
-        {
-          "$ref": "#/definitions/filter_has_done",
-          "$comment": "only :internal"
-        }
+        { "$ref": "#/definitions/filter_has_done" }
       ]
     },
     "filter_not": {

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -593,8 +593,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           timezone: site.timezone,
           include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
-        },
-        :internal
+        }
       )
     end
 
@@ -609,8 +608,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters.",
-        :internal
+        "Invalid filters. Behavioral filters (has_done, has_not_done) can only be used with event dimension filters."
       )
     end
 
@@ -625,8 +623,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       }
       |> check_error(
         site,
-        "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested.",
-        :internal
+        "Invalid filters. Behavioral filters (has_done, has_not_done) cannot be nested."
       )
     end
 
@@ -1239,8 +1236,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
           timezone: site.timezone,
           include: @default_include,
           pagination: %{limit: 10_000, offset: 0}
-        },
-        :internal
+        }
       )
       |> check_goals(
         preloaded_goals: %{all: ["Signup"], matching_toplevel_filters: ["Signup"]},

--- a/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_test.exs
@@ -4662,7 +4662,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "visits", "events", "pageviews"],
           "date_range" => "all",
@@ -4688,7 +4688,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "events", "pageviews"],
           "date_range" => "all",
@@ -4729,7 +4729,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4770,7 +4770,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4816,7 +4816,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4861,7 +4861,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4892,7 +4892,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       ])
 
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors", "pageviews"],
           "date_range" => "all",
@@ -4912,7 +4912,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryTest do
       site: site
     } do
       conn =
-        post(conn, "/api/v2/query-internal-test", %{
+        post(conn, "/api/v2/query", %{
           "site_id" => site.domain,
           "metrics" => ["visitors"],
           "date_range" => "all",


### PR DESCRIPTION
### Changes

The functionality has been there for a while but not yet released for the public. 

Docs PR: https://github.com/plausible/docs/pull/600