### PR TITLE
Script v2: Allow saving npm installation type

### DIFF
--- a/lib/plausible/site/tracker_script_configuration.ex
+++ b/lib/plausible/site/tracker_script_configuration.ex
@@ -22,7 +22,7 @@ defmodule Plausible.Site.TrackerScriptConfiguration do
 
   @primary_key {:id, Plausible.Ecto.Types.TrackerScriptNanoid, autogenerate: true}
   schema "tracker_script_configuration" do
-    field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, nil]
+    field :installation_type, Ecto.Enum, values: [:manual, :wordpress, :gtm, :npm, nil]
 
     field :track_404_pages, :boolean, default: false
     field :hash_based_routing, :boolean, default: false


### PR DESCRIPTION
### Changes

It wasn't possible to save tracker config on the npm tab, which caused a server error when pressing "Verify NPM installation"

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) sites-api.md needs an update about possible installation_type values.

### Dark mode
- [x] This PR does not change the UI
