### PR TITLE
Add +Mdai max emulator flag

### DIFF
--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -9,3 +9,4 @@
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
++Mdai max


### PR DESCRIPTION

> +Mdai max|<amount> - Set amount of dirty allocator instances used. Defaults to 0. That is, by default no instances will be used. The maximum amount of instances equals the amount of dirty CPU schedulers on the system.

> By default, each normal scheduler thread has its own allocator instance for each allocator. All other threads in the system, including dirty schedulers, share one instance for each allocator. By enabling dirty allocator instances, dirty schedulers will get and use their own set of allocator instances. Note that these instances are not exclusive to each dirty scheduler, but instead shared among dirty schedulers. The more instances used the less risk of lock contention on these allocator instances. Memory consumption do however increase with increased amount of dirty allocator instances.

https://www.erlang.org/doc/apps/erts/erts_alloc.html


Ref https://ananthakumaran.in/2025/01/04/erlang-vm-tuning.html