### PR TITLE
CRM: New default site limit: 10; remove growth estimation

### DIFF
--- a/extra/lib/plausible/customer_support/enterprise_plan.ex
+++ b/extra/lib/plausible/customer_support/enterprise_plan.ex
@@ -3,7 +3,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlan do
   Custom plan price estimation
   """
   @spec estimate(
-          :business | :growth,
           String.t(),
           pos_integer(),
           pos_integer(),
@@ -12,7 +11,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlan do
           list(String.t())
         ) :: Decimal.t()
   def estimate(
-        kind,
         billing_interval,
         pageviews_per_month,
         sites_limit,
@@ -21,7 +19,7 @@ defmodule Plausible.CustomerSupport.EnterprisePlan do
         features
       ) do
     pv_rate =
-      pv_rate(kind, pageviews_per_month)
+      pv_rate(pageviews_per_month)
 
     sites_rate =
       sites_rate(sites_limit)
@@ -52,41 +50,23 @@ defmodule Plausible.CustomerSupport.EnterprisePlan do
     end
   end
 
-  def pv_rate(:growth, pvs) when pvs <= 10_000, do: 9
-  def pv_rate(:growth, pvs) when pvs <= 100_000, do: 19
-  def pv_rate(:growth, pvs) when pvs <= 200_000, do: 29
-  def pv_rate(:growth, pvs) when pvs <= 500_000, do: 49
-  def pv_rate(:growth, pvs) when pvs <= 1_000_000, do: 69
-  def pv_rate(:growth, pvs) when pvs <= 2_000_000, do: 89
-  def pv_rate(:growth, pvs) when pvs <= 5_000_000, do: 129
-  def pv_rate(:growth, pvs) when pvs <= 10_000_000, do: 169
-  def pv_rate(:growth, pvs) when pvs <= 20_000_000, do: 319
-  def pv_rate(:growth, pvs) when pvs <= 50_000_000, do: 689
-  def pv_rate(:growth, pvs) when pvs <= 100_000_000, do: 1029
-  def pv_rate(:growth, pvs) when pvs <= 200_000_000, do: 1629
-  def pv_rate(:growth, pvs) when pvs <= 300_000_000, do: 2369
-  def pv_rate(:growth, pvs) when pvs <= 400_000_000, do: 2989
-  def pv_rate(:growth, pvs) when pvs <= 500_000_000, do: 3729
-  def pv_rate(:growth, pvs) when pvs <= 1_000_000_000, do: 7219
-  def pv_rate(:growth, _), do: 7219
-
-  def pv_rate(:business, pvs) when pvs <= 10_000, do: 19
-  def pv_rate(:business, pvs) when pvs <= 100_000, do: 39
-  def pv_rate(:business, pvs) when pvs <= 200_000, do: 59
-  def pv_rate(:business, pvs) when pvs <= 500_000, do: 99
-  def pv_rate(:business, pvs) when pvs <= 1_000_000, do: 139
-  def pv_rate(:business, pvs) when pvs <= 2_000_000, do: 179
-  def pv_rate(:business, pvs) when pvs <= 5_000_000, do: 259
-  def pv_rate(:business, pvs) when pvs <= 10_000_000, do: 339
-  def pv_rate(:business, pvs) when pvs <= 20_000_000, do: 639
-  def pv_rate(:business, pvs) when pvs <= 50_000_000, do: 1379
-  def pv_rate(:business, pvs) when pvs <= 100_000_000, do: 2059
-  def pv_rate(:business, pvs) when pvs <= 200_000_000, do: 3259
-  def pv_rate(:business, pvs) when pvs <= 300_000_000, do: 4739
-  def pv_rate(:business, pvs) when pvs <= 400_000_000, do: 5979
-  def pv_rate(:business, pvs) when pvs <= 500_000_000, do: 7459
-  def pv_rate(:business, pvs) when pvs <= 1_000_000_000, do: 14_439
-  def pv_rate(:business, _), do: 14_439
+  def pv_rate(pvs) when pvs <= 10_000, do: 19
+  def pv_rate(pvs) when pvs <= 100_000, do: 39
+  def pv_rate(pvs) when pvs <= 200_000, do: 59
+  def pv_rate(pvs) when pvs <= 500_000, do: 99
+  def pv_rate(pvs) when pvs <= 1_000_000, do: 139
+  def pv_rate(pvs) when pvs <= 2_000_000, do: 179
+  def pv_rate(pvs) when pvs <= 5_000_000, do: 259
+  def pv_rate(pvs) when pvs <= 10_000_000, do: 339
+  def pv_rate(pvs) when pvs <= 20_000_000, do: 639
+  def pv_rate(pvs) when pvs <= 50_000_000, do: 1379
+  def pv_rate(pvs) when pvs <= 100_000_000, do: 2059
+  def pv_rate(pvs) when pvs <= 200_000_000, do: 3259
+  def pv_rate(pvs) when pvs <= 300_000_000, do: 4739
+  def pv_rate(pvs) when pvs <= 400_000_000, do: 5979
+  def pv_rate(pvs) when pvs <= 500_000_000, do: 7459
+  def pv_rate(pvs) when pvs <= 1_000_000_000, do: 14_439
+  def pv_rate(_), do: 14_439
 
   def sites_rate(n) when n <= 50, do: 0
   def sites_rate(n), do: n * 0.1

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -73,7 +73,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
         %{
           monthly_pageview_limit: 10_000,
           hourly_api_request_limit: 600,
-          site_limit: 50,
+          site_limit: 10,
           team_member_limit: 10,
           features: Plausible.Billing.Feature.list() -- [Plausible.Billing.Feature.SSO]
         }
@@ -95,8 +95,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
        show_plan_form?: false,
        editing_plan: nil,
        tab: "billing",
-       cost_estimate: 0,
-       cost_estimate_tier: :business
+       cost_estimate: 0
      )}
   end
 
@@ -431,16 +430,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
             />
 
             <div class="mt-8 flex align-center gap-x-4">
-              <.input
-                mt?={false}
-                type="select"
-                id="cost-estimate-tier"
-                name="enterprise_plan[cost-estimate-tier]"
-                options={[{"business", "business"}, {"growth", "growth"}]}
-                label="Plan"
-                value={@cost_estimate_tier}
-              />
-
               <.input_with_clipboard
                 id="cost-estimate"
                 name="cost-estimate"
@@ -705,11 +694,8 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
     params = sanitize_params(params)
 
-    kind = String.to_existing_atom(params["cost-estimate-tier"])
-
     cost_estimate =
       Plausible.CustomerSupport.EnterprisePlan.estimate(
-        kind,
         params["billing_interval"],
         get_int_param(params, "monthly_pageview_limit"),
         get_int_param(params, "site_limit"),
@@ -720,7 +706,6 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
     socket =
       assign(socket,
-        cost_estimate_tier: params["cost-estimate-tier"],
         cost_estimate: cost_estimate,
         plan_form: form
       )

--- a/test/plausible/customer_support/enterprise_plan_test.exs
+++ b/test/plausible/customer_support/enterprise_plan_test.exs
@@ -10,7 +10,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlanTest do
       test "calculates cost for business plan with monthly billing" do
         result =
           EnterprisePlan.estimate(
-            :business,
             "monthly",
             20_000_000,
             1000,
@@ -25,7 +24,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlanTest do
       test "bugfix - from float" do
         result =
           EnterprisePlan.estimate(
-            :business,
             "monthly",
             20_000_000,
             0,
@@ -40,7 +38,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlanTest do
       test "Bogdan's example (https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/8506177450#__recording_8689686259)" do
         result =
           EnterprisePlan.estimate(
-            :business,
             "monthly",
             10_000,
             500,
@@ -55,7 +52,6 @@ defmodule Plausible.CustomerSupport.EnterprisePlanTest do
       test "calculates cost for business plan with yearly billing" do
         result =
           EnterprisePlan.estimate(
-            :business,
             "yearly",
             20_000_000,
             1000,
@@ -69,44 +65,24 @@ defmodule Plausible.CustomerSupport.EnterprisePlanTest do
     end
 
     describe "pv_rate/2" do
-      test "returns correct rate for growth plan" do
-        assert EnterprisePlan.pv_rate(:growth, 10_000) == 9
-        assert EnterprisePlan.pv_rate(:growth, 100_000) == 19
-        assert EnterprisePlan.pv_rate(:growth, 200_000) == 29
-        assert EnterprisePlan.pv_rate(:growth, 500_000) == 49
-        assert EnterprisePlan.pv_rate(:growth, 1_000_000) == 69
-        assert EnterprisePlan.pv_rate(:growth, 2_000_000) == 89
-        assert EnterprisePlan.pv_rate(:growth, 5_000_000) == 129
-        assert EnterprisePlan.pv_rate(:growth, 10_000_000) == 169
-        assert EnterprisePlan.pv_rate(:growth, 20_000_000) == 319
-        assert EnterprisePlan.pv_rate(:growth, 50_000_000) == 689
-        assert EnterprisePlan.pv_rate(:growth, 100_000_000) == 1029
-        assert EnterprisePlan.pv_rate(:growth, 200_000_000) == 1629
-        assert EnterprisePlan.pv_rate(:growth, 300_000_000) == 2369
-        assert EnterprisePlan.pv_rate(:growth, 400_000_000) == 2989
-        assert EnterprisePlan.pv_rate(:growth, 500_000_000) == 3729
-        assert EnterprisePlan.pv_rate(:growth, 1_000_000_000) == 7219
-        assert EnterprisePlan.pv_rate(:growth, 1_500_000_000) == 7219
-      end
-
       test "returns correct rate for business plan" do
-        assert EnterprisePlan.pv_rate(:business, 10_000) == 19
-        assert EnterprisePlan.pv_rate(:business, 100_000) == 39
-        assert EnterprisePlan.pv_rate(:business, 200_000) == 59
-        assert EnterprisePlan.pv_rate(:business, 500_000) == 99
-        assert EnterprisePlan.pv_rate(:business, 1_000_000) == 139
-        assert EnterprisePlan.pv_rate(:business, 2_000_000) == 179
-        assert EnterprisePlan.pv_rate(:business, 5_000_000) == 259
-        assert EnterprisePlan.pv_rate(:business, 10_000_000) == 339
-        assert EnterprisePlan.pv_rate(:business, 20_000_000) == 639
-        assert EnterprisePlan.pv_rate(:business, 50_000_000) == 1379
-        assert EnterprisePlan.pv_rate(:business, 100_000_000) == 2059
-        assert EnterprisePlan.pv_rate(:business, 200_000_000) == 3259
-        assert EnterprisePlan.pv_rate(:business, 300_000_000) == 4739
-        assert EnterprisePlan.pv_rate(:business, 400_000_000) == 5979
-        assert EnterprisePlan.pv_rate(:business, 500_000_000) == 7459
-        assert EnterprisePlan.pv_rate(:business, 1_000_000_000) == 14_439
-        assert EnterprisePlan.pv_rate(:business, 1_500_000_000) == 14_439
+        assert EnterprisePlan.pv_rate(10_000) == 19
+        assert EnterprisePlan.pv_rate(100_000) == 39
+        assert EnterprisePlan.pv_rate(200_000) == 59
+        assert EnterprisePlan.pv_rate(500_000) == 99
+        assert EnterprisePlan.pv_rate(1_000_000) == 139
+        assert EnterprisePlan.pv_rate(2_000_000) == 179
+        assert EnterprisePlan.pv_rate(5_000_000) == 259
+        assert EnterprisePlan.pv_rate(10_000_000) == 339
+        assert EnterprisePlan.pv_rate(20_000_000) == 639
+        assert EnterprisePlan.pv_rate(50_000_000) == 1379
+        assert EnterprisePlan.pv_rate(100_000_000) == 2059
+        assert EnterprisePlan.pv_rate(200_000_000) == 3259
+        assert EnterprisePlan.pv_rate(300_000_000) == 4739
+        assert EnterprisePlan.pv_rate(400_000_000) == 5979
+        assert EnterprisePlan.pv_rate(500_000_000) == 7459
+        assert EnterprisePlan.pv_rate(1_000_000_000) == 14_439
+        assert EnterprisePlan.pv_rate(1_500_000_000) == 14_439
       end
     end
 


### PR DESCRIPTION
### Changes

Per @metmarkosaric we don't need growth price estimation in CRM anymore; site limit now defaults to 10.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
