### PR TITLE
tracker_script_configuration: schema, double-writes (step 2)

### DIFF
--- a/lib/plausible/ecto/types/nanoid.ex
+++ b/lib/plausible/ecto/types/nanoid.ex
@@ -1,0 +1,20 @@
+defmodule Plausible.Ecto.Types.Nanoid do
+  @moduledoc """
+  Custom column type for nanoid strings
+  """
+
+  use Ecto.Type
+
+  def type(), do: :string
+
+  def cast(value) when is_binary(value), do: {:ok, value}
+  def cast(_), do: :error
+
+  def load(value), do: {:ok, value}
+
+  def dump(value) when is_binary(value), do: {:ok, value}
+  def dump(_), do: :error
+
+  @spec autogenerate() :: String.t()
+  def autogenerate(), do: Nanoid.generate()
+end

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -41,6 +41,8 @@ defmodule Plausible.Site do
       on_replace: :update,
       defaults_to_struct: true
 
+    has_one :tracker_script_configuration, Plausible.Site.TrackerScriptConfiguration
+
     has_many :goals, Plausible.Goal, preload_order: [desc: :id]
     has_many :revenue_goals, Plausible.Goal, where: [currency: {:not, nil}]
     has_one :google_auth, GoogleAuth

--- a/lib/plausible/site/installation_meta.ex
+++ b/lib/plausible/site/installation_meta.ex
@@ -4,10 +4,35 @@ defmodule Plausible.Site.InstallationMeta do
   """
   use Ecto.Schema
 
+  alias Plausible.Site.TrackerScriptConfiguration
+
   @type t() :: %__MODULE__{}
 
   embedded_schema do
     field :installation_type, :string, default: "manual"
     field :script_config, :map, default: %{}
   end
+
+  def to_tracker_script_configuration(site, installation_meta \\ nil) do
+    installation_meta =
+      installation_meta || site.installation_meta || %Plausible.Site.InstallationMeta{}
+
+    %TrackerScriptConfiguration{
+      site_id: site.id,
+      installation_type:
+        Map.get(installation_meta, :installation_type) |> remap_installation_type(),
+      track_404_pages: Map.get(installation_meta.script_config, "404", false),
+      hash_based_routing: Map.get(installation_meta.script_config, "hash", false),
+      outbound_links: Map.get(installation_meta.script_config, "outbound-links", false),
+      file_downloads: Map.get(installation_meta.script_config, "file-downloads", false),
+      revenue_tracking: Map.get(installation_meta.script_config, "revenue", false),
+      tagged_events: Map.get(installation_meta.script_config, "tagged-events", false),
+      form_submissions: Map.get(installation_meta.script_config, "form-submissions", false),
+      pageview_props: Map.get(installation_meta.script_config, "pageview-props", false)
+    }
+  end
+
+  defp remap_installation_type("WordPress"), do: "wordpress"
+  defp remap_installation_type("GTM"), do: "gtm"
+  defp remap_installation_type(value), do: value
 end

--- a/lib/plausible/site/tracker_script_configuration.ex
+++ b/lib/plausible/site/tracker_script_configuration.ex
@@ -1,0 +1,68 @@
+defmodule Plausible.Site.TrackerScriptConfiguration do
+  @moduledoc """
+  Schema for tracker script configuration
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t() :: %__MODULE__{}
+
+  @primary_key {:id, Plausible.Ecto.Types.Nanoid, autogenerate: true}
+  schema "tracker_script_configuration" do
+    field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, nil]
+
+    field :track_404_pages, :boolean, default: false
+    field :hash_based_routing, :boolean, default: false
+    field :outbound_links, :boolean, default: false
+    field :file_downloads, :boolean, default: false
+    field :revenue_tracking, :boolean, default: false
+    field :tagged_events, :boolean, default: false
+    field :form_submissions, :boolean, default: false
+    field :pageview_props, :boolean, default: false
+
+    belongs_to :site, Plausible.Site
+
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [
+      :installation_type,
+      :track_404_pages,
+      :hash_based_routing,
+      :outbound_links,
+      :file_downloads,
+      :revenue_tracking,
+      :tagged_events,
+      :form_submissions,
+      :pageview_props,
+      :site_id
+    ])
+    |> validate_required([:site_id])
+  end
+
+  def upsert(configuration_map) do
+    changeset = changeset(%__MODULE__{}, configuration_map)
+
+    Plausible.Repo.insert(
+      changeset,
+      on_conflict: {:replace, fields_to_update(configuration_map)},
+      conflict_target: [:site_id],
+      returning: true
+    )
+  end
+
+  defp fields_to_update(configuration_map) do
+    fields = __MODULE__.__schema__(:fields)
+
+    configuration_map
+    |> Map.keys()
+    |> Enum.map(fn
+      key when is_atom(key) -> key
+      key when is_binary(key) -> String.to_existing_atom(key)
+    end)
+    |> Enum.filter(&(&1 in fields))
+    |> Enum.concat([:updated_at])
+  end
+end

--- a/test/plausible/site/tracker_script_configuration_test.exs
+++ b/test/plausible/site/tracker_script_configuration_test.exs
@@ -1,0 +1,55 @@
+defmodule Plausible.Site.TrackerScriptConfigurationTest do
+  use Plausible
+  use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
+
+  alias Plausible.Site.TrackerScriptConfiguration
+
+  test "#upsert/2" do
+    site = insert(:site)
+
+    {:ok, initial_configuration} =
+      TrackerScriptConfiguration.upsert(%{
+        site_id: site.id,
+        installation_type: nil,
+        track_404_pages: true,
+        hash_based_routing: true,
+        outbound_links: true
+      })
+
+    assert_matches %{
+                     id: ^any(:string),
+                     site_id: ^site.id,
+                     installation_type: nil,
+                     track_404_pages: true,
+                     hash_based_routing: true,
+                     outbound_links: true,
+                     file_downloads: false,
+                     revenue_tracking: false,
+                     tagged_events: false,
+                     form_submissions: false
+                   } = initial_configuration
+
+    {:ok, updated_configuration} =
+      TrackerScriptConfiguration.upsert(%{
+        site_id: site.id,
+        installation_type: :wordpress,
+        track_404_pages: false,
+        outbound_links: true,
+        file_downloads: true
+      })
+
+    assert_matches %{
+                     id: ^initial_configuration.id,
+                     site_id: ^site.id,
+                     installation_type: :wordpress,
+                     track_404_pages: false,
+                     hash_based_routing: true,
+                     outbound_links: true,
+                     file_downloads: true,
+                     revenue_tracking: false,
+                     tagged_events: false,
+                     form_submissions: false
+                   } = updated_configuration
+  end
+end

--- a/test/plausible/site/tracker_script_configuration_test.exs
+++ b/test/plausible/site/tracker_script_configuration_test.exs
@@ -14,7 +14,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
         installation_type: nil,
         track_404_pages: true,
         hash_based_routing: true,
-        outbound_links: true
+        outbound_links: true,
+        pageview_props: true
       })
 
     assert_matches %{
@@ -27,7 +28,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
                      file_downloads: false,
                      revenue_tracking: false,
                      tagged_events: false,
-                     form_submissions: false
+                     form_submissions: false,
+                     pageview_props: true
                    } = initial_configuration
 
     {:ok, updated_configuration} =
@@ -36,7 +38,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
         installation_type: :wordpress,
         track_404_pages: false,
         outbound_links: true,
-        file_downloads: true
+        file_downloads: true,
+        pageview_props: false
       })
 
     assert_matches %{
@@ -49,7 +52,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
                      file_downloads: true,
                      revenue_tracking: false,
                      tagged_events: false,
-                     form_submissions: false
+                     form_submissions: false,
+                     pageview_props: false
                    } = updated_configuration
   end
 end


### PR DESCRIPTION
PR in a series:
1. `tracker_script_configuration` migration
2. `tracker_script_configuration` schema, double-writes
3. `tracker_script_configuration` backfill
4. `tracker_script_configuration`: drop writes and reads to `installation_meta`
5. Plugins API for `tracker_script_configuration`