### PR TITLE
SSO: implement domain validation background service

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -797,7 +797,8 @@ cloud_queues = [
   notify_annual_renewal: 1,
   lock_sites: 1,
   legacy_time_on_page_cutoff: 1,
-  purge_cdn_cache: 1
+  purge_cdn_cache: 1,
+  sso_domain_validations: 32
 ]
 
 queues = if(is_selfhost, do: base_queues, else: base_queues ++ cloud_queues)

--- a/extra/lib/plausible/auth/sso/domain.ex
+++ b/extra/lib/plausible/auth/sso/domain.ex
@@ -30,7 +30,10 @@ defmodule Plausible.Auth.SSO.Domain do
     field :domain, :string
     field :validated_via, Ecto.Enum, values: @validation_methods
     field :last_validated_at, :naive_datetime
-    field :status, Ecto.Enum, values: [:pending, :validated], default: :pending
+
+    field :status, Ecto.Enum,
+      values: [:pending, :in_progress, :validated, :invalid],
+      default: :pending
 
     belongs_to :sso_integration, Plausible.Auth.SSO.Integration
 
@@ -59,13 +62,13 @@ defmodule Plausible.Auth.SSO.Domain do
     |> put_change(:status, :validated)
   end
 
-  @spec invalid_changeset(t(), NaiveDateTime.t()) :: Ecto.Changeset.t()
-  def invalid_changeset(sso_domain, now) do
+  @spec invalid_changeset(t(), NaiveDateTime.t(), atom()) :: Ecto.Changeset.t()
+  def invalid_changeset(sso_domain, now, status \\ :in_progress) do
     sso_domain
     |> change()
     |> put_change(:validated_via, nil)
     |> put_change(:last_validated_at, now)
-    |> put_change(:status, :pending)
+    |> put_change(:status, status)
   end
 
   @spec valid_domain?(String.t()) :: boolean()

--- a/extra/lib/plausible/auth/sso/domain/validation/worker.ex
+++ b/extra/lib/plausible/auth/sso/domain/validation/worker.ex
@@ -1,0 +1,119 @@
+defmodule Plausible.Auth.SSO.Domain.Validation.Worker do
+  @moduledoc """
+  Background service validating SSO domains ownership
+
+  `bypass_checks` and `skip_checks` job args are for testing purposes only
+  (former will fail the verification, latter will succeed with `dns_txt` method)
+  """
+  use Oban.Worker,
+    queue: :sso_domain_validations,
+    unique: true
+
+  alias Plausible.Auth.SSO
+  alias Plausible.Repo
+
+  # roughly around 34h, given the snooze back-off
+  @max_snoozes 14
+
+  def enqueue(domain) do
+    {:ok, result} =
+      Repo.transaction(fn ->
+        with {:ok, sso_domain} <- SSO.Domains.get(domain) do
+          SSO.Domains.mark_invalid!(sso_domain, :in_progress)
+        end
+
+        {:ok, job} =
+          %{domain: domain}
+          |> new()
+          |> Oban.insert()
+
+        :ok = Oban.retry_job(job)
+        {:ok, job}
+      end)
+
+    result
+  end
+
+  @impl true
+  def perform(%{
+        attempt: attempt,
+        meta: meta,
+        args: %{"domain" => domain}
+      })
+      when attempt <= @max_snoozes do
+    service_opts = [
+      skip_checks?: meta["skip_checks"] == true
+    ]
+
+    service_opts =
+      if meta["bypass_checks"] == true do
+        Keyword.merge(service_opts, verification_opts: [methods: []])
+      else
+        service_opts
+      end
+
+    case SSO.Domains.get(domain) do
+      {:ok, sso_domain} ->
+        case SSO.Domains.verify(sso_domain, service_opts) do
+          %SSO.Domain{status: :validated} = validated ->
+            validation_complete(sso_domain)
+            {:ok, validated}
+
+          _ ->
+            {:snooze, snooze_backoff(attempt)}
+        end
+
+      {:error, :not_found} ->
+        {:cancel, :domain_not_found}
+    end
+  end
+
+  def perform(job) do
+    validation_failure(job.args["domain"])
+    {:cancel, :max_snoozes}
+  end
+
+  defp validation_complete(sso_domain) do
+    send_success_notification(sso_domain)
+
+    :ok
+  end
+
+  defp validation_failure(domain) do
+    with {:ok, sso_domain} <- SSO.Domains.get(domain) do
+      sso_domain
+      |> SSO.Domains.mark_invalid!(:invalid)
+      |> send_failure_notification()
+    end
+
+    :ok
+  end
+
+  defp send_success_notification(sso_domain) do
+    owners = Repo.preload(sso_domain.sso_integration.team, :owners).owners
+
+    Enum.each(owners, fn owner ->
+      sso_domain.domain
+      |> PlausibleWeb.Email.sso_domain_validation_success(owner)
+      |> Plausible.Mailer.send()
+    end)
+
+    :ok
+  end
+
+  defp send_failure_notification(sso_domain) do
+    owners = Repo.preload(sso_domain.sso_integration.team, :owners).owners
+
+    Enum.each(owners, fn owner ->
+      sso_domain.domain
+      |> PlausibleWeb.Email.sso_domain_validation_failure(owner)
+      |> Plausible.Mailer.send()
+    end)
+
+    :ok
+  end
+
+  defp snooze_backoff(attempt) do
+    trunc(:math.pow(2, attempt - 1) * 15)
+  end
+end

--- a/extra/lib/plausible/auth/sso/domains.ex
+++ b/extra/lib/plausible/auth/sso/domains.ex
@@ -18,23 +18,40 @@ defmodule Plausible.Auth.SSO.Domains do
   end
 
   @spec verify(SSO.Domain.t(), Keyword.t()) :: SSO.Domain.t()
-  def verify(sso_domain, opts \\ []) do
+  def verify(%SSO.Domain{} = sso_domain, opts \\ []) do
     skip_checks? = Keyword.get(opts, :skip_checks?, false)
     verification_opts = Keyword.get(opts, :verification_opts, [])
     now = Keyword.get(opts, :now, NaiveDateTime.utc_now(:second))
 
     if skip_checks? do
-      mark_valid(sso_domain, :dns_txt, now)
+      mark_validated!(sso_domain, :dns_txt, now)
     else
       case SSO.Domain.Validation.run(sso_domain.domain, sso_domain.identifier, verification_opts) do
         {:ok, step} ->
-          mark_valid(sso_domain, step, now)
+          mark_validated!(sso_domain, step, now)
 
         {:error, :invalid} ->
-          mark_invalid(sso_domain, now)
+          mark_invalid!(sso_domain, :in_progress, now)
       end
+    end
+  end
 
-      mark_invalid(sso_domain, now)
+  @spec get(String.t()) :: {:ok, SSO.Domain.t()} | {:error, :not_found}
+  def get(domain) when is_binary(domain) do
+    result =
+      from(
+        d in SSO.Domain,
+        inner_join: i in assoc(d, :sso_integration),
+        inner_join: t in assoc(i, :team),
+        where: d.domain == ^domain,
+        preload: [sso_integration: {i, team: t}]
+      )
+      |> Repo.one()
+
+    if result do
+      {:ok, result}
+    else
+      {:error, :not_found}
     end
   end
 
@@ -114,6 +131,21 @@ defmodule Plausible.Auth.SSO.Domains do
     end
   end
 
+  @spec mark_validated!(SSO.Domain.t(), SSO.Domain.validation_method(), DateTime.t()) ::
+          SSO.Domain.t()
+  def mark_validated!(sso_domain, method, now \\ NaiveDateTime.utc_now(:second)) do
+    sso_domain
+    |> SSO.Domain.valid_changeset(method, now)
+    |> Repo.update!()
+  end
+
+  @spec mark_invalid!(SSO.Domain.t(), atom(), DateTime.t()) :: SSO.Domain.t()
+  def mark_invalid!(sso_domain, status, now \\ NaiveDateTime.utc_now(:second)) do
+    sso_domain
+    |> SSO.Domain.invalid_changeset(now, status)
+    |> Repo.update!()
+  end
+
   defp users_by_domain(sso_domain) do
     sso_domain
     |> users_by_domain_query()
@@ -141,17 +173,5 @@ defmodule Plausible.Auth.SSO.Domains do
     |> List.last()
     |> String.trim()
     |> String.downcase()
-  end
-
-  defp mark_valid(sso_domain, method, now) do
-    sso_domain
-    |> SSO.Domain.valid_changeset(method, now)
-    |> Repo.update!()
-  end
-
-  defp mark_invalid(sso_domain, now) do
-    sso_domain
-    |> SSO.Domain.invalid_changeset(now)
-    |> Repo.update!()
   end
 end

--- a/extra/lib/plausible/auth/sso/domains.ex
+++ b/extra/lib/plausible/auth/sso/domains.ex
@@ -131,7 +131,7 @@ defmodule Plausible.Auth.SSO.Domains do
     end
   end
 
-  @spec mark_validated!(SSO.Domain.t(), SSO.Domain.validation_method(), DateTime.t()) ::
+  @spec mark_validated!(SSO.Domain.t(), SSO.Domain.validation_method(), NaiveDateTime.t()) ::
           SSO.Domain.t()
   def mark_validated!(sso_domain, method, now \\ NaiveDateTime.utc_now(:second)) do
     sso_domain
@@ -139,7 +139,7 @@ defmodule Plausible.Auth.SSO.Domains do
     |> Repo.update!()
   end
 
-  @spec mark_invalid!(SSO.Domain.t(), atom(), DateTime.t()) :: SSO.Domain.t()
+  @spec mark_invalid!(SSO.Domain.t(), atom(), NaiveDateTime.t()) :: SSO.Domain.t()
   def mark_invalid!(sso_domain, status, now \\ NaiveDateTime.utc_now(:second)) do
     sso_domain
     |> SSO.Domain.invalid_changeset(now, status)

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -545,6 +545,22 @@ defmodule PlausibleWeb.Email do
     )
   end
 
+  on_ee do
+    def sso_domain_validation_success(domain, user) do
+      priority_email()
+      |> to(user.email)
+      |> subject("Your SSO domain #{domain} is ready!")
+      |> render("sso_domain_validation_success.html", domain: domain)
+    end
+
+    def sso_domain_validation_failure(domain, user) do
+      priority_email()
+      |> to(user)
+      |> subject("SSO domain #{domain} validation failure")
+      |> render("sso_domain_validation_failure.html", domain: domain)
+    end
+  end
+
   @doc """
     Unlike the default 'base' emails, priority emails cannot be unsubscribed from. This is achieved
     by sending them through a dedicated 'priority' message stream in Postmark.

--- a/lib/plausible_web/templates/email/sso_domain_validation_failure.html.heex
+++ b/lib/plausible_web/templates/email/sso_domain_validation_failure.html.heex
@@ -1,0 +1,3 @@
+We were unable to verify the SSO domain '{@domain}' you attempted to set up. Despite multiple attempts, the validation process could not be completed and we have exhausted all automatic retries.<br />
+Please review your domain configuration and follow our configuration guide to resolve common issues:
+<a href="https://plausible.io/docs/sso" target="_blank">SSO Documentation</a>.

--- a/lib/plausible_web/templates/email/sso_domain_validation_success.html.heex
+++ b/lib/plausible_web/templates/email/sso_domain_validation_success.html.heex
@@ -1,0 +1,2 @@
+We are pleased to inform you that your Single Sign-On (SSO) domain '{@domain}' has been successfully verified and is now ready for use.<br />
+You can now enable SSO for your organization and allow users to sign in using their corporate credentials.

--- a/test/plausible/auth/sso/domains_test.exs
+++ b/test/plausible/auth/sso/domains_test.exs
@@ -114,7 +114,7 @@ defmodule Plausible.Auth.SSO.DomainsTest do
         assert valid_domain.last_validated_at
       end
 
-      test "does not mark domain as validated when no skip flag passed", %{
+      test "does mark domain as in progress, when no skip flag passed", %{
         integration: integration
       } do
         domain = generate_domain()
@@ -124,7 +124,7 @@ defmodule Plausible.Auth.SSO.DomainsTest do
 
         assert invalid_domain.id == sso_domain.id
         refute invalid_domain.validated_via
-        assert invalid_domain.status == :pending
+        assert invalid_domain.status == :in_progress
         assert invalid_domain.last_validated_at
       end
     end

--- a/test/workers/sso_domain_validation_worker_test.exs
+++ b/test/workers/sso_domain_validation_worker_test.exs
@@ -1,100 +1,109 @@
 defmodule Plausible.Auth.SSO.Domain.Validation.WorkerTest do
   use Plausible.DataCase
-  use Oban.Testing, repo: Plausible.Repo
+  use Plausible
 
-  use Bamboo.Test, shared: true
+  on_ee do
+    use Oban.Testing, repo: Plausible.Repo
 
-  alias Plausible.Auth.SSO.Domain.Validation.Worker
+    use Bamboo.Test, shared: true
 
-  alias Plausible.Auth.SSO
+    alias Plausible.Auth.SSO.Domain.Validation.Worker
 
-  use Plausible.Teams.Test
+    alias Plausible.Auth.SSO
 
-  test "no sso domain cancels the job" do
-    assert {:cancel, :domain_not_found} = perform_job(Worker, %{"domain" => "hello.example.com"})
-  end
+    use Plausible.Teams.Test
 
-  test "enqueue works" do
-    {:ok, _} = Worker.enqueue("example.com")
-    assert_enqueued(worker: Worker, args: %{domain: "example.com"})
-  end
-
-  test "enqueue is idempotent" do
-    {:ok, %{id: id}} = Worker.enqueue("example.com")
-    {:ok, %{id: ^id, conflict?: true}} = Worker.enqueue("example.com")
-    assert_enqueued(worker: Worker, args: %{domain: "example.com"})
-  end
-
-  describe "integration set up" do
-    setup do
-      owner = new_user()
-      team = new_site(owner: owner).team
-      integration = SSO.initiate_saml_integration(team)
-      domain = "#{Enum.random(1..10_000)}.example.com"
-      {:ok, sso_domain} = SSO.Domains.add(integration, domain)
-
-      {:ok,
-       owner: owner, team: team, integration: integration, domain: domain, sso_domain: sso_domain}
+    test "no sso domain cancels the job" do
+      assert {:cancel, :domain_not_found} =
+               perform_job(Worker, %{"domain" => "hello.example.com"})
     end
 
-    test "enqueue resets domain status", %{sso_domain: sso_domain} do
-      %{status: :invalid} = SSO.Domains.mark_invalid!(sso_domain, :invalid)
-      {:ok, _} = Worker.enqueue(sso_domain.domain)
-      assert Plausible.Repo.reload!(sso_domain).status == :in_progress
+    test "enqueue works" do
+      {:ok, _} = Worker.enqueue("example.com")
+      assert_enqueued(worker: Worker, args: %{domain: "example.com"})
     end
 
-    test "domain is marked as in progress and job is snoozed", %{domain: domain} do
-      assert {:ok, %{status: :pending}} = SSO.Domains.get(domain)
-
-      assert {:snooze, 15} =
-               perform_job(Worker, %{"domain" => domain}, meta: %{bypass_checks: true})
-
-      assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
-
-      assert {:snooze, 7680} =
-               perform_job(Worker, %{"domain" => domain},
-                 attempt: 10,
-                 meta: %{bypass_checks: true}
-               )
-
-      assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
+    test "enqueue is idempotent" do
+      {:ok, %{id: id}} = Worker.enqueue("example.com")
+      {:ok, %{id: ^id, conflict?: true}} = Worker.enqueue("example.com")
+      assert_enqueued(worker: Worker, args: %{domain: "example.com"})
     end
 
-    test "domain is marked as validated and emails are sent", %{
-      domain: domain,
-      team: team,
-      owner: owner
-    } do
-      owner2 = add_member(team, role: :owner)
+    describe "integration set up" do
+      setup do
+        owner = new_user()
+        team = new_site(owner: owner).team
+        integration = SSO.initiate_saml_integration(team)
+        domain = "#{Enum.random(1..10_000)}.example.com"
+        {:ok, sso_domain} = SSO.Domains.add(integration, domain)
 
-      assert {:ok, %{status: :validated}} =
-               perform_job(Worker, %{"domain" => domain}, meta: %{skip_checks: true})
+        {:ok,
+         owner: owner,
+         team: team,
+         integration: integration,
+         domain: domain,
+         sso_domain: sso_domain}
+      end
 
-      assert_email_delivered_with(
-        to: [nil: owner.email],
-        subject: "Your SSO domain #{domain} is ready!"
-      )
+      test "enqueue resets domain status", %{sso_domain: sso_domain} do
+        %{status: :invalid} = SSO.Domains.mark_invalid!(sso_domain, :invalid)
+        {:ok, _} = Worker.enqueue(sso_domain.domain)
+        assert Plausible.Repo.reload!(sso_domain).status == :in_progress
+      end
 
-      assert_email_delivered_with(
-        to: [nil: owner2.email],
-        subject: "Your SSO domain #{domain} is ready!"
-      )
-    end
+      test "domain is marked as in progress and job is snoozed", %{domain: domain} do
+        assert {:ok, %{status: :pending}} = SSO.Domains.get(domain)
 
-    test "domain is marked as invalid when max snoozes exhausted", %{domain: domain} do
-      assert {:snooze, _} =
-               perform_job(Worker, %{"domain" => domain},
-                 attempt: 14,
-                 meta: %{bypass_checks: true}
-               )
+        assert {:snooze, 15} =
+                 perform_job(Worker, %{"domain" => domain}, meta: %{bypass_checks: true})
 
-      assert {:cancel, :max_snoozes} =
-               perform_job(Worker, %{"domain" => domain},
-                 attempt: 15,
-                 meta: %{bypass_checks: true}
-               )
+        assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
 
-      assert_email_delivered_with(subject: "SSO domain #{domain} validation failure")
+        assert {:snooze, 7680} =
+                 perform_job(Worker, %{"domain" => domain},
+                   attempt: 10,
+                   meta: %{bypass_checks: true}
+                 )
+
+        assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
+      end
+
+      test "domain is marked as validated and emails are sent", %{
+        domain: domain,
+        team: team,
+        owner: owner
+      } do
+        owner2 = add_member(team, role: :owner)
+
+        assert {:ok, %{status: :validated}} =
+                 perform_job(Worker, %{"domain" => domain}, meta: %{skip_checks: true})
+
+        assert_email_delivered_with(
+          to: [nil: owner.email],
+          subject: "Your SSO domain #{domain} is ready!"
+        )
+
+        assert_email_delivered_with(
+          to: [nil: owner2.email],
+          subject: "Your SSO domain #{domain} is ready!"
+        )
+      end
+
+      test "domain is marked as invalid when max snoozes exhausted", %{domain: domain} do
+        assert {:snooze, _} =
+                 perform_job(Worker, %{"domain" => domain},
+                   attempt: 14,
+                   meta: %{bypass_checks: true}
+                 )
+
+        assert {:cancel, :max_snoozes} =
+                 perform_job(Worker, %{"domain" => domain},
+                   attempt: 15,
+                   meta: %{bypass_checks: true}
+                 )
+
+        assert_email_delivered_with(subject: "SSO domain #{domain} validation failure")
+      end
     end
   end
 end

--- a/test/workers/sso_domain_validation_worker_test.exs
+++ b/test/workers/sso_domain_validation_worker_test.exs
@@ -1,0 +1,100 @@
+defmodule Plausible.Auth.SSO.Domain.Validation.WorkerTest do
+  use Plausible.DataCase
+  use Oban.Testing, repo: Plausible.Repo
+
+  use Bamboo.Test, shared: true
+
+  alias Plausible.Auth.SSO.Domain.Validation.Worker
+
+  alias Plausible.Auth.SSO
+
+  use Plausible.Teams.Test
+
+  test "no sso domain cancels the job" do
+    assert {:cancel, :domain_not_found} = perform_job(Worker, %{"domain" => "hello.example.com"})
+  end
+
+  test "enqueue works" do
+    {:ok, _} = Worker.enqueue("example.com")
+    assert_enqueued(worker: Worker, args: %{domain: "example.com"})
+  end
+
+  test "enqueue is idempotent" do
+    {:ok, %{id: id}} = Worker.enqueue("example.com")
+    {:ok, %{id: ^id, conflict?: true}} = Worker.enqueue("example.com")
+    assert_enqueued(worker: Worker, args: %{domain: "example.com"})
+  end
+
+  describe "integration set up" do
+    setup do
+      owner = new_user()
+      team = new_site(owner: owner).team
+      integration = SSO.initiate_saml_integration(team)
+      domain = "#{Enum.random(1..10_000)}.example.com"
+      {:ok, sso_domain} = SSO.Domains.add(integration, domain)
+
+      {:ok,
+       owner: owner, team: team, integration: integration, domain: domain, sso_domain: sso_domain}
+    end
+
+    test "enqueue resets domain status", %{sso_domain: sso_domain} do
+      %{status: :invalid} = SSO.Domains.mark_invalid!(sso_domain, :invalid)
+      {:ok, _} = Worker.enqueue(sso_domain.domain)
+      assert Plausible.Repo.reload!(sso_domain).status == :in_progress
+    end
+
+    test "domain is marked as in progress and job is snoozed", %{domain: domain} do
+      assert {:ok, %{status: :pending}} = SSO.Domains.get(domain)
+
+      assert {:snooze, 15} =
+               perform_job(Worker, %{"domain" => domain}, meta: %{bypass_checks: true})
+
+      assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
+
+      assert {:snooze, 7680} =
+               perform_job(Worker, %{"domain" => domain},
+                 attempt: 10,
+                 meta: %{bypass_checks: true}
+               )
+
+      assert {:ok, %{status: :in_progress}} = SSO.Domains.get(domain)
+    end
+
+    test "domain is marked as validated and emails are sent", %{
+      domain: domain,
+      team: team,
+      owner: owner
+    } do
+      owner2 = add_member(team, role: :owner)
+
+      assert {:ok, %{status: :validated}} =
+               perform_job(Worker, %{"domain" => domain}, meta: %{skip_checks: true})
+
+      assert_email_delivered_with(
+        to: [nil: owner.email],
+        subject: "Your SSO domain #{domain} is ready!"
+      )
+
+      assert_email_delivered_with(
+        to: [nil: owner2.email],
+        subject: "Your SSO domain #{domain} is ready!"
+      )
+    end
+
+    test "domain is marked as invalid when max snoozes exhausted", %{domain: domain} do
+      assert {:snooze, _} =
+               perform_job(Worker, %{"domain" => domain},
+                 attempt: 14,
+                 meta: %{bypass_checks: true}
+               )
+
+      assert {:cancel, :max_snoozes} =
+               perform_job(Worker, %{"domain" => domain},
+                 attempt: 15,
+                 meta: %{bypass_checks: true}
+               )
+
+      assert_email_delivered_with(subject: "SSO domain #{domain} validation failure")
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This PR implements background worker for SSO domain validation. The job gets exponential snooze on validation failure, leading up to 14 retries over roughly ~34 hours. Instead of deleting already running jobs, a retry is always called on `enqueue`, effectively scheduling the job for immediate execution (to provide the ability to quickly restart the process via UI).

New status indicators per `SSO.Domain` have been introduced: `in_progress` and `invalid` to mirror job's status. Each unique enqueue resets the status to `in_progress`. For now, nothing actually enqueues the job - a follow-up PR will be submitted with end to end integration.

On domain validation success/failure e-mail notifications will be sent to the relevant team's owners. Copy is subject to change, but paging @metmarkosaric to have a look at:

- https://github.com/plausible/analytics/blob/domain-verification-worker/lib/plausible_web/templates/email/sso_domain_validation_failure.html.heex
- https://github.com/plausible/analytics/blob/domain-verification-worker/lib/plausible_web/templates/email/sso_domain_validation_success.html.heex


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
