### PR TITLE
CRM: Refund lock

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -59,8 +59,7 @@ defmodule Plausible.Teams do
     def on_trial?(team) do
       team = with_subscription(team)
 
-      not Plausible.Billing.Subscriptions.active?(team.subscription) &&
-        trial_days_left(team) >= 0
+      is_nil(team.subscription) and trial_days_left(team) >= 0
     end
   else
     def on_trial?(_), do: always(true)

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -114,14 +114,28 @@ defmodule PlausibleWeb.Components.Billing.Notice do
         } = assigns
       ) do
     ~H"""
-    <aside id="global-subscription-cancelled-notice" class="container">
+    <aside
+      :if={not Subscriptions.expired?(@subscription)}
+      id="global-subscription-cancelled-notice"
+      class="container"
+    >
       <.notice
         dismissable_id={Plausible.Billing.cancelled_subscription_notice_dismiss_id(@subscription.id)}
         title={Plausible.Billing.subscription_cancelled_notice_title()}
         theme={:red}
         class="shadow-md dark:shadow-none"
       >
-        <.subscription_cancelled_notice_body subscription={@subscription} />
+        <p>
+          You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@subscription.next_bill_date, "%b %-d, %Y") %></span>.
+          <.link
+            class="underline inline-block"
+            href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
+          >
+            Upgrade your subscription
+          </.link>
+          to make sure you don't lose access.
+        </p>
+        <.lose_grandfathering_warning subscription={@subscription} />
       </.notice>
     </aside>
     """
@@ -136,13 +150,23 @@ defmodule PlausibleWeb.Components.Billing.Notice do
     assigns = assign(assigns, :container_id, "local-subscription-cancelled-notice")
 
     ~H"""
-    <aside id={@container_id} class="hidden">
+    <aside :if={not Subscriptions.expired?(@subscription)} id={@container_id} class="hidden">
       <.notice
         title={Plausible.Billing.subscription_cancelled_notice_title()}
         theme={:red}
         class="shadow-md dark:shadow-none"
       >
-        <.subscription_cancelled_notice_body subscription={@subscription} />
+        <p>
+          You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@subscription.next_bill_date, "%b %-d, %Y") %></span>.
+          <.link
+            class="underline inline-block"
+            href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
+          >
+            Upgrade your subscription
+          </.link>
+          to make sure you don't lose access.
+        </p>
+        <.lose_grandfathering_warning subscription={@subscription} />
       </.notice>
     </aside>
     <script
@@ -259,34 +283,6 @@ defmodule PlausibleWeb.Components.Billing.Notice do
       Your subscription has been grandfathered in at the same rate and terms as when you first joined. If you don't need the "Business" features, you're welcome to stay on this plan. You can adjust the pageview limit or change the billing frequency of this grandfathered plan. If you're interested in business features, you can upgrade to a "Business" plan.
     </div>
     """
-  end
-
-  defp subscription_cancelled_notice_body(assigns) do
-    if Subscriptions.expired?(assigns.subscription) do
-      ~H"""
-      <.link
-        class="underline inline-block"
-        href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
-      >
-        Upgrade your subscription
-      </.link>
-      to get access to your stats again.
-      """
-    else
-      ~H"""
-      <p>
-        You have access to your stats until <span class="font-semibold inline"><%= Calendar.strftime(@subscription.next_bill_date, "%b %-d, %Y") %></span>.
-        <.link
-          class="underline inline-block"
-          href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
-        >
-          Upgrade your subscription
-        </.link>
-        to make sure you don't lose access.
-      </p>
-      <.lose_grandfathering_warning subscription={@subscription} />
-      """
-    end
   end
 
   defp lose_grandfathering_warning(%{subscription: subscription} = assigns) do

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -205,8 +205,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
         |> html_response(200)
         |> text_of_element("#global-subscription-cancelled-notice")
 
-      assert notice_text =~ "Subscription cancelled"
-      assert notice_text =~ "Upgrade your subscription to get access to your stats again"
+      refute notice_text =~ Plausible.Billing.subscription_cancelled_notice_title()
     end
 
     @tag :ee_only


### PR DESCRIPTION
### Changes

This PR adds a "Refund lock" link to cancelled subscriptions. 
This is different than a grace period lock (it does not depend on it). This lock cannot be undone manually, the user will have to resubscribe in order to unlock their dashboards.


![image](https://github.com/user-attachments/assets/0ce0b258-36e7-46f1-b7a4-3b25a72ba564)

![image](https://github.com/user-attachments/assets/4eab4059-7074-4539-bf1b-5434a9a0f3f8)


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
