### PR TITLE
Slight copy tweak for the "Create a team" page

### DIFF
--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -66,7 +66,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
         </div>
       </:title>
       <:subtitle>
-        Add your team members and assign their roles
+        Name your team, add team members and assign roles. When ready, click "Create Team" to send invitations
       </:subtitle>
 
       <.form


### PR DESCRIPTION
we've had some people stuck on this screen, expecting the team to be created and invitations to be sent even without clicking on the "Create team" button.... then when nothing gets sent, they refresh the screen and lose all changes they made... so just changing the top copy a little bit to clarify that... let's see if it helps 

cc @zoldar 