### PR TITLE
allow binding to a unix domain socket

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -62,6 +62,8 @@ http_port =
 
 https_port = get_int_from_path_or_env(config_dir, "HTTPS_PORT")
 
+http_uds = get_var_from_path_or_env(config_dir, "HTTPS_UDS")
+
 base_url = get_var_from_path_or_env(config_dir, "BASE_URL")
 
 if !base_url do
@@ -322,6 +324,12 @@ config :plausible, PlausibleWeb.Endpoint,
   secret_key_base: secret_key_base,
   websocket_url: websocket_url,
   secure_cookie: secure_cookie
+
+if http_uds do
+  uds_bind = [ip: {:local, http_uds}, port: 0]
+  uds_opts = Config.Reader.merge(default_http_opts, uds_bind)
+  config :plausible, PlausibleWeb.Endpoint, http: uds_opts
+end
 
 # maybe enable HTTPS in CE
 if config_env() in [:ce, :ce_dev, :ce_test] do


### PR DESCRIPTION
### Changes

The infrastructure I am running plausible on enforces that client applications cannot bind to TCP ports, and must expose their services on unix domain sockets.

This change binds the PlausibleWeb.Endpoint to a unix domain socket at the path specified by the `HTTP_UDS` if it is defined.

If the approach/feature is acceptable I'm happy to complete the requirements list below, but wanted to open it first for feedback before investing time.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
