### PR TITLE
tracker_script_configuration: drop writes and reads to `installation_meta` (step 4)

### DIFF
--- a/lib/plausible/site/tracker_script_configuration.ex
+++ b/lib/plausible/site/tracker_script_configuration.ex
@@ -4,6 +4,7 @@ defmodule Plausible.Site.TrackerScriptConfiguration do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
 
   @type t() :: %__MODULE__{}
 
@@ -51,6 +52,20 @@ defmodule Plausible.Site.TrackerScriptConfiguration do
       conflict_target: [:site_id],
       returning: true
     )
+  end
+
+  def get_or_create!(site_id) do
+    existing_configuration =
+      Plausible.Repo.one(
+        from(c in Plausible.Site.TrackerScriptConfiguration, where: c.site_id == ^site_id)
+      )
+
+    if existing_configuration do
+      existing_configuration
+    else
+      {:ok, new_configuration} = upsert(%{site_id: site_id})
+      new_configuration
+    end
   end
 
   defp fields_to_update(configuration_map) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -345,13 +345,6 @@ defmodule Plausible.Sites do
     base <> domain <> "?auth=" <> link.slug
   end
 
-  def update_installation_meta!(site, meta) do
-    site
-    |> Ecto.Changeset.change()
-    |> Ecto.Changeset.put_change(:installation_meta, meta)
-    |> Repo.update!()
-  end
-
   def update_legacy_time_on_page_cutoff!(site, cutoff) do
     site
     |> Ecto.Changeset.change()

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -472,8 +472,13 @@ defmodule PlausibleWeb.Live.Installation do
 
   @domain_change PlausibleWeb.Flows.domain_change()
   defp get_installation_type(@domain_change, tracker_script_configuration, params) do
-    tracker_script_configuration.installation_type || get_installation_type(nil, nil, params) ||
-      "manual"
+    case tracker_script_configuration.installation_type do
+      nil ->
+        get_installation_type(nil, nil, params)
+
+      installation_type ->
+        Atom.to_string(installation_type)
+    end
   end
 
   defp get_installation_type(_type, _tracker_script_configuration, params) do

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.Live.Installation do
   """
   use PlausibleWeb, :live_view
   alias Plausible.Verification.{Checks, State}
-  alias Plausible.Site.InstallationMeta
+  alias Plausible.Site.TrackerScriptConfiguration
 
   @script_extension_params %{
     "outbound_links" => "outbound-links",
@@ -50,7 +50,7 @@ defmodule PlausibleWeb.Live.Installation do
 
     flow = params["flow"]
 
-    tracker_script_configuration = InstallationMeta.to_tracker_script_configuration(site)
+    tracker_script_configuration = TrackerScriptConfiguration.get_or_create!(site.id)
     installation_type = get_installation_type(flow, tracker_script_configuration, params)
 
     config =
@@ -472,7 +472,8 @@ defmodule PlausibleWeb.Live.Installation do
 
   @domain_change PlausibleWeb.Flows.domain_change()
   defp get_installation_type(@domain_change, tracker_script_configuration, params) do
-    tracker_script_configuration.installation_type || get_installation_type(nil, nil, params)
+    tracker_script_configuration.installation_type || get_installation_type(nil, nil, params) ||
+      "manual"
   end
 
   defp get_installation_type(_type, _tracker_script_configuration, params) do

--- a/lib/plausible_web/plugs/tracker_plug.ex
+++ b/lib/plausible_web/plugs/tracker_plug.ex
@@ -74,6 +74,9 @@ defmodule PlausibleWeb.TrackerPlug do
       |> put_resp_header("cross-origin-resource-policy", "cross-origin")
       |> put_resp_header("access-control-allow-origin", "*")
       |> put_resp_header("cache-control", "public, max-age=60, no-transform")
+      # CDN-Tag is used by BunnyCDN to tag cached resources. This allows us to purge
+      # specific tracker scripts from the CDN cache.
+      |> put_resp_header("cdn-tag", "tracker_script::#{tracker_script_configuration.id}")
       |> send_resp(200, script_tag)
       |> halt()
     else

--- a/lib/plausible_web/plugs/tracker_plug.ex
+++ b/lib/plausible_web/plugs/tracker_plug.ex
@@ -60,10 +60,13 @@ defmodule PlausibleWeb.TrackerPlug do
   end
 
   defp request_tracker_script(tag, conn) do
-    site = Plausible.Repo.one(from s in Plausible.Site, where: s.installation_meta["id"] == ^tag)
+    tracker_script_configuration =
+      Plausible.Repo.one(
+        from s in Plausible.Site.TrackerScriptConfiguration, where: s.id == ^tag, preload: [:site]
+      )
 
-    if site do
-      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(site)
+    if tracker_script_configuration do
+      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(tracker_script_configuration)
 
       conn
       |> put_resp_header("content-type", "application/javascript")

--- a/test/plausible_web/live/installation_test.exs
+++ b/test/plausible_web/live/installation_test.exs
@@ -48,7 +48,11 @@ defmodule PlausibleWeb.Live.InstallationTest do
 
     test "static verification screen renders for flow=domain_change using original installation type",
          %{conn: conn, site: site} do
-      site = Plausible.Sites.update_installation_meta!(site, %{installation_type: "WordPress"})
+      {:ok, _} =
+        Plausible.Site.TrackerScriptConfiguration.upsert(%{
+          site_id: site.id,
+          installation_type: :wordpress
+        })
 
       resp =
         conn
@@ -58,7 +62,7 @@ defmodule PlausibleWeb.Live.InstallationTest do
       assert resp =~ "Your domain has been changed"
       assert resp =~ "I understand, I'll update my website"
       assert resp =~ "WordPress plugin"
-      refute resp =~ "Manuial installation"
+      refute resp =~ "Manual installation"
       refute resp =~ "Review your existing installation."
 
       assert resp =~

--- a/test/plausible_web/live/installation_test.exs
+++ b/test/plausible_web/live/installation_test.exs
@@ -30,6 +30,12 @@ defmodule PlausibleWeb.Live.InstallationTest do
     end
 
     test "static verification screen renders for flow=domain_change", %{conn: conn, site: site} do
+      {:ok, _} =
+        Plausible.Site.TrackerScriptConfiguration.upsert(%{
+          site_id: site.id,
+          installation_type: :manual
+        })
+
       resp =
         conn
         |> get("/#{site.domain}/installation?flow=#{PlausibleWeb.Flows.domain_change()}")

--- a/test/plausible_web/tracker_test.exs
+++ b/test/plausible_web/tracker_test.exs
@@ -2,23 +2,25 @@ defmodule PlausibleWeb.TrackerTest do
   use Plausible.DataCase, async: true
   use Plausible.Teams.Test
 
+  alias Plausible.Site.TrackerScriptConfiguration
+
   describe "plausible-main.js" do
     @example_config %{
-      "404" => true,
-      "hash" => true,
-      "file-downloads" => false,
-      "outbound-links" => false,
-      "pageview-props" => false,
-      "tagged-events" => true,
-      "revenue" => false
+      installation_type: :manual,
+      track_404_pages: true,
+      hash_based_routing: true,
+      file_downloads: false,
+      outbound_links: false,
+      pageview_props: false,
+      tagged_events: true,
+      revenue_tracking: false
     }
 
     test "can calculate config" do
-      site =
-        new_site()
-        |> Plausible.Sites.update_installation_meta!(%{script_config: @example_config})
+      site = new_site()
+      tracker_script_configuration = create_config(site)
 
-      assert PlausibleWeb.Tracker.plausible_main_config(site) == %{
+      assert PlausibleWeb.Tracker.plausible_main_config(tracker_script_configuration) == %{
                domain: site.domain,
                endpoint: "#{PlausibleWeb.Endpoint.url()}/api/event",
                hash: true,
@@ -32,25 +34,29 @@ defmodule PlausibleWeb.TrackerTest do
     end
 
     test "can turn config into a script tag" do
-      site =
-        new_site()
-        |> Plausible.Sites.update_installation_meta!(%{script_config: @example_config})
+      site = new_site()
+      tracker_script_configuration = create_config(site)
 
-      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(site)
+      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(tracker_script_configuration)
 
       assert script_tag =~
                ~s(={endpoint:"#{PlausibleWeb.Endpoint.url()}/api/event",domain:"#{site.domain}",taggedEvents:!0,hash:!0})
     end
 
     test "script tag escapes problematic characters as expected" do
-      site =
-        new_site()
-        |> Plausible.Sites.update_installation_meta!(%{script_config: @example_config})
-        |> Map.merge(%{domain: "naughty domain &amp;<> \"\'\nfoo "})
-
-      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(site)
+      site = new_site(domain: "naughty domain &amp;<> \"\'\nfoo ")
+      tracker_script_configuration = create_config(site)
+      script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(tracker_script_configuration)
 
       assert script_tag =~ ~s(domain:"naughty domain &amp;<> \\"'\\nfoo ")
+    end
+
+    def create_config(site) do
+      {:ok, _} = TrackerScriptConfiguration.upsert(Map.put(@example_config, :site_id, site.id))
+
+      Plausible.Repo.one(
+        from(c in TrackerScriptConfiguration, where: c.site_id == ^site.id, preload: [:site])
+      )
     end
   end
 end


### PR DESCRIPTION
PR in a series:
1. `tracker_script_configuration` migration (https://github.com/plausible/analytics/pull/5406)
2. `tracker_script_configuration` schema, double-writes (https://github.com/plausible/analytics/pull/5407)
3. `tracker_script_configuration` backfill (https://github.com/plausible/analytics/pull/5408)
4. **`tracker_script_configuration`: drop writes and reads to `installation_meta` (this PR)**
5. Plugins API for `tracker_script_configuration` (https://github.com/plausible/analytics/pull/5410)

See sections below for more details:

<details><summary><b>On schema</b></summary>

- `id` uses Nanoid library to generate ids for nice and readable ids as these will be used for serving scripts. Example: `qyhkWtOWaTN0YPkhrcJgy`
- `installation_type` is marked as nullable since old installation flow could cause inserts where `installation_type` would not be set. This is for backwards compatibility to avoid messing with the schema too much.
- `revenue_tracking`, `tagged_events`, `pageview_props` and `track_404_pages` columns are for old schema compatibility and will not be used once new onboarding is fully live
- Old embedded schema was not removed as new installation flow (which I did not modify to avoid conflicts) relies on it.
- Backfill created a new DataMigration to make it possible to use (snapshot) of schema + app code in migration

</details>


<details><summary><b>On plugins API</b></summary>

This will be used by wordpress plugin to integrate into the app.

Currently it also creates goals as part of it's code but this will be changed as the new onboarding goes live.
</details>