### PR TITLE
Make clicking Compare / Disable Comparison in period picker menu close the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed 
 
+### Fixed
+
+- Make clicking Compare / Disable Comparison in period picker menu close the menu
+
 ## v3.0.0 - 2025-04-11
 
 ### Added

--- a/assets/js/dashboard/nav-menu/query-periods/query-period-menu.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/query-period-menu.tsx
@@ -121,7 +121,11 @@ const QueryPeriodMenuInner = ({
   const { query, expandedSegment } = useQueryContext()
 
   const groups = useMemo(() => {
-    const compareLink = getCompareLinkItem({ site, query })
+    const compareLink = getCompareLinkItem({
+      site,
+      query,
+      onEvent: closeDropdown
+    })
     return getDatePeriodGroups({
       site,
       onEvent: closeDropdown,

--- a/assets/js/dashboard/query-time-periods.ts
+++ b/assets/js/dashboard/query-time-periods.ts
@@ -474,16 +474,19 @@ export const getDatePeriodGroups = ({
 
 export const getCompareLinkItem = ({
   query,
-  site
+  site,
+  onEvent
 }: {
   query: DashboardQuery
   site: PlausibleSite
+  onEvent: () => void
 }): LinkItem => [
   [
     isComparisonEnabled(query.comparison) ? 'Disable comparison' : 'Compare',
     'X'
   ],
   {
+    onEvent,
     search: getSearchToToggleComparison({ site, query }),
     isActive: () => false
   }


### PR DESCRIPTION
### Changes

Fixes tiny issue with period picker menu, see changelog.

### Tests
- [x] Tested manually

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI visually
