### PR TITLE
Handle another Browserless error response

### DIFF
--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -150,6 +150,13 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
 
         put_diagnostics(state, plausible_installed?: false, service_error: status)
 
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning(
+          "[VERIFICATION] Unexpected Browserless response (data_domain='#{data_domain}'): status=#{status}, body=#{inspect(body)}"
+        )
+
+        put_diagnostics(state, plausible_installed?: false, service_error: status)
+
       {:error, %{reason: reason}} ->
         Logger.warning(
           "[VERIFICATION] Browserless request error (data_domain='#{data_domain}'): #{inspect(reason)}"


### PR DESCRIPTION
### Changes

Tackles one specific case that surfaces in Sentry from time to time:

```
Error running check Plausible.InstallationSupport.Checks.Installation on https://some.website: {:case_clause, {:ok, %Req.Response{status: 400, headers: %{"connection" => ["keep-alive"], "content-type" => ["text/plain; charset=UTF-8"], "date" => ["Tue, 29 Jul 2025 09:09:01 GMT"], "server" => ["openresty/1.27.1.2"], "transfer-encoding" => ["chunked"]}, body: "Protocol error (Runtime.callFunctionOn): Target closed\n", trailers: %{}, private: %{}}}}
```

This error appears to be thrown from Browserless even before our verification code runs. Instead of a JSON body with a known `error` key, we get status 400 with a `text/plain` body. Currently, since there's no case clause matching, the LiveView keeps re-attempting the Browserless request with no prevail.

This PR adds a new case clause catching that error and rendering a "We could not reach your site" error message to the user.

_Note: Should be incorporated into verifier v2 and tested for v2._ (cc @apata)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
