### PR TITLE
Change default period to today for brand new sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Default period for brand new sites is now `today` rather than `last 28 days`. On the next day, the default changes to `last 28 days`.
 - Increase decimal precision of the "Conversion rate" metric from 1 to 2 (e.g. 16.7 -> 16.67)
 - The "Last 30 days" period is now "Last 28 days" on the dashboard and also the new default. Keyboard shortcut `T` still works for last 30 days.
 - Last `7d` and `30d` periods do not include today anymore

--- a/assets/js/dashboard/query-context.tsx
+++ b/assets/js/dashboard/query-context.tsx
@@ -68,6 +68,7 @@ export default function QueryContextProvider({
     const defaultValues = queryDefaultValue
     const storedValues = getSavedTimePreferencesFromStorage({ site })
     const timeQuery = getDashboardTimeSettings({
+      site,
       searchValues: { period, comparison, match_day_of_week },
       storedValues,
       defaultValues,

--- a/assets/js/dashboard/query-time-periods.test.ts
+++ b/assets/js/dashboard/query-time-periods.test.ts
@@ -1,4 +1,4 @@
-import { defaultSite } from '../../test-utils/app-context-providers'
+import { DEFAULT_SITE } from '../../test-utils/app-context-providers'
 import {
   ComparisonMode,
   getDashboardTimeSettings,
@@ -24,7 +24,7 @@ describe(`${getStoredPeriod.name}`, () => {
 })
 
 describe(`${getDashboardTimeSettings.name}`, () => {
-  const site = defaultSite
+  const site = DEFAULT_SITE
 
   const defaultValues = {
     period: QueryPeriod['28d'],

--- a/assets/js/dashboard/query-time-periods.test.ts
+++ b/assets/js/dashboard/query-time-periods.test.ts
@@ -1,3 +1,4 @@
+import { defaultSite } from '../../test-utils/app-context-providers'
 import {
   ComparisonMode,
   getDashboardTimeSettings,
@@ -5,6 +6,7 @@ import {
   getStoredPeriod,
   QueryPeriod
 } from './query-time-periods'
+import { formatISO, utcNow } from './util/date'
 
 describe(`${getStoredPeriod.name}`, () => {
   const domain = 'any.site'
@@ -22,8 +24,10 @@ describe(`${getStoredPeriod.name}`, () => {
 })
 
 describe(`${getDashboardTimeSettings.name}`, () => {
+  const site = defaultSite
+
   const defaultValues = {
-    period: QueryPeriod['7d'],
+    period: QueryPeriod['28d'],
     comparison: null,
     match_day_of_week: true
   }
@@ -41,6 +45,7 @@ describe(`${getDashboardTimeSettings.name}`, () => {
   it('returns defaults if nothing stored and no search', () => {
     expect(
       getDashboardTimeSettings({
+        site: site,
         searchValues: emptySearchValues,
         storedValues: emptyStoredValues,
         defaultValues,
@@ -49,9 +54,37 @@ describe(`${getDashboardTimeSettings.name}`, () => {
     ).toEqual(defaultValues)
   })
 
+  it('defaults period to today if the site was created today', () => {
+    expect(
+      getDashboardTimeSettings({
+        site: { ...site, nativeStatsBegin: formatISO(utcNow()) },
+        searchValues: emptySearchValues,
+        storedValues: emptyStoredValues,
+        defaultValues,
+        segmentIsExpanded: false
+      })
+    ).toEqual({ ...defaultValues, period: 'day' })
+  })
+
+  it('defaults period to today if the site was created yesterday', () => {
+    expect(
+      getDashboardTimeSettings({
+        site: {
+          ...site,
+          nativeStatsBegin: formatISO(utcNow().subtract(1, 'day'))
+        },
+        searchValues: emptySearchValues,
+        storedValues: emptyStoredValues,
+        defaultValues,
+        segmentIsExpanded: false
+      })
+    ).toEqual({ ...defaultValues, period: 'day' })
+  })
+
   it('returns stored values if no search', () => {
     expect(
       getDashboardTimeSettings({
+        site: site,
         searchValues: emptySearchValues,
         storedValues: {
           period: QueryPeriod['12mo'],
@@ -71,6 +104,7 @@ describe(`${getDashboardTimeSettings.name}`, () => {
   it('uses values from search above all else, treats ComparisonMode.off as null', () => {
     expect(
       getDashboardTimeSettings({
+        site: site,
         searchValues: {
           period: QueryPeriod['year'],
           comparison: ComparisonMode.off,
@@ -94,6 +128,7 @@ describe(`${getDashboardTimeSettings.name}`, () => {
   it('respects segmentIsExpanded: true option: comparison and edit segment mode are mutually exclusive', () => {
     expect(
       getDashboardTimeSettings({
+        site: site,
         searchValues: {
           period: QueryPeriod['custom'],
           comparison: ComparisonMode.previous_period,

--- a/assets/js/dashboard/query-time-periods.ts
+++ b/assets/js/dashboard/query-time-periods.ts
@@ -16,6 +16,7 @@ import {
   isThisMonth,
   isThisYear,
   isToday,
+  isTodayOrYesterday,
   lastMonth,
   nowForSite,
   parseNaiveDate,
@@ -533,11 +534,13 @@ export function getSavedTimePreferencesFromStorage({
 }
 
 export function getDashboardTimeSettings({
+  site,
   searchValues,
   storedValues,
   defaultValues,
   segmentIsExpanded
 }: {
+  site: PlausibleSite
   searchValues: Record<'period' | 'comparison' | 'match_day_of_week', unknown>
   storedValues: ReturnType<typeof getSavedTimePreferencesFromStorage>
   defaultValues: Pick<
@@ -549,10 +552,12 @@ export function getDashboardTimeSettings({
   let period: QueryPeriod
   if (isValidPeriod(searchValues.period)) {
     period = searchValues.period
+  } else if (isValidPeriod(storedValues.period)) {
+    period = storedValues.period
+  } else if (isTodayOrYesterday(site.nativeStatsBegin)) {
+    period = QueryPeriod.day
   } else {
-    period = isValidPeriod(storedValues.period)
-      ? storedValues.period
-      : defaultValues.period
+    period = defaultValues.period
   }
 
   let comparison: ComparisonMode | null

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -3,6 +3,10 @@ import utc from 'dayjs/plugin/utc'
 
 dayjs.extend(utc)
 
+export function utcNow() {
+  return dayjs()
+}
+
 // https://stackoverflow.com/a/50130338
 export function formatISO(date) {
   return date.format('YYYY-MM-DD')
@@ -93,6 +97,12 @@ export function isSameMonth(date1, date2) {
 
 export function isToday(site, date) {
   return isSameDate(date, nowForSite(site))
+}
+
+export function isTodayOrYesterday(isoDate) {
+  const isoToday = formatISO(dayjs())
+  const isoYesterday = formatISO(dayjs().subtract(1, 'day'))
+  return isoDate === isoToday || isoDate === isoYesterday
 }
 
 export function isThisMonth(site, date) {

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -22,6 +22,29 @@ type TestContextProvidersProps = {
   preloaded?: { segments?: SavedSegments }
 }
 
+export const defaultSite: PlausibleSite = {
+  domain: 'plausible.io/unit',
+  offset: 0,
+  hasGoals: false,
+  hasProps: false,
+  funnelsAvailable: false,
+  propsAvailable: false,
+  siteSegmentsAvailable: false,
+  conversionsOptedOut: false,
+  funnelsOptedOut: false,
+  propsOptedOut: false,
+  revenueGoals: [],
+  funnels: [],
+  statsBegin: '',
+  nativeStatsBegin: '',
+  embedded: false,
+  background: '',
+  isDbip: false,
+  flags: {},
+  validIntervalsByPeriod: {},
+  shared: false
+}
+
 export const TestContextProviders = ({
   children,
   routerProps,
@@ -29,29 +52,6 @@ export const TestContextProviders = ({
   preloaded,
   user
 }: TestContextProvidersProps) => {
-  const defaultSite: PlausibleSite = {
-    domain: 'plausible.io/unit',
-    offset: 0,
-    hasGoals: false,
-    hasProps: false,
-    funnelsAvailable: false,
-    propsAvailable: false,
-    siteSegmentsAvailable: false,
-    conversionsOptedOut: false,
-    funnelsOptedOut: false,
-    propsOptedOut: false,
-    revenueGoals: [],
-    funnels: [],
-    statsBegin: '',
-    nativeStatsBegin: '',
-    embedded: false,
-    background: '',
-    isDbip: false,
-    flags: {},
-    validIntervalsByPeriod: {},
-    shared: false
-  }
-
   const site = { ...defaultSite, ...siteOptions }
 
   const queryClient = new QueryClient({

--- a/assets/test-utils/app-context-providers.tsx
+++ b/assets/test-utils/app-context-providers.tsx
@@ -22,7 +22,7 @@ type TestContextProvidersProps = {
   preloaded?: { segments?: SavedSegments }
 }
 
-export const defaultSite: PlausibleSite = {
+export const DEFAULT_SITE: PlausibleSite = {
   domain: 'plausible.io/unit',
   offset: 0,
   hasGoals: false,
@@ -52,7 +52,7 @@ export const TestContextProviders = ({
   preloaded,
   user
 }: TestContextProvidersProps) => {
-  const site = { ...defaultSite, ...siteOptions }
+  const site = { ...DEFAULT_SITE, ...siteOptions }
 
   const queryClient = new QueryClient({
     defaultOptions: {


### PR DESCRIPTION
### Changes

Default query period to `today` rather than `28d` for brand new dashboards (i.e. created today). When a user lands on the dashboard for the first time, they should see the graph display visitors straight away.

On the next day, when the user returns to the dashboard, the period will default to `28d` *unless* they interact with the datepicker on the first day already which will store the preference in localStorage.

Basecamp ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8509441108

**Tricky:**

The `site.native_stats_start_at` field is the best fit for checking this. However, it gets recorded in UTC (`naive_datetime`), and therefore it's value might end up being one day before or after "today" in `site.timezone`.

When deciding whether to default to today, we are comparing two UTC dates - `utc_today` vs `site.native_stats_start_date`. The only issue that surfaces from comparing UTC dates is that the day might "end quicker". E.g. when in site timezone it's 01:00 and in UTC it's 23:00, we would consider the day to be over in an hour already, while for the customer it would be 2AM on the same day.

To overcome this issue, we will also default to today when `site.native_stats_start_date == utc_yesterday`. That means sometimes we will default to `today` for longer than just during the first 24 hours, but it shouldn't be an issue.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
