### PR TITLE
Reload dashboard when Stats API version changes

### DIFF
--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -5,6 +5,9 @@ import { serializeApiFilters } from './util/filters'
 let abortController = new AbortController()
 let SHARED_LINK_AUTH: null | string = null
 
+// And keep in sync with lib/plausible_web/controllers/api/stats_controller.ex
+const EXPECTED_API_VERSION = 0
+
 export class ApiError extends Error {
   payload: unknown
   constructor(message: string, payload: unknown) {
@@ -85,6 +88,17 @@ async function handleApiResponse(response: Response) {
   const payload = await response.json()
   if (!response.ok) {
     throw new ApiError(payload.error, payload)
+  }
+
+  if (
+    payload?.api_version !== undefined &&
+    payload?.api_version !== EXPECTED_API_VERSION
+  ) {
+    console.log('Received unexpected version from API. Reloading page...', {
+      payload,
+      EXPECTED_API_VERSION
+    })
+    window.location.reload()
   }
 
   return payload

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -15,6 +15,12 @@ defmodule PlausibleWeb.Api.StatsController do
 
   plug(:date_validation_plug)
 
+  # Version of the internal dashboard stats API. If this is incremented, frontend dashboards
+  # automatically reload to avoid version incompatibilities.
+  #
+  # Keep in sync with assets/js/dashboard/api.ts#EXPECTED_API_VERSION
+  @api_version 0
+
   @doc """
   Returns a time-series based on given parameters.
 
@@ -115,7 +121,8 @@ defmodule PlausibleWeb.Api.StatsController do
         comparison_plot: comparison_result && plot_timeseries(comparison_result, metric),
         comparison_labels: comparison_result && label_timeseries(comparison_result, nil),
         present_index: present_index,
-        full_intervals: full_intervals
+        full_intervals: full_intervals,
+        api_version: @api_version
       })
     else
       {:error, message} when is_binary(message) -> bad_request(conn, message)
@@ -210,7 +217,8 @@ defmodule PlausibleWeb.Api.StatsController do
       comparing_from: query.include.comparisons && Query.date_range(comparison_query).first,
       comparing_to: query.include.comparisons && Query.date_range(comparison_query).last,
       from: Query.date_range(query).first,
-      to: Query.date_range(query).last
+      to: Query.date_range(query).last,
+      api_version: @api_version
     })
   end
 
@@ -496,7 +504,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -530,7 +539,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -614,7 +624,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -644,7 +655,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -674,7 +686,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -704,7 +717,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -734,7 +748,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -764,7 +779,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: res,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -812,7 +828,7 @@ defmodule PlausibleWeb.Api.StatsController do
         |> json(%{error_code: :period_too_recent})
 
       {{:ok, terms}, _} ->
-        json(conn, %{results: terms})
+        json(conn, %{results: terms, api_version: @api_version})
 
       {{:error, error}, _} ->
         Logger.error("Plausible.Google.API.fetch_stats failed with error: `#{inspect(error)}`")
@@ -847,7 +863,8 @@ defmodule PlausibleWeb.Api.StatsController do
     json(conn, %{
       results: referrers,
       meta: Stats.Breakdown.formatted_date_ranges(query),
-      skip_imported_reason: meta[:imports_skip_reason]
+      skip_imported_reason: meta[:imports_skip_reason],
+      api_version: @api_version
     })
   end
 
@@ -886,7 +903,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: pages,
         meta: Map.merge(meta, Stats.Breakdown.formatted_date_ranges(query)),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -923,7 +941,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: entry_pages,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -968,7 +987,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: exit_pages,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1026,7 +1046,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: countries,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1067,7 +1088,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: regions,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1113,7 +1135,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: cities,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1147,7 +1170,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: browsers,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1190,7 +1214,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: results,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1224,7 +1249,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: systems,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1267,7 +1293,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: results,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1301,7 +1328,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: sizes,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1335,7 +1363,8 @@ defmodule PlausibleWeb.Api.StatsController do
       json(conn, %{
         results: conversions,
         meta: Stats.Breakdown.formatted_date_ranges(query),
-        skip_imported_reason: meta[:imports_skip_reason]
+        skip_imported_reason: meta[:imports_skip_reason],
+        api_version: @api_version
       })
     end
   end
@@ -1413,7 +1442,8 @@ defmodule PlausibleWeb.Api.StatsController do
     %{
       results: props,
       meta: Stats.Breakdown.formatted_date_ranges(query),
-      skip_imported_reason: meta[:imports_skip_reason]
+      skip_imported_reason: meta[:imports_skip_reason],
+      api_version: @api_version
     }
   end
 
@@ -1591,7 +1621,7 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp bad_request(conn, message, extra \\ %{}) do
-    payload = Map.merge(extra, %{error: message})
+    payload = Map.merge(extra, %{error: message, api_version: @api_version})
 
     conn
     |> put_status(400)

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -95,7 +95,7 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
           |> get("/api/stats/#{site.domain}/funnels/foobar/?period=day")
           |> json_response(400)
 
-        assert resp == %{"error" => "There was an error with your request"}
+        assert_matches %{"error" => "There was an error with your request"} = resp
       end
 
       test "computes all-time funnel with filters", %{conn: conn, user: user} do
@@ -257,11 +257,11 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
           |> get("/api/stats/#{site.domain}/funnels/#{funnel.id}/?period=day&filters=#{filters}")
           |> json_response(400)
 
-        assert resp == %{
-                 "error" =>
-                   "We are unable to show funnels when the dashboard is filtered by pages",
-                 "level" => "normal"
-               }
+        assert_matches %{
+                         "error" =>
+                           "We are unable to show funnels when the dashboard is filtered by pages",
+                         "level" => "normal"
+                       } = resp
       end
 
       test "event:goal", %{conn: conn, site: site} do
@@ -275,11 +275,11 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
           |> get("/api/stats/#{site.domain}/funnels/#{funnel.id}/?period=day&filters=#{filters}")
           |> json_response(400)
 
-        assert resp == %{
-                 "error" =>
-                   "We are unable to show funnels when the dashboard is filtered by goals",
-                 "level" => "normal"
-               }
+        assert_matches %{
+                         "error" =>
+                           "We are unable to show funnels when the dashboard is filtered by goals",
+                         "level" => "normal"
+                       } = resp
       end
 
       test "period: realtime", %{conn: conn, site: site} do
@@ -290,11 +290,11 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
           |> get("/api/stats/#{site.domain}/funnels/#{funnel.id}/?period=realtime")
           |> json_response(400)
 
-        assert resp == %{
-                 "error" =>
-                   "We are unable to show funnels when the dashboard is filtered by realtime period",
-                 "level" => "normal"
-               }
+        assert_matches %{
+                         "error" =>
+                           "We are unable to show funnels when the dashboard is filtered by realtime period",
+                         "level" => "normal"
+                       } = resp
       end
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/main_graph_test.exs
@@ -1062,10 +1062,10 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=day&date=2021-01-01&metric=visitors&interval=month"
         )
 
-      assert %{
-               "error" =>
-                 "Invalid combination of interval and period. Interval must be smaller than the selected period, e.g. `period=day,interval=minute`"
-             } == json_response(conn, 400)
+      assert_matches %{
+                       "error" =>
+                         "Invalid combination of interval and period. Interval must be smaller than the selected period, e.g. `period=day,interval=minute`"
+                     } = json_response(conn, 400)
     end
 
     test "returns error when the interval is not valid", %{
@@ -1078,10 +1078,10 @@ defmodule PlausibleWeb.Api.StatsController.MainGraphTest do
           "/api/stats/#{site.domain}/main-graph?period=day&date=2021-01-01&metric=visitors&interval=biweekly"
         )
 
-      assert %{
-               "error" =>
-                 "Invalid value for interval. Accepted values are: minute, hour, day, week, month"
-             } == json_response(conn, 400)
+      assert_matches %{
+                       "error" =>
+                         "Invalid value for interval. Accepted values are: minute, hour, day, week, month"
+                     } = json_response(conn, 400)
     end
 
     test "displays visitors for a month on a weekly scale", %{conn: conn, site: site} do

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -1763,7 +1763,7 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=30d&filters=#{filters}")
 
-      assert json_response(conn, 200) == %{"results" => []}
+      assert_matches %{"results" => []} = json_response(conn, 200)
     end
 
     test "returns 422 with error when no data returned and queried range is too recent", %{

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -769,10 +769,10 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
           "/api/stats/#{site.domain}/suggestions/custom-prop-values/author?period=all&date=CLEVER_SECURITY_RESEARCH&filters=#{filters}"
         )
 
-      assert json_response(conn, 400) == %{
+      assert %{
                "error" =>
                  "Failed to parse 'date' argument. Only ISO 8601 dates are allowed, e.g. `2019-09-07`, `2020-01-01`"
-             }
+             } = json_response(conn, 400)
     end
   end
 


### PR DESCRIPTION
Idea from the lovely @apata for making easier breaking changes in the dashboard API: reload the dashboard when the internal API version changes.

This will help us make 'breaking' changes easier.