### PR TITLE
CRM: internal TCP endpoint 

### DIFF
--- a/config/.env.dev
+++ b/config/.env.dev
@@ -1,5 +1,5 @@
 BASE_URL=http://localhost:8000
-INTERNAL_BASE_URL=http://localhost:8009
+INTERNAL_BASE_URL=http://cs.localtest.me:8009
 SECURE_COOKIE=false
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_dev
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_events_db

--- a/config/.env.dev
+++ b/config/.env.dev
@@ -1,5 +1,5 @@
 BASE_URL=http://localhost:8000
-INTERNAL_BASE_URL=http://cs.localtest.me:8009
+INTERNAL_BASE_URL=http://localhost:8009
 SECURE_COOKIE=false
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_dev
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_events_db

--- a/config/.env.dev
+++ b/config/.env.dev
@@ -1,4 +1,5 @@
 BASE_URL=http://localhost:8000
+INTERNAL_BASE_URL=http://localhost:8009
 SECURE_COOKIE=false
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/plausible_dev
 CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_events_db

--- a/config/.env.test
+++ b/config/.env.test
@@ -3,6 +3,7 @@ CLICKHOUSE_DATABASE_URL=http://127.0.0.1:8123/plausible_test
 SECRET_KEY_BASE=/njrhntbycvastyvtk1zycwfm981vpo/0xrvwjjvemdakc/vsvbrevlwsc6u8rcg
 TOTP_VAULT_KEY=1Jah1HEOnCEnmBE+4/OgbJRraJIppPmYCNbZoFJboZs=
 BASE_URL=http://localhost:8000
+INTERNAL_BASE_URL=http://localhost:8009
 CRON_ENABLED=false
 LOG_LEVEL=warning
 ENVIRONMENT=test

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,16 @@ config :plausible, PlausibleWeb.Endpoint,
     accepts: ~w(html json)
   ]
 
+config :plausible, PlausibleWeb.InternalEndpoint,
+  # Does not to have to be secret, as per: https://github.com/phoenixframework/phoenix/issues/2146
+  live_view: [signing_salt: "f+bZg/crMtgjZJJY7X6OwIWc3XJR2C5Y"],
+  pubsub_server: Plausible.PubSub,
+  render_errors: [
+    view: PlausibleWeb.ErrorView,
+    layout: {PlausibleWeb.LayoutView, "base_error.html"},
+    accepts: ~w(html json)
+  ]
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,6 +27,22 @@ config :plausible, PlausibleWeb.Endpoint,
     ]
   ]
 
+config :plausible, PlausibleWeb.InternalEndpoint,
+  server: true,
+  debug_errors: true,
+  code_reloader: true,
+  check_origin: false,
+  live_reload: [
+    dirs: [
+      "extra"
+    ],
+    patterns: [
+      ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
+      ~r"lib/plausible_web/(controllers|live|components|templates|views|plugs)/.*(ex|heex)$",
+      ~r"storybook/.*(exs)$"
+    ]
+  ]
+
 config :plausible, paddle_api: Plausible.Billing.DevPaddleApiMock
 
 config :phoenix, :stacktrace_depth, 20

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,3 +5,9 @@ config :plausible, PlausibleWeb.Endpoint,
   check_origin: false,
   server: true,
   code_reloader: false
+
+config :plausible, PlausibleWeb.InternalEndpoint,
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  check_origin: false,
+  server: true,
+  code_reloader: false

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -60,9 +60,13 @@ http_port =
   get_int_from_path_or_env(config_dir, "HTTP_PORT") ||
     get_int_from_path_or_env(config_dir, "PORT", 8000)
 
+internal_http_port =
+  get_int_from_path_or_env(config_dir, "INTERNAL_HTTP_PORT", 8009)
+
 https_port = get_int_from_path_or_env(config_dir, "HTTPS_PORT")
 
 base_url = get_var_from_path_or_env(config_dir, "BASE_URL")
+internal_base_url = URI.parse(get_var_from_path_or_env(config_dir, "INTERNAL_BASE_URL", ""))
 
 if !base_url do
   raise "BASE_URL configuration option is required. See https://github.com/plausible/community-edition/wiki/configuration#base_url"
@@ -337,6 +341,18 @@ default_http_opts = [
 config :plausible, PlausibleWeb.Endpoint,
   url: [scheme: base_url.scheme, host: base_url.host, path: base_url.path, port: base_url.port],
   http: [port: http_port, ip: listen_ip] ++ default_http_opts,
+  secret_key_base: secret_key_base,
+  websocket_url: websocket_url,
+  secure_cookie: secure_cookie
+
+config :plausible, PlausibleWeb.InternalEndpoint,
+  url: [
+    scheme: internal_base_url.scheme,
+    host: internal_base_url.host,
+    path: internal_base_url.path,
+    port: internal_base_url.port
+  ],
+  http: [port: internal_http_port, ip: listen_ip] ++ default_http_opts,
   secret_key_base: secret_key_base,
   websocket_url: websocket_url,
   secure_cookie: secure_cookie

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,7 @@ import Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :plausible, PlausibleWeb.Endpoint, server: false
+config :plausible, PlausibleWeb.InternalEndpoint, server: false
 
 config :bcrypt_elixir, :log_rounds, 4
 

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -11,7 +11,7 @@ defmodule Plausible.HelpScout do
   alias Plausible.Repo
   alias Plausible.Teams
 
-  alias PlausibleWeb.Router.Helpers, as: Routes
+  alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
 
   require Plausible.Billing.Subscription.Status
 
@@ -106,8 +106,8 @@ defmodule Plausible.HelpScout do
           end)
 
         user_link =
-          Routes.customer_support_resource_url(
-            PlausibleWeb.Endpoint,
+          InternalRoutes.customer_support_resource_url(
+            PlausibleWeb.InternalEndpoint,
             :details,
             :users,
             :user,
@@ -136,16 +136,16 @@ defmodule Plausible.HelpScout do
 
         status_link =
           if team do
-            Routes.customer_support_resource_url(
-              PlausibleWeb.Endpoint,
+            InternalRoutes.customer_support_resource_url(
+              PlausibleWeb.InternalEndpoint,
               :details,
               :teams,
               :team,
               team.id
             )
           else
-            Routes.customer_support_resource_url(
-              PlausibleWeb.Endpoint,
+            InternalRoutes.customer_support_resource_url(
+              PlausibleWeb.InternalEndpoint,
               :details,
               :users,
               :user,

--- a/extra/lib/plausible_web/controllers/customer_support_controller.ex
+++ b/extra/lib/plausible_web/controllers/customer_support_controller.ex
@@ -1,0 +1,7 @@
+defmodule PlausibleWeb.CustomerSupportController do
+  use PlausibleWeb, :controller
+
+  def redirect_to_root(conn, _params) do
+    redirect(conn, to: "/cs")
+  end
+end

--- a/extra/lib/plausible_web/internal_endpoint.ex
+++ b/extra/lib/plausible_web/internal_endpoint.ex
@@ -1,0 +1,82 @@
+defmodule PlausibleWeb.InternalEndpoint do
+  @moduledoc """
+  Superadmin area endpoint
+  """
+
+  use Sentry.PlugCapture
+  use Phoenix.Endpoint, otp_app: :plausible
+
+  plug(Plug.RequestId)
+  plug(PromEx.Plug, prom_ex_module: Plausible.PromEx)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint], log: false)
+
+  plug(Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+  )
+
+  plug(Sentry.PlugContext)
+
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+
+  plug(:runtime_session)
+
+  plug(CORSPlug)
+
+  plug(
+    Plug.Static,
+    at: "/",
+    from: :plausible,
+    only: ~w(css js images favicon.ico)
+  )
+
+  plug(PlausibleWeb.InternalRouter)
+
+  @session_options [
+    key: "_plausible_key",
+    store: :cookie,
+    signing_salt: "I45i0SKHEku2f3tJh6y4v8gztrb/eG5KGCOe/o/AwFb7VHeuvDOn7AAq6KsdmOFM",
+    # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
+    max_age: 60 * 60 * 24 * 365 * 5,
+    extra: "SameSite=Lax"
+  ]
+
+  socket("/live", Phoenix.LiveView.Socket,
+    websocket: [
+      check_origin: true,
+      connect_info: [
+        :peer_data,
+        :uri,
+        :user_agent,
+        session: {__MODULE__, :runtime_session_opts, []}
+      ]
+    ]
+  )
+
+  def runtime_session(conn, _opts) do
+    Plug.run(conn, [{Plug.Session, runtime_session_opts()}])
+  end
+
+  def runtime_session_opts() do
+    # `host()` provided by Phoenix.Endpoint's compilation hooks
+    # is used to inject the domain - this way we can authenticate
+    # websocket requests within single root domain, in case websocket_url()
+    # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
+    session_options =
+      Keyword.put(@session_options, :domain, host())
+      |> Keyword.put(:key, "_plausible_#{Application.fetch_env!(:plausible, :environment)}")
+
+    session_options
+    |> Keyword.put(:secure, secure_cookie?())
+  end
+
+  def secure_cookie?, do: config!(:secure_cookie)
+
+  defp config!(key) do
+    :plausible
+    |> Application.fetch_env!(__MODULE__)
+    |> Keyword.fetch!(key)
+  end
+end

--- a/extra/lib/plausible_web/internal_endpoint.ex
+++ b/extra/lib/plausible_web/internal_endpoint.ex
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.InternalEndpoint do
   plug(PlausibleWeb.InternalRouter)
 
   @session_options [
-    key: "_plausible_key",
+    key: "_plausible_key_internal",
     store: :cookie,
     signing_salt: "I45i0SKHEku2f3tJh6y4v8gztrb/eG5KGCOe/o/AwFb7VHeuvDOn7AAq6KsdmOFM",
     # 5 years, this is super long but the SlidingSessionTimeout will log people out if they don't return for 2 weeks
@@ -68,7 +68,10 @@ defmodule PlausibleWeb.InternalEndpoint do
     # returns a ws{s}:// scheme (in which case SameSite=Lax is not applicable).
     session_options =
       Keyword.put(@session_options, :domain, host())
-      |> Keyword.put(:key, "_plausible_#{Application.fetch_env!(:plausible, :environment)}")
+      |> Keyword.put(
+        :key,
+        "_plausible_internal_#{Application.fetch_env!(:plausible, :environment)}"
+      )
 
     session_options
     |> Keyword.put(:secure, secure_cookie?())

--- a/extra/lib/plausible_web/internal_endpoint.ex
+++ b/extra/lib/plausible_web/internal_endpoint.ex
@@ -25,6 +25,8 @@ defmodule PlausibleWeb.InternalEndpoint do
 
   plug(CORSPlug)
 
+  plug(PlausibleWeb.Favicon)
+
   plug(
     Plug.Static,
     at: "/",

--- a/extra/lib/plausible_web/internal_router.ex
+++ b/extra/lib/plausible_web/internal_router.ex
@@ -7,6 +7,20 @@ defmodule PlausibleWeb.InternalRouter do
 
   import Phoenix.LiveView.Router
 
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
+    plug PlausibleWeb.AuthPlug
+    plug PlausibleWeb.Plugs.UserSessionTouch
+  end
+
+  pipeline :csrf do
+    plug :protect_from_forgery
+  end
+
   pipeline :superadmin_area do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -18,6 +32,24 @@ defmodule PlausibleWeb.InternalRouter do
     plug PlausibleWeb.Plugs.UserSessionTouch
     plug PlausibleWeb.Plugs.NoRobots
     plug PlausibleWeb.SuperAdminOnlyPlug
+  end
+
+  scope "/", PlausibleWeb do
+    pipe_through [:browser, :csrf]
+
+    get "/", CustomerSupportController, :redirect_to_root
+    get "/sites", CustomerSupportController, :redirect_to_root
+    get "/login", AuthController, :login_form
+    post "/login", AuthController, :login
+    get "/logout", AuthController, :logout
+    get "/password/request-reset", AuthController, :password_reset_request_form
+    post "/password/request-reset", AuthController, :password_reset_request
+    get "/2fa/verify", AuthController, :verify_2fa_form
+    post "/2fa/verify", AuthController, :verify_2fa
+    get "/2fa/use_recovery_code", AuthController, :verify_2fa_recovery_code_form
+    post "/2fa/use_recovery_code", AuthController, :verify_2fa_recovery_code
+    get "/password/reset", AuthController, :password_reset_form
+    post "/password/reset", AuthController, :password_reset
   end
 
   scope path: "/flags" do

--- a/extra/lib/plausible_web/internal_router.ex
+++ b/extra/lib/plausible_web/internal_router.ex
@@ -12,15 +12,11 @@ defmodule PlausibleWeb.InternalRouter do
     plug :fetch_session
     plug :fetch_live_flash
     plug :put_secure_browser_headers
-    plug PlausibleWeb.Plugs.NoRobots
-    plug PlausibleWeb.AuthPlug
-    plug PlausibleWeb.Plugs.UserSessionTouch
     plug :protect_from_forgery
     plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
-    plug :put_secure_browser_headers
-    plug PlausibleWeb.Plugs.NoRobots
-    plug :fetch_session
     plug PlausibleWeb.AuthPlug
+    plug PlausibleWeb.Plugs.UserSessionTouch
+    plug PlausibleWeb.Plugs.NoRobots
     plug PlausibleWeb.SuperAdminOnlyPlug
   end
 

--- a/extra/lib/plausible_web/internal_router.ex
+++ b/extra/lib/plausible_web/internal_router.ex
@@ -1,0 +1,38 @@
+defmodule PlausibleWeb.InternalRouter do
+  @moduledoc """
+  Superadmin area router
+  """
+
+  use PlausibleWeb, :router
+
+  import Phoenix.LiveView.Router
+
+  pipeline :superadmin_area do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
+    plug PlausibleWeb.AuthPlug
+    plug PlausibleWeb.Plugs.UserSessionTouch
+    plug :protect_from_forgery
+    plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
+    plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.NoRobots
+    plug :fetch_session
+    plug PlausibleWeb.AuthPlug
+    plug PlausibleWeb.SuperAdminOnlyPlug
+  end
+
+  scope path: "/flags" do
+    pipe_through :superadmin_area
+    forward "/", FunWithFlags.UI.Router, namespace: "flags"
+  end
+
+  scope alias: PlausibleWeb.Live, assigns: %{connect_live_socket: true} do
+    pipe_through :superadmin_area
+
+    live "/cs", CustomerSupport, :index, as: :customer_support
+    live "/cs/:any/:resource/:id", CustomerSupport, :details, as: :customer_support_resource
+  end
+end

--- a/extra/lib/plausible_web/internal_router.ex
+++ b/extra/lib/plausible_web/internal_router.ex
@@ -25,7 +25,8 @@ defmodule PlausibleWeb.InternalRouter do
     forward "/", FunWithFlags.UI.Router, namespace: "flags"
   end
 
-  scope alias: PlausibleWeb.Live, assigns: %{connect_live_socket: true} do
+  scope alias: PlausibleWeb.Live,
+        assigns: %{connect_live_socket: true, skip_plausible_tracking: true} do
     pipe_through :superadmin_area
 
     live "/cs", CustomerSupport, :index, as: :customer_support

--- a/extra/lib/plausible_web/live/customer_support/live/site.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/site.ex
@@ -116,14 +116,14 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
 
           <.styled_link
             new_tab={true}
-            href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, @site.domain, [])}
+            href={Routes.stats_url(PlausibleWeb.Endpoint, :stats, @site.domain, [])}
           >
             Dashboard
           </.styled_link>
 
           <.styled_link
             new_tab={true}
-            href={Routes.site_path(PlausibleWeb.Endpoint, :settings_general, @site.domain, [])}
+            href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, @site.domain, [])}
           >
             Settings
           </.styled_link>

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -464,7 +464,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
               <.td>
                 <.styled_link
                   new_tab={true}
-                  href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain, [])}
+                  href={Routes.stats_url(PlausibleWeb.Endpoint, :stats, site.domain, [])}
                 >
                   Dashboard
                 </.styled_link>
@@ -472,7 +472,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
               <.td>
                 <.styled_link
                   new_tab={true}
-                  href={Routes.site_path(PlausibleWeb.Endpoint, :settings_general, site.domain, [])}
+                  href={Routes.site_url(PlausibleWeb.Endpoint, :settings_general, site.domain, [])}
                 >
                   Settings
                 </.styled_link>

--- a/extra/lib/plausible_web/live/customer_support/live/user.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/user.ex
@@ -12,7 +12,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.User do
     if is_nil(user) do
       redirect(
         socket,
-        to: Routes.customer_support_path(socket, :index)
+        to: InternalRoutes.customer_support_path(socket, :index)
       )
     else
       form = user |> Plausible.Auth.User.changeset() |> to_form()

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -137,6 +137,9 @@ defmodule Plausible.Application do
         {Finch, name: Plausible.Finch, pools: finch_pool_config()},
         {Phoenix.PubSub, name: Plausible.PubSub},
         endpoint,
+        on_ee do
+          PlausibleWeb.InternalEndpoint
+        end,
         {Oban, Application.get_env(:plausible, Oban)},
         on_ee do
           help_scout_vault()

--- a/lib/plausible_web.ex
+++ b/lib/plausible_web.ex
@@ -14,6 +14,7 @@ defmodule PlausibleWeb do
       end
 
       alias PlausibleWeb.Router.Helpers, as: Routes
+      alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
       alias Phoenix.LiveView.JS
 
       import PlausibleWeb.Components.Generic
@@ -28,6 +29,7 @@ defmodule PlausibleWeb do
       import PlausibleWeb.Live.Components.Form
       alias Phoenix.LiveView.JS
       alias PlausibleWeb.Router.Helpers, as: Routes
+      alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
     end
   end
 
@@ -38,6 +40,7 @@ defmodule PlausibleWeb do
       import PlausibleWeb.Live.Components.Form
       alias Phoenix.LiveView.JS
       alias PlausibleWeb.Router.Helpers, as: Routes
+      alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
     end
   end
 
@@ -48,6 +51,7 @@ defmodule PlausibleWeb do
       import Plug.Conn
       import PlausibleWeb.ControllerHelpers
       alias PlausibleWeb.Router.Helpers, as: Routes
+      alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
     end
   end
 
@@ -65,6 +69,7 @@ defmodule PlausibleWeb do
       import PlausibleWeb.Components.Generic
       import PlausibleWeb.Live.Components.Form
       alias PlausibleWeb.Router.Helpers, as: Routes
+      alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
     end
   end
 

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -293,6 +293,7 @@ defmodule PlausibleWeb.AuthController do
 
         conn
         |> TwoFactor.Session.set_2fa_user(user)
+        |> tap(&IO.inspect(get_session(&1)))
         |> redirect(to: Routes.auth_path(conn, :verify_2fa, query_params))
     end
   end
@@ -400,6 +401,8 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def verify_2fa_form(conn, _params) do
+    IO.inspect(get_session(conn))
+
     case TwoFactor.Session.get_2fa_user(conn) do
       {:ok, user} ->
         if Auth.TOTP.enabled?(user) do
@@ -616,7 +619,9 @@ defmodule PlausibleWeb.AuthController do
   end
 
   defp redirect_to_login(conn) do
-    redirect(conn, to: Routes.auth_path(conn, :login_form))
+    redirect(conn,
+      to: Routes.auth_path(conn, :login_form) |> IO.inspect(label: :redirect_to_login)
+    )
   end
 
   defp maybe_log_failed_login_attempts(message) do

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -293,7 +293,6 @@ defmodule PlausibleWeb.AuthController do
 
         conn
         |> TwoFactor.Session.set_2fa_user(user)
-        |> tap(&IO.inspect(get_session(&1)))
         |> redirect(to: Routes.auth_path(conn, :verify_2fa, query_params))
     end
   end
@@ -401,8 +400,6 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def verify_2fa_form(conn, _params) do
-    IO.inspect(get_session(conn))
-
     case TwoFactor.Session.get_2fa_user(conn) do
       {:ok, user} ->
         if Auth.TOTP.enabled?(user) do
@@ -619,9 +616,7 @@ defmodule PlausibleWeb.AuthController do
   end
 
   defp redirect_to_login(conn) do
-    redirect(conn,
-      to: Routes.auth_path(conn, :login_form) |> IO.inspect(label: :redirect_to_login)
-    )
+    redirect(conn, to: Routes.auth_path(conn, :login_form))
   end
 
   defp maybe_log_failed_login_attempts(message) do

--- a/lib/plausible_web/plugs/super_admin_only_plug.ex
+++ b/lib/plausible_web/plugs/super_admin_only_plug.ex
@@ -5,6 +5,8 @@ defmodule PlausibleWeb.SuperAdminOnlyPlug do
 
   import Plug.Conn
 
+  alias PlausibleWeb.Router.Helpers, as: Routes
+
   def init(options) do
     options
   end
@@ -17,7 +19,7 @@ defmodule PlausibleWeb.SuperAdminOnlyPlug do
     else
       conn
       |> PlausibleWeb.UserAuth.log_out_user()
-      |> send_resp(403, "Not allowed")
+      |> Phoenix.Controller.redirect(to: Routes.auth_path(conn, :login_form))
       |> halt()
     end
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -88,17 +88,6 @@ defmodule PlausibleWeb.Router do
   end
 
   on_ee do
-    scope alias: PlausibleWeb.Live,
-          assigns: %{connect_live_socket: true, skip_plausible_tracking: true} do
-      pipe_through [:browser, :csrf, :app_layout, :flags]
-
-      live "/cs", CustomerSupport, :index, as: :customer_support
-
-      live "/cs/:any/:resource/:id", CustomerSupport, :details, as: :customer_support_resource
-    end
-  end
-
-  on_ee do
     scope path: "/flags" do
       pipe_through :flags
       forward "/", FunWithFlags.UI.Router, namespace: "flags"

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -88,13 +88,6 @@ defmodule PlausibleWeb.Router do
   end
 
   on_ee do
-    scope path: "/flags" do
-      pipe_through :flags
-      forward "/", FunWithFlags.UI.Router, namespace: "flags"
-    end
-  end
-
-  on_ee do
     if Mix.env() in [:dev, :test] do
       scope "/dev", PlausibleWeb do
         pipe_through :browser

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -62,7 +62,7 @@
               >
                 <.styled_link
                   class="text-sm text-yellow-900 dark:text-yellow-900 rounded px-3 py-2 rounded-md bg-yellow-100 dark:bg-yellow-100"
-                  href={Routes.settings_path(@conn, :subscription)}
+                  href={Routes.settings_url(PlausibleWeb.Endpoint, :subscription)}
                 >
                   {trial_notification(@conn.assigns[:current_team])}
                 </.styled_link>
@@ -93,12 +93,18 @@
                       more_teams?={@more_teams?}
                     />
                     <.dropdown_divider />
-                    <.dropdown_item href={Routes.settings_path(@conn, :index)}>
+                    <.dropdown_item href={Routes.settings_url(PlausibleWeb.Endpoint, :index)}>
                       Account Settings
                     </.dropdown_item>
 
-                    <div :if={@my_team && @my_team.id == @current_team.id}>
-                      <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
+                    <div :if={
+                      @my_team && @my_team.id == @current_team.id &&
+                        Plausible.Billing.Feature.Teams.check_availability(@current_team) == :ok
+                    }>
+                      <.dropdown_item
+                        class="flex"
+                        href={Routes.team_setup_url(PlausibleWeb.Endpoint, :setup)}
+                      >
                         <span data-test="create-a-team-cta" class="flex-1">
                           Create a Team
                         </span>
@@ -109,7 +115,7 @@
                     <div :if={Plausible.Teams.setup?(@current_team)}>
                       <.dropdown_item
                         class="flex"
-                        href={Routes.settings_path(@conn, :team_general)}
+                        href={Routes.settings_url(PlausibleWeb.Endpoint, :team_general)}
                       >
                         <span class="flex-1">
                           Team Settings

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -36,8 +36,21 @@
                   Plausible.Auth.is_super_admin?(@conn.assigns[:current_user])
               }>
                 <.styled_link
+                  :if={ee?()}
                   class="text-sm mr-6"
-                  href={"/cs/sites/site/#{@conn.assigns.site.id}"}
+                  href={
+                    apply(
+                      InternalRoutes,
+                      :customer_support_resource_url,
+                      [
+                        PlausibleWeb.InternalEndpoint,
+                        :details,
+                        :sites,
+                        :site,
+                        @site.id
+                      ]
+                    )
+                  }
                   new_tab={true}
                 >
                   CS

--- a/lib/plausible_web/two_factor/session.ex
+++ b/lib/plausible_web/two_factor/session.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.TwoFactor.Session do
   @spec set_2fa_user(Plug.Conn.t(), Auth.User.t()) :: Plug.Conn.t()
   def set_2fa_user(conn, %Auth.User{} = user) do
     put_resp_cookie(conn, @session_2fa_cookie, %{current_2fa_user_id: user.id},
-      domain: domain(),
+      domain: conn.private.phoenix_endpoint.host(),
       secure: secure_cookie?(),
       encrypt: true,
       max_age: @session_2fa_seconds,
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.TwoFactor.Session do
   @spec clear_2fa_user(Plug.Conn.t()) :: Plug.Conn.t()
   def clear_2fa_user(conn) do
     delete_resp_cookie(conn, @session_2fa_cookie,
-      domain: domain(),
+      domain: conn.private.phoenix_endpoint.host(),
       secure: secure_cookie?(),
       encrypt: true,
       max_age: @session_2fa_seconds,
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.TwoFactor.Session do
   @spec maybe_set_remember_2fa(Plug.Conn.t(), Auth.User.t(), String.t() | nil) :: Plug.Conn.t()
   def maybe_set_remember_2fa(conn, user, "true") do
     put_resp_cookie(conn, @remember_2fa_cookie, user.totp_token,
-      domain: domain(),
+      domain: conn.private.phoenix_endpoint.host(),
       secure: secure_cookie?(),
       encrypt: true,
       max_age: @remember_2fa_seconds,
@@ -78,15 +78,13 @@ defmodule PlausibleWeb.TwoFactor.Session do
   @spec clear_remember_2fa(Plug.Conn.t()) :: Plug.Conn.t()
   def clear_remember_2fa(conn) do
     delete_resp_cookie(conn, @remember_2fa_cookie,
-      domain: domain(),
+      domain: conn.private.phoenix_endpoint.host(),
       secure: secure_cookie?(),
       encrypt: true,
       max_age: @remember_2fa_seconds,
       same_site: "Lax"
     )
   end
-
-  defp domain(), do: PlausibleWeb.Endpoint.host()
 
   defp secure_cookie?() do
     :plausible

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -36,9 +36,9 @@ defmodule PlausibleWeb.LayoutView do
 
   def home_dest(conn) do
     if conn.assigns[:current_user] do
-      "/sites"
+      Routes.site_url(PlausibleWeb.Endpoint, :index)
     else
-      "/"
+      Routes.page_url(PlausibleWeb.Endpoint, :index)
     end
   end
 

--- a/test/plausible/help_scout_test.exs
+++ b/test/plausible/help_scout_test.exs
@@ -59,7 +59,7 @@ defmodule Plausible.HelpScoutTest do
         stub_help_scout_requests(email)
         team = team_of(user)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/cs/teams/team/#{team.id}"
+        crm_url = "#{PlausibleWeb.InternalEndpoint.url()}/cs/teams/team/#{team.id}"
 
         assert {:ok,
                 %{
@@ -407,7 +407,7 @@ defmodule Plausible.HelpScoutTest do
 
         team = team_of(user)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/cs/teams/team/#{team.id}"
+        crm_url = "#{PlausibleWeb.InternalEndpoint.url()}/cs/teams/team/#{team.id}"
 
         assert {:ok,
                 %{
@@ -442,7 +442,7 @@ defmodule Plausible.HelpScoutTest do
         new_site(owner: user2)
         team2 = team_of(user2)
 
-        crm_url = "#{PlausibleWeb.Endpoint.url()}/cs/teams/team/#{team2.id}"
+        crm_url = "#{PlausibleWeb.InternalEndpoint.url()}/cs/teams/team/#{team2.id}"
 
         assert {:ok,
                 %{

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -1562,6 +1562,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       password: password
     })
     |> recycle()
+    |> put_private(:phoenix_endpoint, PlausibleWeb.Endpoint)
     |> Map.put(:secret_key_base, secret_key_base())
     |> Plug.Conn.put_req_header("x-forwarded-for", Plausible.TestUtils.random_ip())
   end
@@ -1570,6 +1571,7 @@ defmodule PlausibleWeb.AuthControllerTest do
     conn
     |> PlausibleWeb.TwoFactor.Session.maybe_set_remember_2fa(user, "true")
     |> recycle()
+    |> put_private(:phoenix_endpoint, PlausibleWeb.Endpoint)
     |> Map.put(:secret_key_base, secret_key_base())
     |> Plug.Conn.put_req_header("x-forwarded-for", Plausible.TestUtils.random_ip())
   end

--- a/test/plausible_web/live/customer_support/sites_test.exs
+++ b/test/plausible_web/live/customer_support/sites_test.exs
@@ -10,9 +10,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
+    @endpoint PlausibleWeb.InternalEndpoint
+    alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
+
     defp open_site(id, opts \\ []) do
-      Routes.customer_support_resource_path(
-        PlausibleWeb.Endpoint,
+      InternalRoutes.customer_support_resource_path(
+        PlausibleWeb.InternalEndpoint,
         :details,
         :sites,
         :site,

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -10,9 +10,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
 
     require Plausible.Billing.Subscription.Status
 
+    @endpoint PlausibleWeb.InternalEndpoint
+    alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
+
     defp open_team(id, qs \\ []) do
-      Routes.customer_support_resource_path(
-        PlausibleWeb.Endpoint,
+      InternalRoutes.customer_support_resource_path(
+        PlausibleWeb.InternalEndpoint,
         :details,
         :teams,
         :team,

--- a/test/plausible_web/live/customer_support/users_test.exs
+++ b/test/plausible_web/live/customer_support/users_test.exs
@@ -8,9 +8,12 @@ defmodule PlausibleWeb.Live.CustomerSupport.UsersTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
+    @endpoint PlausibleWeb.InternalEndpoint
+    alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
+
     defp open_user(id, qs \\ []) do
-      Routes.customer_support_resource_path(
-        PlausibleWeb.Endpoint,
+      InternalRoutes.customer_support_resource_path(
+        PlausibleWeb.InternalEndpoint,
         :details,
         :users,
         :user,

--- a/test/plausible_web/live/customer_support_test.exs
+++ b/test/plausible_web/live/customer_support_test.exs
@@ -15,14 +15,14 @@ defmodule PlausibleWeb.Live.CustomerSupportTest do
     describe "unauthenticated" do
       test "not allowed if not logged in", %{conn: conn} do
         conn = get(conn, @cs_index)
-        assert response(conn, 403) == "Not allowed"
+        assert redirected_to(conn, 302) == "/login"
       end
     end
 
     describe "authenticated regular user" do
       test "not allowed if not superadmin", %{conn: conn} do
         conn = get(conn, @cs_index)
-        assert response(conn, 403) == "Not allowed"
+        assert redirected_to(conn, 302) == "/login"
       end
     end
 

--- a/test/plausible_web/live/customer_support_test.exs
+++ b/test/plausible_web/live/customer_support_test.exs
@@ -5,7 +5,9 @@ defmodule PlausibleWeb.Live.CustomerSupportTest do
   @moduletag :ee_only
 
   on_ee do
-    @cs_index Routes.customer_support_path(PlausibleWeb.Endpoint, :index)
+    alias PlausibleWeb.InternalRouter.Helpers, as: InternalRoutes
+    @endpoint PlausibleWeb.InternalEndpoint
+    @cs_index InternalRoutes.customer_support_path(PlausibleWeb.InternalEndpoint, :index)
 
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
@@ -100,8 +102,8 @@ defmodule PlausibleWeb.Live.CustomerSupportTest do
       assert [link] = find(doc, ~s|a[data-test-type="#{type}"][data-test-id="#{id}"]|)
 
       assert text_of_attr(link, "href") ==
-               Routes.customer_support_resource_path(
-                 PlausibleWeb.Endpoint,
+               InternalRoutes.customer_support_resource_path(
+                 PlausibleWeb.InternalEndpoint,
                  :details,
                  "#{type}s",
                  type,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -42,6 +42,7 @@ defmodule PlausibleWeb.ConnCase do
     # rate limiting during tests
     conn =
       Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:phoenix_endpoint, PlausibleWeb.Endpoint)
       |> Map.put(:secret_key_base, secret_key_base())
       |> Plug.Conn.put_req_header("x-forwarded-for", Plausible.TestUtils.random_ip())
 


### PR DESCRIPTION
### Changes

This PR introduces new endpoint for superadmin access, so we can expose it internally via tailscale.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
