### PR TITLE
ScriptV2: Remove hashBasedRouting from server-interpolated config

### DIFF
--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -36,7 +36,6 @@ defmodule PlausibleWeb.Tracker do
     %{
       domain: tracker_script_configuration.site.domain,
       endpoint: tracker_ingestion_endpoint(),
-      hashBasedRouting: tracker_script_configuration.hash_based_routing,
       outboundLinks: tracker_script_configuration.outbound_links,
       fileDownloads: tracker_script_configuration.file_downloads,
       formSubmissions: tracker_script_configuration.form_submissions

--- a/test/plausible_web/plugs/tracker_plug_test.exs
+++ b/test/plausible_web/plugs/tracker_plug_test.exs
@@ -46,7 +46,6 @@ defmodule PlausibleWeb.TrackerPlugTest do
 
       assert String.contains?(response, "!function(){var")
       assert String.contains?(response, "domain:\"#{site.domain}\"")
-      assert String.contains?(response, "hashBasedRouting:!0")
       assert String.contains?(response, "formSubmissions:!0")
       refute String.contains?(response, "outboundLinks:!0")
       refute String.contains?(response, "fileDownloads:!0")

--- a/test/plausible_web/tracker_test.exs
+++ b/test/plausible_web/tracker_test.exs
@@ -27,7 +27,6 @@ defmodule PlausibleWeb.TrackerTest do
       assert PlausibleWeb.Tracker.plausible_main_config(tracker_script_configuration) == %{
                domain: site.domain,
                endpoint: "#{PlausibleWeb.Endpoint.url()}/api/event",
-               hashBasedRouting: true,
                outboundLinks: false,
                fileDownloads: false,
                formSubmissions: true
@@ -121,7 +120,7 @@ defmodule PlausibleWeb.TrackerTest do
       script_tag = PlausibleWeb.Tracker.plausible_main_script_tag(tracker_script_configuration)
 
       assert script_tag =~
-               ~s(={endpoint:"#{PlausibleWeb.Endpoint.url()}/api/event",domain:"#{site.domain}",hashBasedRouting:!0,formSubmissions:!0})
+               ~s(={endpoint:"#{PlausibleWeb.Endpoint.url()}/api/event",domain:"#{site.domain}",formSubmissions:!0})
     end
 
     test "script tag escapes problematic characters as expected" do


### PR DESCRIPTION
New onboarding _does not_ have a checkbox for hash based routing, so remove it from server-interpolated config