### PR TITLE
CRM: UX tweaks

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -375,8 +375,8 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
         <div :if={@tab == "overview"} class="mt-8">
           <.form :let={f} for={@form} phx-submit="save-team" phx-target={@myself}>
-            <.input field={f[:trial_expiry_date]} label="Trial Expiry Date" />
-            <.input field={f[:accept_traffic_until]} label="Accept  traffic Until" />
+            <.input field={f[:trial_expiry_date]} type="date" label="Trial Expiry Date" />
+            <.input field={f[:accept_traffic_until]} type="date" label="Accept  traffic Until" />
             <.input
               type="checkbox"
               field={f[:allow_next_upgrade_override]}

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -849,7 +849,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
         number_format(n) <> " (#{PlausibleWeb.StatsView.large_number_format(n)})"
 
       _ ->
-        "❓🙈❓"
+        "0"
     end
   end
 

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -864,7 +864,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
       width="w-[500]"
       readonly
       value={preview_number(@for.value)}
-      class="border-0 p-0 m-0 text-sm w-full"
+      class="bg-transparent border-0 p-0 m-0 text-sm w-full"
     />
     """
   end

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -99,12 +99,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
     ~H"""
     <div>
       <script type="text/javascript">
-        const numberFormatCallback = function(e) {
-          const numeric = Number(e.target.value.replace(/[^0-9]/g, ''))
-          const value = numeric > 0 ? new Intl.NumberFormat("en-GB").format(numeric) : ''
-          e.target.value = value
-        }
-
         const featureChangeCallback = function(e) {
           const value = e.target.value
           const checked = e.target.checked
@@ -293,32 +287,43 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
               autocomplete="off"
             />
 
-            <.input
-              x-init="numberFormatCallback({target: $el})"
-              x-on:input="numberFormatCallback(event)"
-              field={f[:monthly_pageview_limit]}
-              label="Monthly Pageview Limit"
-              autocomplete="off"
-            />
-            <.input
-              x-init="numberFormatCallback({target: $el})"
-              x-on:input="numberFormatCallback(event)"
-              field={f[:site_limit]}
-              label="Site Limit"
-              autocomplete="off"
-            />
-            <.input
-              field={f[:team_member_limit]}
-              label="Team Member Limit (-1/unlimited for unlimited)"
-              autocomplete="off"
-            />
-            <.input
-              x-init="numberFormatCallback({target: $el})"
-              x-on:input="numberFormatCallback(event)"
-              field={f[:hourly_api_request_limit]}
-              label="Hourly API Request Limit"
-              autocomplete="off"
-            />
+            <div class="flex items-center gap-x-4">
+              <.input
+                field={f[:monthly_pageview_limit]}
+                label="Monthly Pageview Limit"
+                autocomplete="off"
+                width="w-[500]"
+              />
+
+              <.preview for={f[:monthly_pageview_limit]} />
+            </div>
+            <div class="flex items-center gap-x-4">
+              <.input width="w-[500]" field={f[:site_limit]} label="Site Limit" autocomplete="off" />
+
+              <.preview for={f[:site_limit]} />
+            </div>
+
+            <div class="flex items-center gap-x-4">
+              <.input
+                field={f[:team_member_limit]}
+                label="Team Member Limit"
+                autocomplete="off"
+                width="w-[500]"
+              />
+
+              <.preview for={f[:team_member_limit]} />
+            </div>
+
+            <div class="flex items-center gap-x-4">
+              <.input
+                field={f[:hourly_api_request_limit]}
+                label="Hourly API Request Limit"
+                autocomplete="off"
+                width="w-[500]"
+              />
+
+              <.preview for={f[:hourly_api_request_limit]} />
+            </div>
 
             <.input
               :for={
@@ -809,34 +814,11 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
   defp number_format(other), do: other
 
-  @numeric_fields [
-    "team_id",
-    "paddle_plan_id",
-    "monthly_pageview_limit",
-    "site_limit",
-    "team_member_limit",
-    "hourly_api_request_limit"
-  ]
-
   defp sanitize_params(params) do
     params
     |> Enum.map(&clear_param/1)
     |> Enum.reject(&(&1 == ""))
     |> Map.new()
-  end
-
-  defp clear_param({key, value}) when key in @numeric_fields do
-    if value in ["unlimited", "-1"] do
-      {key, value}
-    else
-      value =
-        value
-        |> to_string()
-        |> String.replace(~r/[^0-9-]/, "")
-        |> String.trim()
-
-      {key, value}
-    end
   end
 
   defp clear_param({key, value}) when is_binary(value) do
@@ -859,5 +841,31 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
   defp update_features_to_list(params) do
     Map.put(params, "features", Enum.reject(params["features[]"], &(&1 == "false" or &1 == "")))
+  end
+
+  defp preview_number(n) do
+    case Integer.parse("#{n}") do
+      {n, ""} ->
+        number_format(n) <> " (#{PlausibleWeb.StatsView.large_number_format(n)})"
+
+      _ ->
+        "❓🙈❓"
+    end
+  end
+
+  attr :for, :any, required: true
+
+  defp preview(assigns) do
+    ~H"""
+    <.input
+      name={"#{@for.name}-preview"}
+      label="Preview (read-only)"
+      autocomplete="off"
+      width="w-[500]"
+      readonly
+      value={preview_number(@for.value)}
+      class="border-0 p-0 m-0 text-sm w-full"
+    />
+    """
   end
 end

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -92,10 +92,10 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         |> render_change(%{
           "enterprise_plan" => %{
             "billing_interval" => "yearly",
-            "monthly_pageview_limit" => "20,000,000",
-            "site_limit" => "1,000",
+            "monthly_pageview_limit" => "20000000",
+            "site_limit" => "1000",
             "team_member_limit" => "30",
-            "hourly_api_request_limit" => "1,000",
+            "hourly_api_request_limit" => "1000",
             "features[]" => [
               "false",
               "false",
@@ -125,10 +125,10 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
           "enterprise_plan" => %{
             "paddle_plan_id" => "1111",
             "billing_interval" => "yearly",
-            "monthly_pageview_limit" => "20,000,000",
-            "site_limit" => "1,000",
+            "monthly_pageview_limit" => "20000000",
+            "site_limit" => "1000",
             "team_member_limit" => "30",
-            "hourly_api_request_limit" => "1,000",
+            "hourly_api_request_limit" => "1000",
             "features[]" => [
               "false",
               "false",
@@ -182,10 +182,10 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
           "enterprise_plan" => %{
             "paddle_plan_id" => "1111",
             "billing_interval" => "yearly",
-            "monthly_pageview_limit" => "20,000,000",
-            "site_limit" => "1,000",
+            "monthly_pageview_limit" => "20000000",
+            "site_limit" => "1000",
             "team_member_limit" => "unlimited",
-            "hourly_api_request_limit" => "1,000"
+            "hourly_api_request_limit" => "1000"
           }
         })
 


### PR DESCRIPTION
### Changes

Team dates are now date-type inputs

![image](https://github.com/user-attachments/assets/94648079-b7d9-4865-9276-ad1b433a0c69)

Custom plans limits have extra field previews next to them

![image](https://github.com/user-attachments/assets/e5e2980f-a191-4248-9981-1deecd572a1a)


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
