### PR TITLE
CS: Enable searching for teams with subscriptions

### DIFF
--- a/extra/lib/plausible/customer_support/resource/user.ex
+++ b/extra/lib/plausible/customer_support/resource/user.ex
@@ -9,7 +9,11 @@ defmodule Plausible.CustomerSupport.Resource.User do
   end
 
   @impl true
-  def search("", limit) do
+  def search(input, opts \\ [])
+
+  def search("", opts) do
+    limit = Keyword.fetch!(opts, :limit)
+
     q =
       from u in Plausible.Auth.User,
         order_by: [
@@ -21,7 +25,9 @@ defmodule Plausible.CustomerSupport.Resource.User do
     Plausible.Repo.all(q)
   end
 
-  def search(input, limit) do
+  def search(input, opts) do
+    limit = Keyword.fetch!(opts, :limit)
+
     q =
       from u in Plausible.Auth.User,
         where: ilike(u.email, ^"%#{input}%") or ilike(u.name, ^"%#{input}%"),

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -480,6 +480,13 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
           Team
         </span>
+
+        <span
+          :if={@resource.object.subscription}
+          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800"
+        >
+          $
+        </span>
       </div>
 
       <hr class="mt-4 mb-4 flex-grow border-t border-gray-200 dark:border-gray-600" />

--- a/test/plausible_web/live/customer_support_test.exs
+++ b/test/plausible_web/live/customer_support_test.exs
@@ -60,6 +60,40 @@ defmodule PlausibleWeb.Live.CustomerSupportTest do
 
         assert_search_result(html, "site", site2.id)
       end
+
+      test "search teams", %{conn: conn} do
+        team1 = new_user(team: [name: "Team One"]) |> team_of()
+
+        team2 =
+          new_user(team: [name: "Team Two"])
+          |> subscribe_to_growth_plan()
+          |> team_of()
+
+        team3 = new_user(team: [name: "Team Three"]) |> team_of()
+
+        {:ok, lv, _html} = live(conn, @cs_index)
+
+        type_into_input(lv, "filter-text", "team:Team")
+        html = render(lv)
+
+        assert_search_result(html, "team", team1.id)
+        assert_search_result(html, "team", team2.id)
+        assert_search_result(html, "team", team3.id)
+
+        type_into_input(lv, "filter-text", "team:Team T")
+        html = render(lv)
+
+        refute_search_result(html, "team", team1.id)
+        assert_search_result(html, "team", team2.id)
+        assert_search_result(html, "team", team3.id)
+
+        type_into_input(lv, "filter-text", "team:Team T +sub")
+        html = render(lv)
+
+        refute_search_result(html, "team", team1.id)
+        assert_search_result(html, "team", team2.id)
+        refute_search_result(html, "team", team3.id)
+      end
     end
 
     defp assert_search_result(doc, type, id) do


### PR DESCRIPTION
### Changes

Enables search for teams w/ subscriptions via the new CRM, and also indicates existing subscriptions on search results view. Displays a legend for search modifiers.


Uploading record-2025-05-21-14-51-42-rosy when ream.mp4…


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
