### PR TITLE
Implement backfill migration for enterprise plans

### DIFF
--- a/priv/repo/migrations/20250429093725_backfill_enterise_plans_feautres_sites_api.exs
+++ b/priv/repo/migrations/20250429093725_backfill_enterise_plans_feautres_sites_api.exs
@@ -1,0 +1,27 @@
+defmodule Plausible.Repo.Migrations.BackfillEnterisePlansFeautresSitesApi do
+  use Ecto.Migration
+
+  def change do
+    execute """
+            UPDATE enterprise_plans ep SET features = array_append(features, 'sites_api')
+            WHERE
+              'stats_api' = ANY(features) AND
+              EXISTS (
+                SELECT 1 FROM team_memberships AS tm
+                WHERE 
+                  tm.team_id = ep.team_id AND
+                  EXISTS(
+                    SELECT 1 FROM api_keys ak
+                    WHERE
+                      ak.user_id = tm.user_id AND
+                      'sites:provision:*' = ANY(ak.scopes)
+                  )
+              )
+            """,
+            """
+            UPDATE enterprise_plans SET features = array(
+              SELECT unnest(features) EXCEPT SELECT unnest('{"sites_api"}'::varchar[])
+            )
+            """
+  end
+end


### PR DESCRIPTION
### Changes

Migration extracted from https://github.com/plausible/analytics/pull/5361

Adds "sites_api" feature to all existing enterprise plans which 1) have "stats_api" feature already set 2) have members with Sites API enabled API keys (queried the same way feature usage is done via billing).

### TODO

- [x] run migration in staging

### Tests
- [x] Manual tests have been done locally

