### PR TITLE
Script v2: Handle verifying sites where there's an immediate JS redirect

### DIFF
--- a/lib/plausible/installation_support/verification/diagnostics.ex
+++ b/lib/plausible/installation_support/verification/diagnostics.ex
@@ -14,7 +14,8 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
             diagnostics_are_from_cache_bust: nil,
             test_event: nil,
             cookie_banner_likely: nil,
-            service_error: nil
+            service_error: nil,
+            attempts: nil
 
   @type t :: %__MODULE__{}
 

--- a/lib/plausible_web/live/components/verification.ex
+++ b/lib/plausible_web/live/components/verification.ex
@@ -127,33 +127,34 @@ defmodule PlausibleWeb.Live.Components.Verification do
               </.styled_link>
             </:item>
           </.focus_list>
-          <div
-            :if={@verification_state && @super_admin? && @finished?}
-            class="flex flex-col dark:text-gray-200 mt-4 pt-4 border-t border-gray-300 dark:border-gray-700"
-            x-data="{ showDiagnostics: false }"
-            id="super-admin-report"
-          >
-            <p class="text-sm">
-              <a
-                href="#"
-                @click.prevent="showDiagnostics = !showDiagnostics"
-                class="bg-yellow-100 dark:text-gray-800"
-              >
-                As a super-admin, you're eligible to see diagnostics details. Click to expand.
-              </a>
-            </p>
-            <div x-show="showDiagnostics" x-cloak>
-              <.focus_list>
-                <:item :for={{diag, value} <- Map.from_struct(@verification_state.diagnostics)}>
-                  <span class="text-sm">
-                    {Phoenix.Naming.humanize(diag)}:
-                    <span class="font-mono">{to_string_value(value)}</span>
-                  </span>
-                </:item>
-              </.focus_list>
-            </div>
-          </div>
         </:footer>
+      </.focus_box>
+      <.focus_box :if={not is_nil(@verification_state) && @super_admin? && @finished?}>
+        <div
+          class="flex flex-col dark:text-gray-200"
+          x-data="{ showDiagnostics: false }"
+          id="super-admin-report"
+        >
+          <p class="text-sm">
+            <a
+              href="#"
+              @click.prevent="showDiagnostics = !showDiagnostics"
+              class="bg-yellow-100 dark:text-gray-800"
+            >
+              As a super-admin, you're eligible to see diagnostics details. Click to expand.
+            </a>
+          </p>
+          <div x-show="showDiagnostics" x-cloak>
+            <.focus_list>
+              <:item :for={{diag, value} <- Map.from_struct(@verification_state.diagnostics)}>
+                <span class="text-sm">
+                  {Phoenix.Naming.humanize(diag)}:
+                  <span class="font-mono">{to_string_value(value)}</span>
+                </span>
+              </:item>
+            </.focus_list>
+          </div>
+        </div>
       </.focus_box>
     </div>
     """

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -136,7 +136,9 @@ defmodule PlausibleWeb.Live.Verification do
       installation_type = socket.assigns.installation_type
 
       {:ok, pid} =
-        if(FunWithFlags.enabled?(:scriptv2, for: socket.assigns.site),
+        if(
+          FunWithFlags.enabled?(:scriptv2, for: socket.assigns.site) or
+            FunWithFlags.enabled?(:scriptv2, for: socket.assigns.current_user),
           do:
             Verification.Checks.run(url_to_verify, domain, installation_type,
               report_to: report_to,


### PR DESCRIPTION
### Changes

Like legacy verifier, v2 verifier should handle verifying sites where there's an immediate JS redirect. 

To do so, this PR adds logic to catch puppeteer errors about 'execution context' being canceled (which is the signal that navigation happened in the browser tab, canceling the function that was being evaluated), and to reattempt verification in the new location.

It also fixes the installation v2 module verifier loading logic to match the improved v1 module logic. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
