### PR TITLE
Periodically refresh salts so that non-rotating nodes catch up

### DIFF
--- a/lib/plausible/session/salts.ex
+++ b/lib/plausible/session/salts.ex
@@ -9,8 +9,6 @@ defmodule Plausible.Session.Salts do
 
   @impl true
   def init(opts) do
-    Process.flag(:trap_exit, true)
-
     name = opts[:name] || __MODULE__
     now = opts[:now] || DateTime.utc_now()
     clean_old_salts(now)
@@ -23,8 +21,13 @@ defmodule Plausible.Session.Salts do
         {:read_concurrency, true}
       ])
 
-    salts =
-      Repo.all(from s in "salts", select: s.salt, order_by: [desc: s.inserted_at], limit: 2)
+    refresh(name, now)
+
+    {:ok, name}
+  end
+
+  def refresh(name, now) do
+    salts = Repo.all(from s in "salts", select: s.salt, order_by: [desc: s.id], limit: 2)
 
     state =
       case salts do
@@ -39,13 +42,18 @@ defmodule Plausible.Session.Salts do
           %{previous: nil, current: new}
       end
 
-    log_state("init", state)
     true = :ets.insert(name, {:state, state})
-    {:ok, name}
+    Process.send_after(self(), {:refresh, now}, :timer.seconds(90))
+    :ok
   end
 
   def rotate(name \\ __MODULE__, now \\ DateTime.utc_now()) do
     GenServer.call(name, {:rotate, now})
+  end
+
+  def fetch(name \\ __MODULE__) do
+    [state: state] = :ets.lookup(name, :state)
+    state
   end
 
   @impl true
@@ -59,20 +67,18 @@ defmodule Plausible.Session.Salts do
         previous: current
       }
 
-    log_state("rotated", state)
     true = :ets.insert(name, {:state, state})
     {:reply, :ok, name}
   end
 
-  def fetch(name \\ __MODULE__) do
-    [state: state] = :ets.lookup(name, :state)
-
-    state
+  @impl true
+  def handle_info({:refresh, now}, name) do
+    refresh(name, now)
+    {:noreply, name}
   end
 
   defp generate_and_persist_new_salt(now) do
     salt = :crypto.strong_rand_bytes(16)
-    Logger.warning("[salts] generated #{:erlang.phash2(salt)}")
     Repo.insert_all("salts", [%{salt: salt, inserted_at: now}])
     salt
   end
@@ -82,18 +88,5 @@ defmodule Plausible.Session.Salts do
       DateTime.shift(now, hour: -48)
 
     Repo.delete_all(from s in "salts", where: s.inserted_at < ^h48_ago)
-  end
-
-  @impl true
-  def terminate(_reason, name) do
-    log_state("terminating", fetch(name))
-  end
-
-  defp log_state(stage, state) do
-    %{current: current, previous: previous} = state
-
-    Logger.warning(
-      "[salts] stage=#{stage} current=#{:erlang.phash2(current)} previous=#{:erlang.phash2(previous)}"
-    )
   end
 end

--- a/test/plausible/session/salts_test.exs
+++ b/test/plausible/session/salts_test.exs
@@ -20,15 +20,13 @@ defmodule Plausible.Session.SaltsTest do
   end
 
   test "old salts can be cleaned" do
-    h30_ago =
-      DateTime.shift(DateTime.utc_now(), hour: -48)
+    t1 = ~U[2025-06-10 15:29:40Z]
 
-    {:ok, _} = Salts.start_link(name: __MODULE__, now: h30_ago)
+    {:ok, _} = Salts.start_link(name: __MODULE__, now: t1)
 
-    h24_ago =
-      DateTime.shift(DateTime.utc_now(), hour: -24)
+    t2 = ~U[2025-06-11 15:29:40Z]
 
-    :ok = Salts.rotate(__MODULE__, h24_ago)
+    :ok = Salts.rotate(__MODULE__, t2)
 
     %{current: old_current, previous: _old_previous} =
       Salts.fetch(__MODULE__)
@@ -37,10 +35,9 @@ defmodule Plausible.Session.SaltsTest do
     count = Repo.aggregate(q, :count)
     assert count == 2
 
-    future =
-      DateTime.shift(DateTime.utc_now(), hour: 24, minute: 5)
+    t3 = ~U[2025-06-13 15:34:40Z]
 
-    :ok = Salts.rotate(__MODULE__, future)
+    :ok = Salts.rotate(__MODULE__, t3)
 
     %{current: _current, previous: ^old_current} =
       Salts.fetch(__MODULE__)
@@ -48,5 +45,23 @@ defmodule Plausible.Session.SaltsTest do
     q = from(s in "salts")
     count = Repo.aggregate(q, :count)
     assert count == 2
+  end
+
+  test "salts refresh when another node roates them" do
+    t1 = ~U[2024-06-10 15:29:40Z]
+    {:ok, _} = Salts.start_link(name: :node_1, now: t1)
+    {:ok, _} = Salts.start_link(name: :node_2, now: t1)
+
+    t2 = ~U[2024-06-11 15:29:40Z]
+
+    :ok = Salts.rotate(:node_2, t2)
+
+    assert Salts.fetch(:node_1) != Salts.fetch(:node_2)
+
+    send(:node_1, {:refresh, t2})
+
+    assert eventually(fn ->
+             {Salts.fetch(:node_1) == Salts.fetch(:node_2), :ok}
+           end)
   end
 end


### PR DESCRIPTION
### Changes

Salts are rotated via Oban cron-type job that is executed once at midnight on a single node exclusively. This means, other nodes won't update their salts state until they're restarted. Before we have a cluster over which we could broadcast updates to secondary nodes, each will periodically refresh salts from db, resulting in - at most - a minute-ish out of sync window, which should be acceptable. This should help with session tracking and session hand-off.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
