### PR TITLE
Include "Direct / None" in source filter suggestions

### DIFF
--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -86,6 +86,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         get(conn, "/api/stats/#{site.domain}/suggestions/source?period=month&date=2019-01-01")
 
       assert json_response(conn, 200) == [
+               %{"label" => "Direct / None", "value" => "Direct / None"},
                %{"label" => "Bing", "value" => "Bing"},
                %{"label" => "10words", "value" => "10words"}
              ]
@@ -1158,10 +1159,18 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
             "/api/stats/#{site.domain}/suggestions/source?period=month&date=2019-01-01&q=#{unquote(q)}&with_imported=true"
           )
 
-        assert json_response(conn, 200) == [
-                 %{"value" => "Google", "label" => "Google"},
-                 %{"value" => "Bing", "label" => "Bing"}
-               ]
+        if unquote(label) == "with filter" do
+          assert json_response(conn, 200) == [
+                   %{"value" => "Google", "label" => "Google"},
+                   %{"value" => "Bing", "label" => "Bing"}
+                 ]
+        else
+          assert json_response(conn, 200) == [
+                   %{"value" => "Direct / None", "label" => "Direct / None"},
+                   %{"value" => "Google", "label" => "Google"},
+                   %{"value" => "Bing", "label" => "Bing"}
+                 ]
+        end
       end
 
       test "merges channel suggestions from native and imported data #{label}", %{


### PR DESCRIPTION
### Changes

We support "Direct / None" source filtering via dashboard click, but it doesn't show up as a filter suggestion when typing. This PR fixes that.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
