### PR TITLE
Script v2: Sync event.props.path for special path-based events from event.pathname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 - All dropmenus on dashboard are navigable with Tab (used to be a mix between tab and arrow keys), and no two dropmenus can be open at once on the dashboard
 
+- Special path-based events like "404" don't need `event.props.path` to be explicitly defined when tracking: it is set to be the same as `event.pathname` in event ingestion. If it is explicitly defined, it is not overridden for backwards compatibility.
+
 ### Fixed
 
 - Make clicking Compare / Disable Comparison in period picker menu close the menu

--- a/lib/plausible/exports.ex
+++ b/lib/plausible/exports.ex
@@ -564,7 +564,7 @@ defmodule Plausible.Exports do
           fragment(
             "if(? in ?, ?, '')",
             e.name,
-            ^Plausible.Imported.goals_with_url(),
+            ^Plausible.Goals.SystemGoals.goals_with_url(),
             get_by_key(e, :meta, "url")
           ),
           :link_url
@@ -573,7 +573,7 @@ defmodule Plausible.Exports do
           fragment(
             "if(? in ?, ?, '')",
             e.name,
-            ^Plausible.Imported.goals_with_path(),
+            ^Plausible.Goals.SystemGoals.goals_with_path(),
             get_by_key(e, :meta, "path")
           ),
           :path

--- a/lib/plausible/goals/system_goals.ex
+++ b/lib/plausible/goals/system_goals.ex
@@ -19,14 +19,17 @@ defmodule Plausible.Goals.SystemGoals do
     @goals_with_path
   end
 
+  @spec special_goals_for(String.t()) :: [String.t()]
   def special_goals_for("event:props:url"), do: goals_with_url()
   def special_goals_for("event:props:path"), do: goals_with_path()
 
+  @spec maybe_sync_props_path_with_pathname(String.t(), map()) ::
+          {:ok, map()} | {:error, String.t()}
   def maybe_sync_props_path_with_pathname(_pathname, %{"path" => _} = _props) do
     {:error, "Path has been already set in props, won't override"}
   end
 
-  def maybe_sync_props_path_with_pathname(pathname, props) do
+  def maybe_sync_props_path_with_pathname(pathname, %{} = props) do
     {:ok, Map.merge(props, %{"path" => pathname})}
   end
 end

--- a/lib/plausible/goals/system_goals.ex
+++ b/lib/plausible/goals/system_goals.ex
@@ -1,0 +1,32 @@
+defmodule Plausible.Goals.SystemGoals do
+  @moduledoc """
+  This module contains logic for special goals
+  """
+
+  # Special system goals which can be filtered by 'url' custom property
+  @goals_with_url ["Outbound Link: Click", "Cloaked Link: Click", "File Download"]
+
+  # Special system goals which can be filtered by 'path' custom property
+  @goals_with_path ["404", "WP Form Completions", "Form: Submission"]
+
+  @spec goals_with_url() :: [String.t()]
+  def goals_with_url() do
+    @goals_with_url
+  end
+
+  @spec goals_with_path() :: [String.t()]
+  def goals_with_path() do
+    @goals_with_path
+  end
+
+  def special_goals_for("event:props:url"), do: goals_with_url()
+  def special_goals_for("event:props:path"), do: goals_with_path()
+
+  def maybe_sync_props_path_with_pathname(_pathname, %{"path" => _} = _props) do
+    {:error, "Path has been already set in props, won't override"}
+  end
+
+  def maybe_sync_props_path_with_pathname(pathname, props) do
+    {:ok, Map.merge(props, %{"path" => pathname})}
+  end
+end

--- a/lib/plausible/goals/system_goals.ex
+++ b/lib/plausible/goals/system_goals.ex
@@ -23,13 +23,22 @@ defmodule Plausible.Goals.SystemGoals do
   def special_goals_for("event:props:url"), do: goals_with_url()
   def special_goals_for("event:props:path"), do: goals_with_path()
 
-  @spec maybe_sync_props_path_with_pathname(String.t(), map()) ::
-          {:ok, map()} | {:error, String.t()}
-  def maybe_sync_props_path_with_pathname(_pathname, %{"path" => _} = _props) do
-    {:error, "Path has been already set in props, won't override"}
-  end
+  @doc """
+  Checks if the event name is for a special goal that should have the event.props.path synced with the event.pathname property.
 
-  def maybe_sync_props_path_with_pathname(pathname, %{} = props) do
-    {:ok, Map.merge(props, %{"path" => pathname})}
+  ### Examples
+  iex> should_sync_props_path_with_pathname?("404", [{"path", "/foo"}])
+  false
+
+  iex> should_sync_props_path_with_pathname?("404", [{"path", nil}])
+  false
+
+  iex> should_sync_props_path_with_pathname?("404", [])
+  true
+  """
+  @spec should_sync_props_path_with_pathname?(String.t(), [{String.t(), String.t()}]) :: boolean()
+  def should_sync_props_path_with_pathname?(event_name, props_in_request) do
+    event_name in goals_with_path() and
+      not Enum.any?(props_in_request, fn {k, _} -> k == "path" end)
   end
 end

--- a/lib/plausible/goals/system_goals.ex
+++ b/lib/plausible/goals/system_goals.ex
@@ -27,17 +27,21 @@ defmodule Plausible.Goals.SystemGoals do
   Checks if the event name is for a special goal that should have the event.props.path synced with the event.pathname property.
 
   ### Examples
-  iex> should_sync_props_path_with_pathname?("404", [{"path", "/foo"}])
+  iex> sync_props_path_with_pathname?("404", [{"path", "/foo"}])
   false
 
-  iex> should_sync_props_path_with_pathname?("404", [{"path", nil}])
+  Note: Should not override event.props.path if it is set deliberately to nil
+  iex> sync_props_path_with_pathname?("404", [{"path", nil}])
   false
 
-  iex> should_sync_props_path_with_pathname?("404", [])
+  iex> sync_props_path_with_pathname?("404", [{"other", "value"}])
+  true
+
+  iex> sync_props_path_with_pathname?("404", [])
   true
   """
-  @spec should_sync_props_path_with_pathname?(String.t(), [{String.t(), String.t()}]) :: boolean()
-  def should_sync_props_path_with_pathname?(event_name, props_in_request) do
+  @spec sync_props_path_with_pathname?(String.t(), [{String.t(), String.t()}]) :: boolean()
+  def sync_props_path_with_pathname?(event_name, props_in_request) do
     event_name in goals_with_path() and
       not Enum.any?(props_in_request, fn {k, _} -> k == "path" end)
   end

--- a/lib/plausible/imported.ex
+++ b/lib/plausible/imported.ex
@@ -32,11 +32,6 @@ defmodule Plausible.Imported do
   # Maximum number of complete imports to account for when querying stats
   @max_complete_imports 5
 
-  # Goals which can be filtered by url property
-  @goals_with_url ["Outbound Link: Click", "Cloaked Link: Click", "File Download"]
-  # Goals which can be filtered by path property
-  @goals_with_path ["404", "WP Form Completions"]
-
   @spec schemas() :: [module()]
   def schemas, do: @tables
 
@@ -54,16 +49,6 @@ defmodule Plausible.Imported do
     # but _ignore_ unsupported keys. Currently, `search_query` is
     # not supported in imported queries.
     Enum.map(~w(url path), &("event:props:" <> &1))
-  end
-
-  @spec goals_with_url() :: [String.t()]
-  def goals_with_url() do
-    @goals_with_url
-  end
-
-  @spec goals_with_path() :: [String.t()]
-  def goals_with_path() do
-    @goals_with_path
   end
 
   @spec any_completed_imports?(Site.t()) :: boolean()

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -172,7 +172,7 @@ defmodule Plausible.Ingestion.Request do
   end
 
   defp maybe_set_props_path_to_pathname(props_in_request, changeset) do
-    if Plausible.Goals.SystemGoals.should_sync_props_path_with_pathname?(
+    if Plausible.Goals.SystemGoals.sync_props_path_with_pathname?(
          Changeset.get_field(changeset, :event_name),
          props_in_request
        ) do

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -173,18 +173,16 @@ defmodule Plausible.Ingestion.Request do
   end
 
   defp maybe_put_props_path(changeset) do
-    if Changeset.get_field(changeset, :event_name) in Plausible.Goals.SystemGoals.goals_with_path() do
-      with {:ok, props} <-
-             Plausible.Goals.SystemGoals.maybe_sync_props_path_with_pathname(
-               Changeset.get_field(changeset, :pathname),
-               Changeset.get_field(changeset, :props)
-             ) do
-        Changeset.put_change(changeset, :props, props)
-      else
-        {:error, _} -> changeset
-      end
+    with true <-
+           Changeset.get_field(changeset, :event_name) in Plausible.Goals.SystemGoals.goals_with_path(),
+         {:ok, props} <-
+           Plausible.Goals.SystemGoals.maybe_sync_props_path_with_pathname(
+             Changeset.get_field(changeset, :pathname),
+             Changeset.get_field(changeset, :props)
+           ) do
+      Changeset.put_change(changeset, :props, props)
     else
-      changeset
+      _ -> changeset
     end
   end
 

--- a/lib/plausible/ingestion/request.ex
+++ b/lib/plausible/ingestion/request.ex
@@ -175,10 +175,10 @@ defmodule Plausible.Ingestion.Request do
   defp maybe_put_props_path(changeset) do
     if Changeset.get_field(changeset, :event_name) in Plausible.Goals.SystemGoals.goals_with_path() do
       with {:ok, props} <-
-        Plausible.Goals.SystemGoals.maybe_sync_props_path_with_pathname(
-          Changeset.get_field(changeset, :pathname),
-          Changeset.get_field(changeset, :props)
-        ) do
+             Plausible.Goals.SystemGoals.maybe_sync_props_path_with_pathname(
+               Changeset.get_field(changeset, :pathname),
+               Changeset.get_field(changeset, :props)
+             ) do
         Changeset.put_change(changeset, :props, props)
       else
         {:error, _} -> changeset

--- a/lib/plausible/stats/imported/base.ex
+++ b/lib/plausible/stats/imported/base.ex
@@ -130,7 +130,7 @@ defmodule Plausible.Stats.Imported.Base do
         [:is, "event:goal", names | _rest] -> names
         _ -> []
       end)
-      |> Enum.any?(&(&1 in special_goals_for(property)))
+      |> Enum.any?(&(&1 in Plausible.Goals.SystemGoals.special_goals_for(property)))
 
     has_unsupported_filters? =
       query.filters
@@ -201,7 +201,4 @@ defmodule Plausible.Stats.Imported.Base do
       _ -> []
     end
   end
-
-  def special_goals_for("event:props:url"), do: Imported.goals_with_url()
-  def special_goals_for("event:props:path"), do: Imported.goals_with_path()
 end

--- a/lib/plausible/stats/imported/imported.ex
+++ b/lib/plausible/stats/imported/imported.ex
@@ -11,23 +11,15 @@ defmodule Plausible.Stats.Imported do
 
   @property_to_table_mappings Imported.Base.property_to_table_mappings()
 
-  @goals_with_url Plausible.Imported.goals_with_url()
-
-  def goals_with_url(), do: @goals_with_url
-
-  @goals_with_path Plausible.Imported.goals_with_path()
-
-  def goals_with_path(), do: @goals_with_path
-
   @doc """
   Returns a boolean indicating whether the combination of filters and
   breakdown property is possible to query from the imported tables.
 
   Usually, when no filters are used, the imported schema supports the
   query. There is one exception though - breakdown by a custom property.
-  We are currently importing only two custom properties - `url` and `path.
+  We are currently importing only two custom properties - `url` and `path`.
   Both these properties can only be used with their special goal filter
-  (see `@goals_with_url` and `@goals_with_path`).
+  (see Plausible.Goals.SystemGoals).
   """
   def schema_supports_query?(query) do
     length(Imported.Base.decide_tables(query)) > 0

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -4,6 +4,8 @@ defmodule Plausible.GoalsTest do
   use Plausible.Teams.Test
   alias Plausible.Goals
 
+  doctest Plausible.Goals.SystemGoals, import: true
+
   test "create/2 creates goals and trims input" do
     site = new_site()
     {:ok, goal} = Goals.create(site, %{"page_path" => "/foo bar "})

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -3372,7 +3372,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert %{"source" => "Google", "events" => 1} = breakdown_and_first.("visit:source")
     end
 
-    for goal_name <- Plausible.Imported.goals_with_url() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_url() do
       test "returns url breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)
@@ -3432,7 +3432,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       end
     end
 
-    for goal_name <- Plausible.Imported.goals_with_path() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_path() do
       test "returns path breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)

--- a/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_imported_test.exs
@@ -681,7 +681,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
                breakdown_and_first.("visit:source")
     end
 
-    for goal_name <- Plausible.Imported.goals_with_url() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_url() do
       test "returns url breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)
@@ -734,7 +734,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryImportedTest do
       end
     end
 
-    for goal_name <- Plausible.Imported.goals_with_path() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_path() do
       test "returns path breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)

--- a/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/custom_prop_breakdown_test.exs
@@ -1261,7 +1261,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
              ]
     end
 
-    for goal_name <- Plausible.Imported.goals_with_path() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_path() do
       test "returns path breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)
@@ -1320,7 +1320,7 @@ defmodule PlausibleWeb.Api.StatsController.CustomPropBreakdownTest do
       end
     end
 
-    for goal_name <- Plausible.Imported.goals_with_url() do
+    for goal_name <- Plausible.Goals.SystemGoals.goals_with_url() do
       test "returns url breakdown for #{goal_name} goal", %{conn: conn, site: site} do
         insert(:goal, event_name: unquote(goal_name), site: site)
         site_import = insert(:site_import, site: site)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -141,14 +141,19 @@ defmodule Plausible.Factory do
       index_of_path_key = Enum.find_index(meta_keys, &(&1 == "path"))
 
       if index_of_path_key == nil do
-        attrs = attrs
-        |> Map.put(:"meta.key", meta_keys ++ ["path"])
-        |> Map.put(:"meta.value", meta_values ++ [pathname])
+        attrs =
+          attrs
+          |> Map.put(:"meta.key", meta_keys ++ ["path"])
+          |> Map.put(:"meta.value", meta_values ++ [pathname])
       else
         if index_of_path_key !== nil && Enum.at(meta_values, index_of_path_key) == nil do
-          attrs = attrs
-          |> Map.put(:"meta.key", List.delete_at(meta_keys, index_of_path_key) ++ ["path"])
-          |> Map.put(:"meta.value", List.delete_at(meta_values, index_of_path_key) ++ [pathname])
+          attrs =
+            attrs
+            |> Map.put(:"meta.key", List.delete_at(meta_keys, index_of_path_key) ++ ["path"])
+            |> Map.put(
+              :"meta.value",
+              List.delete_at(meta_values, index_of_path_key) ++ [pathname]
+            )
         end
       end
     end

--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- "Form: Submission" event payload does not need to contain props.path any more: it is saved to be the same as the pathname of the event
+
 ## [0.3.1] - 2025-07-08
 
 - Do not send "Form: Submission" event if the form is tagged

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 22,
+  "tracker_script_version": 23,
   "type": "module",
   "scripts": {
     "deploy": "node compile.js",

--- a/tracker/src/custom-events.js
+++ b/tracker/src/custom-events.js
@@ -191,7 +191,7 @@ export function init() {
           // If the form is tagged, we don't track it as a generic form submission.
           return
         }
-        track('Form: Submission', { props: { path: location.pathname } });
+        track('Form: Submission');
       }
     }
 

--- a/tracker/test/form-submissions.spec.ts
+++ b/tracker/test/form-submissions.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test'
 import { LOCAL_SERVER_ADDR } from './support/server'
 import {
+  e,
   ensurePlausibleInitialized,
   expectPlausibleInAction,
   isEngagementEvent,
@@ -45,9 +46,7 @@ test('does not track form submissions when the feature is disabled', async ({
 })
 
 test.describe('form submissions feature is enabled', () => {
-  test('tracks forms that use GET method', async ({ page }, {
-    testId
-  }) => {
+  test('tracks forms that use GET method', async ({ page }, { testId }) => {
     const { url } = await initializePageDynamically(page, {
       testId,
       scriptConfig: { ...DEFAULT_CONFIG, formSubmissions: true },
@@ -69,7 +68,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })
@@ -98,7 +98,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })
@@ -137,7 +138,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })
@@ -169,7 +171,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })
@@ -265,7 +268,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })
@@ -279,7 +283,8 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          u: `${LOCAL_SERVER_ADDR}${url}`
+          u: `${LOCAL_SERVER_ADDR}${url}`,
+          p: e.toBeUndefined()
         }
       ]
     })

--- a/tracker/test/form-submissions.spec.ts
+++ b/tracker/test/form-submissions.spec.ts
@@ -69,7 +69,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })
@@ -98,7 +98,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })
@@ -137,7 +137,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })
@@ -169,7 +169,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })
@@ -265,7 +265,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })
@@ -279,7 +279,7 @@ test.describe('form submissions feature is enabled', () => {
       expectedRequests: [
         {
           n: 'Form: Submission',
-          p: { path: url }
+          u: `${LOCAL_SERVER_ADDR}${url}`
         }
       ]
     })


### PR DESCRIPTION
### Changes
If this PR is merged, then special path-based system goals (new term / module, name up for debate) won't need to have event.props.path defined during tracking requests. 

These goals/events are "WP Form Completions", "Form: Submission", "404".

It will instead be set on receiving the event to be the same as event.pathname, unless event.props.path is explicitly defined. 

We don't override it when it is explicitly defined to remain backwards compatible with users that are already sending these events with a particular value. 

From our side, we can't distinguish intentional values and unintentional values for event.props.path, so the benefits of the sync will mostly apply to new customers, or customers that begin using these features after this PR is merged.

This approach stores the same pathname twice on our side for special path-based events, but the rate of these special events is many magnitudes less than rate of other events, so the duplicated data is insignificant in the grand scheme of things. 

### Todo after merge
- [ ] Make sure 404 snippet in docs is accurate https://plausible.io/docs/error-pages-tracking-404#step-3-paste-this-piece-of-code-to-your-404-page-template
- [ ] Remove unnecessary event.props.path from form submissions logic in current Wordpress Plausible plugin

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
