### PR TITLE
Add SitesAPI plan feature

### DIFF
--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -73,6 +73,7 @@ defmodule Plausible.Billing.Feature do
   @features [
     Plausible.Billing.Feature.Goals,
     Plausible.Billing.Feature.StatsAPI,
+    Plausible.Billing.Feature.SitesAPI,
     Plausible.Billing.Feature.Props,
     Plausible.Billing.Feature.Funnels,
     Plausible.Billing.Feature.RevenueGoals,
@@ -211,4 +212,13 @@ defmodule Plausible.Billing.Feature.StatsAPI do
   use Plausible.Billing.Feature,
     name: :stats_api,
     display_name: "Stats API"
+end
+
+defmodule Plausible.Billing.Feature.SitesAPI do
+  use Plausible
+
+  @moduledoc false
+  use Plausible.Billing.Feature,
+    name: :sites_api,
+    display_name: "Sites API"
 end

--- a/lib/plausible_web/plugins/api/schemas/capabilities.ex
+++ b/lib/plausible_web/plugins/api/schemas/capabilities.ex
@@ -33,6 +33,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Capabilities do
         Props: false,
         RevenueGoals: false,
         StatsAPI: false,
+        SitesAPI: false,
         SiteSegments: false
       }
     }

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -601,7 +601,7 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features when user in on trial" do
       team = new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: 7)) |> team_of()
 
-      assert Plausible.Billing.Feature.list() ==
+      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -619,7 +619,7 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features for enterprise users who have not upgraded yet and are on trial" do
       team = new_user() |> subscribe_to_enterprise_plan(subscription?: false) |> team_of()
 
-      assert Plausible.Billing.Feature.list() ==
+      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -639,6 +639,19 @@ defmodule Plausible.Billing.QuotaTest do
       team = team_of(user)
 
       assert [Plausible.Billing.Feature.StatsAPI] ==
+               Plausible.Teams.Billing.allowed_features_for(team)
+    end
+
+    test "returns SitesAPI feature for enterprise customers with appropriate plan" do
+      user = new_user()
+
+      subscribe_to_enterprise_plan(user,
+        features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI]
+      )
+
+      team = team_of(user)
+
+      assert [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
   end

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Billing.QuotaTest do
   use Plausible.DataCase, async: true
   use Plausible
   alias Plausible.Billing.{Quota, Plans}
-  alias Plausible.Billing.Feature.{Goals, Props, StatsAPI}
+  alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI}
 
   use Plausible.Teams.Test
 
@@ -515,6 +515,18 @@ defmodule Plausible.Billing.QuotaTest do
       insert(:api_key, user: user)
 
       assert [StatsAPI] == Plausible.Teams.Billing.features_usage(team)
+    end
+
+    test "returns [SitesAPI] when user has a Sites API enabled api key" do
+      user =
+        new_user()
+        |> subscribe_to_enterprise_plan(features: [StatsAPI, SitesAPI])
+
+      team = team_of(user)
+
+      insert(:api_key, user: user, scopes: ["sites:provision:*"])
+
+      assert [StatsAPI, SitesAPI] == Plausible.Teams.Billing.features_usage(team)
     end
 
     test "returns feature usage based on a user and a custom list of site_ids" do

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -30,6 +30,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
+                   "SitesAPI" => false,
                    "SiteSegments" => false
                  }
                }
@@ -55,6 +56,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
+                   "SitesAPI" => false,
                    "SiteSegments" => false
                  }
                }
@@ -82,6 +84,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => true,
                    "RevenueGoals" => true,
                    "StatsAPI" => true,
+                   "SitesAPI" => false,
                    "SiteSegments" => true
                  }
                }
@@ -111,6 +114,40 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
+                   "SitesAPI" => false,
+                   "SiteSegments" => false
+                 }
+               }
+
+      assert_schema(resp, "Capabilities", spec())
+    end
+
+    @tag :ee_only
+    test "enterprise with SitesAPI", %{conn: conn, site: site, token: token} do
+      [owner | _] = Plausible.Repo.preload(site, :owners).owners
+
+      subscribe_to_enterprise_plan(owner,
+        features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI]
+      )
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> authenticate(site.domain, token)
+        |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
+        |> json_response(200)
+
+      assert resp ==
+               %{
+                 "authorized" => true,
+                 "data_domain" => site.domain,
+                 "features" => %{
+                   "Funnels" => false,
+                   "Goals" => true,
+                   "Props" => false,
+                   "RevenueGoals" => false,
+                   "StatsAPI" => true,
+                   "SitesAPI" => true,
                    "SiteSegments" => false
                  }
                }


### PR DESCRIPTION
### Changes

Extracted from https://github.com/plausible/analytics/pull/5361.

Introduces new billing feature, Sites API access, which is a prerequisite to supporting Sites API key provisioning by customers.

The feature is only available as a part of enterprise plans which have it explicitly configured.

### Tests
- [x] Automated tests have been added
