### PR TITLE
Slight change to the plugin token copy 

### DIFF
--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -84,7 +84,7 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
           </div>
 
           <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-            Please copy the token and store it in a secure place as it won't be shown again. 
+            Please copy the token and store it in a secure place as it won't be shown again.
             Then click the "**Add Plugin Token**" button to confirm.
             <span :if={@token_description == "WordPress"}>
               You'll need to paste the token in the settings area of the Plausible WordPress plugin.


### PR DESCRIPTION
we've had several cases of people not knowing that they have to click on the button to confirm the creation of the plugin token. they just copy the token and close the window which results in an error message when they paste the token in our WP plugin. trying to clarify that with this change of copy

cc @aerosol 