### PR TITLE
Revert "Add SitesAPI plan feature (#5366)"

### DIFF
--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -73,7 +73,6 @@ defmodule Plausible.Billing.Feature do
   @features [
     Plausible.Billing.Feature.Goals,
     Plausible.Billing.Feature.StatsAPI,
-    Plausible.Billing.Feature.SitesAPI,
     Plausible.Billing.Feature.Props,
     Plausible.Billing.Feature.Funnels,
     Plausible.Billing.Feature.RevenueGoals,
@@ -212,13 +211,4 @@ defmodule Plausible.Billing.Feature.StatsAPI do
   use Plausible.Billing.Feature,
     name: :stats_api,
     display_name: "Stats API"
-end
-
-defmodule Plausible.Billing.Feature.SitesAPI do
-  use Plausible
-
-  @moduledoc false
-  use Plausible.Billing.Feature,
-    name: :sites_api,
-    display_name: "Sites API"
 end

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -13,7 +13,7 @@ defmodule Plausible.Teams.Billing do
   alias Plausible.Teams
 
   alias Plausible.Billing.{EnterprisePlan, Feature, Plan, Plans, Quota}
-  alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI}
+  alias Plausible.Billing.Feature.{Goals, Props, StatsAPI}
 
   require Plausible.Billing.Subscription.Status
 
@@ -494,28 +494,8 @@ defmodule Plausible.Teams.Billing do
             )
       )
 
-    site_scoped_feature_usage =
-      if stats_api_used? do
-        site_scoped_feature_usage ++ [Feature.StatsAPI]
-      else
-        site_scoped_feature_usage
-      end
-
-    sites_api_used? =
-      Repo.exists?(
-        from tm in Plausible.Teams.Membership,
-          as: :team_membership,
-          where: tm.team_id == ^team.id,
-          where:
-            exists(
-              from ak in Plausible.Auth.ApiKey,
-                where: ak.user_id == parent_as(:team_membership).user_id,
-                where: "sites:provision:*" in ak.scopes
-            )
-      )
-
-    if sites_api_used? do
-      site_scoped_feature_usage ++ [SitesAPI]
+    if stats_api_used? do
+      site_scoped_feature_usage ++ [Feature.StatsAPI]
     else
       site_scoped_feature_usage
     end
@@ -617,7 +597,7 @@ defmodule Plausible.Teams.Billing do
 
       nil ->
         if Teams.on_trial?(team) do
-          Feature.list() -- [SitesAPI]
+          Feature.list()
         else
           [Goals]
         end

--- a/lib/plausible_web/plugins/api/schemas/capabilities.ex
+++ b/lib/plausible_web/plugins/api/schemas/capabilities.ex
@@ -33,7 +33,6 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Capabilities do
         Props: false,
         RevenueGoals: false,
         StatsAPI: false,
-        SitesAPI: false,
         SiteSegments: false
       }
     }

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -3,7 +3,7 @@ defmodule Plausible.Billing.QuotaTest do
   use Plausible.DataCase, async: true
   use Plausible
   alias Plausible.Billing.{Quota, Plans}
-  alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI}
+  alias Plausible.Billing.Feature.{Goals, Props, StatsAPI}
 
   use Plausible.Teams.Test
 
@@ -517,18 +517,6 @@ defmodule Plausible.Billing.QuotaTest do
       assert [StatsAPI] == Plausible.Teams.Billing.features_usage(team)
     end
 
-    test "returns [SitesAPI] when user has a Sites API enabled api key" do
-      user =
-        new_user()
-        |> subscribe_to_enterprise_plan(features: [StatsAPI, SitesAPI])
-
-      team = team_of(user)
-
-      insert(:api_key, user: user, scopes: ["sites:provision:*"])
-
-      assert [StatsAPI, SitesAPI] == Plausible.Teams.Billing.features_usage(team)
-    end
-
     test "returns feature usage based on a user and a custom list of site_ids" do
       user = new_user(trial_expiry_date: Date.utc_today())
       team = team_of(user)
@@ -613,7 +601,7 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features when user in on trial" do
       team = new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: 7)) |> team_of()
 
-      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
+      assert Plausible.Billing.Feature.list() ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -631,7 +619,7 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features for enterprise users who have not upgraded yet and are on trial" do
       team = new_user() |> subscribe_to_enterprise_plan(subscription?: false) |> team_of()
 
-      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
+      assert Plausible.Billing.Feature.list() ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -651,19 +639,6 @@ defmodule Plausible.Billing.QuotaTest do
       team = team_of(user)
 
       assert [Plausible.Billing.Feature.StatsAPI] ==
-               Plausible.Teams.Billing.allowed_features_for(team)
-    end
-
-    test "returns SitesAPI feature for enterprise customers with appropriate plan" do
-      user = new_user()
-
-      subscribe_to_enterprise_plan(user,
-        features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI]
-      )
-
-      team = team_of(user)
-
-      assert [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
   end

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -30,7 +30,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
-                   "SitesAPI" => false,
                    "SiteSegments" => false
                  }
                }
@@ -56,7 +55,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
-                   "SitesAPI" => false,
                    "SiteSegments" => false
                  }
                }
@@ -84,7 +82,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => true,
                    "RevenueGoals" => true,
                    "StatsAPI" => true,
-                   "SitesAPI" => false,
                    "SiteSegments" => true
                  }
                }
@@ -114,40 +111,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "Props" => false,
                    "RevenueGoals" => false,
                    "StatsAPI" => false,
-                   "SitesAPI" => false,
-                   "SiteSegments" => false
-                 }
-               }
-
-      assert_schema(resp, "Capabilities", spec())
-    end
-
-    @tag :ee_only
-    test "enterprise with SitesAPI", %{conn: conn, site: site, token: token} do
-      [owner | _] = Plausible.Repo.preload(site, :owners).owners
-
-      subscribe_to_enterprise_plan(owner,
-        features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI]
-      )
-
-      resp =
-        conn
-        |> put_req_header("content-type", "application/json")
-        |> authenticate(site.domain, token)
-        |> get(Routes.plugins_api_capabilities_url(PlausibleWeb.Endpoint, :index))
-        |> json_response(200)
-
-      assert resp ==
-               %{
-                 "authorized" => true,
-                 "data_domain" => site.domain,
-                 "features" => %{
-                   "Funnels" => false,
-                   "Goals" => true,
-                   "Props" => false,
-                   "RevenueGoals" => false,
-                   "StatsAPI" => true,
-                   "SitesAPI" => true,
                    "SiteSegments" => false
                  }
                }


### PR DESCRIPTION
This reverts commit 6afd12cdab6096094b0a81b327d8f7847893687b.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
