### PR TITLE
Tracker: `fetch.catch`

### DIFF
--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 1,
+  "tracker_script_version": 2,
   "scripts": {
     "deploy": "node compile.js",
     "test": "npm run deploy && npx playwright test",

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -287,7 +287,7 @@
         body: JSON.stringify(payload)
       }).then(function(response) {
         options && options.callback && options.callback({status: response.status})
-      })
+      }).catch(function() {})
     }
     {{/if}}
   }


### PR DESCRIPTION
Without this, errors from the API result in uncaught exceptions in clients pages.

Ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8490110926