### PR TITLE
Bugfix: enable nameservers fallback when no DNS configured explicitly for SSO

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -315,9 +315,9 @@ sso_saml_adapter =
 sso_verification_nameservers =
   case get_var_from_path_or_env(config_dir, "SSO_VERIFICATION_NAMESERVERS") do
     nil ->
-      []
+      nil
 
-    some ->
+    some when is_binary(some) ->
       some
       |> String.split(",")
       |> Enum.map(fn addr ->

--- a/extra/lib/plausible/auth/sso/domain/verification.ex
+++ b/extra/lib/plausible/auth/sso/domain/verification.ex
@@ -74,12 +74,20 @@ defmodule Plausible.Auth.SSO.Domain.Verification do
     record_value = to_charlist("#{@prefix}=#{domain_identifier}")
 
     timeout = Keyword.get(opts, :timeout, 5_000)
-    nameservers = Keyword.get(opts, :nameservers, [])
-    opts = [timeout: timeout, nameservers: nameservers]
+    nameservers = Keyword.get(opts, :nameservers)
+
+    lookup_opts =
+      case nameservers do
+        nil ->
+          [timeout: timeout]
+
+        [_ | _] ->
+          [timeout: timeout, nameservers: nameservers]
+      end
 
     sso_domain
     |> to_charlist()
-    |> :inet_res.lookup(:in, :txt, opts, timeout)
+    |> :inet_res.lookup(:in, :txt, lookup_opts, timeout)
     |> Enum.find_value(false, fn
       [^record_value] -> true
       _ -> false


### PR DESCRIPTION
### Changes

This PR makes sure no empty nameservers list is passed to `:inet_res.lookup`
This prevented us from running the verification end to end in the wild, with no configured SSO nameservers. 