### PR TITLE
ScriptV2: BunnyCDN cache purging

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -786,7 +786,8 @@ cloud_queues = [
   check_usage: 1,
   notify_annual_renewal: 1,
   lock_sites: 1,
-  legacy_time_on_page_cutoff: 1
+  legacy_time_on_page_cutoff: 1,
+  purge_cdn_cache: 1
 ]
 
 queues = if(is_selfhost, do: base_queues, else: base_queues ++ cloud_queues)
@@ -827,6 +828,10 @@ config :plausible, Plausible.Sentry.Client,
     pool_timeout: get_int_from_path_or_env(config_dir, "SENTRY_FINCH_POOL_TIMEOUT", 5000),
     receive_timeout: get_int_from_path_or_env(config_dir, "SENTRY_FINCH_RECEIVE_TIMEOUT", 15000)
   ]
+
+config :plausible, Plausible.Workers.PurgeCDNCache,
+  pullzone_id: get_var_from_path_or_env(config_dir, "BUNNY_PULLZONE_ID"),
+  api_key: get_var_from_path_or_env(config_dir, "BUNNY_API_KEY")
 
 config :ref_inspector,
   init: {Plausible.Release, :configure_ref_inspector}

--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -3,6 +3,7 @@ defmodule PlausibleWeb.Tracker do
   Helper module for building the dynamic tracker script. Used by PlausibleWeb.TrackerPlug.
   """
 
+  use Plausible
   use Plausible.Repo
   alias Plausible.Site.TrackerScriptConfiguration
 
@@ -49,6 +50,12 @@ defmodule PlausibleWeb.Tracker do
     updated_config = Repo.update!(changeset)
 
     sync_goals(site, original_config, updated_config)
+
+    on_ee do
+      %{id: updated_config.id}
+      |> Plausible.Workers.PurgeCDNCache.new()
+      |> Oban.insert!()
+    end
 
     updated_config
   end

--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -52,8 +52,12 @@ defmodule PlausibleWeb.Tracker do
     sync_goals(site, original_config, updated_config)
 
     on_ee do
-      %{id: updated_config.id}
-      |> Plausible.Workers.PurgeCDNCache.new()
+      Plausible.Workers.PurgeCDNCache.new(
+        %{id: updated_config.id},
+        # See PurgeCDNCache.ex for more details
+        schedule_in: 10,
+        replace: [scheduled: [:scheduled_at]]
+      )
       |> Oban.insert!()
     end
 

--- a/lib/workers/purge_cdn_cache.ex
+++ b/lib/workers/purge_cdn_cache.ex
@@ -10,7 +10,14 @@ defmodule Plausible.Workers.PurgeCDNCache do
 
   use Oban.Worker,
     queue: :purge_cdn_cache,
-    max_attempts: 5
+    max_attempts: 5,
+    # To avoid running into API rate limits, we:
+    # - Schedule jobs with a delay
+    # - Bump the scheduled time every time a new one is scheduled with the same args
+    unique: [
+      states: [:scheduled],
+      fields: [:args]
+    ]
 
   require Logger
 

--- a/lib/workers/purge_cdn_cache.ex
+++ b/lib/workers/purge_cdn_cache.ex
@@ -1,0 +1,64 @@
+defmodule Plausible.Workers.PurgeCDNCache do
+  @moduledoc """
+  Worker for purging CDN cache for tracker scripts on cloud.
+
+  Uses Bunny CDN's API to purge cache by tag.
+  Docs ref: https://docs.bunny.net/reference/pullzonepublic_purgecachepostbytag
+
+  Note that purging by id "*" is equivelent to purging ALL cache.
+  """
+
+  use Oban.Worker,
+    queue: :purge_cdn_cache,
+    max_attempts: 5
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"id" => id}}) do
+    pullzone_id = Application.get_env(:plausible, __MODULE__, [])[:pullzone_id]
+    api_key = Application.get_env(:plausible, __MODULE__, [])[:api_key]
+
+    purge_cache(id, pullzone_id, api_key)
+  end
+
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}) do
+    # Exponential backoff starting at 3 minutes
+    trunc(:math.pow(2, attempt - 1) * 180)
+  end
+
+  defp purge_cache(id, pullzone_id, api_key) when is_nil(pullzone_id) or is_nil(api_key) do
+    Logger.warning("Ignoring purge CDN cache for tracker script #{id}: Configuration missing")
+    {:discard, "Configuration missing"}
+  end
+
+  defp purge_cache(id, pullzone_id, api_key) do
+    options =
+      [
+        headers: [
+          {"content-type", "application/json"},
+          {"AccessKey", api_key}
+        ],
+        body: Jason.encode!(%{"CacheTag" => "tracker_script::#{id}"})
+      ]
+      |> Keyword.merge(Application.get_env(:plausible, __MODULE__)[:req_opts] || [])
+
+    case Req.post("https://api.bunny.net/pullzone/#{pullzone_id}/purgeCache", options) do
+      {:ok, %{status: 204}} ->
+        Logger.info("Successfully purged CDN cache for tracker script #{id}")
+        {:ok, :success}
+
+      {:ok, %{status: status}} ->
+        Logger.warning(
+          "Failed to purge CDN cache for tracker script #{id}: Unexpected status: #{status}"
+        )
+
+        {:error, "Unexpected status: #{status}"}
+
+      {:error, reason} ->
+        Logger.warning("Failed to purge CDN cache for tracker script #{id}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+end

--- a/lib/workers/purge_cdn_cache.ex
+++ b/lib/workers/purge_cdn_cache.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Workers.PurgeCDNCache do
   Uses Bunny CDN's API to purge cache by tag.
   Docs ref: https://docs.bunny.net/reference/pullzonepublic_purgecachepostbytag
 
-  Note that purging by id "*" is equivelent to purging ALL cache.
+  Note that purging by id "*" is equivalent to purging ALL cache.
   """
 
   use Oban.Worker,

--- a/test/workers/purge_cdn_cache_test.exs
+++ b/test/workers/purge_cdn_cache_test.exs
@@ -1,0 +1,77 @@
+defmodule Plausible.Workers.PurgeCDNCacheTest do
+  use Plausible.DataCase, async: true
+  import ExUnit.CaptureLog
+  import Plug.Conn
+
+  alias Plausible.Workers.PurgeCDNCache
+
+  describe "perform/1" do
+    setup do
+      # Set test configuration
+      Application.put_env(:plausible, Plausible.Workers.PurgeCDNCache,
+        pullzone_id: "456",
+        api_key: "test-api-key",
+        req_opts: [
+          plug: {Req.Test, Plausible.Workers.PurgeCDNCache}
+        ]
+      )
+
+      :ok
+    end
+
+    test "successfully purges cache" do
+      Req.Test.expect(Plausible.Workers.PurgeCDNCache, &send_resp(&1, 204, "ok"))
+
+      assert {:ok, :success} = PurgeCDNCache.perform(%Oban.Job{args: %{"id" => "adf"}})
+    end
+
+    test "handles missing configuration" do
+      # Clear configuration
+      Application.put_env(:plausible, Plausible.Workers.PurgeCDNCache, [])
+
+      {result, log} =
+        with_log(fn -> PurgeCDNCache.perform(%Oban.Job{args: %{"id" => "adf"}}) end)
+
+      assert {:discard, "Configuration missing"} = result
+      assert log =~ "Ignoring purge CDN cache for tracker script adf: Configuration missing"
+    end
+
+    test "handles unexpected status code" do
+      Req.Test.expect(
+        Plausible.Workers.PurgeCDNCache,
+        &send_resp(&1, 500, "internal server error")
+      )
+
+      {result, log} =
+        with_log(fn -> PurgeCDNCache.perform(%Oban.Job{args: %{"id" => "adf"}}) end)
+
+      assert {:error, "Unexpected status: 500"} = result
+      assert log =~ "Failed to purge CDN cache for tracker script adf: Unexpected status: 500"
+    end
+
+    test "handles network errors" do
+      Req.Test.expect(
+        Plausible.Workers.PurgeCDNCache,
+        &Req.Test.transport_error(&1, :econnrefused)
+      )
+
+      {result, log} =
+        with_log(fn -> PurgeCDNCache.perform(%Oban.Job{args: %{"id" => "adf"}}) end)
+
+      assert {:error, %Req.TransportError{reason: :econnrefused}} = result
+
+      assert log =~
+               "Failed to purge CDN cache for tracker script adf: %Req.TransportError{reason: :econnrefused}"
+    end
+  end
+
+  describe "backoff/1" do
+    test "implements exponential backoff starting at 3 minutes" do
+      assert PurgeCDNCache.backoff(%Oban.Job{attempt: 1}) == 180
+      assert PurgeCDNCache.backoff(%Oban.Job{attempt: 2}) == 360
+      assert PurgeCDNCache.backoff(%Oban.Job{attempt: 3}) == 720
+      assert PurgeCDNCache.backoff(%Oban.Job{attempt: 4}) == 1440
+      assert PurgeCDNCache.backoff(%Oban.Job{attempt: 5}) == 2880
+    end
+  end
+end


### PR DESCRIPTION
### Changes

After this change, each time TrackerScriptConfiguration is changed (via onboarding or plugins API), we schedule to purge the cached script from BunnyCDN.

Related k8s commit: https://github.com/plausible/plausible-app-k8s/commit/dbdae29f39e057e1f1c93611e76cef03780c7ec3