### PR TITLE
Keep google auth deletions idempotent

### DIFF
--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -300,10 +300,11 @@ defmodule PlausibleWeb.SiteController do
       conn.assigns[:site]
       |> Repo.preload(:google_auth)
 
-    Repo.delete!(site.google_auth)
+    if site.google_auth do
+      Repo.delete!(site.google_auth)
+    end
 
-    conn = put_flash(conn, :success, "Google account unlinked from Plausible")
-
+    put_flash(conn, :success, "Google account unlinked from Plausible")
     redirect(conn, to: Routes.site_path(conn, :settings_integrations, site.domain))
   end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -867,6 +867,21 @@ defmodule PlausibleWeb.SiteControllerTest do
                "/#{URI.encode_www_form(site.domain)}/settings/integrations"
     end
 
+    test "won't crash if associated google auth has been already deleted", %{
+      conn: conn1,
+      user: user,
+      site: site
+    } do
+      insert(:google_auth, user: user, site: site)
+      delete(conn1, "/#{site.domain}/settings/google-search")
+      conn = delete(conn1, "/#{site.domain}/settings/google-search")
+
+      refute Repo.exists?(Plausible.Site.GoogleAuth)
+
+      assert redirected_to(conn, 302) ==
+               "/#{URI.encode_www_form(site.domain)}/settings/integrations"
+    end
+
     test "fails to delete associated google auth from the outside", %{
       conn: conn,
       user: user


### PR DESCRIPTION
### Changes

Rapid double-click and similar scenarios likely weren't handled well when deleting google auth. 