### PR TITLE
Bump CACHE_VERSION to ensure latest plausible-main

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_VERSION: v13
+  CACHE_VERSION: v14
   PERSISTENT_CACHE_DIR: cached
 
 jobs:


### PR DESCRIPTION
In a recent branch https://github.com/plausible/analytics/pull/5389 a cached value got renamed, causing issues like in the following build:

https://github.com/plausible/analytics/actions/runs/15137498435/job/42552696051?pr=5402