### PR TITLE
Experiment: Adjust sampling minimum and by filters

### DIFF
--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -86,7 +86,7 @@ defmodule Plausible.Stats.Sampling do
   end
 
   defp min_sample_rate(false = _sampling_adjustments?), do: 0.01
-  defp min_sample_rate(true = _sampling_adjustments?), do: 0.007
+  defp min_sample_rate(true = _sampling_adjustments?), do: 0.013
 
   defp estimate_traffic(traffic_30_day, duration, query, sampling_adjustments?) do
     duration_adjusted_traffic = traffic_30_day / 30.0 * duration
@@ -100,8 +100,6 @@ defmodule Plausible.Stats.Sampling do
   end
 
   @filter_traffic_multiplier 1 / 20.0
-  defp estimate_by_filters(estimation, []), do: estimation
-
-  defp estimate_by_filters(estimation, [_filter | rest]),
-    do: estimate_by_filters(estimation * @filter_traffic_multiplier, rest)
+  defp estimate_by_filters(estimation, filters),
+    do: estimation * @filter_traffic_multiplier ** length(filters)
 end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -39,7 +39,7 @@ defmodule Plausible.Stats.SamplingTest do
 
       test "very low sampling rate" do
         assert fractional_sample_rate(@threshold * 500, query(30), false) == 0.01
-        assert fractional_sample_rate(@threshold * 500, query(30), true) == 0.007
+        assert fractional_sample_rate(@threshold * 500, query(30), true) == 0.013
       end
 
       @filter ["is", "event:name", ["pageview"]]

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -4,50 +4,70 @@ defmodule Plausible.Stats.SamplingTest do
   use Plausible
 
   on_ee do
-    import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
+    import Plausible.Stats.Sampling, only: [fractional_sample_rate: 3]
     alias Plausible.Stats.{Query, DateTimeRange, Sampling}
 
     describe "&fractional_sample_rate/2" do
       @threshold Sampling.default_sample_threshold()
 
       test "no traffic estimate" do
-        assert fractional_sample_rate(nil, query(30)) == :no_sampling
+        assert fractional_sample_rate(nil, query(30), false) == :no_sampling
       end
 
       test "scales sampling rate according to query duration" do
-        assert fractional_sample_rate(@threshold * 2, query(30)) == :no_sampling
-        assert fractional_sample_rate(@threshold * 2, query(60)) == 0.25
-        assert fractional_sample_rate(@threshold * 2, query(100)) == 0.15
+        assert fractional_sample_rate(@threshold * 2, query(30), false) == :no_sampling
+        assert fractional_sample_rate(@threshold * 2, query(60), false) == 0.25
+        assert fractional_sample_rate(@threshold * 2, query(100), false) == 0.15
 
-        assert fractional_sample_rate(@threshold * 5, query(1)) == :no_sampling
-        assert fractional_sample_rate(@threshold * 5, query(5)) == :no_sampling
-        assert fractional_sample_rate(@threshold * 5, query(10)) == :no_sampling
-        assert fractional_sample_rate(@threshold * 5, query(15)) == 0.40
-        assert fractional_sample_rate(@threshold * 5, query(30)) == 0.20
-        assert fractional_sample_rate(@threshold * 5, query(60)) == 0.10
-        assert fractional_sample_rate(@threshold * 5, query(100)) == 0.06
+        assert fractional_sample_rate(@threshold * 5, query(1), false) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(5), false) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(10), false) == :no_sampling
+        assert fractional_sample_rate(@threshold * 5, query(15), false) == 0.40
+        assert fractional_sample_rate(@threshold * 5, query(30), false) == 0.20
+        assert fractional_sample_rate(@threshold * 5, query(60), false) == 0.10
+        assert fractional_sample_rate(@threshold * 5, query(100), false) == 0.06
 
-        assert fractional_sample_rate(@threshold * 15, query(2)) == :no_sampling
-        assert fractional_sample_rate(@threshold * 15, query(5)) == 0.40
-        assert fractional_sample_rate(@threshold * 15, query(10)) == 0.20
+        assert fractional_sample_rate(@threshold * 15, query(2), false) == :no_sampling
+        assert fractional_sample_rate(@threshold * 15, query(5), false) == 0.40
+        assert fractional_sample_rate(@threshold * 15, query(10), false) == 0.20
       end
 
       test "short durations" do
-        assert fractional_sample_rate(@threshold * 15, query(1, :hour)) == :no_sampling
+        assert fractional_sample_rate(@threshold * 15, query(1, unit: :hour), false) ==
+                 :no_sampling
       end
 
       test "very low sampling rate" do
-        assert fractional_sample_rate(@threshold * 500, query(30)) == 0.01
+        assert fractional_sample_rate(@threshold * 500, query(30), false) == 0.01
+        assert fractional_sample_rate(@threshold * 500, query(30), true) == 0.007
+      end
+
+      @filter ["is", "event:name", ["pageview"]]
+      test "scales sampling rate according to query filters (when sampling adjustments are enabled)" do
+        assert fractional_sample_rate(@threshold * 50, query(30, filters: []), true) == 0.02
+
+        assert fractional_sample_rate(@threshold * 50, query(30, filters: [@filter]), true) ==
+                 0.40
+
+        assert fractional_sample_rate(
+                 @threshold * 50,
+                 query(30, filters: [@filter, @filter]),
+                 true
+               ) == :no_sampling
       end
     end
 
-    def query(duration, unit \\ :day) do
+    def query(duration, opts \\ []) do
+      unit = Keyword.get(opts, :unit, :day)
+      filters = Keyword.get(opts, :filters, [])
+
       first = DateTime.utc_now()
       last = DateTime.add(first, duration, unit)
 
       %Query{
         utc_time_range: DateTimeRange.new!(first, last),
-        timezone: "UTC"
+        timezone: "UTC",
+        filters: filters
       }
     end
   end


### PR DESCRIPTION
This PR adjusts sampling logic:
- Moving minimum sample rate to 0.007
- Adjusting sample rate if filters are present. Essentially each filter is assumed to filter out 1/20th the data.

This should help with edge cases where highly selective filters being present results in off-looking data.

(All new logic is feature flagged)