### PR TITLE
Add `locked` column to `teams`

### DIFF
--- a/priv/repo/migrations/20250409113820_add_teams_locked.exs
+++ b/priv/repo/migrations/20250409113820_add_teams_locked.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddTeamsLocked do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :locked, :boolean, null: false, default: false
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Refs https://github.com/plausible/analytics/pull/5304

First step towards moving from `sites.locked` to `teams.locked`. Adds the relevant column to "teams" schema.
