### PR TITLE
ScriptV2: Rework WordPress plugin token adding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ All notable changes to this project will be documented in this file.
 - Always set site and team member limits to unlimited for Community Edition
 - Stats API now supports more `date_range` shorthand options like `30d`, `3mo`.
 - Stop showing Plausible footer when viewing stats, except when viewing a public dashboard or unembedded shared link dashboard.
+- Changed Plugins API Token creation flow to only display token once it's created.
 
 ### Fixed
 

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -25,7 +25,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
     {:ok,
      assign(socket,
        domain: domain,
-       add_token?: not is_nil(session["new_token"]),
+       create_token?: not is_nil(session["new_token"]),
        token_description: session["new_token"] || ""
      )}
   end
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
     <div>
       <.flash_messages flash={@flash} />
 
-      <%= if @add_token? do %>
+      <%= if @create_token? do %>
         {live_render(
           @socket,
           PlausibleWeb.Live.Plugins.API.TokenForm,
@@ -50,8 +50,8 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
 
       <div>
         <.filter_bar filtering_enabled?={false}>
-          <.button phx-click="add-token" mt?={false}>
-            Add Plugin Token
+          <.button phx-click="create-token" mt?={false}>
+            Create Plugin Token
           </.button>
         </.filter_bar>
 
@@ -89,21 +89,21 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
     """
   end
 
-  def handle_event("add-token", _params, socket) do
-    {:noreply, assign(socket, :add_token?, true)}
+  def handle_event("create-token", _params, socket) do
+    {:noreply, assign(socket, :create_token?, true)}
   end
 
   def handle_event("revoke-token", %{"token-id" => token_id}, socket) do
     :ok = Tokens.delete(socket.assigns.site, token_id)
     displayed_tokens = Enum.reject(socket.assigns.displayed_tokens, &(&1.id == token_id))
-    {:noreply, assign(socket, add_token?: false, displayed_tokens: displayed_tokens)}
+    {:noreply, assign(socket, create_token?: false, displayed_tokens: displayed_tokens)}
   end
 
-  def handle_info(:cancel_add_token, socket) do
-    {:noreply, assign(socket, add_token?: false)}
+  def handle_info(:close_token_modal, socket) do
+    {:noreply, assign(socket, create_token?: false)}
   end
 
-  def handle_info({:token_added, token}, socket) do
+  def handle_info({:token_created, token}, socket) do
     displayed_tokens = [token | socket.assigns.displayed_tokens]
 
     socket = put_live_flash(socket, :success, "Plugins Token created successfully")
@@ -111,7 +111,6 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
     {:noreply,
      assign(socket,
        displayed_tokens: displayed_tokens,
-       add_token?: false,
        token_description: ""
      )}
   end

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -36,8 +36,7 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
        token: token,
        form: form,
        domain: domain,
-       rendered_by: pid,
-       tabs: %{custom_events: true, pageviews: false}
+       rendered_by: pid
      )}
   end
 

--- a/lib/plausible_web/live/plugins/api/token_form.ex
+++ b/lib/plausible_web/live/plugins/api/token_form.ex
@@ -36,7 +36,8 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
        token: token,
        form: form,
        domain: domain,
-       rendered_by: pid
+       rendered_by: pid,
+       token_generated: false
      )}
   end
 
@@ -44,73 +45,83 @@ defmodule PlausibleWeb.Live.Plugins.API.TokenForm do
     ~H"""
     <div
       class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity z-50"
-      phx-window-keydown="cancel-add-token"
+      phx-window-keydown="close-tokens-modal"
       phx-key="Escape"
     >
     </div>
     <div class="fixed inset-0 flex items-center justify-center mt-16 z-50 overflow-y-auto overflow-x-hidden">
       <div class="w-1/2 h-full">
-        <.form
-          :let={f}
-          for={@form}
+        <div
           class="max-w-md w-full mx-auto bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-8"
-          phx-submit="save-token"
-          phx-click-away="cancel-add-token"
+          phx-click-away="close-token-modal"
         >
-          <.title>
-            Add Plugin Token for {@domain}
-          </.title>
+          <%= if @token_generated do %>
+            <div :if={@token_generated} class="mt-4">
+              <.input_with_clipboard
+                id="token-clipboard"
+                name="token_clipboard"
+                label="Plugin Token"
+                value={@token.raw}
+                onfocus="this.value = this.value;"
+              />
+            </div>
+            <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+              Please copy the token and store it in a secure place as it won't be shown again.
+              <span :if={@token_description == "WordPress"}>
+                You'll need to paste the token in the settings area of the Plausible WordPress plugin.
+              </span>
+            </p>
+            <.button
+              phx-click="close-token-modal"
+              class="w-full border !border-gray-300 dark:!border-gray-500 !text-gray-700 dark:!text-gray-300 !bg-transparent hover:!bg-gray-100 dark:hover:!bg-gray-850"
+            >
+              Close modal
+            </.button>
+          <% else %>
+            <.form :let={f} for={@form} phx-submit="generate-token">
+              <.title>
+                Create Plugin Token for {@domain}
+              </.title>
 
-          <div class="mt-4">
-            <.input
-              autofocus
-              field={f[:description]}
-              label="Description"
-              placeholder="e.g. Your Plugin Name"
-              value={@token_description}
-              autocomplete="off"
-            />
-          </div>
+              <div class="mt-4">
+                <.input
+                  autofocus
+                  field={f[:description]}
+                  label="Description"
+                  placeholder="e.g. Your Plugin Name"
+                  value={@token_description}
+                  autocomplete="off"
+                  disabled={@token_generated}
+                />
+              </div>
 
-          <div class="mt-4">
-            <.input_with_clipboard
-              id="token-clipboard"
-              name="token_clipboard"
-              label="Plugin Token"
-              value={@token.raw}
-              onfocus="this.value = this.value;"
-            />
-          </div>
-
-          <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-            Please copy the token and store it in a secure place as it won't be shown again.
-            Then click the "**Add Plugin Token**" button to confirm.
-            <span :if={@token_description == "WordPress"}>
-              You'll need to paste the token in the settings area of the Plausible WordPress plugin.
-            </span>
-          </p>
-          <.button type="submit" class="w-full">
-            Add Plugin Token
-          </.button>
-        </.form>
+              <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                Once created, we will display the token so it can be copied.
+              </p>
+              <.button type="submit" class="w-full">
+                Create Plugin Token
+              </.button>
+            </.form>
+          <% end %>
+        </div>
       </div>
     </div>
     """
   end
 
-  def handle_event("save-token", %{"token" => %{"description" => description}}, socket) do
+  def handle_event("generate-token", %{"token" => %{"description" => description}}, socket) do
     case Tokens.create(socket.assigns.site, description, socket.assigns.token) do
       {:ok, token, _} ->
-        send(socket.assigns.rendered_by, {:token_added, token})
-        {:noreply, socket}
+        send(socket.assigns.rendered_by, {:token_created, token})
+        {:noreply, assign(socket, token_generated: true)}
 
       {:error, changeset} ->
         {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
 
-  def handle_event("cancel-add-token", _value, socket) do
-    send(socket.assigns.rendered_by, :cancel_add_token)
+  def handle_event("close-token-modal", _value, socket) do
+    send(socket.assigns.rendered_by, :close_token_modal)
     {:noreply, socket}
   end
 end


### PR DESCRIPTION
### Changes

This PR aims to make plugin token creation flow less error-prone for WordPress users. Basecamp ref: https://3.basecamp.com/5308029/buckets/42034199/card_tables/cards/8720166828

<details>
<summary>Currently, when users are configuring the WordPress plugin users are presented the token before it's actually created.  This has led to issues where users copy the token but don't hit "Add" and run into issues. (click to see screenshot)</summary>
![image](https://github.com/user-attachments/assets/4127e960-ec35-4f07-8b19-aeb8a1767204)
</details>

This PR splits the flow into two: Users first need to add a description and hit create. Only once they've done that is the token created and displayed.

### Recordings of the new flow

Wordpress flow: [wordpress.webm](https://github.com/user-attachments/assets/5ebbf41f-45a6-4f58-9305-fc9be116b032)

Changing via settings screen: [settings.webm](https://github.com/user-attachments/assets/3444e718-a2fa-40fe-b6fe-562e69875ebf)

### Notes for reviewers

Feel free to roast the code - I have little LiveView experience and some feedback on 'proper' ways of doing things would not hurt.