### PR TITLE
Improve SSO naming and setup

### DIFF
--- a/extra/lib/plausible/auth/sso.ex
+++ b/extra/lib/plausible/auth/sso.ex
@@ -134,7 +134,7 @@ defmodule Plausible.Auth.SSO do
              :no_integration
              | :no_domain
              | :no_verified_domain
-             | :owner_mfa_disabled
+             | :owner_2fa_disabled
              | :no_sso_user}
   def set_force_sso(team, mode) do
     with :ok <- check_force_sso(team, mode) do
@@ -153,14 +153,14 @@ defmodule Plausible.Auth.SSO do
              :no_integration
              | :no_domain
              | :no_verified_domain
-             | :owner_mfa_disabled
+             | :owner_2fa_disabled
              | :no_sso_user}
   def check_force_sso(_team, :none), do: :ok
 
   def check_force_sso(team, :all_but_owners) do
     with :ok <- check_integration_configured(team),
          :ok <- check_sso_user_present(team) do
-      check_owners_mfa_enabled(team)
+      check_owners_2fa_enabled(team)
     end
   end
 
@@ -300,8 +300,8 @@ defmodule Plausible.Auth.SSO do
     end
   end
 
-  defp check_owners_mfa_enabled(team) do
-    disabled_mfa_count =
+  defp check_owners_2fa_enabled(team) do
+    disabled_2fa_count =
       Repo.aggregate(
         from(
           tm in Teams.Membership,
@@ -313,10 +313,10 @@ defmodule Plausible.Auth.SSO do
         :count
       )
 
-    if disabled_mfa_count == 0 do
+    if disabled_2fa_count == 0 do
       :ok
     else
-      {:error, :owner_mfa_disabled}
+      {:error, :owner_2fa_disabled}
     end
   end
 

--- a/extra/lib/plausible/auth/sso/saml_config.ex
+++ b/extra/lib/plausible/auth/sso/saml_config.ex
@@ -85,11 +85,19 @@ defmodule Plausible.Auth.SSO.SAMLConfig do
   end
 
   defp clean_pem(pem) do
-    pem
-    |> String.split("\n")
-    |> Enum.map(&String.trim/1)
-    |> Enum.reject(&(&1 == ""))
-    |> Enum.join("\n")
-    |> String.trim()
+    cleaned =
+      pem
+      |> String.split("\n")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.join("\n")
+      |> String.trim()
+
+    # Trying to account for PEM certificates without markers
+    if String.starts_with?(cleaned, "-----BEGIN CERTIFICATE-----") do
+      cleaned
+    else
+      "-----BEGIN CERTIFICATE-----\n" <> cleaned <> "\n-----END CERTIFICATE-----"
+    end
   end
 end

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -225,7 +225,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
           :if={@domain.status in [Status.in_progress(), Status.unverified(), Status.verified()]}
           type="submit"
         >
-          Run verification now
+          Run Verification Now
         </.button>
 
         <.button :if={@domain.status == Status.pending()} type="submit">Continue</.button>

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -26,7 +26,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
     ~H"""
     <.flash_messages flash={@flash} />
 
-    <.tile :if={@mode != :manage} docs="sso">
+    <.tile :if={@mode != :manage} docs={if @mode in [:domain_setup, :domain_verify], do: "sso#sso-domains", else: "sso"}>
       <:title>
         <a id="sso-config">Single Sign-On</a>
       </:title>
@@ -311,7 +311,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
       </div>
     </.tile>
 
-    <.tile docs="sso">
+    <.tile docs="sso#sso-domains">
       <:title>
         <a id="sso-domains-config">SSO Domains</a>
       </:title>

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -379,7 +379,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
       </div>
     </.tile>
 
-    <.tile docs="sso">
+    <.tile docs="sso#sso-policy">
       <:title>
         <a id="sso-policy-config">SSO Policy</a>
       </:title>

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -74,7 +74,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
     ~H"""
     <form id="sso-init" for={} phx-submit="init-sso">
       <p class="text-sm">
-        Single Sign-On (SSO) enables team members to sign in without having to register an account. For more details, 
+        Single Sign-On (SSO) enables team members to sign in without having to register an account. For more details,
         <.styled_link href="https://plausible.io/docs/sso">see our documentation</.styled_link>.
       </p>
 

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -678,8 +678,8 @@ defmodule PlausibleWeb.Live.SSOManagement do
         {{:error, :no_verified_domain}, _} ->
           {false, "you must verify a domain"}
 
-        {{:error, :owner_mfa_disabled}, _} ->
-          {false, "all Owners must have MFA enabled"}
+        {{:error, :owner_2fa_disabled}, _} ->
+          {false, "all Owners must have 2FA enabled"}
 
         {{:error, :no_sso_user}, _} ->
           {false, "at least one SSO user must log in successfully"}

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -93,7 +93,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
       <.input_with_clipboard
         id="sp-acs-url"
         name="sp-acs-url"
-        label="ACS URL / Single sign-on URL / Reply URL"
+        label="ACS URL / Single Sign-On URL / Reply URL"
         value={saml_acs_url(@integration)}
       />
 
@@ -253,7 +253,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
           <.input_with_clipboard
             id="sp-acs-url"
             name="sp-acs-url"
-            label="ACS URL / Single sign-on URL / Reply URL"
+            label="ACS URL / Single Sign-On URL / Reply URL"
             value={saml_acs_url(@integration)}
           />
 
@@ -681,7 +681,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
           {false, "you must be logged in via SSO"}
 
         {{:error, :no_integration}, _} ->
-          {false, "you must first setup Single Sign-on"}
+          {false, "you must first setup Single Sign-On"}
 
         {{:error, :no_domain}, _} ->
           {false, "you must add a domain"}

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -26,7 +26,10 @@ defmodule PlausibleWeb.Live.SSOManagement do
     ~H"""
     <.flash_messages flash={@flash} />
 
-    <.tile :if={@mode != :manage} docs={if @mode in [:domain_setup, :domain_verify], do: "sso#sso-domains", else: "sso"}>
+    <.tile
+      :if={@mode != :manage}
+      docs={if @mode in [:domain_setup, :domain_verify], do: "sso#sso-domains", else: "sso"}
+    >
       <:title>
         <a id="sso-config">Single Sign-On</a>
       </:title>

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -73,7 +73,10 @@ defmodule PlausibleWeb.Live.SSOManagement do
   def init_view(assigns) do
     ~H"""
     <form id="sso-init" for={} phx-submit="init-sso">
-      <p class="text-sm">Click below to start setting up Single Sign-On for your team.</p>
+      <p class="text-sm">
+        Single Sign-On (SSO) enables team members to sign in without having to register an account. For more details, 
+        <.styled_link href="https://plausible.io/docs/sso">see our documentation</.styled_link>.
+      </p>
 
       <.button type="submit">Start Configuring SSO</.button>
     </form>

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -87,24 +87,24 @@ defmodule PlausibleWeb.Live.SSOManagement do
         Use the following parameters when configuring your Identity Provider of choice:
       </p>
 
+      <.input_with_clipboard
+        id="sp-acs-url"
+        name="sp-acs-url"
+        label="ACS URL / Single sign-on URL / Reply URL"
+        value={saml_acs_url(@integration)}
+      />
+
       <.form id="sso-sp-config" for={} class="flex-col space-y-4">
         <.input_with_clipboard
           id="sp-entity-id"
           name="sp-entity-id"
-          label="Entity ID"
+          label="Entity ID / Audience URI / Identifier"
           value={SSO.SAMLConfig.entity_id(@integration)}
-        />
-
-        <.input_with_clipboard
-          id="sp-acs-url"
-          name="sp-acs-url"
-          label="ACS URL"
-          value={saml_acs_url(@integration)}
         />
       </.form>
 
       <div class="flex-col space-y-3">
-        <p class="text-sm">Following attribute mappings must be setup at Identity Provider:</p>
+        <p class="text-sm">Following attribute mappings must be set up at Identity Provider:</p>
 
         <ul role="list" class="list-disc leading-6 text-sm ml-8">
           <li :for={param <- ["email", "first_name", "last_name"]}>
@@ -136,11 +136,19 @@ defmodule PlausibleWeb.Live.SSOManagement do
         class="flex-col space-y-4"
         phx-submit="update-integration"
       >
-        <.input field={f[:idp_signin_url]} label="Sign-in URL" placeholder="<URL>" />
+        <.input
+          field={f[:idp_signin_url]}
+          label="SSO URL / Sign-on URL / Login URL"
+          placeholder="<URL>"
+        />
 
-        <.input field={f[:idp_entity_id]} label="Entity ID" placeholder="<Entity ID>" />
+        <.input
+          field={f[:idp_entity_id]}
+          label="Entity ID / Issuer / Identifier"
+          placeholder="<Entity ID>"
+        />
 
-        <.input field={f[:idp_cert_pem]} type="textarea" label="Certificate in PEM format" />
+        <.input field={f[:idp_cert_pem]} type="textarea" label="Signing Certificate in PEM format" />
 
         <.button type="submit">Save</.button>
       </.form>
@@ -240,17 +248,17 @@ defmodule PlausibleWeb.Live.SSOManagement do
 
         <form id="sso-sp-config" for={} class="flex-col space-y-4">
           <.input_with_clipboard
-            id="sp-entity-id"
-            name="sp-entity-id"
-            label="Entity ID"
-            value={SSO.SAMLConfig.entity_id(@integration)}
+            id="sp-acs-url"
+            name="sp-acs-url"
+            label="ACS URL / Single sign-on URL / Reply URL"
+            value={saml_acs_url(@integration)}
           />
 
           <.input_with_clipboard
-            id="sp-acs-url"
-            name="sp-acs-url"
-            label="ACS URL"
-            value={saml_acs_url(@integration)}
+            id="sp-entity-id"
+            name="sp-entity-id"
+            label="Entity ID / Audience URI / Identifier"
+            value={SSO.SAMLConfig.entity_id(@integration)}
           />
         </form>
 
@@ -273,21 +281,21 @@ defmodule PlausibleWeb.Live.SSOManagement do
             <.input
               field={f[:idp_signin_url]}
               value={@integration.config.idp_signin_url}
-              label="Sign-in URL"
+              label="SSO URL / Sign-on URL / Login URL"
               readonly={true}
             />
 
             <.input
               field={f[:idp_entity_id]}
               value={@integration.config.idp_entity_id}
-              label="Entity ID"
+              label="Entity ID / Issuer / Identifier"
               readonly={true}
             />
 
             <.input
               field={f[:idp_cert_pem]}
               type="textarea"
-              label="Certificate in PEM format"
+              label="Signing Certificate in PEM format"
               value={@integration.config.idp_cert_pem}
               readonly={true}
             />

--- a/extra/lib/plausible_web/templates/sso/login_form.html.heex
+++ b/extra/lib/plausible_web/templates/sso/login_form.html.heex
@@ -1,6 +1,6 @@
 <.focus_box>
   <:title>
-    {Phoenix.Flash.get(@flash, :login_title) || "Enter your Single Sign-on email"}
+    {Phoenix.Flash.get(@flash, :login_title) || "Enter your Single Sign-On email"}
   </:title>
   <:subtitle>
     <%= if Phoenix.Flash.get(@flash, :login_instructions) do %>

--- a/extra/lib/plausible_web/templates/sso/saml_signin.html.heex
+++ b/extra/lib/plausible_web/templates/sso/saml_signin.html.heex
@@ -12,7 +12,7 @@
     </script>
     <div>
       <h1>
-        Processing Single Sign-on request...
+        Processing Single Sign-On request...
       </h1>
       <noscript>
         <p>

--- a/extra/lib/plausible_web/templates/sso/team_sessions.html.heex
+++ b/extra/lib/plausible_web/templates/sso/team_sessions.html.heex
@@ -1,5 +1,5 @@
 <.settings_tiles>
-  <.tile docs="sso-login-management">
+  <.tile docs="sso#team-management">
     <:title>
       <a id="user-sessions">SSO Login Management</a>
     </:title>

--- a/lib/plausible/auth/auth.ex
+++ b/lib/plausible/auth/auth.ex
@@ -13,6 +13,8 @@ defmodule Plausible.Auth do
   alias Plausible.RateLimit
   alias Plausible.Teams
 
+  require Logger
+
   @rate_limits %{
     login_ip: %{
       prefix: "login:ip",
@@ -50,6 +52,15 @@ defmodule Plausible.Auth do
       {:allow, _} -> :ok
       {:deny, _} -> {:error, {:rate_limit, limit_type}}
     end
+  end
+
+  @spec log_failed_login_attempt(String.t()) :: :ok
+  def log_failed_login_attempt(message) do
+    if Application.get_env(:plausible, :log_failed_login_attempts) do
+      Logger.warning("[login] #{message}")
+    end
+
+    :ok
   end
 
   @spec find_user_by(Keyword.t()) :: Auth.User.t() | nil

--- a/lib/plausible/teams/memberships/update_role.ex
+++ b/lib/plausible/teams/memberships/update_role.ex
@@ -51,7 +51,7 @@ defmodule Plausible.Teams.Memberships.UpdateRole do
   on_ee do
     defp check_can_promote_to_owner(team, user, :owner) do
       if team.policy.force_sso == :all_but_owners and not Plausible.Auth.TOTP.enabled?(user) do
-        {:error, :mfa_disabled}
+        {:error, :disabled_2fa}
       else
         :ok
       end
@@ -66,7 +66,7 @@ defmodule Plausible.Teams.Memberships.UpdateRole do
       if :erlang.phash2(1, 1) == 0 do
         :ok
       else
-        {:error, :mfa_disabled}
+        {:error, :disabled_2fa}
       end
     end
   end

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -315,7 +315,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
           "The team has to have at least one owner"
         )
 
-      {{:error, :mfa_disabled}, _} ->
+      {{:error, :disabled_2fa}, _} ->
         socket
         |> put_live_flash(
           :error,

--- a/test/plausible/auth/sso_test.exs
+++ b/test/plausible/auth/sso_test.exs
@@ -111,6 +111,49 @@ defmodule Plausible.Auth.SSOTest do
                  X509.Certificate.from_pem(@cert_pem)
       end
 
+      test "updates integration with PEM missing boundaries" do
+        boundless_pem =
+          "MIIDqjCCApKgAwIBAgIGAZfpTJclMA0GCSqGSIb3DQEBCwUAMIGVMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFjAUBgNVBAMMDXRyaWFsLTU1OTk4NzkxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wHhcNMjUwNzA4MDkwOTAwWhcNMzUwNzA4MDkxMDAwWjCBlTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRYwFAYDVQQDDA10cmlhbC01NTk5ODc5MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzmF1LGsjEQkdLfCR6epCX5uKaJnowd3ZE8/t+kPiW0TIIvp4a3bH7r+pBbbili7Wz8LRs6C99RmtG4KjfBd6IAS1vYVba1RJ3XkoiIfVeDCP5sXKPyRquNj1/gyZkYxTYZVnh3ibXXUmlIkCDrF0TeO+4VfrWXQlc5/vNz7fbhH3bYCFj8jy3tKqXsE18X5USALRH22K4N2ZcGujNMwxzXIqGkPyPfRpnSY+AS8tGnW36Xn4WnKs9ciAnmTtTMXNrGrc6OLkbAEKLxSegpV9oSugChZ21siJXFf2Xz3jp71C12kbEDCXQ8Xi86iS3PnBYvp2ThT0Qiby1vscdNGaUwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCEbceBacHt0sx6Q0sU68E6CyyEfYVHPUOxLwBq4lrqeh9b0fctNuyFAceJbejIto9sqQ+RQzqob5PGfNpFanPbrcOx5F4NLgS9keR/bJGetSfiQe0nw/2ikNd7O0mWeWo1LvRtTGOAS2o3NTkLv3W1mxCkgjbi24hQs6eR5ARY6//AqYQWwWIDMIZotuIuRh285A8Gn1Vxj6ApWski3jttCLzU7NDJU7I6CXfzbDdEpr9I18CEZ7oOei/61q4wNq/x3CT4TsbDnVLVcYs0qqe/EKwQ6alqkHqlp2zxThOVvMW6tz0X8hNnxrXmmZdp7WF6s/8/Pw9Dq691L0AIKnIL"
+
+        pem = """
+        -----BEGIN CERTIFICATE-----
+        MIIDqjCCApKgAwIBAgIGAZfpTJclMA0GCSqGSIb3DQEBCwUAMIGVMQswCQYDVQQGEwJVUzETMBEG
+        A1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEU
+        MBIGA1UECwwLU1NPUHJvdmlkZXIxFjAUBgNVBAMMDXRyaWFsLTU1OTk4NzkxHDAaBgkqhkiG9w0B
+        CQEWDWluZm9Ab2t0YS5jb20wHhcNMjUwNzA4MDkwOTAwWhcNMzUwNzA4MDkxMDAwWjCBlTELMAkG
+        A1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDTAL
+        BgNVBAoMBE9rdGExFDASBgNVBAsMC1NTT1Byb3ZpZGVyMRYwFAYDVQQDDA10cmlhbC01NTk5ODc5
+        MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+        CgKCAQEAzmF1LGsjEQkdLfCR6epCX5uKaJnowd3ZE8/t+kPiW0TIIvp4a3bH7r+pBbbili7Wz8LR
+        s6C99RmtG4KjfBd6IAS1vYVba1RJ3XkoiIfVeDCP5sXKPyRquNj1/gyZkYxTYZVnh3ibXXUmlIkC
+        DrF0TeO+4VfrWXQlc5/vNz7fbhH3bYCFj8jy3tKqXsE18X5USALRH22K4N2ZcGujNMwxzXIqGkPy
+        PfRpnSY+AS8tGnW36Xn4WnKs9ciAnmTtTMXNrGrc6OLkbAEKLxSegpV9oSugChZ21siJXFf2Xz3j
+        p71C12kbEDCXQ8Xi86iS3PnBYvp2ThT0Qiby1vscdNGaUwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+        AQCEbceBacHt0sx6Q0sU68E6CyyEfYVHPUOxLwBq4lrqeh9b0fctNuyFAceJbejIto9sqQ+RQzqo
+        b5PGfNpFanPbrcOx5F4NLgS9keR/bJGetSfiQe0nw/2ikNd7O0mWeWo1LvRtTGOAS2o3NTkLv3W1
+        mxCkgjbi24hQs6eR5ARY6//AqYQWwWIDMIZotuIuRh285A8Gn1Vxj6ApWski3jttCLzU7NDJU7I6
+        CXfzbDdEpr9I18CEZ7oOei/61q4wNq/x3CT4TsbDnVLVcYs0qqe/EKwQ6alqkHqlp2zxThOVvMW6
+        tz0X8hNnxrXmmZdp7WF6s/8/Pw9Dq691L0AIKnIL
+        -----END CERTIFICATE-----
+        """
+
+        team = new_site().team
+        integration = SSO.initiate_saml_integration(team)
+
+        assert {:ok, integration} =
+                 SSO.update_integration(integration, %{
+                   idp_signin_url: "https://example.com",
+                   idp_entity_id: "some-entity",
+                   idp_cert_pem: boundless_pem
+                 })
+
+        assert integration.config.idp_signin_url == "https://example.com"
+        assert integration.config.idp_entity_id == "some-entity"
+
+        assert X509.Certificate.from_pem(integration.config.idp_cert_pem) ==
+                 X509.Certificate.from_pem(pem)
+      end
+
       test "optionally accepts metadata" do
         team = new_site().team
         integration = SSO.initiate_saml_integration(team)

--- a/test/plausible/auth/sso_test.exs
+++ b/test/plausible/auth/sso_test.exs
@@ -538,7 +538,7 @@ defmodule Plausible.Auth.SSOTest do
 
     describe "check_force_sso/2" do
       test "returns ok when conditions are met for setting all_but_owners" do
-        # Owner with MFA enabled
+        # Owner with 2FA enabled
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)
@@ -559,13 +559,13 @@ defmodule Plausible.Auth.SSOTest do
         assert :ok = SSO.check_force_sso(team, :all_but_owners)
       end
 
-      test "returns error when one owner does not have MFA configured" do
+      test "returns error when one owner does not have 2FA configured" do
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)
         team = new_site(owner: owner).team
 
-        # Owner without MFA
+        # Owner without 2FA
         another_owner = new_user()
         add_member(team, user: another_owner, role: :owner)
 
@@ -581,11 +581,11 @@ defmodule Plausible.Auth.SSOTest do
         identity = new_identity("Carrie Mower", "lance@" <> domain)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
 
-        assert {:error, :owner_mfa_disabled} = SSO.check_force_sso(team, :all_but_owners)
+        assert {:error, :owner_2fa_disabled} = SSO.check_force_sso(team, :all_but_owners)
       end
 
       test "returns error when there's no provisioned SSO user present" do
-        # Owner with MFA enabled
+        # Owner with 2FA enabled
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)
@@ -602,7 +602,7 @@ defmodule Plausible.Auth.SSOTest do
       end
 
       test "returns error when there's no verified SSO domain present" do
-        # Owner with MFA enabled
+        # Owner with 2FA enabled
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)
@@ -619,7 +619,7 @@ defmodule Plausible.Auth.SSOTest do
       end
 
       test "returns error when there's no SSO domain present" do
-        # Owner with MFA enabled
+        # Owner with 2FA enabled
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)
@@ -632,7 +632,7 @@ defmodule Plausible.Auth.SSOTest do
       end
 
       test "returns error when there's no SSO integration present" do
-        # Owner with MFA enabled
+        # Owner with 2FA enabled
         owner = new_user()
         {:ok, owner, _} = Auth.TOTP.initiate(owner)
         {:ok, owner, _} = Auth.TOTP.enable(owner, :skip_verify)

--- a/test/plausible/teams/memberships/update_role_test.exs
+++ b/test/plausible/teams/memberships/update_role_test.exs
@@ -183,7 +183,7 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
           new_identity(collaborator.name, collaborator.email)
           |> Plausible.Auth.SSO.provision_user()
 
-        assert {:error, :mfa_disabled} = UpdateRole.update(team, collaborator.id, "owner", user)
+        assert {:error, :disabled_2fa} = UpdateRole.update(team, collaborator.id, "owner", user)
       end
     end
   end

--- a/test/plausible_web/controllers/sso_controller_test.exs
+++ b/test/plausible_web/controllers/sso_controller_test.exs
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Enter your Single Sign-on email"
+        assert html =~ "Enter your Single Sign-On email"
         assert element_exists?(html, "input[name=email]")
         assert text_of_attr(html, "input[name=return_to]", "value") == ""
       end
@@ -79,7 +79,7 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Enter your Single Sign-on email"
+        assert html =~ "Enter your Single Sign-On email"
         assert text_of_attr(html, "input[name=email]", "value") == "user@example.com"
         assert html =~ ~s|document.getElementById("sso-login-form").submit()|
       end
@@ -172,7 +172,7 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Processing Single Sign-on request..."
+        assert html =~ "Processing Single Sign-On request..."
 
         assert text_of_attr(html, "form#sso-req-form", "action") ==
                  Routes.sso_path(conn, :saml_consume, integration.identifier)

--- a/test/plausible_web/live/sso_management_test.exs
+++ b/test/plausible_web/live/sso_management_test.exs
@@ -78,8 +78,8 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
 
         text = text(render(lv))
 
-        assert text =~ "Sign-in URL can't be blank"
-        assert text =~ "Entity ID can't be blank"
+        assert text =~ "SSO URL / Sign-on URL / Login URL can't be blank"
+        assert text =~ "Entity ID / Issuer / Identifier can't be blank"
         assert text =~ "Certificate in PEM format can't be blank"
 
         lv

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
         :setup_team
       ]
 
-      test "fails to save layout with SSO user updated to owner with Force SSO but without MFA",
+      test "fails to save layout with SSO user updated to owner with Force SSO but without 2FA",
            %{
              conn: conn,
              team: team,


### PR DESCRIPTION
### Changes

This PR: 

- improves consistency of copy related to SSO across the app
- adds an improvement to setup procedure, allowing pasting certificate PEM without boundary delimiters (Okta provides it this way for copy-pasting)
- adds IP-based rate limiting to SSO login endpoint to curb email lookup abuse

### Tests
- [x] Automated tests have been added

