### PR TITLE
Migration: Add SharedLinks feature to all enterprise plans

### DIFF
--- a/priv/repo/migrations/20250604115839_add_shared_links_feature_to_enterprise_plans.exs
+++ b/priv/repo/migrations/20250604115839_add_shared_links_feature_to_enterprise_plans.exs
@@ -1,0 +1,15 @@
+defmodule Plausible.Repo.Migrations.AddSharedLinksFeatureToEnterprisePlans do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE enterprise_plans
+    SET features = array_append(features, 'shared_links')
+    WHERE NOT ('shared_links' = ANY(features));
+    """
+  end
+
+  def down do
+    raise "irreversible"
+  end
+end


### PR DESCRIPTION
### Changes

Currently, the Shared Links feature is given to enterprise plans via https://github.com/plausible/analytics/blob/0a2ed563dd0abc4fc95c1828be2f0dd30c7accfb/lib/plausible/teams/billing.ex#L616

However, even though all enterprise plans will likely have access to shared links, we want access to be determined by data, rather than code.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
