### PR TITLE
Fix order of setting window.plausible.l = true

### DIFF
--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Plausible loaded indicator `window.plausible.l = true` is set last in initialisation functions
+
 ## [0.3.3] - 2025-07-22
 
 - Bind the `track` function into `window.plausible`. This makes it possible for the Plausible verification agent to verify a successful installation. Can be disabled setting the `bindToWindow` config option to `false`.

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 24,
+  "tracker_script_version": 25,
   "type": "module",
   "scripts": {
     "deploy": "node compile.js",

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -34,21 +34,22 @@ function init(overrides) {
 
     window.plausible = track
     window.plausible.init = init
-    window.plausible.l = true
     window.plausible.v = COMPILE_TRACKER_SCRIPT_VERSION
-
+    
     if (COMPILE_PLAUSIBLE_WEB) {
       window.plausible.s = 'web'
     }
+
+    window.plausible.l = true
   }
 
   // Bind to window to be detectable by the verifier tool
   // This is done in a 'safe' way to avoid breaking the page if window is frozen or running without window
   if (COMPILE_PLAUSIBLE_NPM && config.bindToWindow && typeof window !== 'undefined') {
     window.plausible = track
-    window.plausible.l = true
     window.plausible.s = 'npm'
     window.plausible.v = COMPILE_TRACKER_SCRIPT_VERSION
+    window.plausible.l = true
   }
 }
 


### PR DESCRIPTION
### Changes

Fixes order of setting window.plausible.l = true

Needed because otherwise even if window.plausible.l = true, window.plausible.s and window.plausible.v might be undefined.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
