### PR TITLE
Don't crash audit browser with weak user association missing

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -1231,7 +1231,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
   defp audit_user(%{user: nil} = assigns) do
     ~H"""
-    (deleted?)
+    (N/A)
     """
   end
 

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -52,7 +52,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
         meta =
           if entry.user_id && entry.user_id > 0 do
-            user = Plausible.Repo.get!(Plausible.Auth.User, entry.user_id)
+            user = Plausible.Repo.get(Plausible.Auth.User, entry.user_id)
             Map.put(meta, :user, user)
           else
             meta
@@ -60,7 +60,7 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
 
         meta =
           if entry.entity == "Plausible.Auth.User" do
-            user = Plausible.Repo.get!(Plausible.Auth.User, String.to_integer(entry.entity_id))
+            user = Plausible.Repo.get(Plausible.Auth.User, String.to_integer(entry.entity_id))
             Map.put(meta, :entity, user)
           else
             meta
@@ -1228,6 +1228,12 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
   end
 
   attr :user, Plausible.Auth.User
+
+  defp audit_user(%{user: nil} = assigns) do
+    ~H"""
+    (deleted?)
+    """
+  end
 
   defp audit_user(assigns) do
     ~H"""

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -677,7 +677,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
 
         text = lv |> render() |> text()
 
-        assert text =~ "(deleted?) (deleted?)"
+        assert text =~ "(N/A) (N/A)"
       end
     end
   end

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -658,6 +658,27 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         assert text_of_element(html, ~s|textarea|) ==
                  "{ &amp;quot;foo&amp;quot;: &amp;quot;bar&amp;quot; }"
       end
+
+      test "shows audit entries when user id does not exists", %{conn: conn, user: user} do
+        team = team_of(user)
+
+        %Plausible.Audit.Entry{
+          name: "Reveal Test",
+          entity: "Plausible.Auth.User",
+          entity_id: "666111",
+          team_id: team.id,
+          datetime: NaiveDateTime.utc_now(),
+          user_id: 666_111,
+          actor_type: :user
+        }
+        |> Plausible.Repo.insert!()
+
+        {:ok, lv, _html} = live(conn, open_team(team.id, tab: :audit))
+
+        text = lv |> render() |> text()
+
+        assert text =~ "(deleted?) (deleted?)"
+      end
     end
   end
 end


### PR DESCRIPTION
### Changes

Audit logs store non-constrained identifiers. So in case the user does not exist anymore, we should still render something.