### PR TITLE
CRM: implement basic SSO audit browser

### DIFF
--- a/extra/lib/plausible/audit/entry.ex
+++ b/extra/lib/plausible/audit/entry.ex
@@ -67,6 +67,13 @@ defmodule Plausible.Audit.Entry do
     |> put_change(:change, Plausible.Audit.encode(struct, raise_on_not_loaded?: false))
   end
 
+  def include_change(audit_entry, map) when is_map(map) do
+    # sometimes a hand-crafted map is passed; we don't need to encode then
+    audit_entry
+    |> change()
+    |> put_change(:change, map)
+  end
+
   def persist!(entry) do
     Plausible.Repo.insert!(entry)
   end

--- a/extra/lib/plausible/auth/sso/domain.ex
+++ b/extra/lib/plausible/auth/sso/domain.ex
@@ -11,7 +11,6 @@ defmodule Plausible.Auth.SSO.Domain do
   recorded.
   """
 
-  use Plausible
   use Ecto.Schema
 
   import Ecto.Changeset
@@ -28,11 +27,9 @@ defmodule Plausible.Auth.SSO.Domain do
 
   use Plausible.Auth.SSO.Domain.Status
 
-  on_ee do
-    @derive {Plausible.Audit.Encoder,
-             only: [:id, :identifier, :domain, :verified_via, :status, :sso_integration],
-             allow_not_loaded: [:sso_integration]}
-  end
+  @derive {Plausible.Audit.Encoder,
+           only: [:id, :identifier, :domain, :verified_via, :status, :sso_integration],
+           allow_not_loaded: [:sso_integration]}
 
   schema "sso_domains" do
     field :identifier, Ecto.UUID

--- a/extra/lib/plausible/auth/sso/domains.ex
+++ b/extra/lib/plausible/auth/sso/domains.ex
@@ -128,6 +128,7 @@ defmodule Plausible.Auth.SSO.Domains do
   @spec remove(SSO.Domain.t(), Keyword.t()) ::
           :ok | {:error, :force_sso_enabled | :sso_users_present}
   def remove(sso_domain, opts \\ []) do
+    sso_domain = Repo.preload(sso_domain, :sso_integration)
     force_deprovision? = Keyword.get(opts, :force_deprovision?, false)
 
     check = check_can_remove(sso_domain)

--- a/extra/lib/plausible/auth/sso/domains.ex
+++ b/extra/lib/plausible/auth/sso/domains.ex
@@ -136,7 +136,10 @@ defmodule Plausible.Auth.SSO.Domains do
       {:ok, _} ->
         {:ok, :ok} =
           Repo.transaction(fn ->
-            Repo.delete!(sso_domain)
+            Repo.delete_with_audit!(sso_domain, "sso_domain_removed", %{
+              team_id: sso_domain.sso_integration.team_id
+            })
+
             :ok = cancel_verification(sso_domain.domain)
           end)
 
@@ -147,7 +150,11 @@ defmodule Plausible.Auth.SSO.Domains do
           Repo.transaction(fn ->
             domain_users = users_by_domain(sso_domain)
             Enum.each(domain_users, &SSO.deprovision_user!/1)
-            Repo.delete!(sso_domain)
+
+            Repo.delete_with_audit!(sso_domain, "sso_domain_removed", %{
+              team_id: sso_domain.sso_integration.team_id
+            })
+
             cancel_verification(sso_domain.domain)
           end)
 

--- a/extra/lib/plausible/auth/sso/identity.ex
+++ b/extra/lib/plausible/auth/sso/identity.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Auth.SSO.Identity do
 
   @type t() :: %__MODULE__{}
 
+  @derive Plausible.Audit.Encoder
   @enforce_keys [:id, :integration_id, :name, :email, :expires_at]
   defstruct [:id, :integration_id, :name, :email, :expires_at]
 end

--- a/extra/lib/plausible/auth/sso/integration.ex
+++ b/extra/lib/plausible/auth/sso/integration.ex
@@ -10,7 +10,6 @@ defmodule Plausible.Auth.SSO.Integration do
   when configuring external services like IdPs.
   """
 
-  use Plausible
   use Ecto.Schema
 
   import Ecto.Changeset
@@ -21,9 +20,7 @@ defmodule Plausible.Auth.SSO.Integration do
 
   @type t() :: %__MODULE__{}
 
-  on_ee do
-    @derive {Plausible.Audit.Encoder, only: [:id, :identifier]}
-  end
+  @derive {Plausible.Audit.Encoder, only: [:id, :identifier]}
 
   schema "sso_integrations" do
     field :identifier, Ecto.UUID

--- a/extra/lib/plausible/auth/sso/saml_config.ex
+++ b/extra/lib/plausible/auth/sso/saml_config.ex
@@ -10,7 +10,6 @@ defmodule Plausible.Auth.SSO.SAMLConfig do
   from IdP again.
   """
 
-  use Plausible
   use Ecto.Schema
 
   alias Plausible.Auth.SSO
@@ -22,10 +21,8 @@ defmodule Plausible.Auth.SSO.SAMLConfig do
   @fields [:idp_signin_url, :idp_entity_id, :idp_cert_pem, :idp_metadata]
   @required_fields @fields -- [:idp_metadata]
 
-  on_ee do
-    @derive {Plausible.Audit.Encoder,
-             only: [:id, :idp_signin_url, :idp_entity_id, :idp_cert_pem, :idp_metadata]}
-  end
+  @derive {Plausible.Audit.Encoder,
+           only: [:id, :idp_signin_url, :idp_entity_id, :idp_cert_pem, :idp_metadata]}
 
   embedded_schema do
     field :idp_signin_url, :string

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -43,6 +43,36 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
     {:ok, assign(socket, tab: "sso")}
   end
 
+  def update(%{tab: "audit"}, %{assigns: %{team: team}} = socket) do
+    audit_entries = Plausible.Audit.list_entries(team_id: team.id)
+
+    audit_entries =
+      Enum.map(audit_entries, fn entry ->
+        meta = entry.meta
+
+        meta =
+          if entry.user_id && entry.user_id > 0 do
+            user = Plausible.Repo.get!(Plausible.Auth.User, entry.user_id)
+            Map.put(meta, :user, user)
+          else
+            meta
+          end
+
+        meta =
+          if entry.entity == "Plausible.Auth.User" do
+            user = Plausible.Repo.get!(Plausible.Auth.User, String.to_integer(entry.entity_id))
+            Map.put(meta, :entity, user)
+          else
+            meta
+          end
+
+        Map.put(entry, :meta, meta)
+      end)
+
+    {:ok,
+     assign(socket, tab: "audit", audit_entries: audit_entries, revealed_audit_entry_id: nil)}
+  end
+
   def update(%{tab: "sites"}, %{assigns: %{team: team}} = socket) do
     sites = Teams.owned_sites(team, 100)
     sites_count = Teams.owned_sites_count(team)
@@ -179,6 +209,9 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
               <.tab to="billing" tab={@tab}>
                 Billing
               </.tab>
+              <.tab to="audit" tab={@tab}>
+                Audit
+              </.tab>
             </nav>
           </div>
         </div>
@@ -289,6 +322,87 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
                   phx-target={@myself}
                   class="text-sm text-red-600"
                   data-confirm={"Are you sure you want to remove domain '#{sso_domain.domain}'? All SSO users will be deprovisioned and logged out."}
+                />
+              </.td>
+            </:tbody>
+          </.table>
+        </div>
+
+        <div :if={@tab == "audit"} class="mt-4 mb-4 text-gray-900 dark:text-gray-400 relative">
+          <div :if={Enum.empty?(@audit_entries)} class="flex justify-center items-center">
+            No audit logs yet
+          </div>
+          <div :if={@revealed_audit_entry_id}>
+            <.input_with_clipboard
+              id="audit-entry-identifier"
+              name="audit-entry-identifier"
+              label="Audit Entry Identifer"
+              value={@revealed_audit_entry_id}
+            />
+            <div class="relative">
+              <.input
+                rows="16"
+                type="textarea"
+                id="audit-entry-change"
+                name="audit-entry-change"
+                value={
+                  Jason.encode!(
+                    Enum.find(@audit_entries, &(&1.id == @revealed_audit_entry_id)).change,
+                    pretty: true
+                  )
+                }
+              >
+              </.input>
+              <.styled_link
+                class="text-sm float-right"
+                onclick="var textarea = document.getElementById('audit-entry-change'); textarea.focus(); textarea.select(); document.execCommand('copy');"
+                href="#"
+              >
+                <div class="flex items-center absolute top-4 right-4 text-xs gap-x-1">
+                  <Heroicons.document_duplicate class="h-4 w-4 text-indigo-700" /> COPY
+                </div>
+              </.styled_link>
+
+              <.styled_link
+                phx-click="reveal-audit-entry"
+                phx-target={@myself}
+                class="float-right pt-4 text-sm"
+              >
+                &larr; Return
+              </.styled_link>
+            </div>
+          </div>
+          <.table :if={is_nil(@revealed_audit_entry_id)} rows={@audit_entries}>
+            <:thead>
+              <.th invisible></.th>
+              <.th invisible></.th>
+              <.th>Name</.th>
+              <.th>Entity</.th>
+              <.th>Actor</.th>
+              <.th invisible>Actions</.th>
+            </:thead>
+            <:tbody :let={entry}>
+              <.td>{Calendar.strftime(entry.datetime, "%Y-%m-%d")}</.td>
+              <.td>{Calendar.strftime(entry.datetime, "%H:%M:%S")}</.td>
+              <.td class="font-mono">{entry.name}</.td>
+              <.td truncate>
+                <.audit_entity entry={entry} />
+              </.td>
+              <.td :if={entry.actor_type == :system}>
+                <div class="flex items-center gap-x-1">
+                  <Heroicons.cog_6_tooth class="size-4" /> SYSTEM
+                </div>
+              </.td>
+              <.td :if={entry.actor_type == :user} truncate>
+                <.audit_user user={entry.meta.user} />
+              </.td>
+
+              <.td actions>
+                <.edit_button
+                  phx-click="reveal-audit-entry"
+                  icon={:magnifying_glass_plus}
+                  phx-value-id={entry.id}
+                  phx-target={@myself}
                 />
               </.td>
             </:tbody>
@@ -651,6 +765,14 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
       </div>
     </div>
     """
+  end
+
+  def handle_event("reveal-audit-entry", %{"id" => id}, socket) do
+    {:noreply, assign(socket, revealed_audit_entry_id: id)}
+  end
+
+  def handle_event("reveal-audit-entry", _, socket) do
+    {:noreply, assign(socket, revealed_audit_entry_id: nil)}
   end
 
   def handle_event("show-plan-form", _, socket) do
@@ -1091,5 +1213,41 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
       |> Enum.into(%{})
 
     assign(socket, team_layout: team_layout, session_counts: session_counts, tab: "members")
+  end
+
+  attr :entry, Plausible.Audit.Entry
+
+  defp audit_entity(assigns) do
+    ~H"""
+    <%= if @entry.entity == "Plausible.Auth.User" do %>
+      <.audit_user user={@entry.meta.entity} />
+    <% else %>
+      {@entry.entity |> String.split(".") |> List.last()} #{String.slice(@entry.entity_id, 0, 8)}
+    <% end %>
+    """
+  end
+
+  attr :user, Plausible.Auth.User
+
+  defp audit_user(assigns) do
+    ~H"""
+    <div class="flex items-center gap-x-1">
+      <img
+        class="w-4"
+        src={
+          Plausible.Auth.User.profile_img_url(%Plausible.Auth.User{
+            email: @user.email
+          })
+        }
+      />
+
+      <.styled_link
+        patch={"/cs/users/user/#{@user.id}"}
+        class="cursor-pointer flex block items-center"
+      >
+        {@user.name}
+      </.styled_link>
+    </div>
+    """
   end
 end

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -336,7 +336,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
             <.input_with_clipboard
               id="audit-entry-identifier"
               name="audit-entry-identifier"
-              label="Audit Entry Identifer"
+              label="Audit Entry Identifier"
               value={@revealed_audit_entry_id}
             />
             <div class="relative">

--- a/extra/lib/plausible_web/live/customer_support/live/user.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/user.ex
@@ -44,7 +44,12 @@ defmodule PlausibleWeb.CustomerSupport.Live.User do
           </div>
           <div class="mt-4 text-center sm:mt-0 sm:pt-1 sm:text-left">
             <p class="text-xl font-bold sm:text-2xl">
-              {@user.name}
+              <div class="flex items-center gap-x-2">
+                {@user.name}
+                <span :if={@user.type == :sso} class="bg-green-700 text-gray-100 text-xs p-1 rounded">
+                  SSO
+                </span>
+              </div>
             </p>
             <p class="text-sm font-medium">
               <span>{@user.email}</span>

--- a/extra/lib/plausible_web/sso/fake_saml_adapter.ex
+++ b/extra/lib/plausible_web/sso/fake_saml_adapter.ex
@@ -47,6 +47,11 @@ defmodule PlausibleWeb.SSO.FakeSAMLAdapter do
             }
           end
 
+        "sso_login_success"
+        |> Plausible.Audit.Entry.new(identity, %{team_id: integration.team.id})
+        |> Plausible.Audit.Entry.include_change(identity)
+        |> Plausible.Audit.Entry.persist!()
+
         PlausibleWeb.UserAuth.log_in_user(conn, identity, params["return_to"])
 
       {:error, :not_found} ->

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -155,7 +155,7 @@ defmodule PlausibleWeb.Live.Components.Form do
       <.label class="mb-2" for={@id}>{@label}</.label>
       <textarea
         id={@id}
-        rows="6"
+        rows={@rest[:rows] || "6"}
         name={@name}
         class="block w-full textarea border-1 border-gray-300 rounded-md p-4 text-sm text-gray-700 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300"
         {@rest}

--- a/test/plausible/audit_test.exs
+++ b/test/plausible/audit_test.exs
@@ -176,6 +176,14 @@ defmodule Plausible.AuditTest do
         entry = Entry.include_change(entry, changeset)
         assert entry.changes.change == %{after: %{name: "baz"}, before: %{name: "bar", id: 1}}
       end
+
+      test "include_change/2 accepts raw map" do
+        struct = %TestSchema{id: 1, name: "bar"}
+
+        entry = Entry.new("update", struct)
+        entry = Entry.include_change(entry, %{foo: :bar})
+        assert entry.changes.change == %{foo: :bar}
+      end
     end
 
     describe "Repo integration" do

--- a/test/plausible/auth/sso/domains_test.exs
+++ b/test/plausible/auth/sso/domains_test.exs
@@ -250,12 +250,6 @@ defmodule Plausible.Auth.SSO.DomainsTest do
         {:ok, domain: domain, sso_domain: sso_domain}
       end
 
-      test "returns ok when all conditions met", %{sso_domain: sso_domain} do
-        assert :ok = SSO.Domains.remove(sso_domain)
-
-        refute Repo.reload(sso_domain)
-      end
-
       test "returns ok when force SSO enabled and SSO users on other domains present", %{
         team: team,
         integration: integration,
@@ -312,6 +306,8 @@ defmodule Plausible.Auth.SSO.DomainsTest do
       test "removes the domain if conditions met", %{sso_domain: sso_domain} do
         assert :ok = SSO.Domains.remove(sso_domain)
         refute Repo.reload(sso_domain)
+
+        assert audited_entry("sso_domain_removed", team_id: sso_domain.sso_integration.team_id)
       end
 
       test "fails to remove the domain whenSSO users present on it", %{
@@ -346,6 +342,8 @@ defmodule Plausible.Auth.SSO.DomainsTest do
         refute sso_user.sso_identity_id
         refute sso_user.sso_integration_id
         refute sso_user.sso_domain_id
+
+        assert audited_entry("sso_domain_removed", team_id: sso_domain.sso_integration.team_id)
       end
 
       test "fails to remove when force SSO enabled with SSO users only on that domain", %{

--- a/test/plausible_web/controllers/sso_controller_sync_test.exs
+++ b/test/plausible_web/controllers/sso_controller_sync_test.exs
@@ -351,7 +351,7 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email."
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email"
       end
 
       test "redirects with error on mismatch of RelayState", %{
@@ -368,12 +368,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :invalid_relay_state)."
+                 "Authentication failed (reason: :invalid_relay_state)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :invalid_relay_state)."
+                   "error" => ":invalid_relay_state"
                  }
                )
       end
@@ -389,12 +389,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :invalid_relay_state)."
+                 "Authentication failed (reason: :invalid_relay_state)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :invalid_relay_state)."
+                   "error" => ":invalid_relay_state"
                  }
                )
       end
@@ -414,12 +414,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :base64_decoding_failed)."
+                 "Authentication failed (reason: :base64_decoding_failed)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :base64_decoding_failed)."
+                   "error" => ":base64_decoding_failed"
                  }
                )
       end
@@ -447,12 +447,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :malformed_certificate)."
+                 "Authentication failed (reason: :malformed_certificate)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :malformed_certificate)."
+                   "error" => ":malformed_certificate"
                  }
                )
       end
@@ -474,12 +474,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :digest_verification_failed)."
+                 "Authentication failed (reason: :digest_verification_failed)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :digest_verification_failed)."
+                   "error" => ":digest_verification_failed"
                  }
                )
       end
@@ -499,12 +499,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :missing_email_attribute)."
+                 "Authentication failed (reason: :missing_email_attribute)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :missing_email_attribute)."
+                   "error" => ":missing_email_attribute"
                  }
                )
       end
@@ -524,12 +524,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :invalid_email_attribute)."
+                 "Authentication failed (reason: :invalid_email_attribute)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :invalid_email_attribute)."
+                   "error" => ":invalid_email_attribute"
                  }
                )
       end
@@ -549,12 +549,12 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
-                 "Authentication failed (reason: :missing_name_attributes)."
+                 "Authentication failed (reason: :missing_name_attributes)"
 
         assert audited_entry("sso_login_failure",
                  team_id: integration.team_id,
                  change: %{
-                   "error" => "Authentication failed (reason: :missing_name_attributes)."
+                   "error" => ":missing_name_attributes"
                  }
                )
       end

--- a/test/plausible_web/controllers/sso_controller_sync_test.exs
+++ b/test/plausible_web/controllers/sso_controller_sync_test.exs
@@ -331,6 +331,11 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert NaiveDateTime.compare(user_session.timeout_at, timeout_threshold_lower) == :gt
         assert NaiveDateTime.compare(user_session.timeout_at, timeout_threshold_upper) == :lt
+
+        assert entry = audited_entry("sso_login_success", team_id: integration.team_id)
+        assert entry.change["email"] == "user@plausible.test"
+        assert entry.change["name"] == "Jane Smith"
+        assert entry.change["integration_id"] == integration.identifier
       end
 
       test "redirects with error when no matching integration found", %{
@@ -364,6 +369,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :invalid_relay_state)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :invalid_relay_state)."
+                 }
+               )
       end
 
       test "redirects with error on missing relay state", %{
@@ -378,6 +390,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :invalid_relay_state)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :invalid_relay_state)."
+                 }
+               )
       end
 
       test "redirects with error on malformed assertion", %{
@@ -396,6 +415,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :base64_decoding_failed)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :base64_decoding_failed)."
+                 }
+               )
       end
 
       test "redirects with error on malformed certificate in config (should not happen)", %{
@@ -422,6 +448,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :malformed_certificate)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :malformed_certificate)."
+                 }
+               )
       end
 
       test "redirects with error on mismatched certificate in config", %{
@@ -442,6 +475,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :digest_verification_failed)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :digest_verification_failed)."
+                 }
+               )
       end
 
       test "redirects with error on missing email attribute in assertion", %{
@@ -460,6 +500,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :missing_email_attribute)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :missing_email_attribute)."
+                 }
+               )
       end
 
       test "redirects with error on invalid email attribute in assertion", %{
@@ -478,6 +525,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :invalid_email_attribute)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :invalid_email_attribute)."
+                 }
+               )
       end
 
       test "redirects with error on missing name attributes in assertion", %{
@@ -496,6 +550,13 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
                  "Authentication failed (reason: :missing_name_attributes)."
+
+        assert audited_entry("sso_login_failure",
+                 team_id: integration.team_id,
+                 change: %{
+                   "error" => "Authentication failed (reason: :missing_name_attributes)."
+                 }
+               )
       end
     end
 

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -414,8 +414,8 @@ defmodule Plausible.Teams.Test do
       attrs = Keyword.put(attrs, :name, name)
 
       case Plausible.Audit.list_entries(attrs) do
-        [_] ->
-          true
+        [entry] ->
+          entry
 
         _ ->
           raise "Expected audited entry #{inspect(attrs)} but only found #{inspect(Plausible.Audit.list_entries([]), pretty: true)}."
@@ -426,8 +426,8 @@ defmodule Plausible.Teams.Test do
       attrs = Keyword.put(attrs, :name, name)
 
       case Plausible.Audit.list_entries(attrs) do
-        l when is_list(l) and length(l) == length ->
-          true
+        entries when is_list(entries) and length(entries) == length ->
+          entries
 
         _ ->
           raise "Expected audited entry #{inspect(attrs)} but only found #{inspect(Plausible.Audit.list_entries([]), pretty: true)}."


### PR DESCRIPTION
### Changes

This PR is an initial spin of CRM-Audit integration. For now we'll only display (non-paginated) audit entries under Team/Audit tab. Currently only SSO events are audited. 
Additionally, this PR instruments SAML consumption failure/success with audit entries for completeness so we don't rely on users having to tell customer support the errors they're getting (that might end up cryptic for them anyway).

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
