### PR TITLE
Always expire SSO User sessions after `identity.expires_at`

### DIFF
--- a/lib/plausible/auth/user_session.ex
+++ b/lib/plausible/auth/user_session.ex
@@ -4,6 +4,7 @@ defmodule Plausible.Auth.UserSession do
   """
 
   use Ecto.Schema
+  use Plausible
 
   import Ecto.Changeset
 
@@ -37,12 +38,37 @@ defmodule Plausible.Auth.UserSession do
     |> touch_session(now)
   end
 
+  @spec new_sso_session(Auth.User.t(), String.t(), NaiveDateTime.t(), NaiveDateTime.t()) ::
+          Ecto.Changeset.t()
+  def new_sso_session(user, device, timeout_at, now \\ NaiveDateTime.utc_now(:second)) do
+    %__MODULE__{}
+    |> cast(%{device: device}, [:device])
+    |> generate_token()
+    |> put_assoc(:user, user)
+    |> put_change(:timeout_at, timeout_at)
+    |> touch_session(now)
+  end
+
   @spec touch_session(t() | Ecto.Changeset.t(), NaiveDateTime.t()) :: Ecto.Changeset.t()
   def touch_session(session, now \\ NaiveDateTime.utc_now(:second)) do
-    session
-    |> change()
-    |> put_change(:last_used_at, now)
-    |> put_change(:timeout_at, NaiveDateTime.shift(now, @timeout))
+    changeset = change(session)
+
+    on_ee do
+      case get_field(changeset, :user) do
+        %{type: :sso} ->
+          changeset
+          |> put_change(:last_used_at, now)
+
+        _ ->
+          changeset
+          |> put_change(:last_used_at, now)
+          |> put_change(:timeout_at, NaiveDateTime.shift(now, @timeout))
+      end
+    else
+      changeset
+      |> put_change(:last_used_at, now)
+      |> put_change(:timeout_at, NaiveDateTime.shift(now, @timeout))
+    end
   end
 
   defp generate_token(changeset) do

--- a/lib/plausible/auth/user_session.ex
+++ b/lib/plausible/auth/user_session.ex
@@ -56,8 +56,7 @@ defmodule Plausible.Auth.UserSession do
     on_ee do
       case get_field(changeset, :user) do
         %{type: :sso} ->
-          changeset
-          |> put_change(:last_used_at, now)
+          put_change(changeset, :last_used_at, now)
 
         _ ->
           changeset

--- a/test/plausible_web/plugs/user_session_touch_test.exs
+++ b/test/plausible_web/plugs/user_session_touch_test.exs
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Plugs.UserSessionTouchTest do
   test "refreshes session", %{conn: conn, user: user} do
     now = NaiveDateTime.utc_now(:second)
     one_day_ago = NaiveDateTime.shift(now, day: -1)
-    %{sessions: [user_session]} = Repo.preload(user, :sessions)
+    %{sessions: [user_session]} = Repo.preload(user, sessions: :user)
 
     user_session
     |> Plausible.Auth.UserSession.touch_session(one_day_ago)


### PR DESCRIPTION
### Changes

Ensures SSO user sessions always expires after `identity.expires_at`.

### Tests
- [x] Automated tests have been added

