### PR TITLE
CRM: Expose site transfer

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/site.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/site.ex
@@ -4,6 +4,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
 
   alias PlausibleWeb.Live.Components.ComboBox
   alias Plausible.Repo
+  import Ecto.Query
 
   def update(%{resource_id: resource_id}, socket) do
     site = Resource.Site.get(resource_id)
@@ -299,9 +300,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
   end
 
   defp search_email(input) do
-    alias Plausible.Repo
-    import Ecto.Query
-
     Repo.all(
       from u in Plausible.Auth.User,
         where: ilike(u.name, ^"%#{input}%") or ilike(u.email, ^"%#{input}%"),

--- a/lib/plausible/teams/invitations/invite_to_site.ex
+++ b/lib/plausible/teams/invitations/invite_to_site.ex
@@ -37,6 +37,7 @@ defmodule Plausible.Teams.Invitations.InviteToSite do
     end)
   end
 
+  # XXX: remove with kaffy
   @spec bulk_invite([Site.t()], User.t(), String.t(), atom(), Keyword.t()) ::
           {:ok, [invitation]} | {:error, invite_error()}
   def bulk_invite(sites, inviter, invitee_email, role, opts \\ []) do

--- a/lib/plausible/teams/sites/transfer.ex
+++ b/lib/plausible/teams/sites/transfer.ex
@@ -17,6 +17,7 @@ defmodule Plausible.Teams.Sites.Transfer do
           | :multiple_teams
           | :permission_denied
 
+  # XXX: remove with kaffy
   @spec bulk_transfer([Site.t()], Auth.User.t(), Teams.Team.t() | nil) ::
           {:ok, [Teams.Membership.t()]} | {:error, transfer_error()}
   def bulk_transfer(sites, new_owner, team \\ nil) do

--- a/test/plausible_web/live/customer_support/sites_test.exs
+++ b/test/plausible_web/live/customer_support/sites_test.exs
@@ -1,20 +1,23 @@
 defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
   use PlausibleWeb.ConnCase, async: false
-  use Plausible.Teams.Test
-  use Plausible
   @moduletag :ee_only
 
   on_ee do
+    use Plausible.Teams.Test
+    use Plausible
+    use Bamboo.Test, shared: true
+
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
-    defp open_site(id) do
+    defp open_site(id, opts \\ []) do
       Routes.customer_support_resource_path(
         PlausibleWeb.Endpoint,
         :details,
         :sites,
         :site,
-        id
+        id,
+        opts
       )
     end
 
@@ -35,6 +38,67 @@ defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
           {:ok, _lv, _html} = live(conn, open_site(9999))
         end
       end
+    end
+
+    describe "rescue zone" do
+      setup [:create_user, :log_in, :create_site]
+
+      setup %{user: user} do
+        patch_env(:super_admin_user_ids, [user.id])
+      end
+
+      test "form renders", %{site: site, conn: conn} do
+        {:ok, lv, _html} = live(conn, open_site(site.id, tab: "rescue-zone"))
+        html = render(lv)
+
+        form = ~s|form[phx-submit="init-transfer"]|
+
+        assert element_exists?(html, ~s|#{form} input#inviter_email|)
+
+        assert element_exists?(html, ~s|#{form} input#invitee_email|)
+
+        assert element_exists?(html, ~s|#{form} input#submit-inviter_email|)
+
+        assert element_exists?(html, ~s|#{form} input#submit-invitee_email|)
+
+        assert element_exists?(html, ~s|#{form} button[type="submit"]|)
+      end
+
+      @subject_prefix if ee?(), do: "[Plausible Analytics] ", else: "[Plausible CE] "
+      test "form submission creates invitation", %{user: user, site: site, conn: conn} do
+        {:ok, lv, _html} = live(conn, open_site(site.id, tab: "rescue-zone"))
+        render(lv)
+
+        type_into_combo(lv, "inviter_email", user.name)
+
+        lv
+        |> element("li#dropdown-inviter_email-option-1 a")
+        |> render_click()
+
+        type_into_combo(lv, "invitee_email", "arbitrary@example.com")
+
+        lv
+        |> element("li#dropdown-invitee_email-option-0 a")
+        |> render_click()
+
+        form = ~s|form[phx-submit="init-transfer"]|
+        lv |> element(form) |> render_submit()
+
+        assert_email_delivered_with(
+          to: [nil: "arbitrary@example.com"],
+          subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}",
+          html_body: ~r/#{user.email}/
+        )
+      end
+    end
+
+    defp type_into_combo(lv, id, text) do
+      lv
+      |> element("input##{id}")
+      |> render_change(%{
+        "_target" => ["display-#{id}"],
+        "display-#{id}" => "#{text}"
+      })
     end
   end
 end


### PR DESCRIPTION
### Changes

Another CS follow-up: Sites tab now get "Rescue Zone" tab where a transfer request can be initiated in case of customer lock-out.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
