### PR TITLE
Expose team setup state in CRM

### DIFF
--- a/lib/plausible/teams/team_admin.ex
+++ b/lib/plausible/teams/team_admin.ex
@@ -64,6 +64,7 @@ defmodule Plausible.Teams.TeamAdmin do
     [
       name: %{value: &team_name/1},
       inserted_at: %{name: "Created at", value: &format_date(&1.inserted_at)},
+      setup: %{value: &if(&1.setup_complete, do: "Yes", else: "No")},
       owners: %{value: &get_owners/1},
       other_members: %{value: &get_other_members/1},
       trial_expiry_date: %{name: "Trial expiry", value: &format_date(&1.trial_expiry_date)},

--- a/lib/plausible_web/controllers/admin_controller.ex
+++ b/lib/plausible_web/controllers/admin_controller.ex
@@ -187,7 +187,8 @@ defmodule PlausibleWeb.AdminController do
   defp usage_and_limits_html(team, usage, limits, embed?) do
     content = """
       <ul>
-        <li>Team: <b>#{html_escape(team.name)}</b></li>
+        <li>Team: <b>#{html_escape(Teams.name(team))}</b></li>
+        <li>Setup: <b>#{if(team.setup_complete, do: "Yes", else: "No")}</b></li>
         <li>Subscription plan: #{Teams.TeamAdmin.subscription_plan(team)}</li>
         <li>Subscription status: #{Teams.TeamAdmin.subscription_status(team)}</li>
         <li>Grace period: #{Teams.TeamAdmin.grace_period_status(team)}</li>


### PR DESCRIPTION
### Changes

Adds clear indication of whether the team is setup or not in CRM.
