### PR TITLE
Mute automated login attempts

### DIFF
--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -336,6 +336,10 @@ defmodule PlausibleWeb.AuthController do
     end
   end
 
+  def login(conn, _params) do
+    conn |> send_resp(403, "") |> halt()
+  end
+
   defp accept_team_invitation(conn, team_identifier, user, params \\ [])
 
   defp accept_team_invitation(conn, no_identifier, _user, params)

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -706,6 +706,36 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       assert html_response(response, 429) =~ "Too many login attempts"
     end
+
+    test "malicious automated logins", %{conn: conn1} do
+      conn =
+        post(conn1, "/login", %{
+          "g-recaptcha-response" => "NwBMkEWbh",
+          "user[email]" => "some@example.com",
+          "user[name]" => "CJCtGVXVgfORdNN",
+          "user[password]" => "[Filtered]",
+          "user[password_confirmation]" => "[Filtered]",
+          "user[register_action]" => "register_form"
+        })
+
+      assert response(conn, 403)
+
+      conn =
+        conn1
+        |> put_req_header("content-type", "application/json")
+        |> post("/login", """
+          {
+          "g-recaptcha-response": "NwBMkEWbh",
+          "user[email]": "some@example.com",
+          "user[name]": "CJCtGVXVgfORdNN",
+          "user[password]": "[Filtered]",
+          "user[password_confirmation]": "[Filtered]",
+          "user[register_action]": "register_form"
+          }
+        """)
+
+      assert response(conn, 403)
+    end
   end
 
   describe "GET /password/request-reset" do


### PR DESCRIPTION
### Changes

Sending garbage to /dev/null instead of polluting sentry for no reason

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
