### PR TITLE
Add "SSO" billing plan feature and hide SSO setup behind it

### DIFF
--- a/extra/lib/plausible_web/controllers/sso_controller.ex
+++ b/extra/lib/plausible_web/controllers/sso_controller.ex
@@ -78,7 +78,8 @@ defmodule PlausibleWeb.SSOController do
   end
 
   def sso_settings(conn, _params) do
-    if Plausible.Teams.setup?(conn.assigns.current_team) and Plausible.sso_enabled?() do
+    if Plausible.Teams.setup?(conn.assigns.current_team) and Plausible.sso_enabled?() and
+         Plausible.Billing.Feature.SSO.check_availability(conn.assigns.current_team) == :ok do
       render(conn, :sso_settings,
         layout: {PlausibleWeb.LayoutView, :settings},
         connect_live_socket: true

--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -78,7 +78,8 @@ defmodule Plausible.Billing.Feature do
     Plausible.Billing.Feature.RevenueGoals,
     Plausible.Billing.Feature.SiteSegments,
     Plausible.Billing.Feature.SitesAPI,
-    Plausible.Billing.Feature.StatsAPI
+    Plausible.Billing.Feature.StatsAPI,
+    Plausible.Billing.Feature.SSO
   ]
 
   # Generate a union type for features
@@ -229,6 +230,15 @@ defmodule Plausible.Billing.Feature.SitesAPI do
   use Plausible.Billing.Feature,
     name: :sites_api,
     display_name: "Sites API"
+end
+
+defmodule Plausible.Billing.Feature.SSO do
+  use Plausible
+
+  @moduledoc false
+  use Plausible.Billing.Feature,
+    name: :sso,
+    display_name: "Single Sign-On"
 end
 
 defmodule Plausible.Billing.Feature.Teams do

--- a/lib/plausible_web/plugins/api/schemas/capabilities.ex
+++ b/lib/plausible_web/plugins/api/schemas/capabilities.ex
@@ -36,7 +36,8 @@ defmodule PlausibleWeb.Plugins.API.Schemas.Capabilities do
         SitesAPI: false,
         SiteSegments: false,
         Teams: false,
-        SharedLinks: false
+        SharedLinks: false,
+        SSO: false
       }
     }
   })

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -135,7 +135,9 @@ defmodule PlausibleWeb.LayoutView do
           if(current_team_role in [:owner, :billing, :admin, :editor],
             do: %{key: "API Keys", value: "api-keys", icon: :key}
           ),
-          if(Plausible.sso_enabled?() and current_team_role == :owner,
+          if(
+            Plausible.sso_enabled?() and current_team_role == :owner and
+              Plausible.Billing.Feature.SSO.check_availability(current_team) == :ok,
             do: %{key: "Single Sign-On", value: "sso/general", icon: :cloud}
           ),
           if(current_team_role == :owner,

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -622,7 +622,8 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features when user in on trial" do
       team = new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: 7)) |> team_of()
 
-      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
+      assert Plausible.Billing.Feature.list() --
+               [Plausible.Billing.Feature.SitesAPI, Plausible.Billing.Feature.SSO] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -641,7 +642,8 @@ defmodule Plausible.Billing.QuotaTest do
     test "returns all features for enterprise users who have not upgraded yet and are on trial" do
       team = new_user() |> subscribe_to_enterprise_plan(subscription?: false) |> team_of()
 
-      assert Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SitesAPI] ==
+      assert Plausible.Billing.Feature.list() --
+               [Plausible.Billing.Feature.SitesAPI, Plausible.Billing.Feature.SSO] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 

--- a/test/plausible_web/controllers/sso_controller_sync_test.exs
+++ b/test/plausible_web/controllers/sso_controller_sync_test.exs
@@ -37,7 +37,9 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
       end
 
       test "sso team settings item is guarded by the env var", %{conn: conn} do
-        user = new_user()
+        user =
+          new_user() |> subscribe_to_enterprise_plan(features: [Plausible.Billing.Feature.SSO])
+
         team = new_site(owner: user).team |> Plausible.Teams.complete_setup()
         {:ok, ctx} = log_in(%{conn: conn, user: user})
         conn = ctx[:conn]

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -176,7 +176,8 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
               "revenue_goals" => "false",
               "site_segments" => "false",
               "shared_links" => "true",
-              "sites_api" => "true"
+              "sites_api" => "true",
+              "sso" => "false"
             }
           }
         })

--- a/test/plausible_web/live/sso_management_test.exs
+++ b/test/plausible_web/live/sso_management_test.exs
@@ -50,7 +50,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
     """
 
     describe "/settings/sso/general" do
-      setup [:create_user, :log_in, :create_team, :setup_team]
+      setup [:create_user, :log_in, :create_team, :add_plan, :setup_team]
 
       test "renders", %{conn: conn} do
         resp =
@@ -64,7 +64,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
     end
 
     describe "live" do
-      setup [:create_user, :log_in, :create_team, :setup_team]
+      setup [:create_user, :log_in, :create_team, :add_plan, :setup_team]
 
       test "init setup - basic walk through", %{conn: conn} do
         {lv, _html} = get_lv(conn)
@@ -305,6 +305,12 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         conn = assign(conn, :live_module, PlausibleWeb.Live.SSOManagement)
         {:ok, lv, html} = live(conn, Routes.sso_path(conn, :sso_settings))
         {lv, html}
+      end
+
+      defp add_plan(%{user: user}) do
+        subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.SSO])
+
+        :ok
       end
     end
   end

--- a/test/plausible_web/plugins/api/controllers/capabilities_test.exs
+++ b/test/plausible_web/plugins/api/controllers/capabilities_test.exs
@@ -32,7 +32,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "SharedLinks" => false
+                   "SharedLinks" => false,
+                   "SSO" => false
                  }
                }
 
@@ -59,7 +60,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "SharedLinks" => false
+                   "SharedLinks" => false,
+                   "SSO" => false
                  }
                }
 
@@ -88,7 +90,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => false,
                    "SiteSegments" => true,
-                   "SharedLinks" => true
+                   "SharedLinks" => true,
+                   "SSO" => false
                  }
                }
 
@@ -119,7 +122,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => false,
                    "SitesAPI" => false,
                    "SiteSegments" => false,
-                   "SharedLinks" => true
+                   "SharedLinks" => true,
+                   "SSO" => false
                  }
                }
 
@@ -153,7 +157,8 @@ defmodule PlausibleWeb.Plugins.API.Controllers.CapabilitiesTest do
                    "StatsAPI" => true,
                    "SitesAPI" => true,
                    "SiteSegments" => false,
-                   "SharedLinks" => false
+                   "SharedLinks" => false,
+                   "SSO" => false
                  }
                }
 


### PR DESCRIPTION
### Changes

This PR introduces a new plan feature, SSO, which gates access to SSO setup.

SSO login flow is _not_ gated by this feature because there's no team to check against at this stage. It will remain hidden behind env var flag for now.

### Tests
- [x] Automated tests have been added

