### PR TITLE
CS: update tests + display user ID

### DIFF
--- a/extra/lib/plausible/customer_support/resource/site.ex
+++ b/extra/lib/plausible/customer_support/resource/site.ex
@@ -40,7 +40,7 @@ defmodule Plausible.CustomerSupport.Resource.Site do
   @impl true
   def get(id) do
     Plausible.Site
-    |> Plausible.Repo.get(id)
+    |> Plausible.Repo.get!(id)
     |> Plausible.Repo.preload(:team)
   end
 end

--- a/extra/lib/plausible/customer_support/resource/team.ex
+++ b/extra/lib/plausible/customer_support/resource/team.ex
@@ -34,7 +34,7 @@ defmodule Plausible.CustomerSupport.Resource.Team do
   @impl true
   def get(id) do
     Plausible.Teams.Team
-    |> Repo.get(id)
+    |> Repo.get!(id)
     |> Plausible.Teams.with_subscription()
     |> Repo.preload(:owners)
   end

--- a/extra/lib/plausible_web/live/customer_support/live/user.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/user.ex
@@ -41,6 +41,15 @@ defmodule PlausibleWeb.CustomerSupport.Live.User do
             </p>
           </div>
         </div>
+
+        <div class="mt-5 flex justify-center sm:mt-0">
+          <.input_with_clipboard
+            id="user-identifier"
+            name="user-identifier"
+            label="User Identifier"
+            value={@user.id}
+          />
+        </div>
       </div>
 
       <div class="mt-8">

--- a/extra/lib/plausible_web/live/customer_support/live/user.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/user.ex
@@ -5,8 +5,16 @@ defmodule PlausibleWeb.CustomerSupport.Live.User do
 
   def update(assigns, socket) do
     user = socket.assigns[:user] || Resource.User.get(assigns.resource_id)
-    form = user |> Plausible.Auth.User.changeset() |> to_form()
-    {:ok, assign(socket, user: user, form: form)}
+
+    if is_nil(user) do
+      redirect(
+        socket,
+        to: Routes.customer_support_path(socket, :index)
+      )
+    else
+      form = user |> Plausible.Auth.User.changeset() |> to_form()
+      {:ok, assign(socket, user: user, form: form)}
+    end
   end
 
   def render(assigns) do

--- a/test/plausible_web/live/customer_support/sites_test.exs
+++ b/test/plausible_web/live/customer_support/sites_test.exs
@@ -29,6 +29,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
         {:ok, _lv, html} = live(conn, open_site(site.id))
         assert text(html) =~ site.domain
       end
+
+      test "404", %{conn: conn} do
+        assert_raise Ecto.NoResultsError, fn ->
+          {:ok, _lv, _html} = live(conn, open_site(9999))
+        end
+      end
     end
   end
 end

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -30,6 +30,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         {:ok, _lv, html} = live(conn, open_team(team.id))
         assert text(html) =~ team.name
       end
+
+      test "404", %{conn: conn} do
+        assert_raise Ecto.NoResultsError, fn ->
+          {:ok, _lv, _html} = live(conn, open_team(9999))
+        end
+      end
     end
   end
 end

--- a/test/plausible_web/live/customer_support/users_test.exs
+++ b/test/plausible_web/live/customer_support/users_test.exs
@@ -29,6 +29,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.UsersTest do
         {:ok, _lv, html} = live(conn, open_user(user.id))
         assert text(html) =~ user.name
       end
+
+      test "404", %{conn: conn} do
+        assert_raise Ecto.NoResultsError, fn ->
+          {:ok, _lv, _html} = live(conn, open_user(9999))
+        end
+      end
     end
   end
 end

--- a/test/plausible_web/live/customer_support/users_test.exs
+++ b/test/plausible_web/live/customer_support/users_test.exs
@@ -27,7 +27,15 @@ defmodule PlausibleWeb.Live.CustomerSupport.UsersTest do
 
       test "renders", %{conn: conn, user: user} do
         {:ok, _lv, html} = live(conn, open_user(user.id))
-        assert text(html) =~ user.name
+        text = text(html)
+        assert text =~ user.name
+        assert text =~ user.email
+
+        assert [uid] = find(html, "#user-identifier")
+        assert text_of_attr(uid, "value") == "#{user.id}"
+
+        team = team_of(user)
+        assert [_] = find(html, ~s|a[href="/cs/teams/team/#{team.id}"]|)
       end
 
       test "404", %{conn: conn} do

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -54,25 +54,29 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert text_of_element(html, "#invitation-#{invitation2.invitation_id}") =~
                "G.I. Jane has invited you to join the \"My Personal Sites\" as editor member."
 
-      assert find(
-               html,
-               "#invitation-#{invitation1.invitation_id} a[href=#{Routes.invitation_path(PlausibleWeb.Endpoint, :accept_invitation, invitation1.invitation_id)}]"
-             )
+      assert [_] =
+               find(
+                 html,
+                 ~s|#invitation-#{invitation1.invitation_id} a[href="#{Routes.invitation_path(PlausibleWeb.Endpoint, :accept_invitation, invitation1.invitation_id)}"]|
+               )
 
-      assert find(
-               html,
-               "#invitation-#{invitation1.invitation_id} a[href=#{Routes.invitation_path(PlausibleWeb.Endpoint, :reject_invitation, invitation1.invitation_id)}]"
-             )
+      assert [_] =
+               find(
+                 html,
+                 ~s|#invitation-#{invitation1.invitation_id} a[href="#{Routes.invitation_path(PlausibleWeb.Endpoint, :reject_invitation, invitation1.invitation_id)}"]|
+               )
 
-      assert find(
-               html,
-               "#invitation-#{invitation2.invitation_id} a[href=#{Routes.invitation_path(PlausibleWeb.Endpoint, :accept_invitation, invitation2.invitation_id)}]"
-             )
+      assert [_] =
+               find(
+                 html,
+                 ~s|#invitation-#{invitation2.invitation_id} a[href="#{Routes.invitation_path(PlausibleWeb.Endpoint, :accept_invitation, invitation2.invitation_id)}"]|
+               )
 
-      assert find(
-               html,
-               "#invitation-#{invitation2.invitation_id} a[href=#{Routes.invitation_path(PlausibleWeb.Endpoint, :reject_invitation, invitation2.invitation_id)}]"
-             )
+      assert [_] =
+               find(
+                 html,
+                 ~s|#invitation-#{invitation2.invitation_id} a[href="#{Routes.invitation_path(PlausibleWeb.Endpoint, :reject_invitation, invitation2.invitation_id)}"]|
+               )
     end
 
     test "renders metadata for invitation", %{


### PR DESCRIPTION
### Changes

A tiny update to CS tests + clipboard input with user ID.
Fixed an always true assertion in sites tests btw.
 
### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
