### PR TITLE
Change redirects from external to internal where possible

### DIFF
--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -521,7 +521,7 @@ defmodule PlausibleWeb.AuthController do
           :error,
           "We were unable to authenticate your Google Analytics account. Please check that you have granted us permission to 'See and download your Google Analytics data' and try again."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       message when message in ["server_error", "temporarily_unavailable"] ->
         conn
@@ -529,7 +529,7 @@ defmodule PlausibleWeb.AuthController do
           :error,
           "We are unable to authenticate your Google Analytics account because Google's authentication service is temporarily unavailable. Please try again in a few moments."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       _any ->
         Sentry.capture_message("Google OAuth callback failed. Reason: #{inspect(params)}")
@@ -539,7 +539,7 @@ defmodule PlausibleWeb.AuthController do
           :error,
           "We were unable to authenticate your Google Analytics account. If the problem persists, please contact support for assistance."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
     end
   end
 
@@ -554,7 +554,7 @@ defmodule PlausibleWeb.AuthController do
     case redirect_to do
       "import" ->
         redirect(conn,
-          external:
+          to:
             Routes.google_analytics_path(conn, :property_form, site.domain,
               access_token: res["access_token"],
               refresh_token: res["refresh_token"],
@@ -579,7 +579,7 @@ defmodule PlausibleWeb.AuthController do
 
         site = Repo.get(Plausible.Site, site_id)
 
-        redirect(conn, external: "/#{URI.encode_www_form(site.domain)}/settings/integrations")
+        redirect(conn, to: Routes.site_path(conn, :settings_integrations, site.domain))
     end
   end
 

--- a/lib/plausible_web/controllers/google_analytics_controller.ex
+++ b/lib/plausible_web/controllers/google_analytics_controller.ex
@@ -56,7 +56,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics rate limit has been exceeded. Please try again later."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, {:authentication_failed, message}} ->
         default_message =
@@ -72,7 +72,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         conn
         |> put_flash(:ttl, :timer.seconds(5))
         |> put_flash(:error, message)
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, :timeout} ->
         conn
@@ -80,7 +80,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics API has timed out. Please try again."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, _any} ->
         conn
@@ -88,7 +88,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "We were unable to list your Google Analytics properties. If the problem persists, please contact support for assistance."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
     end
   end
 
@@ -110,7 +110,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
          :ok <- ensure_dates(api_start_date, api_end_date),
          {:ok, start_date, end_date} <- Imported.clamp_dates(site, api_start_date, api_end_date) do
       redirect(conn,
-        external:
+        to:
           Routes.google_analytics_path(conn, :confirm, site.domain,
             property: property,
             access_token: access_token,
@@ -135,7 +135,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics rate limit has been exceeded. Please try again later."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, {:authentication_failed, message}} ->
         default_message =
@@ -151,7 +151,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         conn
         |> put_flash(:ttl, :timer.seconds(5))
         |> put_flash(:error, message)
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, :timeout} ->
         conn
@@ -159,7 +159,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics API has timed out. Please try again."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, _any} ->
         conn
@@ -167,7 +167,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "We were unable to retrieve information from Google Analytics. If the problem persists, please contact support for assistance."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
     end
   end
 
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics rate limit has been exceeded. Please try again later."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, {:authentication_failed, message}} ->
         default_message =
@@ -223,7 +223,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
         conn
         |> put_flash(:ttl, :timer.seconds(5))
         |> put_flash(:error, message)
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, :timeout} ->
         conn
@@ -231,7 +231,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics API has timed out. Please try again."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, :not_found} ->
         conn
@@ -239,7 +239,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Google Analytics property not found. Please try again."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, _any} ->
         conn
@@ -247,7 +247,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "We were unable to retrieve information from Google Analytics. If the problem persists, please contact support for assistance."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
     end
   end
 
@@ -282,7 +282,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
          {:ok, _} <- Imported.GoogleAnalytics4.new_import(site, current_user, import_opts) do
       conn
       |> put_flash(:success, "Import scheduled. An email will be sent when it completes.")
-      |> redirect(external: redirect_route)
+      |> redirect(to: redirect_route)
     else
       {:error, :no_time_window} ->
         conn
@@ -290,7 +290,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "Import failed. No data could be imported because date range overlaps with existing data."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
 
       {:error, :import_in_progress} ->
         conn
@@ -298,7 +298,7 @@ defmodule PlausibleWeb.GoogleAnalyticsController do
           :error,
           "There's another import still in progress. Please wait until it's completed or cancel it before starting a new one."
         )
-        |> redirect(external: redirect_route)
+        |> redirect(to: redirect_route)
     end
   end
 

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -29,11 +29,11 @@ defmodule PlausibleWeb.InvitationController do
         if site do
           conn
           |> put_flash(:success, "You now have access to #{site.domain}")
-          |> redirect(external: "/#{URI.encode_www_form(site.domain)}")
+          |> redirect(to: Routes.stats_path(conn, :stats, site.domain, []))
         else
           conn
           |> put_flash(:success, "You now have access to \"#{team.name}\" team")
-          |> redirect(external: "/sites")
+          |> redirect(to: Routes.site_path(conn, :index))
         end
 
       {:error, :invitation_not_found} ->
@@ -99,12 +99,12 @@ defmodule PlausibleWeb.InvitationController do
 
         conn
         |> put_flash(:success, "You have removed the invitation for #{email}")
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
 
       {:error, :invitation_not_found} ->
         conn
         |> put_flash(:error, "Invitation missing or already removed")
-        |> redirect(external: Routes.site_path(conn, :settings_people, conn.assigns.site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, conn.assigns.site.domain))
     end
   end
 
@@ -115,12 +115,12 @@ defmodule PlausibleWeb.InvitationController do
       {:ok, invitation} ->
         conn
         |> put_flash(:success, "You have removed the invitation for #{invitation.email}")
-        |> redirect(external: Routes.settings_path(conn, :team_general))
+        |> redirect(to: Routes.settings_path(conn, :team_general))
 
       {:error, :invitation_not_found} ->
         conn
         |> put_flash(:error, "Invitation missing or already removed")
-        |> redirect(external: Routes.settings_path(conn, :team_general))
+        |> redirect(to: Routes.settings_path(conn, :team_general))
 
       {:error, :permission_denied} ->
         conn

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.Site.MembershipController do
           :success,
           "#{email} has been invited to #{site_domain} as #{PlausibleWeb.SiteView.with_indefinite_article("#{invitation.role}")}"
         )
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
 
       {:error, :already_a_member} ->
         render(conn, "invite_member_form.html",
@@ -83,7 +83,7 @@ defmodule PlausibleWeb.Site.MembershipController do
 
         conn
         |> put_flash(:error, error_msg)
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
     end
   end
 
@@ -111,7 +111,7 @@ defmodule PlausibleWeb.Site.MembershipController do
       {:ok, _invitation} ->
         conn
         |> put_flash(:success, "Site transfer request has been sent to #{email}")
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
 
       {:error, changeset} ->
         errors = Plausible.ChangesetHelpers.traverse_errors(changeset)
@@ -126,7 +126,7 @@ defmodule PlausibleWeb.Site.MembershipController do
         |> put_flash(:ttl, :timer.seconds(5))
         |> put_flash(:error_title, "Transfer error")
         |> put_flash(:error, message)
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
     end
   end
 
@@ -177,7 +177,7 @@ defmodule PlausibleWeb.Site.MembershipController do
       :ok ->
         conn
         |> put_flash(:success, "Site team was changed")
-        |> redirect(external: Routes.site_path(conn, :index, __team: identifier))
+        |> redirect(to: Routes.site_path(conn, :index, __team: identifier))
 
       {:error, :no_plan} ->
         conn
@@ -220,7 +220,7 @@ defmodule PlausibleWeb.Site.MembershipController do
         redirect_target =
           if guest_membership.team_membership.user_id == current_user.id and
                guest_membership.role == :viewer do
-            "/#{URI.encode_www_form(site.domain)}"
+            Routes.stats_path(conn, :stats, site.domain, [])
           else
             Routes.site_path(conn, :settings_people, site.domain)
           end
@@ -230,12 +230,12 @@ defmodule PlausibleWeb.Site.MembershipController do
           :success,
           "#{guest_membership.team_membership.user.name} is now #{PlausibleWeb.SiteView.with_indefinite_article(to_string(guest_membership.role))}"
         )
-        |> redirect(external: redirect_target)
+        |> redirect(to: redirect_target)
 
       {:error, _} ->
         conn
         |> put_flash(:error, "You are not allowed to grant the #{new_role_str} role")
-        |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
     end
   end
 
@@ -247,7 +247,7 @@ defmodule PlausibleWeb.Site.MembershipController do
 
       redirect_target =
         if user_id == conn.assigns[:current_user].id do
-          "/#{URI.encode_www_form(site.domain)}"
+          Routes.stats_path(conn, :index, site.domain, [])
         else
           Routes.site_path(conn, :settings_people, site.domain)
         end
@@ -257,14 +257,14 @@ defmodule PlausibleWeb.Site.MembershipController do
         :success,
         "#{user.name} has been removed from #{site.domain}"
       )
-      |> redirect(external: redirect_target)
+      |> redirect(to: redirect_target)
     else
       conn
       |> put_flash(
         :success,
         "User has been removed from #{site.domain}"
       )
-      |> redirect(external: Routes.site_path(conn, :settings_people, site.domain))
+      |> redirect(to: Routes.site_path(conn, :settings_people, site.domain))
     end
   end
 end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -50,7 +50,7 @@ defmodule PlausibleWeb.SiteController do
         end
 
         redirect(conn,
-          external:
+          to:
             Routes.site_path(conn, :installation, site.domain,
               site_created: true,
               flow: flow
@@ -285,7 +285,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Google integration saved successfully")
-    |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
   def delete_google_auth(conn, _params) do
@@ -297,7 +297,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn = put_flash(conn, :success, "Google account unlinked from Plausible")
 
-    redirect(conn, external: Routes.site_path(conn, :settings_integrations, site.domain))
+    redirect(conn, to: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
   def update_settings(conn, %{"site" => site_params}) do
@@ -311,7 +311,7 @@ defmodule PlausibleWeb.SiteController do
         conn
         |> put_session(site_session_key, nil)
         |> put_flash(:success, "Your site settings have been saved")
-        |> redirect(external: Routes.site_path(conn, :settings_general, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_general, site.domain))
 
       {:error, changeset} ->
         conn
@@ -330,7 +330,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "#{site.domain} stats will be reset in a few minutes")
-    |> redirect(external: Routes.site_path(conn, :settings_danger_zone, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_danger_zone, site.domain))
   end
 
   def delete_site(conn, _params) do
@@ -351,7 +351,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Stats for #{site.domain} are now public.")
-    |> redirect(external: Routes.site_path(conn, :settings_visibility, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
   end
 
   def make_private(conn, _params) do
@@ -362,7 +362,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Stats for #{site.domain} are now private.")
-    |> redirect(external: Routes.site_path(conn, :settings_visibility, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
   end
 
   def enable_weekly_report(conn, _params) do
@@ -379,7 +379,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "You will receive an email report every Monday going forward")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def disable_weekly_report(conn, _params) do
@@ -388,7 +388,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "You will not receive weekly email reports going forward")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def add_weekly_report_recipient(conn, %{"recipient" => recipient}) do
@@ -400,7 +400,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Added #{recipient} as a recipient for the weekly report")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def remove_weekly_report_recipient(conn, %{"recipient" => recipient}) do
@@ -415,7 +415,7 @@ defmodule PlausibleWeb.SiteController do
       :success,
       "Removed #{recipient} as a recipient for the weekly report"
     )
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def enable_monthly_report(conn, _params) do
@@ -433,7 +433,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "You will receive an email report every month going forward")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def disable_monthly_report(conn, _params) do
@@ -442,7 +442,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "You will not receive monthly email reports going forward")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def add_monthly_report_recipient(conn, %{"recipient" => recipient}) do
@@ -454,7 +454,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Added #{recipient} as a recipient for the monthly report")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def remove_monthly_report_recipient(conn, %{"recipient" => recipient}) do
@@ -469,7 +469,7 @@ defmodule PlausibleWeb.SiteController do
       :success,
       "Removed #{recipient} as a recipient for the monthly report"
     )
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def enable_traffic_change_notification(conn, %{"type" => type}) do
@@ -491,12 +491,12 @@ defmodule PlausibleWeb.SiteController do
       {:ok, _} ->
         conn
         |> put_flash(:success, "Traffic #{type} notifications enabled")
-        |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
 
       {:error, _} ->
         conn
         |> put_flash(:error, "Unable to create a #{type} notification")
-        |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
     end
   end
 
@@ -511,7 +511,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Traffic #{type} notifications disabled")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def update_traffic_change_notification(conn, %{
@@ -528,7 +528,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Notification settings updated")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def add_traffic_change_notification_recipient(conn, %{"recipient" => recipient, "type" => type}) do
@@ -540,7 +540,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Added #{recipient} as a recipient for the traffic spike notification")
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def remove_traffic_change_notification_recipient(conn, %{
@@ -558,7 +558,7 @@ defmodule PlausibleWeb.SiteController do
       :success,
       "Removed #{recipient} as a recipient for the monthly report"
     )
-    |> redirect(external: Routes.site_path(conn, :settings_email_reports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_email_reports, site.domain))
   end
 
   def new_shared_link(conn, _params) do
@@ -578,7 +578,7 @@ defmodule PlausibleWeb.SiteController do
 
     case Sites.create_shared_link(site, link["name"], link["password"]) do
       {:ok, _created} ->
-        redirect(conn, external: Routes.site_path(conn, :settings_visibility, site.domain))
+        redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
 
       {:error, changeset} ->
         conn
@@ -610,7 +610,7 @@ defmodule PlausibleWeb.SiteController do
 
     case Repo.update(changeset) do
       {:ok, _created} ->
-        redirect(conn, external: Routes.site_path(conn, :settings_visibility, site.domain))
+        redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
 
       {:error, changeset} ->
         conn
@@ -635,12 +635,12 @@ defmodule PlausibleWeb.SiteController do
       {1, _} ->
         conn
         |> put_flash(:success, "Shared Link deleted")
-        |> redirect(external: Routes.site_path(conn, :settings_visibility, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
 
       {0, _} ->
         conn
         |> put_flash(:error, "Could not find Shared Link")
-        |> redirect(external: Routes.site_path(conn, :settings_visibility, site.domain))
+        |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
     end
   end
 
@@ -663,7 +663,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Imported data has been cleared")
-    |> redirect(external: Routes.site_path(conn, :settings_imports_exports, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_imports_exports, site.domain))
   end
 
   def forget_imported(conn, _params) do
@@ -690,7 +690,7 @@ defmodule PlausibleWeb.SiteController do
 
     conn
     |> put_flash(:success, "Imported data has been cleared")
-    |> redirect(external: Routes.site_path(conn, :settings_integrations, site.domain))
+    |> redirect(to: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 
   on_ee do
@@ -704,7 +704,7 @@ defmodule PlausibleWeb.SiteController do
       else
         conn
         |> put_flash(:error, "Export not found")
-        |> redirect(external: Routes.site_path(conn, :settings_imports_exports, domain))
+        |> redirect(to: Routes.site_path(conn, :settings_imports_exports, domain))
       end
     end
   else
@@ -721,7 +721,7 @@ defmodule PlausibleWeb.SiteController do
       else
         conn
         |> put_flash(:error, "Export not found")
-        |> redirect(external: Routes.site_path(conn, :settings_imports_exports, domain))
+        |> redirect(to: Routes.site_path(conn, :settings_imports_exports, domain))
       end
     end
   end
@@ -749,7 +749,7 @@ defmodule PlausibleWeb.SiteController do
         conn
         |> put_flash(:success, "Website domain changed successfully")
         |> redirect(
-          external:
+          to:
             Routes.site_path(conn, :installation, updated_site.domain,
               flow: PlausibleWeb.Flows.domain_change()
             )

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -89,7 +89,7 @@ defmodule PlausibleWeb.StatsController do
         )
 
       !stats_start_date && can_see_stats? ->
-        redirect(conn, external: Routes.site_path(conn, :verification, site.domain))
+        redirect(conn, to: Routes.site_path(conn, :verification, site.domain))
 
       Teams.locked?(site.team) ->
         site = Plausible.Repo.preload(site, :owners)

--- a/lib/plausible_web/live/csv_export.ex
+++ b/lib/plausible_web/live/csv_export.ex
@@ -228,8 +228,7 @@ defmodule PlausibleWeb.Live.CSVExport do
           socket
           |> put_flash(:error, "There is no data to export")
           |> redirect(
-            external:
-              Routes.site_path(socket, :settings_imports_exports, socket.assigns.site.domain)
+            to: Routes.site_path(socket, :settings_imports_exports, socket.assigns.site.domain)
           )
       end
 

--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -222,9 +222,9 @@ defmodule PlausibleWeb.Live.CSVImport do
       )
 
     redirect_to =
-      Routes.site_path(socket, :settings_imports_exports, URI.encode_www_form(site.domain))
+      Routes.site_path(socket, :settings_imports_exports, site.domain)
 
-    {:noreply, redirect(socket, external: redirect_to)}
+    {:noreply, redirect(socket, to: redirect_to)}
   end
 
   @impl true

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -185,8 +185,8 @@ defmodule PlausibleWeb.Live.Verification do
   end
 
   defp redirect_to_stats(socket) do
-    stats_url = Routes.stats_url(PlausibleWeb.Endpoint, :stats, socket.assigns.domain, [])
-    redirect(socket, external: stats_url)
+    stats_url = Routes.stats_path(PlausibleWeb.Endpoint, :stats, socket.assigns.domain, [])
+    redirect(socket, to: stats_url)
   end
 
   defp reset_component(socket) do

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :success) ==
                "You now have access to #{site.domain}"
 
-      assert redirected_to(conn) == "/#{URI.encode_www_form(site.domain)}"
+      assert redirected_to(conn) == "/#{URI.encode_www_form(site.domain)}/"
 
       refute Repo.exists?(from(i in Plausible.Teams.Invitation, where: i.email == ^user.email))
 
@@ -54,7 +54,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       invitation = invite_guest(site, user.email, role: :editor, inviter: owner)
 
       c1 = post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-      assert redirected_to(c1) == "/#{URI.encode_www_form(site.domain)}"
+      assert redirected_to(c1) == "/#{URI.encode_www_form(site.domain)}/"
 
       assert Phoenix.Flash.get(c1.assigns.flash, :success) ==
                "You now have access to #{site.domain}"
@@ -79,7 +79,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
 
       conn = post(conn, "/sites/invitations/#{transfer.transfer_id}/accept")
 
-      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}"
+      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :success) =~
                "You now have access to"
@@ -141,7 +141,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
 
       conn = post(conn, "/sites/invitations/#{transfer.transfer_id}/accept")
 
-      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}"
+      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :success) =~
                "You now have access to"

--- a/test/plausible_web/live/verification_test.exs
+++ b/test/plausible_web/live/verification_test.exs
@@ -101,7 +101,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
       html = render(lv)
 
       refute text_of_element(html, @awaiting) =~ "Awaiting your first pageview"
-      refute_redirected(lv, "http://localhost:8000/#{URI.encode_www_form(site.domain)}")
+      refute_redirected(lv, "/#{URI.encode_www_form(site.domain)}/")
     end
 
     test "will redirect when first pageview arrives", %{conn: conn, site: site} do
@@ -123,7 +123,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
         build(:pageview)
       ])
 
-      assert_redirect(lv, "http://localhost:8000/#{URI.encode_www_form(site.domain)}/")
+      assert_redirect(lv, "/#{URI.encode_www_form(site.domain)}/")
     end
 
     @tag :ce_build_only
@@ -135,7 +135,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
 
       populate_stats(site, [build(:pageview)])
 
-      assert_redirect(lv, "http://localhost:8000/#{URI.encode_www_form(site.domain)}/")
+      assert_redirect(lv, "/#{URI.encode_www_form(site.domain)}/")
     end
 
     @tag :ee_only


### PR DESCRIPTION
### Changes

We've been using redirect(external: ...) for all paths containing domain because in the past, Phoenix's redirect was overzealous when sanitizing the URL, effectively rejecting URL-encoded UTF8 characters (starting with %). Current version of phoenix has that sanitization relaxed and relying on external redirects is no longer necessary.


