### PR TITLE
Stop segments tooltip cutoff

### DIFF
--- a/assets/js/dashboard/nav-menu/filter-menu.tsx
+++ b/assets/js/dashboard/nav-menu/filter-menu.tsx
@@ -48,6 +48,7 @@ const FilterMenuItems = ({ closeDropdown }: { closeDropdown: () => void }) => {
   const site = useSiteContext()
   const columns = useMemo(() => getFilterListItems(site), [site])
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
 
   return (
     <>
@@ -74,6 +75,7 @@ const FilterMenuItems = ({ closeDropdown }: { closeDropdown: () => void }) => {
         )}
       >
         <Popover.Panel
+          ref={panelRef}
           className={classNames(popover.panel.classNames.roundedSheet)}
           data-testid="filtermenu"
         >
@@ -105,7 +107,10 @@ const FilterMenuItems = ({ closeDropdown }: { closeDropdown: () => void }) => {
               </div>
             ))}
           </div>
-          <SearchableSegmentsSection closeList={closeDropdown} />
+          <SearchableSegmentsSection
+            closeList={closeDropdown}
+            tooltipContainerRef={panelRef}
+          />
         </Popover.Panel>
       </Transition>
     </>

--- a/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
+++ b/assets/js/dashboard/nav-menu/segments/searchable-segments-section.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { RefObject } from 'react'
 import { useQueryContext } from '../../query-context'
 import { useSiteContext } from '../../site-context'
 import {
@@ -32,9 +32,11 @@ const linkClassName = classNames(
 const INITIAL_SEGMENTS_SHOWN = 5
 
 export const SearchableSegmentsSection = ({
-  closeList
+  closeList,
+  tooltipContainerRef
 }: {
   closeList: () => void
+  tooltipContainerRef: RefObject<HTMLElement>
 }) => {
   const site = useSiteContext()
   const segmentsContext = useSegmentsContext()
@@ -93,6 +95,7 @@ export const SearchableSegmentsSection = ({
         {showableData.map((segment) => {
           return (
             <Tooltip
+              containerRef={tooltipContainerRef}
               className="group"
               key={segment.id}
               info={
@@ -122,7 +125,11 @@ export const SearchableSegmentsSection = ({
           )
         })}
         {countOfMoreToShow > 0 && (
-          <Tooltip className="group" info={null}>
+          <Tooltip
+            className="group"
+            info={null}
+            containerRef={tooltipContainerRef}
+          >
             <button
               className={classNames(
                 linkClassName,
@@ -137,7 +144,11 @@ export const SearchableSegmentsSection = ({
         )}
       </div>
       {searching && !filteredData.length && (
-        <Tooltip className="group" info={null}>
+        <Tooltip
+          className="group"
+          info={null}
+          containerRef={tooltipContainerRef}
+        >
           <button
             className={classNames(
               linkClassName,


### PR DESCRIPTION
### Changes

Renders tooltips in searchable segment menu outside the scrollable container using createPortal to stop them from being cut off.

### Tests
- [x] Manual tests Chrome, Firefox, Safari, Edge, mobile instances

### Changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
