### PR TITLE
Tracker bug: engagements not fired on manual trigger SPAs

### DIFF
--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 2,
+  "tracker_script_version": 3,
   "scripts": {
     "deploy": "node compile.js",
     "test": "npm run deploy && npx playwright test",

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -167,6 +167,15 @@
   function trigger(eventName, options) {
     var isPageview = eventName === 'pageview'
 
+    if (isPageview && listeningOnEngagement) {
+      // If we're listening on engagement already, at least one pageview
+      // has been sent by the current script (i.e. it's most likely a SPA).
+      // Trigger an engagement marking the "exit from the previous page".
+      triggerEngagement()
+      currentDocumentHeight = getDocumentHeight()
+      maxScrollDepthPx = getCurrentScrollDepthPx()
+    }
+
     {{#unless local}}
     if (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(location.hostname) || location.protocol === 'file:') {
       return onIgnoredEvent(eventName, 'localhost', options)
@@ -305,12 +314,6 @@
       {{#unless hash}}
       if (isSPANavigation && lastPage === location.pathname) return;
       {{/unless}}
-
-      if (isSPANavigation && listeningOnEngagement) {
-        triggerEngagement()
-        currentDocumentHeight = getDocumentHeight()
-        maxScrollDepthPx = getCurrentScrollDepthPx()
-      }
 
       lastPage = location.pathname
       trigger('pageview')

--- a/tracker/test/engagement.spec.js
+++ b/tracker/test/engagement.spec.js
@@ -62,6 +62,26 @@ test.describe('engagement events', () => {
     expect(request.e).toBeLessThan(1500)
   })
 
+  test('sends engagements when pageviews are triggered manually on a SPA', async ({ page }) => {
+    await expectPlausibleInAction(page, {
+      action: () => page.goto('/engagement-hash-manual.html'),
+      expectedRequests: [{n: 'pageview'}],
+    })
+
+    await page.waitForTimeout(1000)
+
+    const [request] = await expectPlausibleInAction(page, {
+      action: () => page.click('#about-us-hash-link'),
+      expectedRequests: [
+        {n: 'engagement', u: `${LOCAL_SERVER_ADDR}/#home`},
+        {n: 'pageview', u: `${LOCAL_SERVER_ADDR}/#about-us`}
+      ]
+    })
+
+    expect(request.e).toBeGreaterThan(1000)
+    expect(request.e).toBeLessThan(1500)
+  })
+
   test('sends an event with the manually overridden URL', async ({ page }) => {
     await page.goto('/engagement-manual.html')
 

--- a/tracker/test/engagement.spec.js
+++ b/tracker/test/engagement.spec.js
@@ -114,7 +114,7 @@ test.describe('engagement events', () => {
     })
 
     // After the initial pageview is sent, navigate to ignored page ->
-    // pageleave event is sent from the initial page URL
+    // engagement event is sent from the initial page URL
     await expectPlausibleInAction(page, {
       action: () => page.click('#ignored-hash-link'),
       expectedRequests: [{n: 'engagement', u: pageBaseURL, h: 1}]

--- a/tracker/test/fixtures/engagement-hash-manual.html
+++ b/tracker/test/fixtures/engagement-hash-manual.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Plausible Playwright tests</title>
+  <script defer src="/tracker/js/plausible.hash.local.manual.js"></script>
+  <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+</head>
+
+<body>
+  <a id="about-us-hash-link" href="#about">About us</a>
+  <a id="home-hash-link" href="#home">Home</a>
+
+  <div>
+    <p id="page-title">Home</p>
+  </div>
+
+  <script>
+    const titleNode = document.getElementById('page-title')
+
+    function updateContent() {
+      if (location.hash === '#about') {
+        titleNode.innerHTML = 'About us'
+        window.plausible('pageview', {u: 'http://localhost:3000/#about-us'})
+      } else {
+        titleNode.innerHTML = 'Home'
+        window.plausible('pageview', {u: 'http://localhost:3000/#home'})
+      }
+    }
+
+    window.plausible('pageview', {u: 'http://localhost:3000/#home'})
+    window.addEventListener('hashchange', updateContent);
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Changes

Fixes a tracker bug - when pageviews are triggered manually on single page apps, we are not sending engagements when the user navigates to the next page.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
