### PR TITLE
Fix error handling of invitations, 2fa form and clean up team creation

### DIFF
--- a/lib/plausible/site/memberships/create_invitation.ex
+++ b/lib/plausible/site/memberships/create_invitation.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
           Ecto.Changeset.t()
           | :already_a_member
           | {:over_limit, non_neg_integer()}
-          | :forbidden
+          | :permission_denied
 
   @type invitation :: %Teams.GuestInvitation{} | %Teams.SiteTransfer{}
 
@@ -26,7 +26,7 @@ defmodule Plausible.Site.Memberships.CreateInvitation do
   and sends the invitee an email to accept this invitation.
 
   The inviter must have enough permissions to invite the new team member,
-  otherwise this function returns `{:error, :forbidden}`.
+  otherwise this function returns `{:error, :permission_denied}`.
 
   If the new team member role is `:owner`, this function handles the invitation
   as an ownership transfer and requires the inviter to be the owner of the site.

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -359,16 +359,12 @@ defmodule Plausible.Teams do
     team =
       %Teams.Team{}
       |> Teams.Team.changeset(%{name: default_name()})
-      |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
-      |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!()
 
     team_membership =
       team
       |> Teams.Membership.changeset(user, :owner)
       |> Ecto.Changeset.put_change(:is_autocreated, true)
-      |> Ecto.Changeset.put_change(:inserted_at, user.inserted_at)
-      |> Ecto.Changeset.put_change(:updated_at, user.updated_at)
       |> Repo.insert!(
         on_conflict: :nothing,
         conflict_target:

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -498,7 +498,7 @@ defmodule Plausible.Teams.Invitations do
           :ok
 
         _ ->
-          {:error, :forbidden}
+          {:error, :permission_denied}
       end
     else
       :ok
@@ -514,7 +514,7 @@ defmodule Plausible.Teams.Invitations do
           :ok
 
         _ ->
-          {:error, :forbidden}
+          {:error, :permission_denied}
       end
     else
       :ok

--- a/lib/plausible_web/templates/settings/security.html.heex
+++ b/lib/plausible_web/templates/settings/security.html.heex
@@ -205,7 +205,7 @@
           <.input
             type="password"
             id="regenerate_2fa_password"
-            name="regenerate_2fa_password"
+            name="password"
             value=""
             placeholder="Enter password"
             x-ref="regenerate2FAPassword"

--- a/test/plausible/site/memberships/create_invitation_test.exs
+++ b/test/plausible/site/memberships/create_invitation_test.exs
@@ -150,7 +150,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       site = new_site()
       add_guest(site, user: inviter, role: :editor)
 
-      assert {:error, :forbidden} =
+      assert {:error, :permission_denied} =
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :owner)
     end
 
@@ -184,7 +184,7 @@ defmodule Plausible.Site.Memberships.CreateInvitationTest do
       site = new_site(owner: owner)
       add_member(site.team, user: inviter, role: :viewer)
 
-      assert {:error, :forbidden} =
+      assert {:error, :permission_denied} =
                CreateInvitation.create_invitation(site, inviter, "vini@plausible.test", :viewer)
     end
 

--- a/test/plausible/teams/invitations/invite_to_team_test.exs
+++ b/test/plausible/teams/invitations/invite_to_team_test.exs
@@ -212,7 +212,7 @@ defmodule Plausible.Teams.Invitations.InviteToTeamTest do
         team = team_of(owner)
         add_member(team, user: inviter, role: unquote(role))
 
-        assert {:error, :forbidden} =
+        assert {:error, :permission_denied} =
                  InviteToTeam.invite(team, inviter, invitee.email, :owner)
       end
     end


### PR DESCRIPTION
### Changes

A couple fixes of issues observed in the wild when monitoring the app. Also, cleanup of teams creation logic which was useful during transitioning to teams but is no longer necessary.

