### PR TITLE
CRM: allow forceful SSO domain deprovisioning + integration removal

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -99,9 +99,8 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
      )}
   end
 
-  def update(%{tab: "members"}, %{assigns: %{team: team}} = socket) do
-    team_layout = Layout.init(team)
-    {:ok, assign(socket, team_layout: team_layout, tab: "members")}
+  def update(%{tab: "members"}, socket) do
+    {:ok, refresh_members(socket)}
   end
 
   def update(_, socket) do
@@ -239,14 +238,27 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
         </div>
 
         <div :if={@tab == "sso"} class="mt-4 mb-4 text-gray-900 dark:text-gray-400">
-          <p :if={@sso_integration} class="mb-4">
-            Configured?: <code>{SSO.Integration.configured?(@sso_integration)}</code>
-            <br /> IDP Signin URL:
-            <code>
-              {@sso_integration.config.idp_signin_url}
-            </code>
-            <br />IDP Entity ID: <code>{@sso_integration.config.idp_entity_id}</code>
-          </p>
+          <div :if={@sso_integration} class="flex gap-x-8 mb-4 justify-between items-start">
+            <p>
+              Configured?: <code>{SSO.Integration.configured?(@sso_integration)}</code>
+              <br /> IDP Signin URL:
+              <code>
+                {@sso_integration.config.idp_signin_url}
+              </code>
+              <br />IDP Entity ID: <code>{@sso_integration.config.idp_entity_id}</code>
+            </p>
+            <div class="ml-auto">
+              <.button
+                data-confirm="Are you sure you want to remove this SSO team integration, including all its domains and users?"
+                id="remove-sso-integration"
+                phx-click="remove-sso-integration"
+                phx-target={@myself}
+                theme="danger"
+              >
+                Remove Integration
+              </.button>
+            </div>
+          </div>
           <.table
             :if={not Enum.empty?(@sso_integration.sso_domains)}
             rows={@sso_integration.sso_domains}
@@ -271,13 +283,12 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
               </.td>
               <.td actions>
                 <.delete_button
-                  :if={can_delete?(sso_domain)}
-                  id={"remove-domain-#{sso_domain.identifier}"}
-                  phx-click="remove-domain"
+                  id={"remove-sso-domain-#{sso_domain.identifier}"}
+                  phx-click="remove-sso-domain"
                   phx-value-identifier={sso_domain.identifier}
                   phx-target={@myself}
                   class="text-sm text-red-600"
-                  data-confirm={"Are you sure you want to remove domain '#{sso_domain.domain}'?"}
+                  data-confirm={"Are you sure you want to remove domain '#{sso_domain.domain}'? All SSO users will be deprovisioned and logged out."}
                 />
               </.td>
             </:tbody>
@@ -540,6 +551,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
           <.table rows={Layout.sorted_for_display(@team_layout)}>
             <:thead>
               <.th>User</.th>
+              <.th>Sessions</.th>
               <.th>Type</.th>
               <.th>Role</.th>
             </:thead>
@@ -570,13 +582,16 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
                 </div>
               </.td>
               <.td>
+                {@session_counts[member.meta.user.id] || 0}
+              </.td>
+              <.td>
                 <div class="flex items-center gap-x-1">
                   <span :if={member.meta.user.type == :sso}>SSO </span>{member.type}
 
                   <.delete_button
                     :if={member.meta.user.type == :sso}
-                    id={"deprovision-user-#{member.id}"}
-                    phx-click="deprovision-user"
+                    id={"deprovision-sso-user-#{member.id}"}
+                    phx-click="deprovision-sso-user"
                     phx-value-identifier={member.id}
                     phx-target={@myself}
                     class="text-sm"
@@ -655,9 +670,15 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
     end
   end
 
-  def handle_event("remove-domain", %{"identifier" => i}, socket) do
+  def handle_event("remove-sso-integration", _, socket) do
+    :ok = SSO.remove_integration(socket.assigns.sso_integration, force_deprovision?: true)
+    socket = success(socket, "SSO integration removed")
+    {:noreply, assign(socket, sso_integration: nil, tab: "overview")}
+  end
+
+  def handle_event("remove-sso-domain", %{"identifier" => i}, socket) do
     domain = Enum.find(socket.assigns.sso_integration.sso_domains, &(&1.identifier == i))
-    SSO.Domains.remove(domain)
+    :ok = SSO.Domains.remove(domain, force_deprovision?: true)
     {:noreply, assign(socket, sso_integration: get_sso_integration(socket.assigns.team))}
   end
 
@@ -694,14 +715,13 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
     end
   end
 
-  def handle_event("deprovision-user", %{"identifier" => user_id}, socket) do
+  def handle_event("deprovision-sso-user", %{"identifier" => user_id}, socket) do
     [id: String.to_integer(user_id)]
     |> Plausible.Auth.find_user_by()
     |> SSO.deprovision_user!()
 
-    team_layout = Layout.init(socket.assigns.team)
     success(socket, "User deprovisioned")
-    {:noreply, assign(socket, team_layout: team_layout)}
+    {:noreply, refresh_members(socket)}
   end
 
   def handle_event("estimate-cost", %{"enterprise_plan" => params}, socket) do
@@ -1037,14 +1057,22 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
     """
   end
 
-  defp can_delete?(sso_domain) do
-    Plausible.Auth.SSO.Domains.check_can_remove(sso_domain) == :ok
-  end
-
   defp get_sso_integration(team) do
     case SSO.get_integration_for(team) do
       {:error, :not_found} -> nil
       {:ok, integration} -> integration
     end
+  end
+
+  defp refresh_members(socket) do
+    team_layout = Layout.init(socket.assigns.team)
+
+    session_counts =
+      team_layout
+      |> Enum.map(fn {_, entry} -> entry.meta.user end)
+      |> Plausible.Auth.UserSessions.count_for_users()
+      |> Enum.into(%{})
+
+    assign(socket, team_layout: team_layout, session_counts: session_counts, tab: "members")
   end
 end

--- a/lib/plausible/auth/user_sessions.ex
+++ b/lib/plausible/auth/user_sessions.ex
@@ -21,6 +21,19 @@ defmodule Plausible.Auth.UserSessions do
     )
   end
 
+  @spec count_for_users([Auth.User.t()], NaiveDateTime.t()) :: list()
+  def count_for_users(users, now \\ NaiveDateTime.utc_now(:second)) when is_list(users) do
+    Repo.all(
+      from(us in Auth.UserSession,
+        where: us.user_id in ^Enum.map(users, & &1.id),
+        where: us.timeout_at >= ^now,
+        group_by: us.user_id,
+        select: {us.user_id, count(us.id)},
+        order_by: [asc: us.user_id]
+      )
+    )
+  end
+
   on_ee do
     alias Plausible.Teams
 

--- a/test/plausible/auth/user_sessions_test.exs
+++ b/test/plausible/auth/user_sessions_test.exs
@@ -33,6 +33,23 @@ defmodule Plausible.Auth.UserSessionsTest do
     end
   end
 
+  describe "count_for_users/2" do
+    test "counts user sessions" do
+      now = NaiveDateTime.utc_now(:second)
+      thirty_minutes_ago = NaiveDateTime.shift(now, minute: -30)
+
+      u1 = insert(:user)
+      u2 = insert(:user)
+      u3 = insert(:user)
+
+      insert_session(u1, "Recent Device", thirty_minutes_ago)
+      insert_session(u1, "Recent Device 2", thirty_minutes_ago)
+      insert_session(u2, "Recent Device", thirty_minutes_ago)
+
+      assert UserSessions.count_for_users([u1, u2, u3], now) == [{u1.id, 2}, {u2.id, 1}]
+    end
+  end
+
   on_ee do
     describe "list_for_sso_team/1,2" do
       test "lists only SSO member sessions for a given team" do

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -570,7 +570,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         {:ok, domain} = SSO.Domains.add(integration, "sso1.example.com")
         {:ok, lv, _html} = live(conn, open_team(team.id, tab: :sso))
 
-        lv |> element("button#remove-domain-#{domain.identifier}") |> render_click()
+        lv |> element("button#remove-sso-domain-#{domain.identifier}") |> render_click()
         refute render(lv) =~ "sso1.example.com"
       end
 
@@ -597,9 +597,21 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         html = render(lv)
 
         assert text(html) =~ "SSO membership"
-        lv |> element("#deprovision-user-#{user.id}") |> render_click()
+        lv |> element("#deprovision-sso-user-#{user.id}") |> render_click()
 
         assert Plausible.Repo.reload!(user).type == :standard
+      end
+
+      test "removing integration", %{conn: conn, user: user} do
+        team = team_of(user)
+
+        SSO.initiate_saml_integration(team)
+
+        {:ok, lv, _html} = live(conn, open_team(team.id, tab: :sso))
+
+        html = lv |> element("button#remove-sso-integration") |> render_click()
+
+        refute element_exists?(html, ~s|a[href="?tab=sso"]|)
       end
     end
   end


### PR DESCRIPTION
### Changes

This PR:

  - enables SSO domain removal at any time (includes forceful user deprovisioning)
  - enables SSO integration removal (implies domains removal)
  - lists number of active sessions next to each team member (though, sessions are not necessarily team-scoped for standard/non-sso accounts)

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
