### PR TITLE
Adjust notices & permissions

### DIFF
--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       title="Notice"
       {@rest}
     >
-      {account_label(@current_role)} does not have access to {@feature_mod.display_name()}. To get access to this feature,
+      {account_label(@current_team)} does not have access to {@feature_mod.display_name()}. To gain access to this feature,
       <.upgrade_call_to_action current_role={@current_role} current_team={@current_team} />.
     </.notice>
     """
@@ -92,7 +92,7 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   def limit_exceeded(assigns) do
     ~H"""
     <.notice {@rest} title="Notice">
-      {account_label(@current_role)} is limited to {@limit} {@resource}. To increase this limit,
+      {account_label(@current_team)} is limited to {@limit} {@resource}. To increase this limit,
       <.upgrade_call_to_action current_team={@current_team} current_role={@current_role} />.
     </.notice>
     """
@@ -330,8 +330,8 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       end
 
     cond do
-      assigns.current_role not in [:owner, :billing] ->
-        ~H"please reach out to the site owner to upgrade their subscription"
+      not is_nil(assigns.current_role) and assigns.current_role not in [:owner, :billing] ->
+        ~H"please reach out to the team owner to upgrade their subscription"
 
       upgrade_assistance_required? ->
         ~H"""
@@ -352,11 +352,11 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     end
   end
 
-  defp account_label(current_role) do
-    if current_role in [:owner, :billing] do
-      "Your account"
+  defp account_label(current_team) do
+    if current_team do
+      "This team"
     else
-      "The owner of this site"
+      "This account"
     end
   end
 end

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.BillingController do
 
   plug PlausibleWeb.RequireAccountPlug
 
-  plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :admin, :billing]
+  plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :billing]
 
   def ping_subscription(%Plug.Conn{} = conn, _params) do
     subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.current_team)

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.SettingsController do
        [:owner, :admin] when action in [:update_team_name]
 
   plug Plausible.Plugs.AuthorizeTeamAccess,
-       [:owner, :admin, :billing] when action in [:subscription, :invoices]
+       [:owner, :billing] when action in [:subscription, :invoices]
 
   plug Plausible.Plugs.AuthorizeTeamAccess,
        [:owner] when action in [:team_danger_zone, :delete_team]

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -46,7 +46,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
       current_role={@current_team_role}
       current_team={@current_team}
       limit={@team_members_limit}
-      resource="team members"
+      resource="members"
       class="mb-4"
     />
     <div>

--- a/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
+++ b/lib/plausible_web/templates/site/membership/invite_member_form.html.heex
@@ -14,7 +14,7 @@
       current_role={@current_team_role}
       current_team={@site_team}
       limit={Map.get(assigns, :team_member_limit, 0)}
-      resource="team members"
+      resource="members"
     />
 
     <div class="my-6">

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -124,13 +124,15 @@ defmodule PlausibleWeb.LayoutView do
         "Team Settings",
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
-          if(current_team_role in [:owner, :admin, :billing],
+          if(current_team_role in [:owner, :billing],
             do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
           ),
-          if(current_team_role in [:owner, :admin, :billing],
+          if(current_team_role in [:owner, :billing],
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
-          %{key: "API Keys", value: "api-keys", icon: :key},
+          if(current_team_role in [:owner, :billing, :admin, :editor],
+            do: %{key: "API Keys", value: "api-keys", icon: :key}
+          ),
           if(current_team_role == :owner,
             do: %{key: "Danger Zone", value: "team/delete", icon: :exclamation_triangle}
           )

--- a/test/plausible_web/components/billing/notice_test.exs
+++ b/test/plausible_web/components/billing/notice_test.exs
@@ -4,8 +4,6 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
   import Phoenix.LiveViewTest, only: [render_component: 2]
   alias PlausibleWeb.Components.Billing.Notice
 
-  # TODO: Your account tests
-
   test "premium_feature/1 does not render a notice when team is on trial" do
     me = new_user(trial_expiry_date: Date.utc_today())
 
@@ -73,6 +71,18 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
       )
 
     assert rendered == ""
+  end
+
+  test "premium_feature/1 for team-less account" do
+    rendered =
+      render_component(&Notice.premium_feature/1,
+        current_role: nil,
+        current_team: nil,
+        feature_mod: Plausible.Billing.Feature.Funnels
+      )
+
+    assert rendered =~ "This account does not have access to Funnels"
+    assert rendered =~ "upgrade your subscription"
   end
 
   test "limit_exceeded/1 when team is on growth displays upgrade link" do

--- a/test/plausible_web/components/billing/notice_test.exs
+++ b/test/plausible_web/components/billing/notice_test.exs
@@ -4,6 +4,8 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
   import Phoenix.LiveViewTest, only: [render_component: 2]
   alias PlausibleWeb.Components.Billing.Notice
 
+  # TODO: Your account tests
+
   test "premium_feature/1 does not render a notice when team is on trial" do
     me = new_user(trial_expiry_date: Date.utc_today())
 
@@ -25,7 +27,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         feature_mod: Plausible.Billing.Feature.Props
       )
 
-    assert rendered =~ "Your account does not have access to Custom Properties"
+    assert rendered =~ "This team does not have access to Custom Properties"
     assert rendered =~ "upgrade your subscription"
     assert rendered =~ "/billing/choose-plan"
   end
@@ -41,7 +43,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         feature_mod: Plausible.Billing.Feature.Props
       )
 
-    assert rendered =~ "Your account does not have access to Custom Properties"
+    assert rendered =~ "This team does not have access to Custom Properties"
     assert rendered =~ "upgrade your subscription"
     assert rendered =~ "/billing/choose-plan"
   end
@@ -56,8 +58,8 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         feature_mod: Plausible.Billing.Feature.Funnels
       )
 
-    assert rendered =~ "The owner of this site does not have access to Funnels"
-    assert rendered =~ "please reach out to the site owner to upgrade their subscription"
+    assert rendered =~ "This team does not have access to Funnels"
+    assert rendered =~ "please reach out to the team owner to upgrade their subscription"
   end
 
   test "premium_feature/1 does not render a notice when the user has access to the feature" do
@@ -85,7 +87,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         resource: "users"
       )
 
-    assert rendered =~ "Your account is limited to 10 users. To increase this limit"
+    assert rendered =~ "This team is limited to 10 users. To increase this limit"
     assert rendered =~ "upgrade your subscription"
     assert rendered =~ "/billing/choose-plan"
   end
@@ -101,8 +103,8 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         resource: "users"
       )
 
-    assert rendered =~ "The owner of this site is limited to 10 users"
-    assert rendered =~ "please reach out to the site owner to upgrade their subscription"
+    assert rendered =~ "This team is limited to 10 users"
+    assert rendered =~ "please reach out to the team owner to upgrade their subscription"
   end
 
   @tag :ee_only
@@ -117,7 +119,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         resource: "users"
       )
 
-    assert rendered =~ "Your account is limited to 10 users"
+    assert rendered =~ "This team is limited to 10 users"
     assert rendered =~ "upgrade your subscription"
     assert rendered =~ "/billing/choose-plan"
   end
@@ -134,7 +136,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         resource: "users"
       )
 
-    assert rendered =~ "Your account is limited to 10 users."
+    assert rendered =~ "This team is limited to 10 users."
 
     assert rendered =~ "hello@plausible.io"
     assert rendered =~ "upgrade your subscription"
@@ -153,7 +155,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         resource: "users"
       )
 
-    assert rendered =~ "Your account is limited to 10 users."
+    assert rendered =~ "This team is limited to 10 users."
 
     assert rendered =~ "hello@plausible.io"
     assert rendered =~ "upgrade your subscription"

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
         |> get("/sites/#{site.domain}/memberships/invite")
         |> html_response(200)
 
-      assert html =~ "Your account is limited to 3 team members"
+      assert html =~ "This team is limited to 3 members"
     end
   end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -329,7 +329,7 @@ defmodule PlausibleWeb.SiteControllerTest do
         })
 
       assert html = html_response(conn, 200)
-      assert html =~ "Your account is limited to 10 sites"
+      assert html =~ "This team is limited to 10 sites"
       refute Repo.get_by(Plausible.Site, domain: "over-limit.example.com")
     end
 

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -215,7 +215,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       assert attr_defined?(html, ~s|#team-layout-form input[name="input-email"]|, "readonly")
       assert attr_defined?(html, ~s|#invite-member|, "disabled")
-      assert text(html) =~ "Your account is limited to 3 team members"
+      assert text(html) =~ "This team is limited to 3 members"
     end
 
     test "all options are disabled for the sole owner", %{conn: conn} do

--- a/test/support/dev/controllers/dev_subscription_controller.ex
+++ b/test/support/dev/controllers/dev_subscription_controller.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.DevSubscriptionController do
 
     plug PlausibleWeb.RequireAccountPlug
 
-    plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :admin, :billing]
+    plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :billing]
 
     def create_form(conn, %{"plan_id" => plan_id}) do
       render(conn, "create_dev_subscription.html",


### PR DESCRIPTION
### Changes

This PR changes generic notices so they refer to "This team" instead of "Your account" whenever suitable. 

[Only owner and billing roles can access/manage subscriptions](https://github.com/plausible/analytics/commit/c9d9b88a5351514c6e0d0d31d9103c754f3d2b4c)

[Change how Team Settings options are exposed:](https://github.com/plausible/analytics/commit/3e586c0ea9bf0312f54508797e2882312af1f310)
- Subscription only available to owner/billing roles
- Invoices only available to owner/billing roles
- API Keys only available to owner/billing/admin/editor roles

[Only owner/billing can manage dev subscriptions](https://github.com/plausible/analytics/commit/73cbba56bbf817151f97463814c3ec82dfb048f8)

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
