### PR TITLE
Starter Tier: Teams UI follow-ups

### DIFF
--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -72,7 +72,6 @@ defmodule Plausible.Billing.Feature do
 
   @features [
     Plausible.Billing.Feature.Props,
-    Plausible.Billing.Feature.Teams,
     Plausible.Billing.Feature.SharedLinks,
     Plausible.Billing.Feature.Funnels,
     Plausible.Billing.Feature.Goals,
@@ -200,13 +199,6 @@ defmodule Plausible.Billing.Feature.Props do
     toggle_field: :props_enabled
 end
 
-defmodule Plausible.Billing.Feature.Teams do
-  @moduledoc false
-  use Plausible.Billing.Feature,
-    name: :teams,
-    display_name: "Team Management"
-end
-
 defmodule Plausible.Billing.Feature.SharedLinks do
   @moduledoc false
   use Plausible.Billing.Feature,
@@ -237,4 +229,20 @@ defmodule Plausible.Billing.Feature.SitesAPI do
   use Plausible.Billing.Feature,
     name: :sites_api,
     display_name: "Sites API"
+end
+
+defmodule Plausible.Billing.Feature.Teams do
+  @moduledoc """
+  Unlike other feature modules, this one only exists to make feature gating
+  settings views more convenient. Other than that, it's not even considered
+  a feature on its own. The real access to "Teams" is controlled by the
+  team member limit.
+  """
+  def check_availability(team) do
+    if Plausible.Teams.Billing.solo?(team) do
+      {:error, :upgrade_required}
+    else
+      :ok
+    end
+  end
 end

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -219,6 +219,15 @@ defmodule Plausible.Teams.Billing do
     Teams.owned_sites_count(team)
   end
 
+  def solo?(nil), do: true
+
+  def solo?(team) do
+    case team_member_limit(team) do
+      0 -> true
+      _limit_or_unlimited -> false
+    end
+  end
+
   on_ee do
     @team_member_limit_for_trials 3
 
@@ -605,19 +614,19 @@ defmodule Plausible.Teams.Billing do
 
     case Plans.get_subscription_plan(team.subscription) do
       %EnterprisePlan{features: features} ->
-        features ++ [Feature.Teams, SharedLinks]
+        features ++ [SharedLinks]
 
       %Plan{features: features} ->
         features
 
       :free_10k ->
-        [Goals, Props, StatsAPI, Feature.Teams, SharedLinks]
+        [Goals, Props, StatsAPI, SharedLinks]
 
       nil ->
         if Teams.on_trial?(team) do
           Feature.list() -- [SitesAPI]
         else
-          [Goals, Feature.Teams, SharedLinks]
+          [Goals, SharedLinks]
         end
     end
   end

--- a/lib/plausible_web/components/billing/billing.ex
+++ b/lib/plausible_web/components/billing/billing.ex
@@ -5,21 +5,14 @@ defmodule PlausibleWeb.Components.Billing do
   use Plausible
 
   require Plausible.Billing.Subscription.Status
-  alias Plausible.Billing.{Subscription, Subscriptions, Feature, Plan, Plans, EnterprisePlan}
+  alias Plausible.Billing.{Subscription, Subscriptions, Plan, Plans, EnterprisePlan}
 
   attr :current_role, :atom, required: true
   attr :current_team, :any, required: true
-  attr :feature_mod, :atom, required: true, values: Feature.list()
+  attr :locked?, :boolean, required: true
   slot :inner_block, required: true
 
   def feature_gate(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :locked?,
-        assigns.feature_mod.check_availability(assigns.current_team) != :ok
-      )
-
     ~H"""
     <div id="feature-gate-inner-block-container" class={if(@locked?, do: "pointer-events-none")}>
       {render_slot(@inner_block)}

--- a/lib/plausible_web/components/billing/plan_benefits.ex
+++ b/lib/plausible_web/components/billing/plan_benefits.ex
@@ -62,7 +62,8 @@ defmodule PlausibleWeb.Components.Billing.PlanBenefits do
     [
       "Everything in Starter",
       site_limit_benefit(growth_plan),
-      team_member_limit_benefit(growth_plan)
+      team_member_limit_benefit(growth_plan),
+      "Team Management"
     ]
     |> Kernel.++(feature_benefits(growth_plan))
     |> Kernel.--(starter_benefits)

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -472,7 +472,7 @@ defmodule PlausibleWeb.Components.Generic do
       <div class="relative">
         <%= if @feature_mod do %>
           <PlausibleWeb.Components.Billing.feature_gate
-            feature_mod={@feature_mod}
+            locked?={@feature_mod.check_availability(@current_team) != :ok}
             current_role={@current_role}
             current_team={@current_team}
           >

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -634,6 +634,7 @@ defmodule PlausibleWeb.Components.Generic do
   slot :subtitle
   slot :inner_block, required: true
   slot :footer
+  attr :padding?, :boolean, default: true
   attr :rest, :global
 
   def focus_box(assigns) do
@@ -642,7 +643,7 @@ defmodule PlausibleWeb.Components.Generic do
       class="bg-white w-full max-w-lg mx-auto dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-md rounded-md mt-12"
       {@rest}
     >
-      <div class="p-8">
+      <div class={if(@padding?, do: "p-8")}>
         <.title :if={@title != []}>
           {render_slot(@title)}
         </.title>

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -56,9 +56,9 @@ defmodule PlausibleWeb.Live.TeamSetup do
 
   def render(assigns) do
     ~H"""
-    <.focus_box>
+    <.focus_box padding?={false}>
       <:title>
-        <div class="flex justify-between">
+        <div class="pt-8 px-8 flex justify-between">
           <div>Create a new team</div>
           <div class="ml-auto">
             <.docs_info slug="users-roles" />
@@ -66,39 +66,49 @@ defmodule PlausibleWeb.Live.TeamSetup do
         </div>
       </:title>
       <:subtitle>
-        Name your team, add team members and assign roles. When ready, click "Create Team" to send invitations
+        <p class="px-8">
+          Name your team, add team members and assign roles. When ready, click "Create Team" to send invitations
+        </p>
       </:subtitle>
 
-      <.form
-        :let={f}
-        for={@team_name_form}
-        method="post"
-        phx-change="update-team"
-        phx-blur="update-team"
-        id="update-team-form"
-        class="mt-4 mb-8"
-      >
-        <.input
-          type="text"
-          placeholder={"#{@current_user.name}'s Team"}
-          autofocus
-          field={f[:name]}
-          label="Name"
-          width="w-full"
-          phx-debounce="500"
-        />
-      </.form>
+      <div class="relative pb-8 px-8">
+        <PlausibleWeb.Components.Billing.feature_gate
+          current_role={@current_team_role}
+          current_team={@current_team}
+          locked?={Plausible.Teams.Billing.solo?(@current_team)}
+        >
+          <.form
+            :let={f}
+            for={@team_name_form}
+            method="post"
+            phx-change="update-team"
+            phx-blur="update-team"
+            id="update-team-form"
+            class="mt-4 mb-8"
+          >
+            <.input
+              type="text"
+              placeholder={"#{@current_user.name}'s Team"}
+              autofocus
+              field={f[:name]}
+              label="Name"
+              width="w-full"
+              phx-debounce="500"
+            />
+          </.form>
 
-      <.label class="mb-2">
-        Team Members
-      </.label>
-      {live_render(@socket, PlausibleWeb.Live.TeamManagement,
-        id: "team-management-setup",
-        container: {:div, id: "team-setup"},
-        session: %{
-          "mode" => "team-setup"
-        }
-      )}
+          <.label class="mb-2">
+            Team Members
+          </.label>
+          {live_render(@socket, PlausibleWeb.Live.TeamManagement,
+            id: "team-management-setup",
+            container: {:div, id: "team-setup"},
+            session: %{
+              "mode" => "team-setup"
+            }
+          )}
+        </PlausibleWeb.Components.Billing.feature_gate>
+      </div>
     </.focus_box>
     """
   end

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -92,10 +92,7 @@
                       Account Settings
                     </.dropdown_item>
 
-                    <div :if={
-                      @my_team && @my_team.id == @current_team.id &&
-                        not Plausible.Teams.Billing.solo?(@current_team)
-                    }>
+                    <div :if={@my_team && @my_team.id == @current_team.id}>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span data-test="create-a-team-cta" class="flex-1">
                           Create a Team

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -94,7 +94,7 @@
 
                     <div :if={
                       @my_team && @my_team.id == @current_team.id &&
-                        Plausible.Billing.Feature.Teams.check_availability(@current_team) == :ok
+                        not Plausible.Teams.Billing.solo?(@current_team)
                     }>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span data-test="create-a-team-cta" class="flex-1">

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -1,5 +1,5 @@
 <.settings_tiles>
-  <%= if not Plausible.Teams.setup?(@site.team) and Plausible.Billing.Feature.Teams.check_availability(@site.team) == :ok do %>
+  <%= if not Plausible.Teams.setup?(@site.team) and not Plausible.Teams.Billing.solo?(@site.team) do %>
     <PlausibleWeb.Team.Notice.owner_cta_banner :if={@site_role == :owner} />
     <PlausibleWeb.Team.Notice.guest_cta_banner :if={@site_role != :owner} />
   <% end %>

--- a/priv/plans_v1.json
+++ b/priv/plans_v1.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -139,7 +131,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -155,7 +146,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/plans_v2.json
+++ b/priv/plans_v2.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -139,7 +131,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -155,7 +146,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/plans_v3.json
+++ b/priv/plans_v3.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -142,7 +134,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -161,7 +152,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -180,7 +170,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -199,7 +188,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -218,7 +206,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -237,7 +224,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -256,7 +242,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -275,7 +260,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/plans_v4.json
+++ b/priv/plans_v4.json
@@ -9,7 +9,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -24,7 +23,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -39,7 +37,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -54,7 +51,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -69,7 +65,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -84,7 +79,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -99,7 +93,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -114,7 +107,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -134,7 +126,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -154,7 +145,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -174,7 +164,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -194,7 +183,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -214,7 +202,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -234,7 +221,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -254,7 +240,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -274,7 +259,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5

--- a/priv/plans_v5.json
+++ b/priv/plans_v5.json
@@ -113,7 +113,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -129,7 +128,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -145,7 +143,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -161,7 +158,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -177,7 +173,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -193,7 +188,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -209,7 +203,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -225,7 +218,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -241,7 +233,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -261,7 +252,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -281,7 +271,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -301,7 +290,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -321,7 +309,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -341,7 +328,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -361,7 +347,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -381,7 +366,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",

--- a/priv/sandbox_plans_v1.json
+++ b/priv/sandbox_plans_v1.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -139,7 +131,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -155,7 +146,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/sandbox_plans_v2.json
+++ b/priv/sandbox_plans_v2.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -139,7 +131,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -155,7 +146,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/sandbox_plans_v3.json
+++ b/priv/sandbox_plans_v3.json
@@ -11,7 +11,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -27,7 +26,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -43,7 +41,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -59,7 +56,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -75,7 +71,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -91,7 +86,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -107,7 +101,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -123,7 +116,6 @@
       "goals",
       "props",
       "stats_api",
-      "teams",
       "shared_links"
     ]
   },
@@ -142,7 +134,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -161,7 +152,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -180,7 +170,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -199,7 +188,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -218,7 +206,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -237,7 +224,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -256,7 +242,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   },
@@ -275,7 +260,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ]
   }

--- a/priv/sandbox_plans_v4.json
+++ b/priv/sandbox_plans_v4.json
@@ -9,7 +9,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -24,7 +23,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -39,7 +37,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -54,7 +51,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -69,7 +65,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -84,7 +79,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -99,7 +93,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -114,7 +107,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 3
@@ -134,7 +126,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -154,7 +145,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -174,7 +164,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -194,7 +183,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -214,7 +202,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -234,7 +221,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -254,7 +240,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5
@@ -274,7 +259,6 @@
       "funnels",
       "stats_api",
       "site_segments",
-      "teams",
       "shared_links"
     ],
     "data_retention_in_years": 5

--- a/priv/sandbox_plans_v5.json
+++ b/priv/sandbox_plans_v5.json
@@ -113,7 +113,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -129,7 +128,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -145,7 +143,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -161,7 +158,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -177,7 +173,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -193,7 +188,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -209,7 +203,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -225,7 +218,6 @@
     "team_member_limit": 3,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments"
     ],
@@ -241,7 +233,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -261,7 +252,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -281,7 +271,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -301,7 +290,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -321,7 +309,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -341,7 +328,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -361,7 +347,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",
@@ -381,7 +366,6 @@
     "team_member_limit": 10,
     "features": [
       "goals",
-      "teams",
       "shared_links",
       "site_segments",
       "props",

--- a/test/plausible/billing/feature_test.exs
+++ b/test/plausible/billing/feature_test.exs
@@ -30,11 +30,6 @@ defmodule Plausible.Billing.FeatureTest do
     end
   end
 
-  test "Plausible.Billing.Feature.Teams.check_availability/2 returns :ok when user is on an enterprise plan" do
-    team = new_user() |> subscribe_to_enterprise_plan() |> team_of()
-    assert :ok == Plausible.Billing.Feature.Teams.check_availability(team)
-  end
-
   test "Plausible.Billing.Feature.SharedLinks.check_availability/2 returns :ok when user is on an enterprise plan" do
     team = new_user() |> subscribe_to_enterprise_plan() |> team_of()
     assert :ok == Plausible.Billing.Feature.SharedLinks.check_availability(team)

--- a/test/plausible_web/components/billing/billing_test.exs
+++ b/test/plausible_web/components/billing/billing_test.exs
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: :owner,
           current_team: user |> subscribe_to_growth_plan() |> team_of(),
-          feature_mod: Plausible.Billing.Feature.Props
+          locked?: true
         }
         |> render_feature_gate()
 
@@ -28,7 +28,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: nil,
           current_team: nil,
-          feature_mod: Plausible.Billing.Feature.Props
+          locked?: true
         }
         |> render_feature_gate()
 
@@ -43,7 +43,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: :owner,
           current_team: user |> subscribe_to_business_plan() |> team_of(),
-          feature_mod: Plausible.Billing.Feature.Funnels
+          locked?: false
         }
         |> render_feature_gate()
 
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: :owner,
           current_team: user |> subscribe_to_growth_plan() |> team_of(),
-          feature_mod: Plausible.Billing.Feature.Props
+          locked?: true
         }
         |> render_feature_gate()
 
@@ -70,7 +70,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: :billing,
           current_team: user |> subscribe_to_growth_plan() |> team_of(),
-          feature_mod: Plausible.Billing.Feature.Props
+          locked?: true
         }
         |> render_feature_gate()
 
@@ -85,7 +85,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         %{
           current_role: :editor,
           current_team: user |> subscribe_to_growth_plan() |> team_of(),
-          feature_mod: Plausible.Billing.Feature.Props
+          locked?: true
         }
         |> render_feature_gate()
 
@@ -94,10 +94,11 @@ defmodule PlausibleWeb.Components.BillingTest do
   end
 
   defp render_feature_gate(assigns) do
-    rendered_to_string(~H"""
+    ~H"""
     <PlausibleWeb.Components.Billing.feature_gate {assigns}>
       <div>content...</div>
     </PlausibleWeb.Components.Billing.feature_gate>
-    """)
+    """
+    |> rendered_to_string()
   end
 end

--- a/test/plausible_web/controllers/admin_controller_test.exs
+++ b/test/plausible_web/controllers/admin_controller_test.exs
@@ -263,7 +263,7 @@ defmodule PlausibleWeb.AdminControllerTest do
       conn = get(conn, "/crm/billing/team/#{team.id}/current_plan")
 
       assert json_response(conn, 200) == %{
-               "features" => ["goals", "teams", "shared_links"],
+               "features" => ["goals", "shared_links"],
                "monthly_pageview_limit" => 10_000_000,
                "site_limit" => 10,
                "team_member_limit" => 3

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1421,16 +1421,6 @@ defmodule PlausibleWeb.SettingsControllerTest do
       assert text_of_element(html, ~s/[data-test="create-a-team-cta"]/) == "Create a Team"
     end
 
-    test "does not render the 'Create a Team' option if Teams feature is unavailable", %{
-      conn: conn,
-      user: user
-    } do
-      subscribe_to_starter_plan(user)
-      conn = get(conn, Routes.settings_path(conn, :preferences))
-      html = html_response(conn, 200)
-      refute element_exists?(html, ~s/[data-test="create-a-team-cta"]/)
-    end
-
     test "does not render the 'Create a Team' option if a team is already set up", %{
       conn: conn,
       user: user

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -128,7 +128,6 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
               "false",
               "false",
               "false",
-              "teams",
               "false",
               "shared_links",
               "false",
@@ -150,7 +149,6 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
                  %Plausible.Billing.EnterprisePlan{
                    billing_interval: :yearly,
                    features: [
-                     Plausible.Billing.Feature.Teams,
                      Plausible.Billing.Feature.SharedLinks,
                      Plausible.Billing.Feature.SitesAPI
                    ],

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -83,6 +83,20 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       _ = render(lv)
       assert Repo.reload!(team).name == "Team Name 1"
     end
+
+    test "blurs UI with an upgrade CTA if the subscription team member limit is 0", %{
+      conn: conn,
+      user: user
+    } do
+      subscribe_to_starter_plan(user)
+
+      {:ok, _lv, html} = live(conn, @url)
+
+      assert class_of_element(html, "#feature-gate-inner-block-container") =~
+               "pointer-events-none"
+
+      assert class_of_element(html, "#feature-gate-overlay") =~ "backdrop-blur-[6px]"
+    end
   end
 
   describe "/team/setup - full integration" do

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -32,7 +32,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "Teams" => false,
                    "SharedLinks" => false
                  }
                }
@@ -60,7 +59,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "Teams" => false,
                    "SharedLinks" => false
                  }
                }
@@ -90,7 +88,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => false,
                    "SiteSegments" => true,
-                   "Teams" => true,
                    "SharedLinks" => true
                  }
                }
@@ -122,7 +119,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "Teams" => true,
                    "SharedLinks" => true
                  }
                }
@@ -157,7 +153,6 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => true,
                    "SiteSegments" => false,
-                   "Teams" => true,
                    "SharedLinks" => true
                  }
                }


### PR DESCRIPTION
### Changes

* Make sure the "Create a Team" CTA is still rendered, even for Starter tier, but the team creation itself is disabled (see screenshot below)
* Code refactor: stop treating `Feature.Teams` like any other feature module. Instead keep it around explicitly for the UI feature gate

![image](https://github.com/user-attachments/assets/cddab7a0-3490-4707-9bb6-5185e32fa492)


### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
