### PR TITLE
ScriptV2: Show warning when using Legacy GTM template, update links

### DIFF
--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -102,8 +102,23 @@ defmodule PlausibleWeb.Live.InstallationV2 do
           }>
             <.notice class="mt-4" theme={:yellow}>
               Your website is running an outdated version of the tracking script. Please
-              <.styled_link new_tab href="https://plausible.io/docs">update</.styled_link>
+              <.styled_link new_tab href="https://plausible.io/docs/script-update-guide.md">
+                update
+              </.styled_link>
               your tracking script before continuing
+            </.notice>
+          </div>
+
+          <div :if={
+            @v1_detected.result == true and @recommended_installation_type.result == "gtm" and
+              @installation_type.result == "gtm"
+          }>
+            <.notice class="mt-4" theme={:yellow}>
+              Your website is using an outdated version of our Google Tag Manager template. Please
+              <.styled_link new_tab href="https://plausible.io/docs/gtm-update-guide.md">
+                update
+              </.styled_link>
+              your Google Tag Manager template before continuing
             </.notice>
           </div>
 

--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -114,7 +114,8 @@ defmodule PlausibleWeb.Live.InstallationV2 do
               @installation_type.result == "gtm"
           }>
             <.notice class="mt-4" theme={:yellow}>
-              Your website is using an outdated version of our Google Tag Manager template. Please
+              Your website might be using an outdated version of our Google Tag Manager template.
+              If so,
               <.styled_link new_tab href="https://plausible.io/docs/gtm-update-guide.md">
                 update
               </.styled_link>


### PR DESCRIPTION
### Changes

Shows a warning linking to (not yet written) GTM template upgrade guide.

<img width="524" height="576" alt="image" src="https://github.com/user-attachments/assets/84bd522e-f8c1-48f4-a7b9-063c77d46178" />