### PR TITLE
Verifier v1: Retry verification on JS navigation

### DIFF
--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -10,7 +10,15 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
 
   # Puppeteer wrapper function that executes the vanilla JS verifier code.
 
-  # ### TRICKY (NOT TESTED): Handling client side JS navigation.
+  # ### NO AUTOMATIC TEST COVERAGE
+
+  # Unfortunately, as things stand today, this Puppeteer wrapper logic
+  # cannot be tested without spinning up a real Browserless instance or
+  # bringing in a bunch of test deps for Puppeteer. Therefore, take extra
+  # care when changing this and make sure to run manual tests on local
+  # browserless (`make browserless`) before releasing an update.
+
+  # ### TRICKY: Handling client side JS navigation.
 
   # We've seen numerous cases where client JS navigates or refreshes the
   # page after load. Any such JS behaviour destroys the Puppeteer page
@@ -23,10 +31,6 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
   # Important: On retries, we work with the client-modified page context
   # instead of calling `page.goto(context.url)` again (which would most
   # likely result in another interruptive navigation).
-
-  # Unfortunately, as things stand today, we cannot test this without
-  # spinning up a real Browserless instance or bringing in a bunch of
-  # test deps for Puppeteer.
   @puppeteer_wrapper_code """
   export default async function({ page, context }) {
     const MAX_RETRIES = 2


### PR DESCRIPTION
### Changes

Retry verifier-v1 execution when client JS navigates and destroys current page context.

I've tested this with a local Browserless instance against a few sites that end up with the following warning log on current master:

```
[warning] [VERIFICATION] Browserless JS error: "Protocol error (Runtime.callFunctionOn): Execution context was destroyed."
```

With the changes introduced in this PR, the local Browserless call returns successful diagnostics. Therefore, merging this, I would expect the volume of these specific error cases to drop significantly.

Unfortunately, as stated in a code comment, this behaviour is currently not testable. 

### Tests
- [ ] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
