### PR TITLE
Remove sampling flag code and reduce sampling threshold

### DIFF
--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -56,19 +56,9 @@ defmodule Plausible.Stats.Sampling do
   end
 
   defp decide_sample_rate(site, query) do
-    cond do
-      FunWithFlags.enabled?(:fractional_hardcoded_sample_rate, for: site) ->
-        # Hard-coded sample rate to temporarily fix an issue for a client.
-        # To be solved as part of https://3.basecamp.com/5308029/buckets/39750953/messages/7978775089
-        0.1
-
-      FunWithFlags.enabled?(:fractional_sample_rate, for: site) ->
-        traffic_30_day = SamplingCache.get(site.id)
-        fractional_sample_rate(traffic_30_day, query)
-
-      true ->
-        @default_sample_threshold
-    end
+    site.id
+    |> SamplingCache.get()
+    |> fractional_sample_rate(query)
   end
 
   def fractional_sample_rate(nil = _traffic_30_day, _query), do: :no_sampling

--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -2,7 +2,7 @@ defmodule Plausible.Stats.Sampling do
   @moduledoc """
   Sampling related functions
   """
-  @default_sample_threshold 20_000_000
+  @default_sample_threshold 10_000_000
   # 1 percent
   @min_sample_rate 0.01
 

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -5,37 +5,39 @@ defmodule Plausible.Stats.SamplingTest do
 
   on_ee do
     import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
-    alias Plausible.Stats.{Query, DateTimeRange}
+    alias Plausible.Stats.{Query, DateTimeRange, Sampling}
 
     describe "&fractional_sample_rate/2" do
+      @threshold Sampling.default_sample_threshold()
+
       test "no traffic estimate" do
         assert fractional_sample_rate(nil, query(30)) == :no_sampling
       end
 
       test "scales sampling rate according to query duration" do
-        assert fractional_sample_rate(40_000_000, query(30)) == :no_sampling
-        assert fractional_sample_rate(40_000_000, query(60)) == 0.25
-        assert fractional_sample_rate(40_000_000, query(100)) == 0.15
+        assert fractional_sample_rate(@threshold * 2, query(30)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 2, query(60)) == 0.25
+        assert fractional_sample_rate(@threshold * 2, query(100)) == 0.15
 
-        assert fractional_sample_rate(100_000_000, query(1)) == :no_sampling
-        assert fractional_sample_rate(100_000_000, query(5)) == :no_sampling
-        assert fractional_sample_rate(100_000_000, query(10)) == :no_sampling
-        assert fractional_sample_rate(100_000_000, query(15)) == 0.40
-        assert fractional_sample_rate(100_000_000, query(30)) == 0.20
-        assert fractional_sample_rate(100_000_000, query(60)) == 0.10
-        assert fractional_sample_rate(100_000_000, query(100)) == 0.06
+        assert fractional_sample_rate(@threshold * 5, query(1)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(5)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(10)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(15)) == 0.40
+        assert fractional_sample_rate(@threshold * 5, query(30)) == 0.20
+        assert fractional_sample_rate(@threshold * 5, query(60)) == 0.10
+        assert fractional_sample_rate(@threshold * 5, query(100)) == 0.06
 
-        assert fractional_sample_rate(300_000_000, query(2)) == :no_sampling
-        assert fractional_sample_rate(300_000_000, query(5)) == 0.40
-        assert fractional_sample_rate(300_000_000, query(10)) == 0.20
+        assert fractional_sample_rate(@threshold * 15, query(2)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 15, query(5)) == 0.40
+        assert fractional_sample_rate(@threshold * 15, query(10)) == 0.20
       end
 
       test "short durations" do
-        assert fractional_sample_rate(300_000_000_000, query(1, :hour)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 15, query(1, :hour)) == :no_sampling
       end
 
       test "very low sampling rate" do
-        assert fractional_sample_rate(300_000_000_000, query(30)) == 0.01
+        assert fractional_sample_rate(@threshold * 500, query(30)) == 0.01
       end
     end
 


### PR DESCRIPTION
This PR:
- Removes code around a feature flag that has been enabled in production for months
- Reduces sampling rate (some users near current threshold have reported issues)

Basecamp ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8505102605