### PR TITLE
Ensure team locked state is updated on site creation and removal

### DIFF
--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -4,7 +4,6 @@ defmodule Plausible.Site.Removal do
   """
   use Plausible
 
-  alias Plausible.Billing
   alias Plausible.Repo
   alias Plausible.Teams
 
@@ -21,7 +20,7 @@ defmodule Plausible.Site.Removal do
       Teams.Invitations.prune_guest_invitations(site.team)
 
       on_ee do
-        Billing.SiteLocker.update_for(site.team, send_email?: false)
+        Plausible.Billing.SiteLocker.update_for(site.team, send_email?: false)
       end
 
       %{delete_all: result}

--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -2,7 +2,9 @@ defmodule Plausible.Site.Removal do
   @moduledoc """
   A site deletion service stub.
   """
+  alias Plausible.Billing
   alias Plausible.Repo
+  alias Plausible.Teams
 
   import Ecto.Query
 
@@ -13,8 +15,10 @@ defmodule Plausible.Site.Removal do
 
       result = Repo.delete_all(from(s in Plausible.Site, where: s.domain == ^site.domain))
 
-      Plausible.Teams.Memberships.prune_guests(site.team)
-      Plausible.Teams.Invitations.prune_guest_invitations(site.team)
+      Teams.Memberships.prune_guests(site.team)
+      Teams.Invitations.prune_guest_invitations(site.team)
+
+      Billing.SiteLocker.update_for(site.team, send_email?: false)
 
       %{delete_all: result}
     end)

--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -2,6 +2,8 @@ defmodule Plausible.Site.Removal do
   @moduledoc """
   A site deletion service stub.
   """
+  use Plausible
+
   alias Plausible.Billing
   alias Plausible.Repo
   alias Plausible.Teams
@@ -18,7 +20,9 @@ defmodule Plausible.Site.Removal do
       Teams.Memberships.prune_guests(site.team)
       Teams.Invitations.prune_guest_invitations(site.team)
 
-      Billing.SiteLocker.update_for(site.team, send_email?: false)
+      on_ee do
+        Billing.SiteLocker.update_for(site.team, send_email?: false)
+      end
 
       %{delete_all: result}
     end)

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -2,6 +2,7 @@ defmodule Plausible.Sites do
   @moduledoc """
   Sites context functions.
   """
+  use Plausible
 
   import Ecto.Query
 
@@ -275,7 +276,12 @@ defmodule Plausible.Sites do
       end
     end)
     |> Ecto.Multi.run(:updated_lock, fn _repo, %{create_team: team} ->
-      lock_state = Billing.SiteLocker.update_for(team, send_email?: false)
+      lock_state =
+        if ee?() do
+          Billing.SiteLocker.update_for(team, send_email?: false)
+        else
+          :unlocked
+        end
 
       {:ok, lock_state}
     end)

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -6,10 +6,11 @@ defmodule Plausible.Sites do
   import Ecto.Query
 
   alias Plausible.Auth
+  alias Plausible.Billing
   alias Plausible.Repo
   alias Plausible.Site
-  alias Plausible.Teams
   alias Plausible.Site.SharedLink
+  alias Plausible.Teams
 
   require Plausible.Site.UserPreference
 
@@ -272,6 +273,11 @@ defmodule Plausible.Sites do
       else
         {:ok, :trial_already_started}
       end
+    end)
+    |> Ecto.Multi.run(:updated_lock, fn _repo, %{create_team: team} ->
+      lock_state = Billing.SiteLocker.update_for(team, send_email?: false)
+
+      {:ok, lock_state}
     end)
     |> Repo.transaction()
   end

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -219,6 +219,20 @@ defmodule Plausible.Billing.SiteLockerTest do
       assert Repo.reload!(site.team).locked
     end
 
+    test "does not lock if team has no sites" do
+      user = new_user(trial_expiry_date: Date.utc_today() |> Date.shift(day: -1))
+      site = new_site(owner: user)
+      team = team_of(user)
+
+      Plausible.Site.Removal.run(site)
+
+      team = Repo.reload!(team)
+
+      assert SiteLocker.update_for(team) == :unlocked
+
+      refute Repo.reload!(site.team).locked
+    end
+
     test "locks sites for user with empty trial - shouldn't happen under normal circumstances" do
       user = new_user()
       site = new_site(owner: user)

--- a/test/plausible/site/site_removal_test.exs
+++ b/test/plausible/site/site_removal_test.exs
@@ -39,6 +39,7 @@ defmodule Plausible.Site.SiteRemovalTest do
     refute Repo.reload(team_invitation)
   end
 
+  @tag :ee_only
   test "site deletion updates team dashboard lock state" do
     owner = new_user(team: [locked: true])
     site = new_site(owner: owner)

--- a/test/plausible/site/site_removal_test.exs
+++ b/test/plausible/site/site_removal_test.exs
@@ -38,4 +38,18 @@ defmodule Plausible.Site.SiteRemovalTest do
     refute Repo.reload(team_membership)
     refute Repo.reload(team_invitation)
   end
+
+  test "site deletion updates team dashboard lock state" do
+    owner = new_user(team: [locked: true])
+    site = new_site(owner: owner)
+    team = site.team
+
+    assert team.locked
+
+    assert {:ok, context} = Removal.run(site)
+    assert context.delete_all == {1, nil}
+    refute Sites.get_by_domain(site.domain)
+
+    refute Repo.reload(team).locked
+  end
 end

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -23,6 +23,7 @@ defmodule Plausible.SitesTest do
                Sites.create(user, params)
     end
 
+    @tag :ee_only
     test "updates team's locked state" do
       user = new_user(trial_expiry_date: Date.add(Date.utc_today(), -1), team: [locked: false])
 

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -23,6 +23,21 @@ defmodule Plausible.SitesTest do
                Sites.create(user, params)
     end
 
+    test "updates team's locked state" do
+      user = new_user(trial_expiry_date: Date.add(Date.utc_today(), -1), team: [locked: false])
+
+      team = new_site(owner: user).team
+
+      refute team.locked
+
+      params = %{"domain" => "example.com", "timezone" => "Europe/London"}
+
+      assert {:ok, %{site: %{domain: "example.com", timezone: "Europe/London"}}} =
+               Sites.create(user, params, team)
+
+      assert Repo.reload(team).locked
+    end
+
     test "does not start a trial for pre-teams guest users without trial expiry date" do
       user = new_user() |> subscribe_to_growth_plan()
       new_site(owner: user)


### PR DESCRIPTION
### Changes

The dashboard lock flag was move from individual sites to teams some time ago. However, the locked state was not re-evaluated when adding and removing sites however. This PR addresses it.

### Tests
- [x] Automated tests have been added

