### PR TITLE
ScriptV2: On NPM release, link to NPM in basecamp

### DIFF
--- a/.github/workflows/tracker-script-npm-release.yml
+++ b/.github/workflows/tracker-script-npm-release.yml
@@ -69,7 +69,7 @@ jobs:
           url: ${{ secrets.BUILD_NOTIFICATION_URL }}
           method: 'POST'
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"content": "<h1>🚀 New tracker script version has been released to NPM!</h1>"}'
+          data: '{"content": "<h1>🚀 New tracker script version has been released to <a href=\"https://www.npmjs.com/package/@plausible-analytics/tracker\">NPM</a>!</h1>"}'
 
       - name: Notify team on failure
         if: ${{ failure() }}


### PR DESCRIPTION
### Changes

Tiny quality-of-life tweak: When we release a new NPM tracker script version, we will start to also link to the NPM page.