### PR TITLE
Does not include tracking script on /cs module

### DIFF
--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -109,7 +109,8 @@ defmodule PlausibleWeb.Router do
   end
 
   on_ee do
-    scope alias: PlausibleWeb.Live, assigns: %{connect_live_socket: true} do
+    scope alias: PlausibleWeb.Live,
+          assigns: %{connect_live_socket: true, skip_plausible_tracking: true} do
       pipe_through [:browser, :csrf, :app_layout, :flags]
 
       live "/cs", CustomerSupport, :index, as: :customer_support


### PR DESCRIPTION
### Changes

Stops tracker script from being started on /cs module

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
