### PR TITLE
fix CE warning in tests

### DIFF
--- a/test/plausible/installation_support/checks_test.exs
+++ b/test/plausible/installation_support/checks_test.exs
@@ -1,968 +1,973 @@
 defmodule Plausible.InstallationSupport.LegacyVerification.ChecksTest do
   use Plausible.DataCase, async: true
+  use Plausible
 
-  alias Plausible.InstallationSupport.{State, Checks, LegacyVerification}
+  @moduletag :ee_only
 
-  import ExUnit.CaptureLog
-  import Plug.Conn
+  on_ee do
+    alias Plausible.InstallationSupport.{State, Checks, LegacyVerification}
 
-  @errors LegacyVerification.Errors.all()
+    import ExUnit.CaptureLog
+    import Plug.Conn
 
-  @moduletag :capture_log
+    @errors LegacyVerification.Errors.all()
 
-  describe "successful verification" do
-    @normal_body """
-    <html>
-    <head>
-    <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
+    @moduletag :capture_log
 
-    test "definite success" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation()
+    describe "successful verification" do
+      @normal_body """
+      <html>
+      <head>
+      <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
+      test "definite success" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+      end
+
+      test "fetching will follow 2 redirects" do
+        ref = :counters.new(1, [:atomics])
+        test = self()
+
+        Req.Test.stub(Checks.FetchBody, fn conn ->
+          if :counters.get(ref, 1) < 2 do
+            :counters.add(ref, 1, 1)
+            send(test, :redirect_sent)
+
+            conn
+            |> put_resp_header("location", "https://example.com")
+            |> send_resp(302, "redirecting to https://example.com")
+          else
+            conn
+            |> put_resp_header("content-type", "text/html")
+            |> send_resp(200, @normal_body)
+          end
+        end)
+
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+
+        assert_receive :redirect_sent
+        assert_receive :redirect_sent
+        refute_receive _
+      end
+
+      test "allowed via content-security-policy" do
+        stub_fetch_body(fn conn ->
+          conn
+          |> put_resp_header(
+            "content-security-policy",
+            Enum.random([
+              "default-src 'self'; script-src plausible.io; connect-src #{PlausibleWeb.Endpoint.host()}",
+              "default-src 'self' *.#{PlausibleWeb.Endpoint.host()}"
+            ])
+          )
+          |> put_resp_content_type("text/html")
+          |> send_resp(200, @normal_body)
+        end)
+
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+      end
+
+      @proxied_script_body """
+      <html>
+      <head>
+      <script defer data-domain="example.com" src="https://proxy.example.com/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "proxied setup working OK" do
+        stub_fetch_body(200, @proxied_script_body)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+      end
+
+      @body_no_snippet """
+      <html> <head> </head> <body> Hello </body> </html>
+      """
+
+      test "non-standard integration where the snippet cannot be found but it works ok in headless" do
+        stub_fetch_body(200, @body_no_snippet)
+        stub_installation(200, plausible_installed(true, 202))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+      end
+
+      @different_data_domain_body """
+      <html>
+      <head>
+      <script defer data-domain="www.example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "data-domain mismatch on redirect chain" do
+        ref = :counters.new(1, [:atomics])
+        test = self()
+
+        Req.Test.stub(Checks.FetchBody, fn conn ->
+          if :counters.get(ref, 1) == 0 do
+            :counters.add(ref, 1, 1)
+            send(test, :redirect_sent)
+
+            conn
+            |> put_resp_header("location", "https://www.example.com")
+            |> send_resp(302, "redirecting to https://www.example.com")
+          else
+            conn
+            |> put_resp_header("content-type", "text/html")
+            |> send_resp(200, @different_data_domain_body)
+          end
+        end)
+
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+
+        assert_receive :redirect_sent
+      end
     end
 
-    test "fetching will follow 2 redirects" do
-      ref = :counters.new(1, [:atomics])
-      test = self()
+    describe "errors" do
+      test "service error - 400" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation(400, %{})
 
-      Req.Test.stub(Checks.FetchBody, fn conn ->
-        if :counters.get(ref, 1) < 2 do
-          :counters.add(ref, 1, 1)
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.temporary)
+      end
+
+      @tag :slow
+      test "can't fetch body but headless reports ok" do
+        stub_fetch_body(500, "")
+        stub_installation()
+
+        {_, log} =
+          with_log(fn ->
+            run_checks()
+            |> LegacyVerification.Checks.interpret_diagnostics()
+            |> assert_ok()
+          end)
+
+        assert log =~ "3 attempts left"
+        assert log =~ "2 attempts left"
+        assert log =~ "1 attempt left"
+      end
+
+      test "fetching will give up at 5th redirect" do
+        test = self()
+
+        stub_fetch_body(fn conn ->
           send(test, :redirect_sent)
 
           conn
           |> put_resp_header("location", "https://example.com")
           |> send_resp(302, "redirecting to https://example.com")
-        else
-          conn
-          |> put_resp_header("content-type", "text/html")
-          |> send_resp(200, @normal_body)
-        end
-      end)
-
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-
-      assert_receive :redirect_sent
-      assert_receive :redirect_sent
-      refute_receive _
-    end
-
-    test "allowed via content-security-policy" do
-      stub_fetch_body(fn conn ->
-        conn
-        |> put_resp_header(
-          "content-security-policy",
-          Enum.random([
-            "default-src 'self'; script-src plausible.io; connect-src #{PlausibleWeb.Endpoint.host()}",
-            "default-src 'self' *.#{PlausibleWeb.Endpoint.host()}"
-          ])
-        )
-        |> put_resp_content_type("text/html")
-        |> send_resp(200, @normal_body)
-      end)
-
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-    end
-
-    @proxied_script_body """
-    <html>
-    <head>
-    <script defer data-domain="example.com" src="https://proxy.example.com/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "proxied setup working OK" do
-      stub_fetch_body(200, @proxied_script_body)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-    end
-
-    @body_no_snippet """
-    <html> <head> </head> <body> Hello </body> </html>
-    """
-
-    test "non-standard integration where the snippet cannot be found but it works ok in headless" do
-      stub_fetch_body(200, @body_no_snippet)
-      stub_installation(200, plausible_installed(true, 202))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-    end
-
-    @different_data_domain_body """
-    <html>
-    <head>
-    <script defer data-domain="www.example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "data-domain mismatch on redirect chain" do
-      ref = :counters.new(1, [:atomics])
-      test = self()
-
-      Req.Test.stub(Checks.FetchBody, fn conn ->
-        if :counters.get(ref, 1) == 0 do
-          :counters.add(ref, 1, 1)
-          send(test, :redirect_sent)
-
-          conn
-          |> put_resp_header("location", "https://www.example.com")
-          |> send_resp(302, "redirecting to https://www.example.com")
-        else
-          conn
-          |> put_resp_header("content-type", "text/html")
-          |> send_resp(200, @different_data_domain_body)
-        end
-      end)
-
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-
-      assert_receive :redirect_sent
-    end
-  end
-
-  describe "errors" do
-    test "service error - 400" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation(400, %{})
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.temporary)
-    end
-
-    @tag :slow
-    test "can't fetch body but headless reports ok" do
-      stub_fetch_body(500, "")
-      stub_installation()
-
-      {_, log} =
-        with_log(fn ->
-          run_checks()
-          |> LegacyVerification.Checks.interpret_diagnostics()
-          |> assert_ok()
         end)
 
-      assert log =~ "3 attempts left"
-      assert log =~ "2 attempts left"
-      assert log =~ "1 attempt left"
-    end
+        stub_installation()
 
-    test "fetching will give up at 5th redirect" do
-      test = self()
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unreachable, url: "https://example.com")
 
-      stub_fetch_body(fn conn ->
-        send(test, :redirect_sent)
-
-        conn
-        |> put_resp_header("location", "https://example.com")
-        |> send_resp(302, "redirecting to https://example.com")
-      end)
-
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unreachable, url: "https://example.com")
-
-      assert_receive :redirect_sent
-      assert_receive :redirect_sent
-      assert_receive :redirect_sent
-      assert_receive :redirect_sent
-      assert_receive :redirect_sent
-      refute_receive _
-    end
-
-    @snippet_in_body """
-    <html>
-    <head>
-    </head>
-    <body>
-    Hello
-    <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </body>
-    </html>
-    """
-
-    test "detecting snippet in body" do
-      stub_fetch_body(200, @snippet_in_body)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.snippet_in_body)
-    end
-
-    @many_snippets """
-    <html>
-    <head>
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-    </head>
-    <body>
-    Hello
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-    <!-- maybe proxy? -->
-    <script defer data-domain="example.com" src="https://example.com/js/script.js"></script>
-    </body>
-    </html>
-    """
-
-    test "detecting many snippets" do
-      stub_fetch_body(200, @many_snippets)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.multiple_snippets)
-    end
-
-    @no_src_scripts """
-    <html>
-    <head>
-    <script defer data-domain="example.com"></script>
-    </head>
-    <body>
-    Hello
-    <script defer data-domain="example.com"></script>
-    </body>
-    </html>
-    """
-    test "no src attr doesn't count as snippet" do
-      stub_fetch_body(200, @no_src_scripts)
-      stub_installation(200, plausible_installed(false))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.no_snippet)
-    end
-
-    @many_snippets_ok """
-    <html>
-    <head>
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
-    <script defer data-domain="example.com" src="https://plausible.io/js/script.manual.js"></script>
-    </head>
-    <body>
-    Hello
-    </body>
-    </html>
-    """
-
-    test "skipping many snippets when manual found" do
-      stub_fetch_body(200, @many_snippets_ok)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_ok()
-    end
-
-    test "detecting snippet after busting cache" do
-      stub_fetch_body(fn conn ->
-        conn = fetch_query_params(conn)
-
-        if conn.query_params["plausible_verification"] do
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @normal_body)
-        else
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @body_no_snippet)
-        end
-      end)
-
-      stub_installation(fn conn ->
-        {:ok, body, _} = read_body(conn)
-
-        if String.contains?(body, "?plausible_verification") do
-          conn
-          |> put_resp_content_type("application/json")
-          |> send_resp(200, Jason.encode!(plausible_installed()))
-        else
-          raise "Should not get here even"
-        end
-      end)
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.cache_general)
-    end
-
-    @normal_body_wordpress """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "detecting snippet after busting WordPress cache - no official plugin" do
-      stub_fetch_body(fn conn ->
-        conn = fetch_query_params(conn)
-
-        if conn.query_params["plausible_verification"] do
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @normal_body_wordpress)
-        else
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @body_no_snippet)
-        end
-      end)
-
-      stub_installation(fn conn ->
-        {:ok, body, _} = read_body(conn)
-
-        if String.contains?(body, "?plausible_verification") do
-          conn
-          |> put_resp_content_type("application/json")
-          |> send_resp(200, Jason.encode!(plausible_installed()))
-        else
-          raise "Should not get here even"
-        end
-      end)
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.cache_wp_no_plugin)
-    end
-
-    @normal_body_wordpress_official_plugin """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    <meta name='plausible-analytics-version' content='2.0.9' />
-    <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "detecting snippet after busting WordPress cache - official plugin" do
-      stub_fetch_body(fn conn ->
-        conn = fetch_query_params(conn)
-
-        if conn.query_params["plausible_verification"] do
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @normal_body_wordpress_official_plugin)
-        else
-          conn
-          |> put_resp_content_type("text/html")
-          |> send_resp(200, @body_no_snippet)
-        end
-      end)
-
-      stub_installation(fn conn ->
-        {:ok, body, _} = read_body(conn)
-
-        if String.contains?(body, "?plausible_verification") do
-          conn
-          |> put_resp_content_type("application/json")
-          |> send_resp(200, Jason.encode!(plausible_installed()))
-        else
-          raise "Should not get here even"
-        end
-      end)
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.cache_wp_plugin)
-    end
-
-    test "detecting no snippet" do
-      stub_fetch_body(200, @body_no_snippet)
-      stub_installation(200, plausible_installed(false))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.no_snippet)
-    end
-
-    @body_no_snippet_wp """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    </head>
-    <body>
-    Hello
-    </body>
-    </html>
-    """
-
-    test "detecting no snippet on a wordpress site" do
-      stub_fetch_body(200, @body_no_snippet_wp)
-      stub_installation(200, plausible_installed(false))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.no_snippet_wp)
-    end
-
-    test "a check that raises" do
-      defmodule FaultyCheckRaise do
-        use Plausible.InstallationSupport.Check
-
-        @impl true
-        def report_progress_as, do: "Faulty check"
-
-        @impl true
-        def perform(_), do: raise("boom")
+        assert_receive :redirect_sent
+        assert_receive :redirect_sent
+        assert_receive :redirect_sent
+        assert_receive :redirect_sent
+        assert_receive :redirect_sent
+        refute_receive _
       end
 
-      {result, log} =
-        with_log(fn ->
-          run_checks(checks: [FaultyCheckRaise])
-        end)
+      @snippet_in_body """
+      <html>
+      <head>
+      </head>
+      <body>
+      Hello
+      <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </body>
+      </html>
+      """
 
-      assert log =~
-               ~s|Error running check Plausible.InstallationSupport.LegacyVerification.ChecksTest.FaultyCheckRaise on https://example.com: %RuntimeError{message: "boom"}|
+      test "detecting snippet in body" do
+        stub_fetch_body(200, @snippet_in_body)
+        stub_installation()
 
-      result
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unreachable, url: "https://example.com")
-    end
-
-    test "a check that throws" do
-      defmodule FaultyCheckThrow do
-        use Plausible.InstallationSupport.Check
-
-        @impl true
-        def report_progress_as, do: "Faulty check"
-
-        @impl true
-        def perform(_), do: :erlang.throw(:boom)
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.snippet_in_body)
       end
 
-      {result, log} =
-        with_log(fn ->
-          run_checks(checks: [FaultyCheckThrow])
+      @many_snippets """
+      <html>
+      <head>
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
+      </head>
+      <body>
+      Hello
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
+      <!-- maybe proxy? -->
+      <script defer data-domain="example.com" src="https://example.com/js/script.js"></script>
+      </body>
+      </html>
+      """
+
+      test "detecting many snippets" do
+        stub_fetch_body(200, @many_snippets)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.multiple_snippets)
+      end
+
+      @no_src_scripts """
+      <html>
+      <head>
+      <script defer data-domain="example.com"></script>
+      </head>
+      <body>
+      Hello
+      <script defer data-domain="example.com"></script>
+      </body>
+      </html>
+      """
+      test "no src attr doesn't count as snippet" do
+        stub_fetch_body(200, @no_src_scripts)
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.no_snippet)
+      end
+
+      @many_snippets_ok """
+      <html>
+      <head>
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.js"></script>
+      <script defer data-domain="example.com" src="https://plausible.io/js/script.manual.js"></script>
+      </head>
+      <body>
+      Hello
+      </body>
+      </html>
+      """
+
+      test "skipping many snippets when manual found" do
+        stub_fetch_body(200, @many_snippets_ok)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_ok()
+      end
+
+      test "detecting snippet after busting cache" do
+        stub_fetch_body(fn conn ->
+          conn = fetch_query_params(conn)
+
+          if conn.query_params["plausible_verification"] do
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @normal_body)
+          else
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @body_no_snippet)
+          end
         end)
 
-      assert log =~
-               ~s|Error running check Plausible.InstallationSupport.LegacyVerification.ChecksTest.FaultyCheckThrow on https://example.com: :boom|
+        stub_installation(fn conn ->
+          {:ok, body, _} = read_body(conn)
 
-      result
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unreachable, url: "https://example.com")
-    end
+          if String.contains?(body, "?plausible_verification") do
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(200, Jason.encode!(plausible_installed()))
+          else
+            raise "Should not get here even"
+          end
+        end)
 
-    test "disallowed via content-security-policy" do
-      stub_fetch_body(fn conn ->
-        conn
-        |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
-        |> put_resp_content_type("text/html")
-        |> send_resp(200, @normal_body)
-      end)
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.cache_general)
+      end
 
-      stub_installation(200, plausible_installed(false))
+      @normal_body_wordpress """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.csp)
-    end
+      test "detecting snippet after busting WordPress cache - no official plugin" do
+        stub_fetch_body(fn conn ->
+          conn = fetch_query_params(conn)
 
-    test "disallowed via content-security-policy with no snippet should make the latter a priority" do
-      stub_fetch_body(fn conn ->
-        conn
-        |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
-        |> put_resp_content_type("text/html")
-        |> send_resp(200, @body_no_snippet)
-      end)
+          if conn.query_params["plausible_verification"] do
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @normal_body_wordpress)
+          else
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @body_no_snippet)
+          end
+        end)
 
-      stub_installation(200, plausible_installed(false))
+        stub_installation(fn conn ->
+          {:ok, body, _} = read_body(conn)
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.no_snippet)
-    end
+          if String.contains?(body, "?plausible_verification") do
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(200, Jason.encode!(plausible_installed()))
+          else
+            raise "Should not get here even"
+          end
+        end)
 
-    test "running checks sends progress messages" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation()
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.cache_wp_no_plugin)
+      end
 
-      final_state = run_checks(report_to: self())
+      @normal_body_wordpress_official_plugin """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      <meta name='plausible-analytics-version' content='2.0.9' />
+      <script defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
 
-      assert_receive {:check_start, {Checks.FetchBody, %State{}}}
-      assert_receive {:check_start, {Checks.CSP, %State{}}}
-      assert_receive {:check_start, {Checks.ScanBody, %State{}}}
-      assert_receive {:check_start, {Checks.Snippet, %State{}}}
+      test "detecting snippet after busting WordPress cache - official plugin" do
+        stub_fetch_body(fn conn ->
+          conn = fetch_query_params(conn)
 
-      assert_receive {:check_start, {Checks.SnippetCacheBust, %State{}}}
+          if conn.query_params["plausible_verification"] do
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @normal_body_wordpress_official_plugin)
+          else
+            conn
+            |> put_resp_content_type("text/html")
+            |> send_resp(200, @body_no_snippet)
+          end
+        end)
 
-      assert_receive {:check_start, {Checks.Installation, %State{}}}
-      assert_receive {:all_checks_done, %State{} = ^final_state}
-      refute_receive _
-    end
+        stub_installation(fn conn ->
+          {:ok, body, _} = read_body(conn)
 
-    @gtm_body """
-    <html>
-    <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','XXXX');</script>
-    <!-- End Google Tag Manager -->
-    </head>
-    <body>
-    Hello
-    </body>
-    </html>
-    """
+          if String.contains?(body, "?plausible_verification") do
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(200, Jason.encode!(plausible_installed()))
+          else
+            raise "Should not get here even"
+          end
+        end)
 
-    test "disallowed via content-security-policy and GTM should make CSP a priority" do
-      stub_fetch_body(fn conn ->
-        conn
-        |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
-        |> put_resp_content_type("text/html")
-        |> send_resp(200, @gtm_body)
-      end)
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.cache_wp_plugin)
+      end
 
-      stub_installation(200, plausible_installed(false))
+      test "detecting no snippet" do
+        stub_fetch_body(200, @body_no_snippet)
+        stub_installation(200, plausible_installed(false))
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.csp)
-    end
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.no_snippet)
+      end
 
-    test "detecting gtm" do
-      stub_fetch_body(200, @gtm_body)
-      stub_installation(200, plausible_installed(false))
+      @body_no_snippet_wp """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      </head>
+      <body>
+      Hello
+      </body>
+      </html>
+      """
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.gtm)
-    end
+      test "detecting no snippet on a wordpress site" do
+        stub_fetch_body(200, @body_no_snippet_wp)
+        stub_installation(200, plausible_installed(false))
 
-    @gtm_body_with_cookiebot """
-    <html>
-    <head>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.no_snippet_wp)
+      end
+
+      test "a check that raises" do
+        defmodule FaultyCheckRaise do
+          use Plausible.InstallationSupport.Check
+
+          @impl true
+          def report_progress_as, do: "Faulty check"
+
+          @impl true
+          def perform(_), do: raise("boom")
+        end
+
+        {result, log} =
+          with_log(fn ->
+            run_checks(checks: [FaultyCheckRaise])
+          end)
+
+        assert log =~
+                 ~s|Error running check Plausible.InstallationSupport.LegacyVerification.ChecksTest.FaultyCheckRaise on https://example.com: %RuntimeError{message: "boom"}|
+
+        result
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unreachable, url: "https://example.com")
+      end
+
+      test "a check that throws" do
+        defmodule FaultyCheckThrow do
+          use Plausible.InstallationSupport.Check
+
+          @impl true
+          def report_progress_as, do: "Faulty check"
+
+          @impl true
+          def perform(_), do: :erlang.throw(:boom)
+        end
+
+        {result, log} =
+          with_log(fn ->
+            run_checks(checks: [FaultyCheckThrow])
+          end)
+
+        assert log =~
+                 ~s|Error running check Plausible.InstallationSupport.LegacyVerification.ChecksTest.FaultyCheckThrow on https://example.com: :boom|
+
+        result
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unreachable, url: "https://example.com")
+      end
+
+      test "disallowed via content-security-policy" do
+        stub_fetch_body(fn conn ->
+          conn
+          |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
+          |> put_resp_content_type("text/html")
+          |> send_resp(200, @normal_body)
+        end)
+
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.csp)
+      end
+
+      test "disallowed via content-security-policy with no snippet should make the latter a priority" do
+        stub_fetch_body(fn conn ->
+          conn
+          |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
+          |> put_resp_content_type("text/html")
+          |> send_resp(200, @body_no_snippet)
+        end)
+
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.no_snippet)
+      end
+
+      test "running checks sends progress messages" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation()
+
+        final_state = run_checks(report_to: self())
+
+        assert_receive {:check_start, {Checks.FetchBody, %State{}}}
+        assert_receive {:check_start, {Checks.CSP, %State{}}}
+        assert_receive {:check_start, {Checks.ScanBody, %State{}}}
+        assert_receive {:check_start, {Checks.Snippet, %State{}}}
+
+        assert_receive {:check_start, {Checks.SnippetCacheBust, %State{}}}
+
+        assert_receive {:check_start, {Checks.Installation, %State{}}}
+        assert_receive {:all_checks_done, %State{} = ^final_state}
+        refute_receive _
+      end
+
+      @gtm_body """
+      <html>
+      <head>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','XXXX');</script>
-    <!-- End Google Tag Manager -->
-    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="some-uuid" data-blockingmode="auto" type="text/javascript"></script>
-    </head>
-    <body>
-    Hello
-    </body>
-    </html>
-    """
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','XXXX');</script>
+      <!-- End Google Tag Manager -->
+      </head>
+      <body>
+      Hello
+      </body>
+      </html>
+      """
 
-    test "detecting gtm with cookie consent" do
-      stub_fetch_body(200, @gtm_body_with_cookiebot)
-      stub_installation(200, plausible_installed(false))
+      test "disallowed via content-security-policy and GTM should make CSP a priority" do
+        stub_fetch_body(fn conn ->
+          conn
+          |> put_resp_header("content-security-policy", "default-src 'self' foo.local")
+          |> put_resp_content_type("text/html")
+          |> send_resp(200, @gtm_body)
+        end)
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.gtm_cookie_banner)
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.csp)
+      end
+
+      test "detecting gtm" do
+        stub_fetch_body(200, @gtm_body)
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.gtm)
+      end
+
+      @gtm_body_with_cookiebot """
+      <html>
+      <head>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','XXXX');</script>
+      <!-- End Google Tag Manager -->
+      <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="some-uuid" data-blockingmode="auto" type="text/javascript"></script>
+      </head>
+      <body>
+      Hello
+      </body>
+      </html>
+      """
+
+      test "detecting gtm with cookie consent" do
+        stub_fetch_body(200, @gtm_body_with_cookiebot)
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.gtm_cookie_banner)
+      end
+
+      test "non-html body" do
+        stub_fetch_body(fn conn ->
+          conn
+          |> put_resp_content_type("image/png")
+          |> send_resp(200, :binary.copy(<<0>>, 100))
+        end)
+
+        stub_installation(200, plausible_installed(false))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unreachable, url: "https://example.com")
+      end
+
+      test "proxied setup, function defined but callback won't fire" do
+        stub_fetch_body(200, @proxied_script_body)
+        stub_installation(200, plausible_installed(true, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.proxy_misconfigured)
+      end
+
+      @proxied_script_body_wordpress """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      <script defer data-domain="example.com" src="https://proxy.example.com/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "proxied WordPress setup, function undefined, callback won't fire" do
+        stub_fetch_body(200, @proxied_script_body_wordpress)
+        stub_installation(200, plausible_installed(false, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.proxy_wp_no_plugin)
+      end
+
+      test "proxied setup, function undefined, callback won't fire" do
+        stub_fetch_body(200, @proxied_script_body)
+        stub_installation(200, plausible_installed(false, 0))
+
+        result = run_checks()
+        interpretation = LegacyVerification.Checks.interpret_diagnostics(result)
+
+        refute interpretation.ok?
+        assert interpretation.errors == ["We encountered an error with your Plausible proxy"]
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.proxy_general)
+      end
+
+      test "non-proxied setup, but callback fails to fire" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation(200, plausible_installed(true, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unknown)
+      end
+
+      @body_unknown_attributes """
+      <html>
+      <head>
+      <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "unknown attributes" do
+        stub_fetch_body(200, @body_unknown_attributes)
+        stub_installation(200, plausible_installed(false, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.illegal_attrs_general)
+      end
+
+      @body_unknown_attributes_wordpress """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "unknown attributes for WordPress installation" do
+        stub_fetch_body(200, @body_unknown_attributes_wordpress)
+        stub_installation(200, plausible_installed(false, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.illegal_attrs_wp_no_plugin)
+      end
+
+      @body_unknown_attributes_wordpress_official_plugin """
+      <html>
+      <head>
+      <meta name="foo" content="/wp-content/plugins/bar"/>
+      <meta name='plausible-analytics-version' content='2.0.9' />
+      <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
+      </head>
+      <body>Hello</body>
+      </html>
+      """
+
+      test "unknown attributes for WordPress installation - official plugin" do
+        stub_fetch_body(200, @body_unknown_attributes_wordpress_official_plugin)
+        stub_installation(200, plausible_installed(false, 0))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.illegal_attrs_wp_plugin)
+      end
+
+      test "callback handling not found for non-wordpress site" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation(200, plausible_installed(true, -1))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.generic)
+      end
+
+      test "callback handling not found for wordpress site" do
+        stub_fetch_body(200, @normal_body_wordpress)
+        stub_installation(200, plausible_installed(true, -1))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.old_script_wp_no_plugin)
+      end
+
+      test "callback handling not found for wordpress site using our plugin" do
+        stub_fetch_body(200, @normal_body_wordpress_official_plugin)
+        stub_installation(200, plausible_installed(true, -1))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.old_script_wp_plugin)
+      end
+
+      test "fails due to callback status being something unlikely like 500" do
+        stub_fetch_body(200, @normal_body)
+        stub_installation(200, plausible_installed(true, 500))
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.unknown)
+      end
+
+      test "data-domain mismatch" do
+        stub_fetch_body(200, @different_data_domain_body)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.different_data_domain, domain: "example.com")
+      end
+
+      @many_snippets_with_domain_mismatch """
+      <html>
+      <head>
+      <script defer data-domain="example.org" src="https://plausible.io/js/script.js"></script>
+      <script defer data-domain="example.org" src="https://plausible.io/js/script.js"></script>
+      </head>
+      <body>
+      Hello
+      </body>
+      </html>
+      """
+
+      test "prioritizes data-domain mismatch over multiple snippets" do
+        stub_fetch_body(200, @many_snippets_with_domain_mismatch)
+        stub_installation()
+
+        run_checks()
+        |> LegacyVerification.Checks.interpret_diagnostics()
+        |> assert_error(@errors.different_data_domain, domain: "example.com")
+      end
     end
 
-    test "non-html body" do
+    describe "unhhandled cases from sentry" do
+      test "APP-58: 4b1435e3f8a048eb949cc78fa578d1e4" do
+        %LegacyVerification.Diagnostics{
+          plausible_installed?: true,
+          snippets_found_in_head: 0,
+          snippets_found_in_body: 0,
+          snippet_found_after_busting_cache?: false,
+          snippet_unknown_attributes?: false,
+          disallowed_via_csp?: false,
+          service_error: nil,
+          body_fetched?: true,
+          wordpress_likely?: true,
+          cookie_banner_likely?: false,
+          gtm_likely?: false,
+          callback_status: -1,
+          proxy_likely?: false,
+          manual_script_extension?: false,
+          data_domain_mismatch?: false,
+          wordpress_plugin?: false
+        }
+        |> interpret_sentry_case()
+        |> assert_error(@errors.old_script_wp_no_plugin)
+      end
+
+      test "service timeout" do
+        %LegacyVerification.Diagnostics{
+          plausible_installed?: false,
+          snippets_found_in_head: 1,
+          snippets_found_in_body: 0,
+          snippet_found_after_busting_cache?: false,
+          snippet_unknown_attributes?: false,
+          disallowed_via_csp?: false,
+          service_error: :timeout,
+          body_fetched?: true,
+          wordpress_likely?: true,
+          cookie_banner_likely?: false,
+          gtm_likely?: false,
+          callback_status: 0,
+          proxy_likely?: true,
+          manual_script_extension?: false,
+          data_domain_mismatch?: false,
+          wordpress_plugin?: false
+        }
+        |> interpret_sentry_case()
+        |> assert_error(@errors.generic)
+      end
+
+      test "malformed snippet code, that headless somewhat accepts" do
+        %LegacyVerification.Diagnostics{
+          plausible_installed?: true,
+          snippets_found_in_head: 0,
+          snippets_found_in_body: 0,
+          snippet_found_after_busting_cache?: false,
+          snippet_unknown_attributes?: false,
+          disallowed_via_csp?: false,
+          service_error: nil,
+          body_fetched?: true,
+          wordpress_likely?: false,
+          cookie_banner_likely?: false,
+          gtm_likely?: false,
+          callback_status: 405,
+          proxy_likely?: false,
+          manual_script_extension?: false,
+          data_domain_mismatch?: false,
+          wordpress_plugin?: false
+        }
+        |> interpret_sentry_case()
+        |> assert_error(@errors.no_snippet)
+      end
+
+      test "gtm+wp detected, but likely script id attribute interfering" do
+        %LegacyVerification.Diagnostics{
+          plausible_installed?: false,
+          snippets_found_in_head: 1,
+          snippets_found_in_body: 0,
+          snippet_found_after_busting_cache?: false,
+          snippet_unknown_attributes?: true,
+          disallowed_via_csp?: false,
+          service_error: nil,
+          body_fetched?: true,
+          wordpress_likely?: true,
+          cookie_banner_likely?: true,
+          gtm_likely?: true,
+          callback_status: 0,
+          proxy_likely?: true,
+          manual_script_extension?: false,
+          data_domain_mismatch?: false,
+          wordpress_plugin?: true
+        }
+        |> interpret_sentry_case()
+        |> assert_error(@errors.illegal_attrs_wp_plugin)
+      end
+    end
+
+    defp interpret_sentry_case(diagnostics) do
+      diagnostics
+      |> LegacyVerification.Diagnostics.interpret("example.com")
+      |> refute_unhandled()
+    end
+
+    defp run_checks(extra_opts \\ []) do
+      LegacyVerification.Checks.run(
+        "https://example.com",
+        "example.com",
+        Keyword.merge([async?: false, report_to: nil, slowdown: 0], extra_opts)
+      )
+    end
+
+    defp stub_fetch_body(f) when is_function(f, 1) do
+      Req.Test.stub(Checks.FetchBody, f)
+    end
+
+    defp stub_installation(f) when is_function(f, 1) do
+      Req.Test.stub(Checks.Installation, f)
+    end
+
+    defp stub_fetch_body(status, body) do
       stub_fetch_body(fn conn ->
         conn
-        |> put_resp_content_type("image/png")
-        |> send_resp(200, :binary.copy(<<0>>, 100))
+        |> put_resp_content_type("text/html")
+        |> send_resp(status, body)
       end)
-
-      stub_installation(200, plausible_installed(false))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unreachable, url: "https://example.com")
     end
 
-    test "proxied setup, function defined but callback won't fire" do
-      stub_fetch_body(200, @proxied_script_body)
-      stub_installation(200, plausible_installed(true, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.proxy_misconfigured)
+    defp stub_installation(status \\ 200, json \\ plausible_installed()) do
+      stub_installation(fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(status, Jason.encode!(json))
+      end)
     end
 
-    @proxied_script_body_wordpress """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    <script defer data-domain="example.com" src="https://proxy.example.com/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "proxied WordPress setup, function undefined, callback won't fire" do
-      stub_fetch_body(200, @proxied_script_body_wordpress)
-      stub_installation(200, plausible_installed(false, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.proxy_wp_no_plugin)
+    defp plausible_installed(bool \\ true, callback_status \\ 202) do
+      %{
+        "data" => %{
+          "completed" => true,
+          "snippetsFoundInHead" => 0,
+          "snippetsFoundInBody" => 0,
+          "plausibleInstalled" => bool,
+          "callbackStatus" => callback_status
+        }
+      }
     end
 
-    test "proxied setup, function undefined, callback won't fire" do
-      stub_fetch_body(200, @proxied_script_body)
-      stub_installation(200, plausible_installed(false, 0))
+    defp refute_unhandled(interpretation) do
+      refute interpretation.errors == [
+               @errors.unknown.message
+             ]
 
-      result = run_checks()
-      interpretation = LegacyVerification.Checks.interpret_diagnostics(result)
+      refute interpretation.recommendations == [
+               @errors.unknown.recommendation
+             ]
 
+      interpretation
+    end
+
+    defp assert_error(interpretation, error) do
       refute interpretation.ok?
-      assert interpretation.errors == ["We encountered an error with your Plausible proxy"]
 
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.proxy_general)
+      assert interpretation.errors == [
+               error.message
+             ]
+
+      assert interpretation.recommendations == [
+               %{text: error.recommendation, url: error.url}
+             ]
     end
 
-    test "non-proxied setup, but callback fails to fire" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation(200, plausible_installed(true, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unknown)
+    defp assert_error(interpretation, error, assigns) do
+      recommendation = EEx.eval_string(error.recommendation, assigns: assigns)
+      assert_error(interpretation, %{error | recommendation: recommendation})
     end
 
-    @body_unknown_attributes """
-    <html>
-    <head>
-    <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "unknown attributes" do
-      stub_fetch_body(200, @body_unknown_attributes)
-      stub_installation(200, plausible_installed(false, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.illegal_attrs_general)
+    defp assert_ok(interpretation) do
+      assert interpretation.ok?
+      assert interpretation.errors == []
+      assert interpretation.recommendations == []
     end
-
-    @body_unknown_attributes_wordpress """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "unknown attributes for WordPress installation" do
-      stub_fetch_body(200, @body_unknown_attributes_wordpress)
-      stub_installation(200, plausible_installed(false, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.illegal_attrs_wp_no_plugin)
-    end
-
-    @body_unknown_attributes_wordpress_official_plugin """
-    <html>
-    <head>
-    <meta name="foo" content="/wp-content/plugins/bar"/>
-    <meta name='plausible-analytics-version' content='2.0.9' />
-    <script foo="bar" defer data-domain="example.com" src="http://localhost:8000/js/script.js"></script>
-    </head>
-    <body>Hello</body>
-    </html>
-    """
-
-    test "unknown attributes for WordPress installation - official plugin" do
-      stub_fetch_body(200, @body_unknown_attributes_wordpress_official_plugin)
-      stub_installation(200, plausible_installed(false, 0))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.illegal_attrs_wp_plugin)
-    end
-
-    test "callback handling not found for non-wordpress site" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation(200, plausible_installed(true, -1))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.generic)
-    end
-
-    test "callback handling not found for wordpress site" do
-      stub_fetch_body(200, @normal_body_wordpress)
-      stub_installation(200, plausible_installed(true, -1))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.old_script_wp_no_plugin)
-    end
-
-    test "callback handling not found for wordpress site using our plugin" do
-      stub_fetch_body(200, @normal_body_wordpress_official_plugin)
-      stub_installation(200, plausible_installed(true, -1))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.old_script_wp_plugin)
-    end
-
-    test "fails due to callback status being something unlikely like 500" do
-      stub_fetch_body(200, @normal_body)
-      stub_installation(200, plausible_installed(true, 500))
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.unknown)
-    end
-
-    test "data-domain mismatch" do
-      stub_fetch_body(200, @different_data_domain_body)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.different_data_domain, domain: "example.com")
-    end
-
-    @many_snippets_with_domain_mismatch """
-    <html>
-    <head>
-    <script defer data-domain="example.org" src="https://plausible.io/js/script.js"></script>
-    <script defer data-domain="example.org" src="https://plausible.io/js/script.js"></script>
-    </head>
-    <body>
-    Hello
-    </body>
-    </html>
-    """
-
-    test "prioritizes data-domain mismatch over multiple snippets" do
-      stub_fetch_body(200, @many_snippets_with_domain_mismatch)
-      stub_installation()
-
-      run_checks()
-      |> LegacyVerification.Checks.interpret_diagnostics()
-      |> assert_error(@errors.different_data_domain, domain: "example.com")
-    end
-  end
-
-  describe "unhhandled cases from sentry" do
-    test "APP-58: 4b1435e3f8a048eb949cc78fa578d1e4" do
-      %LegacyVerification.Diagnostics{
-        plausible_installed?: true,
-        snippets_found_in_head: 0,
-        snippets_found_in_body: 0,
-        snippet_found_after_busting_cache?: false,
-        snippet_unknown_attributes?: false,
-        disallowed_via_csp?: false,
-        service_error: nil,
-        body_fetched?: true,
-        wordpress_likely?: true,
-        cookie_banner_likely?: false,
-        gtm_likely?: false,
-        callback_status: -1,
-        proxy_likely?: false,
-        manual_script_extension?: false,
-        data_domain_mismatch?: false,
-        wordpress_plugin?: false
-      }
-      |> interpret_sentry_case()
-      |> assert_error(@errors.old_script_wp_no_plugin)
-    end
-
-    test "service timeout" do
-      %LegacyVerification.Diagnostics{
-        plausible_installed?: false,
-        snippets_found_in_head: 1,
-        snippets_found_in_body: 0,
-        snippet_found_after_busting_cache?: false,
-        snippet_unknown_attributes?: false,
-        disallowed_via_csp?: false,
-        service_error: :timeout,
-        body_fetched?: true,
-        wordpress_likely?: true,
-        cookie_banner_likely?: false,
-        gtm_likely?: false,
-        callback_status: 0,
-        proxy_likely?: true,
-        manual_script_extension?: false,
-        data_domain_mismatch?: false,
-        wordpress_plugin?: false
-      }
-      |> interpret_sentry_case()
-      |> assert_error(@errors.generic)
-    end
-
-    test "malformed snippet code, that headless somewhat accepts" do
-      %LegacyVerification.Diagnostics{
-        plausible_installed?: true,
-        snippets_found_in_head: 0,
-        snippets_found_in_body: 0,
-        snippet_found_after_busting_cache?: false,
-        snippet_unknown_attributes?: false,
-        disallowed_via_csp?: false,
-        service_error: nil,
-        body_fetched?: true,
-        wordpress_likely?: false,
-        cookie_banner_likely?: false,
-        gtm_likely?: false,
-        callback_status: 405,
-        proxy_likely?: false,
-        manual_script_extension?: false,
-        data_domain_mismatch?: false,
-        wordpress_plugin?: false
-      }
-      |> interpret_sentry_case()
-      |> assert_error(@errors.no_snippet)
-    end
-
-    test "gtm+wp detected, but likely script id attribute interfering" do
-      %LegacyVerification.Diagnostics{
-        plausible_installed?: false,
-        snippets_found_in_head: 1,
-        snippets_found_in_body: 0,
-        snippet_found_after_busting_cache?: false,
-        snippet_unknown_attributes?: true,
-        disallowed_via_csp?: false,
-        service_error: nil,
-        body_fetched?: true,
-        wordpress_likely?: true,
-        cookie_banner_likely?: true,
-        gtm_likely?: true,
-        callback_status: 0,
-        proxy_likely?: true,
-        manual_script_extension?: false,
-        data_domain_mismatch?: false,
-        wordpress_plugin?: true
-      }
-      |> interpret_sentry_case()
-      |> assert_error(@errors.illegal_attrs_wp_plugin)
-    end
-  end
-
-  defp interpret_sentry_case(diagnostics) do
-    diagnostics
-    |> LegacyVerification.Diagnostics.interpret("example.com")
-    |> refute_unhandled()
-  end
-
-  defp run_checks(extra_opts \\ []) do
-    LegacyVerification.Checks.run(
-      "https://example.com",
-      "example.com",
-      Keyword.merge([async?: false, report_to: nil, slowdown: 0], extra_opts)
-    )
-  end
-
-  defp stub_fetch_body(f) when is_function(f, 1) do
-    Req.Test.stub(Checks.FetchBody, f)
-  end
-
-  defp stub_installation(f) when is_function(f, 1) do
-    Req.Test.stub(Checks.Installation, f)
-  end
-
-  defp stub_fetch_body(status, body) do
-    stub_fetch_body(fn conn ->
-      conn
-      |> put_resp_content_type("text/html")
-      |> send_resp(status, body)
-    end)
-  end
-
-  defp stub_installation(status \\ 200, json \\ plausible_installed()) do
-    stub_installation(fn conn ->
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(status, Jason.encode!(json))
-    end)
-  end
-
-  defp plausible_installed(bool \\ true, callback_status \\ 202) do
-    %{
-      "data" => %{
-        "completed" => true,
-        "snippetsFoundInHead" => 0,
-        "snippetsFoundInBody" => 0,
-        "plausibleInstalled" => bool,
-        "callbackStatus" => callback_status
-      }
-    }
-  end
-
-  defp refute_unhandled(interpretation) do
-    refute interpretation.errors == [
-             @errors.unknown.message
-           ]
-
-    refute interpretation.recommendations == [
-             @errors.unknown.recommendation
-           ]
-
-    interpretation
-  end
-
-  defp assert_error(interpretation, error) do
-    refute interpretation.ok?
-
-    assert interpretation.errors == [
-             error.message
-           ]
-
-    assert interpretation.recommendations == [
-             %{text: error.recommendation, url: error.url}
-           ]
-  end
-
-  defp assert_error(interpretation, error, assigns) do
-    recommendation = EEx.eval_string(error.recommendation, assigns: assigns)
-    assert_error(interpretation, %{error | recommendation: recommendation})
-  end
-
-  defp assert_ok(interpretation) do
-    assert interpretation.ok?
-    assert interpretation.errors == []
-    assert interpretation.recommendations == []
   end
 end

--- a/test/plausible_web/live/change_domain_v2_test.exs
+++ b/test/plausible_web/live/change_domain_v2_test.exs
@@ -1,227 +1,109 @@
 defmodule PlausibleWeb.Live.ChangeDomainV2Test do
   use PlausibleWeb.ConnCase, async: false
-  import Phoenix.LiveViewTest
-  import Plausible.TestUtils
-  import ExUnit.CaptureLog
-  import Mox
+  use Plausible
 
-  alias Plausible.Repo
+  @moduletag :ee_only
 
-  describe "ChangeDomainV2 LiveView" do
-    setup [:create_user, :log_in, :create_site]
+  on_ee do
+    import Phoenix.LiveViewTest
+    import Plausible.TestUtils
+    import ExUnit.CaptureLog
+    import Mox
 
-    setup do
-      # mock all domains resolve
-      Plausible.DnsLookup.Mock
-      |> expect(:lookup, fn _domain, _type, _record, _opts, _timeout ->
-        [{192, 168, 1, 2}]
-      end)
+    alias Plausible.Repo
 
-      :ok
-    end
+    describe "ChangeDomainV2 LiveView" do
+      setup [:create_user, :log_in, :create_site]
 
-    test "mounts and renders form", %{conn: conn, site: site} do
-      {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
+      setup do
+        # mock all domains resolve
+        Plausible.DnsLookup.Mock
+        |> expect(:lookup, fn _domain, _type, _record, _opts, _timeout ->
+          [{192, 168, 1, 2}]
+        end)
 
-      assert html =~ "Change your website domain"
-    end
+        :ok
+      end
 
-    test "form submission when no change is made", %{conn: conn, site: site} do
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+      test "mounts and renders form", %{conn: conn, site: site} do
+        {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
 
-      html =
+        assert html =~ "Change your website domain"
+      end
+
+      test "form submission when no change is made", %{conn: conn, site: site} do
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        html =
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: site.domain}})
+
+        assert html =~ "New domain must be different than the current one"
+      end
+
+      test "form submission to an existing domain", %{conn: conn, site: site} do
+        another_site = insert(:site)
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        html =
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: another_site.domain}})
+
+        assert html =~ "This domain cannot be registered"
+
+        site = Repo.reload!(site)
+        assert site.domain != another_site.domain
+        assert is_nil(site.domain_changed_from)
+      end
+
+      test "form submission to a domain in transition period", %{conn: conn, site: site} do
+        _another_site = insert(:site, domain_changed_from: "foo.example.com")
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        html =
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: "foo.example.com"}})
+
+        assert html =~ "This domain cannot be registered"
+
+        site = Repo.reload!(site)
+        assert site.domain != "foo.example.com"
+        assert is_nil(site.domain_changed_from)
+      end
+
+      test "successful form submission updates database", %{conn: conn, site: site} do
+        stub_detection_result(%{
+          "v1Detected" => false,
+          "gtmLikely" => false,
+          "wordpressLikely" => false,
+          "wordpressPlugin" => false
+        })
+
+        original_domain = site.domain
+        new_domain = "new-example.com"
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
         lv
         |> element("form")
-        |> render_submit(%{site: %{domain: site.domain}})
+        |> render_submit(%{site: %{domain: new_domain}})
 
-      assert html =~ "New domain must be different than the current one"
-    end
+        site = Repo.reload!(site)
+        assert site.domain == new_domain
+        assert site.domain_changed_from == original_domain
+      end
 
-    test "form submission to an existing domain", %{conn: conn, site: site} do
-      another_site = insert(:site)
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+      test "successful form submission navigates to success page", %{conn: conn, site: site} do
+        stub_detection_result(%{
+          "v1Detected" => false,
+          "gtmLikely" => false,
+          "wordpressLikely" => false,
+          "wordpressPlugin" => false
+        })
 
-      html =
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: another_site.domain}})
-
-      assert html =~ "This domain cannot be registered"
-
-      site = Repo.reload!(site)
-      assert site.domain != another_site.domain
-      assert is_nil(site.domain_changed_from)
-    end
-
-    test "form submission to a domain in transition period", %{conn: conn, site: site} do
-      _another_site = insert(:site, domain_changed_from: "foo.example.com")
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      html =
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: "foo.example.com"}})
-
-      assert html =~ "This domain cannot be registered"
-
-      site = Repo.reload!(site)
-      assert site.domain != "foo.example.com"
-      assert is_nil(site.domain_changed_from)
-    end
-
-    test "successful form submission updates database", %{conn: conn, site: site} do
-      stub_detection_result(%{
-        "v1Detected" => false,
-        "gtmLikely" => false,
-        "wordpressLikely" => false,
-        "wordpressPlugin" => false
-      })
-
-      original_domain = site.domain
-      new_domain = "new-example.com"
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      lv
-      |> element("form")
-      |> render_submit(%{site: %{domain: new_domain}})
-
-      site = Repo.reload!(site)
-      assert site.domain == new_domain
-      assert site.domain_changed_from == original_domain
-    end
-
-    test "successful form submission navigates to success page", %{conn: conn, site: site} do
-      stub_detection_result(%{
-        "v1Detected" => false,
-        "gtmLikely" => false,
-        "wordpressLikely" => false,
-        "wordpressPlugin" => false
-      })
-
-      original_domain = site.domain
-      new_domain = "new-example.com"
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      lv
-      |> element("form")
-      |> render_submit(%{site: %{domain: new_domain}})
-
-      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-      html = render_async(lv, 500)
-      assert html =~ "Domain Changed Successfully"
-      assert html =~ original_domain
-      assert html =~ new_domain
-    end
-
-    test "form validation shows error for empty domain", %{conn: conn, site: site} do
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      html =
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: ""}})
-
-      assert html =~ "can&#39;t be blank"
-    end
-
-    test "form validation shows error for invalid domain format", %{conn: conn, site: site} do
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      html =
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: "invalid domain with spaces"}})
-
-      assert html =~ "only letters, numbers, slashes and period allowed"
-    end
-
-    test "renders back to settings link with correct path", %{conn: conn, site: site} do
-      {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      expected_link = Routes.site_path(conn, :settings_general, site.domain)
-      assert html =~ expected_link
-    end
-
-    test "success page shows WordPress plugin notice when detected", %{conn: conn, site: site} do
-      stub_detection_result(%{
-        "v1Detected" => true,
-        "gtmLikely" => false,
-        "wordpressLikely" => true,
-        "wordpressPlugin" => true
-      })
-
-      new_domain = "new-example.com"
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      lv
-      |> element("form")
-      |> render_submit(%{site: %{domain: new_domain}})
-
-      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-      html = render_async(lv, 500)
-      assert html =~ "<i>must</i>"
-      assert html =~ "also update the site"
-      assert html =~ "Plausible Wordpress Plugin settings"
-      assert html =~ "within 72 hours"
-    end
-
-    test "success page shows generic v1 notice when detected but not WordPress", %{
-      conn: conn,
-      site: site
-    } do
-      stub_detection_result(%{
-        "v1Detected" => true,
-        "gtmLikely" => false,
-        "wordpressLikely" => false,
-        "wordpressPlugin" => false
-      })
-
-      new_domain = "new-example.com"
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      lv
-      |> element("form")
-      |> render_submit(%{site: %{domain: new_domain}})
-
-      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-      html = render_async(lv, 500)
-      assert html =~ "<i>must</i>"
-      assert html =~ "also update the site"
-      assert html =~ "Plausible Installation"
-      assert html =~ "within 72 hours"
-      refute html =~ "Wordpress Plugin"
-    end
-
-    test "success page shows no notice when no v1 tracking detected", %{conn: conn, site: site} do
-      stub_detection_result(%{
-        "v1Detected" => false,
-        "gtmLikely" => false,
-        "wordpressLikely" => false,
-        "wordpressPlugin" => false
-      })
-
-      new_domain = "new-example.com"
-      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-      lv
-      |> element("form")
-      |> render_submit(%{site: %{domain: new_domain}})
-
-      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-      html = render_async(lv, 500)
-      refute html =~ "Additional Steps Required"
-      refute html =~ "<i>must</i>"
-      refute html =~ "also update the site"
-    end
-
-    test "success page handles detection error gracefully", %{conn: conn, site: site} do
-      stub_detection_error()
-
-      capture_log(fn ->
+        original_domain = site.domain
         new_domain = "new-example.com"
         {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
 
@@ -232,30 +114,154 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
         assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
 
         html = render_async(lv, 500)
-        assert html =~ "Additional Steps Required"
+        assert html =~ "Domain Changed Successfully"
+        assert html =~ original_domain
+        assert html =~ new_domain
+      end
+
+      test "form validation shows error for empty domain", %{conn: conn, site: site} do
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        html =
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: ""}})
+
+        assert html =~ "can&#39;t be blank"
+      end
+
+      test "form validation shows error for invalid domain format", %{conn: conn, site: site} do
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        html =
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: "invalid domain with spaces"}})
+
+        assert html =~ "only letters, numbers, slashes and period allowed"
+      end
+
+      test "renders back to settings link with correct path", %{conn: conn, site: site} do
+        {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        expected_link = Routes.site_path(conn, :settings_general, site.domain)
+        assert html =~ expected_link
+      end
+
+      test "success page shows WordPress plugin notice when detected", %{conn: conn, site: site} do
+        stub_detection_result(%{
+          "v1Detected" => true,
+          "gtmLikely" => false,
+          "wordpressLikely" => true,
+          "wordpressPlugin" => true
+        })
+
+        new_domain = "new-example.com"
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: new_domain}})
+
+        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+        html = render_async(lv, 500)
+        assert html =~ "<i>must</i>"
+        assert html =~ "also update the site"
+        assert html =~ "Plausible Wordpress Plugin settings"
+        assert html =~ "within 72 hours"
+      end
+
+      test "success page shows generic v1 notice when detected but not WordPress", %{
+        conn: conn,
+        site: site
+      } do
+        stub_detection_result(%{
+          "v1Detected" => true,
+          "gtmLikely" => false,
+          "wordpressLikely" => false,
+          "wordpressPlugin" => false
+        })
+
+        new_domain = "new-example.com"
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: new_domain}})
+
+        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+        html = render_async(lv, 500)
         assert html =~ "<i>must</i>"
         assert html =~ "also update the site"
         assert html =~ "Plausible Installation"
+        assert html =~ "within 72 hours"
+        refute html =~ "Wordpress Plugin"
+      end
+
+      test "success page shows no notice when no v1 tracking detected", %{conn: conn, site: site} do
+        stub_detection_result(%{
+          "v1Detected" => false,
+          "gtmLikely" => false,
+          "wordpressLikely" => false,
+          "wordpressPlugin" => false
+        })
+
+        new_domain = "new-example.com"
+        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: new_domain}})
+
+        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+        html = render_async(lv, 500)
+        refute html =~ "Additional Steps Required"
+        refute html =~ "<i>must</i>"
+        refute html =~ "also update the site"
+      end
+
+      test "success page handles detection error gracefully", %{conn: conn, site: site} do
+        stub_detection_error()
+
+        capture_log(fn ->
+          new_domain = "new-example.com"
+          {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+          lv
+          |> element("form")
+          |> render_submit(%{site: %{domain: new_domain}})
+
+          assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+          html = render_async(lv, 500)
+          assert html =~ "Additional Steps Required"
+          assert html =~ "<i>must</i>"
+          assert html =~ "also update the site"
+          assert html =~ "Plausible Installation"
+        end)
+      end
+    end
+
+    defp stub_detection_result(js_data) do
+      Req.Test.stub(:global, fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
       end)
     end
-  end
 
-  defp stub_detection_result(js_data) do
-    Req.Test.stub(:global, fn conn ->
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
-    end)
-  end
-
-  defp stub_detection_error do
-    Req.Test.stub(:global, fn conn ->
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(
-        200,
-        Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
-      )
-    end)
+    defp stub_detection_error do
+      Req.Test.stub(:global, fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          200,
+          Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
+        )
+      end)
+    end
   end
 end

--- a/test/plausible_web/live/installationv2_test.exs
+++ b/test/plausible_web/live/installationv2_test.exs
@@ -1,540 +1,546 @@
 defmodule PlausibleWeb.Live.InstallationV2Test do
   use PlausibleWeb.ConnCase, async: true
+  use Plausible
 
-  import Phoenix.LiveViewTest
-  import Plausible.Test.Support.HTML
-  import Plausible.Teams.Test
-  import Mox
+  @moduletag :ee_only
 
-  alias Plausible.Site.TrackerScriptConfiguration
+  on_ee do
+    import Phoenix.LiveViewTest
+    import Plausible.Test.Support.HTML
+    import Plausible.Teams.Test
+    import Mox
 
-  setup [:create_user, :log_in, :create_site]
+    alias Plausible.Site.TrackerScriptConfiguration
 
-  setup %{site: site} do
-    FunWithFlags.enable(:scriptv2, for_actor: site)
-    :ok
-  end
+    setup [:create_user, :log_in, :create_site]
 
-  describe "GET /:domain/installationv2" do
-    test "static installation screen renders with spinner", %{conn: conn, site: site} do
-      resp = get(conn, "/#{site.domain}/installationv2") |> html_response(200)
-
-      assert resp =~ "animate-spin"
-    end
-  end
-
-  describe "LiveView" do
-    test "detects installation type when mounted", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site)
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Verify WordPress installation"
+    setup %{site: site} do
+      FunWithFlags.enable(:scriptv2, for_actor: site)
+      :ok
     end
 
-    test "When ?type=wordpress URL parameter is supplied, detected type is unused", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
+    describe "GET /:domain/installationv2" do
+      test "static installation screen renders with spinner", %{conn: conn, site: site} do
+        resp = get(conn, "/#{site.domain}/installationv2") |> html_response(200)
 
-      {lv, _} = get_lv(conn, site, "?type=wordpress")
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Verify WordPress installation"
+        assert resp =~ "animate-spin"
+      end
     end
 
-    test "When ?type=gtm URL parameter is supplied, detected type is unused", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site, "?type=gtm")
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Verify Tag Manager installation"
-    end
-
-    test "When ?type=npm URL parameter is supplied, detected type is unused", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site, "?type=npm")
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Verify NPM installation"
-    end
-
-    test "When ?type=manual URL parameter is supplied, detected type is unused", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site, "?type=manual")
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Verify Script installation"
-    end
-
-    test "allows switching between installation tabs", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-
-      lv
-      |> element("a[href*=\"type=wordpress\"]")
-      |> render_click()
-
-      html = render(lv)
-      assert html =~ "Verify WordPress installation"
-
-      lv
-      |> element("a[href*=\"type=gtm\"]")
-      |> render_click()
-
-      html = render(lv)
-      assert html =~ "Verify Tag Manager installation"
-
-      lv
-      |> element("a[href*=\"type=npm\"]")
-      |> render_click()
-
-      html = render(lv)
-      assert html =~ "Verify NPM installation"
-    end
-
-    test "manual installations has script snippet with expected ID", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-      assert eventually(fn ->
-               html = render(lv)
-               {html =~ "Verify Script installation", html}
-             end)
-
-      html = render(lv)
-      config = Plausible.Repo.get_by!(TrackerScriptConfiguration, site_id: site.id)
-      assert html =~ "Privacy-friendly analytics by Plausible"
-      assert html =~ "/js/#{config.id}.js"
-      assert html =~ "defer=!0"
-    end
-
-    test "manual installation shows optional measurements", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-      assert html =~ "Optional measurements"
-      assert html =~ "Outbound links"
-      assert html =~ "File downloads"
-      assert html =~ "Form submissions"
-    end
-
-    test "manual installation shows advanced options in disclosure", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-      assert html =~ "Advanced options"
-      assert html =~ "Manual tagging"
-      assert html =~ "404 error pages"
-      assert html =~ "Hashed page paths"
-      assert html =~ "Custom properties"
-      assert html =~ "Ecommerce revenue"
-    end
-
-    test "toggling optional measurements updates tracker configuration", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-
-      config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
-      assert config.outbound_links == true
-      assert config.file_downloads == true
-      assert config.form_submissions == true
-
-      lv
-      |> element("form[phx-submit='submit']")
-      |> render_submit(%{
-        "tracker_script_configuration" => %{
-          "installation_type" => "manual",
-          "outbound_links" => "false",
-          "file_downloads" => "true",
-          "form_submissions" => "true"
-        }
-      })
-
-      updated_config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
-      assert updated_config.outbound_links == false
-      assert updated_config.file_downloads == true
-      assert updated_config.form_submissions == true
-    end
-
-    for {type, expected_text} <- [
-          {"manual", "Verify Script installation"},
-          {"wordpress", "Verify WordPress installation"},
-          {"gtm", "Verify Tag Manager installation"},
-          {"npm", "Verify NPM installation"}
-        ] do
-      test "submitting form with #{type} redirects to verification", %{conn: conn, site: site} do
+    describe "LiveView" do
+      test "detects installation type when mounted", %{conn: conn, site: site} do
         stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=#{unquote(type)}")
+        stub_detection_wordpress()
+
+        {lv, _} = get_lv(conn, site)
 
         html = render_async(lv, 500)
-        assert html =~ unquote(expected_text)
+        assert text(html) =~ "Verify WordPress installation"
+      end
+
+      test "When ?type=wordpress URL parameter is supplied, detected type is unused", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+
+        {lv, _} = get_lv(conn, site, "?type=wordpress")
+
+        html = render_async(lv, 500)
+        assert text(html) =~ "Verify WordPress installation"
+      end
+
+      test "When ?type=gtm URL parameter is supplied, detected type is unused", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress()
+
+        {lv, _} = get_lv(conn, site, "?type=gtm")
+
+        html = render_async(lv, 500)
+        assert text(html) =~ "Verify Tag Manager installation"
+      end
+
+      test "When ?type=npm URL parameter is supplied, detected type is unused", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress()
+
+        {lv, _} = get_lv(conn, site, "?type=npm")
+
+        html = render_async(lv, 500)
+        assert text(html) =~ "Verify NPM installation"
+      end
+
+      test "When ?type=manual URL parameter is supplied, detected type is unused", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress()
+
+        {lv, _} = get_lv(conn, site, "?type=manual")
+
+        html = render_async(lv, 500)
+        assert text(html) =~ "Verify Script installation"
+      end
+
+      test "allows switching between installation tabs", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+
+        lv
+        |> element("a[href*=\"type=wordpress\"]")
+        |> render_click()
+
+        html = render(lv)
+        assert html =~ "Verify WordPress installation"
+
+        lv
+        |> element("a[href*=\"type=gtm\"]")
+        |> render_click()
+
+        html = render(lv)
+        assert html =~ "Verify Tag Manager installation"
+
+        lv
+        |> element("a[href*=\"type=npm\"]")
+        |> render_click()
+
+        html = render(lv)
+        assert html =~ "Verify NPM installation"
+      end
+
+      test "manual installations has script snippet with expected ID", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+        assert eventually(fn ->
+                 html = render(lv)
+                 {html =~ "Verify Script installation", html}
+               end)
+
+        html = render(lv)
+        config = Plausible.Repo.get_by!(TrackerScriptConfiguration, site_id: site.id)
+        assert html =~ "Privacy-friendly analytics by Plausible"
+        assert html =~ "/js/#{config.id}.js"
+        assert html =~ "defer=!0"
+      end
+
+      test "manual installation shows optional measurements", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+        assert html =~ "Optional measurements"
+        assert html =~ "Outbound links"
+        assert html =~ "File downloads"
+        assert html =~ "Form submissions"
+      end
+
+      test "manual installation shows advanced options in disclosure", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+        assert html =~ "Advanced options"
+        assert html =~ "Manual tagging"
+        assert html =~ "404 error pages"
+        assert html =~ "Hashed page paths"
+        assert html =~ "Custom properties"
+        assert html =~ "Ecommerce revenue"
+      end
+
+      test "toggling optional measurements updates tracker configuration", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+
+        config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
+        assert config.outbound_links == true
+        assert config.file_downloads == true
+        assert config.form_submissions == true
 
         lv
         |> element("form[phx-submit='submit']")
         |> render_submit(%{
           "tracker_script_configuration" => %{
-            "installation_type" => unquote(type),
+            "installation_type" => "manual",
+            "outbound_links" => "false",
+            "file_downloads" => "true",
+            "form_submissions" => "true"
+          }
+        })
+
+        updated_config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
+        assert updated_config.outbound_links == false
+        assert updated_config.file_downloads == true
+        assert updated_config.form_submissions == true
+      end
+
+      for {type, expected_text} <- [
+            {"manual", "Verify Script installation"},
+            {"wordpress", "Verify WordPress installation"},
+            {"gtm", "Verify Tag Manager installation"},
+            {"npm", "Verify NPM installation"}
+          ] do
+        test "submitting form with #{type} redirects to verification", %{conn: conn, site: site} do
+          stub_dns_lookup_a_records(site.domain)
+          stub_detection_manual()
+          {lv, _html} = get_lv(conn, site, "?type=#{unquote(type)}")
+
+          html = render_async(lv, 500)
+          assert html =~ unquote(expected_text)
+
+          lv
+          |> element("form[phx-submit='submit']")
+          |> render_submit(%{
+            "tracker_script_configuration" => %{
+              "installation_type" => unquote(type),
+              "outbound_links" => "true",
+              "file_downloads" => "true",
+              "form_submissions" => "true"
+            }
+          })
+
+          assert_redirect(
+            lv,
+            Routes.site_path(conn, :verification, site.domain, flow: "provisioning")
+          )
+        end
+      end
+
+      test "404 goal gets created regardless of user options", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+
+        # Test with all options disabled
+        lv
+        |> element("form[phx-submit='submit']")
+        |> render_submit(%{
+          "tracker_script_configuration" => %{
+            "installation_type" => "manual",
+            "outbound_links" => "false",
+            "file_downloads" => "false",
+            "form_submissions" => "false"
+          }
+        })
+
+        # 404 goal should still be created
+        goals = Plausible.Goals.for_site(site)
+        assert Enum.any?(goals, &(&1.event_name == "404"))
+      end
+
+      test "submitting form with review flow redirects to verification with flow param", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+
+        lv
+        |> element("form[phx-submit='submit']")
+        |> render_submit(%{
+          "tracker_script_configuration" => %{
+            "installation_type" => "manual",
             "outbound_links" => "true",
             "file_downloads" => "true",
             "form_submissions" => "true"
           }
         })
 
-        assert_redirect(
-          lv,
-          Routes.site_path(conn, :verification, site.domain, flow: "provisioning")
-        )
+        assert_redirect(lv, Routes.site_path(conn, :verification, site.domain, flow: "review"))
       end
-    end
 
-    test "404 goal gets created regardless of user options", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual")
+      test "detected WordPress installation shows special message", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress()
 
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-
-      # Test with all options disabled
-      lv
-      |> element("form[phx-submit='submit']")
-      |> render_submit(%{
-        "tracker_script_configuration" => %{
-          "installation_type" => "manual",
-          "outbound_links" => "false",
-          "file_downloads" => "false",
-          "form_submissions" => "false"
-        }
-      })
-
-      # 404 goal should still be created
-      goals = Plausible.Goals.for_site(site)
-      assert Enum.any?(goals, &(&1.event_name == "404"))
-    end
-
-    test "submitting form with review flow redirects to verification with flow param", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
-      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
-
-      lv
-      |> element("form[phx-submit='submit']")
-      |> render_submit(%{
-        "tracker_script_configuration" => %{
-          "installation_type" => "manual",
-          "outbound_links" => "true",
-          "file_downloads" => "true",
-          "form_submissions" => "true"
-        }
-      })
-
-      assert_redirect(lv, Routes.site_path(conn, :verification, site.domain, flow: "review"))
-    end
-
-    test "detected WordPress installation shows special message", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site)
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "We've detected your website is using WordPress"
-    end
-
-    test "detected GTM installation shows special message", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_gtm()
-
-      {lv, _} = get_lv(conn, site)
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Tag Manager installation"
-      assert text(html) =~ "We've detected your website is using Google Tag Manager"
-    end
-
-    test "shows v1 detection warning for manual installation", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual_with_v1()
-
-      {lv, _} = get_lv(conn, site, "?type=manual")
-
-      html = render_async(lv, 500)
-      assert text(html) =~ "Your website is running an outdated version of the tracking script"
-    end
-
-    test "does not show v1 detection warning for non-manual installation", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress_with_v1()
-
-      {lv, _} = get_lv(conn, site, "?type=wordpress")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify WordPress installation"
-      refute text(html) =~ "Your website is running an outdated version of the tracking script"
-    end
-
-    test "falls back to manual installation when detection fails at dns check level", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain, [])
-
-      ExUnit.CaptureLog.capture_log(fn ->
-        {lv, _} = get_lv(conn, site)
-
-        assert eventually(fn ->
-                 html = render(lv)
-                 # Should default to manual installation when detection returns {:error, _}
-                 {html =~ "Verify Script installation", html}
-               end)
-      end)
-    end
-
-    test "falls back to manual installation when dns succeeds but detection fails", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_error()
-
-      ExUnit.CaptureLog.capture_log(fn ->
         {lv, _} = get_lv(conn, site)
 
         html = render_async(lv, 500)
-        # Should default to manual installation when detection returns {:error, _}
-        assert html =~ "Verify Script installation"
-      end)
-    end
-  end
+        assert text(html) =~ "We've detected your website is using WordPress"
+      end
 
-  describe "Authorization" do
-    test "requires site access permissions", %{conn: conn} do
-      other_user = insert(:user)
-      other_site = new_site(owner: other_user)
+      test "detected GTM installation shows special message", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_gtm()
 
-      assert_raise Ecto.NoResultsError, fn ->
-        get_lv(conn, other_site)
+        {lv, _} = get_lv(conn, site)
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Tag Manager installation"
+        assert text(html) =~ "We've detected your website is using Google Tag Manager"
+      end
+
+      test "shows v1 detection warning for manual installation", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual_with_v1()
+
+        {lv, _} = get_lv(conn, site, "?type=manual")
+
+        html = render_async(lv, 500)
+        assert text(html) =~ "Your website is running an outdated version of the tracking script"
+      end
+
+      test "does not show v1 detection warning for non-manual installation", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress_with_v1()
+
+        {lv, _} = get_lv(conn, site, "?type=wordpress")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify WordPress installation"
+        refute text(html) =~ "Your website is running an outdated version of the tracking script"
+      end
+
+      test "falls back to manual installation when detection fails at dns check level", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain, [])
+
+        ExUnit.CaptureLog.capture_log(fn ->
+          {lv, _} = get_lv(conn, site)
+
+          assert eventually(fn ->
+                   html = render(lv)
+                   # Should default to manual installation when detection returns {:error, _}
+                   {html =~ "Verify Script installation", html}
+                 end)
+        end)
+      end
+
+      test "falls back to manual installation when dns succeeds but detection fails", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_error()
+
+        ExUnit.CaptureLog.capture_log(fn ->
+          {lv, _} = get_lv(conn, site)
+
+          html = render_async(lv, 500)
+          # Should default to manual installation when detection returns {:error, _}
+          assert html =~ "Verify Script installation"
+        end)
       end
     end
 
-    test "allows viewer access to installation page", %{conn: conn, user: user} do
-      site = new_site()
-      add_guest(site, user: user, role: :viewer)
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
+    describe "Authorization" do
+      test "requires site access permissions", %{conn: conn} do
+        other_user = insert(:user)
+        other_site = new_site(owner: other_user)
 
-      {lv, _} = get_lv(conn, site)
+        assert_raise Ecto.NoResultsError, fn ->
+          get_lv(conn, other_site)
+        end
+      end
 
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
+      test "allows viewer access to installation page", %{conn: conn, user: user} do
+        site = new_site()
+        add_guest(site, user: user, role: :viewer)
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+
+        {lv, _} = get_lv(conn, site)
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+      end
+
+      test "allows editor access to installation page", %{conn: conn, user: user} do
+        site = new_site()
+        add_guest(site, user: user, role: :editor)
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+
+        {lv, _} = get_lv(conn, site)
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+      end
     end
 
-    test "allows editor access to installation page", %{conn: conn, user: user} do
-      site = new_site()
-      add_guest(site, user: user, role: :editor)
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
+    describe "URL Parameter Handling" do
+      test "falls back to manual installation when invalid installation type parameter supplied",
+           %{
+             conn: conn,
+             site: site
+           } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
 
-      {lv, _} = get_lv(conn, site)
+        {lv, _} = get_lv(conn, site, "?type=invalid")
 
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+      end
+
+      test "falls back to provisioning flow when invalid flow parameter supplied", %{
+        conn: conn,
+        site: site
+      } do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+
+        {lv, _} = get_lv(conn, site, "?flow=invalid")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Script installation"
+      end
     end
-  end
 
-  describe "URL Parameter Handling" do
-    test "falls back to manual installation when invalid installation type parameter supplied", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
+    describe "Detection Result Combinations" do
+      test "When GTM + Wordpress detected, GTM takes precedence", %{conn: conn, site: site} do
+        stub_dns_lookup_a_records(site.domain)
 
-      {lv, _} = get_lv(conn, site, "?type=invalid")
+        stub_detection_result(%{
+          "v1Detected" => false,
+          "gtmLikely" => true,
+          "wordpressLikely" => true,
+          "wordpressPlugin" => false
+        })
 
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
+        {lv, _} = get_lv(conn, site)
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify Tag Manager installation"
+      end
     end
 
-    test "falls back to provisioning flow when invalid flow parameter supplied", %{
-      conn: conn,
-      site: site
-    } do
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_manual()
+    describe "Legacy Installations" do
+      test "uses detected type in review flow when installation_type is nil", %{
+        conn: conn,
+        site: site
+      } do
+        _config =
+          PlausibleWeb.Tracker.get_or_create_tracker_script_configuration!(site, %{
+            installation_type: nil,
+            outbound_links: true,
+            file_downloads: false,
+            form_submissions: true
+          })
 
-      {lv, _} = get_lv(conn, site, "?flow=invalid")
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress()
 
-      html = render_async(lv, 500)
-      assert html =~ "Verify Script installation"
+        {lv, _} = get_lv(conn, site, "?flow=review")
+
+        html = render_async(lv, 500)
+        assert html =~ "Verify WordPress installation"
+      end
     end
-  end
 
-  describe "Detection Result Combinations" do
-    test "When GTM + Wordpress detected, GTM takes precedence", %{conn: conn, site: site} do
-      stub_dns_lookup_a_records(site.domain)
-
+    defp stub_detection_manual do
       stub_detection_result(%{
         "v1Detected" => false,
-        "gtmLikely" => true,
+        "gtmLikely" => false,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+    end
+
+    defp stub_detection_wordpress do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => false,
         "wordpressLikely" => true,
         "wordpressPlugin" => false
       })
-
-      {lv, _} = get_lv(conn, site)
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify Tag Manager installation"
     end
-  end
 
-  describe "Legacy Installations" do
-    test "uses detected type in review flow when installation_type is nil", %{
-      conn: conn,
-      site: site
-    } do
-      _config =
-        PlausibleWeb.Tracker.get_or_create_tracker_script_configuration!(site, %{
-          installation_type: nil,
-          outbound_links: true,
-          file_downloads: false,
-          form_submissions: true
-        })
-
-      stub_dns_lookup_a_records(site.domain)
-      stub_detection_wordpress()
-
-      {lv, _} = get_lv(conn, site, "?flow=review")
-
-      html = render_async(lv, 500)
-      assert html =~ "Verify WordPress installation"
+    defp stub_detection_gtm do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => true,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
     end
-  end
 
-  defp stub_detection_manual do
-    stub_detection_result(%{
-      "v1Detected" => false,
-      "gtmLikely" => false,
-      "wordpressLikely" => false,
-      "wordpressPlugin" => false
-    })
-  end
+    defp stub_detection_manual_with_v1 do
+      stub_detection_result(%{
+        "v1Detected" => true,
+        "gtmLikely" => false,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+    end
 
-  defp stub_detection_wordpress do
-    stub_detection_result(%{
-      "v1Detected" => false,
-      "gtmLikely" => false,
-      "wordpressLikely" => true,
-      "wordpressPlugin" => false
-    })
-  end
+    defp stub_detection_wordpress_with_v1 do
+      stub_detection_result(%{
+        "v1Detected" => true,
+        "gtmLikely" => false,
+        "wordpressLikely" => true,
+        "wordpressPlugin" => false
+      })
+    end
 
-  defp stub_detection_gtm do
-    stub_detection_result(%{
-      "v1Detected" => false,
-      "gtmLikely" => true,
-      "wordpressLikely" => false,
-      "wordpressPlugin" => false
-    })
-  end
+    defp stub_detection_result(js_data) do
+      Req.Test.stub(:global, fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
+      end)
+    end
 
-  defp stub_detection_manual_with_v1 do
-    stub_detection_result(%{
-      "v1Detected" => true,
-      "gtmLikely" => false,
-      "wordpressLikely" => false,
-      "wordpressPlugin" => false
-    })
-  end
+    defp stub_detection_error do
+      Req.Test.stub(:global, fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(
+          200,
+          Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
+        )
+      end)
+    end
 
-  defp stub_detection_wordpress_with_v1 do
-    stub_detection_result(%{
-      "v1Detected" => true,
-      "gtmLikely" => false,
-      "wordpressLikely" => true,
-      "wordpressPlugin" => false
-    })
-  end
+    defp get_lv(conn, site, qs \\ nil) do
+      {:ok, lv, html} = live(conn, "/#{site.domain}/installationv2#{qs}")
 
-  defp stub_detection_result(js_data) do
-    Req.Test.stub(:global, fn conn ->
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
-    end)
-  end
+      {lv, html}
+    end
 
-  defp stub_detection_error do
-    Req.Test.stub(:global, fn conn ->
-      conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(
-        200,
-        Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
-      )
-    end)
-  end
+    defp stub_dns_lookup_a_records(domain, a_records \\ [{192, 168, 1, 1}]) do
+      lookup_domain = to_charlist(domain)
 
-  defp get_lv(conn, site, qs \\ nil) do
-    {:ok, lv, html} = live(conn, "/#{site.domain}/installationv2#{qs}")
-
-    {lv, html}
-  end
-
-  defp stub_dns_lookup_a_records(domain, a_records \\ [{192, 168, 1, 1}]) do
-    lookup_domain = to_charlist(domain)
-
-    Plausible.DnsLookup.Mock
-    |> expect(:lookup, fn ^lookup_domain, _type, _record, _opts, _timeout ->
-      a_records
-    end)
+      Plausible.DnsLookup.Mock
+      |> expect(:lookup, fn ^lookup_domain, _type, _record, _opts, _timeout ->
+        a_records
+      end)
+    end
   end
 end


### PR DESCRIPTION
### Changes

Fix console warnings on `ce_test`. Run InstallationSupport related test suites only on Enterprise Edition.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
