### PR TITLE
CRM Audit browser: implement basic pagination

### DIFF
--- a/extra/lib/plausible/audit.ex
+++ b/extra/lib/plausible/audit.ex
@@ -9,8 +9,20 @@ defmodule Plausible.Audit do
   defdelegate set_context(term), to: Plausible.Audit.Entry
 
   def list_entries(attrs) do
-    Plausible.Repo.all(
-      from ae in Plausible.Audit.Entry, where: ^attrs, order_by: [asc: :datetime]
-    )
+    attrs
+    |> entries_query()
+    |> Plausible.Repo.all()
+  end
+
+  def list_entries_paginated(attrs, params \\ %{}) do
+    attrs
+    |> entries_query()
+    |> Plausible.Pagination.paginate(params, cursor_fields: [{:datetime, :asc}])
+  end
+
+  defp entries_query(attrs) do
+    from ae in Plausible.Audit.Entry,
+      where: ^attrs,
+      order_by: [asc: :datetime]
   end
 end

--- a/extra/lib/plausible_web/live/customer_support.ex
+++ b/extra/lib/plausible_web/live/customer_support.ex
@@ -132,9 +132,12 @@ defmodule PlausibleWeb.Live.CustomerSupport do
 
     id = String.to_integer(id)
 
+    tab_params = Map.drop(p, ["id", "resource", "tab"])
+
     send_update(self(), mod.component(),
       id: "#{mod.type()}-#{id}",
-      tab: p["tab"]
+      tab: p["tab"],
+      tab_params: tab_params
     )
 
     {:noreply, assign(socket, type: type, current: mod, id: id)}

--- a/extra/lib/plausible_web/live/customer_support/live/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/live/team.ex
@@ -339,7 +339,12 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
           <div :if={Enum.empty?(@audit_page.entries)} class="flex justify-center items-center">
             No audit logs yet
           </div>
-          <div :if={@revealed_audit_entry_id}>
+          <div
+            :if={@revealed_audit_entry_id}
+            phx-target={@myself}
+            phx-window-keydown="reveal-audit-entry"
+            phx-key="escape"
+          >
             <.input_with_clipboard
               id="audit-entry-identifier"
               name="audit-entry-identifier"
@@ -376,6 +381,9 @@ defmodule PlausibleWeb.CustomerSupport.Live.Team do
                 class="float-right pt-4 text-sm"
               >
                 &larr; Return
+                <kbd class="rounded border border-gray-200 dark:border-gray-600 px-2 font-mono font-normal text-xs text-gray-400">
+                  ESC
+                </kbd>
               </.styled_link>
             </div>
           </div>


### PR DESCRIPTION
### Changes

This PR adds basic pagination to Audit logs CRM browser.
Default item limit per page is `15` but one can alter the URL. 
Next up we'll have to restructure the whole Customer Support <-> tabs code organization before adding any new features. Delegating all the work to a single god-component let us iterate relatively fast on this, but is getting hard to maintain and reason about.

<img width="1591" height="909" alt="image" src="https://github.com/user-attachments/assets/63c1cc12-ea99-475c-8e63-1764d484d3ca" />


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
