### PR TITLE
Use integration from identity during verification

### DIFF
--- a/extra/lib/plausible/auth/sso/identity.ex
+++ b/extra/lib/plausible/auth/sso/identity.ex
@@ -5,6 +5,6 @@ defmodule Plausible.Auth.SSO.Identity do
 
   @type t() :: %__MODULE__{}
 
-  @enforce_keys [:id, :name, :email, :expires_at]
-  defstruct [:id, :name, :email, :expires_at]
+  @enforce_keys [:id, :integration_id, :name, :email, :expires_at]
+  defstruct [:id, :integration_id, :name, :email, :expires_at]
 end

--- a/extra/lib/plausible_web/sso/fake_saml_adapter.ex
+++ b/extra/lib/plausible_web/sso/fake_saml_adapter.ex
@@ -32,6 +32,7 @@ defmodule PlausibleWeb.SSO.FakeSAMLAdapter do
           if user = Repo.get_by(Auth.User, email: params["email"]) do
             %SSO.Identity{
               id: user.sso_identity_id || Ecto.UUID.generate(),
+              integration_id: integration.identifier,
               name: user.name,
               email: user.email,
               expires_at: expires_at
@@ -39,6 +40,7 @@ defmodule PlausibleWeb.SSO.FakeSAMLAdapter do
           else
             %SSO.Identity{
               id: Ecto.UUID.generate(),
+              integration_id: integration.identifier,
               name: name_from_email(params["email"]),
               email: params["email"],
               expires_at: expires_at

--- a/extra/lib/plausible_web/sso/real_saml_adapter.ex
+++ b/extra/lib/plausible_web/sso/real_saml_adapter.ex
@@ -94,6 +94,7 @@ defmodule PlausibleWeb.SSO.RealSAMLAdapter do
       identity =
         %SSO.Identity{
           id: assertion.name_id,
+          integration_id: integration.identifier,
           name: name_from_attributes(attributes),
           email: attributes.email,
           expires_at: expires_at

--- a/test/plausible/auth/sso/domains_test.exs
+++ b/test/plausible/auth/sso/domains_test.exs
@@ -244,7 +244,7 @@ defmodule Plausible.Auth.SSO.DomainsTest do
         other_domain = generate_domain()
         {:ok, other_sso_domain} = SSO.Domains.add(integration, other_domain)
         _other_sso_domain = SSO.Domains.verify(other_sso_domain, skip_checks?: true)
-        other_identity = new_identity("Mary Goodwill", "mary@" <> other_domain)
+        other_identity = new_identity("Mary Goodwill", "mary@" <> other_domain, integration)
         {:ok, _, _, _other_sso_user} = SSO.provision_user(other_identity)
         {:ok, _team} = SSO.set_force_sso(team, :all_but_owners)
 
@@ -254,11 +254,12 @@ defmodule Plausible.Auth.SSO.DomainsTest do
 
       test "returns error when force SSO enabled and SSO users only present on current domain", %{
         team: team,
+        integration: integration,
         domain: domain,
         sso_domain: sso_domain
       } do
         sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
-        identity = new_identity("Claude Leferge", "claude@" <> domain)
+        identity = new_identity("Claude Leferge", "claude@" <> domain, integration)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
         {:ok, _team} = SSO.set_force_sso(team, :all_but_owners)
 
@@ -268,10 +269,11 @@ defmodule Plausible.Auth.SSO.DomainsTest do
 
       test "returns error when SSO users present on current domain", %{
         domain: domain,
+        integration: integration,
         sso_domain: sso_domain
       } do
         sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
-        identity = new_identity("Claude Leferge", "claude@" <> domain)
+        identity = new_identity("Claude Leferge", "claude@" <> domain, integration)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
 
         sso_domain = Repo.reload!(sso_domain)
@@ -293,11 +295,12 @@ defmodule Plausible.Auth.SSO.DomainsTest do
       end
 
       test "fails to remove the domain whenSSO users present on it", %{
+        integration: integration,
         domain: domain,
         sso_domain: sso_domain
       } do
         sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
-        identity = new_identity("Claude Leferge", "claude@" <> domain)
+        identity = new_identity("Claude Leferge", "claude@" <> domain, integration)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
 
         assert {:error, :sso_users_present} = SSO.Domains.remove(sso_domain)
@@ -305,11 +308,12 @@ defmodule Plausible.Auth.SSO.DomainsTest do
       end
 
       test "removes the domain and deprovisions SSO users when force flag set", %{
+        integration: integration,
         domain: domain,
         sso_domain: sso_domain
       } do
         sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
-        identity = new_identity("Claude Leferge", "claude@" <> domain)
+        identity = new_identity("Claude Leferge", "claude@" <> domain, integration)
         {:ok, _, _, sso_user} = SSO.provision_user(identity)
 
         assert :ok = SSO.Domains.remove(sso_domain, force_deprovision?: true)
@@ -326,11 +330,12 @@ defmodule Plausible.Auth.SSO.DomainsTest do
 
       test "fails to remove when force SSO enabled with SSO users only on that domain", %{
         team: team,
+        integration: integration,
         domain: domain,
         sso_domain: sso_domain
       } do
         sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
-        identity = new_identity("Claude Leferge", "claude@" <> domain)
+        identity = new_identity("Claude Leferge", "claude@" <> domain, integration)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
         {:ok, _} = SSO.set_force_sso(team, :all_but_owners)
 

--- a/test/plausible/auth/sso_test.exs
+++ b/test/plausible/auth/sso_test.exs
@@ -296,6 +296,20 @@ defmodule Plausible.Auth.SSOTest do
         assert_team_membership(user, team, :viewer)
       end
 
+      test "does not provision a user from identity when identity integration does not match", %{
+        domain: domain
+      } do
+        other_team = new_site().team
+        other_integration = SSO.initiate_saml_integration(other_team)
+        other_domain = "other-example-#{Enum.random(1..10_000)}.com"
+        {:ok, other_sso_domain} = SSO.Domains.add(other_integration, other_domain)
+        _other_sso_domain = SSO.Domains.verify(other_sso_domain, skip_checks?: true)
+
+        identity = new_identity("Jane Sculley", "jane@" <> domain, other_integration)
+
+        assert {:error, :integration_not_found} = SSO.provision_user(identity)
+      end
+
       test "provisions SSO user from existing user", %{
         integration: integration,
         team: team,

--- a/test/plausible/auth/user_sessions_test.exs
+++ b/test/plausible/auth/user_sessions_test.exs
@@ -53,13 +53,13 @@ defmodule Plausible.Auth.UserSessionsTest do
   on_ee do
     describe "list_for_sso_team/1,2" do
       test "lists only SSO member sessions for a given team" do
-        %{team: sso_team, site: site} =
+        %{team: sso_team, site: site, sso_integration: sso_integration} =
           setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&create_site/1)
           |> setup_do(&setup_sso/1)
 
-        %{team: _other_sso_team} =
+        %{team: _other_sso_team, sso_integration: other_sso_integration} =
           %{domain: "example2.com"}
           |> setup_do(&create_user/1)
           |> setup_do(&create_team/1)
@@ -73,7 +73,10 @@ defmodule Plausible.Auth.UserSessionsTest do
         _other_member_session = Auth.UserSessions.create!(other_member, "Unknown")
 
         %{user: sso_member} =
-          %{user: %{name: "Jerry Wane", email: "wane@example.com"}}
+          %{
+            user: %{name: "Jerry Wane", email: "wane@example.com"},
+            sso_integration: sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         now = NaiveDateTime.utc_now(:second)
@@ -82,7 +85,10 @@ defmodule Plausible.Auth.UserSessionsTest do
           insert_session(sso_member, "Unknown", NaiveDateTime.add(now, -1, :hour))
 
         %{user: sso_member2} =
-          %{user: %{name: "Joan McGuire", email: "joan@example.com"}}
+          %{
+            user: %{name: "Joan McGuire", email: "joan@example.com"},
+            sso_integration: sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         sso_member2_session1 =
@@ -100,13 +106,19 @@ defmodule Plausible.Auth.UserSessionsTest do
         _standard_member_session = insert_session(standard_member, "Unknown", now)
 
         %{user: other_sso_member} =
-          %{user: %{name: "Veronica Dogwright", email: "veronica@example2.com"}}
+          %{
+            user: %{name: "Veronica Dogwright", email: "veronica@example2.com"},
+            sso_integration: other_sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         _other_sso_member_session = insert_session(other_sso_member, "Unknown", now)
 
         %{user: guest_sso_member} =
-          %{user: %{name: "Jimmy Felon", email: "jimmy@example2.com"}}
+          %{
+            user: %{name: "Jimmy Felon", email: "jimmy@example2.com"},
+            sso_integration: other_sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         add_guest(site, user: Repo.reload!(guest_sso_member), role: :viewer)
@@ -123,13 +135,16 @@ defmodule Plausible.Auth.UserSessionsTest do
 
     describe "revoke_sso_by_id/2" do
       test "deletes and disconnects user session" do
-        %{team: sso_team} =
+        %{team: sso_team, sso_integration: sso_integration} =
           setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
         %{user: user} =
-          %{user: %{name: "Jerry Wane", email: "wane@example.com"}}
+          %{
+            user: %{name: "Jerry Wane", email: "wane@example.com"},
+            sso_integration: sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         now = NaiveDateTime.utc_now(:second)
@@ -149,19 +164,22 @@ defmodule Plausible.Auth.UserSessionsTest do
       end
 
       test "does not delete session of user on another team" do
-        %{team: sso_team} =
+        %{team: sso_team, sso_integration: sso_integration} =
           setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
-        %{team: _other_sso_team} =
+        %{team: _other_sso_team, sso_integration: other_sso_integration} =
           %{domain: "example2.com"}
           |> setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
         %{user: user} =
-          %{user: %{name: "Jerry Wane", email: "wane@example.com"}}
+          %{
+            user: %{name: "Jerry Wane", email: "wane@example.com"},
+            sso_integration: sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         now = NaiveDateTime.utc_now(:second)
@@ -169,7 +187,10 @@ defmodule Plausible.Auth.UserSessionsTest do
         active_session = insert_session(user, "Unknown", now)
 
         %{user: other_user} =
-          %{user: %{name: "Judy Wasteland", email: "judy@example2.com"}}
+          %{
+            user: %{name: "Judy Wasteland", email: "judy@example2.com"},
+            sso_integration: other_sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         other_session = insert_session(other_user, "Unknown", now)
@@ -203,14 +224,17 @@ defmodule Plausible.Auth.UserSessionsTest do
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
-        %{team: _other_sso_team} =
+        %{team: _other_sso_team, sso_integration: other_sso_integration} =
           %{domain: "example2.com"}
           |> setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
         %{user: user} =
-          %{user: %{name: "Judy Wasteland", email: "judy@example2.com"}}
+          %{
+            user: %{name: "Judy Wasteland", email: "judy@example2.com"},
+            sso_integration: other_sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         user = add_guest(site, user: Repo.reload!(user), role: :editor)
@@ -224,13 +248,16 @@ defmodule Plausible.Auth.UserSessionsTest do
       end
 
       test "executes gracefully when session does not exist" do
-        %{team: sso_team} =
+        %{team: sso_team, sso_integration: sso_integration} =
           setup_do(&create_user/1)
           |> setup_do(&create_team/1)
           |> setup_do(&setup_sso/1)
 
         %{user: user} =
-          %{user: %{name: "Jerry Wane", email: "wane@example.com"}}
+          %{
+            user: %{name: "Jerry Wane", email: "wane@example.com"},
+            sso_integration: sso_integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         now = NaiveDateTime.utc_now(:second)

--- a/test/plausible/site/sites_test.exs
+++ b/test/plausible/site/sites_test.exs
@@ -129,10 +129,13 @@ defmodule Plausible.SitesTest do
                  Sites.create(user, params, team)
       end
 
-      test "does not allow creating a site in SSO user's personal team", %{team: team} do
+      test "does not allow creating a site in SSO user's personal team", %{
+        team: team,
+        sso_integration: integration
+      } do
         user = add_member(team, role: :editor)
         {:ok, personal_team} = Plausible.Teams.get_or_create(user)
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
         {:ok, _, _, user} = Plausible.Auth.SSO.provision_user(identity)
 
         params = %{"domain" => "example.com", "timezone" => "Europe/London"}

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -612,7 +612,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         {:ok, sso_domain} = Auth.SSO.Domains.add(integration, "example.com")
         _sso_domain = Auth.SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(owner.name, owner.email)
+        identity = new_identity(owner.name, owner.email, integration)
         {:ok, _, _, _sso_user} = Auth.SSO.provision_user(identity)
 
         conn = post(conn, "/login", email: owner.email, password: "password")
@@ -636,7 +636,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         {:ok, sso_domain} = Auth.SSO.Domains.add(integration, "example.com")
         _sso_domain = Auth.SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(member.name, member.email)
+        identity = new_identity(member.name, member.email, integration)
         {:ok, _, _, _sso_user} = Auth.SSO.provision_user(identity)
 
         conn = post(conn, "/login", email: member.email, password: "password")
@@ -660,7 +660,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         {:ok, sso_domain} = Auth.SSO.Domains.add(integration, "example.com")
         _sso_domain = Auth.SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(member.name, member.email)
+        identity = new_identity(member.name, member.email, integration)
         {:ok, _, _, _sso_user} = Auth.SSO.provision_user(identity)
 
         conn = post(conn, "/login", email: member.email, password: "password")

--- a/test/plausible_web/controllers/sso_controller_test.exs
+++ b/test/plausible_web/controllers/sso_controller_test.exs
@@ -387,24 +387,27 @@ defmodule PlausibleWeb.SSOControllerTest do
         {:ok, conn: conn}
       end
 
-      test "lists SSO sessions", %{conn: conn, domain: domain} do
+      test "lists SSO sessions", %{conn: conn, domain: domain, integration: integration} do
         now = NaiveDateTime.utc_now(:second)
 
         %{user: user1} =
-          %{user: %{name: "Frank Rubin", email: "frank@" <> domain}}
+          %{user: %{name: "Frank Rubin", email: "frank@" <> domain}, sso_integration: integration}
           |> setup_do(&provision_sso_user/1)
 
         Auth.UserSessions.create!(user1, "Device 1", now: NaiveDateTime.shift(now, hour: -3))
 
         %{user: user2} =
-          %{user: %{name: "Grace Holmes", email: "grace@" <> domain}}
+          %{
+            user: %{name: "Grace Holmes", email: "grace@" <> domain},
+            sso_integration: integration
+          }
           |> setup_do(&provision_sso_user/1)
 
         Auth.UserSessions.create!(user2, "Device 2")
         Auth.UserSessions.create!(user2, "Device 3", now: NaiveDateTime.shift(now, hour: -6))
 
         %{user: user3} =
-          %{user: %{name: "Kate Loselet", email: "kate@" <> domain}}
+          %{user: %{name: "Kate Loselet", email: "kate@" <> domain}, sso_integration: integration}
           |> setup_do(&provision_sso_user/1)
 
         Auth.UserSessions.create!(user3, "Device 4", now: NaiveDateTime.shift(now, hour: -2))
@@ -444,9 +447,13 @@ defmodule PlausibleWeb.SSOControllerTest do
         {:ok, conn: conn}
       end
 
-      test "revokes session and redirects back to sessions list", %{conn: conn, domain: domain} do
+      test "revokes session and redirects back to sessions list", %{
+        conn: conn,
+        domain: domain,
+        integration: integration
+      } do
         %{user: user} =
-          %{user: %{name: "Frank Rubin", email: "frank@" <> domain}}
+          %{user: %{name: "Frank Rubin", email: "frank@" <> domain}, sso_integration: integration}
           |> setup_do(&provision_sso_user/1)
 
         session = Auth.UserSessions.create!(user, "Unknown")

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -584,6 +584,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         {:ok, :standard, team, user} =
           SSO.provision_user(%SSO.Identity{
             id: Ecto.UUID.generate(),
+            integration_id: integration.identifier,
             name: user.name,
             email: user.email,
             expires_at: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 6, :hour)

--- a/test/plausible_web/live/sso_management_test.exs
+++ b/test/plausible_web/live/sso_management_test.exs
@@ -241,7 +241,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         team: team,
         user: user
       } do
-        setup_integration(team, "org.example.com")
+        integration = setup_integration(team, "org.example.com")
         {_lv, html} = get_lv(conn)
 
         assert element_exists?(html, "button#enable-force-sso-toggle[disabled]")
@@ -249,7 +249,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         {:ok, user, _} = Auth.TOTP.initiate(user)
         {:ok, _user, _} = Auth.TOTP.enable(user, :skip_verify)
 
-        identity = new_identity("Lance Wurst", "lance@org.example.com")
+        identity = new_identity("Lance Wurst", "lance@org.example.com", integration)
         {:ok, _, _, _sso_user} = SSO.provision_user(identity)
 
         {_lv, html} = get_lv(conn)
@@ -263,7 +263,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         team: team,
         user: user
       } do
-        setup_integration(team, "example.com")
+        integration = setup_integration(team, "example.com")
         {_lv, html} = get_lv(conn)
 
         assert element_exists?(html, "button#enable-force-sso-toggle[disabled]")
@@ -271,7 +271,7 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         {:ok, user, _} = Auth.TOTP.initiate(user)
         {:ok, _user, _} = Auth.TOTP.enable(user, :skip_verify)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
         {:ok, _, _, user} = SSO.provision_user(identity)
 
         {:ok, conn: conn} = log_in(%{conn: conn, user: user})
@@ -293,12 +293,14 @@ defmodule PlausibleWeb.Live.SSOMangementTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        {:ok, _integration} =
+        {:ok, integration} =
           SSO.update_integration(integration, %{
             idp_signin_url: "https://#{domain}",
             idp_entity_id: "some-entity",
             idp_cert_pem: @cert_pem
           })
+
+        integration
       end
 
       defp get_lv(conn) do

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -65,7 +65,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
            %{
              conn: conn,
              team: team,
-             user: user
+             user: user,
+             sso_integration: integration
            } do
         {:ok, user, _} = Plausible.Auth.TOTP.initiate(user)
         {:ok, _user, _} = Plausible.Auth.TOTP.enable(user, :skip_verify)
@@ -73,11 +74,11 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
         member = add_member(team, role: :viewer)
 
         {:ok, _, _, _member} =
-          new_identity(member.name, member.email)
+          new_identity(member.name, member.email, integration)
           |> Plausible.Auth.SSO.provision_user()
 
         {:ok, _, _, user} =
-          new_identity(user.name, user.email)
+          new_identity(user.name, user.email, integration)
           |> Plausible.Auth.SSO.provision_user()
 
         {:ok, conn: conn} = log_in(%{conn: conn, user: user})

--- a/test/plausible_web/plugs/sso_team_access_test.exs
+++ b/test/plausible_web/plugs/sso_team_access_test.exs
@@ -96,11 +96,12 @@ defmodule Plausible.Plugs.SSOTeamAccessTest do
       test "redirects to notice for SSO team with force SSO", %{
         conn: conn,
         team: team,
-        user: user
+        user: user,
+        sso_integration: integration
       } do
         {:ok, user, _} = Auth.TOTP.initiate(user)
         {:ok, _user, _} = Auth.TOTP.enable(user, :skip_verify)
-        identity = new_identity("Woozy Wooster", "woozy@example.com")
+        identity = new_identity("Woozy Wooster", "woozy@example.com", integration)
         Auth.SSO.provision_user(identity)
         {:ok, _team} = Auth.SSO.set_force_sso(team, :all_but_owners)
 
@@ -117,14 +118,15 @@ defmodule Plausible.Plugs.SSOTeamAccessTest do
       test "redirects to issue notice for SSO team with force SSO and user in invalid state", %{
         conn: conn,
         team: team,
-        user: user
+        user: user,
+        sso_integration: integration
       } do
         another_team = new_site().team |> Plausible.Teams.complete_setup()
         add_member(another_team, user: user, role: :viewer)
 
         {:ok, user, _} = Auth.TOTP.initiate(user)
         {:ok, _user, _} = Auth.TOTP.enable(user, :skip_verify)
-        identity = new_identity("Woozy Wooster", "woozy@example.com")
+        identity = new_identity("Woozy Wooster", "woozy@example.com", integration)
         Auth.SSO.provision_user(identity)
         {:ok, _team} = Auth.SSO.set_force_sso(team, :all_but_owners)
 

--- a/test/plausible_web/user_auth_test.exs
+++ b/test/plausible_web/user_auth_test.exs
@@ -54,7 +54,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
 
         conn =
           conn
@@ -83,7 +83,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
         {:ok, :standard, _, user} = SSO.provision_user(identity)
 
         assert user.type == :sso
@@ -113,7 +113,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
 
         conn |> init_session() |> UserAuth.log_in_user(user)
 
@@ -135,7 +135,8 @@ defmodule PlausibleWeb.UserAuthTest do
         conn: conn,
         user: user
       } do
-        identity = new_identity("Willy Wonka", "wonka@example.com")
+        identity =
+          new_identity("Willy Wonka", "wonka@example.com", %{identifier: Ecto.UUID.generate()})
 
         conn =
           conn
@@ -168,7 +169,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity("Jane Doe", "jane@" <> domain)
+        identity = new_identity("Jane Doe", "jane@" <> domain, integration)
 
         conn =
           conn
@@ -203,7 +204,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
 
         conn =
           conn
@@ -232,7 +233,7 @@ defmodule PlausibleWeb.UserAuthTest do
         {:ok, sso_domain} = SSO.Domains.add(integration, domain)
         _sso_domain = SSO.Domains.verify(sso_domain, skip_checks?: true)
 
-        identity = new_identity(user.name, user.email)
+        identity = new_identity(user.name, user.email, integration)
 
         conn =
           conn

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -121,8 +121,8 @@ defmodule Plausible.TestUtils do
       {:ok, team: team, sso_integration: integration, sso_domain: sso_domain}
     end
 
-    def provision_sso_user(%{user: user}) do
-      identity = new_identity(user.name, user.email)
+    def provision_sso_user(%{user: user, sso_integration: integration}) do
+      identity = new_identity(user.name, user.email, integration)
       {:ok, _, _, sso_user} = SSO.provision_user(identity)
 
       {:ok, user: sso_user}
@@ -360,9 +360,10 @@ defmodule Plausible.TestUtils do
   end
 
   on_ee do
-    def new_identity(name, email, id \\ Ecto.UUID.generate()) do
+    def new_identity(name, email, integration, id \\ Ecto.UUID.generate()) do
       %Plausible.Auth.SSO.Identity{
         id: id,
+        integration_id: integration.identifier,
         name: name,
         email: email,
         expires_at: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 6, :hour)


### PR DESCRIPTION
### Changes

Ensures the integration from SAML authentication session is used for further verification during provisioning of user.

### Tests
- [x] Automated tests have been added
