### PR TITLE
Script v2: Add more diagnostics cases to verifier v2, more tests for verifier v2

### DIFF
--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -1,0 +1,211 @@
+defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
+  use ExUnit.Case
+  import Plausible.AssertMatches
+  alias Plausible.InstallationSupport.Verification.Diagnostics
+  alias Plausible.InstallationSupport.Result
+
+  describe "interpreting diagnostics" do
+    for status <- [200, 202] do
+      test "success with response status #{status}" do
+        expected_domain = "example.com"
+        url_to_verify = "https://#{expected_domain}"
+
+        diagnostics = %Diagnostics{
+          plausible_is_on_window: true,
+          plausible_is_initialized: true,
+          test_event: %{
+            "normalizedBody" => %{
+              "domain" => "example.com"
+            },
+            "responseStatus" => unquote(status)
+          },
+          service_error: nil
+        }
+
+        assert Diagnostics.interpret(diagnostics, expected_domain, url_to_verify) == %Result{
+                 ok?: true
+               }
+      end
+    end
+
+    test "error when it 'succeeds', but only after cache bust" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        plausible_is_on_window: true,
+        plausible_is_initialized: true,
+        test_event: %{
+          "normalizedBody" => %{
+            "domain" => "example.com"
+          },
+          "responseStatus" => 200
+        },
+        diagnostics_are_from_cache_bust: true,
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*cache.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*cache.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "error when test event domain doesn't match expected domain" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        plausible_is_on_window: true,
+        plausible_is_initialized: true,
+        test_event: %{
+          "normalizedBody" => %{
+            "domain" => "wrong-domain.com"
+          },
+          "responseStatus" => 200
+        },
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*not for this site.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*snippet.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "error when proxy network error occurs" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        plausible_is_on_window: true,
+        plausible_is_initialized: true,
+        test_event: %{
+          "requestUrl" => "https://proxy.example.com/event",
+          "responseStatus" => 500
+        },
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*proxy.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*proxied.*/),
+                           url: "https://plausible.io/docs/proxy/introduction"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "error when plausible network error occurs" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        plausible_is_on_window: true,
+        plausible_is_initialized: true,
+        test_event: %{
+          "requestUrl" => PlausibleWeb.Endpoint.url() <> "/api/event",
+          "responseStatus" => 500
+        },
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*couldn't verify.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*try verifying again.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "error when disallowed by CSP" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        disallowed_by_csp: true,
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*Content Security Policy.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*plausible\.io domain.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "error when GTM selected and cookie banner likely" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        selected_installation_type: "gtm",
+        cookie_banner_likely: true,
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*couldn't verify.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*cookie consent banner.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+
+    test "unknown error when no specific case matches" do
+      expected_domain = "example.com"
+      url_to_verify = "https://#{expected_domain}"
+
+      diagnostics = %Diagnostics{
+        plausible_is_on_window: false,
+        plausible_is_initialized: false,
+        service_error: nil
+      }
+
+      assert_matches %Result{
+                       ok?: false,
+                       errors: [^any(:string, ~r/.*integration is not working.*/)],
+                       recommendations: [
+                         %{
+                           text: ^any(:string, ~r/.*manually check.*/),
+                           url:
+                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                         }
+                       ]
+                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+    end
+  end
+end

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -419,7 +419,7 @@ test.describe('installed plausible web variant', () => {
     const cspHostToCheck = LOCAL_SERVER_ADDR.replace('http://', '')
     const headers = {
       // 'unsafe-inline' is needed to allow the bootstrapper snippet to be executed
-      'content-security-policy': `default-src 'self'; script-src ${cspHostToCheck} unsafe; connect-src ${cspHostToCheck}`
+      'content-security-policy': `default-src 'self'; script-src ${cspHostToCheck}; connect-src ${cspHostToCheck}`
     }
 
     await mockManyRequests({
@@ -480,7 +480,7 @@ test.describe('installed plausible web variant', () => {
     const cspHostToCheck = LOCAL_SERVER_ADDR.replace('http://', '')
     const headers = {
       // 'unsafe-inline' is needed to allow the bootstrapper snippet to be executed
-      'content-security-policy': `default-src 'self'; script-src 'unsafe-inline' ${cspHostToCheck} unsafe; connect-src ${cspHostToCheck}`
+      'content-security-policy': `default-src 'self'; script-src 'unsafe-inline' ${cspHostToCheck}; connect-src ${cspHostToCheck}`
     }
 
     await mockManyRequests({

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -37,9 +37,13 @@ test.describe('installed plausible web variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -93,10 +97,12 @@ test.describe('installed plausible web variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
     const result = await executeVerifyV2(page, {
       ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders,
       timeoutMs
     })
 
@@ -149,9 +155,13 @@ test.describe('installed plausible web variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -191,9 +201,13 @@ test.describe('installed plausible web variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -236,11 +250,16 @@ test.describe('installed plausible web variant', () => {
       bodyContent: 'alfa'
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
+
     await expect(page.getByText('alfa')).toBeVisible()
 
     const [result, _] = await Promise.all([
-      executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS),
+      executeVerifyV2(page, {
+        ...DEFAULT_VERIFICATION_OPTIONS,
+        responseHeaders
+      }),
       page.evaluate(
         ({ targetUrl }) =>
           setTimeout(() => (window.location.href = targetUrl), 250),
@@ -307,14 +326,17 @@ test.describe('installed plausible web variant', () => {
       bodyContent: 'alfa'
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
+
     await expect(page.getByText('alfa')).toBeVisible()
 
     const [result] = await Promise.all([
       executeVerifyV2(page, {
         ...DEFAULT_VERIFICATION_OPTIONS,
         timeoutBetweenAttemptsMs,
-        maxAttempts
+        maxAttempts,
+        responseHeaders
       }),
       page.evaluate(
         (url) => setTimeout(() => (window.location.href = url), 250),
@@ -331,6 +353,187 @@ test.describe('installed plausible web variant', () => {
           message:
             'page.evaluate: Execution context was destroyed, most likely because of a navigation.'
         }
+      }
+    })
+  })
+
+  test('using provided snippet but disallowed by CSP', async ({ page }, {
+    testId
+  }) => {
+    await mockManyRequests({
+      page,
+      path: `https://plausible.io/api/event`,
+      awaitedRequestCount: 1,
+      fulfill: {
+        status: 202,
+        contentType: 'text/plain',
+        body: 'ok'
+      }
+    })
+
+    const { url } = await initializePageDynamically(page, {
+      testId,
+      scriptConfig: {
+        domain: 'example.com',
+        endpoint: `https://plausible.io/api/event`,
+        captureOnLocalhost: true
+      },
+      bodyContent: '',
+      headers: {
+        'content-security-policy': "default-src 'self'; img-src 'self'"
+      }
+    })
+
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
+
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
+
+    expect(result).toEqual({
+      data: {
+        attempts: 1,
+        completed: true,
+        disallowedByCsp: true,
+        plausibleIsOnWindow: false,
+        plausibleIsInitialized: undefined,
+        plausibleVersion: undefined,
+        plausibleVariant: undefined,
+        testEvent: {
+          error: undefined,
+          normalizedBody: undefined,
+          requestUrl: undefined,
+          responseStatus: undefined
+        },
+        cookieBannerLikely: false
+      }
+    })
+  })
+
+  test(`using provided snippet and there is a strict CSP without 'unsafe-inline'`, async ({
+    page
+  }, { testId }) => {
+    const endpoint = `${LOCAL_SERVER_ADDR}/api/event`
+    const cspHostToCheck = LOCAL_SERVER_ADDR.replace('http://', '')
+    const headers = {
+      // 'unsafe-inline' is needed to allow the bootstrapper snippet to be executed
+      'content-security-policy': `default-src 'self'; script-src ${cspHostToCheck} unsafe; connect-src ${cspHostToCheck}`
+    }
+
+    await mockManyRequests({
+      page,
+      path: endpoint,
+      awaitedRequestCount: 1,
+      fulfill: {
+        status: 202,
+        contentType: 'text/plain',
+        body: 'ok'
+      }
+    })
+
+    const { url } = await initializePageDynamically(page, {
+      testId,
+      scriptConfig: {
+        endpoint,
+        domain: 'example.com',
+        captureOnLocalhost: true
+      },
+      bodyContent: '',
+      headers
+    })
+
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
+
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      cspHostToCheck,
+      responseHeaders
+    })
+
+    expect(result).toEqual({
+      data: {
+        attempts: 1,
+        completed: true,
+        disallowedByCsp: false, // scripts from our domain are allowed, but the inline sourceless snippet can't run because 'unsafe-inline' is not present in the CSP
+        plausibleIsOnWindow: false,
+        plausibleIsInitialized: undefined,
+        plausibleVersion: undefined,
+        plausibleVariant: undefined,
+        testEvent: {
+          error: undefined,
+          normalizedBody: undefined,
+          requestUrl: undefined,
+          responseStatus: undefined
+        },
+        cookieBannerLikely: false
+      }
+    })
+  })
+
+  test(`using provided snippet and there is a strict CSP with 'unsafe-inline'`, async ({
+    page
+  }, { testId }) => {
+    const endpoint = `${LOCAL_SERVER_ADDR}/api/event`
+    const cspHostToCheck = LOCAL_SERVER_ADDR.replace('http://', '')
+    const headers = {
+      // 'unsafe-inline' is needed to allow the bootstrapper snippet to be executed
+      'content-security-policy': `default-src 'self'; script-src 'unsafe-inline' ${cspHostToCheck} unsafe; connect-src ${cspHostToCheck}`
+    }
+
+    await mockManyRequests({
+      page,
+      path: endpoint,
+      awaitedRequestCount: 1,
+      fulfill: {
+        status: 202,
+        contentType: 'text/plain',
+        body: 'ok'
+      }
+    })
+
+    const { url } = await initializePageDynamically(page, {
+      testId,
+      scriptConfig: {
+        endpoint,
+        domain: 'example.com',
+        captureOnLocalhost: true
+      },
+      bodyContent: '',
+      headers
+    })
+
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
+
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      cspHostToCheck,
+      responseHeaders
+    })
+
+    expect(result).toEqual({
+      data: {
+        attempts: 1,
+        completed: true,
+        disallowedByCsp: false,
+        plausibleIsOnWindow: true,
+        plausibleIsInitialized: true,
+        plausibleVersion: version,
+        plausibleVariant: 'web',
+        testEvent: {
+          callbackResult: { status: 202 },
+          requestUrl: `${LOCAL_SERVER_ADDR}/api/event`,
+          normalizedBody: {
+            domain: 'example.com',
+            name: 'verification-agent-test',
+            version
+          },
+          responseStatus: 202
+        },
+        cookieBannerLikely: false
       }
     })
   })
@@ -361,9 +564,13 @@ test.describe('installed plausible esm variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -416,9 +623,13 @@ test.describe('installed plausible esm variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -471,9 +682,13 @@ test.describe('installed plausible esm variant', () => {
       }
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {
@@ -515,9 +730,13 @@ test.describe('installed plausible esm variant', () => {
       bodyContent: ''
     })
 
-    await page.goto(url)
+    const response = await page.goto(url)
+    const responseHeaders = response?.headers() ?? {}
 
-    const result = await executeVerifyV2(page, DEFAULT_VERIFICATION_OPTIONS)
+    const result = await executeVerifyV2(page, {
+      ...DEFAULT_VERIFICATION_OPTIONS,
+      responseHeaders
+    })
 
     expect(result).toEqual({
       data: {

--- a/tracker/test/support/initialize-page-dynamically.ts
+++ b/tracker/test/support/initialize-page-dynamically.ts
@@ -7,6 +7,7 @@ interface SharedOptions {
   testId: string
   /** optional path to append to the dynamic page URL */
   path?: string
+  headers?: Record<string, string>
 }
 
 interface TemplatedResponse {
@@ -124,7 +125,8 @@ export async function initializePageDynamically(
 
     await route.fulfill({
       body: responseBody,
-      contentType: 'text/html'
+      contentType: 'text/html',
+      headers: options.headers
     })
   })
   return { url }


### PR DESCRIPTION
### Changes

- Adds more diagnostics cases to verifier v2
- Breaks up diagnostic function to have separate clauses
- Adds CSP related tests to verifier v2

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
