### PR TITLE
Accept after register via team invite

### DIFF
--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -11,9 +11,17 @@ defmodule PlausibleWeb.Live.RegisterForm do
 
   def mount(params, _session, socket) do
     socket =
-      assign_new(socket, :invitation, fn ->
+      socket
+      |> assign_new(:invitation, fn ->
         if invitation_id = params["invitation_id"] do
           find_by_id_unified(invitation_id)
+        end
+      end)
+      |> assign_new(:team_identifier, fn %{invitation: invitation} ->
+        if invitation do
+          invitation.team_identifier
+        else
+          "none"
         end
       end)
 
@@ -100,6 +108,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
         phx-trigger-action={@trigger_submit}
       >
         <input name="user[register_action]" type="hidden" value={@live_action} />
+        <input name="user[team_identifier]" type="hidden" value={@team_identifier} />
 
         <%= if @invitation do %>
           <.email_input field={f[:email]} for_invitation={true} />
@@ -365,7 +374,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
     invitation =
       Teams.Invitation
       |> Repo.get_by(invitation_id: id)
-      |> Repo.preload(:inviter)
+      |> Repo.preload(:team)
 
     case invitation do
       nil ->
@@ -375,7 +384,8 @@ defmodule PlausibleWeb.Live.RegisterForm do
         {:ok,
          %{
            type: :team_invitation,
-           email: team_invitation.email
+           email: team_invitation.email,
+           team_identifier: team_invitation.team.identifier
          }}
     end
   end
@@ -384,7 +394,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
     invitation =
       Teams.GuestInvitation
       |> Repo.get_by(invitation_id: id)
-      |> Repo.preload([:site, team_invitation: :inviter])
+      |> Repo.preload(:team_invitation)
 
     case invitation do
       nil ->
@@ -394,7 +404,8 @@ defmodule PlausibleWeb.Live.RegisterForm do
         {:ok,
          %{
            type: :guest_invitation,
-           email: guest_invitation.team_invitation.email
+           email: guest_invitation.team_invitation.email,
+           team_identifier: "none"
          }}
     end
   end
@@ -403,7 +414,6 @@ defmodule PlausibleWeb.Live.RegisterForm do
     transfer =
       Teams.SiteTransfer
       |> Repo.get_by(transfer_id: id)
-      |> Repo.preload([:site, :initiator])
 
     case transfer do
       nil ->
@@ -413,7 +423,8 @@ defmodule PlausibleWeb.Live.RegisterForm do
         {:ok,
          %{
            type: :site_transfer,
-           email: transfer.email
+           email: transfer.email,
+           team_identifier: "none"
          }}
     end
   end

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -20,8 +20,6 @@ defmodule PlausibleWeb.Live.RegisterForm do
       |> assign_new(:team_identifier, fn %{invitation: invitation} ->
         if invitation do
           invitation.team_identifier
-        else
-          "none"
         end
       end)
 
@@ -108,7 +106,12 @@ defmodule PlausibleWeb.Live.RegisterForm do
         phx-trigger-action={@trigger_submit}
       >
         <input name="user[register_action]" type="hidden" value={@live_action} />
-        <input name="user[team_identifier]" type="hidden" value={@team_identifier} />
+        <input
+          :if={@team_identifier}
+          name="user[team_identifier]"
+          type="hidden"
+          value={@team_identifier}
+        />
 
         <%= if @invitation do %>
           <.email_input field={f[:email]} for_invitation={true} />
@@ -405,7 +408,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
          %{
            type: :guest_invitation,
            email: guest_invitation.team_invitation.email,
-           team_identifier: "none"
+           team_identifier: nil
          }}
     end
   end
@@ -424,7 +427,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
          %{
            type: :site_transfer,
            email: transfer.email,
-           team_identifier: "none"
+           team_identifier: nil
          }}
     end
   end

--- a/lib/plausible_web/templates/auth/activate.html.heex
+++ b/lib/plausible_web/templates/auth/activate.html.heex
@@ -30,6 +30,7 @@
 
   <div :if={@has_email_code?}>
     <.form :let={f} for={@conn} action={@form_submit_url}>
+      <.input type="hidden" field={f[:team_identifier]} />
       <.input
         field={f[:code]}
         class="tracking-widest font-medium shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-36 px-8 border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-200 dark:bg-gray-900 text-center"

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -72,7 +72,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                csrf_input,
                action_input,
-               team_input,
                name_input,
                email_input,
                password_input,
@@ -81,7 +80,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
       assert text_of_attr(action_input, "value") == "register_form"
-      assert text_of_attr(team_input, "value") == "none"
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "mary.sue@plausible.test"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
@@ -169,7 +167,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                csrf_input,
                action_input,
-               team_input,
                email_input,
                name_input,
                password_input,
@@ -178,7 +175,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
       assert text_of_attr(action_input, "value") == "register_from_invitation_form"
-      assert text_of_attr(team_input, "value") == "none"
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "user@email.co"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
@@ -275,11 +271,8 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                _csrf_input,
                _action_input,
-               team_input,
                email_input | _
              ] = find(html, "input")
-
-      assert text_of_attr(team_input, "value") == "none"
 
       # attempt at tampering with form
       assert text_of_attr(email_input, "value") == "mary.sue@plausible.test"

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -72,6 +72,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                csrf_input,
                action_input,
+               team_input,
                name_input,
                email_input,
                password_input,
@@ -80,6 +81,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
       assert text_of_attr(action_input, "value") == "register_form"
+      assert text_of_attr(team_input, "value") == "none"
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "mary.sue@plausible.test"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
@@ -167,6 +169,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                csrf_input,
                action_input,
+               team_input,
                email_input,
                name_input,
                password_input,
@@ -175,6 +178,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
       assert text_of_attr(action_input, "value") == "register_from_invitation_form"
+      assert text_of_attr(team_input, "value") == "none"
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "user@email.co"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
@@ -215,6 +219,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                csrf_input,
                action_input,
+               team_input,
                email_input,
                name_input,
                password_input,
@@ -223,6 +228,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
       assert text_of_attr(action_input, "value") == "register_from_invitation_form"
+      assert text_of_attr(team_input, "value") == team.identifier
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "team-user@email.co"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
@@ -269,8 +275,11 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert [
                _csrf_input,
                _action_input,
+               team_input,
                email_input | _
              ] = find(html, "input")
+
+      assert text_of_attr(team_input, "value") == "none"
 
       # attempt at tampering with form
       assert text_of_attr(email_input, "value") == "mary.sue@plausible.test"


### PR DESCRIPTION
### Changes

This PR simplifies registration flow when registering from team invitation. Now, the invitation is accepted immediately after registering and the user is switched to the new team at once.

In case of email verification flow only "happy path" with verification code already issued is concerned with implicit team invite approval and redirect to team sites.

### TODO

- [x] Add Auth controller test for login action via register from team invite

### Tests
- [x] Automated tests have been added


