### PR TITLE
Verification Diagnostics Fix

### DIFF
--- a/lib/plausible/verification/diagnostics.ex
+++ b/lib/plausible/verification/diagnostics.ex
@@ -211,11 +211,13 @@ defmodule Plausible.Verification.Diagnostics do
   def interpret(
         %__MODULE__{
           plausible_installed?: true,
-          callback_status: 0,
+          callback_status: callback_status,
           proxy_likely?: true
         },
         _url
-      ) do
+      )
+      when callback_status in [0, 500]
+      do
     error(@errors.proxy_misconfigured)
   end
 


### PR DESCRIPTION
### Changes

If verifier finds `proxyLikely` to be true, a `callbackStatus` of 500 also hints a misconfigured proxy.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
