### PR TITLE
Switch from `Site.locked` to `Team.locked`

### DIFF
--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -222,7 +222,7 @@ defmodule Plausible.HelpScout do
       subscription.status == Subscription.Status.paused() ->
         "Paused"
 
-      Teams.owned_sites_locked?(team) ->
+      Teams.locked?(team) ->
         "Dashboard locked"
 
       subscription_active? ->

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -233,7 +233,7 @@ defmodule Plausible.Billing do
     |> Plausible.Teams.update_accept_traffic_until()
     |> Plausible.Teams.remove_grace_period()
     |> Plausible.Teams.maybe_reset_next_upgrade_override()
-    |> tap(&Plausible.Billing.SiteLocker.update_sites_for/1)
+    |> tap(&Plausible.Billing.SiteLocker.update_for/1)
     |> maybe_adjust_api_key_limits()
   end
 

--- a/lib/plausible/billing/site_locker.ex
+++ b/lib/plausible/billing/site_locker.ex
@@ -48,16 +48,6 @@ defmodule Plausible.Billing.SiteLocker do
 
   @spec set_lock_status_for(Teams.Team.t(), boolean()) :: :ok
   def set_lock_status_for(team, status) do
-    site_ids = Teams.owned_sites_ids(team)
-
-    site_q =
-      from(
-        s in Plausible.Site,
-        where: s.id in ^site_ids
-      )
-
-    {_, _} = Repo.update_all(site_q, set: [locked: status])
-
     query = from(t in Teams.Team, where: t.id == ^team.id)
 
     {_, _} = Repo.update_all(query, set: [locked: status])

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -14,7 +14,6 @@ defmodule Plausible.Site do
     field :domain, :string
     field :timezone, :string, default: "Etc/UTC"
     field :public, :boolean
-    field :locked, :boolean
     field :stats_start_date, :date
     field :native_stats_start_at, :naive_datetime
     field :allowed_event_props, {:array, :string}

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -367,10 +367,6 @@ defmodule Plausible.Sites do
     )
   end
 
-  def locked?(%Site{locked: locked}) do
-    locked
-  end
-
   def get_for_user!(user, domain, roles \\ [:owner, :admin, :editor, :viewer]) do
     site =
       if :super_admin in roles and Plausible.Auth.is_super_admin?(user.id) do

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -102,19 +102,6 @@ defmodule Plausible.Teams do
     )
   end
 
-  def owned_sites_locked?(nil) do
-    false
-  end
-
-  def owned_sites_locked?(team) do
-    Repo.exists?(
-      from(s in Plausible.Site,
-        where: s.team_id == ^team.id,
-        where: s.locked == true
-      )
-    )
-  end
-
   def owned_sites_count(nil), do: 0
 
   def owned_sites_count(team) do

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -410,6 +410,7 @@ defmodule Plausible.Teams.Invitations do
     end
 
     on_ee do
+      Billing.SiteLocker.update_sites_for(prior_team, send_email?: false)
       :unlocked = Billing.SiteLocker.update_sites_for(team, send_email?: false)
     end
 

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -410,8 +410,8 @@ defmodule Plausible.Teams.Invitations do
     end
 
     on_ee do
-      Billing.SiteLocker.update_sites_for(prior_team, send_email?: false)
-      :unlocked = Billing.SiteLocker.update_sites_for(team, send_email?: false)
+      Billing.SiteLocker.update_for(prior_team, send_email?: false)
+      :unlocked = Billing.SiteLocker.update_for(team, send_email?: false)
     end
 
     :ok

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   alias Plausible.Auth
   alias Plausible.RateLimit
-  alias Plausible.Sites
+  alias Plausible.Teams
   alias PlausibleWeb.Api.Helpers, as: H
 
   require Logger
@@ -201,7 +201,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
       api_key.team_id && api_key.team_id != site.team_id ->
         {:error, :invalid_api_key}
 
-      Sites.locked?(site) ->
+      Teams.locked?(team) ->
         {:error, :site_locked}
 
       Plausible.Billing.Feature.StatsAPI.check_availability(team) !== :ok ->

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -1,7 +1,7 @@
 <div class={stats_container_class(@conn)} data-site-domain={@site.domain}>
   <PlausibleWeb.Components.FirstDashboardLaunchBanner.render site={@site} />
 
-  <%= if @site.locked do %>
+  <%= if Plausible.Teams.locked?(@site.team) do %>
     <div
       class="w-full px-4 py-4 text-sm font-bold text-center text-yellow-800 bg-yellow-100 rounded transition"
       style="top: 91px"

--- a/lib/workers/lock_sites.ex
+++ b/lib/workers/lock_sites.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Workers.LockSites do
       )
 
     for team <- teams do
-      Plausible.Billing.SiteLocker.update_sites_for(team)
+      Plausible.Billing.SiteLocker.update_for(team)
     end
 
     :ok

--- a/lib/workers/schedule_email_reports.ex
+++ b/lib/workers/schedule_email_reports.ex
@@ -27,6 +27,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
     sites =
       Repo.all(
         from s in Plausible.Site,
+          inner_join: t in assoc(s, :team),
           join: wr in Plausible.Site.WeeklyReport,
           on: wr.site_id == s.id,
           left_join: job in subquery(weekly_jobs),
@@ -34,7 +35,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not s.locked,
+          where: not t.locked,
           preload: [weekly_report: wr]
       )
 
@@ -67,6 +68,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
     sites =
       Repo.all(
         from s in Plausible.Site,
+          inner_join: t in assoc(s, :team),
           join: mr in Plausible.Site.MonthlyReport,
           on: mr.site_id == s.id,
           left_join: job in subquery(monthly_jobs),
@@ -74,7 +76,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not s.locked,
+          where: not t.locked,
           preload: [monthly_report: mr]
       )
 

--- a/lib/workers/traffic_change_notifier.ex
+++ b/lib/workers/traffic_change_notifier.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Workers.TrafficChangeNotifier do
               sn.last_sent < ^NaiveDateTime.add(now, -@min_interval_hours, :hour),
           inner_join: s in assoc(sn, :site),
           inner_join: t in assoc(s, :team),
-          where: not s.locked,
+          where: not t.locked,
           where: is_nil(t.accept_traffic_until) or t.accept_traffic_until > ^today,
           preload: [site: {s, team: t}]
       )

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Plausible.MixProject do
       {:cors_plug, "~> 3.0"},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:double, "~> 0.8.0", only: [:test, :ce_test]},
+      {:double, "~> 0.8.0", only: [:dev, :test, :ce_test]},
       {:ecto, "~> 3.12.0"},
       {:ecto_sql, "~> 3.12.0"},
       {:envy, "~> 1.1.1"},

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -9,14 +9,14 @@ defmodule Plausible.Billing.SiteLockerTest do
 
   @v4_growth_plan_id "857097"
 
-  describe "update_sites_for/1" do
+  describe "update_for/1" do
     test "does not lock sites if user is on trial" do
       user = new_user(trial_expiry_date: Date.utc_today())
       site = new_site(owner: user)
       site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -26,7 +26,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -36,7 +36,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -46,7 +46,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -61,7 +61,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -79,7 +79,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -95,7 +95,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
+      assert SiteLocker.update_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site.team).locked
     end
@@ -109,7 +109,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
 
-      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+      assert SiteLocker.update_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}
 
       assert Repo.reload!(site.team).locked
@@ -122,7 +122,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
 
@@ -141,7 +141,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
 
-      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+      assert SiteLocker.update_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
@@ -171,7 +171,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
 
-      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+      assert SiteLocker.update_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_now}
 
       assert_email_delivered_with(
@@ -183,7 +183,7 @@ defmodule Plausible.Billing.SiteLockerTest do
 
       assert team.locked
 
-      assert SiteLocker.update_sites_for(team, usage_mod: over_limits_usage_stub) ==
+      assert SiteLocker.update_for(team, usage_mod: over_limits_usage_stub) ==
                {:locked, :grace_period_ended_already}
 
       assert_no_emails_delivered()
@@ -204,7 +204,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == :unlocked
+      assert SiteLocker.update_for(team) == :unlocked
 
       refute Repo.reload!(site.team).locked
     end
@@ -214,7 +214,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
+      assert SiteLocker.update_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site.team).locked
     end
@@ -224,7 +224,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       site = new_site(owner: user)
       team = user |> team_of() |> Ecto.Changeset.change(trial_expiry_date: nil) |> Repo.update!()
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
+      assert SiteLocker.update_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(site.team).locked
     end
@@ -237,7 +237,7 @@ defmodule Plausible.Billing.SiteLockerTest do
       add_guest(viewer_site, user: user, role: :viewer)
       team = team_of(user)
 
-      assert SiteLocker.update_sites_for(team) == {:locked, :no_active_trial_or_subscription}
+      assert SiteLocker.update_for(team) == {:locked, :no_active_trial_or_subscription}
 
       assert Repo.reload!(owner_site.team).locked
       refute Repo.reload!(viewer_site.team).locked

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -264,7 +264,8 @@ defmodule Plausible.HelpScoutTest do
       test "returns for user with locked site" do
         user = %{email: email} = new_user(trial_expiry_date: Date.add(Date.utc_today(), -1))
 
-        new_site(owner: user, locked: true)
+        site = new_site(owner: user)
+        site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
         subscribe_to_plan(user, @v4_business_monthly_plan_id)
 
         stub_help_scout_requests(email)

--- a/test/plausible/site/memberships/accept_invitation_test.exs
+++ b/test/plausible/site/memberships/accept_invitation_test.exs
@@ -492,8 +492,12 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
     @tag :ee_only
     test "unlocks a previously locked site after transfer" do
       existing_owner = new_user()
-      site = new_site(owner: existing_owner, locked: true)
+      site = new_site(owner: existing_owner)
+      old_team = site.team
+      old_team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       new_owner = new_user() |> subscribe_to_growth_plan()
+      new_team = team_of(new_owner)
+      new_team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
 
       transfer = invite_transfer(site, new_owner, inviter: existing_owner)
 
@@ -504,7 +508,8 @@ defmodule Plausible.Site.Memberships.AcceptInvitationTest do
                )
 
       refute Repo.reload(transfer)
-      refute Repo.reload!(site).locked
+      refute Repo.reload!(old_team).locked
+      refute Repo.reload!(new_team).locked
     end
 
     for role <- [:viewer, :editor] do

--- a/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/auth_test.exs
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   use PlausibleWeb.ConnCase
   use Plausible.Teams.Test
 
+  alias Plausible.Repo
+
   setup [:create_user, :create_api_key]
 
   test "unauthenticated request - returns 401", %{conn: conn} do
@@ -47,7 +49,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
   end
 
   test "locked site - returns 402", %{conn: conn, api_key: api_key, user: user} do
-    site = new_site(owner: user, locked: true)
+    site = new_site(owner: user)
+    site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
 
     conn
     |> with_api_key(api_key)
@@ -88,7 +91,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.AuthTest do
       api_key: api_key,
       user: user
     } do
-      site = new_site(owner: user, locked: true)
+      site = new_site(owner: user)
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
 
       conn
       |> with_api_key(api_key)

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -169,7 +169,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "shows locked page if site is locked", %{conn: conn, user: user} do
-      locked_site = new_site(locked: true, owner: user)
+      locked_site = new_site(owner: user)
+      locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       conn = get(conn, "/" <> locked_site.domain)
       resp = html_response(conn, 200)
       assert resp =~ "Dashboard locked"
@@ -178,7 +179,8 @@ defmodule PlausibleWeb.StatsControllerTest do
 
     test "shows locked page if site is locked for billing role", %{conn: conn, user: user} do
       other_user = new_user()
-      locked_site = new_site(locked: true, owner: other_user)
+      locked_site = new_site(owner: other_user)
+      locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       add_member(team_of(other_user), user: user, role: :billing)
 
       conn = get(conn, "/" <> locked_site.domain)
@@ -189,7 +191,8 @@ defmodule PlausibleWeb.StatsControllerTest do
 
     test "shows locked page if site is locked for viewer role", %{conn: conn, user: user} do
       other_user = new_user()
-      locked_site = new_site(locked: true, owner: other_user)
+      locked_site = new_site(owner: other_user)
+      locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       add_member(team_of(other_user), user: user, role: :viewer)
 
       conn = get(conn, "/" <> locked_site.domain)
@@ -200,7 +203,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "shows locked page for anonymous" do
-      locked_site = new_site(locked: true, public: true)
+      locked_site = new_site(public: true)
+      locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       conn = get(build_conn(), "/" <> locked_site.domain)
       resp = html_response(conn, 200)
       assert resp =~ "Dashboard locked"
@@ -274,7 +278,8 @@ defmodule PlausibleWeb.StatsControllerTest do
 
     test "can view a private locked dashboard with stats", %{conn: conn} do
       user = new_user()
-      site = new_site(locked: true, owner: user)
+      site = new_site(owner: user)
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
@@ -287,14 +292,16 @@ defmodule PlausibleWeb.StatsControllerTest do
 
     test "can view private locked verification without stats", %{conn: conn} do
       user = new_user()
-      site = new_site(locked: true, owner: user)
+      site = new_site(owner: user)
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
 
       conn = get(conn, conn |> get("/#{site.domain}") |> redirected_to())
       assert html_response(conn, 200) =~ "Verifying your installation"
     end
 
     test "can view a locked public dashboard", %{conn: conn} do
-      site = new_site(locked: true, public: true)
+      site = new_site(public: true)
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       populate_stats(site, [build(:pageview)])
 
       conn = get(conn, "/" <> site.domain)
@@ -1237,7 +1244,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
   describe "GET /share/:domain?auth=:auth" do
     test "prompts a password for a password-protected link", %{conn: conn} do
-      site = insert(:site)
+      site = new_site()
 
       link =
         insert(:shared_link, site: site, password_hash: Plausible.Auth.Password.hash("password"))
@@ -1318,7 +1325,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "shows locked page if page is locked", %{conn: conn} do
-      site = insert(:site, domain: "test-site.com", locked: true)
+      site = new_site(domain: "test-site.com")
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       link = insert(:shared_link, site: site)
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
@@ -1423,8 +1431,8 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     test "only gives access to the correct dashboard", %{conn: conn} do
-      site = insert(:site, domain: "test-site.com")
-      site2 = insert(:site, domain: "test-site2.com")
+      site = new_site(domain: "test-site.com")
+      site2 = new_site(domain: "test-site2.com")
 
       link =
         insert(:shared_link, site: site, password_hash: Plausible.Auth.Password.hash("password"))

--- a/test/plausible_web/plugs/authorize_public_api_test.exs
+++ b/test/plausible_web/plugs/authorize_public_api_test.exs
@@ -5,6 +5,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   import ExUnit.CaptureLog
 
   alias PlausibleWeb.Plugs.AuthorizePublicAPI
+  alias Plausible.Repo
 
   setup %{conn: conn} do
     conn =
@@ -109,7 +110,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
 
   test "halts with error when site is locked", %{conn: conn} do
     user = new_user()
-    site = new_site(owner: user, locked: true)
+    site = new_site(owner: user)
+    site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
     api_key = insert(:api_key, user: user)
 
     conn =
@@ -332,7 +334,8 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPITest do
   test "passes for super admin user even if not a member of the requested site", %{conn: conn} do
     user = new_user()
     patch_env(:super_admin_user_ids, [user.id])
-    site = new_site(locked: true)
+    site = new_site()
+    site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
     api_key = insert(:api_key, user: user)
 
     conn =

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -302,6 +302,32 @@ defmodule Plausible.TestUtils do
     end
   end
 
+  def monthly_pageview_usage_stub(penultimate_usage, last_usage) do
+    last_bill_date = Date.utc_today() |> Date.shift(day: -1)
+
+    Plausible.Teams.Billing
+    |> Double.stub(:monthly_pageview_usage, fn _user ->
+      %{
+        last_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -1),
+              Date.shift(last_bill_date, day: -1)
+            ),
+          total: last_usage
+        },
+        penultimate_cycle: %{
+          date_range:
+            Date.range(
+              Date.shift(last_bill_date, month: -2),
+              Date.shift(last_bill_date, day: -1, month: -1)
+            ),
+          total: penultimate_usage
+        }
+      }
+    end)
+  end
+
   defp secret_key_base() do
     :plausible
     |> Application.fetch_env!(PlausibleWeb.Endpoint)

--- a/test/workers/lock_sites_test.exs
+++ b/test/workers/lock_sites_test.exs
@@ -17,7 +17,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   test "does not lock trial user's site" do
@@ -26,7 +26,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   test "locks site for user whose trial has expired" do
@@ -35,7 +35,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    assert Repo.reload!(site).locked
+    assert Repo.reload!(site.team).locked
   end
 
   test "does not lock active subsriber's sites" do
@@ -44,7 +44,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   test "does not lock user who is past due" do
@@ -53,7 +53,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   test "does not lock user who cancelled subscription but it hasn't expired yet" do
@@ -62,7 +62,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   test "locks user who cancelled subscription and the cancelled subscription has expired" do
@@ -77,7 +77,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    assert Repo.reload!(site).locked
+    assert Repo.reload!(site.team).locked
   end
 
   test "does not lock if user has an old cancelled subscription and a new active subscription" do
@@ -94,7 +94,7 @@ defmodule Plausible.Workers.LockSitesTest do
 
     LockSites.perform(nil)
 
-    refute Repo.reload!(site).locked
+    refute Repo.reload!(site.team).locked
   end
 
   describe "locking" do
@@ -107,11 +107,8 @@ defmodule Plausible.Workers.LockSitesTest do
 
       LockSites.perform(nil)
 
-      owner_site = Repo.reload!(owner_site)
-      viewer_site = Repo.reload!(viewer_site)
-
-      assert owner_site.locked
-      refute viewer_site.locked
+      assert Repo.reload!(owner_site.team).locked
+      refute Repo.reload!(viewer_site.team).locked
     end
   end
 end

--- a/test/workers/schedule_email_reports_test.exs
+++ b/test/workers/schedule_email_reports_test.exs
@@ -1,11 +1,12 @@
 defmodule Plausible.Workers.ScheduleEmailReportsTest do
   use Plausible.DataCase
   use Oban.Testing, repo: Plausible.Repo
+  import Plausible.Teams.Test
   alias Plausible.Workers.{ScheduleEmailReports, SendEmailReport}
 
   describe "weekly reports" do
     test "schedules weekly report on Monday 9am local timezone" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -18,7 +19,7 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "does not schedule more than one weekly report at a time" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -28,7 +29,8 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "does not schedule a weekly report for locked site" do
-      site = insert(:site, locked: true, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -37,7 +39,7 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "schedules a new report as soon as a previous one is completed" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -50,7 +52,7 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
 
   describe "monthly_reports" do
     test "schedules monthly report on first of the next month at 9am local timezone" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -63,7 +65,7 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "does not schedule more than one monthly report at a time" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -73,7 +75,8 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "does not schedule a monthly report for locked site" do
-      site = insert(:site, locked: true, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})
@@ -82,7 +85,7 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     end
 
     test "schedules a new report as soon as a previous one is completed" do
-      site = insert(:site, domain: "test-site.com", timezone: "US/Eastern")
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})

--- a/test/workers/traffic_change_notifier_test.exs
+++ b/test/workers/traffic_change_notifier_test.exs
@@ -269,7 +269,8 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
     end
 
     test "does not check site if it is locked" do
-      site = insert(:site, locked: true)
+      site = new_site()
+      site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
 
       insert(:spike_notification,
         site: site,


### PR DESCRIPTION
### Changes

Move site lock state from individual sites to team.

The changes will be deployed in stages:

- ~first, changes up on updating `team.locked` in parallel with `site.locked`~
- ~next, backfill migration~
- after backfill migration is run and team.locked state confirmed to be consistent, switch to `team.locked` entirely

### TODO

- [x] double check if there are cases of sites with mixed locked state in the same team in the wild
- [x] add backfill
- [x] rename `SiteLocker.update_sites_for`
- [x] see if `SiteLocker` uses can be reduced
- [x] split into multiple PRs, starting from migration

### Tests
- [x] Automated tests have been added

