### PR TITLE
Show messages while waiting for pre-installation scan

### DIFF
--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -70,6 +70,12 @@ defmodule PlausibleWeb.Live.InstallationV2 do
       <.focus_box>
         <.async_result :let={recommended_installation_type} assign={@recommended_installation_type}>
           <:loading>
+            <div class="text-center text-gray-500">
+              {if(@flow == Flows.review(),
+                do: "Scanning your site to detect how Plausible is integrated...",
+                else: "Determining the simplest integration path for your website..."
+              )}
+            </div>
             <div class="flex items-center justify-center py-8">
               <.spinner class="w-6 h-6" />
             </div>


### PR DESCRIPTION
### Changes

Display a message (along with the loading spinner) to notify the customer about what's happening during the pre-installation site scan (detection). The maximum delay on this screen is 5 seconds, but that should not happen under normal circumstances. In 99% of cases the waiting time should be less than 2 seconds. In the provisioning / new site flow (screenshot 1) it will be even faster (< 1s) since we are not doing v1 script detection.

Note that the text is intentionally a bit darker/muted, to not make the customer feel like they missed an important message in case it flashes too quickly.

Provisioning flow message:
<img width="1187" height="441" alt="image" src="https://github.com/user-attachments/assets/0bf9a97a-40ac-4171-95b7-0fbe52df9983" />

Review flow message:
<img width="1142" height="462" alt="image" src="https://github.com/user-attachments/assets/492b68b1-ee17-4a4a-9a4a-7e4b665775fd" />


### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
