### PR TITLE
ScriptV2: Serve scriptv2 under /t/<id>.js over /js/s-<id>.js

### DIFF
--- a/extra/lib/plausible_web/dogfood.ex
+++ b/extra/lib/plausible_web/dogfood.ex
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Dogfood do
 
         env in ["dev", "ce_dev"] ->
           # By default we're not letting the app track itself on localhost.
-          # The requested script will be `s-.js` and it will respond with 404.
+          # The requested script will be `t/.js` and it will respond with 404.
           # If you wish to track the app itself, uncomment the following line
           # and replace the site_id if necessary (1 stands for dummy.site).
 
@@ -44,7 +44,7 @@ defmodule PlausibleWeb.Dogfood do
           ""
       end
 
-    "#{PlausibleWeb.Endpoint.url()}/js/s-#{tracker_script_config_id}.js"
+    "#{PlausibleWeb.Endpoint.url()}/t/#{tracker_script_config_id}.js"
   end
 
   # TRICKY: The React dashboard uses history-based SPA navigation

--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -428,7 +428,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
   end
 
   defp tracker_url(tracker_script_configuration) do
-    "https://plausible.io/js/s-#{tracker_script_configuration.id}.js"
+    "https://plausible.io/t/#{tracker_script_configuration.id}.js"
   end
 
   defp script_icon(assigns) do

--- a/lib/plausible_web/plugs/tracker_plug.ex
+++ b/lib/plausible_web/plugs/tracker_plug.ex
@@ -40,10 +40,17 @@ defmodule PlausibleWeb.TrackerPlug do
 
   def call(conn, files_available: files_available) do
     case conn.request_path do
+      "/t/" <> path ->
+        if String.ends_with?(path, ".js") do
+          request_tracker_script(path, conn)
+        else
+          conn
+        end
+
+      # Legacy path: Can be removed once we've updated GTM template
       "/js/s-" <> path ->
         if String.ends_with?(path, ".js") do
-          tag = String.replace_trailing(path, ".js", "")
-          request_tracker_script(tag, conn)
+          request_tracker_script(path, conn)
         else
           conn
         end
@@ -61,7 +68,8 @@ defmodule PlausibleWeb.TrackerPlug do
 
   def telemetry_event(name), do: [:plausible, :tracker_script, :request, name]
 
-  defp request_tracker_script(tag, conn) do
+  defp request_tracker_script(path, conn) do
+    tag = String.replace_trailing(path, ".js", "")
     script_tag = get_plausible_web_script_tag(tag)
 
     if script_tag do

--- a/test/plausible_web/plugs/tracker_plug_test.exs
+++ b/test/plausible_web/plugs/tracker_plug_test.exs
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.TrackerPlugTest do
           :installation
         )
 
-      response = get(conn, "/js/s-#{tracker_script_configuration.id}.js") |> response(200)
+      response = get(conn, "/t/#{tracker_script_configuration.id}.js") |> response(200)
 
       assert String.contains?(response, "!function(){var")
       assert String.contains?(response, "domain:\"#{site.domain}\"")
@@ -62,14 +62,14 @@ defmodule PlausibleWeb.TrackerPlugTest do
           :installation
         )
 
-      response = get(conn, "/js/s-#{tracker_script_configuration.id}.js") |> response(200)
+      response = get(conn, "/t/#{tracker_script_configuration.id}.js") |> response(200)
 
       assert String.contains?(response, "window.plausible")
     end
 
     test "returns 404 for unknown site", %{conn: conn} do
       conn
-      |> get("/js/s-a14125a2-000-000-0000-000000000000.js")
+      |> get("/t/a14125a2-000-000-0000-000000000000.js")
       |> response(404)
     end
   end


### PR DESCRIPTION
We've already had confusion that the s-<id> was the id, hence the new pathing.

There's also a fallback until we have updated the GTM template.

Companion PRs:
- https://github.com/plausible/website/pull/818
- https://github.com/plausible/docs/pull/617

@ukutaht is taking over this PR.