### PR TITLE
Tidy up Teams logic and improve service functions names

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -215,7 +215,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
           status: existing.status
         })
       else
-        case Teams.Invitations.InviteToSite.create_invitation(
+        case Teams.Invitations.InviteToSite.invite(
                site,
                conn.assigns.current_user,
                email,

--- a/lib/plausible/billing/qouta/quota.ex
+++ b/lib/plausible/billing/qouta/quota.ex
@@ -4,8 +4,19 @@ defmodule Plausible.Billing.Quota do
   """
 
   use Plausible
-  alias Plausible.Billing.{Plan, EnterprisePlan}
+  alias Plausible.Billing.{EnterprisePlan, Plan}
   alias Plausible.Billing.Quota.Limits
+
+  @type cycle() :: :current_cycle | :last_cycle | :penultimate_cycle
+
+  @type cycles_usage() :: %{cycle() => usage_cycle()}
+
+  @type usage_cycle() :: %{
+          date_range: Date.Range.t(),
+          pageviews: non_neg_integer(),
+          custom_events: non_neg_integer(),
+          total: non_neg_integer()
+        }
 
   @doc """
   Ensures that the given usage map is within the limits
@@ -104,14 +115,14 @@ defmodule Plausible.Billing.Quota do
     end
   end
 
-  @spec exceeds_last_two_usage_cycles?(Plausible.Teams.Billing.cycles_usage(), non_neg_integer()) ::
+  @spec exceeds_last_two_usage_cycles?(cycles_usage(), non_neg_integer()) ::
           boolean()
   def exceeds_last_two_usage_cycles?(cycles_usage, allowed_volume) do
     exceeded = exceeded_cycles(cycles_usage, allowed_volume)
     :penultimate_cycle in exceeded && :last_cycle in exceeded
   end
 
-  @spec exceeded_cycles(Plausible.Teams.Billing.cycles_usage(), non_neg_integer()) :: list()
+  @spec exceeded_cycles(cycles_usage(), non_neg_integer()) :: list()
   def exceeded_cycles(cycles_usage, allowed_volume) do
     limit = Limits.pageview_limit_with_margin(allowed_volume)
 

--- a/lib/plausible/site/admin.ex
+++ b/lib/plausible/site/admin.ex
@@ -135,7 +135,7 @@ defmodule Plausible.SiteAdmin do
 
     with {:ok, new_owner} <- Plausible.Auth.get_user_by(email: email),
          {:ok, _} <-
-           Teams.Invitations.InviteToSite.bulk_create_invitation(
+           Teams.Invitations.InviteToSite.bulk_invite(
              sites,
              inviter,
              new_owner.email,
@@ -159,12 +159,7 @@ defmodule Plausible.SiteAdmin do
   defp transfer_ownership_direct(_conn, sites, %{"email" => email} = params) do
     with {:ok, new_owner} <- Plausible.Auth.get_user_by(email: email),
          {:ok, team} <- get_team_by_id(params["team_id"]),
-         {:ok, _} <-
-           Teams.Invitations.Accept.bulk_transfer_ownership_direct(
-             sites,
-             new_owner,
-             team
-           ) do
+         {:ok, _} <- Teams.Sites.Transfer.bulk_transfer(sites, new_owner, team) do
       :ok
     else
       {:error, :user_not_found} ->

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -12,26 +12,15 @@ defmodule Plausible.Teams.Billing do
   alias Plausible.Repo
   alias Plausible.Teams
 
-  alias Plausible.Billing.{Plan, Plans, EnterprisePlan, Feature}
+  alias Plausible.Billing.{EnterprisePlan, Feature, Plan, Plans, Quota}
   alias Plausible.Billing.Feature.{Goals, Props, StatsAPI}
 
   require Plausible.Billing.Subscription.Status
 
   @limit_sites_since ~D[2021-05-05]
 
-  @type cycles_usage() :: %{cycle() => usage_cycle()}
-
-  @typep cycle :: :current_cycle | :last_cycle | :penultimate_cycle
-
-  @typep usage_cycle :: %{
-           date_range: Date.Range.t(),
-           pageviews: non_neg_integer(),
-           custom_events: non_neg_integer(),
-           total: non_neg_integer()
-         }
-
-  @typep last_30_days_usage() :: %{:last_30_days => usage_cycle()}
-  @typep monthly_pageview_usage() :: cycles_usage() | last_30_days_usage()
+  @typep last_30_days_usage() :: %{:last_30_days => Quota.usage_cycle()}
+  @typep monthly_pageview_usage() :: Quota.cycles_usage() | last_30_days_usage()
 
   def grandfathered_team?(nil), do: false
 

--- a/lib/plausible/teams/invitations.ex
+++ b/lib/plausible/teams/invitations.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Teams.Invitations do
 
   import Ecto.Query
 
+  alias Plausible.Auth
   alias Plausible.Billing
   alias Plausible.Repo
   alias Plausible.Teams
@@ -482,6 +483,18 @@ defmodule Plausible.Teams.Invitations do
     for owner <- owners do
       PlausibleWeb.Email.team_changed(owner.email, user, team, site)
       |> Plausible.Mailer.send()
+    end
+  end
+
+  @spec check_can_transfer_site(Teams.Team.t(), Auth.User.t()) ::
+          :ok | {:error, :permission_denied}
+  def check_can_transfer_site(team, user) do
+    case Teams.Memberships.team_role(team, user) do
+      {:ok, role} when role in [:owner, :admin] ->
+        :ok
+
+      _ ->
+        {:error, :permission_denied}
     end
   end
 

--- a/lib/plausible/teams/invitations/accept.ex
+++ b/lib/plausible/teams/invitations/accept.ex
@@ -14,19 +14,7 @@ defmodule Plausible.Teams.Invitations.Accept do
 
   alias Plausible.Auth
   alias Plausible.Billing
-  alias Plausible.Repo
-  alias Plausible.Site
   alias Plausible.Teams
-
-  require Logger
-
-  @type transfer_error() ::
-          Billing.Quota.Limits.over_limits_error()
-          | Ecto.Changeset.t()
-          | :transfer_to_self
-          | :no_plan
-          | :multiple_teams
-          | :permission_denied
 
   @type accept_error() ::
           :invitation_not_found
@@ -37,102 +25,21 @@ defmodule Plausible.Teams.Invitations.Accept do
           | :multiple_teams
           | :permission_denied
 
-  @type membership() :: %Teams.Membership{}
-
-  @spec bulk_transfer_ownership_direct([Site.t()], Auth.User.t(), Teams.Team.t() | nil) ::
-          {:ok, [membership]} | {:error, transfer_error()}
-  def bulk_transfer_ownership_direct(sites, new_owner, team \\ nil) do
-    Repo.transaction(fn ->
-      for site <- sites do
-        case transfer_ownership(site, new_owner, team) do
-          {:ok, membership} ->
-            membership
-
-          {:error, error} ->
-            Repo.rollback(error)
-        end
-      end
-    end)
-  end
-
-  @spec change_team(Site.t(), Auth.User.t(), Teams.Team.t()) ::
-          :ok | {:error, transfer_error()}
-  def change_team(site, user, new_team) do
-    with {:ok, _} <- transfer_ownership(site, user, new_team) do
-      Teams.Invitations.send_team_changed_email(site, user, new_team)
-      :ok
-    end
-  end
-
-  @spec accept_invitation(String.t(), Auth.User.t(), Teams.Team.t() | nil) ::
+  @spec accept(String.t(), Auth.User.t(), Teams.Team.t() | nil) ::
           {:ok, map()} | {:error, accept_error()}
-  def accept_invitation(invitation_or_transfer_id, user, team \\ nil) do
+  def accept(invitation_or_transfer_id, user, team \\ nil) do
     with {:ok, invitation_or_transfer} <-
            Teams.Invitations.find_for_user(invitation_or_transfer_id, user) do
       case invitation_or_transfer do
         %Teams.SiteTransfer{} = site_transfer ->
-          do_accept_ownership_transfer(site_transfer, user, team)
+          Teams.Sites.Transfer.accept(site_transfer, user, team)
 
         %Teams.Invitation{} = team_invitation ->
-          do_accept_team_invitation(team_invitation, user)
+          Teams.Invitations.accept_team_invitation(team_invitation, user)
 
         %Teams.GuestInvitation{} = guest_invitation ->
-          do_accept_guest_invitation(guest_invitation, user)
+          Teams.Invitations.accept_guest_invitation(guest_invitation, user)
       end
     end
-  end
-
-  defp transfer_ownership(site, new_owner, team) do
-    site = Repo.preload(site, :team)
-
-    with {:ok, new_team} <- maybe_get_team(new_owner, team),
-         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
-         :ok <- check_can_transfer_site(new_team, new_owner),
-         :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
-         :ok <- Teams.Invitations.transfer_site(site, new_team) do
-      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
-
-      {:ok, site.ownerships}
-    end
-  end
-
-  defp do_accept_ownership_transfer(site_transfer, new_owner, team) do
-    site = Repo.preload(site_transfer.site, :team)
-
-    with {:ok, new_team} <- maybe_get_team(new_owner, team),
-         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
-         :ok <- check_can_transfer_site(new_team, new_owner),
-         :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
-         :ok <- Teams.Invitations.accept_site_transfer(site_transfer, new_team) do
-      Teams.Invitations.send_transfer_accepted_email(site_transfer, new_team)
-
-      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
-
-      {:ok, %{team: new_team, team_memberships: site.ownerships, site: site}}
-    end
-  end
-
-  defp maybe_get_team(_user, %Teams.Team{} = team) do
-    {:ok, team}
-  end
-
-  defp maybe_get_team(user, nil) do
-    Teams.get_or_create(user)
-  end
-
-  defp check_can_transfer_site(team, user) do
-    if Teams.Memberships.can_transfer_site?(team, user) do
-      :ok
-    else
-      {:error, :permission_denied}
-    end
-  end
-
-  defp do_accept_guest_invitation(guest_invitation, user) do
-    Teams.Invitations.accept_guest_invitation(guest_invitation, user)
-  end
-
-  defp do_accept_team_invitation(team_invitation, user) do
-    Teams.Invitations.accept_team_invitation(team_invitation, user)
   end
 end

--- a/lib/plausible/teams/invitations/invite_to_site.ex
+++ b/lib/plausible/teams/invitations/invite_to_site.ex
@@ -5,8 +5,8 @@ defmodule Plausible.Teams.Invitations.InviteToSite do
   """
 
   alias Plausible.Auth.User
-  alias Plausible.Site
   alias Plausible.Repo
+  alias Plausible.Site
   alias Plausible.Teams
   use Plausible
 
@@ -18,8 +18,6 @@ defmodule Plausible.Teams.Invitations.InviteToSite do
 
   @type invitation :: %Teams.GuestInvitation{} | %Teams.SiteTransfer{}
 
-  @spec create_invitation(Site.t(), User.t(), String.t(), atom()) ::
-          {:ok, invitation} | {:error, invite_error()}
   @doc """
   Invites a new team member to the given site. Returns either
   `%Teams.GuestInvitation{}` or `%Teams.SiteTransfer{}` struct
@@ -31,15 +29,17 @@ defmodule Plausible.Teams.Invitations.InviteToSite do
   If the new team member role is `:owner`, this function handles the invitation
   as an ownership transfer and requires the inviter to be the owner of the site.
   """
-  def create_invitation(site, inviter, invitee_email, role) do
+  @spec invite(Site.t(), User.t(), String.t(), atom()) ::
+          {:ok, invitation} | {:error, invite_error()}
+  def invite(site, inviter, invitee_email, role) do
     Repo.transaction(fn ->
       do_invite(site, inviter, invitee_email, role)
     end)
   end
 
-  @spec bulk_create_invitation([Site.t()], User.t(), String.t(), atom(), Keyword.t()) ::
+  @spec bulk_invite([Site.t()], User.t(), String.t(), atom(), Keyword.t()) ::
           {:ok, [invitation]} | {:error, invite_error()}
-  def bulk_create_invitation(sites, inviter, invitee_email, role, opts \\ []) do
+  def bulk_invite(sites, inviter, invitee_email, role, opts \\ []) do
     Repo.transaction(fn ->
       for site <- sites do
         do_invite(site, inviter, invitee_email, role, opts)
@@ -49,26 +49,10 @@ defmodule Plausible.Teams.Invitations.InviteToSite do
 
   defp do_invite(site, inviter, invitee_email, role, opts \\ []) do
     with site <- Repo.preload(site, [:owners, :team]),
-         :ok <-
-           Teams.Invitations.check_invitation_permissions(
-             site,
-             inviter,
-             role,
-             opts
-           ),
-         :ok <-
-           Teams.Invitations.check_team_member_limit(
-             site.team,
-             role,
-             invitee_email
-           ),
+         :ok <- Teams.Invitations.check_invitation_permissions(site, inviter, role, opts),
+         :ok <- Teams.Invitations.check_team_member_limit(site.team, role, invitee_email),
          invitee = Plausible.Auth.find_user_by(email: invitee_email),
-         :ok <-
-           Teams.Invitations.ensure_new_membership(
-             site,
-             invitee,
-             role
-           ),
+         :ok <- Teams.Invitations.ensure_new_membership(site, invitee, role),
          {:ok, invitation_or_transfer} <-
            Teams.Invitations.invite(site, invitee_email, role, inviter) do
       send_invitation_email(invitation_or_transfer, invitee)

--- a/lib/plausible/teams/invitations/invite_to_team.ex
+++ b/lib/plausible/teams/invitations/invite_to_team.ex
@@ -3,8 +3,8 @@ defmodule Plausible.Teams.Invitations.InviteToTeam do
   Service for inviting new or existing users to team.
   """
 
-  alias Plausible.Teams
   alias Plausible.Repo
+  alias Plausible.Teams
 
   @valid_roles Plausible.Teams.Invitation.roles() -- [:guest]
   @valid_roles @valid_roles ++ Enum.map(@valid_roles, &to_string/1)
@@ -13,28 +13,11 @@ defmodule Plausible.Teams.Invitations.InviteToTeam do
 
   def invite(team, inviter, invitee_email, role, opts) when role in @valid_roles do
     with team <- Repo.preload(team, [:owners]),
-         :ok <-
-           Teams.Invitations.check_invitation_permissions(
-             team,
-             inviter,
-             role,
-             opts
-           ),
-         :ok <-
-           Teams.Invitations.check_team_member_limit(
-             team,
-             role,
-             invitee_email
-           ),
+         :ok <- Teams.Invitations.check_invitation_permissions(team, inviter, role, opts),
+         :ok <- Teams.Invitations.check_team_member_limit(team, role, invitee_email),
          invitee = Plausible.Auth.find_user_by(email: invitee_email),
-         :ok <-
-           Teams.Invitations.ensure_new_membership(
-             team,
-             invitee,
-             role
-           ),
-         {:ok, invitation} <-
-           Teams.Invitations.invite(team, invitee_email, role, inviter) do
+         :ok <- Teams.Invitations.ensure_new_membership(team, invitee, role),
+         {:ok, invitation} <- Teams.Invitations.invite(team, invitee_email, role, inviter) do
       if Keyword.get(opts, :send_email?, true) do
         send_invitation_email(invitation, invitee)
       end

--- a/lib/plausible/teams/invitations/reject.ex
+++ b/lib/plausible/teams/invitations/reject.ex
@@ -6,10 +6,10 @@ defmodule Plausible.Teams.Invitations.Reject do
   alias Plausible.Auth
   alias Plausible.Teams
 
-  @spec reject_invitation(String.t(), Auth.User.t()) ::
+  @spec reject(String.t(), Auth.User.t()) ::
           {:ok, Teams.GuestInvitation.t() | Teams.SiteTransfer.t()}
           | {:error, :invitation_not_found}
-  def reject_invitation(invitation_or_transfer_id, user) do
+  def reject(invitation_or_transfer_id, user) do
     with {:ok, invitation_or_transfer} <-
            Teams.Invitations.find_for_user(invitation_or_transfer_id, user) do
       do_reject(invitation_or_transfer)

--- a/lib/plausible/teams/invitations/remove_from_site.ex
+++ b/lib/plausible/teams/invitations/remove_from_site.ex
@@ -5,10 +5,10 @@ defmodule Plausible.Teams.Invitations.RemoveFromSite do
 
   alias Plausible.Teams
 
-  @spec remove_invitation(String.t(), Plausible.Site.t()) ::
+  @spec remove(String.t(), Plausible.Site.t()) ::
           {:ok, Teams.GuestInvitation.t() | Teams.SiteTransfer.t()}
           | {:error, :invitation_not_found}
-  def remove_invitation(invitation_or_transfer_id, site) do
+  def remove(invitation_or_transfer_id, site) do
     with {:ok, invitation_or_transfer} <-
            Teams.Invitations.find_for_site(invitation_or_transfer_id, site) do
       do_delete(invitation_or_transfer)

--- a/lib/plausible/teams/memberships.ex
+++ b/lib/plausible/teams/memberships.ex
@@ -56,16 +56,6 @@ defmodule Plausible.Teams.Memberships do
     end
   end
 
-  def can_transfer_site?(team, user) do
-    case team_role(team, user) do
-      {:ok, role} when role in [:owner, :admin] ->
-        true
-
-      _ ->
-        false
-    end
-  end
-
   @spec site_role(Plausible.Site.t(), Auth.User.t() | nil) ::
           {:ok, {:team_member | :guest_member, Teams.Membership.role()}} | {:error, :not_a_member}
 

--- a/lib/plausible/teams/sites/transfer.ex
+++ b/lib/plausible/teams/sites/transfer.ex
@@ -1,0 +1,85 @@
+defmodule Plausible.Teams.Sites.Transfer do
+  @moduledoc """
+  Service for transferring sites.
+  """
+
+  alias Plausible.Auth
+  alias Plausible.Billing
+  alias Plausible.Repo
+  alias Plausible.Site
+  alias Plausible.Teams
+
+  @type transfer_error() ::
+          Billing.Quota.Limits.over_limits_error()
+          | Ecto.Changeset.t()
+          | :transfer_to_self
+          | :no_plan
+          | :multiple_teams
+          | :permission_denied
+
+  @spec bulk_transfer([Site.t()], Auth.User.t(), Teams.Team.t() | nil) ::
+          {:ok, [Teams.Membership.t()]} | {:error, transfer_error()}
+  def bulk_transfer(sites, new_owner, team \\ nil) do
+    Repo.transaction(fn ->
+      for site <- sites do
+        case transfer_ownership(site, new_owner, team) do
+          {:ok, membership} ->
+            membership
+
+          {:error, error} ->
+            Repo.rollback(error)
+        end
+      end
+    end)
+  end
+
+  @spec change_team(Site.t(), Auth.User.t(), Teams.Team.t()) ::
+          :ok | {:error, transfer_error()}
+  def change_team(site, user, new_team) do
+    with {:ok, _} <- transfer_ownership(site, user, new_team) do
+      Teams.Invitations.send_team_changed_email(site, user, new_team)
+      :ok
+    end
+  end
+
+  @spec accept(Teams.SiteTransfer.t(), Auth.User.t(), Teams.Team.t() | nil) ::
+          {:ok, %{team: Teams.Team.t(), team_memberships: [Teams.Membership.t()], site: Site.t()}}
+          | {:error, transfer_error()}
+  def accept(site_transfer, new_owner, team) do
+    site = Repo.preload(site_transfer.site, :team)
+
+    with {:ok, new_team} <- maybe_get_team(new_owner, team),
+         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
+         :ok <- Teams.Invitations.check_can_transfer_site(new_team, new_owner),
+         :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
+         :ok <- Teams.Invitations.accept_site_transfer(site_transfer, new_team) do
+      Teams.Invitations.send_transfer_accepted_email(site_transfer, new_team)
+
+      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
+
+      {:ok, %{team: new_team, team_memberships: site.ownerships, site: site}}
+    end
+  end
+
+  defp transfer_ownership(site, new_owner, team) do
+    site = Repo.preload(site, :team)
+
+    with {:ok, new_team} <- maybe_get_team(new_owner, team),
+         :ok <- Teams.Invitations.ensure_transfer_valid(site.team, new_team, :owner),
+         :ok <- Teams.Invitations.check_can_transfer_site(new_team, new_owner),
+         :ok <- Teams.Invitations.ensure_can_take_ownership(site, new_team),
+         :ok <- Teams.Invitations.transfer_site(site, new_team) do
+      site = site |> Repo.reload!() |> Repo.preload(ownerships: :user)
+
+      {:ok, site.ownerships}
+    end
+  end
+
+  defp maybe_get_team(_user, %Teams.Team{} = team) do
+    {:ok, team}
+  end
+
+  defp maybe_get_team(user, nil) do
+    Teams.get_or_create(user)
+  end
+end

--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.InvitationController do
     current_user = conn.assigns.current_user
     team = conn.assigns.current_team
 
-    case Teams.Invitations.Accept.accept_invitation(invitation_id, current_user, team) do
+    case Teams.Invitations.Accept.accept(invitation_id, current_user, team) do
       {:ok, result} ->
         team = result.team
 
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.InvitationController do
   end
 
   def reject_invitation(conn, %{"invitation_id" => invitation_id}) do
-    case Teams.Invitations.Reject.reject_invitation(invitation_id, conn.assigns.current_user) do
+    case Teams.Invitations.Reject.reject(invitation_id, conn.assigns.current_user) do
       {:ok, _invitation} ->
         conn
         |> put_flash(:success, "You have rejected the invitation")
@@ -88,7 +88,7 @@ defmodule PlausibleWeb.InvitationController do
   end
 
   def remove_invitation(conn, %{"invitation_id" => invitation_id}) do
-    case Teams.Invitations.RemoveFromSite.remove_invitation(invitation_id, conn.assigns.site) do
+    case Teams.Invitations.RemoveFromSite.remove(invitation_id, conn.assigns.site) do
       {:ok, invitation_or_transfer} ->
         {site, email} =
           case invitation_or_transfer do

--- a/lib/plausible_web/controllers/site/membership_controller.ex
+++ b/lib/plausible_web/controllers/site/membership_controller.ex
@@ -46,7 +46,7 @@ defmodule PlausibleWeb.Site.MembershipController do
       Plausible.Sites.get_for_user!(conn.assigns.current_user, site_domain)
       |> Plausible.Repo.preload(:owners)
 
-    case Teams.Invitations.InviteToSite.create_invitation(
+    case Teams.Invitations.InviteToSite.invite(
            site,
            conn.assigns.current_user,
            email,
@@ -113,7 +113,7 @@ defmodule PlausibleWeb.Site.MembershipController do
     site =
       Plausible.Sites.get_for_user!(conn.assigns.current_user, site_domain)
 
-    case Teams.Invitations.InviteToSite.create_invitation(
+    case Teams.Invitations.InviteToSite.invite(
            site,
            conn.assigns.current_user,
            email,
@@ -178,7 +178,7 @@ defmodule PlausibleWeb.Site.MembershipController do
     destination_team =
       Repo.one!(Teams.Users.teams_query(user, roles: [:admin, :owner], identifier: identifier))
 
-    case Teams.Invitations.Accept.change_team(
+    case Teams.Sites.Transfer.change_team(
            site,
            conn.assigns.current_user,
            destination_team

--- a/test/plausible/teams/invitations/accept_test.exs
+++ b/test/plausible/teams/invitations/accept_test.exs
@@ -9,272 +9,6 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
 
   @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
-  describe "change_team/3" do
-    @tag :ce_build_only
-    test "changes the team if owner in both teams (CE)" do
-      user = new_user()
-      site = new_site(owner: user)
-
-      another = new_user()
-      new_site(owner: another)
-
-      team2 = team_of(another)
-
-      add_member(team2, user: user, role: :owner)
-
-      assert :ok = Accept.change_team(site, user, team2)
-    end
-
-    @tag :ee_only
-    test "changes the team if owner in both teams (EE)" do
-      user = new_user()
-      site = new_site(owner: user)
-
-      another = new_user()
-      new_site(owner: another)
-
-      team2 = team_of(another)
-
-      add_member(team2, user: user, role: :owner)
-
-      assert {:error, :no_plan} = Accept.change_team(site, user, team2)
-
-      subscribe_to_growth_plan(another)
-
-      assert :ok = Accept.change_team(site, user, team2)
-      assert Repo.reload!(site).team_id == team2.id
-      assert_team_membership(user, team2, :owner)
-
-      assert_email_delivered_with(
-        to: [nil: another.email],
-        subject:
-          @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
-      )
-
-      assert_email_delivered_with(
-        to: [nil: user.email],
-        subject:
-          @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
-      )
-    end
-
-    test "changes the team if admin in second team" do
-      user = new_user()
-      site = new_site(owner: user)
-
-      another = new_user()
-      subscribe_to_growth_plan(another)
-      new_site(owner: another)
-
-      team2 = team_of(another)
-
-      add_member(team2, user: user, role: :admin)
-
-      assert :ok = Accept.change_team(site, user, team2)
-      assert Repo.reload!(site).team_id == team2.id
-      assert_team_membership(user, team2, :admin)
-
-      assert_email_delivered_with(
-        to: [nil: another.email],
-        subject:
-          @subject_prefix <>
-            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
-      )
-    end
-
-    for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do
-      test "refuses to change the team if #{role} in second team" do
-        user = new_user()
-        site = new_site(owner: user)
-
-        another = new_user()
-        subscribe_to_growth_plan(another)
-        new_site(owner: another)
-
-        team2 = team_of(another)
-
-        add_member(team2, user: user, role: unquote(role))
-
-        assert {:error, :permission_denied} = Accept.change_team(site, user, team2)
-        refute Repo.reload!(site).team_id == team2.id
-      end
-    end
-  end
-
-  describe "bulk_transfer_ownership_direct/2" do
-    test "transfers ownership for multiple sites in one action" do
-      current_owner = new_user()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: current_owner)
-
-      assert {:ok, _} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 new_owner
-               )
-
-      team = assert_team_exists(Repo.reload!(new_owner))
-      assert_team_membership(new_owner, team, :owner)
-      assert_team_membership(new_owner, team, :owner)
-      assert_guest_membership(team, site1, current_owner, :editor)
-      assert_guest_membership(team, site2, current_owner, :editor)
-    end
-
-    test "returns error when user is already an owner for one of the sites" do
-      current_owner = new_user()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: new_owner)
-
-      assert {:error, :transfer_to_self} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 new_owner
-               )
-
-      assert_team_membership(current_owner, site1.team, :owner)
-      assert_team_membership(new_owner, site2.team, :owner)
-    end
-
-    test "does not allow transferring ownership without selecting team for owner of more than one team" do
-      new_owner = new_user() |> subscribe_to_growth_plan()
-
-      other_site1 = new_site()
-      add_member(other_site1.team, user: new_owner, role: :owner)
-      other_site2 = new_site()
-      add_member(other_site2.team, user: new_owner, role: :owner)
-
-      current_owner = new_user()
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: current_owner)
-
-      assert {:error, :multiple_teams} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 new_owner
-               )
-    end
-
-    test "allows transferring between teams of the same owner" do
-      current_owner = new_user() |> subscribe_to_growth_plan()
-      another_owner = new_user() |> subscribe_to_growth_plan()
-
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: current_owner)
-
-      new_team = team_of(another_owner)
-      add_member(new_team, user: current_owner, role: :owner)
-
-      assert {:ok, _} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 current_owner,
-                 new_team
-               )
-    end
-
-    test "does not allow transferring ownership to a team where user has no permission" do
-      other_owner = new_user() |> subscribe_to_growth_plan()
-      other_team = team_of(other_owner)
-      new_owner = new_user()
-      add_member(other_team, user: new_owner, role: :viewer)
-
-      current_owner = new_user()
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: current_owner)
-
-      assert {:error, :permission_denied} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 new_owner,
-                 other_team
-               )
-    end
-
-    test "allows transferring ownership to a team where user has permission" do
-      other_owner = new_user() |> subscribe_to_growth_plan()
-      other_team = team_of(other_owner)
-      new_owner = new_user()
-      add_member(other_team, user: new_owner, role: :admin)
-
-      current_owner = new_user()
-      site1 = new_site(owner: current_owner)
-      site2 = new_site(owner: current_owner)
-
-      assert {:ok, _} =
-               Accept.bulk_transfer_ownership_direct(
-                 [site1, site2],
-                 new_owner,
-                 other_team
-               )
-
-      assert Repo.reload(site1).team_id == other_team.id
-      assert_guest_membership(other_team, site1, current_owner, :editor)
-      assert Repo.reload(site2).team_id == other_team.id
-      assert_guest_membership(other_team, site2, current_owner, :editor)
-    end
-
-    @tag :ee_only
-    test "does not allow transferring ownership to a non-member user when at team members limit" do
-      old_owner = new_user() |> subscribe_to_business_plan()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-      site = new_site(owner: old_owner)
-      for _ <- 1..3, do: add_guest(site, role: :editor)
-
-      assert {:error, {:over_plan_limits, [:team_member_limit]}} =
-               Accept.bulk_transfer_ownership_direct([site], new_owner)
-    end
-
-    @tag :ee_only
-    test "allows transferring ownership to existing site member when at team members limit" do
-      old_owner = new_user() |> subscribe_to_business_plan()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-      site = new_site(owner: old_owner)
-      add_guest(site, user: new_owner, role: :editor)
-      for _ <- 1..2, do: add_guest(site, role: :editor)
-
-      assert {:ok, _} =
-               Accept.bulk_transfer_ownership_direct([site], new_owner)
-    end
-
-    @tag :ee_only
-    test "does not allow transferring ownership when sites limit exceeded" do
-      old_owner = new_user() |> subscribe_to_business_plan()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-
-      for _ <- 1..10, do: new_site(owner: new_owner)
-
-      site = new_site(owner: old_owner)
-
-      assert {:error, {:over_plan_limits, [:site_limit]}} =
-               Accept.bulk_transfer_ownership_direct([site], new_owner)
-    end
-
-    @tag :ee_only
-    test "exceeding limits error takes precedence over missing features" do
-      old_owner = new_user() |> subscribe_to_business_plan()
-      new_owner = new_user() |> subscribe_to_growth_plan()
-
-      for _ <- 1..10, do: new_site(owner: new_owner)
-
-      site =
-        new_site(
-          owner: old_owner,
-          props_enabled: true,
-          allowed_event_props: ["author"]
-        )
-
-      for _ <- 1..3, do: add_guest(site, role: :editor)
-
-      assert {:error, {:over_plan_limits, [:team_member_limit, :site_limit]}} =
-               Accept.bulk_transfer_ownership_direct([site], new_owner)
-    end
-  end
-
   describe "accept_invitation/3 - team invitations" do
     @roles Plausible.Teams.Membership.roles() -- [:guest]
 
@@ -288,7 +22,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
         invitation = invite_member(team, invitee, inviter: inviter, role: unquote(role))
 
         assert {:ok, _} =
-                 Accept.accept_invitation(invitation.invitation_id, invitee)
+                 Accept.accept(invitation.invitation_id, invitee)
 
         assert_team_membership(invitee, team, unquote(role))
 
@@ -321,7 +55,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
         invitation = invite_member(team, member, inviter: user, role: unquote(new_role))
 
         assert {:ok, %{team_membership: new_team_membership, guest_memberships: []}} =
-                 Accept.accept_invitation(invitation.invitation_id, member)
+                 Accept.accept(invitation.invitation_id, member)
 
         new_team_membership = Repo.reload!(new_team_membership)
         assert existing_team_membership.id == new_team_membership.id
@@ -342,7 +76,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
         invitation = invite_member(team, member, inviter: user, role: unquote(role))
 
         assert {:ok, _} =
-                 Accept.accept_invitation(invitation.invitation_id, member)
+                 Accept.accept(invitation.invitation_id, member)
       end
     end
 
@@ -363,7 +97,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       invitation = invite_member(team, member, inviter: user, role: :editor)
 
       assert {:ok, %{team_membership: new_team_membership, guest_memberships: []}} =
-               Accept.accept_invitation(invitation.invitation_id, member)
+               Accept.accept(invitation.invitation_id, member)
 
       new_team_membership = Repo.reload!(new_team_membership)
       assert existing_team_membership.id == new_team_membership.id
@@ -383,7 +117,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       invitation = invite_guest(site, invitee, inviter: inviter, role: :editor)
 
       assert {:ok, _} =
-               Accept.accept_invitation(invitation.invitation_id, invitee)
+               Accept.accept(invitation.invitation_id, invitee)
 
       assert_guest_membership(site.team, site, invitee, :editor)
 
@@ -400,7 +134,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       invitation = invite_guest(site, user, inviter: user, role: :editor)
 
       assert {:ok, _} =
-               Accept.accept_invitation(invitation.invitation_id, user)
+               Accept.accept(invitation.invitation_id, user)
 
       assert_team_membership(user, site.team, :owner)
     end
@@ -421,7 +155,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
 
       assert {:ok,
               %{team_membership: new_team_membership, guest_memberships: [new_guest_membership]}} =
-               Accept.accept_invitation(invitation.invitation_id, invitee)
+               Accept.accept(invitation.invitation_id, invitee)
 
       new_team_membership = Repo.reload!(new_team_membership)
       new_guest_membership = Repo.reload!(new_guest_membership)
@@ -438,7 +172,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       invitee = insert(:user)
 
       assert {:error, :invitation_not_found} =
-               Accept.accept_invitation("does_not_exist", invitee)
+               Accept.accept("does_not_exist", invitee)
     end
   end
 
@@ -453,7 +187,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: existing_owner)
 
       assert {:ok, _new_membership} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  new_owner
                )
@@ -483,7 +217,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
         invite_transfer(site, new_owner, inviter: existing_owner)
 
       assert {:ok, _new_membership} =
-               Accept.accept_invitation(site_transfer.transfer_id, new_owner)
+               Accept.accept(site_transfer.transfer_id, new_owner)
 
       assert_guest_invitation(new_team, site, "some@example.com", :viewer)
       assert_team_attached(site, new_team.id)
@@ -502,7 +236,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: existing_owner)
 
       assert {:ok, _new_membership} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  new_owner
                )
@@ -525,7 +259,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
           invite_transfer(site, new_owner, inviter: existing_owner)
 
         assert {:ok, _} =
-                 Accept.accept_invitation(transfer.transfer_id, new_owner)
+                 Accept.accept(transfer.transfer_id, new_owner)
 
         assert_guest_membership(new_team, site, existing_owner, :editor)
 
@@ -548,7 +282,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:error, :multiple_teams} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner)
+               Accept.accept(transfer.transfer_id, new_owner)
     end
 
     test "does not allow transferring ownership to a team where user has no permission" do
@@ -563,7 +297,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:error, :permission_denied} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner, another_team)
+               Accept.accept(transfer.transfer_id, new_owner, another_team)
     end
 
     test "allows transferring ownership to a team where user has permission" do
@@ -579,7 +313,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner, another_team)
+               Accept.accept(transfer.transfer_id, new_owner, another_team)
 
       assert_guest_membership(another_team, site, old_owner, :editor)
       assert Repo.reload(site).team_id == another_team.id
@@ -596,7 +330,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:error, {:over_plan_limits, [:team_member_limit]}} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  new_owner
                )
@@ -615,7 +349,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  new_owner
                )
@@ -633,7 +367,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:error, {:over_plan_limits, [:site_limit]}} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  new_owner
                )
@@ -659,7 +393,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(old_owner_site, new_owner, inviter: old_owner)
 
       assert {:error, {:over_plan_limits, [:monthly_pageview_limit]}} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner)
+               Accept.accept(transfer.transfer_id, new_owner)
     end
 
     @tag :ee_only
@@ -684,7 +418,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer_id = invite_transfer(old_owner_site, new_owner, inviter: old_owner).transfer_id
 
       assert {:error, {:over_plan_limits, [:monthly_pageview_limit]}} =
-               Accept.accept_invitation(transfer_id, new_owner)
+               Accept.accept(transfer_id, new_owner)
     end
 
     @tag :ee_only
@@ -706,7 +440,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: old_owner)
 
       assert {:error, {:over_plan_limits, [:team_member_limit, :site_limit]}} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner)
+               Accept.accept(transfer.transfer_id, new_owner)
     end
 
     @tag :ee_only
@@ -732,28 +466,28 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, trial_user, inviter: current_owner)
 
       assert {:error, :no_plan} =
-               Accept.accept_invitation(transfer.transfer_id, trial_user)
+               Accept.accept(transfer.transfer_id, trial_user)
 
       Repo.delete!(transfer)
 
       transfer = invite_transfer(site, invited_user, inviter: current_owner)
 
       assert {:error, :no_plan} =
-               Accept.accept_invitation(transfer.transfer_id, invited_user)
+               Accept.accept(transfer.transfer_id, invited_user)
 
       Repo.delete!(transfer)
 
       transfer = invite_transfer(site, user_on_free_10k, inviter: current_owner)
 
       assert {:error, :no_plan} =
-               Accept.accept_invitation(transfer.transfer_id, user_on_free_10k)
+               Accept.accept(transfer.transfer_id, user_on_free_10k)
 
       Repo.delete!(transfer)
 
       transfer = invite_transfer(site, user_on_expired_subscription, inviter: current_owner)
 
       assert {:error, :no_plan} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  user_on_expired_subscription
                )
@@ -763,7 +497,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, user_on_paused_subscription, inviter: current_owner)
 
       assert {:error, :no_plan} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  user_on_paused_subscription
                )
@@ -778,7 +512,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, current_owner, inviter: current_owner)
 
       assert {:error, :transfer_to_self} =
-               Accept.accept_invitation(transfer.transfer_id, current_owner)
+               Accept.accept(transfer.transfer_id, current_owner)
     end
 
     test "allows transferring between different teams of the same owner" do
@@ -792,7 +526,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, current_owner, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(transfer.transfer_id, current_owner, new_team)
+               Accept.accept(transfer.transfer_id, current_owner, new_team)
     end
 
     @tag :ee_only
@@ -807,7 +541,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, new_owner, inviter: current_owner)
 
       assert {:error, {:over_plan_limits, [:site_limit]}} =
-               Accept.accept_invitation(transfer.transfer_id, new_owner)
+               Accept.accept(transfer.transfer_id, new_owner)
     end
 
     @tag :ce_build_only
@@ -833,22 +567,22 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, trial_user, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(transfer.transfer_id, trial_user)
+               Accept.accept(transfer.transfer_id, trial_user)
 
       transfer = invite_transfer(site, invited_user, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(transfer.transfer_id, invited_user)
+               Accept.accept(transfer.transfer_id, invited_user)
 
       transfer = invite_transfer(site, user_on_free_10k, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(transfer.transfer_id, user_on_free_10k)
+               Accept.accept(transfer.transfer_id, user_on_free_10k)
 
       transfer = invite_transfer(site, user_on_expired_subscription, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  user_on_expired_subscription
                )
@@ -856,7 +590,7 @@ defmodule Plausible.Teams.Invitations.AcceptTest do
       transfer = invite_transfer(site, user_on_paused_subscription, inviter: current_owner)
 
       assert {:ok, _} =
-               Accept.accept_invitation(
+               Accept.accept(
                  transfer.transfer_id,
                  user_on_paused_subscription
                )

--- a/test/plausible/teams/invitations/invite_to_site_test.exs
+++ b/test/plausible/teams/invitations/invite_to_site_test.exs
@@ -8,21 +8,21 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
 
   @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
 
-  describe "create_invitation/4" do
+  describe "invite/4" do
     test "creates an invitation" do
       inviter = new_user()
       invitee = new_user()
       site = new_site(owner: inviter)
 
       assert {:ok, %Plausible.Teams.GuestInvitation{}} =
-               InviteToSite.create_invitation(site, inviter, invitee.email, :viewer)
+               InviteToSite.invite(site, inviter, invitee.email, :viewer)
     end
 
     test "returns validation errors" do
       inviter = new_user()
       site = new_site(owner: inviter)
 
-      assert {:error, changeset} = InviteToSite.create_invitation(site, inviter, "", :viewer)
+      assert {:error, changeset} = InviteToSite.invite(site, inviter, "", :viewer)
       assert {"can't be blank", _} = changeset.errors[:email]
     end
 
@@ -33,10 +33,10 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_guest(site, user: invitee, role: :viewer)
 
       assert {:error, :already_a_member} =
-               InviteToSite.create_invitation(site, inviter, invitee.email, :viewer)
+               InviteToSite.invite(site, inviter, invitee.email, :viewer)
 
       assert {:error, :already_a_member} =
-               InviteToSite.create_invitation(site, inviter, inviter.email, :viewer)
+               InviteToSite.invite(site, inviter, inviter.email, :viewer)
     end
 
     test "sends invitation email for existing users" do
@@ -44,7 +44,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site = new_site(owner: inviter)
 
       assert {:ok, %Plausible.Teams.GuestInvitation{}} =
-               InviteToSite.create_invitation(site, inviter, invitee.email, :viewer)
+               InviteToSite.invite(site, inviter, invitee.email, :viewer)
 
       assert_email_delivered_with(
         to: [nil: invitee.email],
@@ -57,7 +57,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site = new_site(owner: inviter)
 
       assert {:ok, %Plausible.Teams.GuestInvitation{invitation_id: invitation_id}} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :viewer)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :viewer)
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
@@ -75,7 +75,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       for _ <- 1..4, do: add_guest(site, role: :viewer)
 
       assert {:error, {:over_limit, 3}} =
-               InviteToSite.create_invitation(site, inviter, invitee.email, :viewer)
+               InviteToSite.invite(site, inviter, invitee.email, :viewer)
     end
 
     @tag :ee_only
@@ -84,7 +84,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site = new_site(owner: owner)
 
       invite = fn site, email ->
-        InviteToSite.create_invitation(site, owner, email, :viewer)
+        InviteToSite.invite(site, owner, email, :viewer)
       end
 
       assert {:ok, _} = invite.(site, "i1@example.com")
@@ -110,7 +110,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_guest(site2, user: u3, role: :viewer)
 
       invite = fn site, email ->
-        InviteToSite.create_invitation(site, u1, email, :viewer)
+        InviteToSite.invite(site, u1, email, :viewer)
       end
 
       assert {:error, {:over_limit, 3}} = invite.(site, "another@example.com")
@@ -123,7 +123,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site = new_site(owner: inviter)
 
       assert {:ok, %Plausible.Teams.SiteTransfer{}} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :owner)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :owner)
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
@@ -137,7 +137,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_member(site.team, user: inviter, role: :admin)
 
       assert {:ok, %Plausible.Teams.SiteTransfer{}} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :owner)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :owner)
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
@@ -152,7 +152,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_guest(site, user: inviter, role: :editor)
 
       assert {:error, :permission_denied} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :owner)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :owner)
     end
 
     test "allows ownership transfer to existing site members" do
@@ -162,7 +162,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_guest(site, user: invitee, role: :viewer)
 
       assert {:ok, %Plausible.Teams.SiteTransfer{}} =
-               InviteToSite.create_invitation(site, inviter, invitee.email, :owner)
+               InviteToSite.invite(site, inviter, invitee.email, :owner)
     end
 
     test "allows creating an ownership transfer even when at team member limit" do
@@ -171,7 +171,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       for _ <- 1..3, do: add_guest(site, role: :viewer)
 
       assert {:ok, _invitation} =
-               InviteToSite.create_invitation(
+               InviteToSite.invite(
                  site,
                  inviter,
                  "newowner@plausible.test",
@@ -186,7 +186,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_member(site.team, user: inviter, role: :viewer)
 
       assert {:error, :permission_denied} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :viewer)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :viewer)
     end
 
     test "allows admins to invite editors" do
@@ -195,11 +195,11 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       add_member(site.team, user: inviter, role: :admin)
 
       assert {:ok, %Plausible.Teams.GuestInvitation{}} =
-               InviteToSite.create_invitation(site, inviter, "vini@plausible.test", :editor)
+               InviteToSite.invite(site, inviter, "vini@plausible.test", :editor)
     end
   end
 
-  describe "bulk_create_invitation/5" do
+  describe "bulk_invite/5" do
     test "initiates ownership transfer for multiple sites in one action" do
       admin_user = new_user()
       new_owner = new_user()
@@ -208,7 +208,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site2 = new_site(owner: admin_user)
 
       assert {:ok, _} =
-               InviteToSite.bulk_create_invitation(
+               InviteToSite.bulk_invite(
                  [site1, site2],
                  admin_user,
                  new_owner.email,
@@ -238,7 +238,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
       site2 = new_site()
 
       assert {:ok, _} =
-               InviteToSite.bulk_create_invitation(
+               InviteToSite.bulk_invite(
                  [site1, site2],
                  superadmin_user,
                  new_owner.email,

--- a/test/plausible/teams/invitations/reject_test.exs
+++ b/test/plausible/teams/invitations/reject_test.exs
@@ -16,7 +16,7 @@ defmodule Plausible.Teams.Invitations.RejectTest do
     invitation = invite_guest(site, invitee, inviter: inviter, role: :editor)
 
     assert {:ok, rejected_invitation} =
-             Reject.reject_invitation(invitation.invitation_id, invitee)
+             Reject.reject(invitation.invitation_id, invitee)
 
     assert rejected_invitation.id == invitation.id
     refute Repo.reload(rejected_invitation)
@@ -36,7 +36,7 @@ defmodule Plausible.Teams.Invitations.RejectTest do
     invitation = invite_member(team, invitee, inviter: inviter, role: :editor)
 
     assert {:ok, rejected_invitation} =
-             Reject.reject_invitation(invitation.invitation_id, invitee)
+             Reject.reject(invitation.invitation_id, invitee)
 
     assert rejected_invitation.id == invitation.id
     refute Repo.reload(rejected_invitation)
@@ -56,7 +56,7 @@ defmodule Plausible.Teams.Invitations.RejectTest do
     site_transfer = invite_transfer(site, invitee, inviter: inviter)
 
     assert {:ok, rejected_transfer} =
-             Reject.reject_invitation(site_transfer.transfer_id, invitee)
+             Reject.reject(site_transfer.transfer_id, invitee)
 
     assert rejected_transfer.id == site_transfer.id
     refute Repo.reload(rejected_transfer)
@@ -72,7 +72,7 @@ defmodule Plausible.Teams.Invitations.RejectTest do
     invitee = new_user()
 
     assert {:error, :invitation_not_found} =
-             Reject.reject_invitation("does_not_exist", invitee)
+             Reject.reject("does_not_exist", invitee)
   end
 
   test "does not allow rejecting invitation by anyone other than invitee" do
@@ -83,7 +83,7 @@ defmodule Plausible.Teams.Invitations.RejectTest do
     invitation = invite_guest(site, invitee, role: :editor, inviter: inviter)
 
     assert {:error, :invitation_not_found} =
-             Reject.reject_invitation(invitation.invitation_id, other_user)
+             Reject.reject(invitation.invitation_id, other_user)
 
     assert Repo.reload(invitation)
   end

--- a/test/plausible/teams/invitations/remove_from_site_test.exs
+++ b/test/plausible/teams/invitations/remove_from_site_test.exs
@@ -13,7 +13,7 @@ defmodule Plausible.Teams.Invitations.RemoveFromSiteTest do
       invite_guest(site, invitee, inviter: inviter, role: :editor)
 
     assert {:ok, removed_invitation} =
-             RemoveFromSite.remove_invitation(invitation.invitation_id, site)
+             RemoveFromSite.remove(invitation.invitation_id, site)
 
     assert removed_invitation.id == invitation.id
     refute Repo.reload(removed_invitation)
@@ -23,7 +23,7 @@ defmodule Plausible.Teams.Invitations.RemoveFromSiteTest do
     site = new_site()
 
     assert {:error, :invitation_not_found} =
-             RemoveFromSite.remove_invitation("does_not_exist", site)
+             RemoveFromSite.remove("does_not_exist", site)
   end
 
   test "does not allow removing invitation from another site" do
@@ -34,7 +34,7 @@ defmodule Plausible.Teams.Invitations.RemoveFromSiteTest do
     invitation = invite_guest(site, invitee, role: :editor, inviter: inviter)
 
     assert {:error, :invitation_not_found} =
-             RemoveFromSite.remove_invitation(invitation.invitation_id, other_site)
+             RemoveFromSite.remove(invitation.invitation_id, other_site)
 
     assert Repo.reload(invitation)
   end

--- a/test/plausible/teams/sites/transfer_test.exs
+++ b/test/plausible/teams/sites/transfer_test.exs
@@ -1,0 +1,277 @@
+defmodule Plausible.Teams.Sites.TransferTest do
+  use Plausible
+  require Plausible.Billing.Subscription.Status
+  use Plausible.DataCase, async: true
+  use Bamboo.Test
+  use Plausible.Teams.Test
+
+  alias Plausible.Teams.Sites.Transfer
+
+  @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
+
+  describe "change_team/3" do
+    @tag :ce_build_only
+    test "changes the team if owner in both teams (CE)" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :owner)
+
+      assert :ok = Transfer.change_team(site, user, team2)
+    end
+
+    @tag :ee_only
+    test "changes the team if owner in both teams (EE)" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :owner)
+
+      assert {:error, :no_plan} = Transfer.change_team(site, user, team2)
+
+      subscribe_to_growth_plan(another)
+
+      assert :ok = Transfer.change_team(site, user, team2)
+      assert Repo.reload!(site).team_id == team2.id
+      assert_team_membership(user, team2, :owner)
+
+      assert_email_delivered_with(
+        to: [nil: another.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
+      )
+
+      assert_email_delivered_with(
+        to: [nil: user.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
+      )
+    end
+
+    test "changes the team if admin in second team" do
+      user = new_user()
+      site = new_site(owner: user)
+
+      another = new_user()
+      subscribe_to_growth_plan(another)
+      new_site(owner: another)
+
+      team2 = team_of(another)
+
+      add_member(team2, user: user, role: :admin)
+
+      assert :ok = Transfer.change_team(site, user, team2)
+      assert Repo.reload!(site).team_id == team2.id
+      assert_team_membership(user, team2, :admin)
+
+      assert_email_delivered_with(
+        to: [nil: another.email],
+        subject:
+          @subject_prefix <>
+            "#{user.email} has transferred #{site.domain} to \"#{team2.name}\" team"
+      )
+    end
+
+    for role <- Plausible.Teams.Membership.roles() -- [:admin, :owner] do
+      test "refuses to change the team if #{role} in second team" do
+        user = new_user()
+        site = new_site(owner: user)
+
+        another = new_user()
+        subscribe_to_growth_plan(another)
+        new_site(owner: another)
+
+        team2 = team_of(another)
+
+        add_member(team2, user: user, role: unquote(role))
+
+        assert {:error, :permission_denied} = Transfer.change_team(site, user, team2)
+        refute Repo.reload!(site).team_id == team2.id
+      end
+    end
+  end
+
+  describe "bulk_transfer_ownership_direct/2" do
+    test "transfers ownership for multiple sites in one action" do
+      current_owner = new_user()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:ok, _} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 new_owner
+               )
+
+      team = assert_team_exists(Repo.reload!(new_owner))
+      assert_team_membership(new_owner, team, :owner)
+      assert_team_membership(new_owner, team, :owner)
+      assert_guest_membership(team, site1, current_owner, :editor)
+      assert_guest_membership(team, site2, current_owner, :editor)
+    end
+
+    test "returns error when user is already an owner for one of the sites" do
+      current_owner = new_user()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: new_owner)
+
+      assert {:error, :transfer_to_self} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 new_owner
+               )
+
+      assert_team_membership(current_owner, site1.team, :owner)
+      assert_team_membership(new_owner, site2.team, :owner)
+    end
+
+    test "does not allow transferring ownership without selecting team for owner of more than one team" do
+      new_owner = new_user() |> subscribe_to_growth_plan()
+
+      other_site1 = new_site()
+      add_member(other_site1.team, user: new_owner, role: :owner)
+      other_site2 = new_site()
+      add_member(other_site2.team, user: new_owner, role: :owner)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:error, :multiple_teams} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 new_owner
+               )
+    end
+
+    test "allows transferring between teams of the same owner" do
+      current_owner = new_user() |> subscribe_to_growth_plan()
+      another_owner = new_user() |> subscribe_to_growth_plan()
+
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      new_team = team_of(another_owner)
+      add_member(new_team, user: current_owner, role: :owner)
+
+      assert {:ok, _} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 current_owner,
+                 new_team
+               )
+    end
+
+    test "does not allow transferring ownership to a team where user has no permission" do
+      other_owner = new_user() |> subscribe_to_growth_plan()
+      other_team = team_of(other_owner)
+      new_owner = new_user()
+      add_member(other_team, user: new_owner, role: :viewer)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:error, :permission_denied} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 new_owner,
+                 other_team
+               )
+    end
+
+    test "allows transferring ownership to a team where user has permission" do
+      other_owner = new_user() |> subscribe_to_growth_plan()
+      other_team = team_of(other_owner)
+      new_owner = new_user()
+      add_member(other_team, user: new_owner, role: :admin)
+
+      current_owner = new_user()
+      site1 = new_site(owner: current_owner)
+      site2 = new_site(owner: current_owner)
+
+      assert {:ok, _} =
+               Transfer.bulk_transfer(
+                 [site1, site2],
+                 new_owner,
+                 other_team
+               )
+
+      assert Repo.reload(site1).team_id == other_team.id
+      assert_guest_membership(other_team, site1, current_owner, :editor)
+      assert Repo.reload(site2).team_id == other_team.id
+      assert_guest_membership(other_team, site2, current_owner, :editor)
+    end
+
+    @tag :ee_only
+    test "does not allow transferring ownership to a non-member user when at team members limit" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: old_owner)
+      for _ <- 1..3, do: add_guest(site, role: :editor)
+
+      assert {:error, {:over_plan_limits, [:team_member_limit]}} =
+               Transfer.bulk_transfer([site], new_owner)
+    end
+
+    @tag :ee_only
+    test "allows transferring ownership to existing site member when at team members limit" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+      site = new_site(owner: old_owner)
+      add_guest(site, user: new_owner, role: :editor)
+      for _ <- 1..2, do: add_guest(site, role: :editor)
+
+      assert {:ok, _} =
+               Transfer.bulk_transfer([site], new_owner)
+    end
+
+    @tag :ee_only
+    test "does not allow transferring ownership when sites limit exceeded" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+
+      for _ <- 1..10, do: new_site(owner: new_owner)
+
+      site = new_site(owner: old_owner)
+
+      assert {:error, {:over_plan_limits, [:site_limit]}} =
+               Transfer.bulk_transfer([site], new_owner)
+    end
+
+    @tag :ee_only
+    test "exceeding limits error takes precedence over missing features" do
+      old_owner = new_user() |> subscribe_to_business_plan()
+      new_owner = new_user() |> subscribe_to_growth_plan()
+
+      for _ <- 1..10, do: new_site(owner: new_owner)
+
+      site =
+        new_site(
+          owner: old_owner,
+          props_enabled: true,
+          allowed_event_props: ["author"]
+        )
+
+      for _ <- 1..3, do: add_guest(site, role: :editor)
+
+      assert {:error, {:over_plan_limits, [:team_member_limit, :site_limit]}} =
+               Transfer.bulk_transfer([site], new_owner)
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This is purely a refactoring of Teams context. Transfer service functions are isolated to their own module, service function names are renamed to improve clarity and reduce redundancy and some minor code formatting improvements are done as well. No actual logic is changed.
