### PR TITLE
Implement `SSO.provision_user/1` and extend `UserAuth.log_in_user/3`

### DIFF
--- a/extra/lib/plausible/auth/sso.ex
+++ b/extra/lib/plausible/auth/sso.ex
@@ -3,6 +3,10 @@ defmodule Plausible.Auth.SSO do
   API for SSO.
   """
 
+  import Ecto.Changeset
+  import Ecto.Query
+
+  alias Plausible.Auth
   alias Plausible.Auth.SSO
   alias Plausible.Repo
   alias Plausible.Teams
@@ -26,6 +30,165 @@ defmodule Plausible.Auth.SSO do
     case Repo.update(changeset) do
       {:ok, integration} -> {:ok, integration}
       {:error, changeset} -> {:error, changeset.changes.config}
+    end
+  end
+
+  @spec provision_user(SSO.Identity.t()) ::
+          {:ok, :standard | :sso | :integration, Auth.User.t()}
+          | {:error, :integration_not_found}
+          | {:error, :multiple_memberships, Teams.Team.t(), Auth.User.t()}
+  def provision_user(identity) do
+    case find_user(identity) do
+      {:ok, :standard, user, integration} ->
+        provision_standard_user(user, identity, integration)
+
+      {:ok, :sso, user, _integration} ->
+        provision_sso_user(user, identity)
+
+      {:ok, :integration, integration} ->
+        provision_identity(identity, integration)
+
+      {:error, :not_found} ->
+        {:error, :integration_not_found}
+    end
+  end
+
+  defp find_user(identity) do
+    case find_user_with_fallback(identity) do
+      {:ok, type, user, integration} ->
+        {:ok, type, Repo.preload(user, :sso_integration), integration}
+
+      error ->
+        error
+    end
+  end
+
+  defp find_user_with_fallback(identity) do
+    with {:error, :not_found} <- find_by_identity(identity.id) do
+      find_by_email(identity.email)
+    end
+  end
+
+  defp find_by_identity(id) do
+    if user = Repo.get_by(Auth.User, sso_identity_id: id) do
+      user = Repo.preload(user, :sso_integration)
+
+      {:ok, user.type, user, user.sso_integration}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp find_by_email(email) do
+    with {:ok, sso_domain} <- SSO.Domains.lookup(email) do
+      case find_by_email(sso_domain.sso_integration.team, email) do
+        {:ok, user} ->
+          {:ok, user.type, user, sso_domain.sso_integration}
+
+        {:error, :not_found} ->
+          {:ok, :integration, sso_domain.sso_integration}
+      end
+    end
+  end
+
+  defp find_by_email(team, email) do
+    result =
+      Repo.one(
+        from(
+          u in Auth.User,
+          inner_join: tm in assoc(u, :team_memberships),
+          where: u.email == ^email,
+          where: tm.team_id == ^team.id,
+          where: tm.role != :guest
+        )
+      )
+
+    if result do
+      {:ok, result}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp provision_sso_user(user, identity) do
+    changeset =
+      user
+      |> change()
+      |> put_change(:email, identity.email)
+      |> put_change(:name, identity.name)
+      |> put_change(:sso_identity_id, identity.id)
+      |> put_change(:last_sso_login, NaiveDateTime.utc_now(:second))
+
+    with {:ok, user} <- Repo.update(changeset) do
+      {:ok, :sso, user}
+    end
+  end
+
+  defp provision_standard_user(user, identity, integration) do
+    changeset =
+      user
+      |> change()
+      |> put_change(:type, :sso)
+      |> put_change(:name, identity.name)
+      |> put_change(:sso_identity_id, identity.id)
+      |> put_change(:last_sso_login, NaiveDateTime.utc_now(:second))
+      |> put_assoc(:sso_integration, integration)
+
+    with :ok <- ensure_team_member(integration.team, user),
+         :ok <- ensure_one_membership(user, integration.team),
+         {:ok, user} <- Repo.update(changeset) do
+      {:ok, :standard, user}
+    end
+  end
+
+  defp provision_identity(identity, integration) do
+    random_password =
+      64
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode64(padding: false)
+
+    params = %{
+      email: identity.email,
+      name: identity.name,
+      password: random_password,
+      password_confirmation: random_password
+    }
+
+    changeset =
+      Auth.User.new(params)
+      |> put_change(:email_verified, true)
+      |> put_change(:type, :sso)
+      |> put_change(:sso_identity_id, identity.id)
+      |> put_change(:last_sso_login, NaiveDateTime.utc_now(:second))
+      |> put_assoc(:sso_integration, integration)
+
+    case Repo.insert(changeset) do
+      {:ok, user} ->
+        {:ok, :identity, user}
+
+      {:error, %{errors: [email: {_, attrs}]}} ->
+        true = {:constraint, :unique} in attrs
+        {:error, :integration_not_found}
+    end
+  end
+
+  defp ensure_team_member(team, user) do
+    case Teams.Memberships.team_role(team, user) do
+      {:ok, role} when role != :guest ->
+        :ok
+
+      _ ->
+        {:error, :integration_not_found}
+    end
+  end
+
+  defp ensure_one_membership(user, team) do
+    query = Teams.Users.teams_query(user)
+
+    if Repo.aggregate(query, :count) > 1 do
+      {:error, :multiple_memberships, team, user}
+    else
+      :ok
     end
   end
 end

--- a/extra/lib/plausible/auth/sso.ex
+++ b/extra/lib/plausible/auth/sso.ex
@@ -12,7 +12,7 @@ defmodule Plausible.Auth.SSO do
     changeset = SSO.Integration.init_changeset(team)
 
     Repo.insert!(changeset,
-      on_conflict: [set: [updated_at: NaiveDateTime.utc_now()]],
+      on_conflict: [set: [updated_at: NaiveDateTime.utc_now(:second)]],
       conflict_target: :team_id,
       returning: true
     )

--- a/extra/lib/plausible/auth/sso/identity.ex
+++ b/extra/lib/plausible/auth/sso/identity.ex
@@ -1,0 +1,10 @@
+defmodule Plausible.Auth.SSO.Identity do
+  @moduledoc """
+  SSO Identity struct.
+  """
+
+  @type t() :: %__MODULE__{}
+
+  @enforce_keys [:id, :name, :email, :expires_at]
+  defstruct [:id, :name, :email, :expires_at]
+end

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.UserAuth do
     @type login_subject() :: Auth.User.t()
   end
 
-  @spec log_in_user(Plug.Conn.t(), Auth.User.t() | Auth.SSO.Identity.t(), String.t() | nil) ::
+  @spec log_in_user(Plug.Conn.t(), login_subject(), String.t() | nil) ::
           Plug.Conn.t()
   def log_in_user(conn, subject, redirect_path \\ nil)
 

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -3,6 +3,8 @@ defmodule PlausibleWeb.UserAuth do
   Functions for user session management.
   """
 
+  use Plausible
+
   import Ecto.Query
 
   alias Plausible.Auth
@@ -13,8 +15,17 @@ defmodule PlausibleWeb.UserAuth do
 
   require Logger
 
-  @spec log_in_user(Plug.Conn.t(), Auth.User.t(), String.t() | nil) :: Plug.Conn.t()
-  def log_in_user(conn, user, redirect_path \\ nil) do
+  on_ee do
+    @type login_subject() :: Auth.User.t() | Auth.SSO.Identity.t()
+  else
+    @type login_subject() :: Auth.User.t()
+  end
+
+  @spec log_in_user(Plug.Conn.t(), Auth.User.t() | Auth.SSO.Identity.t(), String.t() | nil) ::
+          Plug.Conn.t()
+  def log_in_user(conn, subject, redirect_path \\ nil)
+
+  def log_in_user(conn, %Auth.User{} = user, redirect_path) do
     redirect_to =
       if String.starts_with?(redirect_path || "", "/") do
         redirect_path
@@ -26,6 +37,29 @@ defmodule PlausibleWeb.UserAuth do
     |> set_user_session(user)
     |> set_logged_in_cookie()
     |> Phoenix.Controller.redirect(to: redirect_to)
+  end
+
+  on_ee do
+    def log_in_user(conn, %Auth.SSO.Identity{} = identity, redirect_path) do
+      case Auth.SSO.provision_user(identity) do
+        {:ok, provisioning_from, user} ->
+          if provisioning_from == :standard do
+            :ok = revoke_all_user_sessions(user)
+          end
+
+          log_in_user(conn, user, redirect_path)
+
+        {:error, :integration_not_found} ->
+          conn
+          |> log_out_user()
+          |> Phoenix.Controller.redirect(to: "/")
+
+        {:error, :multiple_memberships, team, user} ->
+          redirect_path = Routes.site_path(conn, :index, __team: team.identifier)
+
+          log_in_user(conn, user, redirect_path)
+      end
+    end
   end
 
   @spec log_out_user(Plug.Conn.t()) :: Plug.Conn.t()

--- a/test/plausible_web/user_auth_test.exs
+++ b/test/plausible_web/user_auth_test.exs
@@ -1,5 +1,7 @@
 defmodule PlausibleWeb.UserAuthTest do
   use PlausibleWeb.ConnCase, async: true
+  use Plausible
+  use Plausible.Teams.Test
 
   import Ecto.Query, only: [from: 2]
   import Phoenix.ChannelTest
@@ -39,6 +41,88 @@ defmodule PlausibleWeb.UserAuthTest do
         |> UserAuth.log_in_user(user, "/next")
 
       assert redirected_to(conn, 302) == "/next"
+    end
+
+    on_ee do
+      alias Plausible.Auth.SSO
+
+      test "sets up user session from SSO identity", %{conn: conn, user: user} do
+        team = new_site().team
+        integration = SSO.initiate_saml_integration(team)
+        domain = "example-#{Enum.random(1..10_000)}.com"
+        user = user |> Ecto.Changeset.change(email: "jane@" <> domain) |> Repo.update!()
+        add_member(team, user: user, role: :editor)
+
+        {:ok, sso_domain} = SSO.Domains.add(integration, domain)
+        _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
+
+        identity = new_identity(user.name, user.email)
+
+        conn =
+          conn
+          |> init_session()
+          |> UserAuth.log_in_user(identity)
+
+        assert %{sessions: [session]} = user |> Repo.reload!() |> Repo.preload(:sessions)
+        assert session.user_id == user.id
+
+        assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+        assert conn.private[:plug_session_info] == :renew
+        assert conn.resp_cookies["logged_in"].max_age > 0
+        assert get_session(conn, :user_token) == session.token
+      end
+
+      test "tries to log out and redirects if SSO identity is not matched", %{
+        conn: conn,
+        user: user
+      } do
+        identity = new_identity("Willy Wonka", "wonka@example.com")
+
+        conn =
+          conn
+          |> init_session()
+          |> UserAuth.log_in_user(identity)
+
+        assert %{sessions: []} = user |> Repo.reload!() |> Repo.preload(:sessions)
+        assert redirected_to(conn, 302) == "/"
+        assert conn.private[:plug_session_info] == :renew
+        refute get_session(conn, :user_token)
+      end
+
+      test "passes through for user matching SSO identity, redirecting to team", %{
+        conn: conn,
+        user: user
+      } do
+        team = new_site().team
+        integration = SSO.initiate_saml_integration(team)
+        domain = "example-#{Enum.random(1..10_000)}.com"
+        user = user |> Ecto.Changeset.change(email: "jane@" <> domain) |> Repo.update!()
+        add_member(team, user: user, role: :editor)
+        another_team = new_site().team
+        add_member(another_team, user: user, role: :viewer)
+
+        {:ok, sso_domain} = SSO.Domains.add(integration, domain)
+        _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
+
+        identity = new_identity(user.name, user.email)
+
+        conn =
+          conn
+          |> init_session()
+          |> UserAuth.log_in_user(identity)
+
+        assert redirected_to(conn, 302) == Routes.site_path(conn, :index, __team: team.identifier)
+        assert get_session(conn, :user_token)
+      end
+
+      defp new_identity(name, email, id \\ Ecto.UUID.generate()) do
+        %SSO.Identity{
+          id: id,
+          name: name,
+          email: email,
+          expires_at: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 6, :hour)
+        }
+      end
     end
   end
 


### PR DESCRIPTION
### Changes

This PR adds logic for provisioning SSO user during during login, including conversion of existing user and creation of new user on the fly.

### TODO

- [ ] ~expire session according to identity.expires_at~
- [ ] ~do _not_ touch/prolong the session if it's for SSO user~

NOTE: Session expiration will be handled in a follow-up PR

### Tests
- [x] Automated tests have been added
