### PR TITLE
tracker_script_configuration: migration (step 1)

### DIFF
--- a/priv/repo/migrations/20250515164952_add_tracker_script_configuration_table.exs
+++ b/priv/repo/migrations/20250515164952_add_tracker_script_configuration_table.exs
@@ -1,0 +1,24 @@
+defmodule Plausible.Repo.Migrations.AddTrackerScriptConfigurationTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:tracker_script_configuration, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :installation_type, :string, null: true
+
+      add :track_404_pages, :boolean, default: false
+      add :hash_based_routing, :boolean, default: false
+      add :outbound_links, :boolean, default: false
+      add :file_downloads, :boolean, default: false
+      add :revenue_tracking, :boolean, default: false
+      add :tagged_events, :boolean, default: false
+      add :form_submissions, :boolean, default: false
+      add :pageview_props, :boolean, default: false
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:tracker_script_configuration, [:site_id])
+  end
+end


### PR DESCRIPTION
PR in a series:
1. `tracker_script_configuration` migration
2. `tracker_script_configuration` schema, double-writes
3. `tracker_script_configuration` backfill
4. `tracker_script_configuration`: drop writes and reads to `installation_meta`
5. Plugins API for `tracker_script_configuration`

