### PR TITLE
Add unique index on `users.sso_identity_id`

### DIFF
--- a/priv/repo/migrations/20250604094230_add_unique_index_on_users_sso_identity_id.exs
+++ b/priv/repo/migrations/20250604094230_add_unique_index_on_users_sso_identity_id.exs
@@ -1,0 +1,11 @@
+defmodule Plausible.Repo.Migrations.AddUniqueIndexOnUsersSsoIdentityId do
+  use Ecto.Migration
+
+  import Plausible.MigrationUtils
+
+  def change do
+    if enterprise_edition?() do
+      create_if_not_exists unique_index(:users, [:sso_identity_id])
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This index was missing. Given we currently expect SSO user emails being unique across the system, the same expectation should be set for NameID/identity ID (though it's yet to be proved whether we can truly rely on it).


