### PR TITLE
Allow marking custom events as non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Added 
+### Added
 
-### Removed 
+- Custom events can now be marked as non-interactive in events API and tracker script. Events marked as non-interactive are not counted towards bounce rate.
 
-### Changed 
+
+### Removed
+
+### Changed
+
+- A session is now marked as a bounce if it has less than 2 pageviews and no interactive custom events.
 
 ### Fixed
 

--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -49,7 +49,7 @@ defmodule Plausible.ClickhouseEventV2 do
     field :acquisition_channel, Ch, type: "LowCardinality(String)", writable: :never
 
     # Virtual field used during event processing
-    field :interactive?, :boolean, default: true, virtual: true, writable: :never
+    field :interactive?, :boolean, default: true, virtual: true
   end
 
   def new(attrs) do

--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -49,7 +49,7 @@ defmodule Plausible.ClickhouseEventV2 do
     field :acquisition_channel, Ch, type: "LowCardinality(String)", writable: :never
 
     # Virtual field used during event processing
-    field :interactive?, :boolean, default: true, virtual: true
+    field :interactive?, :boolean, default: true, virtual: true, writable: :never
   end
 
   def new(attrs) do

--- a/lib/plausible/clickhouse_event_v2.ex
+++ b/lib/plausible/clickhouse_event_v2.ex
@@ -47,6 +47,9 @@ defmodule Plausible.ClickhouseEventV2 do
     field :browser_version, Ch, type: "LowCardinality(String)"
 
     field :acquisition_channel, Ch, type: "LowCardinality(String)", writable: :never
+
+    # Virtual field used during event processing
+    field :interactive?, :boolean, default: true, virtual: true, writable: :never
   end
 
   def new(attrs) do

--- a/lib/plausible/ingestion/event.ex
+++ b/lib/plausible/ingestion/event.ex
@@ -266,7 +266,8 @@ defmodule Plausible.Ingestion.Event do
       hostname: event.request.hostname,
       pathname: event.request.pathname,
       scroll_depth: event.request.scroll_depth,
-      engagement_time: event.request.engagement_time
+      engagement_time: event.request.engagement_time,
+      interactive?: event.request.interactive?
     })
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -236,11 +236,12 @@ defmodule Plausible.Ingestion.Request do
   end
 
   defp put_interactive(changeset, %{} = request_body) do
-    with interative? when is_boolean(interative?) <-
-           request_body["i"] || request_body["interactive"] do
-      Changeset.put_change(changeset, :interactive?, interative?)
-    else
-      _ -> changeset
+    case request_body["i"] || request_body["interactive"] do
+      interactive? when is_boolean(interactive?) ->
+        Changeset.put_change(changeset, :interactive?, interactive?)
+
+      _ ->
+        changeset
     end
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -55,6 +55,7 @@ defmodule Plausible.Ingestion.Request do
     field :scroll_depth, :integer
     field :engagement_time, :integer
     field :tracker_script_version, :integer, default: 0
+    field :interactive?, :boolean, default: true
 
     on_ee do
       field :revenue_source, :map
@@ -95,6 +96,7 @@ defmodule Plausible.Ingestion.Request do
         |> put_pathname()
         |> put_query_params()
         |> put_revenue_source(request_body)
+        |> put_interactive(request_body)
         |> put_tracker_script_version(request_body)
         |> map_domains(request_body)
         |> Changeset.validate_required([
@@ -231,6 +233,15 @@ defmodule Plausible.Ingestion.Request do
     changeset
     |> Changeset.put_change(:props, props)
     |> validate_props()
+  end
+
+  defp put_interactive(changeset, %{} = request_body) do
+    with interative? when is_boolean(interative?) <-
+           request_body["i"] || request_body["interactive"] do
+      Changeset.put_change(changeset, :interactive?, interative?)
+    else
+      _ -> changeset
+    end
   end
 
   defp filter_bad_props({k, v}, acc) do

--- a/lib/plausible/ingestion/write_buffer.ex
+++ b/lib/plausible/ingestion/write_buffer.ex
@@ -150,5 +150,5 @@ defmodule Plausible.Ingestion.WriteBuffer do
     }
   end
 
-  defp fields_to_ignore(), do: [:acquisition_channel]
+  defp fields_to_ignore(), do: [:acquisition_channel, :interactive?]
 end

--- a/test/plausible/ingestion/request_test.exs
+++ b/test/plausible/ingestion/request_test.exs
@@ -456,6 +456,22 @@ defmodule Plausible.Ingestion.RequestTest do
     assert {:error, _} = exceeding_read_limit
   end
 
+  test "respects interactive parameter" do
+    params = %{
+      name: "pageview",
+      domain: "dummy.site",
+      url: "http://dummy.site/index.html",
+      interactive: false
+    }
+
+    assert {:ok, request} =
+             build_conn(:post, "/api/events", params)
+             |> put_req_header("user-agent", "Mozilla")
+             |> Request.build()
+
+    refute request.interactive?
+  end
+
   @tag :ee_only
   test "encodable" do
     params = %{
@@ -494,7 +510,8 @@ defmodule Plausible.Ingestion.RequestTest do
              "ip_classification" => nil,
              "scroll_depth" => nil,
              "engagement_time" => nil,
-             "tracker_script_version" => 0
+             "tracker_script_version" => 0,
+             "interactive?" => true
            }
 
     assert %NaiveDateTime{} = NaiveDateTime.from_iso8601!(request["timestamp"])

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -87,23 +87,6 @@ defmodule Plausible.TestUtils do
     {:ok, conn: conn}
   end
 
-  def create_pageviews(pageviews) do
-    pageviews =
-      Enum.map(pageviews, fn pageview ->
-        pageview =
-          pageview
-          |> Map.delete(:site)
-          |> Map.put(:site_id, pageview.site.id)
-
-        Factory.build(:pageview, pageview)
-        |> Map.from_struct()
-        |> Map.drop([:__meta__, :acquisition_channel])
-        |> update_in([:timestamp], &to_naive_truncate/1)
-      end)
-
-    Plausible.IngestRepo.insert_all(Plausible.ClickhouseEventV2, pageviews)
-  end
-
   def log_in(%{user: user, conn: conn}) do
     conn =
       conn

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -52,19 +52,19 @@ defmodule Plausible.Workers.SendEmailReportTest do
       sunday_before_last = Timex.shift(last_monday, minutes: -1)
       this_monday = Timex.beginning_of_week(now)
 
-      create_pageviews([
+      populate_stats(site, [
         # Sunday before last, not counted
-        %{site: site, timestamp: Timezone.convert(sunday_before_last, "UTC")},
+        build(:pageview, timestamp: Timezone.convert(sunday_before_last, "UTC")),
         # Sunday before last, not counted
-        %{site: site, timestamp: Timezone.convert(sunday_before_last, "UTC")},
+        build(:pageview, timestamp: Timezone.convert(sunday_before_last, "UTC")),
         # Last monday, counted
-        %{site: site, timestamp: Timezone.convert(last_monday, "UTC")},
+        build(:pageview, timestamp: Timezone.convert(last_monday, "UTC")),
         # Last sunday, counted
-        %{site: site, timestamp: Timezone.convert(last_sunday, "UTC")},
+        build(:pageview, timestamp: Timezone.convert(last_sunday, "UTC")),
         # This monday, not counted
-        %{site: site, timestamp: Timezone.convert(this_monday, "UTC")},
+        build(:pageview, timestamp: Timezone.convert(this_monday, "UTC")),
         # This monday, not counted
-        %{site: site, timestamp: Timezone.convert(this_monday, "UTC")}
+        build(:pageview, timestamp: Timezone.convert(this_monday, "UTC"))
       ])
 
       perform_job(SendEmailReport, %{"site_id" => site.id, "interval" => "weekly"})

--- a/test/workers/send_site_setup_emails_test.exs
+++ b/test/workers/send_site_setup_emails_test.exs
@@ -64,7 +64,10 @@ defmodule Plausible.Workers.SendSiteSetupEmailsTest do
         subject: "Your Plausible setup: Waiting for the first page views"
       )
 
-      create_pageviews([%{site: site}])
+      populate_stats(site, [
+        build(:pageview)
+      ])
+
       perform_job(SendSiteSetupEmails, %{})
 
       assert_email_delivered_with(

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 4,
+  "tracker_script_version": 5,
   "scripts": {
     "deploy": "node compile.js",
     "test": "npm run deploy && npx playwright test",

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -233,6 +233,9 @@
     if (options && options.props) {
       payload.p = options.props
     }
+    if (options && options.interactive === false) {
+      payload.i = false
+    }
     {{#if revenue}}
     if (options && options.revenue) {
       payload.$ = options.revenue

--- a/tracker/test/custom-event-edge-cases.spec.js
+++ b/tracker/test/custom-event-edge-cases.spec.js
@@ -3,34 +3,43 @@ const { test } = require('@playwright/test')
 const { LOCAL_SERVER_ADDR } = require('./support/server')
 
 test.describe('script.file-downloads.outbound-links.tagged-events.js', () => {
-    test('sends only outbound link event when clicked link is both download and outbound', async ({ page }) => {
-        await page.goto('/custom-event-edge-case.html')
-        const downloadURL = await page.locator('#outbound-download-link').getAttribute('href')
+  test('sends only outbound link event when clicked link is both download and outbound', async ({ page }) => {
+    await page.goto('/custom-event-edge-case.html')
+    const downloadURL = await page.locator('#outbound-download-link').getAttribute('href')
 
-        await expectPlausibleInAction(page, {
-            action: () => page.click('#outbound-download-link'),
-            expectedRequests: [{n: 'Outbound Link: Click', p: {url: downloadURL}}]
-        })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#outbound-download-link'),
+      expectedRequests: [{ n: 'Outbound Link: Click', p: { url: downloadURL } }]
     })
+  })
 
-    test('sends file download event when local download link clicked', async ({ page }) => {
-        await page.goto('/custom-event-edge-case.html')
-        const downloadURL = LOCAL_SERVER_ADDR + '/' + await page.locator('#local-download').getAttribute('href')
+  test('sends file download event when local download link clicked', async ({ page }) => {
+    await page.goto('/custom-event-edge-case.html')
+    const downloadURL = LOCAL_SERVER_ADDR + '/' + await page.locator('#local-download').getAttribute('href')
 
-        await expectPlausibleInAction(page, {
-            action: () => page.click('#local-download'),
-            expectedRequests: [{n: 'File Download', p: {url: downloadURL}}]
-        })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#local-download'),
+      expectedRequests: [{ n: 'File Download', p: { url: downloadURL } }]
     })
+  })
 
-    test('sends only tagged event when clicked link is tagged + outbound + download', async ({ page }) => {
-        await page.goto('/custom-event-edge-case.html')
+  test('sends only tagged event when clicked link is tagged + outbound + download', async ({ page }) => {
+    await page.goto('/custom-event-edge-case.html')
 
-        await expectPlausibleInAction(page, {
-            action: () => page.click('#tagged-outbound-download-link'),
-            expectedRequests: [{n: 'Foo', p: {url: 'https://awesome.website.com/file.pdf'}}],
-            awaitedRequestCount: 3,
-            expectedRequestCount: 1
-        })
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#tagged-outbound-download-link'),
+      expectedRequests: [{ n: 'Foo', p: { url: 'https://awesome.website.com/file.pdf' } }],
+      awaitedRequestCount: 3,
+      expectedRequestCount: 1
     })
+  })
+
+  test('sends manual non-interactive custom event', async ({ page }) => {
+    await page.goto('/custom-event-edge-case.html')
+
+    await expectPlausibleInAction(page, {
+      action: () => page.click('#non-interactive-custom-event'),
+      expectedRequests: [{ n: 'non-interactive custom event', i: false }]
+    })
+  })
 })

--- a/tracker/test/fixtures/custom-event-edge-case.html
+++ b/tracker/test/fixtures/custom-event-edge-case.html
@@ -16,6 +16,8 @@
   <a id="local-download" href="file.csv">Local download</a>
 
   <a id="tagged-outbound-download-link" class="plausible-event-name=Foo" href="https://awesome.website.com/file.pdf">Outbound Download</a>
+
+  <a id="non-interactive-custom-event" onclick="plausible('non-interactive custom event', { interactive: false })">Non-interactive custom event</a>
 </body>
 
 </html>


### PR DESCRIPTION
- Custom events can now be marked as non-interactive in events API and tracker script. Events marked as non-interactive are not counted towards bounce rate.
  - To track custom event in tracker, do `plausible('custom event', { interactive: false })`
  - In events API, set `interactive` parameter to false.
- A session is now marked as a bounce if it has less than 2 pageviews and no interactive custom events.

Note that custom events configured via css can not be marked as non-interactive as they require the user to interact with the site.

Basecamp ref: https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/8450017341

Docs: https://github.com/plausible/docs/pull/601