### PR TITLE
Bfcache referrer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Correct referrer is sent in `event` beacon on bfcache
+
 - A session is now marked as a bounce if it has less than 2 pageviews and no interactive custom events.
 
 - All dropmenus on dashboard are navigable with Tab (used to be a mix between tab and arrow keys), and no two dropmenus can be open at once on the dashboard

--- a/tracker/src/autocapture.js
+++ b/tracker/src/autocapture.js
@@ -3,13 +3,13 @@ import { config, location, document } from './config'
 export function init(track) {
   var lastPage;
 
-  function page(isSPANavigation) {
+  function page(isSPANavigation, options) {
     if (!(COMPILE_HASH && (!COMPILE_CONFIG || config.hashBasedRouting))) {
       if (isSPANavigation && lastPage === location.pathname) return;
     }
 
     lastPage = location.pathname
-    track('pageview')
+    track('pageview', options)
   }
 
   var onSPANavigation = function () { page(true) }
@@ -43,7 +43,8 @@ export function init(track) {
   window.addEventListener('pageshow', function (event) {
     if (event.persisted) {
       // Page was restored from bfcache - track a pageview
-      page();
+      page(false, {referrer:sessionStorage.getItem('plausible-referrer')});
     }
+    sessionStorage.setItem('plausible-referrer', window.location.href);
   })
 }

--- a/tracker/src/track.js
+++ b/tracker/src/track.js
@@ -63,7 +63,7 @@ export function track(eventName, options) {
   }
 
   payload.d = config.domain
-  payload.r = document.referrer || null
+  payload.r = options?.referrer || document.referrer || null
   if (COMPILE_PLAUSIBLE_LEGACY_VARIANT && options && options.meta) {
     payload.m = JSON.stringify(options.meta)
   }


### PR DESCRIPTION
… `referrer` from options in `track`

### Changes

Fixes submitting correct referrer on bfcache pagehits.
For discussion, see https://www.linkedin.com/feed/update/urn:li:activity:7352964791960760320/?commentUrn=urn%3Ali%3Acomment%3A(activity%3A7352964791960760320%2C7353132789187166208)&dashCommentUrn=urn%3Ali%3Afsd_comment%3A(7353132789187166208%2Curn%3Ali%3Aactivity%3A7352964791960760320)&dashReplyUrn=urn%3Ali%3Afsd_comment%3A(7353800721567240196%2Curn%3Ali%3Aactivity%3A7352964791960760320)&replyUrn=urn%3Ali%3Acomment%3A(activity%3A7352964791960760320%2C7353800721567240196)

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

This PR might need a test. I already successfully tested it though by visiting plausible.io, override https://plausible.io/js/s-6_srOGVV9SLMWJ1ZpUAbG.js via DevTools localoverrides, reflect my changes over there and adding some `console.logs`.

Both `console.log` as well as the contents for the `event` beacon in my network panel ends up as expected i.e. reflecting correct value for `r` ( = referrer ).

### Changelog
- [x] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

I don't see any bfcache related docs that requires a change.
The referrer paragraph might need an update though, as the first line won't be correct anymore when accepted:
>Referrer for this event. When using the standard tracker script, this is set to document.referrer
https://plausible.io/docs/events-api

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
