### PR TITLE
Starter tier: Upgrade page remodelling

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,7 @@ config :plausible, Plausible.ClickhouseRepo,
 config :plausible, Plausible.Mailer, adapter: Bamboo.TestAdapter
 
 config :plausible,
-  paddle_api: Plausible.PaddleApi.Mock,
+  paddle_api: Plausible.Billing.TestPaddleApiMock,
   google_api: Plausible.Google.API.Mock
 
 config :bamboo, :refute_timeout, 10

--- a/lib/plausible/billing/plan.ex
+++ b/lib/plausible/billing/plan.ex
@@ -16,7 +16,7 @@ defmodule Plausible.Billing.Plan do
     # production plans, contain multiple generations of plans in the same file
     # for testing purposes.
     field :generation, :integer
-    field :kind, Ecto.Enum, values: [:growth, :business]
+    field :kind, Ecto.Enum, values: [:starter, :growth, :business]
 
     field :features, Plausible.Billing.Ecto.FeatureList
     field :monthly_pageview_limit, :integer

--- a/lib/plausible/billing/plans.ex
+++ b/lib/plausible/billing/plans.ex
@@ -32,6 +32,14 @@ defmodule Plausible.Billing.Plans do
     end
   end
 
+  defp starter_plans_for(v5?) do
+    if v5? do
+      Enum.filter(plans_v5(), &(&1.kind == :starter))
+    else
+      []
+    end
+  end
+
   @spec growth_plans_for(Subscription.t(), boolean()) :: [Plan.t()]
   @doc """
   Returns a list of growth plans available for the subscription to choose.
@@ -75,8 +83,11 @@ defmodule Plausible.Billing.Plans do
     v5? = Keyword.get(opts, :v5?, false)
 
     plans =
-      growth_plans_for(subscription, v5?) ++
+      Enum.concat([
+        starter_plans_for(v5?),
+        growth_plans_for(subscription, v5?),
         business_plans_for(subscription, v5?)
+      ])
 
     plans =
       if Keyword.get(opts, :with_prices) do

--- a/lib/plausible_web/components/billing/legacy_plan_benefits.ex
+++ b/lib/plausible_web/components/billing/legacy_plan_benefits.ex
@@ -1,0 +1,139 @@
+defmodule PlausibleWeb.Components.Billing.LegacyPlanBenefits do
+  @moduledoc """
+  [DEPRECATED] This file is essentially a copy of
+  `PlausibleWeb.Components.Billing.PlanBenefits` with the
+  intent of keeping the old behaviour in place for the users without
+  the `starter_tier` feature flag enabled.
+  """
+
+  use Phoenix.Component
+  alias Plausible.Billing.Plan
+
+  attr :benefits, :list, required: true
+  attr :class, :string, default: nil
+
+  @doc """
+  This function takes a list of benefits returned by either one of:
+
+  * `for_growth/1`
+  * `for_business/2`
+  * `for_enterprise/1`.
+
+  and renders them as HTML.
+
+  The benefits in the given list can be either strings or functions
+  returning a Phoenix component. This allows, for example, to render
+  links within the plan benefit text.
+  """
+  def render(assigns) do
+    ~H"""
+    <ul role="list" class={["mt-8 space-y-3 text-sm leading-6 xl:mt-10", @class]}>
+      <li :for={benefit <- @benefits} class="flex gap-x-3">
+        <Heroicons.check class="h-6 w-5 text-indigo-600 dark:text-green-600" />
+        {if is_binary(benefit), do: benefit, else: benefit.(assigns)}
+      </li>
+    </ul>
+    """
+  end
+
+  @doc """
+  This function takes a growth plan and returns a list representing
+  the different benefits a user gets when subscribing to this plan.
+  """
+  def for_growth(plan) do
+    [
+      team_member_limit_benefit(plan),
+      site_limit_benefit(plan),
+      data_retention_benefit(plan),
+      "Intuitive, fast and privacy-friendly dashboard",
+      "Email/Slack reports",
+      "Google Analytics import"
+    ]
+    |> Kernel.++(feature_benefits(plan))
+    |> Kernel.++(["Saved Segments"])
+    |> Enum.filter(& &1)
+  end
+
+  @doc """
+  Returns Business benefits for the given Business plan.
+
+  A second argument is also required - list of Growth benefits. This
+  is because we don't want to list the same benefits in both Growth
+  and Business. Everything in Growth is also included in Business.
+  """
+  def for_business(plan, growth_benefits) do
+    [
+      "Everything in Growth",
+      team_member_limit_benefit(plan),
+      site_limit_benefit(plan),
+      data_retention_benefit(plan)
+    ]
+    |> Kernel.++(feature_benefits(plan))
+    |> Kernel.--(growth_benefits)
+    |> Kernel.++(["Priority support"])
+    |> Enum.filter(& &1)
+  end
+
+  @doc """
+  This function only takes a list of business benefits. Since all
+  limits and features of enterprise plans are configurable, we can
+  say on the upgrade page that enterprise plans include everything
+  in Business.
+  """
+  def for_enterprise(business_benefits) do
+    team_members =
+      if "Up to 10 team members" in business_benefits, do: "10+ team members"
+
+    data_retention =
+      if "5 years of data retention" in business_benefits, do: "5+ years of data retention"
+
+    [
+      "Everything in Business",
+      team_members,
+      "50+ sites",
+      "600+ Stats API requests per hour",
+      &sites_api_benefit/1,
+      data_retention,
+      "Technical onboarding"
+    ]
+    |> Enum.filter(& &1)
+  end
+
+  defp data_retention_benefit(%Plan{} = plan) do
+    if plan.data_retention_in_years, do: "#{plan.data_retention_in_years} years of data retention"
+  end
+
+  defp team_member_limit_benefit(%Plan{} = plan) do
+    case plan.team_member_limit do
+      :unlimited -> "Unlimited team members"
+      number -> "Up to #{number} team members"
+    end
+  end
+
+  defp site_limit_benefit(%Plan{} = plan), do: "Up to #{plan.site_limit} sites"
+
+  defp feature_benefits(%Plan{} = plan) do
+    Enum.flat_map(plan.features, fn feature_mod ->
+      case feature_mod.name() do
+        :goals -> ["Goals and custom events"]
+        :stats_api -> ["Stats API (600 requests per hour)", "Looker Studio Connector"]
+        :revenue_goals -> ["Ecommerce revenue attribution"]
+        _ -> [feature_mod.display_name()]
+      end
+    end)
+  end
+
+  defp sites_api_benefit(assigns) do
+    ~H"""
+    <p>
+      Sites API access for
+      <.link
+        class="text-indigo-500 hover:text-indigo-400"
+        href="https://plausible.io/white-label-web-analytics"
+      >
+        reselling
+      </.link>
+    </p>
+    """
+  end
+end

--- a/lib/plausible_web/components/billing/legacy_plan_box.ex
+++ b/lib/plausible_web/components/billing/legacy_plan_box.ex
@@ -1,0 +1,378 @@
+defmodule PlausibleWeb.Components.Billing.LegacyPlanBox do
+  @moduledoc """
+  [DEPRECATED] This file is essentially a copy of
+  `PlausibleWeb.Components.Billing.PlanBox` with the
+  intent of keeping the old behaviour in place for the users without
+  the `starter_tier` feature flag enabled.
+  """
+
+  use PlausibleWeb, :component
+
+  require Plausible.Billing.Subscription.Status
+  alias PlausibleWeb.Components.Billing.{PlanBenefits, Notice}
+  alias Plausible.Billing.{Plan, Quota, Subscription}
+
+  def standard(assigns) do
+    highlight =
+      cond do
+        assigns.owned && assigns.recommended -> "Current"
+        assigns.recommended -> "Recommended"
+        true -> nil
+      end
+
+    assigns = assign(assigns, :highlight, highlight)
+
+    ~H"""
+    <div
+      id={"#{@kind}-plan-box"}
+      class={[
+        "shadow-lg bg-white rounded-3xl px-6 sm:px-8 py-4 sm:py-6 dark:bg-gray-800",
+        !@highlight && "dark:ring-gray-600",
+        @highlight && "ring-2 ring-indigo-600 dark:ring-indigo-300"
+      ]}
+    >
+      <div class="flex items-center justify-between gap-x-4">
+        <h3 class={[
+          "text-lg font-semibold leading-8",
+          !@highlight && "text-gray-900 dark:text-gray-100",
+          @highlight && "text-indigo-600 dark:text-indigo-300"
+        ]}>
+          {String.capitalize(to_string(@kind))}
+        </h3>
+        <.pill :if={@highlight} text={@highlight} />
+      </div>
+      <div>
+        <.render_price_info available={@available} {assigns} />
+        <%= if @available do %>
+          <.checkout id={"#{@kind}-checkout"} {assigns} />
+        <% else %>
+          <.contact_button class="bg-indigo-600 hover:bg-indigo-500 text-white" />
+        <% end %>
+      </div>
+      <%= if @owned && @kind == :growth && @plan_to_render.generation < 4 do %>
+        <Notice.growth_grandfathered />
+      <% else %>
+        <PlanBenefits.render benefits={@benefits} class="text-gray-600 dark:text-gray-100" />
+      <% end %>
+    </div>
+    """
+  end
+
+  def enterprise(assigns) do
+    ~H"""
+    <div
+      id="enterprise-plan-box"
+      class={[
+        "rounded-3xl px-6 sm:px-8 py-4 sm:py-6 bg-gray-900 shadow-xl dark:bg-gray-800",
+        !@recommended && "dark:ring-gray-600",
+        @recommended && "ring-4 ring-indigo-500 dark:ring-2 dark:ring-indigo-300"
+      ]}
+    >
+      <div class="flex items-center justify-between gap-x-4">
+        <h3 class={[
+          "text-lg font-semibold leading-8",
+          !@recommended && "text-white dark:text-gray-100",
+          @recommended && "text-indigo-400 dark:text-indigo-300"
+        ]}>
+          Enterprise
+        </h3>
+        <span
+          :if={@recommended}
+          id="enterprise-highlight-pill"
+          class="rounded-full ring-1 ring-indigo-500 px-2.5 py-1 text-xs font-semibold leading-5 text-indigo-400 dark:text-indigo-300 dark:ring-1 dark:ring-indigo-300/50"
+        >
+          Recommended
+        </span>
+      </div>
+      <p class="mt-6 flex items-baseline gap-x-1">
+        <span class="text-4xl font-bold tracking-tight text-white dark:text-gray-100">
+          Custom
+        </span>
+      </p>
+      <p class="h-4 mt-1"></p>
+      <.contact_button class="" />
+      <PlanBenefits.render benefits={@benefits} class="text-gray-300 dark:text-gray-100" />
+    </div>
+    """
+  end
+
+  defp pill(assigns) do
+    ~H"""
+    <div class="flex items-center justify-between gap-x-4">
+      <p
+        id="highlight-pill"
+        class="rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs font-semibold leading-5 text-indigo-600 dark:text-indigo-300 dark:ring-1 dark:ring-indigo-300/50"
+      >
+        {@text}
+      </p>
+    </div>
+    """
+  end
+
+  defp render_price_info(%{available: false} = assigns) do
+    ~H"""
+    <p id={"#{@kind}-custom-price"} class="mt-6 flex items-baseline gap-x-1">
+      <span class="text-4xl font-bold tracking-tight text-gray-900 dark:text-white">
+        Custom
+      </span>
+    </p>
+    <p class="h-4 mt-1"></p>
+    """
+  end
+
+  defp render_price_info(assigns) do
+    ~H"""
+    <p class="mt-6 flex items-baseline gap-x-1">
+      <.price_tag
+        kind={@kind}
+        selected_interval={@selected_interval}
+        plan_to_render={@plan_to_render}
+      />
+    </p>
+    <p class="mt-1 text-xs">+ VAT if applicable</p>
+    """
+  end
+
+  defp price_tag(%{plan_to_render: %Plan{monthly_cost: nil}} = assigns) do
+    ~H"""
+    <span class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+      N/A
+    </span>
+    """
+  end
+
+  defp price_tag(%{selected_interval: :monthly} = assigns) do
+    ~H"""
+    <span
+      id={"#{@kind}-price-tag-amount"}
+      class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
+    >
+      {@plan_to_render.monthly_cost |> Plausible.Billing.format_price()}
+    </span>
+    <span
+      id={"#{@kind}-price-tag-interval"}
+      class="text-sm font-semibold leading-6 text-gray-600 dark:text-gray-500"
+    >
+      /month
+    </span>
+    """
+  end
+
+  defp price_tag(%{selected_interval: :yearly} = assigns) do
+    ~H"""
+    <span class="text-2xl font-bold w-max tracking-tight line-through text-gray-500 dark:text-gray-600 mr-1">
+      {@plan_to_render.monthly_cost |> Money.mult!(12) |> Plausible.Billing.format_price()}
+    </span>
+    <span
+      id={"#{@kind}-price-tag-amount"}
+      class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
+    >
+      {@plan_to_render.yearly_cost |> Plausible.Billing.format_price()}
+    </span>
+    <span id={"#{@kind}-price-tag-interval"} class="text-sm font-semibold leading-6 text-gray-600">
+      /year
+    </span>
+    """
+  end
+
+  defp checkout(assigns) do
+    paddle_product_id = get_paddle_product_id(assigns.plan_to_render, assigns.selected_interval)
+    change_plan_link_text = change_plan_link_text(assigns)
+
+    subscription =
+      Plausible.Teams.Billing.get_subscription(assigns.current_team)
+
+    billing_details_expired =
+      Subscription.Status.in?(subscription, [
+        Subscription.Status.paused(),
+        Subscription.Status.past_due()
+      ])
+
+    subscription_deleted = Subscription.Status.deleted?(subscription)
+    usage_check = check_usage_within_plan_limits(assigns)
+
+    {checkout_disabled, disabled_message} =
+      cond do
+        not Quota.eligible_for_upgrade?(assigns.usage) ->
+          {true, nil}
+
+        change_plan_link_text == "Currently on this plan" && not subscription_deleted ->
+          {true, nil}
+
+        usage_check != :ok ->
+          {true, "Your usage exceeds this plan"}
+
+        billing_details_expired ->
+          {true, "Please update your billing details first"}
+
+        true ->
+          {false, nil}
+      end
+
+    exceeded_plan_limits =
+      case usage_check do
+        {:error, {:over_plan_limits, limits}} ->
+          limits
+
+        _ ->
+          []
+      end
+
+    feature_usage_check = Quota.ensure_feature_access(assigns.usage, assigns.plan_to_render)
+
+    assigns =
+      assigns
+      |> assign(:paddle_product_id, paddle_product_id)
+      |> assign(:change_plan_link_text, change_plan_link_text)
+      |> assign(:checkout_disabled, checkout_disabled)
+      |> assign(:disabled_message, disabled_message)
+      |> assign(:exceeded_plan_limits, exceeded_plan_limits)
+      |> assign(:confirm_message, losing_features_message(feature_usage_check))
+
+    ~H"""
+    <%= if @owned_plan && Plausible.Billing.Subscriptions.resumable?(@current_team.subscription) do %>
+      <.change_plan_link {assigns} />
+    <% else %>
+      <PlausibleWeb.Components.Billing.paddle_button
+        user={@current_user}
+        team={@current_team}
+        {assigns}
+      >
+        Upgrade
+      </PlausibleWeb.Components.Billing.paddle_button>
+    <% end %>
+    <.tooltip :if={@exceeded_plan_limits != [] && @disabled_message}>
+      <div class="pt-2 text-sm w-full flex items-center text-red-700 dark:text-red-500 justify-center">
+        {@disabled_message}
+        <Heroicons.information_circle class="hidden sm:block w-5 h-5 sm:ml-2" />
+      </div>
+      <:tooltip_content>
+        Your usage exceeds the following limit(s):<br /><br />
+        <p :for={limit <- @exceeded_plan_limits}>
+          {Phoenix.Naming.humanize(limit)}<br />
+        </p>
+      </:tooltip_content>
+    </.tooltip>
+    <div
+      :if={@disabled_message && @exceeded_plan_limits == []}
+      class="pt-2 text-sm w-full text-red-700 dark:text-red-500 text-center"
+    >
+      {@disabled_message}
+    </div>
+    """
+  end
+
+  defp check_usage_within_plan_limits(%{available: false}) do
+    {:error, :plan_unavailable}
+  end
+
+  defp check_usage_within_plan_limits(%{
+         available: true,
+         usage: usage,
+         current_team: current_team,
+         plan_to_render: plan
+       }) do
+    # At this point, the user is *not guaranteed* to have a team,
+    # with ongoing trial.
+    trial_active_or_ended_recently? =
+      not is_nil(current_team) and not is_nil(current_team.trial_expiry_date) and
+        Plausible.Teams.trial_days_left(current_team) >= -10
+
+    limit_checking_opts =
+      cond do
+        current_team && current_team.allow_next_upgrade_override ->
+          [ignore_pageview_limit: true]
+
+        trial_active_or_ended_recently? && plan.volume == "10k" ->
+          [pageview_allowance_margin: 0.3]
+
+        trial_active_or_ended_recently? ->
+          [pageview_allowance_margin: 0.15]
+
+        true ->
+          []
+      end
+
+    Quota.ensure_within_plan_limits(usage, plan, limit_checking_opts)
+  end
+
+  defp get_paddle_product_id(%Plan{monthly_product_id: plan_id}, :monthly), do: plan_id
+  defp get_paddle_product_id(%Plan{yearly_product_id: plan_id}, :yearly), do: plan_id
+
+  defp change_plan_link_text(
+         %{
+           owned_plan: %Plan{kind: from_kind, monthly_pageview_limit: from_volume},
+           plan_to_render: %Plan{kind: to_kind, monthly_pageview_limit: to_volume},
+           current_interval: from_interval,
+           selected_interval: to_interval
+         } = _assigns
+       ) do
+    cond do
+      from_kind == :business && to_kind == :growth ->
+        "Downgrade to Growth"
+
+      from_kind == :growth && to_kind == :business ->
+        "Upgrade to Business"
+
+      from_volume == to_volume && from_interval == to_interval ->
+        "Currently on this plan"
+
+      from_volume == to_volume ->
+        "Change billing interval"
+
+      from_volume > to_volume ->
+        "Downgrade"
+
+      true ->
+        "Upgrade"
+    end
+  end
+
+  defp change_plan_link_text(_), do: nil
+
+  defp change_plan_link(assigns) do
+    confirmed =
+      if assigns.confirm_message, do: "confirm(\"#{assigns.confirm_message}\")", else: "true"
+
+    assigns = assign(assigns, :confirmed, confirmed)
+
+    ~H"""
+    <button
+      id={"#{@kind}-checkout"}
+      onclick={"if (#{@confirmed}) {window.location = '#{Routes.billing_path(PlausibleWeb.Endpoint, :change_plan_preview, @paddle_product_id)}'}"}
+      class={[
+        "w-full mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 text-white",
+        !@checkout_disabled && "bg-indigo-600 hover:bg-indigo-500",
+        @checkout_disabled && "pointer-events-none bg-gray-400 dark:bg-gray-600"
+      ]}
+    >
+      {@change_plan_link_text}
+    </button>
+    """
+  end
+
+  defp losing_features_message(:ok), do: nil
+
+  defp losing_features_message({:error, {:unavailable_features, features}}) do
+    features_list_str =
+      features
+      |> Enum.map(fn feature_mod -> feature_mod.display_name() end)
+      |> PlausibleWeb.TextHelpers.pretty_join()
+
+    "This plan does not support #{features_list_str}, which you have been using. By subscribing to this plan, you will not have access to #{if length(features) == 1, do: "this feature", else: "these features"}."
+  end
+
+  defp contact_button(assigns) do
+    ~H"""
+    <.link
+      href="https://plausible.io/contact"
+      class={[
+        "mt-6 block rounded-md py-2 px-3 text-center text-sm font-semibold leading-6 bg-gray-800 hover:bg-gray-700 text-white dark:bg-indigo-600 dark:hover:bg-indigo-500",
+        @class
+      ]}
+    >
+      Contact us
+    </.link>
+    """
+  end
+end

--- a/lib/plausible_web/components/billing/plan_benefits.ex
+++ b/lib/plausible_web/components/billing/plan_benefits.ex
@@ -144,7 +144,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
     <p>
       Sites API access for
       <.link
-        class="text-indigo-500 hover:text-indigo-400"
+        class="text-indigo-500 hover:underline"
         href="https://plausible.io/white-label-web-analytics"
       >
         reselling

--- a/lib/plausible_web/components/billing/plan_benefits.ex
+++ b/lib/plausible_web/components/billing/plan_benefits.ex
@@ -13,7 +13,8 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
   @doc """
   This function takes a list of benefits returned by either one of:
 
-  * `for_growth/1`
+  * `for_starter/1`
+  * `for_growth/2`
   * `for_business/2`
   * `for_enterprise/1`.
 
@@ -25,9 +26,9 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
   """
   def render(assigns) do
     ~H"""
-    <ul role="list" class={["mt-8 space-y-3 text-sm leading-6 xl:mt-10", @class]}>
-      <li :for={benefit <- @benefits} class="flex gap-x-3">
-        <Heroicons.check class="h-6 w-5 text-indigo-600 dark:text-green-600" />
+    <ul role="list" class={["mt-8 space-y-1 text-sm leading-6", @class]}>
+      <li :for={benefit <- @benefits} class="flex gap-x-1">
+        <Heroicons.check class="shrink-0 h-5 w-5 text-indigo-600 dark:text-green-600" />
         {if is_binary(benefit), do: benefit, else: benefit.(assigns)}
       </li>
     </ul>
@@ -35,20 +36,36 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
   end
 
   @doc """
-  This function takes a growth plan and returns a list representing
+  This function takes a starter plan and returns a list representing
   the different benefits a user gets when subscribing to this plan.
   """
-  def for_growth(plan) do
+  def for_starter(starter_plan) do
     [
-      team_member_limit_benefit(plan),
-      site_limit_benefit(plan),
-      data_retention_benefit(plan),
+      site_limit_benefit(starter_plan),
+      data_retention_benefit(starter_plan),
       "Intuitive, fast and privacy-friendly dashboard",
       "Email/Slack reports",
       "Google Analytics import"
     ]
-    |> Kernel.++(feature_benefits(plan))
+    |> Kernel.++(feature_benefits(starter_plan))
     |> Kernel.++(["Saved Segments"])
+  end
+
+  @doc """
+  Returns Growth benefits for the given Growth plan.
+
+  A second argument is also required - list of Starter benefits. This
+  is because we don't want to list the same benefits in both Starter
+  and Growth. Everything in Starter is also included in Growth.
+  """
+  def for_growth(growth_plan, starter_benefits) do
+    [
+      "Everything in Starter",
+      site_limit_benefit(growth_plan),
+      team_member_limit_benefit(growth_plan)
+    ]
+    |> Kernel.++(feature_benefits(growth_plan))
+    |> Kernel.--(starter_benefits)
     |> Enum.filter(& &1)
   end
 
@@ -59,7 +76,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
   is because we don't want to list the same benefits in both Growth
   and Business. Everything in Growth is also included in Business.
   """
-  def for_business(plan, growth_benefits) do
+  def for_business(plan, growth_benefits, starter_benefits) do
     [
       "Everything in Growth",
       team_member_limit_benefit(plan),
@@ -68,6 +85,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
     ]
     |> Kernel.++(feature_benefits(plan))
     |> Kernel.--(growth_benefits)
+    |> Kernel.--(starter_benefits)
     |> Kernel.++(["Priority support"])
     |> Enum.filter(& &1)
   end

--- a/lib/plausible_web/components/billing/plan_benefits.ex
+++ b/lib/plausible_web/components/billing/plan_benefits.ex
@@ -79,8 +79,8 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
   def for_business(plan, growth_benefits, starter_benefits) do
     [
       "Everything in Growth",
-      team_member_limit_benefit(plan),
       site_limit_benefit(plan),
+      team_member_limit_benefit(plan),
       data_retention_benefit(plan)
     ]
     |> Kernel.++(feature_benefits(plan))
@@ -133,6 +133,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
       case feature_mod.name() do
         :goals -> ["Goals and custom events"]
         :stats_api -> ["Stats API (600 requests per hour)", "Looker Studio Connector"]
+        :shared_links -> ["Shared Links", "Embedded Dashboards"]
         :revenue_goals -> ["Ecommerce revenue attribution"]
         _ -> [feature_mod.display_name()]
       end

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     <div
       id={"#{@kind}-plan-box"}
       class={[
-        "shadow-lg border border-gray-200 bg-white rounded-xl px-6 sm:px-4 py-4 sm:py-3 dark:bg-gray-800",
+        "shadow-lg border border-gray-200 dark:border-none bg-white rounded-xl px-6 sm:px-4 py-4 sm:py-3 dark:bg-gray-800",
         !@highlight && "dark:ring-gray-600",
         @highlight && "ring-2 ring-indigo-600 dark:ring-indigo-300"
       ]}

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     <div
       id={"#{@kind}-plan-box"}
       class={[
-        "shadow-lg bg-white rounded-3xl px-6 sm:px-8 py-4 sm:py-6 dark:bg-gray-800",
+        "shadow-lg border border-gray-200 bg-white rounded-xl px-6 sm:px-4 py-4 sm:py-3 dark:bg-gray-800",
         !@highlight && "dark:ring-gray-600",
         @highlight && "ring-2 ring-indigo-600 dark:ring-indigo-300"
       ]}
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     <div
       id="enterprise-plan-box"
       class={[
-        "rounded-3xl px-6 sm:px-8 py-4 sm:py-6 bg-gray-900 shadow-xl dark:bg-gray-800",
+        "rounded-xl px-6 sm:px-4 py-4 sm:py-3 bg-gray-900 shadow-xl dark:bg-gray-800",
         !@recommended && "dark:ring-gray-600",
         @recommended && "ring-4 ring-indigo-500 dark:ring-2 dark:ring-indigo-300"
       ]}
@@ -237,7 +237,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       </PlausibleWeb.Components.Billing.paddle_button>
     <% end %>
     <.tooltip :if={@exceeded_plan_limits != [] && @disabled_message}>
-      <div class="pt-2 text-sm w-full flex items-center text-red-700 dark:text-red-500 justify-center">
+      <div class="absolute top-0 text-sm w-full flex items-center text-red-700 dark:text-red-500 justify-center">
         {@disabled_message}
         <Heroicons.information_circle class="hidden sm:block w-5 h-5 sm:ml-2" />
       </div>
@@ -303,10 +303,16 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
          } = _assigns
        ) do
     cond do
+      from_kind in [:growth, :business] && to_kind == :starter ->
+        "Downgrade to Starter"
+
       from_kind == :business && to_kind == :growth ->
         "Downgrade to Growth"
 
-      from_kind == :growth && to_kind == :business ->
+      from_kind == :starter && to_kind == :growth ->
+        "Upgrade to Growth"
+
+      from_kind in [:starter, :growth] && to_kind == :business ->
         "Upgrade to Business"
 
       from_volume == to_volume && from_interval == to_interval ->

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -37,7 +37,9 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
         <.pill :if={@highlight} text={@highlight} />
       </div>
       <div>
-        <.render_price_info available={@available} {assigns} />
+        <div class="h-20 pt-6 max-h-20 whitespace-nowrap overflow-hidden">
+          <.render_price_info available={@available} {assigns} />
+        </div>
         <%= if @available do %>
           <.checkout id={"#{@kind}-checkout"} {assigns} />
         <% else %>
@@ -79,12 +81,11 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
           Recommended
         </span>
       </div>
-      <p class="mt-6 flex items-baseline gap-x-1">
-        <span class="text-4xl font-bold tracking-tight text-white dark:text-gray-100">
+      <div class="h-20 pt-6 max-h-20 whitespace-nowrap overflow-hidden">
+        <span class="text-3xl lg:text-2xl xl:text-3xl font-bold tracking-tight text-white dark:text-gray-100">
           Custom
         </span>
-      </p>
-      <p class="h-4 mt-1"></p>
+      </div>
       <.contact_button class="" />
       <PlanBenefits.render benefits={@benefits} class="text-gray-300 dark:text-gray-100" />
     </div>
@@ -106,8 +107,8 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
   defp render_price_info(%{available: false} = assigns) do
     ~H"""
-    <p id={"#{@kind}-custom-price"} class="mt-6 flex items-baseline gap-x-1">
-      <span class="text-4xl font-bold tracking-tight text-gray-900 dark:text-white">
+    <p id={"#{@kind}-custom-price"} class="flex items-baseline gap-x-1">
+      <span class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
         Custom
       </span>
     </p>
@@ -117,7 +118,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
   defp render_price_info(assigns) do
     ~H"""
-    <p class="mt-6 flex items-baseline gap-x-1">
+    <p class="flex items-baseline gap-x-1">
       <.price_tag
         kind={@kind}
         selected_interval={@selected_interval}
@@ -130,7 +131,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
   defp price_tag(%{plan_to_render: %Plan{monthly_cost: nil}} = assigns) do
     ~H"""
-    <span class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+    <span class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
       N/A
     </span>
     """
@@ -140,7 +141,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
     ~H"""
     <span
       id={"#{@kind}-price-tag-amount"}
-      class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
+      class="text-3xl lg:text-2xl xl:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
     >
       {@plan_to_render.monthly_cost |> Plausible.Billing.format_price()}
     </span>
@@ -155,12 +156,12 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
   defp price_tag(%{selected_interval: :yearly} = assigns) do
     ~H"""
-    <span class="text-2xl font-bold w-max tracking-tight line-through text-gray-500 dark:text-gray-600 mr-1">
+    <span class="text-xl lg:text-lg xl:text-xl font-bold w-max tracking-tight line-through text-gray-500 dark:text-gray-600 mr-1">
       {@plan_to_render.monthly_cost |> Money.mult!(12) |> Plausible.Billing.format_price()}
     </span>
     <span
       id={"#{@kind}-price-tag-amount"}
-      class="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
+      class="text-3xl lg:text-2xl xl:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100"
     >
       {@plan_to_render.yearly_cost |> Plausible.Billing.format_price()}
     </span>

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -483,6 +483,62 @@ defmodule PlausibleWeb.Components.Generic do
     """
   end
 
+  slot :inner_block, required: true
+
+  def accordion_menu(assigns) do
+    ~H"""
+    <dl class="divide-y divide-gray-200">
+      {render_slot(@inner_block)}
+    </dl>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :title, :string, required: true
+  attr :open_by_default, :boolean, default: false
+  slot :inner_block, required: true
+
+  def accordion_item(assigns) do
+    ~H"""
+    <div x-data={"{ open: #{@open_by_default}}"} class="py-4">
+      <dt>
+        <button
+          type="button"
+          class="flex w-full items-start justify-between text-left text-gray-900 dark:text-gray-100"
+          @click="open = !open"
+        >
+          <span class="text-base font-semibold">{@title}</span>
+          <span class="ml-6 flex h-6 items-center">
+            <svg
+              x-show="!open"
+              class="size-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+            </svg>
+            <svg
+              x-show="open"
+              class="size-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M18 12H6" />
+            </svg>
+          </span>
+        </button>
+      </dt>
+      <dd x-show="open" id={@id} class="mt-2 pr-12 text-gray-600 text-sm">
+        {render_slot(@inner_block)}
+      </dd>
+    </div>
+    """
+  end
+
   attr(:rest, :global, include: ~w(fill stroke stroke-width))
   attr(:name, :atom, required: true)
   attr(:outline, :boolean, default: true)

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -487,7 +487,7 @@ defmodule PlausibleWeb.Components.Generic do
 
   def accordion_menu(assigns) do
     ~H"""
-    <dl class="divide-y divide-gray-200">
+    <dl class="divide-y divide-gray-200 dark:divide-gray-700">
       {render_slot(@inner_block)}
     </dl>
     """
@@ -496,6 +496,7 @@ defmodule PlausibleWeb.Components.Generic do
   attr :id, :string, required: true
   attr :title, :string, required: true
   attr :open_by_default, :boolean, default: false
+  attr :title_class, :string, default: ""
   slot :inner_block, required: true
 
   def accordion_item(assigns) do
@@ -504,7 +505,7 @@ defmodule PlausibleWeb.Components.Generic do
       <dt>
         <button
           type="button"
-          class="flex w-full items-start justify-between text-left text-gray-900 dark:text-gray-100"
+          class={"flex w-full items-start justify-between text-left #{@title_class}"}
           @click="open = !open"
         >
           <span class="text-base font-semibold">{@title}</span>
@@ -532,7 +533,7 @@ defmodule PlausibleWeb.Components.Generic do
           </span>
         </button>
       </dt>
-      <dd x-show="open" id={@id} class="mt-2 pr-12 text-gray-600 text-sm">
+      <dd x-show="open" id={@id} class="mt-2 pr-12 text-sm">
         {render_slot(@inner_block)}
       </dd>
     </div>

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -19,11 +19,11 @@ defmodule PlausibleWeb.BillingController do
   def choose_plan(conn, _params) do
     team = conn.assigns.current_team
 
-    live_module =
+    {live_module, hide_header?} =
       if FunWithFlags.enabled?(:starter_tier, for: conn.assigns.current_user) do
-        PlausibleWeb.Live.ChoosePlan
+        {PlausibleWeb.Live.ChoosePlan, true}
       else
-        PlausibleWeb.Live.LegacyChoosePlan
+        {PlausibleWeb.Live.LegacyChoosePlan, false}
       end
 
     if Plausible.Teams.Billing.enterprise_configured?(team) do
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.BillingController do
     else
       render(conn, "choose_plan.html",
         live_module: live_module,
-        hide_header?: true,
+        hide_header?: hide_header?,
         disable_global_notices?: true,
         skip_plausible_tracking: true,
         connect_live_socket: true

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -19,10 +19,18 @@ defmodule PlausibleWeb.BillingController do
   def choose_plan(conn, _params) do
     team = conn.assigns.current_team
 
+    live_module =
+      if FunWithFlags.enabled?(:starter_tier, for: conn.assigns.current_user) do
+        PlausibleWeb.Live.ChoosePlan
+      else
+        PlausibleWeb.Live.LegacyChoosePlan
+      end
+
     if Plausible.Teams.Billing.enterprise_configured?(team) do
       redirect(conn, to: Routes.billing_path(conn, :upgrade_to_enterprise_plan))
     else
       render(conn, "choose_plan.html",
+        live_module: live_module,
         disable_global_notices?: true,
         skip_plausible_tracking: true,
         connect_live_socket: true

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -31,6 +31,7 @@ defmodule PlausibleWeb.BillingController do
     else
       render(conn, "choose_plan.html",
         live_module: live_module,
+        hide_header?: true,
         disable_global_notices?: true,
         skip_plausible_tracking: true,
         connect_live_socket: true

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -143,7 +143,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <div class="mt-6 w-full md:flex">
           <a
             href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
-            class="hidden md:flex md:w-1/6 h-max text-indigo-600 text-sm font-semibold gap-1 items-center"
+            class="hidden md:flex md:w-1/6 h-max text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-bold gap-1 items-center"
           >
             <span>←</span>
             <p>Back to Settings</p>
@@ -162,7 +162,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <div class="md:hidden mt-6 max-w-md mx-auto">
           <a
             href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
-            class="text-indigo-600 text-sm font-semibold"
+            class="text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-bold"
           >
             ← Back to Settings
           </a>
@@ -209,15 +209,25 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         </div>
         <div class="mt-2 mx-auto max-w-md lg:max-w-3xl">
           <.accordion_menu>
-            <.accordion_item open_by_default={true} id="usage" title="What's my current usage?">
-              <.render_usage pageview_usage={@usage.monthly_pageviews} />
+            <.accordion_item
+              open_by_default={true}
+              id="usage"
+              title="What's my current usage?"
+              title_class="text-gray-900 dark:text-gray-200"
+            >
+              <p class="text-gray-600 dark:text-gray-300">
+                <.render_usage pageview_usage={@usage.monthly_pageviews} />
+              </p>
             </.accordion_item>
 
             <.accordion_item
               id="over-limit"
               title="What happens if I go over my monthly pageview limit?"
+              title_class="text-gray-900 dark:text-gray-200"
             >
-              You will never be charged extra for an occasional traffic spike. There are no surprise fees and your card will never be charged unexpectedly.               If your page views exceed your plan for two consecutive months, we will contact you to upgrade to a higher plan for the following month. You will have two weeks to make a decision. You can decide to continue with a higher plan or to cancel your account at that point.
+              <p class="text-gray-600 dark:text-gray-300">
+                You will never be charged extra for an occasional traffic spike. There are no surprise fees and your card will never be charged unexpectedly. If your pageviews exceed your plan for two consecutive months, we will contact you to upgrade to a higher plan for the following month. You will have two weeks to make a decision. You can decide to continue with a higher plan or to cancel your account at that point.
+              </p>
             </.accordion_item>
           </.accordion_menu>
         </div>
@@ -341,8 +351,9 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   defp help_links(assigns) do
     ~H"""
     <div class="mt-16 -mb-16 text-center">
-      Any other questions? <a class="text-indigo-600" href={contact_link()}>Contact us</a>
-      or see <a class="text-indigo-600" href={billing_faq_link()}>billing FAQ</a>
+      Any other questions?
+      <a class="text-indigo-600 hover:underline" href={contact_link()}>Contact us</a>
+      or see <a class="text-indigo-600 hover:underline" href={billing_faq_link()}>billing FAQ</a>
     </div>
     """
   end

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -140,15 +140,15 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <Notice.subscription_paused class="pb-6" subscription={@subscription} />
         <Notice.upgrade_ineligible :if={not Quota.eligible_for_upgrade?(@usage)} />
 
-        <div class="mt-6 w-full flex">
+        <div class="mt-6 w-full md:flex">
           <a
             href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
-            class="w-1/6 h-max flex text-indigo-600 text-sm font-semibold gap-1 items-center"
+            class="hidden md:flex md:w-1/6 h-max text-indigo-600 text-sm font-semibold gap-1 items-center"
           >
-            <Heroicons.arrow_left class="h-5 w-5" />
+            <span>←</span>
             <p>Back to Settings</p>
           </a>
-          <div class="w-4/6">
+          <div class="md:w-4/6">
             <h1 class="mx-auto max-w-4xl text-center text-2xl font-bold tracking-tight lg:text-3xl">
               Traffic based plans that match your growth
             </h1>
@@ -158,6 +158,14 @@ defmodule PlausibleWeb.Live.ChoosePlan do
                 else: "Upgrade your trial to a paid plan"}
             </p>
           </div>
+        </div>
+        <div class="md:hidden mt-6 max-w-md mx-auto">
+          <a
+            href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
+            class="text-indigo-600 text-sm font-semibold"
+          >
+            ← Back to Settings
+          </a>
         </div>
         <div class="mt-10 flex flex-col gap-8 lg:flex-row items-center lg:items-baseline">
           <.interval_picker selected_interval={@selected_interval} />
@@ -199,7 +207,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
             recommended={@recommended_tier == :custom}
           />
         </div>
-        <div class="mt-2 mx-auto max-w-4xl">
+        <div class="mt-2 mx-auto max-w-md lg:max-w-3xl">
           <.accordion_menu>
             <.accordion_item open_by_default={true} id="usage" title="What's my current usage?">
               <.render_usage pageview_usage={@usage.monthly_pageviews} />
@@ -223,19 +231,20 @@ defmodule PlausibleWeb.Live.ChoosePlan do
   defp render_usage(assigns) do
     ~H"""
     You have used
-    <span :if={@pageview_usage[:last_30_days]} class="inline-block">
-      <b><%= PlausibleWeb.AuthView.delimit_integer(@pageview_usage.last_30_days.total) %></b> billable pageviews in the last 30 days
+    <span :if={@pageview_usage[:last_30_days]} class="inline">
+      <b><%= PlausibleWeb.AuthView.delimit_integer(@pageview_usage.last_30_days.total) %></b> billable pageviews in the last 30 days.
     </span>
-    <span :if={@pageview_usage[:last_cycle]} class="inline-block">
-      <b><%= PlausibleWeb.AuthView.delimit_integer(@pageview_usage.last_cycle.total) %></b> billable pageviews in the last billing cycle
-    </span>.
+    <span :if={@pageview_usage[:last_cycle]} class="inline">
+      <b>{PlausibleWeb.AuthView.delimit_integer(@pageview_usage.last_cycle.total)}</b>
+      billable pageviews in the last billing cycle.
+    </span>
     Please see your full usage report (including sites and team members) under the
     <a
-      class="text-indigo-600 inline-block hover:underline"
+      class="text-indigo-600 inline hover:underline"
       href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
     >
-      "Subscription" section in your account settings
-    </a>.
+      "Subscription" section
+    </a> in your account settings.
     """
   end
 
@@ -331,7 +340,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
 
   defp help_links(assigns) do
     ~H"""
-    <div class="mt-16 text-center">
+    <div class="mt-16 -mb-16 text-center">
       Any other questions? <a class="text-indigo-600" href={contact_link()}>Contact us</a>
       or see <a class="text-indigo-600" href={billing_faq_link()}>billing FAQ</a>
     </div>

--- a/lib/plausible_web/live/legacy_choose_plan.ex
+++ b/lib/plausible_web/live/legacy_choose_plan.ex
@@ -1,12 +1,21 @@
-defmodule PlausibleWeb.Live.ChoosePlan do
+defmodule PlausibleWeb.Live.LegacyChoosePlan do
   @moduledoc """
-  LiveView for upgrading to a plan, or changing an existing plan.
+  [DEPRECATED] This file is essentially a copy of
+  `PlausibleWeb.Live.ChoosePlan` with the
+  intent of keeping the old behaviour in place for the users without
+  the `starter_tier` feature flag enabled.
   """
   use PlausibleWeb, :live_view
 
   require Plausible.Billing.Subscription.Status
 
-  alias PlausibleWeb.Components.Billing.{PlanBox, PlanBenefits, Notice, PageviewSlider}
+  alias PlausibleWeb.Components.Billing.{
+    LegacyPlanBox,
+    LegacyPlanBenefits,
+    Notice,
+    PageviewSlider
+  }
+
   alias Plausible.Billing.{Plans, Quota}
 
   @contact_link "https://plausible.io/contact"
@@ -40,11 +49,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         current_user_subscription_interval(subscription)
       end)
       |> assign_new(:available_plans, fn %{subscription: subscription} ->
-        Plans.available_plans_for(subscription,
-          with_prices: true,
-          customer_ip: remote_ip,
-          v5?: true
-        )
+        Plans.available_plans_for(subscription, with_prices: true, customer_ip: remote_ip)
       end)
       |> assign_new(:recommended_tier, fn %{
                                             usage: usage,
@@ -91,12 +96,12 @@ defmodule PlausibleWeb.Live.ChoosePlan do
       assigns.selected_business_plan || List.last(assigns.available_plans.business)
 
     growth_benefits =
-      PlanBenefits.for_growth(growth_plan_to_render)
+      LegacyPlanBenefits.for_growth(growth_plan_to_render)
 
     business_benefits =
-      PlanBenefits.for_business(business_plan_to_render, growth_benefits)
+      LegacyPlanBenefits.for_business(business_plan_to_render, growth_benefits)
 
-    enterprise_benefits = PlanBenefits.for_enterprise(business_benefits)
+    enterprise_benefits = LegacyPlanBenefits.for_enterprise(business_benefits)
 
     assigns =
       assigns
@@ -131,7 +136,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
           />
         </div>
         <div class="mt-6 isolate mx-auto grid max-w-md grid-cols-1 gap-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-          <PlanBox.standard
+          <LegacyPlanBox.standard
             kind={:growth}
             owned={@owned_tier == :growth}
             recommended={@recommended_tier == :growth}
@@ -140,7 +145,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
             available={!!@selected_growth_plan}
             {assigns}
           />
-          <PlanBox.standard
+          <LegacyPlanBox.standard
             kind={:business}
             owned={@owned_tier == :business}
             recommended={@recommended_tier == :business}
@@ -149,7 +154,7 @@ defmodule PlausibleWeb.Live.ChoosePlan do
             available={!!@selected_business_plan}
             {assigns}
           />
-          <PlanBox.enterprise
+          <LegacyPlanBox.enterprise
             benefits={@enterprise_benefits}
             recommended={@recommended_tier == :custom}
           />

--- a/lib/plausible_web/live/legacy_choose_plan.ex
+++ b/lib/plausible_web/live/legacy_choose_plan.ex
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Live.LegacyChoosePlan do
                                           } ->
         highest_growth_plan = List.last(available_plans.growth)
         highest_business_plan = List.last(available_plans.business)
-        Quota.suggest_tier(usage, highest_growth_plan, highest_business_plan, owned_tier)
+        Quota.legacy_suggest_tier(usage, highest_growth_plan, highest_business_plan, owned_tier)
       end)
       |> assign_new(:available_volumes, fn %{available_plans: available_plans} ->
         get_available_volumes(available_plans)

--- a/lib/plausible_web/templates/billing/choose_plan.html.heex
+++ b/lib/plausible_web/templates/billing/choose_plan.html.heex
@@ -1,4 +1,4 @@
-{live_render(@conn, PlausibleWeb.Live.ChoosePlan,
+{live_render(@conn, @live_module,
   id: "choose-plan",
   session: %{"remote_ip" => PlausibleWeb.RemoteIP.get(@conn)}
 )}

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -33,7 +33,7 @@
     ]}
     style={if assigns[:background], do: "background-color: #{assigns[:background]}"}
   >
-    <%= if !assigns[:embedded] do %>
+    <%= if !assigns[:embedded] && !assigns[:hide_header?] do %>
       {render("_header.html", assigns)}
 
       <%= if !assigns[:disable_global_notices?] do %>

--- a/priv/plans_v5.json
+++ b/priv/plans_v5.json
@@ -113,9 +113,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -129,9 +129,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -145,9 +145,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -161,9 +161,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -177,9 +177,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -193,9 +193,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -209,9 +209,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -225,9 +225,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -241,13 +241,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -261,13 +261,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -281,13 +281,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -301,13 +301,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -321,13 +321,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -341,13 +341,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -361,13 +361,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -381,13 +381,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   }

--- a/priv/sandbox_plans_v5.json
+++ b/priv/sandbox_plans_v5.json
@@ -113,9 +113,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -129,9 +129,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -145,9 +145,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -161,9 +161,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -177,9 +177,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -193,9 +193,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -209,9 +209,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -225,9 +225,9 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "site_segments",
       "teams",
-      "shared_links"
+      "shared_links",
+      "site_segments"
     ],
     "data_retention_in_years": 3
   },
@@ -241,13 +241,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -261,13 +261,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -281,13 +281,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -301,13 +301,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -321,13 +321,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -341,13 +341,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -361,13 +361,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   },
@@ -381,13 +381,13 @@
     "team_member_limit": 10,
     "features": [
       "goals",
+      "teams",
+      "shared_links",
+      "site_segments",
       "props",
       "stats_api",
       "revenue_goals",
-      "funnels",
-      "site_segments",
-      "teams",
-      "shared_links"
+      "funnels"
     ],
     "data_retention_in_years": 5
   }

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -179,7 +179,7 @@ defmodule Plausible.Billing.PlansTest do
         Plausible.Teams.Billing.latest_enterprise_plan_with_price(team, "127.0.0.1")
 
       assert enterprise_plan.paddle_plan_id == "123"
-      assert price == Money.new(:EUR, "10.0")
+      assert price == Money.new(:EUR, "123.00")
     end
   end
 

--- a/test/plausible/billing/plans_test.exs
+++ b/test/plausible/billing/plans_test.exs
@@ -36,7 +36,7 @@ defmodule Plausible.Billing.PlansTest do
       |> assert_generation(2)
     end
 
-    test "growth_plans_for/1 returns v4 plans for expired legacy subscriptions" do
+    test "growth_plans_for/1 returns latest plans for expired legacy subscriptions" do
       new_user()
       |> subscribe_to_plan(@v1_plan_id, status: :deleted, next_bill_date: ~D[2023-11-10])
       |> team_of(with_subscription?: true)
@@ -45,7 +45,7 @@ defmodule Plausible.Billing.PlansTest do
       |> assert_generation(4)
     end
 
-    test "growth_plans_for/1 shows v4 plans for everyone else" do
+    test "growth_plans_for/1 shows latest plans for everyone else" do
       new_user(trial_expiry_date: Date.utc_today())
       |> team_of(with_subscription?: true)
       |> Map.fetch!(:subscription)
@@ -92,13 +92,13 @@ defmodule Plausible.Billing.PlansTest do
       assert_generation(business_plans, 3)
     end
 
-    test "business_plans_for/1 returns v4 plans for invited users with trial_expiry = nil" do
+    test "business_plans_for/1 returns latest plans for invited users with trial_expiry = nil" do
       nil
       |> Plans.business_plans_for()
       |> assert_generation(4)
     end
 
-    test "business_plans_for/1 returns v4 plans for expired legacy subscriptions" do
+    test "business_plans_for/1 returns latest plans for expired legacy subscriptions" do
       user =
         new_user()
         |> subscribe_to_plan(@v2_plan_id, status: :deleted, next_bill_date: ~D[2023-11-10])
@@ -110,7 +110,7 @@ defmodule Plausible.Billing.PlansTest do
       |> assert_generation(4)
     end
 
-    test "business_plans_for/1 returns v4 business plans for everyone else" do
+    test "business_plans_for/1 returns latest business plans for everyone else" do
       user = new_user(trial_expiry_date: Date.utc_today())
 
       subscription =
@@ -309,7 +309,31 @@ defmodule Plausible.Billing.PlansTest do
                "857091",
                "857092",
                "857093",
-               "857094"
+               "857094",
+               "910414",
+               "910416",
+               "910418",
+               "910420",
+               "910422",
+               "910424",
+               "910426",
+               "910428",
+               "910430",
+               "910432",
+               "910434",
+               "910436",
+               "910438",
+               "910440",
+               "910442",
+               "910444",
+               "910446",
+               "910448",
+               "910450",
+               "910452",
+               "910454",
+               "910456",
+               "910458",
+               "910460"
              ] == Plans.yearly_product_ids()
     end
   end

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -124,7 +124,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Paid",
                   plan_link: ^plan_link,
-                  plan_label: "10k Plan (€10 monthly)"
+                  plan_label: "10k Plan (€19 monthly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -149,7 +149,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Paid",
                   plan_link: ^plan_link,
-                  plan_label: "10k Plan (€100 yearly)"
+                  plan_label: "10k Plan (€190 yearly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -183,7 +183,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Paid",
                   plan_link: _,
-                  plan_label: "1M Enterprise Plan (€10 monthly)"
+                  plan_label: "1M Enterprise Plan (€123 monthly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -202,7 +202,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Paid",
                   plan_link: _,
-                  plan_label: "1M Enterprise Plan (€10 yearly)"
+                  plan_label: "1M Enterprise Plan (€123 yearly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -220,7 +220,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Pending cancellation",
                   plan_link: _,
-                  plan_label: "10k Plan (€10 monthly)"
+                  plan_label: "10k Plan (€19 monthly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -239,7 +239,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Canceled",
                   plan_link: _,
-                  plan_label: "10k Plan (€10 monthly)"
+                  plan_label: "10k Plan (€19 monthly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -257,7 +257,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Paused",
                   plan_link: _,
-                  plan_label: "10k Plan (€10 monthly)"
+                  plan_label: "10k Plan (€19 monthly)"
                 }} = HelpScout.get_details_for_customer("500")
       end
 
@@ -275,7 +275,7 @@ defmodule Plausible.HelpScoutTest do
                   status_link: _,
                   status_label: "Dashboard locked",
                   plan_link: _,
-                  plan_label: "10k Plan (€10 monthly)",
+                  plan_label: "10k Plan (€19 monthly)",
                   sites_count: 1
                 }} = HelpScout.get_details_for_customer("500")
       end

--- a/test/plausible/release_test.exs
+++ b/test/plausible/release_test.exs
@@ -40,7 +40,7 @@ defmodule Plausible.ReleaseTest do
     assert stdout =~ "Loading plausible.."
     assert stdout =~ "Starting dependencies.."
     assert stdout =~ "Starting repos.."
-    assert stdout =~ "Inserted 54 plans"
+    assert stdout =~ "Inserted 78 plans"
   end
 
   test "ecto_repos sanity check" do

--- a/test/plausible_web/controllers/billing_controller_test.exs
+++ b/test/plausible_web/controllers/billing_controller_test.exs
@@ -146,7 +146,7 @@ defmodule PlausibleWeb.BillingControllerTest do
       assert doc =~ ~r/Up to\s*<b>\s*50M\s*<\/b>\s*monthly pageviews/
       assert doc =~ ~r/Up to\s*<b>\s*20k\s*<\/b>\s*sites/
       assert doc =~ ~r/Up to\s*<b>\s*5k\s*<\/b>\s*hourly api requests/
-      assert doc =~ ~r/The plan is priced at\s*<b>\s*€10\s*<\/b>\s*/
+      assert doc =~ ~r/The plan is priced at\s*<b>\s*€123\s*<\/b>\s*/
       assert doc =~ "per year"
     end
 
@@ -197,7 +197,7 @@ defmodule PlausibleWeb.BillingControllerTest do
       assert doc =~ ~r/Up to\s*<b>\s*50M\s*<\/b>\s*monthly pageviews/
       assert doc =~ ~r/Up to\s*<b>\s*20k\s*<\/b>\s*sites/
       assert doc =~ ~r/Up to\s*<b>\s*5k\s*<\/b>\s*hourly api requests/
-      assert doc =~ ~r/The plan is priced at\s*<b>\s*€10\s*<\/b>\s*/
+      assert doc =~ ~r/The plan is priced at\s*<b>\s*€123\s*<\/b>\s*/
       assert doc =~ "per year"
     end
 
@@ -321,7 +321,7 @@ defmodule PlausibleWeb.BillingControllerTest do
       assert doc =~ ~r/Up to\s*<b>\s*50M\s*<\/b>\s*monthly pageviews/
       assert doc =~ ~r/Up to\s*<b>\s*20k\s*<\/b>\s*sites/
       assert doc =~ ~r/Up to\s*<b>\s*5k\s*<\/b>\s*hourly api requests/
-      assert doc =~ ~r/The plan is priced at\s*<b>\s*€10\s*<\/b>\s*/
+      assert doc =~ ~r/The plan is priced at\s*<b>\s*€123\s*<\/b>\s*/
       assert doc =~ "per year"
     end
 

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -115,8 +115,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "default pageview limit is 10k", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @slider_value) == "10k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€10"
-      assert text_of_element(doc, @business_price_tag_amount) == "€90"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€14"
+      assert text_of_element(doc, @business_price_tag_amount) == "€19"
     end
 
     test "pageview slider changes selected volume and prices shown", %{conn: conn} do
@@ -124,38 +124,38 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "100k")
       assert text_of_element(doc, @slider_value) == "100k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€20"
-      assert text_of_element(doc, @business_price_tag_amount) == "€100"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€29"
+      assert text_of_element(doc, @business_price_tag_amount) == "€39"
 
       doc = set_slider(lv, "200k")
       assert text_of_element(doc, @slider_value) == "200k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€30"
-      assert text_of_element(doc, @business_price_tag_amount) == "€110"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€44"
+      assert text_of_element(doc, @business_price_tag_amount) == "€59"
 
       doc = set_slider(lv, "500k")
       assert text_of_element(doc, @slider_value) == "500k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€40"
-      assert text_of_element(doc, @business_price_tag_amount) == "€120"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€74"
+      assert text_of_element(doc, @business_price_tag_amount) == "€99"
 
       doc = set_slider(lv, "1M")
       assert text_of_element(doc, @slider_value) == "1M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€50"
-      assert text_of_element(doc, @business_price_tag_amount) == "€130"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€104"
+      assert text_of_element(doc, @business_price_tag_amount) == "€139"
 
       doc = set_slider(lv, "2M")
       assert text_of_element(doc, @slider_value) == "2M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€60"
-      assert text_of_element(doc, @business_price_tag_amount) == "€140"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€134"
+      assert text_of_element(doc, @business_price_tag_amount) == "€179"
 
       doc = set_slider(lv, "5M")
       assert text_of_element(doc, @slider_value) == "5M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€70"
-      assert text_of_element(doc, @business_price_tag_amount) == "€150"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€194"
+      assert text_of_element(doc, @business_price_tag_amount) == "€259"
 
       doc = set_slider(lv, "10M")
       assert text_of_element(doc, @slider_value) == "10M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€80"
-      assert text_of_element(doc, @business_price_tag_amount) == "€160"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€254"
+      assert text_of_element(doc, @business_price_tag_amount) == "€339"
     end
 
     test "renders contact links for business and growth tiers when enterprise-level volume selected",
@@ -182,18 +182,18 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "switching billing interval changes business and growth prices", %{conn: conn} do
       {:ok, lv, doc} = get_liveview(conn)
 
-      assert text_of_element(doc, @growth_price_tag_amount) == "€10"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€14"
       assert text_of_element(doc, @growth_price_tag_interval) == "/month"
 
-      assert text_of_element(doc, @business_price_tag_amount) == "€90"
+      assert text_of_element(doc, @business_price_tag_amount) == "€19"
       assert text_of_element(doc, @business_price_tag_interval) == "/month"
 
       doc = element(lv, @yearly_interval_button) |> render_click()
 
-      assert text_of_element(doc, @growth_price_tag_amount) == "€100"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€140"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
-      assert text_of_element(doc, @business_price_tag_amount) == "€900"
+      assert text_of_element(doc, @business_price_tag_amount) == "€190"
       assert text_of_element(doc, @business_price_tag_interval) == "/year"
     end
 
@@ -934,13 +934,13 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€900"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€1,800"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)
       assert text_of_element(doc, @slider_value) == "50M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€1,000"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€2,640"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 10)
@@ -963,7 +963,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€900"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€2,250"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -11,6 +11,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   @v1_10k_yearly_plan_id "572810"
   @v1_50m_yearly_plan_id "650653"
   @v2_20m_yearly_plan_id "653258"
+  @v5_starter_5m_monthly_plan_id "910425"
+  @v4_growth_10k_monthly_plan_id "857097"
   @v4_growth_10k_yearly_plan_id "857079"
   @v4_growth_200k_yearly_plan_id "857081"
   @v5_growth_200k_yearly_plan_id "910434"
@@ -23,6 +25,13 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   @interval_button_active_class "bg-indigo-600 text-white"
   @slider_input ~s/input[name="slider"]/
   @slider_value "#slider-value"
+
+  @starter_plan_box "#starter-plan-box"
+  @starter_plan_tooltip "#starter-plan-box .tooltip-content"
+  @starter_price_tag_amount "#starter-price-tag-amount"
+  @starter_price_tag_interval "#starter-price-tag-interval"
+  @starter_highlight_pill "#{@starter_plan_box} #highlight-pill"
+  @starter_checkout_button "#starter-checkout"
 
   @growth_plan_box "#growth-plan-box"
   @growth_plan_tooltip "#growth-plan-box .tooltip-content"
@@ -48,12 +57,13 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "displays basic page content", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
-      assert doc =~ "Upgrade your account"
+      assert doc =~ "Upgrade your trial"
+      assert doc =~ "Back to Settings"
       assert doc =~ "You have used"
       assert doc =~ "<b>0</b>"
       assert doc =~ "billable pageviews in the last 30 days"
-      assert doc =~ "Questions?"
-      assert doc =~ "What happens if I go over my page views limit?"
+      assert doc =~ "Any other questions?"
+      assert doc =~ "What happens if I go over my monthly pageview limit?"
       assert doc =~ "Enterprise"
       assert doc =~ "+ VAT if applicable"
     end
@@ -66,16 +76,23 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "displays plan benefits", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      starter_box = text_of_element(doc, @starter_plan_box)
       growth_box = text_of_element(doc, @growth_plan_box)
       business_box = text_of_element(doc, @business_plan_box)
       enterprise_box = text_of_element(doc, @enterprise_plan_box)
 
+      assert starter_box =~ "Intuitive, fast and privacy-friendly dashboard"
+      assert starter_box =~ "Email/Slack reports"
+      assert starter_box =~ "Google Analytics import"
+      assert starter_box =~ "Goals and custom events"
+      assert starter_box =~ "Up to 3 sites"
+      assert starter_box =~ "3 years of data retention"
+
       assert growth_box =~ "Up to 3 team members"
       assert growth_box =~ "Up to 10 sites"
-      assert growth_box =~ "Intuitive, fast and privacy-friendly dashboard"
-      assert growth_box =~ "Email/Slack reports"
-      assert growth_box =~ "Google Analytics import"
-      assert growth_box =~ "Goals and custom events"
+      assert growth_box =~ "Team Accounts"
+      assert growth_box =~ "Shared Links"
+      assert growth_box =~ "Shared Segments"
 
       assert business_box =~ "Everything in Growth"
       assert business_box =~ "Up to 10 team members"
@@ -100,23 +117,24 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                "https://plausible.io/white-label-web-analytics"
     end
 
-    test "default billing interval is monthly, and can switch to yearly", %{conn: conn} do
+    test "default billing interval is yearly, and can switch to monthly", %{conn: conn} do
       {:ok, lv, doc} = get_liveview(conn)
 
-      assert class_of_element(doc, @monthly_interval_button) =~ @interval_button_active_class
-      refute class_of_element(doc, @yearly_interval_button) =~ @interval_button_active_class
-
-      doc = element(lv, @yearly_interval_button) |> render_click()
-
-      refute class_of_element(doc, @monthly_interval_button) =~ @interval_button_active_class
       assert class_of_element(doc, @yearly_interval_button) =~ @interval_button_active_class
+      refute class_of_element(doc, @monthly_interval_button) =~ @interval_button_active_class
+
+      doc = element(lv, @monthly_interval_button) |> render_click()
+
+      refute class_of_element(doc, @yearly_interval_button) =~ @interval_button_active_class
+      assert class_of_element(doc, @monthly_interval_button) =~ @interval_button_active_class
     end
 
     test "default pageview limit is 10k", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @slider_value) == "10k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€14"
-      assert text_of_element(doc, @business_price_tag_amount) == "€19"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€90"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€140"
+      assert text_of_element(doc, @business_price_tag_amount) == "€190"
     end
 
     test "pageview slider changes selected volume and prices shown", %{conn: conn} do
@@ -124,41 +142,48 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "100k")
       assert text_of_element(doc, @slider_value) == "100k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€29"
-      assert text_of_element(doc, @business_price_tag_amount) == "€39"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€190"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€290"
+      assert text_of_element(doc, @business_price_tag_amount) == "€390"
 
       doc = set_slider(lv, "200k")
       assert text_of_element(doc, @slider_value) == "200k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€44"
-      assert text_of_element(doc, @business_price_tag_amount) == "€59"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€290"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€440"
+      assert text_of_element(doc, @business_price_tag_amount) == "€590"
 
       doc = set_slider(lv, "500k")
       assert text_of_element(doc, @slider_value) == "500k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€74"
-      assert text_of_element(doc, @business_price_tag_amount) == "€99"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€490"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€740"
+      assert text_of_element(doc, @business_price_tag_amount) == "€990"
 
       doc = set_slider(lv, "1M")
       assert text_of_element(doc, @slider_value) == "1M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€104"
-      assert text_of_element(doc, @business_price_tag_amount) == "€139"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€690"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€1,040"
+      assert text_of_element(doc, @business_price_tag_amount) == "€1,390"
 
       doc = set_slider(lv, "2M")
       assert text_of_element(doc, @slider_value) == "2M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€134"
-      assert text_of_element(doc, @business_price_tag_amount) == "€179"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€890"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€1,340"
+      assert text_of_element(doc, @business_price_tag_amount) == "€1,790"
 
       doc = set_slider(lv, "5M")
       assert text_of_element(doc, @slider_value) == "5M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€194"
-      assert text_of_element(doc, @business_price_tag_amount) == "€259"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€1,290"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€1,940"
+      assert text_of_element(doc, @business_price_tag_amount) == "€2,590"
 
       doc = set_slider(lv, "10M")
       assert text_of_element(doc, @slider_value) == "10M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€254"
-      assert text_of_element(doc, @business_price_tag_amount) == "€339"
+      assert text_of_element(doc, @starter_price_tag_amount) == "€1,690"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€2,540"
+      assert text_of_element(doc, @business_price_tag_amount) == "€3,390"
     end
 
-    test "renders contact links for business and growth tiers when enterprise-level volume selected",
+    test "renders contact links for all tiers when enterprise-level volume selected",
          %{
            conn: conn
          } do
@@ -166,6 +191,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "10M+")
 
+      assert text_of_element(doc, "#starter-custom-price") =~ "Custom"
+      assert text_of_element(doc, @starter_plan_box) =~ "Contact us"
       assert text_of_element(doc, "#growth-custom-price") =~ "Custom"
       assert text_of_element(doc, @growth_plan_box) =~ "Contact us"
       assert text_of_element(doc, "#business-custom-price") =~ "Custom"
@@ -173,28 +200,36 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "10M")
 
+      refute text_of_element(doc, "#starter-custom-price") =~ "Custom"
+      refute text_of_element(doc, @starter_plan_box) =~ "Contact us"
       refute text_of_element(doc, "#growth-custom-price") =~ "Custom"
       refute text_of_element(doc, @growth_plan_box) =~ "Contact us"
       refute text_of_element(doc, "#business-custom-price") =~ "Custom"
       refute text_of_element(doc, @business_plan_box) =~ "Contact us"
     end
 
-    test "switching billing interval changes business and growth prices", %{conn: conn} do
+    test "switching billing interval changes prices", %{conn: conn} do
       {:ok, lv, doc} = get_liveview(conn)
 
-      assert text_of_element(doc, @growth_price_tag_amount) == "€14"
-      assert text_of_element(doc, @growth_price_tag_interval) == "/month"
-
-      assert text_of_element(doc, @business_price_tag_amount) == "€19"
-      assert text_of_element(doc, @business_price_tag_interval) == "/month"
-
-      doc = element(lv, @yearly_interval_button) |> render_click()
+      assert text_of_element(doc, @starter_price_tag_amount) == "€90"
+      assert text_of_element(doc, @starter_price_tag_interval) == "/year"
 
       assert text_of_element(doc, @growth_price_tag_amount) == "€140"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       assert text_of_element(doc, @business_price_tag_amount) == "€190"
       assert text_of_element(doc, @business_price_tag_interval) == "/year"
+
+      doc = element(lv, @monthly_interval_button) |> render_click()
+
+      assert text_of_element(doc, @starter_price_tag_amount) == "€9"
+      assert text_of_element(doc, @starter_price_tag_interval) == "/month"
+
+      assert text_of_element(doc, @growth_price_tag_amount) == "€14"
+      assert text_of_element(doc, @growth_price_tag_interval) == "/month"
+
+      assert text_of_element(doc, @business_price_tag_amount) == "€19"
+      assert text_of_element(doc, @business_price_tag_interval) == "/month"
     end
 
     test "checkout buttons are 'paddle buttons' with dynamic onclick attribute", %{
@@ -219,6 +254,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       set_slider(lv, "5M")
       doc = element(lv, @monthly_interval_button) |> render_click()
 
+      assert get_paddle_checkout_params(find(doc, @starter_checkout_button))["product"] ==
+               @v5_starter_5m_monthly_plan_id
+
       assert get_paddle_checkout_params(find(doc, @business_checkout_button))["product"] ==
                @v5_business_5m_monthly_plan_id
     end
@@ -232,18 +270,30 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
                "if (confirm(\"This plan does not support Custom Properties, which you have been using. By subscribing to this plan, you will not have access to this feature.\")) {Paddle.Checkout.open"
     end
 
-    test "recommends Growth tier when no premium features were used", %{conn: conn} do
+    test "recommends Starter", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      assert text_of_element(doc, @starter_highlight_pill) == "Recommended"
+      refute element_exists?(doc, @growth_highlight_pill)
+      refute element_exists?(doc, @business_highlight_pill)
+    end
+
+    test "recommends Growth", %{conn: conn, site: site} do
+      for _ <- 1..3, do: add_guest(site, role: :viewer)
+
+      {:ok, _lv, doc} = get_liveview(conn)
+
+      refute element_exists?(doc, @starter_highlight_pill)
       assert text_of_element(doc, @growth_highlight_pill) == "Recommended"
       refute element_exists?(doc, @business_highlight_pill)
     end
 
-    test "recommends Business when Revenue Goals used during trial", %{conn: conn, site: site} do
+    test "recommends Business", %{conn: conn, site: site} do
       insert(:goal, site: site, currency: :USD, event_name: "Purchase")
 
       {:ok, _lv, doc} = get_liveview(conn)
 
+      refute element_exists?(doc, @starter_highlight_pill)
       assert text_of_element(doc, @business_highlight_pill) == "Recommended"
       refute element_exists?(doc, @growth_highlight_pill)
     end
@@ -310,6 +360,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "100k")
 
+      refute class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
       refute element_exists?(doc, @growth_plan_tooltip)
@@ -319,6 +370,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "100k")
 
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
 
@@ -338,6 +390,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "10k")
 
+      refute class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
 
@@ -346,6 +399,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "10k")
 
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
     end
@@ -365,6 +419,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "10k")
 
+      refute class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
 
@@ -373,6 +428,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "10k")
 
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
     end
@@ -384,9 +440,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "displays basic page content", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
-      assert doc =~ "Change subscription plan"
-      assert doc =~ "Questions?"
-      refute doc =~ "What happens if I go over my page views limit?"
+      assert doc =~ "Change your subscription plan"
+      assert doc =~ "Any other questions?"
+      assert doc =~ "What happens if I go over my monthly pageview limit?"
     end
 
     test "does not render any global notices", %{conn: conn} do
@@ -397,17 +453,23 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "displays plan benefits", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      starter_box = text_of_element(doc, @starter_plan_box)
       growth_box = text_of_element(doc, @growth_plan_box)
       business_box = text_of_element(doc, @business_plan_box)
       enterprise_box = text_of_element(doc, @enterprise_plan_box)
 
+      assert starter_box =~ "Intuitive, fast and privacy-friendly dashboard"
+      assert starter_box =~ "Email/Slack reports"
+      assert starter_box =~ "Google Analytics import"
+      assert starter_box =~ "Goals and custom events"
+      assert starter_box =~ "Up to 3 sites"
+      assert starter_box =~ "3 years of data retention"
+
       assert growth_box =~ "Up to 3 team members"
       assert growth_box =~ "Up to 10 sites"
-      assert growth_box =~ "Intuitive, fast and privacy-friendly dashboard"
-      assert growth_box =~ "Email/Slack reports"
-      assert growth_box =~ "Google Analytics import"
-      assert growth_box =~ "Goals and custom events"
-      assert growth_box =~ "3 years of data retention"
+      assert growth_box =~ "Team Accounts"
+      assert growth_box =~ "Shared Links"
+      refute growth_box =~ "Shared Segments"
 
       assert business_box =~ "Everything in Growth"
       assert business_box =~ "Up to 10 team members"
@@ -477,6 +539,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       check_notice_titles(doc, [Billing.pending_site_ownerships_notice_title()])
       assert doc =~ "Your account has been invited to become the owner of a site"
 
+      assert text_of_element(doc, @starter_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Team member limit"
+
       assert text_of_element(doc, @growth_plan_tooltip) ==
                "Your usage exceeds the following limit(s): Team member limit"
 
@@ -507,9 +572,17 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       refute element_exists?(doc, @growth_highlight_pill)
     end
 
-    test "gets default selected interval from current subscription plan", %{conn: conn} do
+    test "gets default selected interval from current subscription plan", %{
+      conn: conn,
+      user: user
+    } do
       {:ok, _lv, doc} = get_liveview(conn)
       assert class_of_element(doc, @yearly_interval_button) =~ @interval_button_active_class
+
+      subscribe_to_plan(user, @v4_growth_10k_monthly_plan_id)
+
+      {:ok, _lv, doc} = get_liveview(conn)
+      assert class_of_element(doc, @monthly_interval_button) =~ @interval_button_active_class
     end
 
     test "sets pageview slider according to last cycle usage", %{conn: conn} do
@@ -542,22 +615,27 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "200k")
 
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Currently on this plan"
-      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none bg-gray-400"
       assert text_of_element(doc, @business_checkout_button) == "Upgrade to Business"
+
+      assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none bg-gray-400"
 
       doc = element(lv, @monthly_interval_button) |> render_click()
 
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Change billing interval"
       assert text_of_element(doc, @business_checkout_button) == "Upgrade to Business"
 
       doc = set_slider(lv, "1M")
 
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Upgrade"
       assert text_of_element(doc, @business_checkout_button) == "Upgrade to Business"
 
       doc = set_slider(lv, "100k")
 
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Downgrade"
       assert text_of_element(doc, @business_checkout_button) == "Upgrade to Business"
     end
@@ -574,6 +652,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       set_slider(lv, "5M")
       doc = element(lv, @monthly_interval_button) |> render_click()
+
+      starter_checkout_button = find(doc, @starter_checkout_button)
+
+      assert text_of_attr(starter_checkout_button, "onclick") =~
+               "if (true) {window.location = '#{Routes.billing_path(conn, :change_plan_preview, @v5_starter_5m_monthly_plan_id)}'}"
 
       business_checkout_button = find(doc, @business_checkout_button)
 
@@ -609,6 +692,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       assert class =~ "ring-indigo-600"
       assert text_of_element(doc, @business_highlight_pill) == "Current"
 
+      refute element_exists?(doc, @starter_highlight_pill)
       refute element_exists?(doc, @growth_highlight_pill)
     end
 
@@ -633,6 +717,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, _lv, doc} = get_liveview(conn)
 
       assert text_of_element(doc, @enterprise_highlight_pill) == "Recommended"
+      refute element_exists?(doc, @starter_highlight_pill)
       refute element_exists?(doc, @business_highlight_pill)
       refute element_exists?(doc, @growth_highlight_pill)
     end
@@ -642,23 +727,29 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, "5M")
 
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
+      assert text_of_element(doc, @growth_checkout_button) == "Downgrade to Growth"
       assert text_of_element(doc, @business_checkout_button) == "Currently on this plan"
+
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none bg-gray-400"
 
       doc = element(lv, @yearly_interval_button) |> render_click()
 
-      assert text_of_element(doc, @business_checkout_button) == "Change billing interval"
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Downgrade to Growth"
+      assert text_of_element(doc, @business_checkout_button) == "Change billing interval"
 
       doc = set_slider(lv, "10M")
 
-      assert text_of_element(doc, @business_checkout_button) == "Upgrade"
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Downgrade to Growth"
+      assert text_of_element(doc, @business_checkout_button) == "Upgrade"
 
       doc = set_slider(lv, "100k")
 
-      assert text_of_element(doc, @business_checkout_button) == "Downgrade"
+      assert text_of_element(doc, @starter_checkout_button) == "Downgrade to Starter"
       assert text_of_element(doc, @growth_checkout_button) == "Downgrade to Growth"
+      assert text_of_element(doc, @business_checkout_button) == "Downgrade"
     end
 
     test "checkout is disabled when team member usage exceeds rendered plan limit", %{
@@ -669,6 +760,12 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       for _ <- 1..4, do: add_guest(site, role: :viewer)
 
       {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @starter_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @starter_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Team member limit"
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
@@ -684,6 +781,12 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       for _ <- 1..11, do: new_site(owner: user)
 
       {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @starter_plan_box) =~ "Your usage exceeds this plan"
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
+
+      assert text_of_element(doc, @starter_plan_tooltip) ==
+               "Your usage exceeds the following limit(s): Site limit"
 
       assert text_of_element(doc, @growth_plan_box) =~ "Your usage exceeds this plan"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
@@ -702,6 +805,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       for _ <- 1..4, do: add_guest(site, role: :viewer)
 
       {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_element(doc, @starter_plan_tooltip) =~ "Team member limit"
+      assert text_of_element(doc, @starter_plan_tooltip) =~ "Site limit"
 
       assert text_of_element(doc, @growth_plan_tooltip) =~ "Team member limit"
       assert text_of_element(doc, @growth_plan_tooltip) =~ "Site limit"
@@ -759,16 +865,23 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "displays plan benefits", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      starter_box = text_of_element(doc, @starter_plan_box)
       growth_box = text_of_element(doc, @growth_plan_box)
       business_box = text_of_element(doc, @business_plan_box)
       enterprise_box = text_of_element(doc, @enterprise_plan_box)
 
+      assert starter_box =~ "Intuitive, fast and privacy-friendly dashboard"
+      assert starter_box =~ "Email/Slack reports"
+      assert starter_box =~ "Google Analytics import"
+      assert starter_box =~ "Goals and custom events"
+      assert starter_box =~ "Up to 3 sites"
+      assert starter_box =~ "3 years of data retention"
+
       assert growth_box =~ "Up to 3 team members"
       assert growth_box =~ "Up to 10 sites"
-      assert growth_box =~ "Intuitive, fast and privacy-friendly dashboard"
-      assert growth_box =~ "Email/Slack reports"
-      assert growth_box =~ "Google Analytics import"
-      assert growth_box =~ "Goals and custom events"
+      assert growth_box =~ "Team Accounts"
+      assert growth_box =~ "Shared Links"
+      assert growth_box =~ "Shared Segments"
 
       assert business_box =~ "Everything in Growth"
       assert business_box =~ "Unlimited team members"
@@ -826,6 +939,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, "#{@growth_checkout_button} + div") =~
                "Please update your billing details first"
+
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none bg-gray-400"
+
+      assert text_of_element(doc, "#{@starter_checkout_button} + div") =~
+               "Please update your billing details first"
     end
   end
 
@@ -860,6 +978,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, "#{@growth_checkout_button} + div") =~
                "Please update your billing details first"
+
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none bg-gray-400"
+
+      assert text_of_element(doc, "#{@starter_checkout_button} + div") =~
+               "Please update your billing details first"
     end
   end
 
@@ -873,6 +996,10 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
     test "checkout buttons are paddle buttons", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
+
+      assert text_of_attr(find(doc, @starter_checkout_button), "onclick") =~
+               "Paddle.Checkout.open"
+
       assert text_of_attr(find(doc, @growth_checkout_button), "onclick") =~ "Paddle.Checkout.open"
 
       assert text_of_attr(find(doc, @business_checkout_button), "onclick") =~
@@ -911,7 +1038,8 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
     test "highlights recommended tier", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
-      assert text_of_element(doc, @growth_highlight_pill) == "Recommended"
+      assert text_of_element(doc, @starter_highlight_pill) == "Recommended"
+      refute text_of_element(doc, @growth_highlight_pill) == "Recommended"
       refute text_of_element(doc, @business_highlight_pill) == "Recommended"
     end
   end
@@ -925,7 +1053,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       check_notice_titles(doc, [])
     end
 
-    test "on a 50M v1 plan, Growth tiers are available at 20M, 50M, 50M+, but Business tiers are not",
+    test "on a 50M v1 plan, Growth plans are available at 20M, 50M, 50M+, but Starter and Business plans are not",
          %{conn: conn, user: user} do
       create_subscription_for(user, paddle_plan_id: @v1_50m_yearly_plan_id)
 
@@ -933,23 +1061,27 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
+      assert text_of_element(doc, @starter_plan_box) =~ "Contact us"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
       assert text_of_element(doc, @growth_price_tag_amount) == "€1,800"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)
       assert text_of_element(doc, @slider_value) == "50M"
+      assert text_of_element(doc, @starter_plan_box) =~ "Contact us"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
       assert text_of_element(doc, @growth_price_tag_amount) == "€2,640"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 10)
       assert text_of_element(doc, @slider_value) == "50M+"
+      assert text_of_element(doc, @starter_plan_box) =~ "Contact us"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
       assert text_of_element(doc, @growth_plan_box) =~ "Contact us"
 
       doc = set_slider(lv, 7)
       assert text_of_element(doc, @slider_value) == "10M"
+      refute text_of_element(doc, @starter_plan_box) =~ "Contact us"
       refute text_of_element(doc, @business_plan_box) =~ "Contact us"
       refute text_of_element(doc, @growth_plan_box) =~ "Contact us"
     end
@@ -962,13 +1094,11 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
-      assert text_of_element(doc, @business_plan_box) =~ "Contact us"
       assert text_of_element(doc, @growth_price_tag_amount) == "€2,250"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)
       assert text_of_element(doc, @slider_value) == "20M+"
-      assert text_of_element(doc, @business_plan_box) =~ "Contact us"
       assert text_of_element(doc, @growth_plan_box) =~ "Contact us"
     end
   end
@@ -1002,11 +1132,19 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       refute growth_box =~ "Intuitive, fast and privacy-friendly dashboard"
     end
 
-    test "displays business and enterprise plan benefits", %{conn: conn} do
+    test "displays Starter, Business and Enterprise benefits", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      starter_box = text_of_element(doc, @starter_plan_box)
       business_box = text_of_element(doc, @business_plan_box)
       enterprise_box = text_of_element(doc, @enterprise_plan_box)
+
+      assert starter_box =~ "Intuitive, fast and privacy-friendly dashboard"
+      assert starter_box =~ "Email/Slack reports"
+      assert starter_box =~ "Google Analytics import"
+      assert starter_box =~ "Goals and custom events"
+      assert starter_box =~ "Up to 3 sites"
+      assert starter_box =~ "3 years of data retention"
 
       assert business_box =~ "Everything in Growth"
       assert business_box =~ "Funnels"
@@ -1055,6 +1193,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       {:ok, lv, _doc} = get_liveview(conn)
       doc = set_slider(lv, "100k")
 
+      refute class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
     end
@@ -1063,9 +1202,10 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
   describe "for a free_10k subscription" do
     setup [:create_user, :create_site, :log_in, :subscribe_free_10k]
 
-    test "recommends growth tier when no premium features used", %{conn: conn} do
+    test "recommends starter tier", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
-      assert element_exists?(doc, @growth_highlight_pill)
+      assert element_exists?(doc, @starter_highlight_pill)
+      refute element_exists?(doc, @growth_highlight_pill)
       refute element_exists?(doc, @business_highlight_pill)
     end
 
@@ -1076,6 +1216,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
 
       assert text_of_element(doc, @business_plan_box) =~ "Recommended"
       refute text_of_element(doc, @growth_plan_box) =~ "Recommended"
+      refute text_of_element(doc, @starter_plan_box) =~ "Recommended"
     end
 
     test "renders Paddle upgrade buttons", %{conn: conn, user: user} do
@@ -1105,6 +1246,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       check_notice_titles(doc, [Billing.upgrade_ineligible_notice_title()])
 
       assert text_of_element(doc, "#upgrade-eligible-notice") =~ "You cannot start a subscription"
+      assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
     end
@@ -1129,9 +1271,9 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     test "allows to subscribe", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
 
+      assert text_of_element(doc, @starter_plan_box) =~ "Recommended"
       refute class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
       refute class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
-      assert text_of_element(doc, @growth_plan_box) =~ "Recommended"
     end
   end
 

--- a/test/plausible_web/live/legacy_choose_plan_test.exs
+++ b/test/plausible_web/live/legacy_choose_plan_test.exs
@@ -117,8 +117,8 @@ defmodule PlausibleWeb.Live.LegacyChoosePlanTest do
     test "default pageview limit is 10k", %{conn: conn} do
       {:ok, _lv, doc} = get_liveview(conn)
       assert text_of_element(doc, @slider_value) == "10k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€10"
-      assert text_of_element(doc, @business_price_tag_amount) == "€90"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€9"
+      assert text_of_element(doc, @business_price_tag_amount) == "€19"
     end
 
     test "pageview slider changes selected volume and prices shown", %{conn: conn} do
@@ -126,38 +126,38 @@ defmodule PlausibleWeb.Live.LegacyChoosePlanTest do
 
       doc = set_slider(lv, "100k")
       assert text_of_element(doc, @slider_value) == "100k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€20"
-      assert text_of_element(doc, @business_price_tag_amount) == "€100"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€19"
+      assert text_of_element(doc, @business_price_tag_amount) == "€39"
 
       doc = set_slider(lv, "200k")
       assert text_of_element(doc, @slider_value) == "200k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€30"
-      assert text_of_element(doc, @business_price_tag_amount) == "€110"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€29"
+      assert text_of_element(doc, @business_price_tag_amount) == "€59"
 
       doc = set_slider(lv, "500k")
       assert text_of_element(doc, @slider_value) == "500k"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€40"
-      assert text_of_element(doc, @business_price_tag_amount) == "€120"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€49"
+      assert text_of_element(doc, @business_price_tag_amount) == "€99"
 
       doc = set_slider(lv, "1M")
       assert text_of_element(doc, @slider_value) == "1M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€50"
-      assert text_of_element(doc, @business_price_tag_amount) == "€130"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€69"
+      assert text_of_element(doc, @business_price_tag_amount) == "€139"
 
       doc = set_slider(lv, "2M")
       assert text_of_element(doc, @slider_value) == "2M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€60"
-      assert text_of_element(doc, @business_price_tag_amount) == "€140"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€89"
+      assert text_of_element(doc, @business_price_tag_amount) == "€179"
 
       doc = set_slider(lv, "5M")
       assert text_of_element(doc, @slider_value) == "5M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€70"
-      assert text_of_element(doc, @business_price_tag_amount) == "€150"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€129"
+      assert text_of_element(doc, @business_price_tag_amount) == "€259"
 
       doc = set_slider(lv, "10M")
       assert text_of_element(doc, @slider_value) == "10M"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€80"
-      assert text_of_element(doc, @business_price_tag_amount) == "€160"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€169"
+      assert text_of_element(doc, @business_price_tag_amount) == "€339"
     end
 
     test "renders contact links for business and growth tiers when enterprise-level volume selected",
@@ -184,18 +184,18 @@ defmodule PlausibleWeb.Live.LegacyChoosePlanTest do
     test "switching billing interval changes business and growth prices", %{conn: conn} do
       {:ok, lv, doc} = get_liveview(conn)
 
-      assert text_of_element(doc, @growth_price_tag_amount) == "€10"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€9"
       assert text_of_element(doc, @growth_price_tag_interval) == "/month"
 
-      assert text_of_element(doc, @business_price_tag_amount) == "€90"
+      assert text_of_element(doc, @business_price_tag_amount) == "€19"
       assert text_of_element(doc, @business_price_tag_interval) == "/month"
 
       doc = element(lv, @yearly_interval_button) |> render_click()
 
-      assert text_of_element(doc, @growth_price_tag_amount) == "€100"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€90"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
-      assert text_of_element(doc, @business_price_tag_amount) == "€900"
+      assert text_of_element(doc, @business_price_tag_amount) == "€190"
       assert text_of_element(doc, @business_price_tag_interval) == "/year"
     end
 
@@ -960,13 +960,13 @@ defmodule PlausibleWeb.Live.LegacyChoosePlanTest do
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€900"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€1,800"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)
       assert text_of_element(doc, @slider_value) == "50M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€1,000"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€2,640"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 10)
@@ -989,7 +989,7 @@ defmodule PlausibleWeb.Live.LegacyChoosePlanTest do
       doc = set_slider(lv, 8)
       assert text_of_element(doc, @slider_value) == "20M"
       assert text_of_element(doc, @business_plan_box) =~ "Contact us"
-      assert text_of_element(doc, @growth_price_tag_amount) == "€900"
+      assert text_of_element(doc, @growth_price_tag_amount) == "€2,250"
       assert text_of_element(doc, @growth_price_tag_interval) == "/year"
 
       doc = set_slider(lv, 9)

--- a/test/support/test_paddle_api_mock.ex
+++ b/test/support/test_paddle_api_mock.ex
@@ -1,4 +1,6 @@
 defmodule Plausible.Billing.TestPaddleApiMock do
+  @moduledoc false
+
   def get_subscription(_) do
     {:ok,
      %{

--- a/test/support/test_paddle_api_mock.ex
+++ b/test/support/test_paddle_api_mock.ex
@@ -1,4 +1,4 @@
-defmodule Plausible.PaddleApi.Mock do
+defmodule Plausible.Billing.TestPaddleApiMock do
   def get_subscription(_) do
     {:ok,
      %{
@@ -72,20 +72,7 @@ defmodule Plausible.PaddleApi.Mock do
     end
   end
 
-  # to give a reasonable testing structure for monthly and yearly plan
-  # prices, this function returns prices with the following logic:
-  # 10, 100, 20, 200, 30, 300, ...and so on.
-  def fetch_prices([_ | _] = product_ids, _customer_ip) do
-    {prices, _index} =
-      Enum.reduce(product_ids, {%{}, 1}, fn p, {acc, i} ->
-        price =
-          if rem(i, 2) == 1,
-            do: ceil(i / 2.0) * 10.0,
-            else: ceil(i / 2.0) * 100.0
-
-        {Map.put(acc, p, Money.from_float!(:EUR, price)), i + 1}
-      end)
-
-    {:ok, prices}
+  def fetch_prices(product_ids, customer_ip) do
+    Plausible.Billing.DevPaddleApiMock.fetch_prices(product_ids, customer_ip)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,7 @@ Application.ensure_all_started(:double)
 
 FunWithFlags.enable(:channels)
 FunWithFlags.enable(:scroll_depth)
+FunWithFlags.enable(:starter_tier)
 
 Ecto.Adapters.SQL.Sandbox.mode(Plausible.Repo, :manual)
 


### PR DESCRIPTION
### Feature flag

This PR introduces a new upgrade page under a `starter_tier` feature flag. To make the separation cleaner, all existing upgrade page logic will continue to live in modules/functions with a `legacy` prefix (all of which can safely be deleted once the feature flag is live):

* `choose_plan.ex` -> `legacy_choose_plan.ex`
* `plan_box.ex` -> `legacy_plan_box.ex`
* `plan_benefits.ex` -> `legacy_plan_benefits.ex`
* `choose_plan_test.exs` -> `legacy_choose_plan_test.exs`
* `Plausible.Billing.Quota.suggest_tier` -> `Plausible.Billing.Quota.legacy_suggest_tier`

### Changes

Adds Starter plans on the upgrade page along with some other changes:

* Removes header (Plausible Logo and account dropdown) - replaces it with a simple "<- back to settings" link
* Yearly price is now selected by default (unless the user is already on a monthly plan)
* moves the "current cycle / last 30 days usage" and the "what happens if I go over my pageview limit?" paragraph into a FAQ style accordion menu

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
