### PR TITLE
Replace uses of `Teams.owned_sites/1` with better functions where applicable

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -85,7 +85,7 @@ defmodule Plausible.Teams do
   end
 
   def owned_sites(team) do
-    Repo.preload(team, :sites).sites
+    Repo.all(from(s in Plausible.Site, where: s.team_id == ^team.id))
   end
 
   def owned_sites(team, limit) when is_integer(limit) do

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -84,14 +84,24 @@ defmodule Plausible.Teams do
     Repo.preload(team, subscription: last_subscription_query())
   end
 
-  def owned_sites(team) do
-    Repo.all(from(s in Plausible.Site, where: s.team_id == ^team.id))
+  @spec owned_sites(Teams.Team.t() | nil, pos_integer() | nil) :: [Plausible.Site.t()]
+  def owned_sites(team, limit \\ nil)
+
+  def owned_sites(nil, _), do: []
+
+  def owned_sites(team, limit) do
+    query = from(s in Plausible.Site, where: s.team_id == ^team.id, order_by: [asc: s.domain])
+
+    if limit do
+      query
+      |> limit(^limit)
+      |> Repo.all()
+    else
+      Repo.all(query)
+    end
   end
 
-  def owned_sites(team, limit) when is_integer(limit) do
-    Repo.preload(team, sites: from(s in Plausible.Site, limit: ^limit, order_by: [asc: s.domain])).sites
-  end
-
+  @spec owned_sites_ids(Teams.Team.t() | nil) :: [pos_integer()]
   def owned_sites_ids(nil) do
     []
   end
@@ -106,6 +116,7 @@ defmodule Plausible.Teams do
     )
   end
 
+  @spec owned_sites_count(Teams.Team.t() | nil) :: non_neg_integer()
   def owned_sites_count(nil), do: 0
 
   def owned_sites_count(team) do

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -216,9 +216,7 @@ defmodule Plausible.Teams.Billing do
   def site_usage(nil), do: 0
 
   def site_usage(team) do
-    team
-    |> Teams.owned_sites()
-    |> length()
+    Teams.owned_sites_count(team)
   end
 
   on_ee do
@@ -402,7 +400,7 @@ defmodule Plausible.Teams.Billing do
   def usage_cycle(team, cycle, owned_site_ids \\ nil, today \\ Date.utc_today())
 
   def usage_cycle(team, cycle, nil, today) do
-    owned_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
+    owned_site_ids = Teams.owned_sites_ids(team)
     usage_cycle(team, cycle, owned_site_ids, today)
   end
 
@@ -475,7 +473,7 @@ defmodule Plausible.Teams.Billing do
   def features_usage(nil, nil), do: []
 
   def features_usage(%Teams.Team{} = team, nil) do
-    owned_site_ids = team |> Teams.owned_sites() |> Enum.map(& &1.id)
+    owned_site_ids = Teams.owned_sites_ids(team)
     features_usage(team, owned_site_ids)
   end
 


### PR DESCRIPTION
### Changes

Small refactor of `Teams.owned_sites/1` and its uses.

