### PR TITLE
Only display "Invoices" on sidebar when subscription is present

### DIFF
--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -85,6 +85,8 @@ defmodule PlausibleWeb.LayoutView do
     current_team = conn.assigns[:current_team]
     current_team_role = conn.assigns[:current_team_role]
 
+    subscription? = !!(conn.assigns[:current_team] && conn.assigns.current_team.subscription)
+
     options = %{
       "Account Settings" =>
         [
@@ -93,7 +95,7 @@ defmodule PlausibleWeb.LayoutView do
           if(not Teams.setup?(current_team),
             do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
           ),
-          if(not Teams.setup?(current_team),
+          if(not Teams.setup?(current_team) and subscription?,
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(not Teams.setup?(current_team),
@@ -115,7 +117,7 @@ defmodule PlausibleWeb.LayoutView do
           if(current_team_role in [:owner, :billing],
             do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
           ),
-          if(current_team_role in [:owner, :billing],
+          if(current_team_role in [:owner, :billing] and subscription?,
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(current_team_role in [:owner, :billing, :admin, :editor],

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1374,6 +1374,48 @@ defmodule PlausibleWeb.SettingsControllerTest do
       refute html =~ "Team Settings"
     end
 
+    test "does not render invoices when no subscription present (no team assigned)", %{conn: conn} do
+      conn = get(conn, Routes.settings_path(conn, :preferences))
+      html = html_response(conn, 200)
+      refute html =~ Routes.settings_path(conn, :invoices)
+    end
+
+    test "does render invoices when subscription present (no team assigned)", %{
+      conn: conn,
+      user: user
+    } do
+      subscribe_to_growth_plan(user)
+      conn = get(conn, Routes.settings_path(conn, :preferences))
+      html = html_response(conn, 200)
+      assert html =~ Routes.settings_path(conn, :invoices)
+    end
+
+    test "does not render invoices when no subscription (team set up)", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
+      conn = get(conn, Routes.settings_path(conn, :preferences))
+      html = html_response(conn, 200)
+      refute html =~ Routes.settings_path(conn, :invoices)
+    end
+
+    test "does render invoices when subscription present (team assigned)", %{
+      conn: conn,
+      user: user
+    } do
+      subscribe_to_growth_plan(user)
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
+
+      conn = get(conn, Routes.settings_path(conn, :preferences))
+      html = html_response(conn, 200)
+      assert html =~ Routes.settings_path(conn, :invoices)
+    end
+
     test "renders team settings, when team assigned and set up", %{conn: conn, user: user} do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       team = Plausible.Teams.complete_setup(team)


### PR DESCRIPTION
### Changes

In the settings sidebar, we'll only display invoices when there's (any) subscription present.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
