### PR TITLE
Increase trial team member limit to 10

### DIFF
--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -255,7 +255,7 @@ defmodule Plausible.Teams.Billing do
   end
 
   on_ee do
-    @team_member_limit_for_trials 3
+    @team_member_limit_for_trials 10
 
     def team_member_limit(nil) do
       @team_member_limit_for_trials

--- a/test/plausible/auth/sso_test.exs
+++ b/test/plausible/auth/sso_test.exs
@@ -426,6 +426,8 @@ defmodule Plausible.Auth.SSOTest do
         domain: domain,
         team: team
       } do
+        insert(:growth_subscription, team: team)
+
         add_member(team, role: :viewer)
         add_member(team, role: :viewer)
         add_member(team, role: :viewer)

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -440,10 +440,10 @@ defmodule Plausible.Billing.QuotaTest do
         assert :unlimited == Plausible.Teams.Billing.team_member_limit(team)
       end
 
-      test "returns 5 when user in on trial" do
+      test "returns 10 when user in on trial" do
         team = new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: 7)) |> team_of()
 
-        assert 3 == Plausible.Teams.Billing.team_member_limit(team)
+        assert 10 == Plausible.Teams.Billing.team_member_limit(team)
       end
 
       test "returns the enterprise plan limit" do

--- a/test/plausible/teams/invitations/invite_to_site_test.exs
+++ b/test/plausible/teams/invitations/invite_to_site_test.exs
@@ -70,6 +70,8 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
     test "returns error when owner is over their team member limit" do
       [owner, inviter, invitee] = for _ <- 1..3, do: new_user()
 
+      subscribe_to_growth_plan(owner)
+
       site = new_site(owner: owner)
       inviter = add_member(site.team, user: inviter, role: :admin)
       for _ <- 1..4, do: add_guest(site, role: :viewer)
@@ -81,6 +83,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
     @tag :ee_only
     test "allows inviting users who were already invited to other sites, within the limit" do
       owner = new_user()
+      subscribe_to_growth_plan(owner)
       site = new_site(owner: owner)
 
       invite = fn site, email ->
@@ -100,6 +103,8 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
     @tag :ee_only
     test "allows inviting users who are already members of other sites, within the limit" do
       [u1, u2, u3, u4] = for _ <- 1..4, do: new_user()
+      subscribe_to_growth_plan(u1)
+
       site = new_site(owner: u1)
       add_guest(site, user: u2, role: :viewer)
       add_guest(site, user: u3, role: :viewer)

--- a/test/plausible/teams/invitations/invite_to_team_test.exs
+++ b/test/plausible/teams/invitations/invite_to_team_test.exs
@@ -168,6 +168,7 @@ defmodule Plausible.Teams.Invitations.InviteToTeamTest do
     @tag :ee_only
     test "returns error when owner is over their team member limit" do
       [owner, inviter, invitee] = for _ <- 1..3, do: new_user()
+      subscribe_to_growth_plan(owner)
       _site = new_site(owner: owner)
       team = team_of(owner)
       inviter = add_member(team, user: inviter, role: :admin)

--- a/test/plausible/teams/management/layout_test.exs
+++ b/test/plausible/teams/management/layout_test.exs
@@ -308,6 +308,8 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
     test "limits are checked", %{user: user, team: team} do
       on_ee do
+        subscribe_to_growth_plan(user)
+
         assert {:error, {:over_limit, 3}} =
                  team
                  |> Layout.init()

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     test "display a notice when is over limit", %{conn: conn, user: user} do
       site = new_site(owner: user)
 
-      for _ <- 1..5 do
+      for _ <- 1..11 do
         add_guest(site, role: :viewer)
       end
 
@@ -40,7 +40,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
         |> html_response(200)
 
       assert text_of_element(html, ~s/[data-test="limit-exceeded-notice"]/) =~
-               "This account is limited to 3 members"
+               "This account is limited to 10 members"
     end
   end
 
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
     test "fails to create invitation when is over limit", %{conn: conn, user: user} do
       site = new_site(owner: user)
 
-      for _ <- 1..5 do
+      for _ <- 1..11 do
         add_guest(site, role: :viewer)
       end
 
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
         })
 
       assert html_response(conn, 200) =~
-               "Your account is limited to 3 team members. You can upgrade your plan to increase this limit."
+               "Your account is limited to 10 team members. You can upgrade your plan to increase this limit."
     end
 
     test "fails to create invitation with insufficient permissions", %{conn: conn, user: user} do

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -178,6 +178,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
     @tag :ee_only
     test "fails to save layout with limits breached", %{conn: conn, team: team} do
+      insert(:growth_subscription, team: team)
+
       lv = get_liveview(conn)
       add_invite(lv, "new1@example.com", "admin")
       add_invite(lv, "new2@example.com", "admin")
@@ -205,6 +207,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       user: user,
       team: team
     } do
+      insert(:growth_subscription, team: team)
+
       member2 = add_member(team, role: :admin)
       _invitation = invite_member(team, "sent@example.com", inviter: user, role: :viewer)
 

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -215,7 +215,9 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
     end
 
     @tag :ee_only
-    test "fails to save layout with limits breached", %{conn: conn} do
+    test "fails to save layout with limits breached", %{conn: conn, team: team} do
+      insert(:growth_subscription, team: team)
+
       lv = get_child_lv(conn)
       html = render(lv)
       refute attr_defined?(html, ~s|#team-layout-form input[name="input-email"]|, "readonly")

--- a/test/plausible_web/user_auth_test.exs
+++ b/test/plausible_web/user_auth_test.exs
@@ -158,6 +158,7 @@ defmodule PlausibleWeb.UserAuthTest do
         user: user
       } do
         team = new_site().team
+        insert(:growth_subscription, team: team)
         integration = SSO.initiate_saml_integration(team)
         domain = "example-#{Enum.random(1..10_000)}.com"
         add_member(team, role: :viewer)


### PR DESCRIPTION
### Changes

With the new plans, it makes sense for trials to have the same team member limit as Business tiers. They already have the same number of sites allowed (10). Ref: https://3.basecamp.com/5308029/buckets/41857003/card_tables/cards/8788606725

### Tests
- [X] Automated tests have been adjusted

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
