### PR TITLE
Script v2: Remove fallbacks for /js/s-... urls

### DIFF
--- a/lib/plausible_web/live/installationv2/instructions.ex
+++ b/lib/plausible_web/live/installationv2/instructions.ex
@@ -245,10 +245,6 @@ defmodule PlausibleWeb.Live.InstallationV2.Instructions do
   end
 
   defp tracker_url(tracker_script_configuration) do
-    if String.starts_with?(tracker_script_configuration.id, "pa-") do
-      "https://plausible.io/js/#{tracker_script_configuration.id}.js"
-    else
-      "https://plausible.io/js/s-#{tracker_script_configuration.id}.js"
-    end
+    "https://plausible.io/js/#{tracker_script_configuration.id}.js"
   end
 end

--- a/lib/plausible_web/plugs/tracker_plug.ex
+++ b/lib/plausible_web/plugs/tracker_plug.ex
@@ -40,14 +40,6 @@ defmodule PlausibleWeb.TrackerPlug do
 
   def call(conn, files_available: files_available) do
     case conn.request_path do
-      "/js/s-" <> path ->
-        if String.ends_with?(path, ".js") do
-          id = String.replace_trailing(path, ".js", "")
-          request_tracker_script(id, conn)
-        else
-          conn
-        end
-
       "/js/pa-" <> path ->
         if String.ends_with?(path, ".js") do
           id = String.replace_trailing(path, ".js", "")
@@ -69,7 +61,6 @@ defmodule PlausibleWeb.TrackerPlug do
 
   def telemetry_event(name), do: [:plausible, :tracker_script, :request, name]
 
-  # at this point, id might be both with and without the `pa-` prefix
   defp request_tracker_script(id, conn) do
     case get_plausible_web_script(id) do
       {:ok, script_tag} ->
@@ -104,7 +95,6 @@ defmodule PlausibleWeb.TrackerPlug do
     end
   end
 
-  # at this point, id can be both with and without the `pa-` prefix
   defp get_plausible_web_script(id) do
     script =
       on_ee do
@@ -118,12 +108,7 @@ defmodule PlausibleWeb.TrackerPlug do
     if script do
       {:ok, script}
     else
-      if not String.starts_with?(id, "pa-") do
-        # maybe the script been migrated to the new format already
-        get_plausible_web_script("pa-" <> id)
-      else
-        {:error, :not_found}
-      end
+      {:error, :not_found}
     end
   end
 

--- a/test/plausible_web/plugs/tracker_plug_test.exs
+++ b/test/plausible_web/plugs/tracker_plug_test.exs
@@ -67,36 +67,9 @@ defmodule PlausibleWeb.TrackerPlugTest do
       assert String.contains?(response, "window.plausible")
     end
 
-    test "returns the script requested with the legacy s- prefix, even if the id has been prefixed with pa- in the database",
-         %{conn: conn} do
-      site = new_site()
-
-      tracker_script_configuration =
-        Tracker.update_script_configuration!(
-          site,
-          Map.put(@example_config, :site_id, site.id),
-          :installation
-        )
-
-      assert String.starts_with?(tracker_script_configuration.id, "pa-")
-
-      response =
-        get(
-          conn,
-          "/js/s-#{String.replace_leading(tracker_script_configuration.id, "pa-", "")}.js"
-        )
-        |> response(200)
-
-      assert String.contains?(response, "!function(){var")
-      assert String.contains?(response, "domain:\"#{site.domain}\"")
-      assert String.contains?(response, "formSubmissions:!0")
-      refute String.contains?(response, "outboundLinks:!0")
-      refute String.contains?(response, "fileDownloads:!0")
-    end
-
     test "returns 404 for unknown site", %{conn: conn} do
       conn
-      |> get("/js/s-a14125a2-000-000-0000-000000000000.js")
+      |> get("/js/pa-a14125a2-000-000-0000-000000000000.js")
       |> response(404)
     end
   end


### PR DESCRIPTION
### Changes

After all current sites using the v2 tracker URL starting with s- have migrated, we can remove the fallbacks.

- [x] https://github.com/plausible/analytics/pull/5628
- [x] https://github.com/plausible/docs/pull/629
- [x] https://github.com/plausible/website/pull/827
- [x] Marko's site
- [x] GTM template updated

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update (v2 docs released together)

### Dark mode
- [x] This PR does not change the UI
