### PR TITLE
Create 404 goal always in onboarding

### DIFF
--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -210,6 +210,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
         outbound_links: true,
         form_submissions: true,
         file_downloads: true,
+        track_404_pages: true,
         installation_type: recommended_installation_type
       })
 


### PR DESCRIPTION
Unconditionally creates a `404` goal for every site during onboarding.

This makes it more convenient to start tracking 404 pages since creating the goal manually is not needed. Not much of a downside since the goal does not show up in dashboard unless `404` events are actually sent.