### PR TITLE
Log warning when m/meta parameter used in ingestion

### DIFF
--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -233,7 +233,9 @@ defmodule Plausible.Ingestion.Request do
 
     # Temporary instrumentation to see if `m`/`meta` field was used.
     if request_body["m"] || request_body["meta"] do
-      Logger.warning("Ingestion: request body contains meta field. #{inspect(request_body)}")
+      Logger.warning(
+        "Ingestion: request body contains meta field. domain=#{request_body["d"] || request_body["domain"]}"
+      )
     end
 
     changeset


### PR DESCRIPTION
This parameter was added in October 2020 and then renamed 2 days later: https://github.com/plausible/analytics/commit/40900c7653684d36135b4955b0a0ccfa6b7a304c and https://github.com/plausible/analytics/commit/0b6e645b44b40cc69a01a4fed5445a00277b5a4b

We are hoping we may be able to remove it which this logging will help with.

Planning to revert this once we have a couple of days worth of data.