### PR TITLE
ScriptV2: Add telemetry to tracker script generation

### DIFF
--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -109,6 +109,18 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
           ],
           unit: {:native, :microsecond},
           measurement: :duration
+        ),
+        counter(
+          metric_prefix ++ [:tracker_script, :request, :v2],
+          event_name: PlausibleWeb.TrackerPlug.telemetry_event(:v2),
+          tags: [:status],
+          tag_values: &%{status: &1.status}
+        ),
+        counter(
+          metric_prefix ++ [:tracker_script, :request, :legacy],
+          event_name: PlausibleWeb.TrackerPlug.telemetry_event(:legacy),
+          tags: [:status],
+          tag_values: &%{status: &1.status}
         )
       ]
     )


### PR DESCRIPTION
This will be used to measure rollout success and load after purges