### PR TITLE
ScriptV2: Add updated_at index to tracker_script_configuration

### DIFF
--- a/priv/repo/migrations/20250812103208_tracker_script_configuration_updated_at_index.exs
+++ b/priv/repo/migrations/20250812103208_tracker_script_configuration_updated_at_index.exs
@@ -1,0 +1,7 @@
+defmodule Plausible.Repo.Migrations.TrackerScriptConfigurationUpdatedAtIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:tracker_script_configuration, :updated_at)
+  end
+end


### PR DESCRIPTION
The cache uses updated_at column to look for recently updated rows. This makes that scan cheaper.

Before (full table scan):
```
postgres@127:plausible_dev> explain analyze select * from tracker_script_configuration where updated_at > now() - interval '1 minute'
+-----------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                    |
|-----------------------------------------------------------------------------------------------------------------------------------------------|
| Gather  (cost=1000.00..19849.11 rows=35 width=60) (actual time=177.554..180.492 rows=0 loops=1)                                               |
|   Workers Planned: 2                                                                                                                          |
|   Workers Launched: 2                                                                                                                         |
|   ->  Parallel Seq Scan on tracker_script_configuration  (cost=0.00..18845.61 rows=15 width=60) (actual time=172.125..172.126 rows=0 loops=3) |
|         Filter: (updated_at > (now() - '00:01:00'::interval))                                                                                 |
|         Rows Removed by Filter: 336668                                                                                                        |
| Planning Time: 0.122 ms                                                                                                                       |
| Execution Time: 180.527 ms                                                                                                                    |
+-----------------------------------------------------------------------------------------------------------------------------------------------+
```

After (index scan):
```
postgres@127:plausible_dev> explain analyze select * from tracker_script_configuration where updated_at > now() - interval '1 minute'
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                                  |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Index Scan using tracker_script_configuration_updated_at_index on tracker_script_configuration  (cost=0.43..4.45 rows=1 width=60) (actual time=0.004..0.005 rows=0 loops=1) |
|   Index Cond: (updated_at > (now() - '00:01:00'::interval))                                                                                                                 |
| Planning Time: 0.568 ms                                                                                                                                                     |
| Execution Time: 0.013 ms                                                                                                                                                    |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 4
```