### PR TITLE
ScriptV2: Domain change refinement

### DIFF
--- a/lib/plausible/installation_support/checks/detection.ex
+++ b/lib/plausible/installation_support/checks/detection.ex
@@ -139,7 +139,7 @@ defmodule Plausible.InstallationSupport.Checks.Detection do
     do: [
       v1_detected: data["v1Detected"],
       gtm_likely: data["gtmLikely"],
-      npm_likely: data["npmLikely"],
+      npm: data["npm"],
       wordpress_likely: data["wordpressLikely"],
       wordpress_plugin: data["wordpressPlugin"],
       service_error: nil

--- a/lib/plausible/installation_support/checks/detection.ex
+++ b/lib/plausible/installation_support/checks/detection.ex
@@ -139,6 +139,7 @@ defmodule Plausible.InstallationSupport.Checks.Detection do
     do: [
       v1_detected: data["v1Detected"],
       gtm_likely: data["gtmLikely"],
+      npm_likely: data["npmLikely"],
       wordpress_likely: data["wordpressLikely"],
       wordpress_plugin: data["wordpressPlugin"],
       service_error: nil

--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -106,8 +106,6 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
 
   - `data.gtmLikely` - whether or not the site uses GTM
 
-  - `data.npmLikely` - whether or not the site uses the NPM package
-
   - `data.cookieBannerLikely` - whether or not there's a cookie banner blocking Plausible
   """
   use Plausible.InstallationSupport.Check

--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -106,6 +106,8 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
 
   - `data.gtmLikely` - whether or not the site uses GTM
 
+  - `data.npmLikely` - whether or not the site uses the NPM package
+
   - `data.cookieBannerLikely` - whether or not there's a cookie banner blocking Plausible
   """
   use Plausible.InstallationSupport.Check
@@ -180,6 +182,7 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
             {:wordpress_plugin_diff, :wordpress_plugin?, "wordpressPlugin"},
             {:wordpress_likely_diff, :wordpress_likely?, "wordpressLikely"},
             {:gtm_likely_diff, :gtm_likely?, "gtmLikely"},
+            {:npm_likely_diff, :npm_likely?, "npmLikely"},
             {:cookie_banner_likely_diff, :cookie_banner_likely?, "cookieBannerLikely"}
           ] do
         case {Map.get(elixir_data, elixir_diagnostic), js_data[js_diagnostic]} do

--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -180,7 +180,7 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
             {:wordpress_plugin_diff, :wordpress_plugin?, "wordpressPlugin"},
             {:wordpress_likely_diff, :wordpress_likely?, "wordpressLikely"},
             {:gtm_likely_diff, :gtm_likely?, "gtmLikely"},
-            {:npm_likely_diff, :npm_likely?, "npmLikely"},
+            {:npm_diff, :npm?, "npm"},
             {:cookie_banner_likely_diff, :cookie_banner_likely?, "cookieBannerLikely"}
           ] do
         case {Map.get(elixir_data, elixir_diagnostic), js_data[js_diagnostic]} do

--- a/lib/plausible/installation_support/checks/installation.ex
+++ b/lib/plausible/installation_support/checks/installation.ex
@@ -180,7 +180,6 @@ defmodule Plausible.InstallationSupport.Checks.Installation do
             {:wordpress_plugin_diff, :wordpress_plugin?, "wordpressPlugin"},
             {:wordpress_likely_diff, :wordpress_likely?, "wordpressLikely"},
             {:gtm_likely_diff, :gtm_likely?, "gtmLikely"},
-            {:npm_diff, :npm?, "npm"},
             {:cookie_banner_likely_diff, :cookie_banner_likely?, "cookieBannerLikely"}
           ] do
         case {Map.get(elixir_data, elixir_diagnostic), js_data[js_diagnostic]} do

--- a/lib/plausible/installation_support/detection/diagnostics.ex
+++ b/lib/plausible/installation_support/detection/diagnostics.ex
@@ -9,7 +9,7 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
             gtm_likely: nil,
             wordpress_likely: nil,
             wordpress_plugin: nil,
-            npm_likely: nil,
+            npm: nil,
             service_error: nil
 
   @type t :: %__MODULE__{}
@@ -42,7 +42,7 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
 
   def interpret(
         %__MODULE__{
-          npm_likely: true,
+          npm: true,
           service_error: nil
         } = diagnostics,
         _url
@@ -89,7 +89,7 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
       data: %{
         v1_detected: diagnostics.v1_detected,
         wordpress_plugin: diagnostics.wordpress_plugin,
-        npm_likely: diagnostics.npm_likely,
+        npm: diagnostics.npm,
         suggested_technology: suggested_technology
       }
     }

--- a/lib/plausible/installation_support/detection/diagnostics.ex
+++ b/lib/plausible/installation_support/detection/diagnostics.ex
@@ -9,6 +9,7 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
             gtm_likely: nil,
             wordpress_likely: nil,
             wordpress_plugin: nil,
+            npm_likely: nil,
             service_error: nil
 
   @type t :: %__MODULE__{}

--- a/lib/plausible/installation_support/detection/diagnostics.ex
+++ b/lib/plausible/installation_support/detection/diagnostics.ex
@@ -41,6 +41,16 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
 
   def interpret(
         %__MODULE__{
+          npm_likely: true,
+          service_error: nil
+        } = diagnostics,
+        _url
+      ) do
+    get_result("npm", diagnostics)
+  end
+
+  def interpret(
+        %__MODULE__{
           service_error: nil
         } = diagnostics,
         _url
@@ -78,6 +88,7 @@ defmodule Plausible.InstallationSupport.Detection.Diagnostics do
       data: %{
         v1_detected: diagnostics.v1_detected,
         wordpress_plugin: diagnostics.wordpress_plugin,
+        npm_likely: diagnostics.npm_likely,
         suggested_technology: suggested_technology
       }
     }

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -113,7 +113,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
     case assigns.detection_result do
       %{v1_detected: true, wordpress_plugin: true} -> wordpress_plugin_notice(assigns)
       %{v1_detected: true, wordpress_plugin: false} -> generic_notice(assigns)
-      %{v1_detected: false, npm_likely: true} -> generic_notice(assigns)
+      %{v1_detected: false, npm: true} -> generic_notice(assigns)
       _ -> ~H""
     end
   end

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -86,13 +86,9 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
       </:subtitle>
 
       <:footer>
-        <.focus_list>
-          <:item>
-            <.styled_link href={Routes.site_path(@socket, :settings_general, @site.domain)}>
-              Go to Site Settings
-            </.styled_link>
-          </:item>
-        </.focus_list>
+        <.styled_link href={Routes.site_path(@socket, :settings_general, @site.domain)}>
+          ← Back to Site Settings
+        </.styled_link>
       </:footer>
 
       <.async_result :let={detection_result} assign={@detection_result}>

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -95,7 +95,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
         <:loading>
           <div class="flex items-center">
             <.spinner class="w-4 h-4 mr-2" />
-            <span class="text-sm text-gray-600">Checking your new domain...</span>
+            <span class="text-sm text-gray-600 dark:text-gray-400">Checking your new domain...</span>
           </div>
         </:loading>
 

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -149,7 +149,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
   end
 
   def handle_info({:domain_changed, updated_site}, socket) do
-    PlausibleWeb.Tracker.purge_tracker_script_cache(updated_site)
+    PlausibleWeb.Tracker.purge_tracker_script_cache!(updated_site)
 
     {:noreply,
      socket

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -145,6 +145,8 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
   end
 
   def handle_info({:domain_changed, updated_site}, socket) do
+    PlausibleWeb.Tracker.purge_tracker_script_cache(updated_site)
+
     {:noreply,
      socket
      |> assign(site: updated_site)

--- a/lib/plausible_web/plugins/api/schemas/tracker_script_configuration.ex
+++ b/lib/plausible_web/plugins/api/schemas/tracker_script_configuration.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.TrackerScriptConfiguration do
           installation_type: %Schema{
             type: :string,
             description: "Tracker Script Installation Type",
-            enum: ["manual", "wordpress", "gtm"]
+            enum: ["manual", "wordpress", "gtm", "npm"]
           },
           hash_based_routing: %Schema{type: :boolean, description: "Hash Based Routing"},
           outbound_links: %Schema{type: :boolean, description: "Track Outbound Links"},

--- a/lib/plausible_web/plugins/api/schemas/tracker_script_configuration/update_request.ex
+++ b/lib/plausible_web/plugins/api/schemas/tracker_script_configuration/update_request.ex
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.Plugins.API.Schemas.TrackerScriptConfiguration.UpdateRequ
           installation_type: %Schema{
             type: :string,
             description: "Tracker Script Installation Type",
-            enum: ["manual", "wordpress", "gtm"]
+            enum: ["manual", "wordpress", "gtm", "npm"]
           },
           hash_based_routing: %Schema{type: :boolean, description: "Hash Based Routing"},
           outbound_links: %Schema{type: :boolean, description: "Track Outbound Links"},

--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -82,14 +82,12 @@ defmodule PlausibleWeb.Tracker do
     end)
   end
 
-  def purge_tracker_script_cache(site) do
-    on_ee do
+  on_ee do
+    def purge_tracker_script_cache!(site) do
       tracker_script_configuration = get_or_create_tracker_script_configuration!(site)
       purge_cache!(tracker_script_configuration.id)
     end
-  end
 
-  on_ee do
     defp should_purge_cache?(changeset) do
       Map.keys(changeset.changes) != [:installation_type]
     end
@@ -103,6 +101,8 @@ defmodule PlausibleWeb.Tracker do
       )
       |> Oban.insert!()
     end
+  else
+    def purge_tracker_script_cache!(_site), do: nil
   end
 
   def update_script_configuration!(site, config_update, changeset_type) do

--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -82,6 +82,13 @@ defmodule PlausibleWeb.Tracker do
     end)
   end
 
+  def purge_tracker_script_cache(site) do
+    on_ee do
+      tracker_script_configuration = get_or_create_tracker_script_configuration!(site)
+      purge_cache!(tracker_script_configuration.id)
+    end
+  end
+
   on_ee do
     defp should_purge_cache?(changeset) do
       Map.keys(changeset.changes) != [:installation_type]

--- a/test/plausible_web/live/change_domain_v2_test.exs
+++ b/test/plausible_web/live/change_domain_v2_test.exs
@@ -73,7 +73,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -95,7 +95,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -149,7 +149,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => true,
         "gtmLikely" => false,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => true,
         "wordpressPlugin" => true
       })
@@ -177,7 +177,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => true,
         "gtmLikely" => false,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -203,7 +203,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npmLikely" => true,
+        "npm" => true,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -228,7 +228,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })

--- a/test/plausible_web/live/change_domain_v2_test.exs
+++ b/test/plausible_web/live/change_domain_v2_test.exs
@@ -73,6 +73,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
+        "npmLikely" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -94,6 +95,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
+        "npmLikely" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -147,6 +149,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => true,
         "gtmLikely" => false,
+        "npmLikely" => false,
         "wordpressLikely" => true,
         "wordpressPlugin" => true
       })
@@ -174,6 +177,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       stub_detection_result(%{
         "v1Detected" => true,
         "gtmLikely" => false,
+        "npmLikely" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -195,10 +199,36 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
       refute html =~ "Wordpress Plugin"
     end
 
+    test "success page shows generic npm notice when detected", %{conn: conn, site: site} do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => false,
+        "npmLikely" => true,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      assert html =~ "<i>must</i>"
+      assert html =~ "also update the site"
+      assert html =~ "Plausible Installation"
+      assert html =~ "within 72 hours"
+    end
+
     test "success page shows no notice when no v1 tracking detected", %{conn: conn, site: site} do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
+        "npmLikely" => false,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })

--- a/test/plausible_web/live/installationv2_test.exs
+++ b/test/plausible_web/live/installationv2_test.exs
@@ -301,7 +301,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npmLikely" => true,
+        "npm" => true,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
@@ -440,7 +440,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => true,
-        "npmLikely" => false,
+        "npm" => false,
         "wordpressLikely" => true,
         "wordpressPlugin" => false
       })
@@ -497,7 +497,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => false,
       "gtmLikely" => true,
-      "npmLikely" => false,
+      "npm" => false,
       "wordpressLikely" => false,
       "wordpressPlugin" => false
     })
@@ -507,7 +507,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => true,
       "gtmLikely" => false,
-      "npmLikely" => false,
+      "npm" => false,
       "wordpressLikely" => false,
       "wordpressPlugin" => false
     })
@@ -517,7 +517,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => true,
       "gtmLikely" => false,
-      "npmLikely" => false,
+      "npm" => false,
       "wordpressLikely" => true,
       "wordpressPlugin" => false
     })

--- a/test/plausible_web/live/installationv2_test.exs
+++ b/test/plausible_web/live/installationv2_test.exs
@@ -297,6 +297,21 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
       assert text(html) =~ "We've detected your website is using Google Tag Manager"
     end
 
+    test "detected NPM installation shows npm tab", %{conn: conn, site: site} do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => false,
+        "npmLikely" => true,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify NPM installation"
+    end
+
     test "shows v1 detection warning for manual installation", %{conn: conn, site: site} do
       stub_dns_lookup_a_records(site.domain)
       stub_detection_manual_with_v1()
@@ -425,6 +440,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => true,
+        "npmLikely" => false,
         "wordpressLikely" => true,
         "wordpressPlugin" => false
       })
@@ -481,6 +497,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => false,
       "gtmLikely" => true,
+      "npmLikely" => false,
       "wordpressLikely" => false,
       "wordpressPlugin" => false
     })
@@ -490,6 +507,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => true,
       "gtmLikely" => false,
+      "npmLikely" => false,
       "wordpressLikely" => false,
       "wordpressPlugin" => false
     })
@@ -499,6 +517,7 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
     stub_detection_result(%{
       "v1Detected" => true,
       "gtmLikely" => false,
+      "npmLikely" => false,
       "wordpressLikely" => true,
       "wordpressPlugin" => false
     })

--- a/tracker/installation_support/check-npm.js
+++ b/tracker/installation_support/check-npm.js
@@ -1,0 +1,8 @@
+export function checkNPM(document) {
+  console.log('checkNPM', document, window.plausible)
+  if (typeof document === 'object') {
+    return window.plausible?.s === 'npm'
+  }
+
+  return false
+}

--- a/tracker/installation_support/check-npm.js
+++ b/tracker/installation_support/check-npm.js
@@ -1,5 +1,4 @@
 export function checkNPM(document) {
-  console.log('checkNPM', document, window.plausible)
   if (typeof document === 'object') {
     return window.plausible?.s === 'npm'
   }

--- a/tracker/installation_support/detector.js
+++ b/tracker/installation_support/detector.js
@@ -25,8 +25,8 @@ window.scanPageBeforePlausibleInstallation = async function({ detectV1, debug, t
   const gtmLikely = checkGTM(document)
   log(`gtmLikely: ${gtmLikely}`)
 
-  const npmLikely = checkNPM(document)
-  log(`npmLikely: ${npmLikely}`)
+  const npm = checkNPM(document)
+  log(`npm: ${npm}`)
 
   return {
     data: {
@@ -35,7 +35,7 @@ window.scanPageBeforePlausibleInstallation = async function({ detectV1, debug, t
       wordpressPlugin: wordpressPlugin,
       wordpressLikely: wordpressLikely,
       gtmLikely: gtmLikely,
-      npmLikely: npmLikely
+      npm: npm
     }
   }
 }

--- a/tracker/installation_support/detector.js
+++ b/tracker/installation_support/detector.js
@@ -1,6 +1,7 @@
 import { waitForPlausibleFunction } from "./plausible-function-check"
 import { checkWordPress } from "./check-wordpress"
 import { checkGTM } from "./check-gtm"
+import { checkNPM } from "./check-npm"
 
 window.scanPageBeforePlausibleInstallation = async function({ detectV1, debug, timeoutMs }) {
   function log(message) {
@@ -24,6 +25,9 @@ window.scanPageBeforePlausibleInstallation = async function({ detectV1, debug, t
   const gtmLikely = checkGTM(document)
   log(`gtmLikely: ${gtmLikely}`)
 
+  const npmLikely = checkNPM(document)
+  log(`npmLikely: ${npmLikely}`)
+
   return {
     data: {
       completed: true,
@@ -31,6 +35,7 @@ window.scanPageBeforePlausibleInstallation = async function({ detectV1, debug, t
       wordpressPlugin: wordpressPlugin,
       wordpressLikely: wordpressLikely,
       gtmLikely: gtmLikely,
+      npmLikely: npmLikely
     }
   }
 }

--- a/tracker/test/installation_support/detector.spec.js
+++ b/tracker/test/installation_support/detector.spec.js
@@ -52,6 +52,21 @@ test.describe('detector.js (tech recognition)', () => {
     expect(result.data.wordpressPlugin).toBe(false)
     expect(result.data.wordpressLikely).toBe(false)
     expect(result.data.gtmLikely).toBe(false)
+    expect(result.data.npmLikely).toBe(false)
+  })
+
+  test('npmLikely is reported correctly', async ({ page }, { testId }) => {
+    const { url } = await initializePageDynamically(page, {
+      testId,
+      scriptConfig: `<script type="module">import {init} from "/tracker/js/npm_package/plausible.js"; init({domain: "abc.de"});</script>`
+    })
+
+    const result = await detect(page, {url: url, detectV1: false})
+
+    expect(result.data.wordpressPlugin).toBe(false)
+    expect(result.data.wordpressLikely).toBe(false)
+    expect(result.data.gtmLikely).toBe(false)
+    expect(result.data.npmLikely).toBe(true)
   })
 })
 
@@ -77,6 +92,7 @@ test.describe('detector.js (v1 detection)', () => {
     expect(result.data.wordpressPlugin).toBe(true)
     expect(result.data.wordpressLikely).toBe(true)
     expect(result.data.gtmLikely).toBe(true)
+    expect(result.data.npmLikely).toBe(false)
   })
 
   test('v1Detected is false when plausible function does not exist', async ({ page }, { testId }) => {
@@ -91,6 +107,7 @@ test.describe('detector.js (v1 detection)', () => {
     expect(result.data.wordpressPlugin).toBe(false)
     expect(result.data.wordpressLikely).toBe(false)
     expect(result.data.gtmLikely).toBe(false)
+    expect(result.data.npmLikely).toBe(false)
   })
 
   test('v1Detected is false when v2 plausible installed', async ({ page }, { testId }) => {

--- a/tracker/test/installation_support/detector.spec.js
+++ b/tracker/test/installation_support/detector.spec.js
@@ -52,10 +52,10 @@ test.describe('detector.js (tech recognition)', () => {
     expect(result.data.wordpressPlugin).toBe(false)
     expect(result.data.wordpressLikely).toBe(false)
     expect(result.data.gtmLikely).toBe(false)
-    expect(result.data.npmLikely).toBe(false)
+    expect(result.data.npm).toBe(false)
   })
 
-  test('npmLikely is reported correctly', async ({ page }, { testId }) => {
+  test('npm is reported correctly', async ({ page }, { testId }) => {
     const { url } = await initializePageDynamically(page, {
       testId,
       scriptConfig: `<script type="module">import {init} from "/tracker/js/npm_package/plausible.js"; init({domain: "abc.de"});</script>`
@@ -66,7 +66,7 @@ test.describe('detector.js (tech recognition)', () => {
     expect(result.data.wordpressPlugin).toBe(false)
     expect(result.data.wordpressLikely).toBe(false)
     expect(result.data.gtmLikely).toBe(false)
-    expect(result.data.npmLikely).toBe(true)
+    expect(result.data.npm).toBe(true)
   })
 })
 
@@ -92,7 +92,7 @@ test.describe('detector.js (v1 detection)', () => {
     expect(result.data.wordpressPlugin).toBe(true)
     expect(result.data.wordpressLikely).toBe(true)
     expect(result.data.gtmLikely).toBe(true)
-    expect(result.data.npmLikely).toBe(false)
+    expect(result.data.npm).toBe(false)
   })
 
   test('v1Detected is false when plausible function does not exist', async ({ page }, { testId }) => {
@@ -107,7 +107,7 @@ test.describe('detector.js (v1 detection)', () => {
     expect(result.data.wordpressPlugin).toBe(false)
     expect(result.data.wordpressLikely).toBe(false)
     expect(result.data.gtmLikely).toBe(false)
-    expect(result.data.npmLikely).toBe(false)
+    expect(result.data.npm).toBe(false)
   })
 
   test('v1Detected is false when v2 plausible installed', async ({ page }, { testId }) => {


### PR DESCRIPTION
### Changes

This PR refines the scriptv2 domain change flow by:
1. Improving the "Back to settings button"
2. Tweaking dark mode support
3. Purging CDN cache on domain change

The major change is also detecting whether npm library was used and showing the "warning" to update their configuration in 72 hours.

Along the way we also support storing/detecting npm module within the onboarding module.

Basecamp ref: https://3.basecamp.com/5308029/buckets/42034199/card_tables/cards/8949869924