### PR TITLE
CRM: Bring back site/member counters in Team tabs

### DIFF
--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -36,6 +36,21 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         assert text =~ "Members (1/10)"
       end
 
+      test "renders unlimited limits", %{conn: conn, user: user} do
+        owner = new_user(team: [inserted_at: ~N[2021-01-01 00:00:00]])
+        subscribe_to_enterprise_plan(owner, team_member_limit: :unlimited)
+        team = team_of(owner)
+        add_member(team, user: user, role: :editor)
+        new_site(owner: owner)
+
+        {:ok, _lv, html} = live(conn, open_team(team.id))
+        text = text(html)
+
+        assert text =~ team.name
+        assert text =~ "Sites (1/unlimited)"
+        assert text =~ "Members (1/unlimited)"
+      end
+
       test "delete team", %{conn: conn, user: user} do
         team = team_of(user)
         {:ok, lv, _html} = live(conn, open_team(team.id))

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -25,8 +25,15 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
 
       test "renders", %{conn: conn, user: user} do
         team = team_of(user)
+        new_site(owner: user)
+        add_member(team, role: :editor)
+
         {:ok, _lv, html} = live(conn, open_team(team.id))
-        assert text(html) =~ team.name
+        text = text(html)
+
+        assert text =~ team.name
+        assert text =~ "Sites (2/10)"
+        assert text =~ "Members (1/10)"
       end
 
       test "delete team", %{conn: conn, user: user} do


### PR DESCRIPTION
### Changes

fix regression introduced via #5611 

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
