### PR TITLE
Switch to the team on accepting team invitation

### DIFF
--- a/lib/plausible_web/controllers/invitation_controller.ex
+++ b/lib/plausible_web/controllers/invitation_controller.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.InvitationController do
         else
           conn
           |> put_flash(:success, "You now have access to \"#{team.name}\" team")
-          |> redirect(to: Routes.site_path(conn, :index))
+          |> redirect(to: Routes.site_path(conn, :index, __team: team.identifier))
         end
 
       {:error, :invitation_not_found} ->

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -41,7 +41,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :success) ==
                "You now have access to \"#{team.name}\" team"
 
-      assert redirected_to(conn) == "/sites"
+      assert redirected_to(conn) == "/sites?__team=#{team.identifier}"
 
       refute Repo.get_by(Teams.Invitation, email: user.email)
 


### PR DESCRIPTION
### Changes

Previously user remained in their current team after accepting team invitation. Now they are switched to the new team instead.

### Tests
- [x] Automated tests have been added
