### PR TITLE
Starter Tier: Shared Link Feature Gates

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -301,6 +301,9 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
             url: Sites.shared_link_url(site, link)
           })
 
+        {:error, :reserved_name} ->
+          H.bad_request(conn, "This name is reserved. Please choose another one")
+
         {:error, :upgrade_required} ->
           H.payment_required(conn, "Your current subscription plan does not include Shared Links")
       end

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -300,6 +300,9 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
             name: link.name,
             url: Sites.shared_link_url(site, link)
           })
+
+        {:error, :upgrade_required} ->
+          H.payment_required(conn, "Your current subscription plan does not include Shared Links")
       end
     else
       {:error, :site_not_found} ->

--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -301,8 +301,9 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
             url: Sites.shared_link_url(site, link)
           })
 
-        {:error, :reserved_name} ->
-          H.bad_request(conn, "This name is reserved. Please choose another one")
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {msg, _} = changeset.errors[:name]
+          H.bad_request(conn, msg)
 
         {:error, :upgrade_required} ->
           H.payment_required(conn, "Your current subscription plan does not include Shared Links")

--- a/lib/plausible/plugins/api/shared_links.ex
+++ b/lib/plausible/plugins/api/shared_links.ex
@@ -31,8 +31,14 @@ defmodule Plausible.Plugins.API.SharedLinks do
           {:ok, Plausible.Site.SharedLink.t()}
   def get_or_create(site, name, password \\ nil) do
     case get_by_name(site, name) do
-      nil -> Plausible.Sites.create_shared_link(site, name, password)
-      shared_link -> {:ok, shared_link}
+      nil ->
+        Plausible.Sites.create_shared_link(site, name,
+          password: password,
+          skip_feature_check?: true
+        )
+
+      shared_link ->
+        {:ok, shared_link}
     end
   end
 

--- a/lib/plausible/plugins/api/shared_links.ex
+++ b/lib/plausible/plugins/api/shared_links.ex
@@ -34,7 +34,8 @@ defmodule Plausible.Plugins.API.SharedLinks do
       nil ->
         Plausible.Sites.create_shared_link(site, name,
           password: password,
-          skip_feature_check?: true
+          skip_feature_check?: true,
+          skip_special_name_check?: true
         )
 
       shared_link ->

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -369,13 +369,4 @@ defmodule Plausible.Segments do
 
     "#{field} #{formatted_message}"
   end
-
-  @spec get_site_segments_usage_query(list(pos_integer())) :: Ecto.Query.t()
-  def get_site_segments_usage_query(site_ids) do
-    from(segment in Segment,
-      as: :segment,
-      where: segment.type == :site,
-      where: segment.site_id in ^site_ids
-    )
-  end
 end

--- a/lib/plausible/site/shared_link.ex
+++ b/lib/plausible/site/shared_link.ex
@@ -14,13 +14,25 @@ defmodule Plausible.Site.SharedLink do
     timestamps()
   end
 
-  def changeset(link, attrs \\ %{}) do
+  def changeset(link, attrs \\ %{}, opts \\ []) do
     link
     |> cast(attrs, [:slug, :password, :name])
     |> validate_required([:slug, :name])
+    |> validate_special_name(opts)
     |> unique_constraint(:slug)
     |> unique_constraint(:name, name: :shared_links_site_id_name_index)
     |> hash_password()
+  end
+
+  defp validate_special_name(changeset, opts) do
+    name = get_change(changeset, :name)
+
+    if name not in Plausible.Sites.shared_link_special_names() ||
+         Keyword.get(opts, :skip_special_name_check?, false) do
+      changeset
+    else
+      changeset |> add_error(:name, "This name is reserved. Please choose another one")
+    end
   end
 
   defp hash_password(link) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -13,6 +13,22 @@ defmodule Plausible.Sites do
   require Plausible.Site.UserPreference
 
   @shared_link_special_names ["WordPress - Shared Dashboard"]
+  @doc """
+  Special shared link names are used to distinguish between those
+  created by the Plugins API, and those created in any other way
+  (i.e. via Sites API or in the Dashboard Site Settings UI).
+
+  The intent is to give our WP plugin the ability to display an
+  embedded dashboard even when the user's subscription does not
+  support the shared links feature.
+
+  A shared link with a special name can only be created via the
+  plugins API, and it will not show up under the list of shared
+  links in Site Settings > Visibility.
+
+  Once created with the special name, the link will be accessible
+  even when the team does not have access to SharedLinks feature.
+  """
   def shared_link_special_names(), do: @shared_link_special_names
 
   def get_by_domain(domain) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -355,7 +355,7 @@ defmodule Plausible.Sites do
   end
 
   def create_shared_link(site, name, opts \\ []) do
-    password = Keyword.get(opts, :password, nil)
+    password = Keyword.get(opts, :password)
 
     site = Plausible.Repo.preload(site, :team)
 

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -528,6 +528,11 @@ defmodule Plausible.Teams.Billing do
   end
 
   def features_usage(nil, site_ids) when is_list(site_ids) do
+    shared_links_usage_q =
+      from l in Plausible.Site.SharedLink,
+        where:
+          l.site_id in ^site_ids and l.name not in ^Plausible.Sites.shared_link_special_names()
+
     props_usage_q =
       from s in Plausible.Site,
         where: s.id in ^site_ids and fragment("cardinality(?) > 0", s.allowed_event_props)
@@ -541,6 +546,7 @@ defmodule Plausible.Teams.Billing do
         funnels_usage_q = from f in "funnels", where: f.site_id in ^site_ids
 
         [
+          {Feature.SharedLinks, shared_links_usage_q},
           {Feature.Props, props_usage_q},
           {Feature.Funnels, funnels_usage_q},
           {Feature.RevenueGoals, revenue_goals_usage_q},

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -613,7 +613,7 @@ defmodule Plausible.Teams.Billing do
 
     case Plans.get_subscription_plan(team.subscription) do
       %EnterprisePlan{features: features} ->
-        features ++ [SharedLinks]
+        features
 
       %Plan{features: features} ->
         features
@@ -625,7 +625,7 @@ defmodule Plausible.Teams.Billing do
         if Teams.on_trial?(team) do
           Feature.list() -- [SitesAPI]
         else
-          [Goals, SharedLinks]
+          [Goals]
         end
     end
   end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -162,7 +162,14 @@ defmodule PlausibleWeb.SiteController do
 
   def settings_visibility(conn, _params) do
     site = conn.assigns[:site]
-    shared_links = Repo.all(from(l in Plausible.Site.SharedLink, where: l.site_id == ^site.id))
+
+    shared_links =
+      Repo.all(
+        from(l in Plausible.Site.SharedLink,
+          where:
+            l.site_id == ^site.id and l.name not in ^Plausible.Sites.shared_link_special_names()
+        )
+      )
 
     conn
     |> render("settings_visibility.html",

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -625,17 +625,23 @@ defmodule PlausibleWeb.SiteController do
     shared_link = Repo.get_by(Plausible.Site.SharedLink, slug: slug)
     changeset = Plausible.Site.SharedLink.changeset(shared_link, params)
 
-    case Repo.update(changeset) do
-      {:ok, _created} ->
-        redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
+    if params["name"] in Plausible.Sites.shared_link_special_names() do
+      conn
+      |> put_flash(:error, "This name is reserved. Please choose another one")
+      |> redirect(to: Routes.site_path(conn, :edit_shared_link, site.domain, slug))
+    else
+      case Repo.update(changeset) do
+        {:ok, _created} ->
+          redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
 
-      {:error, changeset} ->
-        conn
-        |> assign(:skip_plausible_tracking, true)
-        |> render("edit_shared_link.html",
-          site: site,
-          changeset: changeset
-        )
+        {:error, changeset} ->
+          conn
+          |> assign(:skip_plausible_tracking, true)
+          |> render("edit_shared_link.html",
+            site: site,
+            changeset: changeset
+          )
+      end
     end
   end
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -592,11 +592,6 @@ defmodule PlausibleWeb.SiteController do
         |> put_flash(:error, "Your current subscription plan does not include Shared Links")
         |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
 
-      {:error, :reserved_name} ->
-        conn
-        |> put_flash(:error, "This name is reserved. Please choose another one")
-        |> redirect(to: Routes.site_path(conn, :new_shared_link, site.domain))
-
       {:error, changeset} ->
         conn
         |> assign(:skip_plausible_tracking, true)
@@ -625,23 +620,17 @@ defmodule PlausibleWeb.SiteController do
     shared_link = Repo.get_by(Plausible.Site.SharedLink, slug: slug)
     changeset = Plausible.Site.SharedLink.changeset(shared_link, params)
 
-    if params["name"] in Plausible.Sites.shared_link_special_names() do
-      conn
-      |> put_flash(:error, "This name is reserved. Please choose another one")
-      |> redirect(to: Routes.site_path(conn, :edit_shared_link, site.domain, slug))
-    else
-      case Repo.update(changeset) do
-        {:ok, _created} ->
-          redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
+    case Repo.update(changeset) do
+      {:ok, _updated} ->
+        redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
 
-        {:error, changeset} ->
-          conn
-          |> assign(:skip_plausible_tracking, true)
-          |> render("edit_shared_link.html",
-            site: site,
-            changeset: changeset
-          )
-      end
+      {:error, changeset} ->
+        conn
+        |> assign(:skip_plausible_tracking, true)
+        |> render("edit_shared_link.html",
+          site: site,
+          changeset: changeset
+        )
     end
   end
 

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -576,9 +576,14 @@ defmodule PlausibleWeb.SiteController do
   def create_shared_link(conn, %{"shared_link" => link}) do
     site = conn.assigns[:site]
 
-    case Sites.create_shared_link(site, link["name"], link["password"]) do
+    case Sites.create_shared_link(site, link["name"], password: link["password"]) do
       {:ok, _created} ->
         redirect(conn, to: Routes.site_path(conn, :settings_visibility, site.domain))
+
+      {:error, :upgrade_required} ->
+        conn
+        |> put_flash(:error, "Your current subscription plan does not include Shared Links")
+        |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
 
       {:error, changeset} ->
         conn

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -585,6 +585,11 @@ defmodule PlausibleWeb.SiteController do
         |> put_flash(:error, "Your current subscription plan does not include Shared Links")
         |> redirect(to: Routes.site_path(conn, :settings_visibility, site.domain))
 
+      {:error, :reserved_name} ->
+        conn
+        |> put_flash(:error, "This name is reserved. Please choose another one")
+        |> redirect(to: Routes.site_path(conn, :new_shared_link, site.domain))
+
       {:error, changeset} ->
         conn
         |> assign(:skip_plausible_tracking, true)

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -341,6 +341,8 @@ defmodule PlausibleWeb.StatsController do
     end
   end
 
+  @wp_shared_link_special_name "WordPress - Shared Dashboard"
+
   defp render_shared_link(conn, shared_link) do
     cond do
       Teams.locked?(shared_link.site.team) ->
@@ -352,7 +354,8 @@ defmodule PlausibleWeb.StatsController do
           dogfood_page_path: "/share/:dashboard"
         )
 
-      SharedLinks.check_availability(shared_link.site.team) != :ok ->
+      SharedLinks.check_availability(shared_link.site.team) != :ok and
+          shared_link.name != @wp_shared_link_special_name ->
         owners = Plausible.Repo.preload(shared_link.site, :owners)
 
         render(conn, "site_locked.html",

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -341,9 +341,11 @@ defmodule PlausibleWeb.StatsController do
     end
   end
 
-  @wp_shared_link_special_name "WordPress - Shared Dashboard"
-
   defp render_shared_link(conn, shared_link) do
+    shared_links_feature_access? =
+      SharedLinks.check_availability(shared_link.site.team) == :ok or
+        shared_link.name in Plausible.Sites.shared_link_special_names()
+
     cond do
       Teams.locked?(shared_link.site.team) ->
         owners = Plausible.Repo.preload(shared_link.site, :owners)
@@ -354,8 +356,7 @@ defmodule PlausibleWeb.StatsController do
           dogfood_page_path: "/share/:dashboard"
         )
 
-      SharedLinks.check_availability(shared_link.site.team) != :ok and
-          shared_link.name != @wp_shared_link_special_name ->
+      not shared_links_feature_access? ->
         owners = Plausible.Repo.preload(shared_link.site, :owners)
 
         render(conn, "site_locked.html",

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -48,6 +48,7 @@ defmodule PlausibleWeb.StatsController do
   alias Plausible.Stats.{Filters, Query}
   alias Plausible.Teams
   alias PlausibleWeb.Api
+  alias Plausible.Billing.Feature.SharedLinks
 
   plug(PlausibleWeb.Plugs.AuthorizeSiteAccess when action in [:stats, :csv_export])
 
@@ -342,6 +343,25 @@ defmodule PlausibleWeb.StatsController do
 
   defp render_shared_link(conn, shared_link) do
     cond do
+      Teams.locked?(shared_link.site.team) ->
+        owners = Plausible.Repo.preload(shared_link.site, :owners)
+
+        render(conn, "site_locked.html",
+          owners: owners,
+          site: shared_link.site,
+          dogfood_page_path: "/share/:dashboard"
+        )
+
+      SharedLinks.check_availability(shared_link.site.team) != :ok ->
+        owners = Plausible.Repo.preload(shared_link.site, :owners)
+
+        render(conn, "site_locked.html",
+          only_shared_link_access_missing?: true,
+          owners: owners,
+          site: shared_link.site,
+          dogfood_page_path: "/share/:dashboard"
+        )
+
       not Teams.locked?(shared_link.site.team) ->
         current_user = conn.assigns[:current_user]
         site_role = get_fallback_site_role(conn)
@@ -378,15 +398,6 @@ defmodule PlausibleWeb.StatsController do
           segments: segments,
           load_dashboard_js: true,
           hide_footer?: if(ce?(), do: embedded?, else: embedded? || site_role != :public)
-        )
-
-      Teams.locked?(shared_link.site.team) ->
-        owners = Plausible.Repo.preload(shared_link.site, :owners)
-
-        render(conn, "site_locked.html",
-          owners: owners,
-          site: shared_link.site,
-          dogfood_page_path: "/share/:dashboard"
         )
     end
   end

--- a/lib/plausible_web/templates/site/settings_visibility.html.heex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.heex
@@ -52,7 +52,7 @@
       No Shared Links configured for this site.
     </p>
 
-    <.table rows={@shared_links}>
+    <.table rows={@shared_links} id="shared-links-table">
       <:thead>
         <.th hide_on_mobile>Name</.th>
         <.th>Link</.th>

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -17,11 +17,19 @@
         </svg>
       </div>
       <h3 class="mt-6 text-center text-2xl leading-6 font-medium text-gray-900 dark:text-gray-200">
-        Dashboard locked
+        <%= if @conn.assigns[:only_shared_link_access_missing?] do %>
+          Shared Link Unavailable
+        <% else %>
+          Dashboard Locked
+        <% end %>
       </h3>
 
-      <%= case @conn.assigns[:site_role] do %>
-        <% role when role in [:owner, :billing] -> %>
+      <%= case @conn.assigns do %>
+        <% %{only_shared_link_access_missing?: true} -> %>
+          <p class="mt-6 text-gray-600 dark:text-gray-300 text-center">
+            This shared link is locked because the owner of the site does not have access to the Shared Links feature. To restore it, the owner must upgrade to a suitable plan.
+          </p>
+        <% %{site_role: role} when role in [:owner, :billing] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
               This dashboard is locked because you don't have a valid subscription.
@@ -40,7 +48,7 @@
               Manage my subscription
             </.button_link>
           </div>
-        <% role when role in [:admin, :viewer, :editor] -> %>
+        <% %{site_role: role} when role in [:admin, :viewer, :editor] -> %>
           <div class="mt-3 text-gray-600 dark:text-gray-300 text-center">
             <p>
               Owner of this site must upgrade their subscription plan in order to unlock the stats.

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -575,8 +575,7 @@ defmodule Plausible.Billing.QuotaTest do
       test "users with expired trials have no access to subscription features" do
         team = new_user(trial_expiry_date: ~D[2023-01-01]) |> team_of()
 
-        assert [Goals, Plausible.Billing.Feature.SharedLinks] ==
-                 Plausible.Teams.Billing.allowed_features_for(team)
+        assert [Goals] == Plausible.Teams.Billing.allowed_features_for(team)
       end
     end
 
@@ -605,7 +604,11 @@ defmodule Plausible.Billing.QuotaTest do
         subscribe_to_enterprise_plan(user,
           monthly_pageview_limit: 100_000,
           site_limit: 500,
-          features: [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.Funnels]
+          features: [
+            Plausible.Billing.Feature.StatsAPI,
+            Plausible.Billing.Feature.Funnels,
+            Plausible.Billing.Feature.SharedLinks
+          ]
         )
 
         team = team_of(user)
@@ -660,10 +663,7 @@ defmodule Plausible.Billing.QuotaTest do
 
       team = team_of(user)
 
-      assert [
-               Plausible.Billing.Feature.StatsAPI,
-               Plausible.Billing.Feature.SharedLinks
-             ] ==
+      assert [Plausible.Billing.Feature.StatsAPI] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -678,8 +678,7 @@ defmodule Plausible.Billing.QuotaTest do
 
       assert [
                Plausible.Billing.Feature.StatsAPI,
-               Plausible.Billing.Feature.SitesAPI,
-               Plausible.Billing.Feature.SharedLinks
+               Plausible.Billing.Feature.SitesAPI
              ] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -713,6 +713,23 @@ defmodule PlausibleWeb.SiteControllerTest do
     end
   end
 
+  describe "GET /:domain/settings/visibility" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "does not render shared links with special names", %{conn: conn, site: site} do
+      for special_name <- Plausible.Sites.shared_link_special_names() do
+        insert(:shared_link, name: special_name, site: site)
+
+        html =
+          conn
+          |> get("/#{site.domain}/settings/visibility")
+          |> html_response(200)
+
+        refute text_of_element(html, "#shared-links-table") =~ special_name
+      end
+    end
+  end
+
   describe "GET /:domain/settings/goals" do
     setup [:create_user, :log_in, :create_site]
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1718,6 +1718,23 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       assert link.name == "Updated link name"
     end
+
+    for special_name <- Plausible.Sites.shared_link_special_names() do
+      test "fails to change link name to #{special_name}", %{conn: conn, site: site} do
+        link = insert(:shared_link, site: site)
+
+        conn =
+          put(conn, "/sites/#{site.domain}/shared-links/#{link.slug}", %{
+            "shared_link" => %{"name" => unquote(special_name)}
+          })
+
+        assert redirected_to(conn, 302) ==
+                 Routes.site_path(conn, :edit_shared_link, site.domain, link.slug)
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+                 "This name is reserved. Please choose another one"
+      end
+    end
   end
 
   describe "DELETE /sites/:domain/shared-links/:slug" do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1656,6 +1656,24 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       refute Repo.exists?(Plausible.Site.SharedLink)
     end
+
+    for special_name <- Plausible.Sites.shared_link_special_names() do
+      test "fails to create with the special '#{special_name}' name intended for Plugins API",
+           %{conn: conn, site: site} do
+        conn =
+          post(conn, "/sites/#{site.domain}/shared-links", %{
+            "shared_link" => %{"name" => unquote(special_name)}
+          })
+
+        assert redirected_to(conn, 302) ==
+                 Routes.site_path(conn, :new_shared_link, site.domain)
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+                 "This name is reserved. Please choose another one"
+
+        refute Repo.exists?(Plausible.Site.SharedLink)
+      end
+    end
   end
 
   describe "GET /sites/:domain/shared-links/edit" do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -1682,12 +1682,7 @@ defmodule PlausibleWeb.SiteControllerTest do
             "shared_link" => %{"name" => unquote(special_name)}
           })
 
-        assert redirected_to(conn, 302) ==
-                 Routes.site_path(conn, :new_shared_link, site.domain)
-
-        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-                 "This name is reserved. Please choose another one"
-
+        assert html_response(conn, 200) =~ "This name is reserved. Please choose another one"
         refute Repo.exists?(Plausible.Site.SharedLink)
       end
     end
@@ -1728,11 +1723,7 @@ defmodule PlausibleWeb.SiteControllerTest do
             "shared_link" => %{"name" => unquote(special_name)}
           })
 
-        assert redirected_to(conn, 302) ==
-                 Routes.site_path(conn, :edit_shared_link, site.domain, link.slug)
-
-        assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-                 "This name is reserved. Please choose another one"
+        assert html_response(conn, 200) =~ "This name is reserved. Please choose another one"
       end
     end
   end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -173,7 +173,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       conn = get(conn, "/" <> locked_site.domain)
       resp = html_response(conn, 200)
-      assert resp =~ "Dashboard locked"
+      assert resp =~ "Dashboard Locked"
       assert resp =~ "Please subscribe to the appropriate tier with the link below"
     end
 
@@ -185,7 +185,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       conn = get(conn, "/" <> locked_site.domain)
       resp = html_response(conn, 200)
-      assert resp =~ "Dashboard locked"
+      assert resp =~ "Dashboard Locked"
       assert resp =~ "Please subscribe to the appropriate tier with the link below"
     end
 
@@ -197,7 +197,7 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       conn = get(conn, "/" <> locked_site.domain)
       resp = html_response(conn, 200)
-      assert resp =~ "Dashboard locked"
+      assert resp =~ "Dashboard Locked"
       refute resp =~ "Please subscribe to the appropriate tier with the link below"
       assert resp =~ "Owner of this site must upgrade their subscription plan"
     end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -1349,20 +1349,22 @@ defmodule PlausibleWeb.StatsControllerTest do
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
 
-    test "shows dashboard if team subscription insufficient but shared link is WordPress specific",
-         %{conn: conn} do
-      site = new_site(domain: "test-site.com")
-      link = insert(:shared_link, site: site, name: "WordPress - Shared Dashboard")
+    for special_name <- Plausible.Sites.shared_link_special_names() do
+      test "shows dashboard if team subscription insufficient but shared link name is '#{special_name}'",
+           %{conn: conn} do
+        site = new_site(domain: "test-site.com")
+        link = insert(:shared_link, site: site, name: unquote(special_name))
 
-      insert(:starter_subscription, team: site.team)
+        insert(:starter_subscription, team: site.team)
 
-      html =
-        conn
-        |> get("/share/test-site.com/?auth=#{link.slug}")
-        |> html_response(200)
+        html =
+          conn
+          |> get("/share/test-site.com/?auth=#{link.slug}")
+          |> html_response(200)
 
-      assert element_exists?(html, @react_container)
-      refute html =~ "Shared Link Unavailable"
+        assert element_exists?(html, @react_container)
+        refute html =~ "Shared Link Unavailable"
+      end
     end
 
     test "renders 404 not found when no auth parameter supplied", %{conn: conn} do

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -1349,6 +1349,22 @@ defmodule PlausibleWeb.StatsControllerTest do
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
 
+    test "shows dashboard if team subscription insufficient but shared link is WordPress specific",
+         %{conn: conn} do
+      site = new_site(domain: "test-site.com")
+      link = insert(:shared_link, site: site, name: "WordPress - Shared Dashboard")
+
+      insert(:starter_subscription, team: site.team)
+
+      html =
+        conn
+        |> get("/share/test-site.com/?auth=#{link.slug}")
+        |> html_response(200)
+
+      assert element_exists?(html, @react_container)
+      refute html =~ "Shared Link Unavailable"
+    end
+
     test "renders 404 not found when no auth parameter supplied", %{conn: conn} do
       conn = get(conn, "/share/example.com")
       assert response(conn, 404) =~ "nothing here"

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       locked_site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
       conn = get(build_conn(), "/" <> locked_site.domain)
       resp = html_response(conn, 200)
-      assert resp =~ "Dashboard locked"
+      assert resp =~ "Dashboard Locked"
       assert resp =~ "You can check back later or contact the site owner"
     end
 
@@ -1331,7 +1331,21 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
 
-      assert html_response(conn, 200) =~ "Dashboard locked"
+      assert html_response(conn, 200) =~ "Dashboard Locked"
+      refute String.contains?(html_response(conn, 200), "Back to my sites")
+    end
+
+    test "shows locked page if shared link is locked due to insufficient team subscription", %{
+      conn: conn
+    } do
+      site = new_site(domain: "test-site.com")
+      link = insert(:shared_link, site: site)
+
+      insert(:starter_subscription, team: site.team)
+
+      conn = get(conn, "/share/test-site.com/?auth=#{link.slug}")
+
+      assert html_response(conn, 200) =~ "Shared Link Unavailable"
       refute String.contains?(html_response(conn, 200), "Back to my sites")
     end
 

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -153,7 +153,7 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => true,
                    "SiteSegments" => false,
-                   "SharedLinks" => true
+                   "SharedLinks" => false
                  }
                }
 

--- a/test/plausible_web/plugins/api/controllers/shared_links_test.exs
+++ b/test/plausible_web/plugins/api/controllers/shared_links_test.exs
@@ -177,6 +177,32 @@ defmodule PlausibleWeb.Plugins.API.Controllers.SharedLinksTest do
 
       assert %{errors: [%{detail: "Missing field: shared_link"}]} = resp
     end
+
+    test "skips shared links feature access check", %{
+      conn: conn,
+      site: site,
+      token: token
+    } do
+      insert(:starter_subscription, team: site.team)
+
+      url = Routes.plugins_api_shared_links_url(PlausibleWeb.Endpoint, :create)
+
+      resp =
+        authenticate(conn, site.domain, token)
+        |> put_req_header("content-type", "application/json")
+        |> put(url, %{
+          shared_link: %{
+            name: "My Shared Link"
+          }
+        })
+        |> json_response(201)
+        |> assert_schema("SharedLink", spec())
+
+      assert resp.shared_link.name == "My Shared Link"
+
+      assert resp.shared_link.href =~
+               "http://localhost:8000/share/#{URI.encode_www_form(site.domain)}?auth="
+    end
   end
 
   describe "get /shared_links" do

--- a/test/plausible_web/plugins/api/controllers/shared_links_test.exs
+++ b/test/plausible_web/plugins/api/controllers/shared_links_test.exs
@@ -203,6 +203,32 @@ defmodule PlausibleWeb.Plugins.API.Controllers.SharedLinksTest do
       assert resp.shared_link.href =~
                "http://localhost:8000/share/#{URI.encode_www_form(site.domain)}?auth="
     end
+
+    for special_name <- Plausible.Sites.shared_link_special_names() do
+      test "can create shared link with the reserved '#{special_name}' name", %{
+        conn: conn,
+        site: site,
+        token: token
+      } do
+        url = Routes.plugins_api_shared_links_url(PlausibleWeb.Endpoint, :create)
+
+        resp =
+          authenticate(conn, site.domain, token)
+          |> put_req_header("content-type", "application/json")
+          |> put(url, %{
+            shared_link: %{
+              name: unquote(special_name)
+            }
+          })
+          |> json_response(201)
+          |> assert_schema("SharedLink", spec())
+
+        assert resp.shared_link.name == unquote(special_name)
+
+        assert resp.shared_link.href =~
+                 "http://localhost:8000/share/#{URI.encode_www_form(site.domain)}?auth="
+      end
+    end
   end
 
   describe "get /shared_links" do


### PR DESCRIPTION
### Changes

This PR implements API feature gates for shared links, while granting special access per `shared_link.name` to links created by the plugin API (i.e. by our WP plugin).

Here's the breakdown of changes in this PR:

* With https://github.com/plausible/analytics/pull/5472 migrated, every enterprise plan has access to the SharedLinks feature according to the data. This PR stops granting `SharedLinks` access to enterprise plans in code.
  * Also, removes SharedLinks access from expired trials. Note that this will take effect immediately - it is not controlled by the `starter_tier` feature flag. The dashboards are locked for them anyway, so this should be OK.
* Shared Links API feature gates 
  * Disable shared link creation without access to SharedLinks (exception: allowed via Plugins API)
  * Declare `WordPress - Shared Dashboard` as the reserved "special" shared link name and prohibit creating new links with that name (except via Plugins API) and renaming existing links to that name.
  * The `GET /share/:domain` (i.e. the shared link itself) route is now restricting access (see screenshot below) according to `SharedLinks` feature availability, UNLESS the shared link has the special `WordPress - Shared Dashboard` name
  * The special WP shared link is not displayed under Site Settings > Visibility > Shared Links 
* Warn about losing access to the shared links feature when the team has any shared links created with a name other than `WordPress - Shared Dashboard` and wants to subscribe to the Starter tier.

![image](https://github.com/user-attachments/assets/4704bf57-2c44-457d-ac25-6ac302b88938)


### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
