### PR TITLE
Change email input under Account Settings > Security to proper type

### DIFF
--- a/lib/plausible_web/templates/settings/security.html.heex
+++ b/lib/plausible_web/templates/settings/security.html.heex
@@ -21,7 +21,7 @@
         disabled
       />
 
-      <.input type="text" field={f[:email]} label="New E-mail" width="w-1/2" />
+      <.input type="email" field={f[:email]} label="New E-mail" width="w-1/2" />
 
       <.input type="password" field={f[:password]} label="Account Password" width="w-1/2" />
 


### PR DESCRIPTION
### Changes

Other places where e-mail is accepted already use type="email" input.

