### PR TITLE
Log salts hash

### DIFF
--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -27,11 +27,11 @@ defmodule Plausible.Session.Salts do
     state =
       case salts do
         [current, prev] ->
-          Logger.notice("[salts] current current salt hash: #{:erlang.phash2(current)}")
+          Logger.notice("[salts] current salt hash: #{:erlang.phash2(current)}")
           %{previous: prev, current: current}
 
         [current] ->
-          Logger.notice("[salts] current current salt hash: #{:erlang.phash2(current)}")
+          Logger.notice("[salts] current salt hash: #{:erlang.phash2(current)}")
           %{previous: nil, current: current}
 
         [] ->

--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -1,6 +1,7 @@
 defmodule Plausible.Session.Salts do
   use GenServer
   use Plausible.Repo
+  require Logger
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: opts[:name] || __MODULE__)
@@ -26,9 +27,11 @@ defmodule Plausible.Session.Salts do
     state =
       case salts do
         [current, prev] ->
+          Logger.notice("[salts] current current salt hash: #{:erlang.phash2(current)}")
           %{previous: prev, current: current}
 
         [current] ->
+          Logger.notice("[salts] current current salt hash: #{:erlang.phash2(current)}")
           %{previous: nil, current: current}
 
         [] ->
@@ -67,7 +70,7 @@ defmodule Plausible.Session.Salts do
 
   defp generate_and_persist_new_salt(now) do
     salt = :crypto.strong_rand_bytes(16)
-
+    Logger.notice("[salts] generated salt hash: #{:erlang.phash2(salt)}")
     Repo.insert_all("salts", [%{salt: salt, inserted_at: now}])
     salt
   end


### PR DESCRIPTION
Attempt at debugging session transfer.

This _temporary_ logging of salts hash might be helpful in identifying if there is a mismatch in salts during session transfer: subsequent `current` or `generated` (old node that gives sessions away) and `current` (new node that takes over the sessions) salt hashes are expected to be the same for the same app node.