### PR TITLE
tracker_script_configuration: backfill (step 3)

### DIFF
--- a/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
+++ b/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
@@ -1,0 +1,94 @@
+defmodule Plausible.DataMigration.BackfillTrackerScriptConfiguration do
+  @moduledoc """
+  Backfill Plausible.Site.TrackerScriptConfiguration for all sites.
+  """
+
+  import Ecto.Query
+
+  alias Plausible.Repo
+
+  defmodule TrackerScriptConfigurationSnapshot do
+    @moduledoc """
+    A snapshot of the Plausible.Site.TrackerScriptConfiguration schema from May 2025.
+    """
+
+    use Ecto.Schema
+
+    @primary_key false
+    schema "tracker_script_configuration" do
+      field :id, :string
+      field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, nil]
+
+      field :track_404_pages, :boolean, default: false
+      field :hash_based_routing, :boolean, default: false
+      field :outbound_links, :boolean, default: false
+      field :file_downloads, :boolean, default: false
+      field :revenue_tracking, :boolean, default: false
+      field :tagged_events, :boolean, default: false
+      field :form_submissions, :boolean, default: false
+      field :pageview_props, :boolean, default: false
+
+      field :site_id, :integer
+
+      timestamps()
+    end
+  end
+
+  def run() do
+    now = NaiveDateTime.utc_now(:second)
+    process_batch(0, now)
+  end
+
+  @batch_size 1000
+
+  def process_batch(offset, now) do
+    sites =
+      Repo.all(
+        from(s in Plausible.Site, order_by: [asc: :id], limit: @batch_size, offset: ^offset)
+      )
+
+    if length(sites) > 0 do
+      create_tracker_script_configurations(sites, now)
+      process_batch(offset + @batch_size, now)
+    end
+  end
+
+  defp create_tracker_script_configurations(sites, now) do
+    configurations = Enum.map(sites, &tracker_script_configuration(&1, now))
+
+    Repo.insert_all(
+      TrackerScriptConfigurationSnapshot,
+      configurations,
+      # Conflicts mean that the site has already been updated and is in sync
+      on_conflict: :nothing,
+      conflict_target: [:site_id]
+    )
+  end
+
+  defp tracker_script_configuration(site, now) do
+    installation_meta = site.installation_meta
+    installation_type = if(installation_meta, do: installation_meta.installation_type, else: nil)
+    script_config = if(installation_meta, do: installation_meta.script_config, else: %{})
+
+    %{
+      id: Nanoid.generate(),
+      site_id: site.id,
+      installation_type: installation_type |> remap_installation_type(),
+      track_404_pages: Map.get(script_config, "404", false),
+      hash_based_routing: Map.get(script_config, "hash", false),
+      outbound_links: Map.get(script_config, "outbound-links", false),
+      file_downloads: Map.get(script_config, "file-downloads", false),
+      revenue_tracking: Map.get(script_config, "revenue", false),
+      tagged_events: Map.get(script_config, "tagged-events", false),
+      form_submissions: Map.get(script_config, "form-submissions", false),
+      pageview_props: Map.get(script_config, "pageview-props", false),
+      inserted_at: now,
+      updated_at: now
+    }
+  end
+
+  defp remap_installation_type("WordPress"), do: :wordpress
+  defp remap_installation_type("GTM"), do: :gtm
+  defp remap_installation_type("manual"), do: :manual
+  defp remap_installation_type(nil), do: nil
+end

--- a/lib/plausible/ecto/types/nanoid.ex
+++ b/lib/plausible/ecto/types/nanoid.ex
@@ -1,0 +1,20 @@
+defmodule Plausible.Ecto.Types.Nanoid do
+  @moduledoc """
+  Custom column type for nanoid strings
+  """
+
+  use Ecto.Type
+
+  def type(), do: :string
+
+  def cast(value) when is_binary(value), do: {:ok, value}
+  def cast(_), do: :error
+
+  def load(value), do: {:ok, value}
+
+  def dump(value) when is_binary(value), do: {:ok, value}
+  def dump(_), do: :error
+
+  @spec autogenerate() :: String.t()
+  def autogenerate(), do: Nanoid.generate()
+end

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -41,6 +41,8 @@ defmodule Plausible.Site do
       on_replace: :update,
       defaults_to_struct: true
 
+    has_one :tracker_script_configuration, Plausible.Site.TrackerScriptConfiguration
+
     has_many :goals, Plausible.Goal, preload_order: [desc: :id]
     has_many :revenue_goals, Plausible.Goal, where: [currency: {:not, nil}]
     has_one :google_auth, GoogleAuth

--- a/lib/plausible/site/installation_meta.ex
+++ b/lib/plausible/site/installation_meta.ex
@@ -4,10 +4,35 @@ defmodule Plausible.Site.InstallationMeta do
   """
   use Ecto.Schema
 
+  alias Plausible.Site.TrackerScriptConfiguration
+
   @type t() :: %__MODULE__{}
 
   embedded_schema do
     field :installation_type, :string, default: "manual"
     field :script_config, :map, default: %{}
   end
+
+  def to_tracker_script_configuration(site, installation_meta \\ nil) do
+    installation_meta =
+      installation_meta || site.installation_meta || %Plausible.Site.InstallationMeta{}
+
+    %TrackerScriptConfiguration{
+      site_id: site.id,
+      installation_type:
+        Map.get(installation_meta, :installation_type) |> remap_installation_type(),
+      track_404_pages: Map.get(installation_meta.script_config, "404", false),
+      hash_based_routing: Map.get(installation_meta.script_config, "hash", false),
+      outbound_links: Map.get(installation_meta.script_config, "outbound-links", false),
+      file_downloads: Map.get(installation_meta.script_config, "file-downloads", false),
+      revenue_tracking: Map.get(installation_meta.script_config, "revenue", false),
+      tagged_events: Map.get(installation_meta.script_config, "tagged-events", false),
+      form_submissions: Map.get(installation_meta.script_config, "form-submissions", false),
+      pageview_props: Map.get(installation_meta.script_config, "pageview-props", false)
+    }
+  end
+
+  defp remap_installation_type("WordPress"), do: "wordpress"
+  defp remap_installation_type("GTM"), do: "gtm"
+  defp remap_installation_type(value), do: value
 end

--- a/lib/plausible/site/tracker_script_configuration.ex
+++ b/lib/plausible/site/tracker_script_configuration.ex
@@ -1,0 +1,68 @@
+defmodule Plausible.Site.TrackerScriptConfiguration do
+  @moduledoc """
+  Schema for tracker script configuration
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t() :: %__MODULE__{}
+
+  @primary_key {:id, Plausible.Ecto.Types.Nanoid, autogenerate: true}
+  schema "tracker_script_configuration" do
+    field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, nil]
+
+    field :track_404_pages, :boolean, default: false
+    field :hash_based_routing, :boolean, default: false
+    field :outbound_links, :boolean, default: false
+    field :file_downloads, :boolean, default: false
+    field :revenue_tracking, :boolean, default: false
+    field :tagged_events, :boolean, default: false
+    field :form_submissions, :boolean, default: false
+    field :pageview_props, :boolean, default: false
+
+    belongs_to :site, Plausible.Site
+
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [
+      :installation_type,
+      :track_404_pages,
+      :hash_based_routing,
+      :outbound_links,
+      :file_downloads,
+      :revenue_tracking,
+      :tagged_events,
+      :form_submissions,
+      :pageview_props,
+      :site_id
+    ])
+    |> validate_required([:site_id])
+  end
+
+  def upsert(configuration_map) do
+    changeset = changeset(%__MODULE__{}, configuration_map)
+
+    Plausible.Repo.insert(
+      changeset,
+      on_conflict: {:replace, fields_to_update(configuration_map)},
+      conflict_target: [:site_id],
+      returning: true
+    )
+  end
+
+  defp fields_to_update(configuration_map) do
+    fields = __MODULE__.__schema__(:fields)
+
+    configuration_map
+    |> Map.keys()
+    |> Enum.map(fn
+      key when is_atom(key) -> key
+      key when is_binary(key) -> String.to_existing_atom(key)
+    end)
+    |> Enum.filter(&(&1 in fields))
+    |> Enum.concat([:updated_at])
+  end
+end

--- a/priv/repo/migrations/20250515164952_add_tracker_script_configuration_table.exs
+++ b/priv/repo/migrations/20250515164952_add_tracker_script_configuration_table.exs
@@ -1,0 +1,24 @@
+defmodule Plausible.Repo.Migrations.AddTrackerScriptConfigurationTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:tracker_script_configuration, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :installation_type, :string, null: true
+
+      add :track_404_pages, :boolean, default: false
+      add :hash_based_routing, :boolean, default: false
+      add :outbound_links, :boolean, default: false
+      add :file_downloads, :boolean, default: false
+      add :revenue_tracking, :boolean, default: false
+      add :tagged_events, :boolean, default: false
+      add :form_submissions, :boolean, default: false
+      add :pageview_props, :boolean, default: false
+      add :site_id, references(:sites, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:tracker_script_configuration, [:site_id])
+  end
+end

--- a/priv/repo/migrations/20250520073535_backfill_tracker_script_configuration.exs
+++ b/priv/repo/migrations/20250520073535_backfill_tracker_script_configuration.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.BackfillTrackerScriptConfiguration do
+  use Ecto.Migration
+
+  def change do
+    execute(&Plausible.DataMigration.BackfillTrackerScriptConfiguration.run/0, &pass/0)
+  end
+
+  defp pass(), do: nil
+end

--- a/test/plausible/site/tracker_script_configuration_test.exs
+++ b/test/plausible/site/tracker_script_configuration_test.exs
@@ -1,0 +1,55 @@
+defmodule Plausible.Site.TrackerScriptConfigurationTest do
+  use Plausible
+  use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
+
+  alias Plausible.Site.TrackerScriptConfiguration
+
+  test "#upsert/2" do
+    site = insert(:site)
+
+    {:ok, initial_configuration} =
+      TrackerScriptConfiguration.upsert(%{
+        site_id: site.id,
+        installation_type: nil,
+        track_404_pages: true,
+        hash_based_routing: true,
+        outbound_links: true
+      })
+
+    assert_matches %{
+                     id: ^any(:string),
+                     site_id: ^site.id,
+                     installation_type: nil,
+                     track_404_pages: true,
+                     hash_based_routing: true,
+                     outbound_links: true,
+                     file_downloads: false,
+                     revenue_tracking: false,
+                     tagged_events: false,
+                     form_submissions: false
+                   } = initial_configuration
+
+    {:ok, updated_configuration} =
+      TrackerScriptConfiguration.upsert(%{
+        site_id: site.id,
+        installation_type: :wordpress,
+        track_404_pages: false,
+        outbound_links: true,
+        file_downloads: true
+      })
+
+    assert_matches %{
+                     id: ^initial_configuration.id,
+                     site_id: ^site.id,
+                     installation_type: :wordpress,
+                     track_404_pages: false,
+                     hash_based_routing: true,
+                     outbound_links: true,
+                     file_downloads: true,
+                     revenue_tracking: false,
+                     tagged_events: false,
+                     form_submissions: false
+                   } = updated_configuration
+  end
+end

--- a/test/plausible/site/tracker_script_configuration_test.exs
+++ b/test/plausible/site/tracker_script_configuration_test.exs
@@ -14,7 +14,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
         installation_type: nil,
         track_404_pages: true,
         hash_based_routing: true,
-        outbound_links: true
+        outbound_links: true,
+        pageview_props: true
       })
 
     assert_matches %{
@@ -27,7 +28,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
                      file_downloads: false,
                      revenue_tracking: false,
                      tagged_events: false,
-                     form_submissions: false
+                     form_submissions: false,
+                     pageview_props: true
                    } = initial_configuration
 
     {:ok, updated_configuration} =
@@ -36,7 +38,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
         installation_type: :wordpress,
         track_404_pages: false,
         outbound_links: true,
-        file_downloads: true
+        file_downloads: true,
+        pageview_props: false
       })
 
     assert_matches %{
@@ -49,7 +52,8 @@ defmodule Plausible.Site.TrackerScriptConfigurationTest do
                      file_downloads: true,
                      revenue_tracking: false,
                      tagged_events: false,
-                     form_submissions: false
+                     form_submissions: false,
+                     pageview_props: false
                    } = updated_configuration
   end
 end

--- a/test/plausible_web/live/installation_test.exs
+++ b/test/plausible_web/live/installation_test.exs
@@ -253,10 +253,12 @@ defmodule PlausibleWeb.Live.InstallationTest do
 
       lv |> render()
 
-      assert [clicks, downloads, track_404_pages] = Plausible.Goals.for_site(site)
-      assert clicks.event_name == "Outbound Link: Click"
-      assert downloads.event_name == "File Download"
+      assert [track_404_pages, downloads, clicks] =
+               Plausible.Goals.for_site(site) |> Enum.sort_by(& &1.event_name)
+
       assert track_404_pages.event_name == "404"
+      assert downloads.event_name == "File Download"
+      assert clicks.event_name == "Outbound Link: Click"
     end
 
     test "turning off file-downloads, outbound-links and 404 deletes special goals", %{


### PR DESCRIPTION
PR in a series:
1. `tracker_script_configuration` migration (https://github.com/plausible/analytics/pull/5406)
2. `tracker_script_configuration` schema, double-writes (https://github.com/plausible/analytics/pull/5407)
3. **`tracker_script_configuration` backfill (this PR)**
4. `tracker_script_configuration`: drop writes and reads to `installation_meta` (https://github.com/plausible/analytics/pull/5409)
5. Plugins API for `tracker_script_configuration` (https://github.com/plausible/analytics/pull/5410)

See sections below for more details:

<details><summary><b>On schema</b></summary>

- `id` uses Nanoid library to generate ids for nice and readable ids as these will be used for serving scripts. Example: `qyhkWtOWaTN0YPkhrcJgy`
- `installation_type` is marked as nullable since old installation flow could cause inserts where `installation_type` would not be set. This is for backwards compatibility to avoid messing with the schema too much.
- `revenue_tracking`, `tagged_events`, `pageview_props` and `track_404_pages` columns are for old schema compatibility and will not be used once new onboarding is fully live
- Old embedded schema was not removed as new installation flow (which I did not modify to avoid conflicts) relies on it.
- Backfill created a new DataMigration to make it possible to use (snapshot) of schema + app code in migration

</details>


<details><summary><b>On plugins API</b></summary>

This will be used by wordpress plugin to integrate into the app.

Currently it also creates goals as part of it's code but this will be changed as the new onboarding goes live.
</details>