### PR TITLE
Don't show "Subscription" settings item when user role not permitted

### DIFF
--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.SettingsController do
        [:owner, :admin] when action in [:update_team_name]
 
   plug Plausible.Plugs.AuthorizeTeamAccess,
-       [:owner, :admin, :billing] when action in [:invoices]
+       [:owner, :admin, :billing] when action in [:subscription, :invoices]
 
   plug Plausible.Plugs.AuthorizeTeamAccess,
        [:owner] when action in [:team_danger_zone, :delete_team]

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -124,7 +124,9 @@ defmodule PlausibleWeb.LayoutView do
         "Team Settings",
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
-          %{key: "Subscription", value: "billing/subscription", icon: :circle_stack},
+          if(current_team_role in [:owner, :admin, :billing],
+            do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
+          ),
           if(current_team_role in [:owner, :admin, :billing],
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),


### PR DESCRIPTION
### Changes

Gates "Subscription" following how "Invoices" are gated.
