### PR TITLE
Add ability to create Sites API keys from Account Settings

### DIFF
--- a/lib/plausible/auth/api_key.ex
+++ b/lib/plausible/auth/api_key.ex
@@ -14,6 +14,8 @@ defmodule Plausible.Auth.ApiKey do
     field :name, :string
     field :scopes, {:array, :string}, default: ["stats:read:*"]
 
+    field :type, :string, virtual: true
+
     field :key, :string, virtual: true
     field :key_hash, :string
     field :key_prefix, :string

--- a/lib/plausible/crm_extensions.ex
+++ b/lib/plausible/crm_extensions.ex
@@ -73,6 +73,28 @@ defmodule Plausible.CrmExtensions do
       [
         Phoenix.HTML.raw("""
         <script type="text/javascript">
+          (() => {
+            const statsFeature = document.querySelector(`input[type=checkbox][value=stats_api]`)
+            const sitesFeature = document.querySelector(`input[type=checkbox][value=sites_api]`)
+
+            statsFeature.addEventListener("change", () => {
+              if (!statsFeature.checked) {
+                sitesFeature.checked = false
+              }
+              return true;
+            })
+
+            sitesFeature.addEventListener("change", () => {
+              if (sitesFeature.checked) {
+                statsFeature.checked = true
+              }
+              return true;
+            })
+          })()
+        </script>
+        """),
+        Phoenix.HTML.raw("""
+        <script type="text/javascript">
           (async () => {
             const CHECK_INTERVAL = 300
 

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -115,7 +115,7 @@ defmodule PlausibleWeb.SettingsController do
     current_team = conn.assigns.current_team
 
     sites_api_enabled? =
-      Plausible.Billing.Feature.SitesAPI.check_availability(current_team) != :ok
+      Plausible.Billing.Feature.SitesAPI.check_availability(current_team) == :ok
 
     api_key_fn =
       if type == "sites_api" do

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -102,23 +102,44 @@ defmodule PlausibleWeb.SettingsController do
   def new_api_key(conn, _params) do
     current_team = conn.assigns[:current_team]
 
-    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{}, current_team, %{})
+    sites_api_enabled? =
+      Plausible.Billing.Feature.SitesAPI.check_availability(current_team) == :ok
 
-    render(conn, "new_api_key.html", changeset: changeset)
+    changeset = Auth.ApiKey.changeset(%Auth.ApiKey{type: "stats_api"}, current_team, %{})
+
+    render(conn, "new_api_key.html", changeset: changeset, sites_api_enabled?: sites_api_enabled?)
   end
 
-  def create_api_key(conn, %{"api_key" => %{"name" => name, "key" => key}}) do
+  def create_api_key(conn, %{"api_key" => %{"name" => name, "key" => key, "type" => type}}) do
     current_user = conn.assigns.current_user
     current_team = conn.assigns.current_team
 
-    case Auth.create_api_key(current_user, current_team, name, key) do
+    sites_api_enabled? =
+      Plausible.Billing.Feature.SitesAPI.check_availability(current_team) != :ok
+
+    api_key_fn =
+      if type == "sites_api" do
+        &Auth.create_sites_api_key/4
+      else
+        &Auth.create_stats_api_key/4
+      end
+
+    case api_key_fn.(current_user, current_team, name, key) do
       {:ok, _api_key} ->
         conn
         |> put_flash(:success, "API key created successfully")
         |> redirect(to: Routes.settings_path(conn, :api_keys) <> "#api-keys")
 
+      {:error, :upgrade_required} ->
+        conn
+        |> put_flash(:error, "Your current subscription plan does not include Sites API access")
+        |> redirect(to: Routes.settings_path(conn, :new_api_key))
+
       {:error, changeset} ->
-        render(conn, "new_api_key.html", changeset: changeset)
+        render(conn, "new_api_key.html",
+          changeset: changeset,
+          sites_api_enabled?: sites_api_enabled?
+        )
     end
   end
 

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -52,6 +52,7 @@ defmodule PlausibleWeb.Live.Components.Form do
 
   attr(:mt?, :boolean, default: true)
   attr(:max_one_error, :boolean, default: false)
+  slot(:help_content)
   slot(:inner_block)
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -102,6 +103,52 @@ defmodule PlausibleWeb.Live.Components.Form do
         class="block h-5 w-5 rounded dark:bg-gray-700 border-gray-300 text-indigo-600 focus:ring-indigo-600"
       />
       <.label for={@id}>{@label}</.label>
+    </div>
+    """
+  end
+
+  def input(%{type: "radio"} = assigns) do
+    input_class =
+      if assigns.rest[:disabled] do
+        "dark:bg-gray-500 bg-gray-200 border-gray-300"
+      else
+        "dark:bg-gray-700 border-gray-300"
+      end
+
+    label_class =
+      if assigns.rest[:disabled] do
+        "flex flex-col flex-inline dark:text-gray-300 text-gray-500"
+      else
+        "flex flex-col flex-inline"
+      end
+
+    assigns = assign(assigns, input_class: input_class, label_class: label_class)
+
+    ~H"""
+    <div class={[
+      "flex flex-inline items-top justify-start gap-x-2",
+      @mt? && "mt-2"
+    ]}>
+      <input
+        type="radio"
+        value={@value}
+        id={@id}
+        name={@name}
+        checked={assigns[:checked]}
+        class={["block h-5 w-5 text-indigo-600 focus:ring-indigo-600", @input_class]}
+        {@rest}
+      />
+      <.label class={@label_class} for={@id}>
+        <span>{@label}</span>
+
+        <span
+          :if={@help_text || @help_content != []}
+          class="text-gray-500 dark:text-gray-400 mb-2 text-sm"
+        >
+          {@help_text}
+          {render_slot(@help_content)}
+        </span>
+      </.label>
     </div>
     """
   end

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -108,25 +108,9 @@ defmodule PlausibleWeb.Live.Components.Form do
   end
 
   def input(%{type: "radio"} = assigns) do
-    input_class =
-      if assigns.rest[:disabled] do
-        "dark:bg-gray-500 bg-gray-200 border-gray-300"
-      else
-        "dark:bg-gray-700 border-gray-300"
-      end
-
-    label_class =
-      if assigns.rest[:disabled] do
-        "flex flex-col flex-inline dark:text-gray-300 text-gray-500"
-      else
-        "flex flex-col flex-inline"
-      end
-
-    assigns = assign(assigns, input_class: input_class, label_class: label_class)
-
     ~H"""
     <div class={[
-      "flex flex-inline items-top justify-start gap-x-2",
+      "flex flex-inline items-center justify-start gap-x-3",
       @mt? && "mt-2"
     ]}>
       <input
@@ -135,10 +119,10 @@ defmodule PlausibleWeb.Live.Components.Form do
         id={@id}
         name={@name}
         checked={assigns[:checked]}
-        class={["block h-5 w-5 text-indigo-600 focus:ring-indigo-600", @input_class]}
+        class="block dark:bg-gray-900 h-4 w-4 mt-0.5 cursor-pointer text-indigo-600 border-gray-300 dark:border-gray-500 focus:ring-indigo-500"
         {@rest}
       />
-      <.label class={@label_class} for={@id}>
+      <.label :if={@label} class="flex flex-col flex-inline" for={@id}>
         <span>{@label}</span>
 
         <span

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -30,7 +30,7 @@
         <.th hide_on_mobile>
           Key
         </.th>
-        <.th hide_on_mobile>
+        <.th :if={ee?()} hide_on_mobile>
           Type
         </.th>
         <.th invisible>
@@ -46,7 +46,7 @@
           {api_key.key_prefix}
           {String.duplicate("*", 32 - 6)}
         </.td>
-        <.td>
+        <.td :if={ee?()}>
           <span :if={api_key.type == "stats_api"}>Stats API</span>
           <span :if={api_key.type == "sites_api"}>Sites API</span>
         </.td>

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -4,7 +4,7 @@
       <a id="api-keys">API Keys</a>
     </:title>
     <:subtitle>
-      Manage your Stats API keys
+      Manage your API keys
     </:subtitle>
 
     <PlausibleWeb.Components.Billing.Notice.premium_feature

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -30,6 +30,9 @@
         <.th hide_on_mobile>
           Key
         </.th>
+        <.th hide_on_mobile>
+          Type
+        </.th>
         <.th invisible>
           Actions
         </.th>
@@ -42,6 +45,10 @@
         <.td hide_on_mobile>
           {api_key.key_prefix}
           {String.duplicate("*", 32 - 6)}
+        </.td>
+        <.td>
+          <span :if={api_key.type == "stats_api"}>Stats API</span>
+          <span :if={api_key.type == "sites_api"}>Sites API</span>
         </.td>
         <.td actions>
           <.delete_button

--- a/lib/plausible_web/templates/settings/new_api_key.html.heex
+++ b/lib/plausible_web/templates/settings/new_api_key.html.heex
@@ -28,7 +28,7 @@
       </.input>
 
       <.input
-        x-on:click="showNotice = true"
+        x-on:click={"showNotice = " <> if(@sites_api_enabled?, do: "false", else: "true")}
         type="radio"
         id={f[:type].id <> "_1"}
         name={f[:type].name}

--- a/lib/plausible_web/templates/settings/new_api_key.html.heex
+++ b/lib/plausible_web/templates/settings/new_api_key.html.heex
@@ -4,7 +4,9 @@
   <.form :let={f} for={@changeset} action={Routes.settings_path(@conn, :api_keys)}>
     <.input type="text" field={f[:name]} label="Name" placeholder="Development" />
 
-    <div x-data="{ showNotice: false }" class="mt-4 flex flex-col gap-y-2">
+    <input :if={ce?()} type="hidden" name={f[:type].name} value={f[:type].value} />
+
+    <div :if={ee?()} x-data="{ showNotice: false }" class="mt-4 flex flex-col gap-y-2">
       <div>
         <.label>Type</.label>
       </div>

--- a/lib/plausible_web/templates/settings/new_api_key.html.heex
+++ b/lib/plausible_web/templates/settings/new_api_key.html.heex
@@ -21,7 +21,7 @@
       >
         <:help_content>
           Full access to
-          <.styled_link href="https://plausible.io/docs/stats-api">Stats API</.styled_link>.
+          <.styled_link href="https://plausible.io/docs/stats-api">Stats API</.styled_link>
         </:help_content>
       </.input>
 
@@ -38,7 +38,7 @@
           Full access to
           <.styled_link href="https://plausible.io/docs/stats-api">Stats API</.styled_link>
           and
-          <.styled_link href="https://plausible.io/docs/sites-api">Sites API</.styled_link>.
+          <.styled_link href="https://plausible.io/docs/sites-api">Sites API</.styled_link>
         </:help_content>
       </.input>
 

--- a/lib/plausible_web/templates/settings/new_api_key.html.heex
+++ b/lib/plausible_web/templates/settings/new_api_key.html.heex
@@ -4,6 +4,54 @@
   <.form :let={f} for={@changeset} action={Routes.settings_path(@conn, :api_keys)}>
     <.input type="text" field={f[:name]} label="Name" placeholder="Development" />
 
+    <div x-data="{ showNotice: false }" class="mt-4 flex flex-col gap-y-2">
+      <div>
+        <.label>Type</.label>
+      </div>
+
+      <.input
+        x-on:click="showNotice = false"
+        type="radio"
+        class="block h-5 w-5 dark:bg-gray-700 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+        id={f[:type].id <> "_0"}
+        name={f[:type].name}
+        value="stats_api"
+        checked={f[:type].value == "stats_api"}
+        label="Stats API"
+      >
+        <:help_content>
+          Full access to
+          <.styled_link href="https://plausible.io/docs/stats-api">Stats API</.styled_link>.
+        </:help_content>
+      </.input>
+
+      <.input
+        x-on:click="showNotice = true"
+        type="radio"
+        id={f[:type].id <> "_1"}
+        name={f[:type].name}
+        value="sites_api"
+        checked={f[:type].value == "sites_api"}
+        label="Sites API"
+      >
+        <:help_content>
+          Full access to
+          <.styled_link href="https://plausible.io/docs/stats-api">Stats API</.styled_link>
+          and
+          <.styled_link href="https://plausible.io/docs/sites-api">Sites API</.styled_link>.
+        </:help_content>
+      </.input>
+
+      <div x-show="showNotice" class="flex gap-x-2 text-sm">
+        <Heroicons.exclamation_triangle class="mt-1 block w-4 h-4 shrink-0" />
+        <div>
+          Your current subscription plan does not include Sites API access.
+          <a href="https://plausible.io/contact" class="underline">Contact us</a>
+          if interested.
+        </div>
+      </div>
+    </div>
+
     <div class="mt-4">
       <.input_with_clipboard id="key-input" name="api_key[key]" label="Key" value={f[:key].value} />
 
@@ -18,7 +66,7 @@
       </p>
     </div>
     <.button type="submit" class="w-full">
-      Continue
+      Create API key
     </.button>
   </.form>
 </.focus_box>

--- a/lib/plausible_web/views/settings_view.ex
+++ b/lib/plausible_web/views/settings_view.ex
@@ -1,6 +1,7 @@
 defmodule PlausibleWeb.SettingsView do
   use PlausibleWeb, :view
   use Phoenix.Component, global_prefixes: ~w(x-)
+  use Plausible
 
   require Plausible.Billing.Subscription.Status
   alias Plausible.Billing.{Plans, Subscription}

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1037,7 +1037,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
           "api_key" => %{
             "user_id" => user.id,
             "name" => "all your code are belong to us",
-            "key" => "swordfish"
+            "key" => "swordfish",
+            "type" => "stats_api"
           }
         })
 
@@ -1061,7 +1062,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
           "api_key" => %{
             "user_id" => user.id,
             "name" => "all your code are belong to us",
-            "key" => "swordfish"
+            "key" => "swordfish",
+            "type" => "stats_api"
           }
         })
 
@@ -1079,7 +1081,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
           "api_key" => %{
             "user_id" => user.id,
             "name" => "all your code are belong to us",
-            "key" => "swordfish"
+            "key" => "swordfish",
+            "type" => "stats_api"
           }
         })
 
@@ -1088,7 +1091,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
           "api_key" => %{
             "user_id" => user.id,
             "name" => "all your code are belong to us",
-            "key" => "swordfish"
+            "key" => "swordfish",
+            "type" => "stats_api"
           }
         })
 
@@ -1105,7 +1109,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
           "api_key" => %{
             "user_id" => other_user.id,
             "name" => "all your code are belong to us",
-            "key" => "swordfish"
+            "key" => "swordfish",
+            "type" => "stats_api"
           }
         })
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1023,6 +1023,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       assert html_response(conn, 200)
     end
 
+    @tag :ee_only
     test "lists types of keys", %{conn: conn, user: user} do
       user
       |> subscribe_to_enterprise_plan(


### PR DESCRIPTION
### Changes

This PR adds ability for user to create a Sites API enabled API key by themselves instead of having to reach out to customer support, provided the feature is enabled for their team's enterprise plan.

Additionally, Enterprise Plan CRM now ensures that Stats API is always checked when Sites API is checked and that Sites API is unchecked if Stats API gets unchecked, to ensure consistency.

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/5a172f58-e6ed-4362-96af-4d66e66230f6" />

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/1f359387-f052-4445-beb4-66397dda8bed" />

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/006d3f0e-93dd-46c6-98dc-46d5647f3583" />

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/7b3d096d-0fca-473c-8b4a-ebd1c9e3fb07" />

### Tests
- [x] Automated tests have been added

### Documentation
- [x] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] The UI has been tested both in dark and light mode

