### PR TITLE
Silence logger warnings in tests

### DIFF
--- a/test/plausible/installation_support/checks_test.exs
+++ b/test/plausible/installation_support/checks_test.exs
@@ -8,6 +8,8 @@ defmodule Plausible.InstallationSupport.LegacyVerification.ChecksTest do
 
   @errors LegacyVerification.Errors.all()
 
+  @moduletag :capture_log
+
   describe "successful verification" do
     @normal_body """
     <html>


### PR DESCRIPTION
### Changes

Single line changed - capture log in tests so the warnings don't litter stdout.