### PR TITLE
Add `teams.locked_by_admin` column

### DIFF
--- a/priv/repo/migrations/20250528081453_add_forceful_lock.exs
+++ b/priv/repo/migrations/20250528081453_add_forceful_lock.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddForcefulLock do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teams) do
+      add :locked_by_admin, :boolean, null: false, default: false
+    end
+  end
+end


### PR DESCRIPTION
### Changes

CRM will expose team (in consequence, sites) (un)locking capability regardless of grace period. Spoke with @ukutaht about this - current locking logic is mostly automated, so a separate field that overrides it unconditionally is the way forward.