### PR TITLE
Add resolved script features to legacy script endpoint metrics

### DIFF
--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -119,8 +119,16 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         counter(
           metric_prefix ++ [:tracker_script, :request, :legacy],
           event_name: PlausibleWeb.TrackerPlug.telemetry_event(:legacy),
-          tags: [:status],
-          tag_values: &%{status: &1.status}
+          tags: [:status] ++ PlausibleWeb.TrackerPlug.telemetry_legacy_variant_labels(),
+          tag_values: fn payload ->
+            Map.merge(
+              Map.new(
+                PlausibleWeb.TrackerPlug.telemetry_legacy_variant_labels(),
+                fn label -> {label, Map.get(payload, label, false)} end
+              ),
+              %{status: payload.status}
+            )
+          end
         )
       ]
     )


### PR DESCRIPTION
### Changes

Adds resolved script features (aka base variant names) to legacy script serving counter metric. May be useful to gauge popularity or lack thereof of particular base variants. Ideally would not be needed, but can't find the breakdown by file in the CDN.

### Tests
Manually testable. Checkout the PR, run the app locally, visit http://localhost:8000/js/plausible.tagged-events.compat.js, then go to http://localhost:8000/metrics and look for the following
```
# HELP plausible_prom_ex_plausible_tracker_script_request_legacy 
# TYPE plausible_prom_ex_plausible_tracker_script_request_legacy counter
plausible_prom_ex_plausible_tracker_script_request_legacy{compat="true",exclusions="false",file_downloads="false",hash="false",local="false",manual="false",outbound_links="false",pageview_props="false",revenue="false",status="200",tagged_events="true"} 1
```

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
