### PR TITLE
Fix bug with pageview queries stacking after verification retries

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -295,6 +295,15 @@ defmodule PlausibleWeb.Live.Sites do
           <.icon_pin :if={!@site.pinned_at} class="size-4" />
           <span :if={!@site.pinned_at}>Pin Site</span>
         </.dropdown_item>
+        <.dropdown_item
+          :if={Application.get_env(:plausible, :environment) == "dev"}
+          href={Routes.site_path(PlausibleWeb.Endpoint, :delete_site, @site.domain)}
+          method="delete"
+          class="!flex items-center gap-x-2"
+        >
+          <Heroicons.trash class="size-4 text-red-500" />
+          <span class="text-red-500">[DEV ONLY] Quick Delete</span>
+        </.dropdown_item>
       </:menu>
     </.dropdown>
     """


### PR DESCRIPTION
### Changes

Fix pageview polling in the verification tool. Basecamp ref: https://3.basecamp.com/5308029/buckets/42034199/card_tables/cards/8967893006

Also add a dev-env-only convenience for quickly deleting sites (something I found annoying when playing around with onboarding UI locally, decided to include in this small PR to get it in):

<img width="439" height="215" alt="image" src="https://github.com/user-attachments/assets/cb40f700-e0fd-4481-8f6d-04f1c8fcd455" />

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
