### PR TITLE
Script v2/include prefix in tracker config

### DIFF
--- a/lib/plausible/data_migration/prefix_tracker_script_configuration_id.ex
+++ b/lib/plausible/data_migration/prefix_tracker_script_configuration_id.ex
@@ -1,0 +1,83 @@
+defmodule Plausible.DataMigration.PrefixTrackerScriptConfigurationId do
+  @moduledoc """
+  Migration to update tracker script configuration IDs to use the new prefixed format.
+
+  This migration:
+  1. Processes tracker configurations in batches to avoid memory issues
+  2. Uses batch updates for better performance
+  3. Handles the case where tracker configurations might not exist for all sites
+  4. Provides progress logging
+  """
+
+  import Ecto.Query
+  alias Plausible.Repo
+  alias Plausible.Site.TrackerScriptConfiguration
+
+  @batch_size 100
+
+  def run do
+    total_configs = count_total_configurations()
+    IO.puts("Found #{total_configs} total tracker configurations to process")
+
+    process_batch(0, total_configs)
+  end
+
+  defp count_total_configurations do
+    Repo.aggregate(
+      from(config in TrackerScriptConfiguration,
+        where: not like(config.id, "pa-%")
+      ),
+      :count,
+      :id
+    )
+  end
+
+  defp process_batch(offset, total_configs) do
+    configs = get_configurations_batch(offset)
+
+    if length(configs) > 0 do
+      IO.puts(
+        "Processing batch #{div(offset, @batch_size) + 1} (#{offset + 1}-#{offset + length(configs)} of #{total_configs})"
+      )
+
+      process_configurations_batch(configs)
+      process_batch(offset + @batch_size, total_configs)
+    else
+      IO.puts("Migration completed!")
+    end
+  end
+
+  defp get_configurations_batch(offset) do
+    Repo.all(
+      from(config in TrackerScriptConfiguration,
+        where: not like(config.id, "pa-%"),
+        order_by: [asc: config.id],
+        limit: ^@batch_size,
+        offset: ^offset,
+        select: %{
+          id: config.id
+        }
+      )
+    )
+  end
+
+  defp process_configurations_batch(configs) do
+    config_ids = Enum.map(configs, & &1.id)
+
+    case Repo.query(
+           "UPDATE tracker_script_configuration SET id = 'pa-' || id WHERE id = ANY($1)",
+           [config_ids]
+         ) do
+      {:ok, %{num_rows: updated_count}} ->
+        if updated_count != length(configs) do
+          IO.puts(
+            "  Warning: Expected to update #{length(configs)} configurations, but updated #{updated_count}"
+          )
+        end
+
+      {:error, error} ->
+        IO.puts("  Error updating batch: #{inspect(error)}")
+        # Continue with next batch instead of crashing
+    end
+  end
+end

--- a/lib/plausible/data_migration/prefix_tracker_script_configuration_id.ex
+++ b/lib/plausible/data_migration/prefix_tracker_script_configuration_id.ex
@@ -13,13 +13,11 @@ defmodule Plausible.DataMigration.PrefixTrackerScriptConfigurationId do
   alias Plausible.Repo
   alias Plausible.Site.TrackerScriptConfiguration
 
-  @batch_size 100
-
-  def run do
+  def run(batch_size \\ 100) do
     total_configs = count_total_configurations()
     IO.puts("Found #{total_configs} total tracker configurations to process")
 
-    process_batch(0, total_configs)
+    process_batch(nil, total_configs, batch_size, 0)
   end
 
   defp count_total_configurations do
@@ -32,36 +30,51 @@ defmodule Plausible.DataMigration.PrefixTrackerScriptConfigurationId do
     )
   end
 
-  defp process_batch(offset, total_configs) do
-    configs = get_configurations_batch(offset)
+  defp process_batch(last_id, total_configs, batch_size, processed_count) do
+    configs = get_configurations_batch(last_id, batch_size)
 
     if length(configs) > 0 do
-      IO.puts(
-        "Processing batch #{div(offset, @batch_size) + 1} (#{offset + 1}-#{offset + length(configs)} of #{total_configs})"
-      )
+      batch_num = div(processed_count, batch_size) + 1
+      start_pos = processed_count + 1
+      end_pos = processed_count + length(configs)
 
-      process_configurations_batch(configs)
-      process_batch(offset + @batch_size, total_configs)
+      IO.puts("Processing batch #{batch_num} (#{start_pos}-#{end_pos} of #{total_configs})")
+
+      process_configurations_batch(configs, batch_num)
+
+      process_batch(
+        List.last(configs).id,
+        total_configs,
+        batch_size,
+        processed_count + length(configs)
+      )
     else
       IO.puts("Migration completed!")
     end
   end
 
-  defp get_configurations_batch(offset) do
-    Repo.all(
+  defp get_configurations_batch(last_id, batch_size) do
+    query =
       from(config in TrackerScriptConfiguration,
         where: not like(config.id, "pa-%"),
         order_by: [asc: config.id],
-        limit: ^@batch_size,
-        offset: ^offset,
+        limit: ^batch_size,
         select: %{
           id: config.id
         }
       )
-    )
+
+    query =
+      if last_id do
+        from(config in query, where: config.id > ^last_id)
+      else
+        query
+      end
+
+    Repo.all(query)
   end
 
-  defp process_configurations_batch(configs) do
+  defp process_configurations_batch(configs, batch_num) do
     config_ids = Enum.map(configs, & &1.id)
 
     case Repo.query(
@@ -71,12 +84,12 @@ defmodule Plausible.DataMigration.PrefixTrackerScriptConfigurationId do
       {:ok, %{num_rows: updated_count}} ->
         if updated_count != length(configs) do
           IO.puts(
-            "  Warning: Expected to update #{length(configs)} configurations, but updated #{updated_count}"
+            "Warning: Batch #{batch_num} - Expected to update #{length(configs)} configurations, but updated #{updated_count}"
           )
         end
 
       {:error, error} ->
-        IO.puts("  Error updating batch: #{inspect(error)}")
+        IO.puts("Error updating batch #{batch_num}: #{inspect(error)}")
         # Continue with next batch instead of crashing
     end
   end

--- a/lib/plausible/ecto/types/nanoid.ex
+++ b/lib/plausible/ecto/types/nanoid.ex
@@ -1,6 +1,6 @@
-defmodule Plausible.Ecto.Types.Nanoid do
+defmodule Plausible.Ecto.Types.NanoidBase do
   @moduledoc """
-  Custom column type for nanoid strings
+  Base module for nanoid string types
   """
 
   use Ecto.Type
@@ -14,6 +14,21 @@ defmodule Plausible.Ecto.Types.Nanoid do
 
   def dump(value) when is_binary(value), do: {:ok, value}
   def dump(_), do: :error
+
+  @callback autogenerate() :: String.t()
+end
+
+defmodule Plausible.Ecto.Types.Nanoid do
+  @moduledoc """
+  Custom column type for nanoid strings
+  """
+
+  @behaviour Plausible.Ecto.Types.NanoidBase
+
+  def type(), do: Plausible.Ecto.Types.NanoidBase.type()
+  def cast(value), do: Plausible.Ecto.Types.NanoidBase.cast(value)
+  def load(value), do: Plausible.Ecto.Types.NanoidBase.load(value)
+  def dump(value), do: Plausible.Ecto.Types.NanoidBase.dump(value)
 
   @spec autogenerate() :: String.t()
   def autogenerate(), do: Nanoid.generate()
@@ -24,17 +39,12 @@ defmodule Plausible.Ecto.Types.TrackerScriptNanoid do
   Custom column type for tracker script configuration nanoid strings with pa- prefix
   """
 
-  use Ecto.Type
+  @behaviour Plausible.Ecto.Types.NanoidBase
 
-  def type(), do: :string
-
-  def cast(value) when is_binary(value), do: {:ok, value}
-  def cast(_), do: :error
-
-  def load(value), do: {:ok, value}
-
-  def dump(value) when is_binary(value), do: {:ok, value}
-  def dump(_), do: :error
+  def type(), do: Plausible.Ecto.Types.NanoidBase.type()
+  def cast(value), do: Plausible.Ecto.Types.NanoidBase.cast(value)
+  def load(value), do: Plausible.Ecto.Types.NanoidBase.load(value)
+  def dump(value), do: Plausible.Ecto.Types.NanoidBase.dump(value)
 
   @spec autogenerate() :: String.t()
   def autogenerate(), do: "pa-#{Nanoid.generate()}"

--- a/lib/plausible/ecto/types/nanoid.ex
+++ b/lib/plausible/ecto/types/nanoid.ex
@@ -18,3 +18,24 @@ defmodule Plausible.Ecto.Types.Nanoid do
   @spec autogenerate() :: String.t()
   def autogenerate(), do: Nanoid.generate()
 end
+
+defmodule Plausible.Ecto.Types.TrackerScriptNanoid do
+  @moduledoc """
+  Custom column type for tracker script configuration nanoid strings with pa- prefix
+  """
+
+  use Ecto.Type
+
+  def type(), do: :string
+
+  def cast(value) when is_binary(value), do: {:ok, value}
+  def cast(_), do: :error
+
+  def load(value), do: {:ok, value}
+
+  def dump(value) when is_binary(value), do: {:ok, value}
+  def dump(_), do: :error
+
+  @spec autogenerate() :: String.t()
+  def autogenerate(), do: "pa-#{Nanoid.generate()}"
+end

--- a/lib/plausible/site/tracker_script_configuration.ex
+++ b/lib/plausible/site/tracker_script_configuration.ex
@@ -20,7 +20,7 @@ defmodule Plausible.Site.TrackerScriptConfiguration do
              :pageview_props
            ]}
 
-  @primary_key {:id, Plausible.Ecto.Types.Nanoid, autogenerate: true}
+  @primary_key {:id, Plausible.Ecto.Types.TrackerScriptNanoid, autogenerate: true}
   schema "tracker_script_configuration" do
     field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, nil]
 

--- a/lib/plausible_web/live/installationv2/instructions.ex
+++ b/lib/plausible_web/live/installationv2/instructions.ex
@@ -245,6 +245,10 @@ defmodule PlausibleWeb.Live.InstallationV2.Instructions do
   end
 
   defp tracker_url(tracker_script_configuration) do
+    if String.starts_with?(tracker_script_configuration.id, "pa-") do
+      "https://plausible.io/js/#{tracker_script_configuration.id}.js"
+    end
+
     "https://plausible.io/js/s-#{tracker_script_configuration.id}.js"
   end
 end

--- a/lib/plausible_web/plugs/tracker_plug.ex
+++ b/lib/plausible_web/plugs/tracker_plug.ex
@@ -42,8 +42,16 @@ defmodule PlausibleWeb.TrackerPlug do
     case conn.request_path do
       "/js/s-" <> path ->
         if String.ends_with?(path, ".js") do
-          tag = String.replace_trailing(path, ".js", "")
-          request_tracker_script(tag, conn)
+          id = String.replace_trailing(path, ".js", "")
+          request_tracker_script(id, conn)
+        else
+          conn
+        end
+
+      "/js/pa-" <> path ->
+        if String.ends_with?(path, ".js") do
+          id = String.replace_trailing(path, ".js", "")
+          request_tracker_script("pa-" <> id, conn)
         else
           conn
         end
@@ -61,10 +69,9 @@ defmodule PlausibleWeb.TrackerPlug do
 
   def telemetry_event(name), do: [:plausible, :tracker_script, :request, name]
 
-  defp request_tracker_script(tag, conn) do
-    script_tag = get_plausible_web_script_tag(tag)
-
-    if script_tag do
+  defp request_tracker_script(id, conn) do
+    with {:ok, script_tag} <-
+           get_plausible_web_script_tag(id) do
       :telemetry.execute(
         telemetry_event(:v2),
         %{},
@@ -79,29 +86,42 @@ defmodule PlausibleWeb.TrackerPlug do
       |> put_resp_header("cache-control", "public, max-age=60, no-transform")
       # CDN-Tag is used by BunnyCDN to tag cached resources. This allows us to purge
       # specific tracker scripts from the CDN cache.
-      |> put_resp_header("cdn-tag", "tracker_script::#{tag}")
+      |> put_resp_header("cdn-tag", "tracker_script::#{id}")
       |> send_resp(200, script_tag)
       |> halt()
     else
-      :telemetry.execute(
-        telemetry_event(:v2),
-        %{},
-        %{status: 404}
-      )
+      {:error, :not_found} ->
+        :telemetry.execute(
+          telemetry_event(:v2),
+          %{},
+          %{status: 404}
+        )
 
-      conn
-      |> send_resp(404, "Not found")
-      |> halt()
+        conn
+        |> send_resp(404, "Not found")
+        |> halt()
     end
   end
 
-  defp get_plausible_web_script_tag(tag) do
-    on_ee do
-      # On cloud, we generate the script always on the fly relying on CDN caching
-      PlausibleWeb.TrackerScriptCache.get_from_source(tag)
+  defp get_plausible_web_script_tag(id) do
+    tag =
+      on_ee do
+        # On cloud, we generate the script always on the fly relying on CDN caching
+        PlausibleWeb.TrackerScriptCache.get_from_source(id)
+      else
+        # On self-hosted, we have a pre-warmed cache for the script
+        PlausibleWeb.TrackerScriptCache.get(id)
+      end
+
+    if tag do
+      {:ok, tag}
     else
-      # On self-hosted, we have a pre-warmed cache for the script
-      PlausibleWeb.TrackerScriptCache.get(tag)
+      if not String.starts_with?(id, "pa-") do
+        # maybe the script been migrated to the new format already
+        get_plausible_web_script_tag("pa-" <> id)
+      else
+        {:error, :not_found}
+      end
     end
   end
 

--- a/test/plausible/data_migration/prefix_tracker_script_configuration_id_test.exs
+++ b/test/plausible/data_migration/prefix_tracker_script_configuration_id_test.exs
@@ -1,0 +1,156 @@
+defmodule Plausible.DataMigration.PrefixTrackerScriptConfigurationIdTest do
+  use Plausible.DataCase, async: true
+  use Plausible.Teams.Test
+
+  import ExUnit.CaptureIO
+  import Ecto.Query
+
+  alias Plausible.DataMigration.PrefixTrackerScriptConfigurationId
+  alias Plausible.Site.TrackerScriptConfiguration
+  alias Plausible.Site
+  alias Plausible.Repo
+
+  setup do
+    # Clear the database tables before each test
+    Repo.delete_all(TrackerScriptConfiguration)
+    Repo.delete_all(Site)
+    :ok
+  end
+
+  describe "running the migration" do
+    setup do
+      remove_constraint_if_exists()
+      :ok
+    end
+
+    test "runs for empty dataset" do
+      output =
+        capture_io(fn ->
+          assert :ok = PrefixTrackerScriptConfigurationId.run(2)
+        end)
+
+      assert output =~ "Found 0 total tracker configurations to process"
+      assert output =~ "Migration completed!"
+    end
+
+    test "handles mixed configurations correctly" do
+      # Mix of old and new format configurations
+      _config1 = create_tracker_config("alpha")
+      _config2 = create_tracker_config("pa-beta")
+      _config3 = create_tracker_config("gamma")
+      _config4 = create_tracker_config("delta")
+      _config5 = create_tracker_config("epsilon")
+
+      output =
+        capture_io(fn ->
+          assert :ok = PrefixTrackerScriptConfigurationId.run(2)
+        end)
+
+      assert output =~ "Found 4 total tracker configurations to process"
+      assert output =~ "Processing batch 1 (1-2 of 4)"
+      assert output =~ "Processing batch 2 (3-4 of 4)"
+      assert output =~ "Migration completed!"
+
+      # Verify only old format configurations were updated
+      updated_configs =
+        Repo.all(
+          from c in TrackerScriptConfiguration,
+            where: c.id in ["pa-alpha", "pa-gamma", "pa-delta", "pa-epsilon"]
+        )
+
+      assert length(updated_configs) == 4
+      # Verify the one with pa- prefix was not changed
+      assert Repo.get_by(TrackerScriptConfiguration, id: "pa-beta")
+    end
+
+    test "is idempotent - can be run multiple times safely" do
+      _config = create_tracker_config("alpha")
+
+      # Run migration first time
+      output1 =
+        capture_io(fn ->
+          assert :ok = PrefixTrackerScriptConfigurationId.run(2)
+        end)
+
+      assert output1 =~ "Found 1 total tracker configurations to process"
+      assert output1 =~ "Processing batch 1 (1-1 of 1)"
+
+      # Run migration second time
+      output2 =
+        capture_io(fn ->
+          assert :ok = PrefixTrackerScriptConfigurationId.run(2)
+        end)
+
+      assert output2 =~ "Found 0 total tracker configurations to process"
+      assert output2 =~ "Migration completed!"
+
+      # Verify configuration still has the prefix
+      assert Repo.get_by(TrackerScriptConfiguration, id: "pa-alpha")
+    end
+  end
+
+  describe "fails gracefully" do
+    setup do
+      add_constraint()
+      :ok
+    end
+
+    test "handles database errors gracefully" do
+      _config1 = create_tracker_config("alpha")
+      _config2 = create_tracker_config("beta")
+
+      output =
+        capture_io(fn ->
+          assert :ok = PrefixTrackerScriptConfigurationId.run(1)
+        end)
+
+      # Should still complete without crashing
+      assert output =~ "Found 2 total tracker configurations to process"
+      assert output =~ "Processing batch 1 (1-1 of 2)"
+      assert output =~ "Error updating batch 1: "
+      assert output =~ "Processing batch 2 (2-2 of 2)"
+      assert output =~ "Migration completed!"
+    end
+  end
+
+  # Helper function to create tracker configurations with specific IDs
+  defp create_tracker_config(id) do
+    site = new_site()
+
+    # Use Repo.insert_all to bypass the autogenerate and set a specific ID
+    Repo.insert_all(
+      TrackerScriptConfiguration,
+      [
+        %{
+          id: id,
+          site_id: site.id,
+          installation_type: :manual,
+          track_404_pages: false,
+          hash_based_routing: false,
+          outbound_links: false,
+          file_downloads: false,
+          revenue_tracking: false,
+          tagged_events: false,
+          form_submissions: false,
+          pageview_props: false,
+          inserted_at: NaiveDateTime.utc_now(:second),
+          updated_at: NaiveDateTime.utc_now(:second)
+        }
+      ]
+    )
+
+    Repo.get_by(TrackerScriptConfiguration, id: id)
+  end
+
+  defp add_constraint() do
+    Repo.query!(
+      "ALTER TABLE tracker_script_configuration ADD CONSTRAINT prevent_pa_prefix CHECK (id NOT LIKE 'pa-%')"
+    )
+  end
+
+  defp remove_constraint_if_exists() do
+    Repo.query!(
+      "ALTER TABLE tracker_script_configuration DROP CONSTRAINT IF EXISTS prevent_pa_prefix"
+    )
+  end
+end

--- a/test/plausible_web/plugs/tracker_plug_test.exs
+++ b/test/plausible_web/plugs/tracker_plug_test.exs
@@ -67,7 +67,8 @@ defmodule PlausibleWeb.TrackerPlugTest do
       assert String.contains?(response, "window.plausible")
     end
 
-    test "returns the script requested with the legacy s- prefix, even if the id has been prefixed with pa- in the database", %{conn: conn} do
+    test "returns the script requested with the legacy s- prefix, even if the id has been prefixed with pa- in the database",
+         %{conn: conn} do
       site = new_site()
 
       tracker_script_configuration =
@@ -80,7 +81,10 @@ defmodule PlausibleWeb.TrackerPlugTest do
       assert String.starts_with?(tracker_script_configuration.id, "pa-")
 
       response =
-        get(conn, "/js/s-#{String.replace_leading(tracker_script_configuration.id, "pa-", "")}.js")
+        get(
+          conn,
+          "/js/s-#{String.replace_leading(tracker_script_configuration.id, "pa-", "")}.js"
+        )
         |> response(200)
 
       assert String.contains?(response, "!function(){var")

--- a/test/plausible_web/plugs/tracker_plug_test.exs
+++ b/test/plausible_web/plugs/tracker_plug_test.exs
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.TrackerPlugTest do
           :installation
         )
 
-      response = get(conn, "/js/s-#{tracker_script_configuration.id}.js") |> response(200)
+      response = get(conn, "/js/#{tracker_script_configuration.id}.js") |> response(200)
 
       assert String.contains?(response, "!function(){var")
       assert String.contains?(response, "domain:\"#{site.domain}\"")
@@ -62,9 +62,32 @@ defmodule PlausibleWeb.TrackerPlugTest do
           :installation
         )
 
-      response = get(conn, "/js/s-#{tracker_script_configuration.id}.js") |> response(200)
+      response = get(conn, "/js/#{tracker_script_configuration.id}.js") |> response(200)
 
       assert String.contains?(response, "window.plausible")
+    end
+
+    test "returns the script requested with the legacy s- prefix, even if the id has been prefixed with pa- in the database", %{conn: conn} do
+      site = new_site()
+
+      tracker_script_configuration =
+        Tracker.update_script_configuration!(
+          site,
+          Map.put(@example_config, :site_id, site.id),
+          :installation
+        )
+
+      assert String.starts_with?(tracker_script_configuration.id, "pa-")
+
+      response =
+        get(conn, "/js/s-#{String.replace_leading(tracker_script_configuration.id, "pa-", "")}.js")
+        |> response(200)
+
+      assert String.contains?(response, "!function(){var")
+      assert String.contains?(response, "domain:\"#{site.domain}\"")
+      assert String.contains?(response, "formSubmissions:!0")
+      refute String.contains?(response, "outboundLinks:!0")
+      refute String.contains?(response, "fileDownloads:!0")
     end
 
     test "returns 404 for unknown site", %{conn: conn} do


### PR DESCRIPTION
### Changes

After this PR, tracker script IDs are saved to Postgres with a prefix like `pa-V5OUguy5m04s95q12fg24` (currently just `V5OUguy5m04s95q12fg24`). 

For the sake of compatibility we still support requesting scripts like `s-V5OUguy5m04s95q12fg24`. 

In that case, it first looks for the config by `V5OUguy5m04s95q12fg24` and if it doesn't find it, tries `pa-V5OUguy5m04s95q12fg24` as well (maybe that config has been migrated already). 

There's a data migration script that prefixes all existing tracker script IDs with `pa-`. 

There's a separate PR for the migrations/2025.... file.  

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] This PR does not change the UI
