### PR TITLE
Remove fallback to empty list for nameservers option in SSO config

### DIFF
--- a/extra/lib/plausible/auth/sso/domain/verification/worker.ex
+++ b/extra/lib/plausible/auth/sso/domain/verification/worker.ex
@@ -48,7 +48,7 @@ defmodule Plausible.Auth.SSO.Domain.Verification.Worker do
     service_opts = [
       skip_checks?: meta["skip_checks"] == true,
       verification_opts: [
-        nameservers: Application.get_env(:plausible, :sso_verification_nameservers) || []
+        nameservers: Application.get_env(:plausible, :sso_verification_nameservers)
       ]
     ]
 


### PR DESCRIPTION
### Changes

Follow-up to #5530 


