### PR TITLE
CRM: Render price estimation in enterprise plans

### DIFF
--- a/extra/lib/plausible/customer_support/enterprise_plan.ex
+++ b/extra/lib/plausible/customer_support/enterprise_plan.ex
@@ -1,0 +1,69 @@
+defmodule Plausible.CustomerSupport.EnterprisePlan do
+  @moduledoc """
+  Custom plan price estimation
+  """
+  @spec estimate(
+          :business | :growth,
+          String.t(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer(),
+          list(String.t())
+        ) :: Decimal.t()
+  def estimate(
+        kind,
+        billing_interval,
+        pageviews_per_month,
+        sites_limit,
+        team_members_limit,
+        api_calls_limit,
+        features
+      ) do
+    cost_per_month =
+      Decimal.from_float(
+        pv_rate(kind, pageviews_per_month) + sites_rate(sites_limit) +
+          team_members_rate(team_members_limit) + api_calls_rate(api_calls_limit) +
+          features_rate(features)
+      )
+      |> Decimal.round(2)
+
+    if billing_interval == "monthly" do
+      cost_per_month
+    else
+      cost_per_month |> Decimal.mult(10) |> Decimal.round(2)
+    end
+  end
+
+  def pv_rate(:growth, pvs) when pvs <= 20_000_000, do: 319
+  def pv_rate(:growth, pvs) when pvs <= 50_000_000, do: 689
+  def pv_rate(:growth, pvs) when pvs <= 100_000_000, do: 1029
+  def pv_rate(:growth, pvs) when pvs <= 200_000_000, do: 1629
+  def pv_rate(:growth, pvs) when pvs <= 300_000_000, do: 2369
+  def pv_rate(:growth, pvs) when pvs <= 400_000_000, do: 2989
+  def pv_rate(:growth, pvs) when pvs <= 500_000_000, do: 3729
+  def pv_rate(:growth, pvs) when pvs <= 1_000_000_000, do: 7219
+  def pv_rate(:growth, _), do: 7219
+
+  def pv_rate(:business, pvs) when pvs <= 20_000_000, do: 639
+  def pv_rate(:business, pvs) when pvs <= 50_000_000, do: 1379
+  def pv_rate(:business, pvs) when pvs <= 100_000_000, do: 2059
+  def pv_rate(:business, pvs) when pvs <= 200_000_000, do: 3259
+  def pv_rate(:business, pvs) when pvs <= 300_000_000, do: 4739
+  def pv_rate(:business, pvs) when pvs <= 400_000_000, do: 5979
+  def pv_rate(:business, pvs) when pvs <= 500_000_000, do: 7459
+  def pv_rate(:business, pvs) when pvs <= 1_000_000_000, do: 14_439
+  def pv_rate(:business, _), do: 14_439
+
+  def sites_rate(n), do: n * 0.1
+
+  def team_members_rate(n), do: n * 5
+
+  def api_calls_rate(n) when n <= 1_000, do: 100
+  def api_calls_rate(n) when n <= 2_000, do: 200
+  def api_calls_rate(_), do: 300
+
+  def features_rate(f) do
+    if "sites_api" in f, do: 99, else: 0
+  end
+end

--- a/extra/lib/plausible_web/live/customer_support.ex
+++ b/extra/lib/plausible_web/live/customer_support.ex
@@ -64,7 +64,9 @@ defmodule PlausibleWeb.Live.CustomerSupport do
       <div class="container pt-6">
         <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
           <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
-            💬 Customer Support
+            <.link replace patch="/cs?filter_text=">
+              💬 Customer Support
+            </.link>
           </h2>
         </div>
 

--- a/test/plausible/customer_support/enterprise_plan_test.exs
+++ b/test/plausible/customer_support/enterprise_plan_test.exs
@@ -1,0 +1,98 @@
+defmodule Plausible.CustomerSupport.EnterprisePlanTest do
+  use Plausible
+  use Plausible.DataCase, async: true
+  @moduletag :ee_only
+
+  on_ee do
+    alias Plausible.CustomerSupport.EnterprisePlan
+
+    describe "estimate/8" do
+      test "calculates cost for business plan with monthly billing" do
+        result =
+          EnterprisePlan.estimate(
+            :business,
+            "monthly",
+            20_000_000,
+            1000,
+            30,
+            1_000,
+            ["sites_api"]
+          )
+
+        assert result == Decimal.new("1088.00")
+      end
+
+      test "calculates cost for business plan with yearly billing" do
+        result =
+          EnterprisePlan.estimate(
+            :business,
+            "yearly",
+            20_000_000,
+            1000,
+            30,
+            1_000,
+            ["sites_api"]
+          )
+
+        assert result == Decimal.new("10880.00")
+      end
+    end
+
+    describe "pv_rate/2" do
+      test "returns correct rate for growth plan" do
+        assert EnterprisePlan.pv_rate(:growth, 20_000_000) == 319
+        assert EnterprisePlan.pv_rate(:growth, 50_000_000) == 689
+        assert EnterprisePlan.pv_rate(:growth, 100_000_000) == 1029
+        assert EnterprisePlan.pv_rate(:growth, 200_000_000) == 1629
+        assert EnterprisePlan.pv_rate(:growth, 300_000_000) == 2369
+        assert EnterprisePlan.pv_rate(:growth, 400_000_000) == 2989
+        assert EnterprisePlan.pv_rate(:growth, 500_000_000) == 3729
+        assert EnterprisePlan.pv_rate(:growth, 1_000_000_000) == 7219
+        assert EnterprisePlan.pv_rate(:growth, 1_500_000_000) == 7219
+      end
+
+      test "returns correct rate for business plan" do
+        assert EnterprisePlan.pv_rate(:business, 20_000_000) == 639
+        assert EnterprisePlan.pv_rate(:business, 50_000_000) == 1379
+        assert EnterprisePlan.pv_rate(:business, 100_000_000) == 2059
+        assert EnterprisePlan.pv_rate(:business, 200_000_000) == 3259
+        assert EnterprisePlan.pv_rate(:business, 300_000_000) == 4739
+        assert EnterprisePlan.pv_rate(:business, 400_000_000) == 5979
+        assert EnterprisePlan.pv_rate(:business, 500_000_000) == 7459
+        assert EnterprisePlan.pv_rate(:business, 1_000_000_000) == 14_439
+        assert EnterprisePlan.pv_rate(:business, 1_500_000_000) == 14_439
+      end
+    end
+
+    describe "sites_rate/1" do
+      test "calculates rate based on number of sites" do
+        assert EnterprisePlan.sites_rate(10) == 1.0
+        assert EnterprisePlan.sites_rate(20) == 2.0
+      end
+    end
+
+    describe "team_members_rate/1" do
+      test "calculates rate based on number of team members" do
+        assert EnterprisePlan.team_members_rate(5) == 25
+        assert EnterprisePlan.team_members_rate(10) == 50
+      end
+    end
+
+    describe "api_calls_rate/1" do
+      test "returns correct rate for API calls" do
+        assert EnterprisePlan.api_calls_rate(500) == 100
+        assert EnterprisePlan.api_calls_rate(1_500) == 200
+        assert EnterprisePlan.api_calls_rate(2_000) == 200
+        assert EnterprisePlan.api_calls_rate(3_000) == 300
+        assert EnterprisePlan.api_calls_rate(3_500) == 300
+      end
+    end
+
+    describe "features_rate/1" do
+      test "returns correct rate based on features" do
+        assert EnterprisePlan.features_rate(["sites_api"]) == 99
+        assert EnterprisePlan.features_rate([]) == 0
+      end
+    end
+  end
+end

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -8,13 +8,14 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
-    defp open_team(id) do
+    defp open_team(id, qs \\ []) do
       Routes.customer_support_resource_path(
         PlausibleWeb.Endpoint,
         :details,
         :teams,
         :team,
-        id
+        id,
+        qs
       )
     end
 
@@ -35,6 +36,116 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         assert_raise Ecto.NoResultsError, fn ->
           {:ok, _lv, _html} = live(conn, open_team(9999))
         end
+      end
+    end
+
+    describe "billing" do
+      setup [:create_user, :log_in, :create_site]
+
+      setup %{user: user} do
+        patch_env(:super_admin_user_ids, [user.id])
+      end
+
+      test "renders custom plan form", %{conn: conn, user: user} do
+        lv = open_custom_plan(conn, team_of(user))
+        html = render(lv)
+
+        assert element_exists?(
+                 html,
+                 ~s|form#save-plan[phx-submit="save-plan"][phx-change="estimate-cost"]|
+               )
+      end
+
+      test "estimates the price", %{conn: conn, user: user} do
+        lv = open_custom_plan(conn, team_of(user))
+
+        lv
+        |> element(~s|form#save-plan|)
+        |> render_change(%{
+          "enterprise_plan" => %{
+            "billing_interval" => "yearly",
+            "monthly_pageview_limit" => "20,000,000",
+            "site_limit" => "1,000",
+            "team_member_limit" => "30",
+            "hourly_api_request_limit" => "1,000",
+            "features[]" => [
+              "false",
+              "false",
+              "false",
+              "teams",
+              "false",
+              "shared_links",
+              "false",
+              "false",
+              "false",
+              "false",
+              "sites_api"
+            ]
+          }
+        })
+
+        html = render(lv)
+        assert text_of_attr(html, ~s|#cost-estimate|, "value") == "10880.00"
+      end
+
+      test "saves custom plan", %{conn: conn, user: user} do
+        lv = open_custom_plan(conn, team_of(user))
+
+        lv
+        |> element(~s|form#save-plan|)
+        |> render_change(%{
+          "enterprise_plan" => %{
+            "paddle_plan_id" => "1111",
+            "billing_interval" => "yearly",
+            "monthly_pageview_limit" => "20,000,000",
+            "site_limit" => "1,000",
+            "team_member_limit" => "30",
+            "hourly_api_request_limit" => "1,000",
+            "features[]" => [
+              "false",
+              "false",
+              "false",
+              "teams",
+              "false",
+              "shared_links",
+              "false",
+              "false",
+              "false",
+              "false",
+              "sites_api"
+            ]
+          }
+        })
+
+        lv |> element("form#save-plan") |> render_submit()
+        html = render(lv)
+        assert text(html) =~ "Plan saved"
+
+        team_id = team_of(user).id
+
+        assert [
+                 %Plausible.Billing.EnterprisePlan{
+                   billing_interval: :yearly,
+                   features: [
+                     Plausible.Billing.Feature.Teams,
+                     Plausible.Billing.Feature.SharedLinks,
+                     Plausible.Billing.Feature.SitesAPI
+                   ],
+                   hourly_api_request_limit: 1000,
+                   monthly_pageview_limit: 20_000_000,
+                   paddle_plan_id: "1111",
+                   site_limit: 1000,
+                   team_id: ^team_id,
+                   team_member_limit: 30
+                 }
+               ] = Plausible.Repo.all(Plausible.Billing.EnterprisePlan)
+      end
+
+      defp open_custom_plan(conn, team) do
+        {:ok, lv, _html} = live(conn, open_team(team.id, tab: :billing))
+        render(lv)
+        lv |> element("button#new-custom-plan") |> render_click()
+        lv
       end
     end
   end


### PR DESCRIPTION
### Changes

This PR adds an "input with clipboard" widget containing price estimation for a custom plan, depending on its parameters (such as limits, billing interval etc.)

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
