### PR TITLE
Remove tables and columns that are unused after migrating to teams

### DIFF
--- a/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
+++ b/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
@@ -25,7 +25,7 @@ defmodule Plausible.Repo.Migrations.RemoveUnusedTablesAndColumns do
 
       alter table(:subscriptions) do
         remove :user_id
-        modify :team_id, references(:teams, on_delete: :delete_all)
+        modify :team_id, references(:teams, on_delete: :delete_all), null: false
       end
 
       drop constraint(:enterprise_plans, "enterprise_plans_user_id_fkey")
@@ -33,7 +33,7 @@ defmodule Plausible.Repo.Migrations.RemoveUnusedTablesAndColumns do
 
       alter table(:enterprise_plans) do
         remove :user_id
-        modify :team_id, references(:teams, on_delete: :delete_all)
+        modify :team_id, references(:teams, on_delete: :delete_all), null: false
       end
 
       drop table(:invitations)

--- a/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
+++ b/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
@@ -1,0 +1,50 @@
+defmodule Plausible.Repo.Migrations.RemoveUnusedTablesAndColumns do
+  use Ecto.Migration
+
+  import Plausible.MigrationUtils
+
+  def up do
+    if enterprise_edition?() do
+      alter table(:users) do
+        remove :accept_traffic_until
+        remove :trial_expiry_date
+        remove :grace_period
+        remove :allow_next_upgrade_override
+      end
+
+      drop constraint(:sites, "sites_team_id_fkey")
+
+      alter table(:sites) do
+        remove :accept_traffic_until
+        modify :team_id, references(:teams, on_delete: :delete_all)
+      end
+
+      alter table(:api_keys) do
+        remove :hourly_request_limit
+      end
+
+      drop constraint(:subscriptions, "subscriptions_user_id_fkey")
+      drop constraint(:subscriptions, "subscriptions_team_id_fkey")
+
+      alter table(:subscriptions) do
+        remove :user_id
+        modify :team_id, references(:teams, on_delete: :delete_all)
+      end
+
+      drop constraint(:enterprise_plans, "enterprise_plans_user_id_fkey")
+      drop constraint(:enterprise_plans, "enterprise_plans_team_id_fkey")
+
+      alter table(:enterprise_plans) do
+        remove :user_id
+        modify :team_id, references(:teams, on_delete: :delete_all)
+      end
+
+      drop table(:invitations)
+      drop table(:site_memberships)
+    end
+  end
+
+  def down do
+    raise "Irreversible"
+  end
+end

--- a/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
+++ b/priv/repo/migrations/20250407110434_remove_unused_tables_and_columns.exs
@@ -12,11 +12,8 @@ defmodule Plausible.Repo.Migrations.RemoveUnusedTablesAndColumns do
         remove :allow_next_upgrade_override
       end
 
-      drop constraint(:sites, "sites_team_id_fkey")
-
       alter table(:sites) do
         remove :accept_traffic_until
-        modify :team_id, references(:teams, on_delete: :delete_all)
       end
 
       alter table(:api_keys) do


### PR DESCRIPTION
### Changes

Migration cleaning up Postgres schema from tables and columns which are no longer used after migrating to teams.

The constraints are modified to cascade as well to ensure data integrity and no orphaned entries.

The migration will be only run on EE. CE will be handled separately when preparing to cut another release.