### PR TITLE
Fix UI access to not yet published features

### DIFF
--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -13,7 +13,7 @@ defmodule Plausible.Teams.Billing do
   alias Plausible.Teams
 
   alias Plausible.Billing.{EnterprisePlan, Feature, Plan, Plans, Quota}
-  alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI}
+  alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI, SharedLinks}
 
   require Plausible.Billing.Subscription.Status
 
@@ -605,19 +605,19 @@ defmodule Plausible.Teams.Billing do
 
     case Plans.get_subscription_plan(team.subscription) do
       %EnterprisePlan{features: features} ->
-        features
+        features ++ [Feature.Teams, SharedLinks]
 
       %Plan{features: features} ->
         features
 
       :free_10k ->
-        [Goals, Props, StatsAPI]
+        [Goals, Props, StatsAPI, Feature.Teams, SharedLinks]
 
       nil ->
         if Teams.on_trial?(team) do
           Feature.list() -- [SitesAPI]
         else
-          [Goals]
+          [Goals, Feature.Teams, SharedLinks]
         end
     end
   end

--- a/test/plausible/billing/feature_test.exs
+++ b/test/plausible/billing/feature_test.exs
@@ -30,6 +30,16 @@ defmodule Plausible.Billing.FeatureTest do
     end
   end
 
+  test "Plausible.Billing.Feature.Teams.check_availability/2 returns :ok when user is on an enterprise plan" do
+    team = new_user() |> subscribe_to_enterprise_plan() |> team_of()
+    assert :ok == Plausible.Billing.Feature.Teams.check_availability(team)
+  end
+
+  test "Plausible.Billing.Feature.SharedLinks.check_availability/2 returns :ok when user is on an enterprise plan" do
+    team = new_user() |> subscribe_to_enterprise_plan() |> team_of()
+    assert :ok == Plausible.Billing.Feature.SharedLinks.check_availability(team)
+  end
+
   test "Plausible.Billing.Feature.StatsAPI.check_availability/2 returns :ok when user is on a business plan" do
     team = new_user() |> subscribe_to_business_plan() |> team_of()
     assert :ok == Plausible.Billing.Feature.StatsAPI.check_availability(team)

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -574,7 +574,9 @@ defmodule Plausible.Billing.QuotaTest do
     on_ee do
       test "users with expired trials have no access to subscription features" do
         team = new_user(trial_expiry_date: ~D[2023-01-01]) |> team_of()
-        assert [Goals] == Plausible.Teams.Billing.allowed_features_for(team)
+
+        assert [Goals, Plausible.Billing.Feature.Teams, Plausible.Billing.Feature.SharedLinks] ==
+                 Plausible.Teams.Billing.allowed_features_for(team)
       end
     end
 
@@ -593,11 +595,13 @@ defmodule Plausible.Billing.QuotaTest do
                Plausible.Teams.Billing.allowed_features_for(team_on_v3)
     end
 
-    test "returns [Goals, Props, StatsAPI] when user is on free_10k plan" do
+    test "returns features for a free_10k plan" do
       user = new_user()
       subscribe_to_plan(user, "free_10k")
       team = team_of(user)
-      assert [Goals, Props, StatsAPI] == Plausible.Teams.Billing.allowed_features_for(team)
+
+      assert [Goals, Props, StatsAPI, Teams, SharedLinks] ==
+               Plausible.Teams.Billing.allowed_features_for(team)
     end
 
     on_ee do
@@ -612,7 +616,12 @@ defmodule Plausible.Billing.QuotaTest do
 
         team = team_of(user)
 
-        assert [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.Funnels] ==
+        assert [
+                 Plausible.Billing.Feature.StatsAPI,
+                 Plausible.Billing.Feature.Funnels,
+                 Plausible.Billing.Feature.Teams,
+                 Plausible.Billing.Feature.SharedLinks
+               ] ==
                  Plausible.Teams.Billing.allowed_features_for(team)
       end
     end
@@ -658,7 +667,11 @@ defmodule Plausible.Billing.QuotaTest do
 
       team = team_of(user)
 
-      assert [Plausible.Billing.Feature.StatsAPI] ==
+      assert [
+               Plausible.Billing.Feature.StatsAPI,
+               Plausible.Billing.Feature.Teams,
+               Plausible.Billing.Feature.SharedLinks
+             ] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -671,7 +684,12 @@ defmodule Plausible.Billing.QuotaTest do
 
       team = team_of(user)
 
-      assert [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.SitesAPI] ==
+      assert [
+               Plausible.Billing.Feature.StatsAPI,
+               Plausible.Billing.Feature.SitesAPI,
+               Plausible.Billing.Feature.Teams,
+               Plausible.Billing.Feature.SharedLinks
+             ] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
   end

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -157,8 +157,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => true,
                    "SiteSegments" => false,
-                   "Teams" => false,
-                   "SharedLinks" => false
+                   "Teams" => true,
+                   "SharedLinks" => true
                  }
                }
 


### PR DESCRIPTION
### Changes

[This PR](https://github.com/plausible/analytics/pull/5426) restricted access to `Teams` and `SharedLinks` features. While these are not yet live, this PR gives access to these features to everyone.

### Tests
- [x] Automated tests have been adjusted

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
