### PR TITLE
CRM: team (un)lock regardless of grace period

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/site.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/site.ex
@@ -79,6 +79,13 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
             <.styled_link patch={"/cs/teams/team/#{@site.team.id}"}>
               {@site.team.name}
             </.styled_link>
+
+            <span
+              :if={Plausible.Teams.locked?(@site.team)}
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800"
+            >
+              Locked
+            </span>
           </p>
           <p class="text-sm font-medium">
             <span :if={@site.domain_changed_from}>(previously: {@site.domain_changed_from})</span>
@@ -236,6 +243,10 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
 
         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
           Site
+        </span>
+
+        <span :if={Plausible.Teams.locked?(@resource.object.team)} class="inline-flex items-center">
+          <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
         </span>
       </div>
 

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -69,7 +69,8 @@ defmodule Plausible.Teams do
   @spec locked?(Teams.Team.t() | nil) :: boolean()
   def locked?(nil), do: false
 
-  def locked?(%Teams.Team{locked: locked}), do: locked
+  def locked?(%Teams.Team{locked: locked, locked_by_admin: locked_by_admin}),
+    do: locked or locked_by_admin
 
   @spec trial_days_left(Teams.Team.t()) :: integer()
   def trial_days_left(nil) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -28,6 +28,7 @@ defmodule Plausible.Teams.Team do
     field :accept_traffic_until, :date
     field :allow_next_upgrade_override, :boolean, default: false
     field :locked, :boolean, default: false
+    field :locked_by_admin, :boolean, default: false
 
     field :setup_complete, :boolean, default: false
     field :setup_at, :naive_datetime

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -9,7 +9,7 @@
     grace_period_end={grace_period_end(@current_team)}
   />
 
-  <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@current_team)} />
+  <Notice.dashboard_locked :if={Plausible.Teams.locked?(@current_team)} />
 
   <Notice.subscription_cancelled subscription={@current_team.subscription} />
 

--- a/lib/workers/schedule_email_reports.ex
+++ b/lib/workers/schedule_email_reports.ex
@@ -35,7 +35,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not t.locked,
+          where: not t.locked and not t.locked_by_admin,
           preload: [weekly_report: wr]
       )
 
@@ -76,7 +76,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not t.locked,
+          where: not t.locked and not t.locked_by_admin,
           preload: [monthly_report: mr]
       )
 

--- a/lib/workers/traffic_change_notifier.ex
+++ b/lib/workers/traffic_change_notifier.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Workers.TrafficChangeNotifier do
               sn.last_sent < ^NaiveDateTime.add(now, -@min_interval_hours, :hour),
           inner_join: s in assoc(sn, :site),
           inner_join: t in assoc(s, :team),
-          where: not t.locked,
+          where: not t.locked and not t.locked_by_admin,
           where: is_nil(t.accept_traffic_until) or t.accept_traffic_until > ^today,
           preload: [site: {s, team: t}]
       )

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -8,6 +8,8 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
+    alias Plausible.Teams
+
     defp open_team(id, qs \\ []) do
       Routes.customer_support_resource_path(
         PlausibleWeb.Endpoint,
@@ -36,6 +38,27 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         assert_raise Ecto.NoResultsError, fn ->
           {:ok, _lv, _html} = live(conn, open_team(9999))
         end
+      end
+
+      test "lock/unlock a team", %{user: user, conn: conn} do
+        team = team_of(user)
+        {:ok, lv, html} = live(conn, open_team(team.id))
+        refute element_exists?(html, "#unlock-dashboards")
+
+        lv |> element("#lock-dashboards") |> render_click()
+        html = render(lv)
+
+        assert text(html) =~ "Team locked"
+        assert Teams.locked?(Plausible.Repo.reload!(team))
+
+        refute element_exists?(html, "#lock-dashboards")
+        assert element_exists?(html, "#unlock-dashboards")
+
+        lv |> element("#unlock-dashboards") |> render_click()
+        html = render(lv)
+
+        assert text(html) =~ "Team unlocked"
+        refute Teams.locked?(Plausible.Repo.reload!(team))
       end
     end
 

--- a/test/workers/schedule_email_reports_test.exs
+++ b/test/workers/schedule_email_reports_test.exs
@@ -38,6 +38,16 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
       assert Enum.empty?(all_enqueued(worker: SendEmailReport))
     end
 
+    test "does not schedule a weekly report for admin-locked site" do
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
+      Plausible.Teams.admin_lock!(site.team)
+      insert(:weekly_report, site: site, recipients: ["user@email.com"])
+
+      perform_job(ScheduleEmailReports, %{})
+
+      assert Enum.empty?(all_enqueued(worker: SendEmailReport))
+    end
+
     test "schedules a new report as soon as a previous one is completed" do
       site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
@@ -77,6 +87,16 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     test "does not schedule a monthly report for locked site" do
       site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
+      insert(:monthly_report, site: site, recipients: ["user@email.com"])
+
+      perform_job(ScheduleEmailReports, %{})
+
+      assert Enum.empty?(all_enqueued(worker: SendEmailReport))
+    end
+
+    test "does not schedule a monthly report for admin-locked site" do
+      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
+      Plausible.Teams.admin_lock!(site.team)
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})

--- a/test/workers/traffic_change_notifier_test.exs
+++ b/test/workers/traffic_change_notifier_test.exs
@@ -288,6 +288,47 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
       assert_no_emails_delivered()
     end
 
+    test "does not check site if it is admin-locked" do
+      site = new_site()
+
+      Plausible.Teams.admin_lock!(site.team)
+
+      insert(:spike_notification,
+        site: site,
+        threshold: 1,
+        recipients: ["uku@example.com"]
+      )
+
+      populate_stats(site, [
+        build(:pageview, timestamp: minutes_ago(1)),
+        build(:pageview, timestamp: minutes_ago(1))
+      ])
+
+      TrafficChangeNotifier.perform(nil)
+
+      assert_no_emails_delivered()
+    end
+
+    test "does not check site if it is admin-locked" do
+      site = new_site()
+      Plausible.Teams.admin_lock!(site.team)
+
+      insert(:spike_notification,
+        site: site,
+        threshold: 1,
+        recipients: ["uku@example.com"]
+      )
+
+      populate_stats(site, [
+        build(:pageview, timestamp: minutes_ago(1)),
+        build(:pageview, timestamp: minutes_ago(1))
+      ])
+
+      TrafficChangeNotifier.perform(nil)
+
+      assert_no_emails_delivered()
+    end
+
     test "does not send notifications more than once every 12 hours" do
       site = new_site()
       insert(:spike_notification, site: site, threshold: 1, recipients: ["uku@example.com"])

--- a/test/workers/traffic_change_notifier_test.exs
+++ b/test/workers/traffic_change_notifier_test.exs
@@ -309,26 +309,6 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
       assert_no_emails_delivered()
     end
 
-    test "does not check site if it is admin-locked" do
-      site = new_site()
-      Plausible.Teams.admin_lock!(site.team)
-
-      insert(:spike_notification,
-        site: site,
-        threshold: 1,
-        recipients: ["uku@example.com"]
-      )
-
-      populate_stats(site, [
-        build(:pageview, timestamp: minutes_ago(1)),
-        build(:pageview, timestamp: minutes_ago(1))
-      ])
-
-      TrafficChangeNotifier.perform(nil)
-
-      assert_no_emails_delivered()
-    end
-
     test "does not send notifications more than once every 12 hours" do
       site = new_site()
       insert(:spike_notification, site: site, threshold: 1, recipients: ["uku@example.com"])


### PR DESCRIPTION
### Changes

On top of #5438 this PR implements Team (un)locking capability in CRM.
If grace period is present it'll be ended (on lock) or removed (on unlock). 
Otherwise, the manually applied lock will hold and prevent users from accessing dashboards, regardless of any background quota/usage checks. This means, the only way to remove CRM-applied lock, is to manually remove it via CRM.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
