### PR TITLE
CRM: revert #5440; implement lock/unlock for grace period 

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/site.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/site.ex
@@ -79,13 +79,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
             <.styled_link patch={"/cs/teams/team/#{@site.team.id}"}>
               {@site.team.name}
             </.styled_link>
-
-            <span
-              :if={Plausible.Teams.locked?(@site.team)}
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800"
-            >
-              Locked
-            </span>
           </p>
           <p class="text-sm font-medium">
             <span :if={@site.domain_changed_from}>(previously: {@site.domain_changed_from})</span>
@@ -268,10 +261,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Site do
 
         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
           Site
-        </span>
-
-        <span :if={Plausible.Teams.locked?(@resource.object.team)} class="inline-flex items-center">
-          <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
         </span>
       </div>
 

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -139,40 +139,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
                 </p>
               </div>
             </div>
-            <div :if={@team.grace_period}>
-              <span :if={@team.locked} class="flex items-center">
-                <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
-                <.styled_link phx-click="unlock" phx-target={@myself}>Unlock Team</.styled_link>
-              </span>
 
-<<<<<<< HEAD
-            <span :if={Teams.locked?(@team)} class="flex items-center">
-              <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
-              <.styled_link id="unlock-dashboards" phx-click="unlock" phx-target={@myself}>
-                Unlock Dashboards
-              </.styled_link>
-            </span>
-
-            <span :if={not Teams.locked?(@team)} class="flex items-center font-xs">
-              <Heroicons.lock_open class="inline stroke-2 w-4 h-4 text-gray-800 mr-2" />
-              <.styled_link id="lock-dashboards" phx-click="lock" phx-target={@myself}>
-                Lock Dashboards
-              </.styled_link>
-            </span>
-||||||| bb63c0d0e4 (CRM: team (un)lock regardless of grace period (#5440))
-            <span :if={Teams.locked?(@team)} class="flex items-center">
-              <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
-              <.styled_link id="unlock-dashboards" phx-click="unlock" phx-target={@myself}>
-                Unlock Dashboards
-              </.styled_link>
-            </span>
-
-            <span :if={not Teams.locked?(@team)} class="flex items-center">
-              <Heroicons.lock_open class="inline stroke-2 w-4 h-4 text-gray-800 mr-2" />
-              <.styled_link id="lock-dashboards" phx-click="lock" phx-target={@myself}>
-                Lock Dashboards
-              </.styled_link>
-            </span>
             <div class="mt-5 flex justify-center sm:mt-0">
               <.input_with_clipboard
                 id="team-identifier"
@@ -219,6 +186,20 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
           <div class="px-6 py-5 text-center text-sm font-medium">
             <span>
               <strong>Grace Period</strong> <br />{grace_period_status(@team)}
+
+              <div :if={@team.grace_period}>
+                <span class="flex items-center gap-x-8 justify-center mt-1">
+                  <div>
+                    <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-1" />
+                    <.styled_link phx-click="unlock" phx-target={@myself}>Unlock</.styled_link>
+                  </div>
+
+                  <div>
+                    <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-1" />
+                    <.styled_link phx-click="lock" phx-target={@myself}>Lock</.styled_link>
+                  </div>
+                </span>
+              </div>
             </span>
           </div>
         </div>
@@ -779,9 +760,8 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
   defp lock_team(socket) do
     if socket.assigns.team.grace_period do
-      team = socket.assigns.team
+      team = Plausible.Teams.end_grace_period(socket.assigns.team)
       Plausible.Billing.SiteLocker.set_lock_status_for(team, true)
-      Plausible.Teams.end_grace_period(team)
 
       success(socket, "Team locked. Grace period ended.")
       assign(socket, team: team)
@@ -793,10 +773,8 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
   defp unlock_team(socket) do
     if socket.assigns.team.grace_period do
-      team =
-        socket.assigns.team
-        |> Plausible.Teams.remove_grace_period()
-        |> Plausible.Billing.SiteLocker.set_lock_status_for(false)
+      team = Plausible.Teams.remove_grace_period(socket.assigns.team)
+      Plausible.Billing.SiteLocker.set_lock_status_for(team, false)
 
       success(socket, "Team unlocked. Grace period removed.")
       assign(socket, team: team)

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -139,7 +139,13 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
                 </p>
               </div>
             </div>
+            <div :if={@team.grace_period}>
+              <span :if={@team.locked} class="flex items-center">
+                <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
+                <.styled_link phx-click="unlock" phx-target={@myself}>Unlock Team</.styled_link>
+              </span>
 
+<<<<<<< HEAD
             <span :if={Teams.locked?(@team)} class="flex items-center">
               <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
               <.styled_link id="unlock-dashboards" phx-click="unlock" phx-target={@myself}>
@@ -148,6 +154,20 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
             </span>
 
             <span :if={not Teams.locked?(@team)} class="flex items-center font-xs">
+              <Heroicons.lock_open class="inline stroke-2 w-4 h-4 text-gray-800 mr-2" />
+              <.styled_link id="lock-dashboards" phx-click="lock" phx-target={@myself}>
+                Lock Dashboards
+              </.styled_link>
+            </span>
+||||||| bb63c0d0e4 (CRM: team (un)lock regardless of grace period (#5440))
+            <span :if={Teams.locked?(@team)} class="flex items-center">
+              <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
+              <.styled_link id="unlock-dashboards" phx-click="unlock" phx-target={@myself}>
+                Unlock Dashboards
+              </.styled_link>
+            </span>
+
+            <span :if={not Teams.locked?(@team)} class="flex items-center">
               <Heroicons.lock_open class="inline stroke-2 w-4 h-4 text-gray-800 mr-2" />
               <.styled_link id="lock-dashboards" phx-click="lock" phx-target={@myself}>
                 Lock Dashboards
@@ -501,10 +521,10 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
   def render_result(assigns) do
     ~H"""
     <div class="flex-1 -mt-px w-full">
-      <div class="w-full flex items-center justify-between space-x-2">
+      <div class="w-full flex items-center justify-between space-x-4">
         <div class={[
           team_bg(@resource.object.identifier),
-          "rounded-full p-1 flex items-center justify-center mr-2"
+          "rounded-full p-1 flex items-center justify-center"
         ]}>
           <Heroicons.user_group class="h-4 w-4 text-white" />
         </div>
@@ -524,10 +544,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
           class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800"
         >
           $
-        </span>
-
-        <span :if={Teams.locked?(@resource.object)} class="inline-flex items-center">
-          <Heroicons.lock_closed solid class="inline stroke-2 w-4 h-4 text-red-400 mr-2" />
         </span>
       </div>
 
@@ -762,15 +778,31 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
   end
 
   defp lock_team(socket) do
-    team = Teams.admin_lock!(socket.assigns.team)
-    success(socket, "Team locked")
-    assign(socket, team: team)
+    if socket.assigns.team.grace_period do
+      team = socket.assigns.team
+      Plausible.Billing.SiteLocker.set_lock_status_for(team, true)
+      Plausible.Teams.end_grace_period(team)
+
+      success(socket, "Team locked. Grace period ended.")
+      assign(socket, team: team)
+    else
+      failure(socket, "No grace period")
+      socket
+    end
   end
 
   defp unlock_team(socket) do
-    team = Teams.admin_unlock!(socket.assigns.team)
-    success(socket, "Team unlocked")
-    assign(socket, team: team)
+    if socket.assigns.team.grace_period do
+      team =
+        socket.assigns.team
+        |> Plausible.Teams.remove_grace_period()
+        |> Plausible.Billing.SiteLocker.set_lock_status_for(false)
+
+      success(socket, "Team unlocked. Grace period removed.")
+      assign(socket, team: team)
+    else
+      socket
+    end
   end
 
   defp monthly_pageviews_usage(usage, limit) do

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -69,40 +69,7 @@ defmodule Plausible.Teams do
   @spec locked?(Teams.Team.t() | nil) :: boolean()
   def locked?(nil), do: false
 
-  def locked?(%Teams.Team{locked: locked, locked_by_admin: locked_by_admin}),
-    do: locked or locked_by_admin
-
-  def admin_lock!(%Teams.Team{} = team) do
-    {:ok, team} =
-      Repo.transaction(fn ->
-        if team.grace_period do
-          Plausible.Billing.SiteLocker.set_lock_status_for(team, true)
-          Plausible.Teams.end_grace_period(team)
-        else
-          team
-        end
-        |> Ecto.Changeset.change(locked_by_admin: true)
-        |> Repo.update!()
-      end)
-
-    team
-  end
-
-  def admin_unlock!(%Teams.Team{} = team) do
-    {:ok, team} =
-      Repo.transaction(fn ->
-        if team.grace_period do
-          Plausible.Billing.SiteLocker.set_lock_status_for(team, false)
-          Plausible.Teams.remove_grace_period(team)
-        else
-          team
-        end
-        |> Ecto.Changeset.change(locked_by_admin: false)
-        |> Repo.update!()
-      end)
-
-    team
-  end
+  def locked?(%Teams.Team{locked: locked}), do: locked
 
   @spec trial_days_left(Teams.Team.t()) :: integer()
   def trial_days_left(nil) do

--- a/lib/plausible/teams/team.ex
+++ b/lib/plausible/teams/team.ex
@@ -28,7 +28,6 @@ defmodule Plausible.Teams.Team do
     field :accept_traffic_until, :date
     field :allow_next_upgrade_override, :boolean, default: false
     field :locked, :boolean, default: false
-    field :locked_by_admin, :boolean, default: false
 
     field :setup_complete, :boolean, default: false
     field :setup_at, :naive_datetime

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -9,7 +9,7 @@
     grace_period_end={grace_period_end(@current_team)}
   />
 
-  <Notice.dashboard_locked :if={Plausible.Teams.locked?(@current_team)} />
+  <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@current_team)} />
 
   <Notice.subscription_cancelled subscription={@current_team.subscription} />
 

--- a/lib/workers/schedule_email_reports.ex
+++ b/lib/workers/schedule_email_reports.ex
@@ -35,7 +35,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not t.locked and not t.locked_by_admin,
+          where: not t.locked,
           preload: [weekly_report: wr]
       )
 
@@ -76,7 +76,7 @@ defmodule Plausible.Workers.ScheduleEmailReports do
             fragment("(? -> 'site_id')::int", job.args) == s.id and
               job.state not in ["completed", "discarded"],
           where: is_nil(job),
-          where: not t.locked and not t.locked_by_admin,
+          where: not t.locked,
           preload: [monthly_report: mr]
       )
 

--- a/lib/workers/traffic_change_notifier.ex
+++ b/lib/workers/traffic_change_notifier.ex
@@ -23,7 +23,7 @@ defmodule Plausible.Workers.TrafficChangeNotifier do
               sn.last_sent < ^NaiveDateTime.add(now, -@min_interval_hours, :hour),
           inner_join: s in assoc(sn, :site),
           inner_join: t in assoc(s, :team),
-          where: not t.locked and not t.locked_by_admin,
+          where: not t.locked,
           where: is_nil(t.accept_traffic_until) or t.accept_traffic_until > ^today,
           preload: [site: {s, team: t}]
       )

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -8,8 +8,6 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
     import Phoenix.LiveViewTest
     import Plausible.Test.Support.HTML
 
-    alias Plausible.Teams
-
     defp open_team(id, qs \\ []) do
       Routes.customer_support_resource_path(
         PlausibleWeb.Endpoint,
@@ -38,27 +36,6 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         assert_raise Ecto.NoResultsError, fn ->
           {:ok, _lv, _html} = live(conn, open_team(9999))
         end
-      end
-
-      test "lock/unlock a team", %{user: user, conn: conn} do
-        team = team_of(user)
-        {:ok, lv, html} = live(conn, open_team(team.id))
-        refute element_exists?(html, "#unlock-dashboards")
-
-        lv |> element("#lock-dashboards") |> render_click()
-        html = render(lv)
-
-        assert text(html) =~ "Team locked"
-        assert Teams.locked?(Plausible.Repo.reload!(team))
-
-        refute element_exists?(html, "#lock-dashboards")
-        assert element_exists?(html, "#unlock-dashboards")
-
-        lv |> element("#unlock-dashboards") |> render_click()
-        html = render(lv)
-
-        assert text(html) =~ "Team unlocked"
-        refute Teams.locked?(Plausible.Repo.reload!(team))
       end
     end
 

--- a/test/workers/schedule_email_reports_test.exs
+++ b/test/workers/schedule_email_reports_test.exs
@@ -38,16 +38,6 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
       assert Enum.empty?(all_enqueued(worker: SendEmailReport))
     end
 
-    test "does not schedule a weekly report for admin-locked site" do
-      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
-      Plausible.Teams.admin_lock!(site.team)
-      insert(:weekly_report, site: site, recipients: ["user@email.com"])
-
-      perform_job(ScheduleEmailReports, %{})
-
-      assert Enum.empty?(all_enqueued(worker: SendEmailReport))
-    end
-
     test "schedules a new report as soon as a previous one is completed" do
       site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
@@ -87,16 +77,6 @@ defmodule Plausible.Workers.ScheduleEmailReportsTest do
     test "does not schedule a monthly report for locked site" do
       site = new_site(domain: "test-site.com", timezone: "US/Eastern")
       site.team |> Ecto.Changeset.change(locked: true) |> Repo.update!()
-      insert(:monthly_report, site: site, recipients: ["user@email.com"])
-
-      perform_job(ScheduleEmailReports, %{})
-
-      assert Enum.empty?(all_enqueued(worker: SendEmailReport))
-    end
-
-    test "does not schedule a monthly report for admin-locked site" do
-      site = new_site(domain: "test-site.com", timezone: "US/Eastern")
-      Plausible.Teams.admin_lock!(site.team)
       insert(:monthly_report, site: site, recipients: ["user@email.com"])
 
       perform_job(ScheduleEmailReports, %{})

--- a/test/workers/traffic_change_notifier_test.exs
+++ b/test/workers/traffic_change_notifier_test.exs
@@ -288,27 +288,6 @@ defmodule Plausible.Workers.TrafficChangeNotifierTest do
       assert_no_emails_delivered()
     end
 
-    test "does not check site if it is admin-locked" do
-      site = new_site()
-
-      Plausible.Teams.admin_lock!(site.team)
-
-      insert(:spike_notification,
-        site: site,
-        threshold: 1,
-        recipients: ["uku@example.com"]
-      )
-
-      populate_stats(site, [
-        build(:pageview, timestamp: minutes_ago(1)),
-        build(:pageview, timestamp: minutes_ago(1))
-      ])
-
-      TrafficChangeNotifier.perform(nil)
-
-      assert_no_emails_delivered()
-    end
-
     test "does not send notifications more than once every 12 hours" do
       site = new_site()
       insert(:spike_notification, site: site, threshold: 1, recipients: ["uku@example.com"])


### PR DESCRIPTION
### Changes

#5440 was a misunderstanding - we needed to flesh out more precise requirements, to be addressed separately. This PR only implements CRM locking parity with kaffy. 

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
