### PR TITLE
Script v2: Do not send Form: Submission events for tagged forms

### DIFF
--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Do not send "Form: Submission" event if the form is tagged
+
 ## [0.3.0] - 2025-06-27
 
 - Remove now unnecessary navigation delays on link clicks and form submissions.

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 21,
+  "tracker_script_version": 22,
   "type": "module",
   "scripts": {
     "deploy": "node compile.js",

--- a/tracker/src/custom-events.js
+++ b/tracker/src/custom-events.js
@@ -187,6 +187,10 @@ export function init() {
   if (COMPILE_CONFIG && config.formSubmissions) {
     function trackFormSubmission(e) {
       if (e.target.hasAttribute('novalidate') || e.target.checkValidity()) {
+        if (COMPILE_TAGGED_EVENTS && isElementOrParentTagged(e.target, 0)) {
+          // If the form is tagged, we don't track it as a generic form submission.
+          return
+        }
         track('Form: Submission', { props: { path: location.pathname } });
       }
     }

--- a/tracker/test/features-hierarchy-on-overlap.spec.ts
+++ b/tracker/test/features-hierarchy-on-overlap.spec.ts
@@ -10,6 +10,7 @@ import { LOCAL_SERVER_ADDR } from './support/server'
 import { initializePageDynamically } from './support/initialize-page-dynamically'
 import { mockManyRequests } from './support/mock-many-requests'
 import { ScriptConfig } from './support/types'
+import { customSubmitHandlerStub } from './support/html-fixtures'
 
 const DEFAULT_CONFIG: ScriptConfig = {
   domain: 'example.com',
@@ -17,7 +18,7 @@ const DEFAULT_CONFIG: ScriptConfig = {
   captureOnLocalhost: true
 }
 
-for (const mode of ['legacy', 'web']) {
+for (const mode of ['legacy', 'web'] as const) {
   test.describe(`outbound links, file downloads, tagged events features hierarchy on overlap legacy/v2 parity (${mode})`, () => {
     test('sends only tagged event if the link is a tagged outbound download link', async ({
       page
@@ -156,7 +157,7 @@ for (const mode of ['legacy', 'web']) {
   })
 }
 
-for (const mode of ['web', 'esm']) {
+for (const mode of ['web', 'esm'] as const) {
   test.describe(`form submissions and tagged events features hierarchy on overlap v2-specific (${mode})`, () => {
     test('sends only tagged event if a form is tagged', async ({
       page
@@ -224,7 +225,7 @@ for (const mode of ['web', 'esm']) {
         ),
         bodyContent: `
           <div class="plausible-event-name--A+Tagged+Form">
-            <form onsubmit="event.preventDefault(); console.log('Form submitted');">
+            <form onsubmit="${customSubmitHandlerStub}">
               <input type="email" />
             </form>
           </div>

--- a/tracker/test/form-submissions.spec.ts
+++ b/tracker/test/form-submissions.spec.ts
@@ -1,6 +1,7 @@
-import { test, Page } from '@playwright/test'
+import { test } from '@playwright/test'
 import { LOCAL_SERVER_ADDR } from './support/server'
 import {
+  ensurePlausibleInitialized,
   expectPlausibleInAction,
   isEngagementEvent,
   isPageviewEvent
@@ -21,12 +22,10 @@ test('does not track form submissions when the feature is disabled', async ({
     testId,
     scriptConfig: DEFAULT_CONFIG,
     bodyContent: `
-      <div>
-        <form>
-          <input type="text" /><input type="submit" value="Submit" />
-        </form>
-      </div>
-      `
+      <form>
+        <input type="text" /><input type="submit" value="Submit" />
+      </form>
+    `
   })
 
   await expectPlausibleInAction(page, {
@@ -52,11 +51,9 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form method="GET">
           <input id="name" type="text" placeholder="Name" /><input type="submit" value="Submit" />
         </form>
-      </div>
       `
     })
 
@@ -84,11 +81,9 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form onsubmit="${customSubmitHandlerStub}">
           <input type="text" /><input type="submit" value="Submit" />
         </form>
-      </div>
       `
     })
 
@@ -154,12 +149,10 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form novalidate onsubmit="${customSubmitHandlerStub}">
           <input type="email" />
           <input type="submit" value="Submit" />
         </form>
-      </div>
       `
     })
 
@@ -188,12 +181,10 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form>
           <input type="email" />
           <input type="submit" value="Submit" />
         </form>
-      </div>
       `
     })
 
@@ -221,12 +212,10 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form id="form">
           <input type="text" placeholder="Name" />
         </form>
         <button id="trigger-FormElement-submit" onclick="document.getElementById('form').submit()">Submit</button>
-      </div>
       `
     })
 
@@ -254,7 +243,6 @@ test.describe('form submissions feature is enabled', () => {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
       bodyContent: `
-      <div>
         <form onsubmit="${customSubmitHandlerStub}">
           <h2>Form 1</h2>
           <input type="text" /><input type="submit" value="Submit" />
@@ -263,7 +251,6 @@ test.describe('form submissions feature is enabled', () => {
           <h2>Form 2</h2>
           <input type="email" />
         </form>
-      </div>
       `
     })
 
@@ -297,14 +284,6 @@ test.describe('form submissions feature is enabled', () => {
     })
   })
 })
-/**
- * This function ensures that the tracker script has attached the event listener before test is run.
- * Note that this race condition happens in the real world as well:
- * forms submitted before the tracker script is initialized will not be tracked.
- */
-function ensurePlausibleInitialized(page: Page) {
-  return page.waitForFunction(() => (window as any).plausible?.l === true)
-}
 
 /**
  * This is a stub for custom form onsubmit handlers Plausible users may have on their websites.

--- a/tracker/test/form-submissions.spec.ts
+++ b/tracker/test/form-submissions.spec.ts
@@ -8,6 +8,7 @@ import {
 } from './support/test-utils'
 import { initializePageDynamically } from './support/initialize-page-dynamically'
 import { ScriptConfig } from './support/types'
+import { customSubmitHandlerStub } from './support/html-fixtures'
 
 const DEFAULT_CONFIG: ScriptConfig = {
   domain: 'example.com',
@@ -284,10 +285,3 @@ test.describe('form submissions feature is enabled', () => {
     })
   })
 })
-
-/**
- * This is a stub for custom form onsubmit handlers Plausible users may have on their websites.
- * Overriding onsubmit with a custom handler is common practice in web development for a variety of reasons (mostly UX),
- * so it's important to track form submissions from forms with such handlers.
- */
-const customSubmitHandlerStub = "event.preventDefault(); console.log('Form submitted')"

--- a/tracker/test/support/html-fixtures.ts
+++ b/tracker/test/support/html-fixtures.ts
@@ -1,0 +1,6 @@
+/**
+ * This is a stub for custom form onsubmit handlers Plausible users may have on their websites.
+ * Overriding onsubmit with a custom handler is common practice in web development for a variety of reasons (mostly UX),
+ * so this stub can be used in tests to simulate such behavior.
+ */
+export const customSubmitHandlerStub = "event.preventDefault(); console.log('Submitted')"

--- a/tracker/test/support/test-utils.js
+++ b/tracker/test/support/test-utils.js
@@ -203,3 +203,14 @@ export function switchByMode(cases, mode) {
       throw new Error(`Unimplemented mode: ${mode}`)
   }
 }
+
+/**
+ * This function ensures that the tracker script has attached the event listener before test is run.
+ * Note that this race condition happens in the real world as well:
+ * Events from features like form submissions, file downloads, outbound links, tagged events 
+ * that work with event handlers registered on the document
+ * will not be tracked if the event happens before the tracker script has attached the event listener.
+ */
+export function ensurePlausibleInitialized(page) {
+  return page.waitForFunction(() =>(window.plausible?.l === true))
+}

--- a/tracker/test/support/types.ts
+++ b/tracker/test/support/types.ts
@@ -1,7 +1,7 @@
 export type Options = {
   hashBasedRouting: boolean
   outboundLinks: boolean
-  fileDownloads: boolean | string[]
+  fileDownloads: boolean | { fileExtensions: string[] }
   formSubmissions: boolean
   captureOnLocalhost: boolean
   autoCapturePageviews: boolean

--- a/tracker/test/tagged-events.spec.ts
+++ b/tracker/test/tagged-events.spec.ts
@@ -527,7 +527,7 @@ test.describe('tagged events feature when using legacy .compat extension', () =>
     const [[, trackingResponseTime], [, navigationTime]] =
       await resolveWithTimestamps([trackingPromise, navigationPromise])
     await expect(page.getByText('Subscription successful')).toBeVisible()
-    expect(trackingResponseTime).toBeLessThan(navigationTime)
+    expect(trackingResponseTime).toBeLessThanOrEqual(navigationTime)
     await expect(eventsApiMock.getRequestList()).resolves.toEqual([
       expect.objectContaining({
         n: 'Subscribe',


### PR DESCRIPTION
### Changes

- Stops duplicate events if formSubmissions tracking is enabled and the form is tagged.

- Also removes some noise from formSubmissions tests

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
