### PR TITLE
Note about no invoices

### DIFF
--- a/lib/plausible_web/templates/settings/invoices.html.heex
+++ b/lib/plausible_web/templates/settings/invoices.html.heex
@@ -10,7 +10,7 @@
       <% {:error, :no_invoices} -> %>
         <p class="mt-12 mb-8 text-center text-sm">
           <span>
-            No invoices issued yet
+            Your invoice will be created once you upgrade to a subscription
           </span>
         </p>
       <% {:error, :request_failed} -> %>


### PR DESCRIPTION
we had someone confused about the "no invoices" note. turns out they were looking at "my personal sites" which didn't have a subscription rather than at their team where the invoice was issued.

I've changed the note on that page to say that invoice will be issued after you get a subscription. alternative approach (and maybe better) would be to not show the invoice page at all for those without a subscription 

cc @zoldar 