### PR TITLE
Script v2: Verifier accepts cookies

### DIFF
--- a/lib/plausible/installation_support/checks/installation_v2.ex
+++ b/lib/plausible/installation_support/checks/installation_v2.ex
@@ -165,7 +165,7 @@ defmodule Plausible.InstallationSupport.Checks.InstallationV2 do
       plausible_version: data["plausibleVersion"],
       plausible_variant: data["plausibleVariant"],
       test_event: data["testEvent"],
-      cookie_banner_likely: data["cookieBannerLikely"],
+      cookies_consent_result: data["cookiesConsentResult"],
       attempts: data["attempts"],
       response_status: data["responseStatus"],
       service_error: nil

--- a/lib/plausible/installation_support/verification/diagnostics.ex
+++ b/lib/plausible/installation_support/verification/diagnostics.ex
@@ -13,7 +13,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
             plausible_variant: nil,
             diagnostics_are_from_cache_bust: nil,
             test_event: nil,
-            cookie_banner_likely: nil,
+            cookies_consent_result: nil,
             response_status: nil,
             service_error: nil,
             attempts: nil
@@ -180,24 +180,6 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
         _url
       ),
       do: error(@error_csp_disallowed)
-
-  @error_gtm_selected_maybe_cookie_banner Error.new!(%{
-                                            message: "We couldn't verify your website",
-                                            recommendation:
-                                              "A cookie consent banner may be stopping Plausible from loading on your site. If that is intentional, you'll need to verify that Plausible works manually",
-                                            url:
-                                              "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
-                                          })
-  def interpret(
-        %__MODULE__{
-          selected_installation_type: "gtm",
-          cookie_banner_likely: true,
-          service_error: nil
-        },
-        _expected_domain,
-        _url
-      ),
-      do: error(@error_gtm_selected_maybe_cookie_banner)
 
   @error_domain_not_found Error.new!(%{
                             message: "We couldn't find your website at <%= @attempted_url %>",

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -162,29 +162,6 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "error when GTM selected and cookie banner likely" do
-      expected_domain = "example.com"
-      url_to_verify = "https://#{expected_domain}"
-
-      diagnostics = %Diagnostics{
-        selected_installation_type: "gtm",
-        cookie_banner_likely: true,
-        service_error: nil
-      }
-
-      assert_matches %Result{
-                       ok?: false,
-                       errors: [^any(:string, ~r/.*couldn't verify.*/)],
-                       recommendations: [
-                         %{
-                           text: ^any(:string, ~r/.*cookie consent banner.*/),
-                           url:
-                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
-                         }
-                       ]
-                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
-    end
-
     for error_code <- [:domain_not_found, :invalid_url] do
       test "error when DNS check fails (#{error_code})" do
         expected_domain = "example.com"

--- a/tracker/compiler/index.js
+++ b/tracker/compiler/index.js
@@ -8,6 +8,7 @@ import { canSkipCompile } from './can-skip-compile.js'
 import packageJson from '../package.json' with { type: 'json' }
 import progress from 'cli-progress'
 import { spawn, Worker, Pool } from "threads"
+import json from '@rollup/plugin-json'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -110,6 +111,7 @@ export function compileWebSnippet() {
 async function bundleCode(entryPoint = 'src/plausible.js') {
   const bundle = await rollup({
     input: entryPoint,
+    plugins: [json()]
   })
 
   const { output } = await bundle.generate({ format: 'esm' })

--- a/tracker/compiler/index.js
+++ b/tracker/compiler/index.js
@@ -111,7 +111,7 @@ export function compileWebSnippet() {
 async function bundleCode(entryPoint = 'src/plausible.js') {
   const bundle = await rollup({
     input: entryPoint,
-    plugins: [json()]
+    plugins: [json({compact: true})]
   })
 
   const { output } = await bundle.generate({ format: 'esm' })

--- a/tracker/installation_support/autoconsent-rules/autoconsent/cookiebot.json
+++ b/tracker/installation_support/autoconsent-rules/autoconsent/cookiebot.json
@@ -1,0 +1,9 @@
+{
+    "name": "cookiebot",
+    "prehideSelectors": [],
+    "detectCmp": [{ "exists": "#CybotCookiebotDialogBodyButtonAccept, #CybotCookiebotDialogBody, #CybotCookiebotDialogBodyLevelButtonPreferences, #cb-cookieoverlay, #CybotCookiebotDialog" }],
+    "detectPopup": [{ "visible": "#CybotCookiebotDialogBodyButtonAccept, #CybotCookiebotDialogBody, #CybotCookiebotDialogBodyLevelButtonPreferences, #cb-cookieoverlay, #CybotCookiebotDialog, #cookiebanner" }],
+    "optIn": [{ "waitForThenClick": "#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll" }],
+    "optOut": [],
+    "test": []
+}

--- a/tracker/installation_support/autoconsent-to-cookies.js
+++ b/tracker/installation_support/autoconsent-to-cookies.js
@@ -1,71 +1,70 @@
-/** 
- * This module contains the code for starting a process 
+/**
+ * This module contains the code for starting a process
  * that tries to detect Consent Management Platforms (CMPs)
- * and if it finds any, to opt in. 
- * 
+ * and if it finds any, to opt in.
+ *
  * This is necessary because it's possible that Plausible script
  * is conditional on the client opting in to tracking cookies.
  */
 
 // Note: these imports are using relative path syntax so rollup would bundle them
 import AutoConsent from '../node_modules/@duckduckgo/autoconsent/dist/autoconsent.esm.js'
-import { autoconsent } from '../node_modules/@duckduckgo/autoconsent/rules/rules.json'
+import compact from '../node_modules/@duckduckgo/autoconsent/rules/compact-rules.json'
 import { consentomatic } from '../node_modules/@duckduckgo/autoconsent/rules/consentomatic.json'
 
 export function initializeCookieConsentEngine({
-    debug,
-    onConsentDone,
-    onLifecycleUpdate,
-    onConsentError
-  }) {
-    const onMessage = (message) => {
-      switch (message?.type) {
-        case 'autoconsentDone':
-          return onConsentDone(message.cmp)
-        case 'autoconsentError':
-          return onConsentError(message.details)
-        case 'report':
-          return onLifecycleUpdate(message.state.lifecycle)
-        default:
-          return
-      }
-    }
-  
-    try {
-      const engine = new AutoConsent(
-        onMessage,
-        {
-          enabled: true,
-          autoAction: 'optIn',
-          disabledCmps: [],
-          enablePrehide: false,
-          enableCosmeticRules: false,
-          enableGeneratedRules: true,
-          enableHeuristicDetection: false,
-          detectRetries: 2,
-          isMainWorld: false,
-          prehideTimeout: 0,
-          enableFilterList: false,
-          visualTest: false,
-          logs: {
-            lifecycle: debug,
-            rulesteps: debug,
-            detectionsteps: debug,
-            evals: debug,
-            errors: debug,
-            messages: debug,
-            waits: debug
-          }
-        },
-        { autoconsent, consentomatic }
-      )
-  
-      return { handled: null, engineLifecycle: engine.state.lifecycle }
-    } catch (e) {
-      return {
-        handled: false,
-        error: { message: 'Error initializing cookie consent engine' }
-      }
+  debug,
+  onConsentDone,
+  onLifecycleUpdate,
+  onConsentError
+}) {
+  const onMessage = (message) => {
+    switch (message?.type) {
+      case 'autoconsentDone':
+        return onConsentDone(message.cmp)
+      case 'autoconsentError':
+        return onConsentError(message.details)
+      case 'report':
+        return onLifecycleUpdate(message.state.lifecycle)
+      default:
+        return
     }
   }
-  
+
+  try {
+    const engine = new AutoConsent(
+      onMessage,
+      {
+        enabled: true,
+        autoAction: 'optIn',
+        disabledCmps: [],
+        enablePrehide: false,
+        enableCosmeticRules: false,
+        enableGeneratedRules: true,
+        enableHeuristicDetection: false,
+        detectRetries: 2,
+        isMainWorld: false,
+        prehideTimeout: 0,
+        enableFilterList: false,
+        visualTest: false,
+        logs: {
+          lifecycle: debug,
+          rulesteps: debug,
+          detectionsteps: debug,
+          evals: debug,
+          errors: debug,
+          messages: debug,
+          waits: debug
+        }
+      },
+      { compact, consentomatic }
+    )
+
+    return { handled: null, engineLifecycle: engine.state.lifecycle }
+  } catch (e) {
+    return {
+      handled: false,
+      error: { message: 'Error initializing cookie consent engine' }
+    }
+  }
+}

--- a/tracker/installation_support/autoconsent-to-cookies.js
+++ b/tracker/installation_support/autoconsent-to-cookies.js
@@ -1,0 +1,71 @@
+/** 
+ * This module contains the code for starting a process 
+ * that tries to detect Consent Management Platforms (CMPs)
+ * and if it finds any, to opt in. 
+ * 
+ * This is necessary because it's possible that Plausible script
+ * is conditional on the client opting in to tracking cookies.
+ */
+
+// Note: these imports are using relative path syntax so rollup would bundle them
+import AutoConsent from '../node_modules/@duckduckgo/autoconsent/dist/autoconsent.esm.js'
+import { autoconsent } from '../node_modules/@duckduckgo/autoconsent/rules/rules.json'
+import { consentomatic } from '../node_modules/@duckduckgo/autoconsent/rules/consentomatic.json'
+
+export function initializeCookieConsentEngine({
+    debug,
+    onConsentDone,
+    onLifecycleUpdate,
+    onConsentError
+  }) {
+    const onMessage = (message) => {
+      switch (message?.type) {
+        case 'autoconsentDone':
+          return onConsentDone(message.cmp)
+        case 'autoconsentError':
+          return onConsentError(message.details)
+        case 'report':
+          return onLifecycleUpdate(message.state.lifecycle)
+        default:
+          return
+      }
+    }
+  
+    try {
+      const engine = new AutoConsent(
+        onMessage,
+        {
+          enabled: true,
+          autoAction: 'optIn',
+          disabledCmps: [],
+          enablePrehide: false,
+          enableCosmeticRules: false,
+          enableGeneratedRules: true,
+          enableHeuristicDetection: false,
+          detectRetries: 2,
+          isMainWorld: false,
+          prehideTimeout: 0,
+          enableFilterList: false,
+          visualTest: false,
+          logs: {
+            lifecycle: debug,
+            rulesteps: debug,
+            detectionsteps: debug,
+            evals: debug,
+            errors: debug,
+            messages: debug,
+            waits: debug
+          }
+        },
+        { autoconsent, consentomatic }
+      )
+  
+      return { handled: null, engineLifecycle: engine.state.lifecycle }
+    } catch (e) {
+      return {
+        handled: false,
+        error: { message: 'Error initializing cookie consent engine' }
+      }
+    }
+  }
+  

--- a/tracker/installation_support/autoconsent-to-cookies.js
+++ b/tracker/installation_support/autoconsent-to-cookies.js
@@ -9,8 +9,18 @@
 
 // Note: these imports are using relative path syntax so rollup would bundle them
 import AutoConsent from '../node_modules/@duckduckgo/autoconsent/dist/autoconsent.esm.js'
-import compact from '../node_modules/@duckduckgo/autoconsent/rules/compact-rules.json'
+import usercentricsButton from '../node_modules/@duckduckgo/autoconsent/rules/autoconsent/usercentrics-button.json'
+import iubenda from '../node_modules/@duckduckgo/autoconsent/rules/autoconsent/iubenda.json'
+import quantcast from '../node_modules/@duckduckgo/autoconsent/rules/autoconsent/quantcast.json'
 import { consentomatic } from '../node_modules/@duckduckgo/autoconsent/rules/consentomatic.json'
+import cookiebotHandrolled from './autoconsent-rules/autoconsent/cookiebot.json'
+
+const autoconsent = [
+  usercentricsButton,
+  iubenda,
+  cookiebotHandrolled,
+  quantcast
+]
 
 export function initializeCookieConsentEngine({
   debug,
@@ -40,7 +50,7 @@ export function initializeCookieConsentEngine({
         disabledCmps: [],
         enablePrehide: false,
         enableCosmeticRules: false,
-        enableGeneratedRules: true,
+        enableGeneratedRules: false,
         enableHeuristicDetection: false,
         detectRetries: 2,
         isMainWorld: false,
@@ -57,7 +67,7 @@ export function initializeCookieConsentEngine({
           waits: debug
         }
       },
-      { compact, consentomatic }
+      { autoconsent, consentomatic }
     )
 
     return { handled: null, engineLifecycle: engine.state.lifecycle }

--- a/tracker/installation_support/verifier-v2.js
+++ b/tracker/installation_support/verifier-v2.js
@@ -1,7 +1,9 @@
 /** @typedef {import('../test/support/types').VerifyV2Args} VerifyV2Args */
 /** @typedef {import('../test/support/types').VerifyV2Result} VerifyV2Result */
-import { checkCookieBanner } from './check-cookie-banner'
 import { checkDisallowedByCSP } from './check-disallowed-by-csp'
+import AutoConsent from '../node_modules/@duckduckgo/autoconsent/dist/autoconsent.esm.js'
+import { autoconsent } from '../node_modules/@duckduckgo/autoconsent/rules/rules.json'
+import { consentomatic } from '../node_modules/@duckduckgo/autoconsent/rules/consentomatic.json'
 
 /**
  * Function that verifies if Plausible is installed correctly.
@@ -23,16 +25,22 @@ async function verifyPlausibleInstallation({
 
   const { stopRecording, getInterceptedFetch } = startRecordingEventFetchCalls()
 
-  const {
-    plausibleIsInitialized,
-    plausibleIsOnWindow,
-    plausibleVersion,
-    plausibleVariant,
-    testEvent,
-    error: testPlausibleFunctionError
-  } = await testPlausibleFunction({
-    timeoutMs
-  })
+  const [
+    {
+      plausibleIsInitialized,
+      plausibleIsOnWindow,
+      plausibleVersion,
+      plausibleVariant,
+      testEvent,
+      error: testPlausibleFunctionError
+    },
+    cookiesConsentResult
+  ] = await Promise.all([
+    testPlausibleFunction({
+      timeoutMs
+    }),
+    handleCookieConsent({ timeoutMs: Math.max(timeoutMs - 300, 100) })
+  ])
 
   if (testPlausibleFunctionError) {
     log(
@@ -61,7 +69,7 @@ async function verifyPlausibleInstallation({
       responseStatus: interceptedTestEvent?.response?.status,
       error: interceptedTestEvent?.error
     },
-    cookieBannerLikely: checkCookieBanner()
+    cookiesConsentResult
   }
 
   log({
@@ -210,6 +218,96 @@ async function testPlausibleFunction({ timeoutMs }) {
         })
       }
     })
+  })
+}
+
+async function handleCookieConsent({ timeoutMs, debug }) {
+  return new Promise((_resolve) => {
+    let resolved = false
+
+    const resolve = (payload) => {
+      if (!resolved) {
+        resolved = true
+        _resolve(payload)
+      }
+    }
+
+    try {
+      let engineLifecycle = null
+
+      const onMessage = (message) => {
+        switch (message?.type) {
+          case 'autoconsentDone':
+            resolve({ handled: true, cmp: message.cmp })
+            break
+          case 'autoconsentError':
+            resolve({
+              handled: false,
+              error: message.details
+            })
+            break
+          case 'report':
+            if (message.state.lifecycle === 'done') {
+              resolve({ handled: true })
+            } else {
+              console.log(message)
+              engineLifecycle = message.state.lifecycle
+            }
+            break
+          case undefined:
+          default:
+            break
+        }
+      }
+
+      setTimeout(() => {
+        if (!resolved) {
+          resolve({
+            handled: false,
+            error: {
+              message: 'Time allocated for cookie consent engine exceeded',
+              engineLifecycle
+            }
+          })
+        }
+      }, timeoutMs)
+
+      const engine = new AutoConsent(
+        onMessage,
+        {
+          enabled: true,
+          autoAction: 'optIn',
+          disabledCmps: [],
+          enablePrehide: false,
+          enableCosmeticRules: false,
+          enableGeneratedRules: true,
+          enableHeuristicDetection: false,
+          detectRetries: 2,
+          isMainWorld: false,
+          prehideTimeout: 0,
+          enableFilterList: false,
+          visualTest: false,
+          logs: {
+            lifecycle: debug,
+            rulesteps: debug,
+            detectionsteps: debug,
+            evals: debug,
+            errors: debug,
+            messages: debug,
+            waits: debug
+          }
+        },
+        { autoconsent, consentomatic }
+      )
+      engineLifecycle = engine.state.lifecycle
+    } catch (e) {
+      resolve({
+        handled: false,
+        error: {
+          message: 'Error initializing cookie consent engine'
+        }
+      })
+    }
   })
 }
 

--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Minor update: Allow setting `lib` option for other tools integrating with plausible.
+- Minor update: Allow setting `lib` option for other tools integrating with Plausible.
 
 ## [0.4.0] - 2025-08-12
 

--- a/tracker/package-lock.json
+++ b/tracker/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
+        "@duckduckgo/autoconsent": "^14.16.0",
         "@swc/core": "^1.11.24",
         "chokidar": "^4.0.3",
         "cli-progress": "^3.12.0",
@@ -15,6 +16,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.52.0",
+        "@rollup/plugin-json": "^6.1.0",
         "@types/node": "^22.13.4",
         "eslint": "^9.20.1",
         "eslint-plugin-playwright": "^2.2.2",
@@ -29,6 +31,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@duckduckgo/autoconsent": {
+      "version": "14.16.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.16.0.tgz",
+      "integrity": "sha512-BSSiuv7tLrjY42EYKBbkZv7N8xLxJJS4FJqvrDMOQq6JVyWiaPKM+Yt4wxThyrAMnCEiSdMNk7UQJUWWhuwAiQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker": "^2.0.4",
+        "@ghostery/adblocker-content": "^2.0.4",
+        "tldts-experimental": "^7.0.4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -147,6 +160,45 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@ghostery/adblocker": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.5.tgz",
+      "integrity": "sha512-rJ3N+3XPy1SEeEaeQKowYT/R/Tt1ac9cqYSin1igLY7XqIaGdCYq3tQjBQQ4Vx6ZM2ic412aM84hAKn+D/EDvA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-content": "^2.11.5",
+        "@ghostery/adblocker-extended-selectors": "^2.11.5",
+        "@ghostery/url-parser": "^1.3.0",
+        "@remusao/guess-url-type": "^2.1.0",
+        "@remusao/small": "^2.1.0",
+        "@remusao/smaz": "^2.2.0",
+        "tldts-experimental": "^7.0.12"
+      }
+    },
+    "node_modules/@ghostery/adblocker-content": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.5.tgz",
+      "integrity": "sha512-7mDOic2lJGxHtmqcbME/oi4XnygYbJ0vgCj/7KedHzhTR8/w/HLpkEQRFiEAKRxQMrEfLVXy+m171Yeia3TaRw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-extended-selectors": "^2.11.5"
+      }
+    },
+    "node_modules/@ghostery/adblocker-extended-selectors": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.5.tgz",
+      "integrity": "sha512-O0Diq8pgFeC+IUnS8Ud00aHLHv87djFiXwfUPBiwmwmS8eNRj0FnaRYFd/Du4Xu4pgNe8lkD+OVsBMtG1DGwSw==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ghostery/url-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.0.tgz",
+      "integrity": "sha512-FEzdSeiva0Mt3bR4xePFzthhjT4IzvA5QTvS1xXkNyLpMGeq40mb3V2fSs0ZItRaP9IybZthDfHUSbQ1HLdx4Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "tldts-experimental": "^7.0.8"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -222,6 +274,93 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@remusao/guess-url-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/small": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/smaz": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
+      }
+    },
+    "node_modules/@remusao/smaz-compress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/trie": "^2.1.0"
+      }
+    },
+    "node_modules/@remusao/smaz-decompress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/trie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -732,10 +871,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1332,6 +1472,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -2114,6 +2261,19 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
@@ -2565,6 +2725,21 @@
       "optional": true,
       "dependencies": {
         "esm": "^3.2.25"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
+      "integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-experimental": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.12.tgz",
+      "integrity": "sha512-riDDp/JrJJuh/2GV1Tgg6OnOwcWlgleBKi4/xkhd0DW7tvvmNjmWXCh2nj7Z2G1k9S/AGN4RiiPRbvhGJUCxeg==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.12"
       }
     },
     "node_modules/toidentifier": {

--- a/tracker/package-lock.json
+++ b/tracker/package-lock.json
@@ -7,6 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.16.0",
+        "@rollup/plugin-json": "^6.1.0",
         "@swc/core": "^1.11.24",
         "chokidar": "^4.0.3",
         "cli-progress": "^3.12.0",
@@ -16,7 +17,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.52.0",
-        "@rollup/plugin-json": "^6.1.0",
         "@types/node": "^22.13.4",
         "eslint": "^9.20.1",
         "eslint-plugin-playwright": "^2.2.2",
@@ -323,7 +323,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
       "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.0"
@@ -344,7 +343,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
       "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -1477,7 +1475,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -2265,7 +2262,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 29,
+  "tracker_script_version": 30,
   "type": "module",
   "scripts": {
     "deploy": "node compile.js",

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -14,6 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@duckduckgo/autoconsent": "^14.16.0",
     "@swc/core": "^1.11.24",
     "chokidar": "^4.0.3",
     "cli-progress": "^3.12.0",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
+    "@rollup/plugin-json": "^6.1.0",
     "@types/node": "^22.13.4",
     "eslint": "^9.20.1",
     "eslint-plugin-playwright": "^2.2.2",

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.16.0",
+    "@rollup/plugin-json": "^6.1.0",
     "@swc/core": "^1.11.24",
     "chokidar": "^4.0.3",
     "cli-progress": "^3.12.0",
@@ -24,7 +25,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",
-    "@rollup/plugin-json": "^6.1.0",
     "@types/node": "^22.13.4",
     "eslint": "^9.20.1",
     "eslint-plugin-playwright": "^2.2.2",

--- a/tracker/test/fixtures/cookies-cookiebot.html
+++ b/tracker/test/fixtures/cookies-cookiebot.html
@@ -1,0 +1,4788 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plausible Playwright tests</title>
+  </head>
+
+  <body>
+    cookiebot fixture
+    <div
+      id="CybotCookiebotDialog"
+      name="CybotCookiebotDialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="CybotCookiebotDialogBodyContentTitle"
+      tabindex="-1"
+      lang="en"
+      dir="ltr"
+      ng-non-bindable=""
+      style="display: flex"
+      data-template="popup"
+      class="CybotCookiebotDialogActive"
+    >
+      <div class="CybotCookiebotDialogContentWrapper">
+        <div id="CybotCookiebotDialogHeader">
+          <div id="CybotCookiebotDialogHeaderLogosWrapper">
+            <div id="CybotCookiebotDialogPoweredbyLink">
+              <img
+                id="CybotCookiebotDialogPoweredbyImage"
+                src="data:,"
+                alt="logo"
+                style="display: none"
+              />
+            </div>
+            <a
+              href="https://www.cookiebot.com/en/what-is-behind-powered-by-cookiebot/"
+              rel="noopener nofollow"
+              target="_blank"
+              id="CybotCookiebotDialogPoweredbyCybot"
+              aria-label="Usercentrics Cookiebot - opens in a new window"
+              ><svg
+                viewBox="0 0 843 248"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M249.651 182.059C246.815 181.906 243.999 182.606 241.573 184.067C239.147 185.528 237.225 187.681 236.06 190.244H235.469V167.003H226.162V229.564H235.174V222.256H235.912C237.11 224.825 239.06 226.979 241.51 228.439C243.959 229.898 246.796 230.596 249.651 230.441C261.174 230.441 269.447 221.379 269.447 206.177C269.447 190.975 261.174 182.059 249.651 182.059ZM247.731 222.694C239.753 222.694 235.321 215.97 235.321 206.031C235.321 196.091 239.606 189.659 247.731 189.659C256.151 189.659 260.288 196.676 260.288 206.031C260.288 215.386 256.004 222.694 247.731 222.694Z"
+                ></path>
+                <path
+                  d="M294.854 219.182H294.411L282.445 182.786H272.547L289.979 230.291L288.797 233.361C286.433 239.646 283.183 240.085 278.013 238.769L275.797 246.224C277.841 246.916 279.989 247.262 282.149 247.247C289.831 247.247 294.559 243.3 297.366 235.846L316.866 182.64H306.968L294.854 219.182Z"
+                ></path>
+                <path
+                  d="M385.555 207.488C385.555 215.966 379.646 222.105 370.044 222.105C360.441 222.105 354.532 215.966 354.532 207.488V167.145H344.93V208.365C344.93 221.52 354.828 230.875 370.044 230.875C385.26 230.875 395.158 221.52 395.158 208.365V167.145H385.555V207.488Z"
+                ></path>
+                <path
+                  d="M429.594 203.412L422.06 201.658C416.89 200.489 414.526 198.735 414.674 195.519C414.674 191.865 418.662 189.38 423.833 189.38C429.594 189.38 432.254 192.596 433.288 195.665L441.708 194.203C439.788 186.895 434.026 182.071 423.833 182.071C413.049 182.071 405.514 187.626 405.514 195.958C405.514 202.681 409.651 207.067 418.515 208.967L426.492 210.721C431.072 211.744 433.14 213.79 433.14 216.714C433.14 220.368 429.151 223.145 423.094 223.145C417.628 223.145 414.083 220.807 412.901 216.129L404.037 217.445C405.514 225.776 412.605 230.454 423.242 230.454C434.765 230.454 442.595 224.461 442.595 215.983C442.595 209.405 438.311 205.312 429.594 203.412Z"
+                ></path>
+                <path
+                  d="M470.358 182.071C457.062 182.071 448.494 192.011 448.494 206.482C448.494 220.953 457.062 230.6 471.097 230.6C481.438 230.6 488.824 225.484 490.892 217.883L482.176 216.275C480.551 220.66 476.563 222.999 471.244 222.999C463.267 222.999 457.949 217.883 457.801 208.821H491.483V205.605C491.336 188.649 481.142 182.071 470.358 182.071ZM457.653 202.097C458.097 195.373 462.972 189.672 470.358 189.672C477.744 189.672 482.176 194.934 482.324 202.097H457.653Z"
+                ></path>
+                <path
+                  d="M508.912 190.117H508.469V182.663H499.605V229.583H508.912V200.934C508.912 194.795 513.64 190.41 520.288 190.41C521.932 190.383 523.572 190.58 525.163 190.994V182.224C523.837 182.097 522.505 182.048 521.174 182.078C518.527 181.93 515.903 182.634 513.694 184.082C511.484 185.531 509.807 187.648 508.912 190.117Z"
+                ></path>
+                <path
+                  d="M549.091 189.818C551.519 189.708 553.908 190.456 555.83 191.929C557.752 193.402 559.081 195.504 559.58 197.858H568.592C567.557 188.357 559.728 182.071 548.943 182.071C535.5 182.071 526.932 192.011 526.932 206.336C526.932 220.66 535.205 230.6 549.091 230.6C560.319 230.6 567.557 223.876 568.592 214.814H559.58C559.106 217.18 557.784 219.298 555.856 220.775C553.928 222.253 551.526 222.991 549.091 222.853C541.261 222.853 536.239 216.421 536.239 206.189C536.239 195.958 541.261 189.818 549.091 189.818Z"
+                ></path>
+                <path
+                  d="M596.077 182.071C582.929 182.071 574.213 192.011 574.213 206.482C574.213 220.953 582.781 230.6 596.816 230.6C607.157 230.6 614.543 225.484 616.612 217.883L607.895 216.275C606.27 220.66 602.282 222.999 596.963 222.999C588.986 222.999 583.815 217.883 583.52 208.821H617.203V205.605C617.055 188.649 606.861 182.071 596.077 182.071ZM583.372 202.097C583.815 195.373 588.69 189.672 596.077 189.672C603.464 189.672 607.896 194.934 608.043 202.097H583.372Z"
+                ></path>
+                <path
+                  d="M648.673 182.071C641.582 182.071 636.854 185.287 634.638 190.257H634.047V182.656H625.184V229.577H634.491V201.658C634.491 194.204 639.07 189.818 645.57 189.818C651.775 189.818 655.616 193.911 655.616 200.635V229.431H664.923V199.612C664.775 188.21 658.275 182.071 648.673 182.071Z"
+                ></path>
+                <path
+                  d="M692.999 222.117C690.044 222.117 687.385 221.094 687.385 215.832V189.959H697.135V182.651H687.385V171.396H678.078V182.651H671.135V189.959H678.078V217.732C678.078 226.21 684.578 230.449 691.965 230.302C694.03 230.338 696.085 229.991 698.021 229.279L696.396 221.678C695.285 221.957 694.145 222.104 692.999 222.117V222.117Z"
+                ></path>
+                <path
+                  d="M714.571 190.117H714.127V182.663H705.264V229.583H714.571V200.934C714.571 194.795 719.298 190.41 725.945 190.41C727.59 190.383 729.23 190.58 730.821 190.994V182.224C729.495 182.097 728.163 182.048 726.832 182.078C724.185 181.93 721.561 182.634 719.352 184.082C717.142 185.531 715.465 187.648 714.571 190.117V190.117Z"
+                ></path>
+                <path
+                  d="M741.007 164.516C739.502 164.472 738.04 165.014 736.935 166.025C735.83 167.036 735.171 168.436 735.098 169.924C735.122 170.664 735.295 171.393 735.606 172.066C735.918 172.74 736.361 173.346 736.911 173.849C737.46 174.352 738.105 174.742 738.808 174.997C739.512 175.251 740.259 175.365 741.007 175.332C741.758 175.387 742.513 175.288 743.224 175.041C743.935 174.794 744.587 174.404 745.139 173.897C745.692 173.389 746.132 172.774 746.433 172.091C746.734 171.407 746.89 170.67 746.89 169.924C746.89 169.178 746.734 168.441 746.433 167.757C746.132 167.073 745.692 166.459 745.139 165.951C744.587 165.444 743.935 165.054 743.224 164.807C742.513 164.56 741.758 164.461 741.007 164.516V164.516Z"
+                ></path>
+                <path d="M745.739 182.64H736.432V229.56H745.739V182.64Z"></path>
+                <path
+                  d="M775.853 189.818C778.281 189.708 780.67 190.456 782.591 191.929C784.513 193.402 785.842 195.504 786.341 197.858H795.353C794.319 188.357 786.489 182.071 775.705 182.071C762.262 182.071 753.693 192.011 753.693 206.336C753.693 220.66 761.966 230.6 775.853 230.6C787.08 230.6 794.319 223.876 795.353 214.814H786.341C785.868 217.18 784.545 219.298 782.617 220.775C780.69 222.253 778.287 222.991 775.853 222.853C768.023 222.853 763 216.421 763 206.189C763 195.958 768.171 189.818 775.853 189.818Z"
+                ></path>
+                <path
+                  d="M826.532 203.412L818.998 201.658C813.827 200.489 811.463 198.735 811.611 195.519C811.611 191.865 815.6 189.38 820.771 189.38C826.532 189.38 829.191 192.596 830.225 195.665L838.646 194.203C836.725 186.895 830.964 182.071 820.771 182.071C809.986 182.071 802.452 187.626 802.452 195.958C802.452 202.681 806.588 207.067 815.452 208.967L823.43 210.721C828.009 211.744 830.078 213.79 830.078 216.714C830.078 220.368 826.089 223.145 820.032 223.145C814.566 223.145 811.02 220.807 809.838 216.129L800.975 217.445C802.452 225.776 809.543 230.454 820.18 230.454C831.703 230.454 839.532 224.461 839.532 215.983C839.532 209.405 835.248 205.312 826.532 203.412Z"
+                ></path>
+                <path
+                  d="M428.098 136.595L388.359 84.2654L426.916 40.5603H395.45L359.108 83.6807V4.01758H333.551V136.741H359.108V112.184L370.483 100.198L396.041 136.741H428.098V136.595Z"
+                ></path>
+                <path
+                  d="M444.939 30.9215H445.382C449.435 30.8502 453.301 29.2257 456.167 26.3901C459.032 23.5545 460.674 19.7292 460.746 15.7197C460.674 11.7103 459.032 7.88492 456.167 5.04934C453.301 2.21377 449.435 0.589264 445.382 0.517951C441.375 0.490103 437.518 2.02279 434.644 4.78502C431.769 7.54725 430.108 11.3174 430.019 15.2812V15.7197C429.979 17.6899 430.335 19.6482 431.066 21.4814C431.796 23.3146 432.887 24.9863 434.274 26.3999C435.662 27.8135 437.319 28.941 439.149 29.7171C440.98 30.4932 442.948 30.9026 444.939 30.9215V30.9215Z"
+                ></path>
+                <path
+                  d="M432.086 137.925H456.905V41.7441H432.086V137.925Z"
+                ></path>
+                <path
+                  d="M794.165 113.808C794.165 131.495 803.767 140.411 821.642 140.411C829.047 140.746 836.374 138.806 842.62 134.857L837.597 115.855C834.995 117.617 831.883 118.489 828.733 118.34H828.142C825.606 117.97 823.317 116.629 821.77 114.606C820.222 112.583 819.54 110.039 819.87 107.523V63.964H839.665V41.8922H819.87V15.2891H794.312V41.8922H778.357V63.964H794.312V113.808H794.165Z"
+                ></path>
+                <path
+                  d="M601.247 125.337C604.819 129.867 609.393 133.526 614.617 136.035C619.841 138.543 625.577 139.834 631.384 139.808C655.611 139.808 674.225 121.537 674.225 89.233C674.225 57.66 655.759 38.6578 631.384 38.6578C625.58 38.6472 619.849 39.9448 614.627 42.4522C609.406 44.9595 604.83 48.6107 601.247 53.1287V3.86914H575.689V136.592H601.247V125.337ZM601.247 72.131C603.744 68.7245 607.003 65.9359 610.771 63.9834C614.538 62.0308 618.711 60.9672 622.963 60.8758C637.588 60.8758 647.191 72.131 647.191 88.6483C647.191 105.166 637.588 116.421 622.963 116.421C618.752 116.364 614.608 115.361 610.846 113.487C607.084 111.613 603.801 108.918 601.247 105.604V72.131Z"
+                ></path>
+                <path
+                  d="M533.583 111.188C528.083 114.821 521.394 116.253 514.868 115.195C508.341 114.137 502.464 110.667 498.423 105.487L560.47 70.1137L557.959 65.1439C542.004 38.1023 514.526 29.0397 489.56 43.0721C488.821 43.5106 488.082 43.9491 487.491 44.3876C481.985 47.7516 477.206 52.1599 473.428 57.3587C469.651 62.5575 466.95 68.4442 465.481 74.6799C464.012 80.9157 463.803 87.3773 464.868 93.693C465.933 100.009 468.249 106.054 471.684 111.48C472.423 112.796 473.162 113.965 473.753 115.134C477.248 120.525 481.785 125.181 487.102 128.835C492.419 132.488 498.412 135.068 504.739 136.426C511.065 137.784 517.6 137.893 523.97 136.748C530.339 135.602 536.417 133.225 541.856 129.751C554.233 123.118 563.817 112.339 568.891 99.3479L551.015 90.5776C547.936 99.3191 541.737 106.648 533.583 111.188ZM499.753 60.1741C499.901 60.0279 500.049 60.0279 500.196 59.8817C502.689 58.3111 505.473 57.2495 508.386 56.7594C511.299 56.2693 514.282 56.3607 517.159 57.028C520.036 57.6954 522.749 58.9253 525.138 60.6454C527.527 62.3655 529.545 64.5411 531.072 67.0441L490.151 90.5776C487.573 85.247 487.131 79.1486 488.912 73.5083C490.693 67.868 494.567 63.104 499.753 60.1741V60.1741Z"
+                ></path>
+                <path
+                  d="M122.747 125.073C117.827 130.28 111.88 134.432 105.273 137.273C98.6668 140.114 91.5411 141.584 84.3374 141.59C70.0953 141.552 56.4521 135.916 46.4091 125.925C36.3661 115.933 30.7461 102.403 30.7852 88.3111C30.8244 74.2193 36.5196 60.7201 46.618 50.7831C56.7164 40.8461 70.3907 35.2853 84.6328 35.3241C98.6314 35.3093 112.068 40.7741 122.009 50.5259C128.016 42.2847 135.914 35.5718 145.054 30.939C133.725 18.5119 118.836 9.79775 102.373 5.9589C85.9098 2.12005 68.655 3.33893 52.9099 9.45299C37.1648 15.567 23.6779 26.2856 14.2481 40.1792C4.81822 54.0727 -0.106318 70.4807 0.131255 87.2148C-0.0261505 109.171 8.62812 130.291 24.1941 145.94C39.7602 161.588 60.9657 170.485 83.1555 170.678H83.7464C95.4187 170.591 106.949 168.132 117.621 163.456C128.294 158.779 137.883 151.984 145.793 143.491C136.936 138.95 129.097 132.686 122.747 125.073V125.073Z"
+                ></path>
+                <path
+                  d="M170.624 36.9093C157.088 37.0838 144.175 42.5718 134.728 52.1661C125.281 61.7605 120.072 74.6752 120.248 88.0691C120.425 101.463 125.971 114.239 135.668 123.587C145.365 132.934 158.417 138.088 171.954 137.913C172.102 137.913 172.102 137.913 172.102 138.06C185.533 137.921 198.362 132.52 207.776 123.04C217.191 113.56 222.425 100.775 222.33 87.4845V86.7536C222.259 80.1169 220.863 73.5595 218.223 67.458C215.583 61.3566 211.751 55.8314 206.946 51.1998C202.141 46.5682 196.459 42.9214 190.226 40.469C183.993 38.0166 177.332 36.8069 170.624 36.9093ZM171.954 113.795C164.854 113.697 158.073 110.863 153.052 105.895C148.031 100.927 145.166 94.2171 145.067 87.1921C145.067 81.9305 146.644 76.7871 149.598 72.4122C152.553 68.0374 156.752 64.6276 161.665 62.614C166.578 60.6005 171.984 60.0737 177.199 61.1002C182.415 62.1267 187.206 64.6604 190.966 68.3809C194.726 72.1014 197.287 76.8416 198.324 82.0021C199.362 87.1626 198.829 92.5116 196.794 97.3727C194.759 102.234 191.313 106.389 186.892 109.312C182.47 112.235 177.272 113.795 171.954 113.795V113.795Z"
+                ></path>
+                <path
+                  d="M276.685 36.9093C269.982 36.9957 263.362 38.3875 257.203 41.0053C251.044 43.623 245.466 47.4155 240.788 52.1661C231.341 61.7605 226.133 74.6752 226.309 88.0691C226.485 101.463 232.032 114.239 241.729 123.587C251.425 132.934 264.478 138.088 278.015 137.913C278.162 137.913 278.162 137.913 278.162 138.06C291.594 137.921 304.422 132.52 313.837 123.04C323.252 113.56 328.485 100.775 328.39 87.4845V86.7536C328.319 80.1169 326.924 73.5595 324.284 67.458C321.643 61.3566 317.811 55.8314 313.006 51.1998C308.202 46.5682 302.52 42.9214 296.287 40.469C290.054 38.0166 283.392 36.8069 276.685 36.9093V36.9093ZM278.015 113.795C270.908 113.719 264.113 110.892 259.088 105.919C254.062 100.947 251.204 94.2241 251.128 87.1921C251.128 81.9305 252.705 76.7871 255.659 72.4122C258.613 68.0374 262.812 64.6276 267.725 62.614C272.638 60.6005 278.044 60.0737 283.26 61.1002C288.475 62.1267 293.266 64.6604 297.026 68.3809C300.787 72.1014 303.347 76.8416 304.385 82.0021C305.422 87.1626 304.89 92.5116 302.855 97.3727C300.82 102.234 297.374 106.389 292.952 109.312C288.531 112.235 283.332 113.795 278.015 113.795V113.795Z"
+                ></path>
+                <path
+                  d="M729.639 137.91C736.297 137.885 742.885 136.56 749.024 134.009C755.163 131.459 760.733 127.734 765.413 123.049C770.094 118.363 773.793 112.809 776.299 106.706C778.805 100.602 780.067 94.0688 780.015 87.4811V86.7502C779.883 76.7631 776.76 67.039 771.043 58.8076C765.325 50.5763 757.269 44.2072 747.893 40.5059C738.517 36.8045 728.243 35.9371 718.369 38.0133C708.495 40.0895 699.464 45.016 692.42 52.17C685.376 59.3239 680.633 68.384 678.793 78.2046C676.953 88.0252 678.097 98.1652 682.08 107.343C686.064 116.52 692.709 124.322 701.174 129.763C709.639 135.204 719.545 138.039 729.639 137.91V137.91ZM730.377 60.7318C737.508 60.7318 744.347 63.5346 749.389 68.5237C754.432 73.5127 757.264 80.2793 757.264 87.3349C757.264 94.3905 754.432 101.157 749.389 106.146C744.347 111.135 737.508 113.938 730.377 113.938C723.247 113.938 716.408 111.135 711.366 106.146C706.323 101.157 703.491 94.3905 703.491 87.3349C703.491 80.2793 706.323 73.5127 711.366 68.5237C716.408 63.5346 723.247 60.7318 730.377 60.7318Z"
+                ></path></svg
+            ></a>
+          </div>
+          <button class="CybotCookiebotBannerCloseButton" aria-label="">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+            >
+              <path
+                d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+              ></path>
+            </svg>
+          </button>
+        </div>
+        <div id="CybotCookiebotDialogNav" class="CybotCookiebotScrollAreaSide">
+          <div
+            class="CybotCookiebotFader CybotCookiebotFaderLeft"
+            style="
+              background-image: linear-gradient(
+                to right,
+                rgb(255, 255, 255),
+                rgba(255, 255, 255, 0.8),
+                rgba(255, 255, 255, 0)
+              );
+            "
+          ></div>
+          <div
+            class="CybotCookiebotFader CybotCookiebotFaderRight"
+            style="
+              background-image: linear-gradient(
+                to left,
+                rgb(255, 255, 255),
+                rgba(255, 255, 255, 0.8),
+                rgba(255, 255, 255, 0)
+              );
+            "
+          ></div>
+          <ul
+            id="CybotCookiebotDialogNavList"
+            class="CybotCookiebotDialogNavItems"
+            role="tablist"
+          >
+            <li class="CybotCookiebotDialogNavItem" role="presentation">
+              <a
+                id="CybotCookiebotDialogNavDeclaration"
+                class="CybotCookiebotDialogNavItemLink CybotCookiebotDialogActive"
+                href="#"
+                data-target="CybotCookiebotDialogBody"
+                tabindex="0"
+                role="tab"
+                aria-selected="true"
+                lang="en"
+                >Consent</a
+              >
+            </li>
+            <li class="CybotCookiebotDialogNavItem" role="presentation">
+              <a
+                id="CybotCookiebotDialogNavDetails"
+                class="CybotCookiebotDialogNavItemLink"
+                href="#"
+                data-target="CybotCookiebotDialogTabContentDetails"
+                tabindex="0"
+                role="tab"
+                aria-selected="false"
+                lang="en"
+                >Details</a
+              >
+            </li>
+            <li
+              id="CybotCookiebotDialogNavItemAdSettings"
+              class="CybotCookiebotDialogNavItem CybotCookiebotDialogHide"
+              role="presentation"
+            >
+              <a
+                id="CybotCookiebotDialogNavAdSettings"
+                class="CybotCookiebotDialogNavItemLink"
+                href="#"
+                data-target="CybotCookiebotDialogDetailBodyContentTextIABv2"
+                tabindex="0"
+                role="tab"
+                aria-selected="false"
+                lang="en"
+                >[#IABV2SETTINGS#]</a
+              >
+            </li>
+            <li class="CybotCookiebotDialogNavItem" role="presentation">
+              <a
+                id="CybotCookiebotDialogNavAbout"
+                class="CybotCookiebotDialogNavItemLink"
+                href="#"
+                data-target="CybotCookiebotDialogDetailBodyContentTextAbout"
+                tabindex="0"
+                role="tab"
+                aria-selected="false"
+                lang="en"
+                >About</a
+              >
+            </li>
+          </ul>
+        </div>
+        <div id="CybotCookiebotDialogTabContent">
+          <div
+            id="CybotCookiebotDialogBody"
+            class="CybotCookiebotDialogTabPanel"
+            role="tabpanel"
+            aria-labelledby="CybotCookiebotDialogNavDeclaration"
+            lang="en"
+          >
+            <div class="CybotCookiebotScrollContainer">
+              <div
+                id="CybotCookiebotDialogBodyContent"
+                class="CybotCookiebotScrollArea"
+              >
+                <div
+                  class="CybotCookiebotFader"
+                  style="
+                    background-image: linear-gradient(
+                      to top,
+                      rgb(255, 255, 255),
+                      rgba(255, 255, 255, 0.8),
+                      rgba(255, 255, 255, 0)
+                    );
+                  "
+                ></div>
+                <div
+                  id="CybotCookiebotDialogBodyContentTitle"
+                  class="CybotCookiebotDialogBodyContentHeading"
+                  lang="en"
+                  role="heading"
+                  aria-level="2"
+                >
+                  This website uses cookies
+                </div>
+                <div id="CybotCookiebotDialogBodyContentText" lang="en">
+                  We use cookies to personalise content and ads, to provide
+                  social media features and to analyse our traffic. We also
+                  share information about your use of our site with our social
+                  media, advertising and analytics partners who may combine it
+                  with other information that you’ve provided to them or that
+                  they’ve collected from your use of their services.
+                </div>
+              </div>
+              <div class="CybotCookiebotScrollbarContainer"></div>
+            </div>
+            <div class="CybotCookiebotDialogBodyBottomWrapper">
+              <div
+                id="CybotCookiebotDialogBodyLevelWrapper"
+                class="CybotCookiebotDialogHide"
+              >
+                <div id="CybotCookiebotDialogBodyLevelButtons">
+                  <div id="CybotCookiebotDialogBodyLevelButtonsTable">
+                    <div id="CybotCookiebotDialogBodyLevelButtonsRow">
+                      <div id="CybotCookiebotDialogBodyLevelButtonsSelectPane">
+                        <form>
+                          <fieldset>
+                            <legend class="visuallyhidden">
+                              Consent Selection
+                            </legend>
+                            <div
+                              id="CybotCookiebotDialogBodyFieldsetInnerContainer"
+                            >
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonWrapper"
+                              >
+                                <label
+                                  class="CybotCookiebotDialogBodyLevelButtonLabel"
+                                  for="CybotCookiebotDialogBodyLevelButtonNecessary"
+                                  ><strong
+                                    class="CybotCookiebotDialogBodyLevelButtonDescription"
+                                    >Necessary</strong
+                                  ></label
+                                >
+                                <div
+                                  class="CybotCookiebotDialogBodyLevelButtonSliderWrapper CybotCookiebotDialogBodyLevelButtonSliderWrapperDisabled"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonNecessary"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelButtonDisabled"
+                                    disabled="disabled"
+                                    checked="checked"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </div>
+                              </div>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonWrapper"
+                              >
+                                <label
+                                  class="CybotCookiebotDialogBodyLevelButtonLabel"
+                                  for="CybotCookiebotDialogBodyLevelButtonPreferences"
+                                  ><strong
+                                    class="CybotCookiebotDialogBodyLevelButtonDescription"
+                                    >Preferences</strong
+                                  ></label
+                                >
+                                <div
+                                  class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonPreferences"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonPreferencesInline"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </div>
+                              </div>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonWrapper"
+                              >
+                                <label
+                                  class="CybotCookiebotDialogBodyLevelButtonLabel"
+                                  for="CybotCookiebotDialogBodyLevelButtonStatistics"
+                                  ><strong
+                                    class="CybotCookiebotDialogBodyLevelButtonDescription"
+                                    >Statistics</strong
+                                  ></label
+                                >
+                                <div
+                                  class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonStatistics"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonStatisticsInline"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </div>
+                              </div>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonWrapper"
+                              >
+                                <label
+                                  class="CybotCookiebotDialogBodyLevelButtonLabel"
+                                  for="CybotCookiebotDialogBodyLevelButtonMarketing"
+                                  ><strong
+                                    class="CybotCookiebotDialogBodyLevelButtonDescription"
+                                    >Marketing</strong
+                                  ></label
+                                >
+                                <div
+                                  class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonMarketing"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonMarketingInline"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </div>
+                              </div>
+                            </div>
+                          </fieldset>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div id="CybotCookiebotDialogBodyEdgeMoreDetails">
+                <a
+                  id="CybotCookiebotDialogBodyEdgeMoreDetailsLink"
+                  href="#"
+                  class=""
+                  >Show details</a
+                >
+              </div>
+            </div>
+          </div>
+          <div class="CybotCookiebotScrollContainer CybotCookiebotDialogHide">
+            <div
+              id="CybotCookiebotDialogTabContentDetails"
+              class="CybotCookiebotDialogTabPanel CybotCookiebotDialogHide CybotCookiebotScrollArea"
+              role="tabpanel"
+              aria-labelledby="CybotCookiebotDialogNavDetails"
+              lang="en"
+            >
+              <div
+                class="CybotCookiebotFader"
+                style="
+                  background-image: linear-gradient(
+                    to top,
+                    rgb(255, 255, 255),
+                    rgba(255, 255, 255, 0.8),
+                    rgba(255, 255, 255, 0)
+                  );
+                "
+              ></div>
+              <div
+                class="CybotCookiebotDialogSROnly"
+                role="heading"
+                aria-level="2"
+              >
+                Details
+              </div>
+              <div id="CybotCookiebotDialogDetailBody">
+                <div id="CybotCookiebotDialogDetailBodyContent">
+                  <div
+                    id="CybotCookiebotDialogDetailBodyContentTextOverview"
+                    lang="en"
+                  >
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentCookieContainer"
+                    >
+                      <ul
+                        id="CybotCookiebotDialogDetailBodyContentCookieContainerTypes"
+                        style="list-style-type: none"
+                      >
+                        <li class="CookieCard">
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieContainerNecessaryCard"
+                          >
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieContainerHeader"
+                            >
+                              <button
+                                id="CybotCookiebotDialogDetailBodyContentCookieContainerNecessary"
+                                class="CybotCookiebotDialogDetailBodyContentCookieContainerButton CybotCookiebotDialogCollapsed"
+                                lang="en"
+                                data-target="CybotCookiebotDialogDetailBodyContentCookieTabsNecessary"
+                                aria-label="Necessary (41)"
+                                aria-controls="CybotCookiebotDialogDetailBodyContentCookieTabsNecessary"
+                                aria-expanded="false"
+                              >
+                                <label
+                                  for="CybotCookiebotDialogBodyLevelButtonNecessaryInline"
+                                  >Necessary
+                                </label>
+                                <span
+                                  class="CybotCookiebotDialogDetailBulkConsentCount"
+                                  >41</span
+                                >
+                              </button>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonSliderWrapper CybotCookiebotDialogBodyLevelButtonSliderWrapperDisabled"
+                              >
+                                <form>
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonNecessaryInline"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelButtonDisabled"
+                                    disabled="disabled"
+                                    checked="checked"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </form>
+                              </div>
+                            </div>
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeIntro"
+                            >
+                              Necessary cookies help make a website usable by
+                              enabling basic functions like page navigation and
+                              access to secure areas of the website. The website
+                              cannot function properly without these cookies.
+                            </div>
+                            <div
+                              id="CybotCookiebotDialogDetailBodyContentCookieTabsNecessary"
+                              class="CollapseCard CybotCookiebotDialogHide"
+                              aria-labelledby="CybotCookiebotDialogDetailBodyContentCookieContainerNecessaryCard"
+                            >
+                              <div
+                                class="CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer"
+                              >
+                                <ul
+                                  class="CybotCookiebotDialogDetailBodyContentCookieTabContent"
+                                  style="list-style-type: none"
+                                >
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Cookiebot
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        23
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Cookiebot's privacy policy - opens in a new window"
+                                      href="https://www.cookiebot.com/goto/privacy-policy/"
+                                      title="Cookiebot's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >CookieConsent&nbsp;[x10]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's cookie consent
+                                          state for the current domain</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_abck</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to detect and defend against
+                                          replay-cookie-attacks – The cookie is
+                                          necessary for the security and
+                                          integrity of the website.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ak_bmsc</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie is used to distinguish
+                                          between humans and bots. This is
+                                          beneficial for the website, in order
+                                          to make valid reports on the use of
+                                          their website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ASPXAUTH</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Identifies the user and allows
+                                          authentication to the server</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >bm_mi</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with the website's
+                                          BotManager. The BotManager detects,
+                                          categorizes and compiles reports on
+                                          potential bots trying to access the
+                                          website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >bm_sv</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with the website's
+                                          BotManager. The BotManager detects,
+                                          categorizes and compiles reports on
+                                          potential bots trying to access the
+                                          website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >bm_sz</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with the website's
+                                          BotManager. The BotManager detects,
+                                          categorizes and compiles reports on
+                                          potential bots trying to access the
+                                          website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cb_admin</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Identies the Cookiebot system
+                                          onboarding</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >CrossConsent</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's cookie consent
+                                          state for the current domain</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_help_center_session</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Preserves users states across page
+                                          requests.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_zendesk_authenticated</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers whether the user is logged
+                                          in. This allows the website owner to
+                                          make parts of the website
+                                          inaccessible, based on the user's
+                                          log-in status.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_zendesk_session</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Preserves users states across page
+                                          requests.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_zendesk_shared_session</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Preserves users states across page
+                                          requests.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cb_experiments</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie is used to ensure the
+                                          correct version of a page is displayed
+                                          to the user. It assigns a variant flag
+                                          (a, b, or c) as part of an A/B testing
+                                          process to maintain a consistent user
+                                          experience across page visits. This
+                                          cookie does not store personal
+                                          information or track user behavior
+                                          beyond delivering the correct page
+                                          layout.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Usercentrics
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        3
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Usercentrics's privacy policy - opens in a new window"
+                                      href="https://www.cookiebot.com/en/privacy-policy/"
+                                      title="Usercentrics's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >__akfp_storage_test__</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to detect whether the website
+                                          can store user data in local
+                                          storage.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ASP.NET_SessionId</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Preserves the visitor's session state
+                                          across page requests.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >dummy</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to detect whether the website
+                                          can store user data in local
+                                          storage.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >assets.storylane.io
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cookietest</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie is used to determine if
+                                          the visitor has accepted the cookie
+                                          consent box.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        cookiebot.zendesk.com<br />g2.com<br />g2crowd.com<br />support.cookiebot.com<br />www.cybot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        6
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >__cf_bm&nbsp;[x6]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie is used to distinguish
+                                          between humans and bots. This is
+                                          beneficial for the website, in order
+                                          to make valid reports on the use of
+                                          their website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        cookiebot.zendesk.com<br />support.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        2
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_cfuvid&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie is a part of the services
+                                          provided by Cloudflare - Including
+                                          load-balancing, deliverance of website
+                                          content and serving DNS connection for
+                                          website operators.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        img.sct.eu1.usercentrics.eu<br />imgsct.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        2
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >1.gif&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to count the number of sessions
+                                          to the website, necessary for
+                                          optimizing CMP product delivery.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        pi.pardot.com<br />resources.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        4
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >visitor_id#-hash&nbsp;[x4]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to encrypt and contain visitor
+                                          data. This is necessary for the
+                                          security of the user data.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 10
+                                            years</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li class="CookieCard">
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieContainerPreferenceCard"
+                          >
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieContainerHeader"
+                            >
+                              <button
+                                id="CybotCookiebotDialogDetailBodyContentCookieContainerPreference"
+                                class="CybotCookiebotDialogDetailBodyContentCookieContainerButton CybotCookiebotDialogCollapsed"
+                                lang="en"
+                                data-target="CybotCookiebotDialogDetailBodyContentCookieTabsPreference"
+                                aria-label="Preferences (16)"
+                                aria-controls="CybotCookiebotDialogDetailBodyContentCookieTabsPreference"
+                                aria-expanded="false"
+                              >
+                                <label
+                                  for="CybotCookiebotDialogBodyLevelButtonPreferencesInline"
+                                  >Preferences
+                                </label>
+                                <span
+                                  class="CybotCookiebotDialogDetailBulkConsentCount"
+                                  >16</span
+                                >
+                              </button>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                              >
+                                <form>
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonPreferencesInline"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonPreferences"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </form>
+                              </div>
+                            </div>
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeIntro"
+                            >
+                              Preference cookies enable a website to remember
+                              information that changes the way the website
+                              behaves or looks, like your preferred language or
+                              the region that you are in.
+                            </div>
+                            <div
+                              id="CybotCookiebotDialogDetailBodyContentCookieTabsPreference"
+                              class="CollapseCard CybotCookiebotDialogHide"
+                              aria-labelledby="CybotCookiebotDialogDetailBodyContentCookieContainerPreferenceCard"
+                            >
+                              <div
+                                class="CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer"
+                              >
+                                <ul
+                                  class="CybotCookiebotDialogDetailBodyContentCookieTabContent"
+                                  style="list-style-type: none"
+                                >
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Cookiebot
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        9
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Cookiebot's privacy policy - opens in a new window"
+                                      href="https://www.cookiebot.com/goto/privacy-policy/"
+                                      title="Cookiebot's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >CookieConsentBulkSetting-#&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Enables cookie consent across
+                                          multiple websites</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >MasterPopup</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Pending</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 30
+                                            days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_answer_bot_service_session</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with the Zendesk
+                                          Answer Bot function – This function
+                                          sets an account-ID, in order to
+                                          identify users upon support-requests
+                                          and detect whether an existing
+                                          help-article is relevant.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >loglevel</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Maintains settings and outputs when
+                                          using the Developer Tools Console on
+                                          current session.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cb_preferences</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Remembers whether the user has
+                                          minimized or closed pop-up messages on
+                                          the website. And to maintain filter
+                                          selection when browsing the
+                                          website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cb-currency</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's currency
+                                          preference</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >userlang</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Necessary for maintaining
+                                          language-settings across subpages on
+                                          the website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 29
+                                            days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Intercom
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        3
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Intercom's privacy policy - opens in a new window"
+                                      href="https://www.intercom.com/terms-and-policies#privacy"
+                                      title="Intercom's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >intercom-device-id-#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Sets a specific ID for the user which
+                                          ensures the integrity of the website’s
+                                          chat function.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            271 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >intercom-id-#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Allows the website to recoqnise the
+                                          visitor, in order to optimize the
+                                          chat-box functionality.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            271 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >intercom-session-#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Sets a specific ID for the user which
+                                          ensures the integrity of the website’s
+                                          chat function.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 7
+                                            days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Zendesk
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Zendesk's privacy policy - opens in a new window"
+                                      href="https://www.zendesk.com/company/customers-partners/privacy-policy/"
+                                      title="Zendesk's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ZD-automaticAnswers</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with the Zendesk
+                                          Answer Bot function – This function
+                                          sets an account-ID, in order to
+                                          identify users upon support-requests
+                                          and detect whether an existing
+                                          help-article is relevant.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        js.intercomcdn.com<br />manage.cookiebot.com<br />support.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        3
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >intercom.intercom-state-#&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Remembers whether the user has
+                                          minimized or closed chat-box or pop-up
+                                          messages on the website.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li class="CookieCard">
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieContainerStatisticsCard"
+                          >
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieContainerHeader"
+                            >
+                              <button
+                                id="CybotCookiebotDialogDetailBodyContentCookieContainerStatistics"
+                                class="CybotCookiebotDialogDetailBodyContentCookieContainerButton CybotCookiebotDialogCollapsed"
+                                lang="en"
+                                data-target="CybotCookiebotDialogDetailBodyContentCookieTabsStatistics"
+                                aria-label="Statistics (17)"
+                                aria-controls="CybotCookiebotDialogDetailBodyContentCookieTabsStatistics"
+                                aria-expanded="false"
+                              >
+                                <label
+                                  for="CybotCookiebotDialogBodyLevelButtonStatisticsInline"
+                                  >Statistics
+                                </label>
+                                <span
+                                  class="CybotCookiebotDialogDetailBulkConsentCount"
+                                  >17</span
+                                >
+                              </button>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                              >
+                                <form>
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonStatisticsInline"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonStatistics"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </form>
+                              </div>
+                            </div>
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeIntro"
+                            >
+                              Statistic cookies help website owners to
+                              understand how visitors interact with websites by
+                              collecting and reporting information anonymously.
+                            </div>
+                            <div
+                              id="CybotCookiebotDialogDetailBodyContentCookieTabsStatistics"
+                              class="CollapseCard CybotCookiebotDialogHide"
+                              aria-labelledby="CybotCookiebotDialogDetailBodyContentCookieContainerStatisticsCard"
+                            >
+                              <div
+                                class="CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer"
+                              >
+                                <ul
+                                  class="CybotCookiebotDialogDetailBodyContentCookieTabContent"
+                                  style="list-style-type: none"
+                                >
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Cookiebot
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        3
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Cookiebot's privacy policy - opens in a new window"
+                                      href="https://www.cookiebot.com/goto/privacy-policy/"
+                                      title="Cookiebot's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >FPGSID</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >FPID</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            400 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >FPLC</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID that is used to
+                                          generate statistical data on how the
+                                          visitor uses the website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >G2Crowd
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="G2Crowd's privacy policy - opens in a new window"
+                                      href="https://www.g2crowd.com/static/privacy"
+                                      title="G2Crowd's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >g2tracking</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Hotjar
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        5
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Hotjar's privacy policy - opens in a new window"
+                                      href="https://www.hotjar.com/legal/policies/privacy/"
+                                      title="Hotjar's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_hjSession_#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Collects statistics on the visitor's
+                                          visits to the website, such as the
+                                          number of visits, average time spent
+                                          on the website and what pages have
+                                          been read.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_hjSessionUser_#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Collects statistics on the visitor's
+                                          visits to the website, such as the
+                                          number of visits, average time spent
+                                          on the website and what pages have
+                                          been read.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_hjTLDTest</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >hjActiveViewportIds</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >This cookie contains an ID string on
+                                          the current session. This contains
+                                          non-personal information on what
+                                          subpages the visitor enters – this
+                                          information is used to optimize the
+                                          visitor's experience.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >hjViewportId</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Saves the user's screen size in order
+                                          to adjust the size of images on the
+                                          website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Zendesk
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Zendesk's privacy policy - opens in a new window"
+                                      href="https://www.zendesk.com/company/customers-partners/privacy-policy/"
+                                      title="Zendesk's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >hc:#:recently_visited_articles</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers which articles the user has
+                                          visited in a Zendesk knowledge
+                                          base.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >cdn.amplitude.com
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        7
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >AMP_unsent_#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >AMP_#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >AMP_MKTG_#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >AMP_TEST&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >AMP_TLDTEST</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li class="CookieCard">
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieContainerAdvertisingCard"
+                          >
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieContainerHeader"
+                            >
+                              <button
+                                id="CybotCookiebotDialogDetailBodyContentCookieContainerAdvertising"
+                                class="CybotCookiebotDialogDetailBodyContentCookieContainerButton CybotCookiebotDialogCollapsed"
+                                lang="en"
+                                data-target="CybotCookiebotDialogDetailBodyContentCookieTabsAdvertising"
+                                aria-label="Marketing (91)"
+                                aria-controls="CybotCookiebotDialogDetailBodyContentCookieTabsAdvertising"
+                                aria-expanded="false"
+                              >
+                                <label
+                                  for="CybotCookiebotDialogBodyLevelButtonMarketingInline"
+                                  >Marketing
+                                </label>
+                                <span
+                                  class="CybotCookiebotDialogDetailBulkConsentCount"
+                                  >91</span
+                                >
+                              </button>
+                              <div
+                                class="CybotCookiebotDialogBodyLevelButtonSliderWrapper"
+                              >
+                                <form>
+                                  <input
+                                    type="checkbox"
+                                    id="CybotCookiebotDialogBodyLevelButtonMarketingInline"
+                                    class="CybotCookiebotDialogBodyLevelButton CybotCookiebotDialogBodyLevelConsentCheckbox"
+                                    data-target="CybotCookiebotDialogBodyLevelButtonMarketing"
+                                    checked="checked"
+                                    tabindex="0"
+                                  />
+                                  <span
+                                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                                  ></span>
+                                </form>
+                              </div>
+                            </div>
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeIntro"
+                            >
+                              Marketing cookies are used to track visitors
+                              across websites. The intention is to display ads
+                              that are relevant and engaging for the individual
+                              user and thereby more valuable for publishers and
+                              third party advertisers.
+                            </div>
+                            <div
+                              id="CybotCookiebotDialogDetailBodyContentCookieTabsAdvertising"
+                              class="CollapseCard CybotCookiebotDialogHide"
+                              aria-labelledby="CybotCookiebotDialogDetailBodyContentCookieContainerAdvertisingCard"
+                            >
+                              <div
+                                class="CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer"
+                              >
+                                <ul
+                                  class="CybotCookiebotDialogDetailBodyContentCookieTabContent"
+                                  style="list-style-type: none"
+                                >
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                    >
+                                      Meta Platforms, Inc.
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        5
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label=" Meta Platforms, Inc.'s privacy policy - opens in a new window"
+                                      href="https://www.facebook.com/policy.php/"
+                                      title=" Meta Platforms, Inc.'s privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >lastExternalReferrer</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Detects how the user reached the
+                                          website by registering their last
+                                          URL-address.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >lastExternalReferrerTime</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Detects how the user reached the
+                                          website by registering their last
+                                          URL-address.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >log/error</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to detect and log potential
+                                          tracking errors.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >topicsLastReferenceTime</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Collects data on the user across
+                                          websites - This data is used to make
+                                          advertisement more relevant.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_fbp</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by Facebook to deliver a series
+                                          of advertisement products such as real
+                                          time bidding from third party
+                                          advertisers.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 3
+                                            months</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Cookiebot
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Cookiebot's privacy policy - opens in a new window"
+                                      href="https://www.cookiebot.com/goto/privacy-policy/"
+                                      title="Cookiebot's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >cb_mktg</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers statistical data on users'
+                                          behaviour on the website. Used for
+                                          internal analytics by the website
+                                          operator.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 30
+                                            days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Google
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        24
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Google's privacy policy - opens in a new window"
+                                      href="https://business.safety.google/privacy/"
+                                      title="Google's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <p
+                                        class="CybotCookiebotDialogDetailBodyContentCookieProviderDescription"
+                                      >
+                                        Some of the data collected by this
+                                        provider is for the purposes of
+                                        personalization and measuring
+                                        advertising effectiveness.
+                                      </p>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_ga&nbsp;[x5]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID that is used to
+                                          generate statistical data on how the
+                                          visitor uses the website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 2
+                                            years</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_ga_#&nbsp;[x5]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by Google Analytics to collect
+                                          data on the number of times a user has
+                                          visited the website as well as dates
+                                          for the first and most recent visit.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 2
+                                            years</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_gat&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by Google Analytics to throttle
+                                          request rate</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_gcl_au</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by Google AdSense for
+                                          experimenting with advertisement
+                                          efficiency across websites using their
+                                          services.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 3
+                                            months</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_gid&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID that is used to
+                                          generate statistical data on how the
+                                          visitor uses the website.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >IDE</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by Google DoubleClick to
+                                          register and report the website user's
+                                          actions after viewing or clicking one
+                                          of the advertiser's ads with the
+                                          purpose of measuring the efficacy of
+                                          an ad and to present targeted ads to
+                                          the user.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            400 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >test_cookie</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to check if the user's browser
+                                          supports cookies.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >Google Icon</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Pending</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >NID</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID that identifies
+                                          a returning user's device. The ID is
+                                          used for targeted ads.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 6
+                                            months</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >pagead/1p-user-list/#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Tracks if the user has shown interest
+                                          in specific products or events across
+                                          multiple websites and detects how the
+                                          user navigates between sites. This is
+                                          used for measurement of advertisement
+                                          efforts and facilitates payment of
+                                          referral-fees between websites.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >pagead/gen_204/</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Pending</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_gcl_ls</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Tracks the conversion rate between
+                                          the user and the advertisement banners
+                                          on the website - This serves to
+                                          optimise the relevance of the
+                                          advertisements on the website.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Intercom
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Intercom's privacy policy - opens in a new window"
+                                      href="https://www.intercom.com/terms-and-policies#privacy"
+                                      title="Intercom's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >gtm_id</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to send data to Google Analytics
+                                          about the visitor's device and
+                                          behavior. Tracks the visitor across
+                                          devices and marketing channels.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >LinkedIn
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        3
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="LinkedIn's privacy policy - opens in a new window"
+                                      href="https://www.linkedin.com/legal/privacy-policy"
+                                      title="LinkedIn's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >bcookie</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by the social networking
+                                          service, LinkedIn, for tracking the
+                                          use of embedded services.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >li_gc</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's cookie consent
+                                          state for the current domain</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            180 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >lidc</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used by the social networking
+                                          service, LinkedIn, for tracking the
+                                          use of embedded services.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Microsoft
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        8
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Microsoft's privacy policy - opens in a new window"
+                                      href="https://privacy.microsoft.com/en-US/privacystatement"
+                                      title="Microsoft's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetsid</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track visitors on multiple
+                                          websites, in order to present relevant
+                                          advertisement based on the visitor's
+                                          preferences.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetsid_exp</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Contains the expiry-date for the
+                                          cookie with corresponding name.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetvid</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track visitors on multiple
+                                          websites, in order to present relevant
+                                          advertisement based on the visitor's
+                                          preferences.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetvid_exp</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Contains the expiry-date for the
+                                          cookie with corresponding name.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >MR</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track visitors on multiple
+                                          websites, in order to present relevant
+                                          advertisement based on the visitor's
+                                          preferences.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 7
+                                            days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >MUID</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used widely by Microsoft as a unique
+                                          user ID. The cookie enables user
+                                          tracking by synchronising the ID
+                                          across many Microsoft domains.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetsid</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Collects data on visitor behaviour
+                                          from multiple websites, in order to
+                                          present more relevant advertisement -
+                                          This also allows the website to limit
+                                          the number of times that they are
+                                          shown the same advertisement.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_uetvid</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track visitors on multiple
+                                          websites, in order to present relevant
+                                          advertisement based on the visitor's
+                                          preferences.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            year</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Pardot
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        1
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Pardot's privacy policy - opens in a new window"
+                                      href="https://www.salesforce.com/company/privacy/"
+                                      title="Pardot's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >lpv#</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with behavioral
+                                          tracking by the website. The cookie
+                                          registers the user’s behavior and
+                                          navigation across multiple websites
+                                          and ensures that no tracking errors
+                                          occur when the user has multiple
+                                          browser-tabs open.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >Reddit
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        4
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="Reddit's privacy policy - opens in a new window"
+                                      href="https://www.redditinc.com/policies/privacy-policy"
+                                      title="Reddit's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >rp.gif</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Necessary for the implementation of
+                                          the Reddit.com's share-button
+                                          function.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: Pixel Tracker</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >_rdt_uuid&nbsp;[x3]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track visitors on multiple
+                                          websites, in order to present relevant
+                                          advertisement based on the visitor's
+                                          preferences.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 3
+                                            months</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      >YouTube
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        38
+                                      </div></a
+                                    ><a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                      target="_blank"
+                                      rel="noopener noreferrer nofollow"
+                                      aria-label="YouTube's privacy policy - opens in a new window"
+                                      href="https://business.safety.google/privacy/"
+                                      title="YouTube's privacy policy"
+                                      >Learn more about this provider<img
+                                        class="CybotExternalLinkArrow"
+                                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                        alt=""
+                                    /></a>
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >#-#&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >iU5q-!O9@[#COOKIETABLE_ADVERTISING#]nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID to keep
+                                          statistics of what videos from YouTube
+                                          the user has seen.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >LAST_RESULT_ENTRY_KEY&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >nextId</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >requests</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >TESTCOOKIESENABLED&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 1
+                                            day</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt.innertube::nextId</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID to keep
+                                          statistics of what videos from YouTube
+                                          the user has seen.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt.innertube::requests</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID to keep
+                                          statistics of what videos from YouTube
+                                          the user has seen.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ytidb::LAST_RESULT_ENTRY_KEY&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >YtIdbMeta#databases&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: IndexedDB</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-cast-available&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-cast-installed&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-connected-devices&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-device-id&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-fast-check-period&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-session-app&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-remote-session-name&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >__Secure-ROLLOUT_TOKEN</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            180 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >__Secure-YEC</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Stores the user's video player
+                                          preferences using embedded YouTube
+                                          video</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >LogsDatabaseV2:V#||LogsRequestsStore</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used to track user’s interaction with
+                                          embedded content.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: IndexedDB</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >remote_sid</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Necessary for the implementation and
+                                          functionality of YouTube video-content
+                                          on the website.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >ServiceWorkerLogsDatabase#SWHealthLog</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Necessary for the implementation and
+                                          functionality of YouTube video-content
+                                          on the website.
+                                        </span>
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: IndexedDB</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >VISITOR_INFO1_LIVE</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Tries to estimate the users'
+                                          bandwidth on pages with integrated
+                                          YouTube videos.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            180 days</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >YSC</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Registers a unique ID to keep
+                                          statistics of what videos from YouTube
+                                          the user has seen.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >yt-player-user-settings</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Pending</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Persistent</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTML Local
+                                            Storage</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        pardot.com<br />resources.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        2
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >pardot&nbsp;[x2]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with
+                                          Account-Based-Marketing (ABM). The
+                                          cookie registers data such as
+                                          IP-addresses, time spent on the
+                                          website and page requests for the
+                                          visit. This is used for retargeting of
+                                          multiple users rooting from the same
+                                          IP-addresses. ABM usually facilitates
+                                          B2B marketing purposes.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>:
+                                            Session</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                  <li
+                                    class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                  >
+                                    <a
+                                      class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                      role="button"
+                                      aria-expanded="false"
+                                      href="#"
+                                      ><div>
+                                        pi.pardot.com<br />resources.cookiebot.com<br />
+                                      </div>
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                      >
+                                        4
+                                      </div></a
+                                    >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                    >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                      >
+                                        <strong
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                          >visitor_id#&nbsp;[x4]</strong
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                          >Used in context with
+                                          Account-Based-Marketing (ABM). The
+                                          cookie registers data such as
+                                          IP-addresses, time spent on the
+                                          website and page requests for the
+                                          visit. This is used for retargeting of
+                                          multiple users rooting from the same
+                                          IP-addresses. ABM usually facilitates
+                                          B2B marketing purposes.</span
+                                        >
+                                        <div
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                        >
+                                          <span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Maximum Storage Duration</b>: 10
+                                            years</span
+                                          ><span
+                                            class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                            ><b>Type</b>: HTTP Cookie</span
+                                          >
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li class="CookieCard">
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieContainerUnclassifiedCard"
+                          >
+                            <button
+                              id="CybotCookiebotDialogDetailBodyContentCookieContainerUnclassified"
+                              class="CybotCookiebotDialogDetailBodyContentCookieContainerButton CybotCookiebotDialogCollapsed"
+                              lang="en"
+                              data-target="CybotCookiebotDialogDetailBodyContentCookieTabsUnclassified"
+                              aria-label="Unclassified (1)"
+                              aria-controls="CybotCookiebotDialogDetailBodyContentCookieTabsUnclassified"
+                              aria-expanded="false"
+                            >
+                              Unclassified
+                              <span
+                                class="CybotCookiebotDialogDetailBulkConsentCount"
+                                >1</span
+                              >
+                            </button>
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeIntro"
+                            >
+                              Unclassified cookies are cookies that we are in
+                              the process of classifying, together with the
+                              providers of individual cookies.
+                            </div>
+                          </div>
+                          <div
+                            id="CybotCookiebotDialogDetailBodyContentCookieTabsUnclassified"
+                            class="CollapseCard CybotCookiebotDialogHide"
+                            aria-labelledby="CybotCookiebotDialogDetailBodyContentCookieContainerUnclassifiedCard"
+                            aria-expanded="false"
+                          >
+                            <div
+                              class="CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer"
+                            >
+                              <ul
+                                class="CybotCookiebotDialogDetailBodyContentCookieTabContent"
+                                style="list-style-type: none"
+                              >
+                                <li
+                                  class="CybotCookiebotDialogDetailBodyContentCookieGroup"
+                                >
+                                  <a
+                                    class="CybotCookiebotDialogDetailBodyContentCookieProvider CybotCookiebotDialogCollapsed"
+                                    role="button"
+                                    aria-expanded="false"
+                                    href="#"
+                                    >Cookiebot
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfoCount CybotCookiebotDialogDetailBulkConsentCount"
+                                    >
+                                      1
+                                    </div></a
+                                  ><a
+                                    class="CybotCookiebotDialogDetailBodyContentCookieLink"
+                                    target="_blank"
+                                    rel="noopener noreferrer nofollow"
+                                    aria-label="Cookiebot's privacy policy - opens in a new window"
+                                    href="https://www.cookiebot.com/goto/privacy-policy/"
+                                    title="Cookiebot's privacy policy"
+                                    >Learn more about this provider<img
+                                      class="CybotExternalLinkArrow"
+                                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgBpdTdCcMgEAdwT/vk04EOkBG6QifpHH3rCF2hk3SVvBaEuoDYu4IgRRMv/iEkD/Hn+QnOuatS6gEAqDoJIQC/vfe594+m576FjAZKL6XXkSDiYox5UQFLXZEoNZJzXg9B/0hK6SKGWkiMcRVBewjnNIuURdIzyFBFo0jZPnoGqaMbCEqRJkSNIiFPCfILj7F1GLkySfvuqnFlShDxWesF6D76zF4jPJ/GWvum7/NRjBCegtsXQuuTY/odOJIAAAAASUVORK5CYII="
+                                      alt=""
+                                  /></a>
+                                  <div
+                                    class="CybotCookiebotDialogDetailBodyContentCookieInfoWrapper CybotCookiebotDialogHide"
+                                  >
+                                    <div
+                                      class="CybotCookiebotDialogDetailBodyContentCookieInfo"
+                                    >
+                                      <strong
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoTitle"
+                                        >_/set_cookie</strong
+                                      ><span
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoDescription"
+                                        >Pending</span
+                                      >
+                                      <div
+                                        class="CybotCookiebotDialogDetailBodyContentCookieInfoFooter"
+                                      >
+                                        <span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                          ><b>Maximum Storage Duration</b>:
+                                          Session</span
+                                        ><span
+                                          class="CybotCookiebotDialogDetailBodyContentCookieInfoFooterContent"
+                                          ><b>Type</b>: Pixel Tracker</span
+                                        >
+                                      </div>
+                                    </div>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div id="CybotCookiebotDialogDetailBulkConsent" lang="en">
+                  <a
+                    id="CybotCookiebotDialogDetailBulkConsentLink"
+                    href="#"
+                    class="CybotExpandLink CybotCookiebotDialogCollapsed"
+                    data-target="CybotCookiebotDialogDetailBulkConsentListWrapper"
+                    >Cross-domain consent<span
+                      class="CybotCookiebotDialogDetailBulkConsentCount"
+                      >7</span
+                    ></a
+                  >
+                  <span class="CybotCookiebotDialogDetailBulkConsentDescription"
+                    >Your consent applies to the following domains:</span
+                  >
+                  <div
+                    id="CybotCookiebotDialogDetailBulkConsentListWrapper"
+                    class="CybotCookiebotDialogHide"
+                    aria-expanded="false"
+                  >
+                    <span>List of domains your consent applies to:</span>
+                    <dl id="CybotCookiebotDialogDetailBulkConsentList">
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://www.cookiebot.com"
+                          rel="noopener noreferrer nofollow"
+                          >www.cookiebot.com</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://admin.cookiebot.com"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          admin.cookiebot.com</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://manage.cookiebot.com"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          manage.cookiebot.com</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://support.cookiebot.com"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          support.cookiebot.com</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://www.cybot.com"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          www.cybot.com</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://admin.usercentrics.eu"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          admin.usercentrics.eu</a
+                        >
+                      </dt>
+                      <dt>
+                        <a
+                          target="_blank"
+                          href="https://account.usercentrics.eu/?lng=en"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          account.usercentrics.eu</a
+                        >
+                      </dt>
+                    </dl>
+                  </div>
+                </div>
+                <div id="CybotCookiebotDialogDetailFooter" lang="en">
+                  Cookie declaration last updated on 8/27/25 by
+                  <a
+                    href="https://www.cookiebot.com"
+                    target="_blank"
+                    rel="noopener"
+                    title="Cookiebot"
+                    >Cookiebot</a
+                  >
+                </div>
+              </div>
+            </div>
+            <div class="CybotCookiebotScrollbarContainer"></div>
+          </div>
+          <div class="CybotCookiebotScrollContainer CybotCookiebotDialogHide">
+            <div
+              id="CybotCookiebotDialogDetailBodyContentTextIABv2"
+              class="CybotCookiebotDialogTabPanel CybotCookiebotDialogHide CybotCookiebotScrollArea"
+              role="tabpanel"
+              aria-labelledby="CybotCookiebotDialogNavAdSettings"
+              lang="en"
+            >
+              <div
+                class="CybotCookiebotFader"
+                style="
+                  background-image: linear-gradient(
+                    to top,
+                    rgb(255, 255, 255),
+                    rgba(255, 255, 255, 0.8),
+                    rgba(255, 255, 255, 0)
+                  );
+                "
+              ></div>
+              <div id="CybotCookiebotDialogDetailBodyContentIABContainer">
+                <div id="CybotCookiebotDialogDetailBodyContentIABv2Tabs">
+                  <div
+                    class="CybotCookiebotDialogDetailBodyContentIABv2TabsIntro"
+                  >
+                    <div
+                      class="CybotCookiebotDialogBodyContentHeading"
+                      role="heading"
+                      aria-level="2"
+                    >
+                      [#IABV2_TITLE#]
+                    </div>
+                    [#IABV2_BODY_INTRO#]
+                  </div>
+                  <div
+                    class="CybotCookiebotDialogDetailBodyContentIABv2TabsIntro"
+                  >
+                    [#IABV2_BODY_LEGITIMATE_INTEREST_INTRO#]
+                  </div>
+                  <div
+                    class="CybotCookiebotDialogDetailBodyContentIABv2TabsIntro"
+                  >
+                    [#IABV2_BODY_PREFERENCE_INTRO#]
+                  </div>
+                  <div class="CookieCard">
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2PurposesCard"
+                    >
+                      <button
+                        id="CybotCookiebotDialogDetailBodyContentIABv2Purposes"
+                        class="CybotCookiebotDialogDetailBodyContentIABv2Tab CybotCookiebotDialogCollapsed"
+                        tabindex="0"
+                        data-target="CybotCookiebotDialogDetailBodyContentIABv2PurposesBody"
+                        lang="en"
+                        aria-label="[#IABV2_LABEL_PURPOSES_ARIA_LABEL#]"
+                        aria-controls="CybotCookiebotDialogDetailBodyContentIABv2PurposesBody"
+                      >
+                        [#IABV2_LABEL_PURPOSES#]
+                      </button>
+                      <div
+                        class="CybotCookiebotDialogDetailBodyContentIABv2CardIntro"
+                      >
+                        [#IABV2_BODY_PURPOSES_INTRO#]
+                      </div>
+                    </div>
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2PurposesBody"
+                      class="CollapseCard CybotCookiebotDialogHide"
+                      aria-labelledby="CybotCookiebotDialogDetailBodyContentIABv2PurposesCard"
+                      aria-expanded="false"
+                    >
+                      [#IABV2_BODY_PURPOSES#]
+                    </div>
+                  </div>
+                  <div class="CookieCard">
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2FeaturesCard"
+                    >
+                      <button
+                        id="CybotCookiebotDialogDetailBodyContentIABv2Features"
+                        class="CybotCookiebotDialogDetailBodyContentIABv2Tab CybotCookiebotDialogCollapsed"
+                        tabindex="0"
+                        data-target="CybotCookiebotDialogDetailBodyContentIABv2FeaturesBody"
+                        lang="en"
+                        aria-label="[#IABV2_LABEL_FEATURES_ARIA_LABEL#]"
+                        aria-controls="CybotCookiebotDialogDetailBodyContentIABv2FeaturesBody"
+                      >
+                        [#IABV2_LABEL_FEATURES#]
+                      </button>
+                      <div
+                        class="CybotCookiebotDialogDetailBodyContentIABv2CardIntro"
+                      >
+                        [#IABV2_BODY_FEATURES_INTRO#]
+                      </div>
+                    </div>
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2FeaturesBody"
+                      class="CollapseCard CybotCookiebotDialogHide"
+                      aria-labelledby="CybotCookiebotDialogDetailBodyContentIABv2FeaturesCard"
+                      aria-expanded="false"
+                    >
+                      [#IABV2_BODY_FEATURES#]
+                    </div>
+                  </div>
+                  <div class="CookieCard">
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2PartnersCard"
+                    >
+                      <button
+                        id="CybotCookiebotDialogDetailBodyContentIABv2Partners"
+                        class="CybotCookiebotDialogDetailBodyContentIABv2Tab CybotCookiebotDialogCollapsed"
+                        tabindex="0"
+                        data-target="CybotCookiebotDialogDetailBodyContentIABv2PartnersBody"
+                        lang="en"
+                        aria-label="[#IABV2_LABEL_PARTNERS_ARIA_LABEL#]"
+                        aria-controls="CybotCookiebotDialogDetailBodyContentIABv2PartnersBody"
+                      >
+                        [#IABV2_LABEL_PARTNERS#]
+                      </button>
+                      <div
+                        class="CybotCookiebotDialogDetailBodyContentIABv2CardIntro"
+                      >
+                        [#IABV2_BODY_PARTNERS_INTRO#]
+                      </div>
+                    </div>
+                    <div
+                      id="CybotCookiebotDialogDetailBodyContentIABv2PartnersBody"
+                      class="CollapseCard CybotCookiebotDialogHide"
+                      aria-labelledby="CybotCookiebotDialogDetailBodyContentIABv2PartnersCard"
+                      aria-expanded="false"
+                    >
+                      [#IABV2_BODY_PARTNERS#]
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="CybotCookiebotScrollbarContainer"></div>
+          </div>
+          <div class="CybotCookiebotScrollContainer CybotCookiebotDialogHide">
+            <div
+              id="CybotCookiebotDialogDetailBodyContentTextAbout"
+              class="CybotCookiebotDialogTabPanel CybotCookiebotDialogHide CybotCookiebotScrollArea"
+              role="tabpanel"
+              aria-labelledby="CybotCookiebotDialogNavAbout"
+              lang="en"
+            >
+              <div
+                class="CybotCookiebotDialogSROnly"
+                role="heading"
+                aria-level="2"
+              >
+                About
+              </div>
+              <div
+                class="CybotCookiebotFader"
+                style="
+                  background-image: linear-gradient(
+                    to top,
+                    rgb(255, 255, 255),
+                    rgba(255, 255, 255, 0.8),
+                    rgba(255, 255, 255, 0)
+                  );
+                "
+              ></div>
+              Cookies are small text files that can be used by websites to make
+              a user's experience more efficient.<br style="" /><br
+                style=""
+              />The law states that we can store cookies on your device if they
+              are strictly necessary for the operation of this site. For all
+              other types of cookies we need your permission.&nbsp;This means
+              that cookies which are categorized as necessary, are processed
+              based on GDPR Art. 6 (1) (f). All other cookies, meaning those
+              from the categories preferences and marketing, are processed based
+              on GDPR Art. 6 (1) (a) GDPR.<br style="" /><br style="" />This
+              site uses different types of cookies. Some cookies are placed by
+              third party services that appear on our pages.<br style="" /><br
+                style=""
+              />You can at any time change or withdraw your consent from the
+              <a
+                href="https://www.cookiebot.com/en/cookie-declaration/"
+                style="color: rgba(16, 50, 207, 1)"
+                >Cookie Declaration</a
+              >
+              on our website.<br style="" /><br style="" />Learn more about who
+              we are, how you can contact us and how we process personal data in
+              our
+              <a
+                style="color: rgba(16, 50, 207, 1)"
+                href="https://www.cookiebot.com/en/privacy-policy/"
+                >Privacy Policy</a
+              >.<br style="" /><br style="" />Please state your consent ID and
+              date when you contact us regarding your consent.
+              <div style="">
+                <strong
+                  data-stringify-type="bold"
+                  style="
+                    box-sizing: inherit;
+                    color: rgba(209, 210, 211, 1);
+                    font-family: Slack-Lato, Slack-Fractions, appleLogo,
+                      sans-serif;
+                    font-size: 15px;
+                    font-variant-ligatures: common-ligatures;
+                    background-color: rgba(34, 37, 41, 1);
+                  "
+                  ><br style=""
+                /></strong>
+              </div>
+              <br /><br />
+            </div>
+            <div class="CybotCookiebotScrollbarContainer"></div>
+          </div>
+        </div>
+        <div
+          id="CybotCookiebotDialogFooter"
+          class="CybotCookiebotScrollContainer"
+        >
+          <div class="CybotCookiebotScrollArea">
+            <div id="CybotCookiebotDialogBodyButtons">
+              <div
+                class="CybotCookiebotDialogBodyLevelButtonWrapper CybotCookiebotDialogBodyContentControlsWrapper CybotCookiebotDialogHide"
+              >
+                <form class="CybotCookiebotDialogBodyLevelButtonSliderWrapper">
+                  <input
+                    type="checkbox"
+                    id="CybotCookiebotDialogBodyContentCheckboxPersonalInformation"
+                    class="CybotCookiebotDialogBodyLevelButton"
+                  />
+                  <span
+                    class="CybotCookiebotDialogBodyLevelButtonSlider"
+                  ></span>
+                </form>
+                <label
+                  class="CybotCookiebotDialogBodyLevelButtonLabel"
+                  for="CybotCookiebotDialogBodyContentCheckboxPersonalInformation"
+                  ><strong
+                    class="CybotCookiebotDialogBodyLevelButtonDescription"
+                    >Do not sell or share my personal information</strong
+                  ></label
+                >
+              </div>
+              <div id="CybotCookiebotDialogBodyButtonsWrapper">
+                <button
+                  id="CybotCookiebotDialogBodyButtonDecline"
+                  class="CybotCookiebotDialogBodyButton"
+                  tabindex="0"
+                  lang="en"
+                >
+                  Deny
+                </button>
+                <button
+                  id="CybotCookiebotDialogBodyLevelButtonLevelOptinAllowallSelection"
+                  class="CybotCookiebotDialogBodyButton CybotCookiebotDialogHide"
+                  tabindex="0"
+                  lang="en"
+                >
+                  Allow selection
+                </button>
+                <button
+                  id="CybotCookiebotDialogBodyLevelButtonCustomize"
+                  class="CybotCookiebotDialogBodyButton"
+                  tabindex="0"
+                  lang="en"
+                >
+                  Customize
+                  <div class="CybotCookiebotDialogArrow"></div>
+                </button>
+                <button
+                  id="CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll"
+                  class="CybotCookiebotDialogBodyButton"
+                  tabindex="0"
+                  lang="en"
+                >
+                  Allow all
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="CybotCookiebotScrollbarContainer"></div>
+        </div>
+        <button
+          id="CybotCookiebotBannerCloseButtonE2E"
+          class="CybotCookiebotBannerCloseButton"
+          aria-label=""
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+          >
+            <path
+              d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+            ></path>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tracker/test/fixtures/cookies-iubenda.html
+++ b/tracker/test/fixtures/cookies-iubenda.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plausible Playwright tests</title>
+  </head>
+
+  <body>
+    iubenda fixture
+    <div
+      id="iubenda-cs-banner"
+      style="z-index: 99999998 !important"
+      class="iubenda-cs-default-floating iubenda-cs-top iubenda-cs-center iubenda-cs-slidein iubenda-cs-branded iubenda-cs-padded iubenda-cs-visible"
+      role="alertdialog"
+      aria-describedby="iubenda-cs-paragraph"
+      aria-labelledby="iubenda-cs-title"
+    >
+      <div role="region" class="iubenda-cs-container iubenda-cs-themed">
+        <div
+          class="iubenda-cs-content"
+          style="
+            background-color: white !important;
+            color: black !important;
+            font-size: 14px !important;
+          "
+        >
+          <div class="iubenda-cs-rationale">
+            <div class="iubenda-cs-brand">
+              <img
+                src="/assets/site/general/logo-whiteongreen-18a11ce988ecc91e9cd5433bcdc55e4023983ea75b8542ca108728f511881cf1.svg"
+                alt="logo"
+              />
+            </div>
+            <button
+              type="button"
+              class="iubenda-cs-close-btn"
+              tabindex="0"
+              role="button"
+              aria-label="Close this notice"
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+            <div
+              class="iubenda-banner-content iubenda-custom-content iubenda-banner-content-padded"
+              role="document"
+            >
+              <h2 id="iubenda-cs-title">Notice</h2>
+              <div id="iubenda-cs-paragraph" class="iubenda-cs-no-margin-top">
+                <p class="iub-p">
+                  We and selected third parties use cookies or similar
+                  technologies for technical purposes and, with your consent,
+                  for other purposes as specified in the
+                  <a
+                    href="https://www.iubenda.com/privacy-policy/252372/cookie-policy?an=no&amp;s_ck=false&amp;newmarkup=yes"
+                    role="button"
+                    target="_blank"
+                    rel="noopener"
+                    class="iubenda-cs-cookie-policy-lnk"
+                    >cookie policy</a
+                  >.
+                </p>
+                <p class="iub-p"></p>
+                <p class="iub-p">
+                  Use the “Accept” button to consent. Use the “Reject” button or
+                  close this notice to continue without accepting.
+                </p>
+              </div>
+            </div>
+            <div class="iubenda-cs-counter" style="display: none">
+              Press again to continue 0/1
+            </div>
+            <div class="iubenda-cs-opt-group" style="color: white !important">
+              <div class="iubenda-cs-opt-group-custom">
+                <button
+                  class="iubenda-cs-customize-btn"
+                  tabindex="0"
+                  role="button"
+                >
+                  Learn more and customize
+                </button>
+              </div>
+              <div class="iubenda-cs-opt-group-consent">
+                <button
+                  class="iubenda-cs-reject-btn iubenda-cs-btn-primary"
+                  tabindex="0"
+                  role="button"
+                >
+                  Reject</button
+                ><button
+                  class="iubenda-cs-accept-btn iubenda-cs-btn-primary"
+                  tabindex="0"
+                  role="button"
+                >
+                  Accept
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="iubenda-cs-brand-badge-outer">
+          <a
+            class="iubenda-cs-brand-badge"
+            href="https://www.iubenda.com/en/cookie-solution?utm_source=cs&amp;utm_medium=web&amp;utm_campaign=csbr2"
+            target="_blank"
+            rel="noopener"
+            title="iubenda - Cookie Policy and Cookie Compliance Management"
+            ><span
+              >Created with <span>iubenda</span
+              ><span class="iub-sr-only">(link opens in a new tab)</span></span
+            ></a
+          >
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tracker/test/fixtures/cookies-onetrust.html
+++ b/tracker/test/fixtures/cookies-onetrust.html
@@ -1,0 +1,809 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style id="onetrust-style">
+      #onetrust-banner-sdk{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}#onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{height:64px;width:64px}#onetrust-banner-sdk .ot-tcf2-vendor-count.ot-text-bold{font-weight:bold}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block;text-decoration:none;font-size:.75em}#onetrust-banner-sdk .powered-by-logo:hover,#onetrust-banner-sdk .ot-pc-footer-logo a:hover,#onetrust-pc-sdk .powered-by-logo:hover,#onetrust-pc-sdk .ot-pc-footer-logo a:hover,#ot-sync-ntfy .powered-by-logo:hover,#ot-sync-ntfy .ot-pc-footer-logo a:hover{color:#565656}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-banner-sdk button.ot-link-btn:hover,#onetrust-pc-sdk button.ot-link-btn:hover,#ot-sync-ntfy button.ot-link-btn:hover{text-decoration:underline;opacity:1}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type=checkbox]:checked,#onetrust-pc-sdk [type=checkbox]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type=checkbox]:disabled+label::before,#onetrust-pc-sdk [type=checkbox]:disabled+label:after,#onetrust-pc-sdk [type=checkbox]:disabled+label{pointer-events:none;opacity:.7}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type=checkbox]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type=checkbox]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px .1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat;display:inline-flex;justify-content:center;align-items:center}#onetrust-pc-sdk .pc-logo img,#onetrust-pc-sdk .ot-pc-logo img{max-height:100%;max-width:100%}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#68b631;border:1px solid #68b631;height:auto;white-space:normal;word-wrap:break-word;padding:.8em 2em;font-size:.8em;line-height:1.2;cursor:pointer;-moz-transition:.1s ease;-o-transition:.1s ease;-webkit-transition:1s ease;transition:.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#68b631}.onetrust-pc-dark-filter{background:rgba(0,0,0,.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px)and (max-width: 896px)and (orientation: landscape){#onetrust-pc-sdk p{font-size:.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info a,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info a{margin-right:auto}#onetrust-pc-sdk .ot-pc-footer-logo img{width:136px;height:16px}#onetrust-pc-sdk .ot-pur-vdr-count{font-weight:400;font-size:.7rem;padding-top:3px;display:block}#onetrust-banner-sdk .ot-optout-signal,#onetrust-pc-sdk .ot-optout-signal{border:1px solid #32ae88;border-radius:3px;padding:5px;margin-bottom:10px;background-color:#f9fffa;font-size:.85rem;line-height:2}#onetrust-banner-sdk .ot-optout-signal .ot-optout-icon,#onetrust-pc-sdk .ot-optout-signal .ot-optout-icon{display:inline;margin-right:5px}#onetrust-banner-sdk .ot-optout-signal svg,#onetrust-pc-sdk .ot-optout-signal svg{height:20px;width:30px;transform:scale(0.5)}#onetrust-banner-sdk .ot-optout-signal svg path,#onetrust-pc-sdk .ot-optout-signal svg path{fill:#32ae88}#onetrust-consent-sdk .ot-general-modal{overflow:hidden;position:fixed;margin:0 auto;top:50%;left:50%;width:40%;padding:1.5rem;max-width:575px;min-width:575px;z-index:2147483647;border-radius:2.5px;transform:translate(-50%, -50%)}#onetrust-consent-sdk .ot-signature-health-group{margin-top:1rem;padding-left:1.25rem;padding-right:1.25rem;margin-bottom:.625rem;width:calc(100% - 2.5rem)}#onetrust-consent-sdk .ot-signature-health-group .ot-signature-health-form{gap:.5rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-health-form{width:70%;gap:.35rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-input{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-consent-sdk .ot-signature-health .ot-signature-subtitle{font-size:1.125rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-group-title{font-size:1.125rem;font-weight:bold}#onetrust-consent-sdk .ot-signature-health,#onetrust-consent-sdk .ot-signature-health-group{display:flex;flex-direction:column;gap:1rem}#onetrust-consent-sdk .ot-signature-health .ot-signature-cont,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-cont{display:flex;flex-direction:column;gap:.25rem}#onetrust-consent-sdk .ot-signature-health .ot-signarure-paragraph,#onetrust-consent-sdk .ot-signature-health-group .ot-signarure-paragraph{margin:0;line-height:20px;font-size:max(14px,.875rem)}#onetrust-consent-sdk .ot-signature-health .ot-health-signature-error,#onetrust-consent-sdk .ot-signature-health-group .ot-health-signature-error{color:#4d4d4d;font-size:min(12px,.75rem)}#onetrust-consent-sdk .ot-signature-health .ot-signature-buttons-cont,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-buttons-cont{margin-top:max(.75rem,2%);gap:1rem;display:flex;justify-content:flex-end}#onetrust-consent-sdk .ot-signature-health .ot-signature-button,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-button{flex:1;height:auto;color:#fff;cursor:pointer;line-height:1.2;min-width:125px;font-weight:600;font-size:.813em;border-radius:2px;padding:12px 10px;white-space:normal;word-wrap:break-word;word-break:break-word;background-color:#68b631;border:2px solid #68b631}#onetrust-consent-sdk .ot-signature-health .ot-signature-button.reject,#onetrust-consent-sdk .ot-signature-health-group .ot-signature-button.reject{background-color:#fff}#onetrust-consent-sdk .ot-input-field-cont{display:flex;flex-direction:column;gap:.5rem}#onetrust-consent-sdk .ot-input-field-cont .ot-signature-input{width:65%}#onetrust-consent-sdk .ot-signature-health-form{display:flex;flex-direction:column}#onetrust-consent-sdk .ot-signature-health-form .ot-signature-label{margin-bottom:0;line-height:20px;font-size:max(14px,.875rem)}@media only screen and (max-width: 600px){#onetrust-consent-sdk .ot-general-modal{min-width:100%}#onetrust-consent-sdk .ot-signature-health .ot-signature-health-form{width:100%}#onetrust-consent-sdk .ot-input-field-cont .ot-signature-input{width:100%}}#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media(min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media(min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media(min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p,#onetrust-pc-sdk p,#ot-sdk-cookie-policy p{margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:.9em;font-weight:400;line-height:38px;letter-spacing:.01em;text-decoration:none;white-space:nowrap;background-color:rgba(0,0,0,0);border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus{color:#333;border-color:#888;opacity:.7}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type=text]:focus,#onetrust-pc-sdk input[type=text]:focus,#ot-sdk-cookie-policy input[type=text]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:.5rem;font-weight:600}#onetrust-banner-sdk input[type=checkbox],#onetrust-pc-sdk input[type=checkbox],#ot-sdk-cookie-policy input[type=checkbox]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block}#onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold;margin-left:5px}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{position:absolute;top:50%;transform:translateY(-50%);left:0px}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-policy{margin-left:65px}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid rgba(0,0,0,0);border-bottom:6px solid rgba(0,0,0,0);border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-button-group-parent{padding-left:50px}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-accept-btn-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-reject-all-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-accept-btn-handler,#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group #onetrust-reject-all-handler{float:left}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:75%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk .ot-optout-signal{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
+                  #onetrust-consent-sdk #onetrust-banner-sdk {background-color: #FFFFFF;}
+                      #onetrust-consent-sdk #onetrust-policy-title,
+                              #onetrust-consent-sdk #onetrust-policy-text,
+                              #onetrust-consent-sdk .ot-b-addl-desc,
+                              #onetrust-consent-sdk .ot-dpd-desc,
+                              #onetrust-consent-sdk .ot-dpd-title,
+                              #onetrust-consent-sdk #onetrust-policy-text *:not(.onetrust-vendors-list-handler),
+                              #onetrust-consent-sdk .ot-dpd-desc *:not(.onetrust-vendors-list-handler),
+                              #onetrust-consent-sdk #onetrust-banner-sdk #banner-options *,
+                              #onetrust-banner-sdk .ot-cat-header,
+                              #onetrust-banner-sdk .ot-optout-signal
+                              {
+                                  color: #2b273c;
+                              }
+                      #onetrust-consent-sdk #onetrust-banner-sdk .banner-option-details {
+                              background-color: #E9E9E9;}
+                       #onetrust-consent-sdk #onetrust-banner-sdk a[href],
+                              #onetrust-consent-sdk #onetrust-banner-sdk a[href] font,
+                              #onetrust-consent-sdk #onetrust-banner-sdk .ot-link-btn
+                                  {
+                                      color: #2B273C;
+                                  }#onetrust-consent-sdk #onetrust-accept-btn-handler,
+                                   #onetrust-banner-sdk #onetrust-reject-all-handler {
+                                      background-color: #E00707;border-color: #E00707;
+                          color: #FFFFFF;
+                      }
+                      #onetrust-consent-sdk #onetrust-banner-sdk *:focus,
+                      #onetrust-consent-sdk #onetrust-banner-sdk:focus {
+                         outline-color: #000000;
+                         outline-width: 1px;
+                      }
+                      #onetrust-consent-sdk #onetrust-pc-btn-handler,
+                      #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+                          color: #2B273C; border-color: #2B273C;
+                          background-color:
+                          #FFFFFF;
+                      }#onetrust-banner-sdk {
+              font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif !important;
+              text-decoration: none !important;
+          }
+
+          #onetrust-accept-btn-handler {
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 40px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+          }
+
+          #onetrust-reject-all-handler {
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 40px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+          }
+
+          #onetrust-pc-btn-handler {
+              color: #2b273c !important;
+              background: transparent !important;
+              border: 1px solid #bbbac0 !important;
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 40px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+          }
+
+          #onetrust-policy-title {
+              font-size: 20px !important;
+              line-height: 26px !important;
+              font-weight: 700 !important;
+          }
+
+          #onetrust-policy-text {
+              line-height: 22px !important;
+              font-size: 16px !important;
+          }#onetrust-pc-sdk.otPcCenter{overflow:hidden;position:fixed;margin:0 auto;top:5%;right:0;left:0;width:40%;max-width:575px;min-width:575px;border-radius:2.5px;z-index:2147483647;background-color:#fff;-webkit-box-shadow:0px 2px 10px -3px #999;-moz-box-shadow:0px 2px 10px -3px #999;box-shadow:0px 2px 10px -3px #999}#onetrust-pc-sdk.otPcCenter[dir=rtl]{right:0;left:0}#onetrust-pc-sdk.otRelFont{font-size:1rem}#onetrust-pc-sdk .ot-optout-signal{margin-top:.625rem}#onetrust-pc-sdk #ot-addtl-venlst .ot-arw-cntr,#onetrust-pc-sdk #ot-addtl-venlst .ot-plus-minus,#onetrust-pc-sdk .ot-hide-tgl{visibility:hidden}#onetrust-pc-sdk #ot-addtl-venlst .ot-arw-cntr *,#onetrust-pc-sdk #ot-addtl-venlst .ot-plus-minus *,#onetrust-pc-sdk .ot-hide-tgl *{visibility:hidden}#onetrust-pc-sdk #ot-gn-venlst .ot-ven-item .ot-acc-hdr{min-height:40px}#onetrust-pc-sdk .ot-pc-header{height:39px;padding:10px 0 10px 30px;border-bottom:1px solid #e9e9e9}#onetrust-pc-sdk #ot-pc-title,#onetrust-pc-sdk #ot-category-title,#onetrust-pc-sdk .ot-cat-header,#onetrust-pc-sdk #ot-lst-title,#onetrust-pc-sdk .ot-ven-hdr .ot-ven-name,#onetrust-pc-sdk .ot-always-active{font-weight:bold;color:dimgray}#onetrust-pc-sdk .ot-always-active-group .ot-cat-header{width:55%;font-weight:700}#onetrust-pc-sdk .ot-cat-item p{clear:both;float:left;margin-top:10px;margin-bottom:5px;line-height:1.5;font-size:.812em;color:dimgray}#onetrust-pc-sdk .ot-close-icon{height:44px;width:44px;background-size:10px}#onetrust-pc-sdk #ot-pc-title{float:left;font-size:1em;line-height:1.5;margin-bottom:10px;margin-top:10px;width:100%}#onetrust-pc-sdk #accept-recommended-btn-handler{margin-right:10px;margin-bottom:25px;outline-offset:-1px}#onetrust-pc-sdk #ot-pc-desc{clear:both;width:100%;font-size:.812em;line-height:1.5;margin-bottom:25px}#onetrust-pc-sdk #ot-pc-desc a{margin-left:5px}#onetrust-pc-sdk #ot-pc-desc *{font-size:inherit;line-height:inherit}#onetrust-pc-sdk #ot-pc-desc ul li{padding:10px 0px}#onetrust-pc-sdk a{color:#656565;cursor:pointer}#onetrust-pc-sdk a:hover{color:#3860be}#onetrust-pc-sdk label{margin-bottom:0}#onetrust-pc-sdk #vdr-lst-dsc{font-size:.812em;line-height:1.5;padding:10px 15px 5px 15px}#onetrust-pc-sdk button{max-width:394px;padding:12px 30px;line-height:1;word-break:break-word;word-wrap:break-word;white-space:normal;font-weight:bold;height:auto}#onetrust-pc-sdk .ot-link-btn{padding:0;margin-bottom:0;border:0;font-weight:normal;line-height:normal;width:auto;height:auto}#onetrust-pc-sdk #ot-pc-content{position:absolute;overflow-y:scroll;padding-left:0px;padding-right:30px;top:60px;bottom:110px;margin:1px 3px 0 30px;width:calc(100% - 63px)}#onetrust-pc-sdk .ot-vs-list .ot-always-active,#onetrust-pc-sdk .ot-cat-grp .ot-always-active{float:right;clear:none;color:#3860be;margin:0;font-size:.813em;line-height:1.3}#onetrust-pc-sdk .ot-pc-scrollbar::-webkit-scrollbar-track{margin-right:20px}#onetrust-pc-sdk .ot-pc-scrollbar::-webkit-scrollbar{width:11px}#onetrust-pc-sdk .ot-pc-scrollbar::-webkit-scrollbar-thumb{border-radius:10px;background:#d8d8d8}#onetrust-pc-sdk input[type=checkbox]:focus+.ot-acc-hdr{outline:#000 1px solid}#onetrust-pc-sdk .ot-pc-scrollbar{scrollbar-arrow-color:#d8d8d8;scrollbar-darkshadow-color:#d8d8d8;scrollbar-face-color:#d8d8d8;scrollbar-shadow-color:#d8d8d8}#onetrust-pc-sdk .save-preference-btn-handler{margin-right:20px}#onetrust-pc-sdk .ot-pc-refuse-all-handler{margin-right:10px}#onetrust-pc-sdk #ot-pc-desc .privacy-notice-link{margin-left:0;margin-right:8px}#onetrust-pc-sdk #ot-pc-desc .ot-imprint-handler{margin-left:0;margin-right:8px}#onetrust-pc-sdk .ot-subgrp-cntr{display:inline-block;clear:both;width:100%;padding-top:15px}#onetrust-pc-sdk .ot-switch+.ot-subgrp-cntr{padding-top:10px}#onetrust-pc-sdk ul.ot-subgrps{margin:0;font-size:initial}#onetrust-pc-sdk ul.ot-subgrps li p,#onetrust-pc-sdk ul.ot-subgrps li h5{font-size:.813em;line-height:1.4;color:dimgray}#onetrust-pc-sdk ul.ot-subgrps .ot-switch{min-height:auto}#onetrust-pc-sdk ul.ot-subgrps .ot-switch-nob{top:0}#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr{display:inline-block;width:100%}#onetrust-pc-sdk ul.ot-subgrps .ot-acc-txt{margin:0}#onetrust-pc-sdk ul.ot-subgrps li{padding:0;border:none}#onetrust-pc-sdk ul.ot-subgrps li h5{position:relative;top:5px;font-weight:bold;margin-bottom:0;float:left}#onetrust-pc-sdk li.ot-subgrp{margin-left:20px;overflow:auto}#onetrust-pc-sdk li.ot-subgrp>h5{width:calc(100% - 100px)}#onetrust-pc-sdk .ot-cat-item p>ul,#onetrust-pc-sdk li.ot-subgrp p>ul{margin:0px;list-style:disc;margin-left:15px;font-size:inherit}#onetrust-pc-sdk .ot-cat-item p>ul li,#onetrust-pc-sdk li.ot-subgrp p>ul li{font-size:inherit;padding-top:10px;padding-left:0px;padding-right:0px;border:none}#onetrust-pc-sdk .ot-cat-item p>ul li:last-child,#onetrust-pc-sdk li.ot-subgrp p>ul li:last-child{padding-bottom:10px}#onetrust-pc-sdk .ot-pc-logo{height:40px;width:120px}#onetrust-pc-sdk .ot-pc-footer{position:absolute;bottom:0px;width:100%;max-height:160px;border-top:1px solid #d8d8d8}#onetrust-pc-sdk.ot-ftr-stacked .ot-pc-refuse-all-handler{margin-bottom:0px}#onetrust-pc-sdk.ot-ftr-stacked #ot-pc-content{bottom:160px}#onetrust-pc-sdk.ot-ftr-stacked .ot-pc-footer button{width:100%;max-width:none}#onetrust-pc-sdk.ot-ftr-stacked .ot-btn-container{margin:0 30px;width:calc(100% - 60px);padding-right:0}#onetrust-pc-sdk .ot-pc-footer-logo{height:30px;width:100%;text-align:right;background:#f4f4f4}#onetrust-pc-sdk .ot-pc-footer-logo a{display:inline-block;margin-top:5px;margin-right:10px}#onetrust-pc-sdk[dir=rtl] .ot-pc-footer-logo{direction:rtl}#onetrust-pc-sdk[dir=rtl] .ot-pc-footer-logo a{margin-right:25px}#onetrust-pc-sdk .ot-tgl{float:right;position:relative;z-index:1}#onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob{background-color:#468254;border:1px solid #fff}#onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob:before{-webkit-transform:translateX(20px);-ms-transform:translateX(20px);transform:translateX(20px);background-color:#fff;border-color:#fff}#onetrust-pc-sdk .ot-tgl input:focus+.ot-switch{outline:#000 solid 1px}#onetrust-pc-sdk .ot-switch{position:relative;display:inline-block;width:45px;height:25px}#onetrust-pc-sdk .ot-switch-nob{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:#767676;border:1px solid #ddd;transition:all .2s ease-in 0s;-moz-transition:all .2s ease-in 0s;-o-transition:all .2s ease-in 0s;-webkit-transition:all .2s ease-in 0s;border-radius:20px}#onetrust-pc-sdk .ot-switch-nob:before{position:absolute;content:"";height:18px;width:18px;bottom:3px;left:3px;background-color:#fff;-webkit-transition:.4s;transition:.4s;border-radius:20px}#onetrust-pc-sdk .ot-chkbox input:checked~label::before{background-color:#3860be}#onetrust-pc-sdk .ot-chkbox input+label::after{content:none;color:#fff}#onetrust-pc-sdk .ot-chkbox input:checked+label::after{content:""}#onetrust-pc-sdk .ot-chkbox input:focus+label::before{outline-style:solid;outline-width:2px;outline-style:auto}#onetrust-pc-sdk .ot-chkbox label{position:relative;display:inline-block;padding-left:30px;cursor:pointer;font-weight:500}#onetrust-pc-sdk .ot-chkbox label::before,#onetrust-pc-sdk .ot-chkbox label::after{position:absolute;content:"";display:inline-block;border-radius:3px}#onetrust-pc-sdk .ot-chkbox label::before{height:18px;width:18px;border:1px solid #3860be;left:0px;top:auto}#onetrust-pc-sdk .ot-chkbox label::after{height:5px;width:9px;border-left:3px solid;border-bottom:3px solid;transform:rotate(-45deg);-o-transform:rotate(-45deg);-ms-transform:rotate(-45deg);-webkit-transform:rotate(-45deg);left:4px;top:5px}#onetrust-pc-sdk .ot-label-txt{display:none}#onetrust-pc-sdk .ot-chkbox input,#onetrust-pc-sdk .ot-tgl input{position:absolute;opacity:0;width:0;height:0}#onetrust-pc-sdk .ot-arw-cntr{float:right;position:relative;pointer-events:none}#onetrust-pc-sdk .ot-arw-cntr .ot-arw{width:16px;height:16px;margin-left:5px;color:dimgray;display:inline-block;vertical-align:middle;-webkit-transition:all 150ms ease-in 0s;-moz-transition:all 150ms ease-in 0s;-o-transition:all 150ms ease-in 0s;transition:all 150ms ease-in 0s}#onetrust-pc-sdk input:checked~.ot-acc-hdr .ot-arw,#onetrust-pc-sdk button[aria-expanded=true]~.ot-acc-hdr .ot-arw-cntr svg{transform:rotate(90deg);-o-transform:rotate(90deg);-ms-transform:rotate(90deg);-webkit-transform:rotate(90deg)}#onetrust-pc-sdk input[type=checkbox]:focus+.ot-acc-hdr{outline:#000 1px solid}#onetrust-pc-sdk .ot-tgl-cntr,#onetrust-pc-sdk .ot-arw-cntr{display:inline-block}#onetrust-pc-sdk .ot-tgl-cntr{width:45px;float:right;margin-top:2px}#onetrust-pc-sdk #ot-lst-cnt .ot-tgl-cntr{margin-top:10px}#onetrust-pc-sdk .ot-always-active-subgroup{width:auto;padding-left:0px !important;top:3px;position:relative}#onetrust-pc-sdk .ot-label-status{padding-left:5px;font-size:.75em;display:none}#onetrust-pc-sdk .ot-arw-cntr{margin-top:-1px}#onetrust-pc-sdk .ot-arw-cntr svg{-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s;transition:all 300ms ease-in 0s;height:10px;width:10px}#onetrust-pc-sdk input:checked~.ot-acc-hdr .ot-arw{transform:rotate(90deg);-o-transform:rotate(90deg);-ms-transform:rotate(90deg);-webkit-transform:rotate(90deg)}#onetrust-pc-sdk .ot-arw{width:10px;margin-left:15px;transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-pc-sdk .ot-vlst-cntr{margin-bottom:0}#onetrust-pc-sdk .ot-hlst-cntr{margin-top:5px;display:inline-block;width:100%}#onetrust-pc-sdk .category-vendors-list-handler,#onetrust-pc-sdk .category-vendors-list-handler+a,#onetrust-pc-sdk .category-host-list-handler{clear:both;color:#3860be;margin-left:0;font-size:.813em;text-decoration:none;float:left;overflow:hidden}#onetrust-pc-sdk .category-vendors-list-handler:hover,#onetrust-pc-sdk .category-vendors-list-handler+a:hover,#onetrust-pc-sdk .category-host-list-handler:hover{text-decoration-line:underline}#onetrust-pc-sdk .category-vendors-list-handler+a{clear:none}#onetrust-pc-sdk .ot-vlst-cntr .ot-ext-lnk,#onetrust-pc-sdk .ot-ven-hdr .ot-ext-lnk{display:inline-block;height:13px;width:13px;background-repeat:no-repeat;margin-left:1px;margin-top:6px;cursor:pointer}#onetrust-pc-sdk .ot-ven-hdr .ot-ext-lnk{margin-bottom:-1px}#onetrust-pc-sdk .back-btn-handler{font-size:1em;text-decoration:none}#onetrust-pc-sdk .back-btn-handler:hover{opacity:.6}#onetrust-pc-sdk #ot-lst-title h3{display:inline-block;word-break:break-word;word-wrap:break-word;margin-bottom:0;color:#656565;font-size:1em;font-weight:bold;margin-left:15px}#onetrust-pc-sdk #ot-lst-title{margin:10px 0 10px 0px;font-size:1em;text-align:left}#onetrust-pc-sdk #ot-pc-hdr{margin:0 0 0 30px;height:auto;width:auto}#onetrust-pc-sdk #ot-pc-hdr input::placeholder{color:#d4d4d4;font-style:italic}#onetrust-pc-sdk #vendor-search-handler{height:31px;width:100%;border-radius:50px;font-size:.8em;padding-right:35px;padding-left:15px;float:left;margin-left:15px}#onetrust-pc-sdk .ot-ven-name{display:block;width:auto;padding-right:5px}#onetrust-pc-sdk #ot-lst-cnt{overflow-y:auto;margin-left:20px;margin-right:7px;width:calc(100% - 27px);max-height:calc(100% - 80px);height:100%;transform:translate3d(0, 0, 0)}#onetrust-pc-sdk #ot-pc-lst{width:100%;bottom:100px;position:absolute;top:60px}#onetrust-pc-sdk #ot-pc-lst:not(.ot-enbl-chr) .ot-tgl-cntr .ot-arw-cntr,#onetrust-pc-sdk #ot-pc-lst:not(.ot-enbl-chr) .ot-tgl-cntr .ot-arw-cntr *{visibility:hidden}#onetrust-pc-sdk #ot-pc-lst .ot-tgl-cntr{right:12px;position:absolute}#onetrust-pc-sdk #ot-pc-lst .ot-arw-cntr{float:right;position:relative}#onetrust-pc-sdk #ot-pc-lst .ot-arw{margin-left:10px}#onetrust-pc-sdk #ot-pc-lst .ot-acc-hdr{overflow:hidden;cursor:pointer}#onetrust-pc-sdk .ot-vlst-cntr{overflow:hidden}#onetrust-pc-sdk #ot-sel-blk{overflow:hidden;width:100%;position:sticky;position:-webkit-sticky;top:0;z-index:3}#onetrust-pc-sdk #ot-back-arw{height:12px;width:12px}#onetrust-pc-sdk .ot-lst-subhdr{width:100%;display:inline-block}#onetrust-pc-sdk .ot-search-cntr{float:left;width:78%;position:relative}#onetrust-pc-sdk .ot-search-cntr>svg{width:30px;height:30px;position:absolute;float:left;right:-15px}#onetrust-pc-sdk .ot-fltr-cntr{float:right;right:50px;position:relative}#onetrust-pc-sdk #filter-btn-handler{background-color:#3860be;border-radius:17px;display:inline-block;position:relative;width:32px;height:32px;-moz-transition:.1s ease;-o-transition:.1s ease;-webkit-transition:1s ease;transition:.1s ease;padding:0;margin:0}#onetrust-pc-sdk #filter-btn-handler:hover{background-color:#3860be}#onetrust-pc-sdk #filter-btn-handler svg{width:12px;height:12px;margin:3px 10px 0 10px;display:block;position:static;right:auto;top:auto}#onetrust-pc-sdk .ot-ven-link,#onetrust-pc-sdk .ot-ven-legclaim-link{color:#3860be;text-decoration:none;font-weight:100;display:inline-block;padding-top:10px;transform:translate(0, 1%);-o-transform:translate(0, 1%);-ms-transform:translate(0, 1%);-webkit-transform:translate(0, 1%);position:relative;z-index:2}#onetrust-pc-sdk .ot-ven-link *,#onetrust-pc-sdk .ot-ven-legclaim-link *{font-size:inherit}#onetrust-pc-sdk .ot-ven-link:hover,#onetrust-pc-sdk .ot-ven-legclaim-link:hover{text-decoration:underline}#onetrust-pc-sdk .ot-ven-hdr{width:calc(100% - 160px);height:auto;float:left;word-break:break-word;word-wrap:break-word;vertical-align:middle;padding-bottom:3px}#onetrust-pc-sdk .ot-ven-link,#onetrust-pc-sdk .ot-ven-legclaim-link{letter-spacing:.03em;font-size:.75em;font-weight:400}#onetrust-pc-sdk .ot-ven-dets{border-radius:2px;background-color:#f8f8f8}#onetrust-pc-sdk .ot-ven-dets li:first-child p:first-child{border-top:none}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc:not(:first-child){border-top:1px solid #ddd !important}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc:nth-child(n+3) p{display:inline-block}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc:nth-child(n+3) p:nth-of-type(odd){width:30%}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc:nth-child(n+3) p:nth-of-type(even){width:50%;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc p,#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc h4{padding-top:5px;padding-bottom:5px;display:block}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc h4{display:inline-block}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc p:nth-last-child(-n+1){padding-bottom:10px}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc p:nth-child(-n+2):not(.disc-pur){padding-top:10px}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc .disc-pur-cont{display:inline}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc .disc-pur{position:relative;width:50% !important;word-break:break-word;word-wrap:break-word;left:calc(30% + 17px)}#onetrust-pc-sdk .ot-ven-dets .ot-ven-disc .disc-pur:nth-child(-n+1){position:static}#onetrust-pc-sdk .ot-ven-dets p,#onetrust-pc-sdk .ot-ven-dets h4,#onetrust-pc-sdk .ot-ven-dets span{font-size:.69em;text-align:left;vertical-align:middle;word-break:break-word;word-wrap:break-word;margin:0;padding-bottom:10px;padding-left:15px;color:#2e3644}#onetrust-pc-sdk .ot-ven-dets h4{padding-top:5px}#onetrust-pc-sdk .ot-ven-dets span{color:dimgray;padding:0;vertical-align:baseline}#onetrust-pc-sdk .ot-ven-dets .ot-ven-pur h4{border-top:1px solid #e9e9e9;border-bottom:1px solid #e9e9e9;padding-bottom:5px;margin-bottom:5px;font-weight:bold}#onetrust-pc-sdk #ot-host-lst .ot-sel-all{float:right;position:relative;margin-right:42px;top:10px}#onetrust-pc-sdk #ot-host-lst .ot-sel-all input[type=checkbox]{width:auto;height:auto}#onetrust-pc-sdk #ot-host-lst .ot-sel-all label{height:20px;width:20px;padding-left:0px}#onetrust-pc-sdk #ot-host-lst .ot-acc-txt{overflow:hidden;width:95%}#onetrust-pc-sdk .ot-host-hdr{position:relative;z-index:1;pointer-events:none;width:calc(100% - 125px);float:left}#onetrust-pc-sdk .ot-host-name,#onetrust-pc-sdk .ot-host-desc{display:inline-block;width:90%}#onetrust-pc-sdk .ot-host-name{pointer-events:none}#onetrust-pc-sdk .ot-host-hdr>a{text-decoration:underline;font-size:.82em;position:relative;z-index:2;float:left;margin-bottom:5px;pointer-events:initial}#onetrust-pc-sdk .ot-host-name+a{margin-top:5px}#onetrust-pc-sdk .ot-host-name,#onetrust-pc-sdk .ot-host-name a,#onetrust-pc-sdk .ot-host-desc,#onetrust-pc-sdk .ot-host-info{color:dimgray;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk .ot-host-name,#onetrust-pc-sdk .ot-host-name a{font-weight:bold;font-size:.82em;line-height:1.3}#onetrust-pc-sdk .ot-host-name a{font-size:1em}#onetrust-pc-sdk .ot-host-expand{margin-top:3px;margin-bottom:3px;clear:both;display:block;color:#3860be;font-size:.72em;font-weight:normal}#onetrust-pc-sdk .ot-host-expand *{font-size:inherit}#onetrust-pc-sdk .ot-host-desc,#onetrust-pc-sdk .ot-host-info{font-size:.688em;line-height:1.4;font-weight:normal}#onetrust-pc-sdk .ot-host-desc{margin-top:10px}#onetrust-pc-sdk .ot-host-opt{margin:0;font-size:inherit;display:inline-block;width:100%}#onetrust-pc-sdk .ot-host-opt li>div div{font-size:.8em;padding:5px 0}#onetrust-pc-sdk .ot-host-opt li>div div:nth-child(1){width:30%;float:left}#onetrust-pc-sdk .ot-host-opt li>div div:nth-child(2){width:70%;float:left;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk .ot-host-info{border:none;display:inline-block;width:calc(100% - 10px);padding:10px;margin-bottom:10px;background-color:#f8f8f8}#onetrust-pc-sdk .ot-host-info>div{overflow:auto}#onetrust-pc-sdk #no-results{text-align:center;margin-top:30px}#onetrust-pc-sdk #no-results p{font-size:1em;color:#2e3644;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk #no-results p span{font-weight:bold}#onetrust-pc-sdk #ot-fltr-modal{width:100%;height:auto;display:none;-moz-transition:.2s ease;-o-transition:.2s ease;-webkit-transition:2s ease;transition:.2s ease;overflow:hidden;opacity:1;right:0}#onetrust-pc-sdk #ot-fltr-modal .ot-label-txt{display:inline-block;font-size:.85em;color:dimgray}#onetrust-pc-sdk #ot-fltr-cnt{z-index:2147483646;background-color:#fff;position:absolute;height:90%;max-height:300px;width:325px;left:210px;margin-top:10px;margin-bottom:20px;padding-right:10px;border-radius:3px;-webkit-box-shadow:0px 0px 12px 2px #c7c5c7;-moz-box-shadow:0px 0px 12px 2px #c7c5c7;box-shadow:0px 0px 12px 2px #c7c5c7}#onetrust-pc-sdk .ot-fltr-scrlcnt{overflow-y:auto;overflow-x:hidden;clear:both;max-height:calc(100% - 60px)}#onetrust-pc-sdk #ot-anchor{border:12px solid rgba(0,0,0,0);display:none;position:absolute;z-index:2147483647;right:55px;top:75px;transform:rotate(45deg);-o-transform:rotate(45deg);-ms-transform:rotate(45deg);-webkit-transform:rotate(45deg);background-color:#fff;-webkit-box-shadow:-3px -3px 5px -2px #c7c5c7;-moz-box-shadow:-3px -3px 5px -2px #c7c5c7;box-shadow:-3px -3px 5px -2px #c7c5c7}#onetrust-pc-sdk .ot-fltr-btns{margin-left:15px}#onetrust-pc-sdk #filter-apply-handler{margin-right:15px}#onetrust-pc-sdk .ot-fltr-opt{margin-bottom:25px;margin-left:15px;width:75%;position:relative}#onetrust-pc-sdk .ot-fltr-opt p{display:inline-block;margin:0;font-size:.9em;color:#2e3644}#onetrust-pc-sdk .ot-chkbox label span{font-size:.85em;color:dimgray}#onetrust-pc-sdk .ot-chkbox input[type=checkbox]+label::after{content:none;color:#fff}#onetrust-pc-sdk .ot-chkbox input[type=checkbox]:checked+label::after{content:""}#onetrust-pc-sdk .ot-chkbox input[type=checkbox]:focus+label::before{outline-style:solid;outline-width:2px;outline-style:auto}#onetrust-pc-sdk #ot-selall-vencntr,#onetrust-pc-sdk #ot-selall-adtlvencntr,#onetrust-pc-sdk #ot-selall-hostcntr,#onetrust-pc-sdk #ot-selall-licntr,#onetrust-pc-sdk #ot-selall-gnvencntr{right:15px;position:relative;width:20px;height:20px;float:right}#onetrust-pc-sdk #ot-selall-vencntr label,#onetrust-pc-sdk #ot-selall-adtlvencntr label,#onetrust-pc-sdk #ot-selall-hostcntr label,#onetrust-pc-sdk #ot-selall-licntr label,#onetrust-pc-sdk #ot-selall-gnvencntr label{float:left;padding-left:0}#onetrust-pc-sdk #ot-ven-lst:first-child{border-top:1px solid #e2e2e2}#onetrust-pc-sdk ul{list-style:none;padding:0}#onetrust-pc-sdk ul li{position:relative;margin:0;padding:15px 15px 15px 10px;border-bottom:1px solid #e2e2e2}#onetrust-pc-sdk ul li h3{font-size:.75em;color:#656565;margin:0;display:inline-block;width:70%;height:auto;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk ul li p{margin:0;font-size:.7em}#onetrust-pc-sdk ul li input[type=checkbox]{position:absolute;cursor:pointer;width:100%;height:100%;opacity:0;margin:0;top:0;left:0}#onetrust-pc-sdk .ot-cat-item>button:focus,#onetrust-pc-sdk .ot-acc-cntr>button:focus,#onetrust-pc-sdk li>button:focus{outline:#000 solid 2px}#onetrust-pc-sdk .ot-cat-item>button,#onetrust-pc-sdk .ot-acc-cntr>button,#onetrust-pc-sdk li>button{position:absolute;cursor:pointer;width:100%;height:100%;margin:0;top:0;left:0;z-index:1;max-width:none;border:none}#onetrust-pc-sdk .ot-cat-item>button[aria-expanded=false]~.ot-acc-txt,#onetrust-pc-sdk .ot-acc-cntr>button[aria-expanded=false]~.ot-acc-txt,#onetrust-pc-sdk li>button[aria-expanded=false]~.ot-acc-txt{margin-top:0;max-height:0;opacity:0;overflow:hidden;width:100%;transition:.25s ease-out;display:none}#onetrust-pc-sdk .ot-cat-item>button[aria-expanded=true]~.ot-acc-txt,#onetrust-pc-sdk .ot-acc-cntr>button[aria-expanded=true]~.ot-acc-txt,#onetrust-pc-sdk li>button[aria-expanded=true]~.ot-acc-txt{transition:.1s ease-in;margin-top:10px;width:100%;overflow:auto;display:block}#onetrust-pc-sdk .ot-cat-item>button[aria-expanded=true]~.ot-acc-grpcntr,#onetrust-pc-sdk .ot-acc-cntr>button[aria-expanded=true]~.ot-acc-grpcntr,#onetrust-pc-sdk li>button[aria-expanded=true]~.ot-acc-grpcntr{width:auto;margin-top:0px;padding-bottom:10px}#onetrust-pc-sdk .ot-host-item>button:focus,#onetrust-pc-sdk .ot-ven-item>button:focus{outline:0;border:2px solid #000}#onetrust-pc-sdk .ot-hide-acc>button{pointer-events:none}#onetrust-pc-sdk .ot-hide-acc .ot-plus-minus>*,#onetrust-pc-sdk .ot-hide-acc .ot-arw-cntr>*{visibility:hidden}#onetrust-pc-sdk .ot-hide-acc .ot-acc-hdr{min-height:30px}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt){padding-right:10px;width:calc(100% - 37px);margin-top:10px;max-height:calc(100% - 90px)}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) #ot-sel-blk{background-color:#f9f9fc;border:1px solid #e2e2e2;width:calc(100% - 2px);padding-bottom:5px;padding-top:5px}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) #ot-sel-blk.ot-vnd-list-cnt{border:unset;background-color:unset}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) #ot-sel-blk.ot-vnd-list-cnt .ot-sel-all-hdr{display:none}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) #ot-sel-blk.ot-vnd-list-cnt .ot-sel-all{padding-right:.5rem}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) #ot-sel-blk.ot-vnd-list-cnt .ot-sel-all .ot-chkbox{right:0}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) .ot-sel-all{padding-right:34px}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) .ot-sel-all-chkbox{width:auto}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) ul li{border:1px solid #e2e2e2;margin-bottom:10px}#onetrust-pc-sdk.ot-addtl-vendors #ot-lst-cnt:not(.ot-host-cnt) .ot-acc-cntr>.ot-acc-hdr{padding:10px 0 10px 15px}#onetrust-pc-sdk.ot-addtl-vendors .ot-sel-all-chkbox{float:right}#onetrust-pc-sdk.ot-addtl-vendors .ot-plus-minus~.ot-sel-all-chkbox{right:34px}#onetrust-pc-sdk.ot-addtl-vendors #ot-ven-lst:first-child{border-top:none}#onetrust-pc-sdk .ot-acc-cntr{position:relative;border-left:1px solid #e2e2e2;border-right:1px solid #e2e2e2;border-bottom:1px solid #e2e2e2}#onetrust-pc-sdk .ot-acc-cntr input{z-index:1}#onetrust-pc-sdk .ot-acc-cntr>.ot-acc-hdr{background-color:#f9f9fc;padding:5px 0 5px 15px;width:auto}#onetrust-pc-sdk .ot-acc-cntr>.ot-acc-hdr .ot-plus-minus{vertical-align:middle;top:auto}#onetrust-pc-sdk .ot-acc-cntr>.ot-acc-hdr .ot-arw-cntr{right:10px}#onetrust-pc-sdk .ot-acc-cntr>.ot-acc-hdr input{z-index:2}#onetrust-pc-sdk .ot-acc-cntr.ot-add-tech .ot-acc-hdr{padding:10px 0 10px 15px}#onetrust-pc-sdk .ot-acc-cntr>input[type=checkbox]:checked~.ot-acc-hdr{border-bottom:1px solid #e2e2e2}#onetrust-pc-sdk .ot-acc-cntr>.ot-acc-txt{padding-left:10px;padding-right:10px}#onetrust-pc-sdk .ot-acc-cntr button[aria-expanded=true]~.ot-acc-txt{width:auto}#onetrust-pc-sdk .ot-acc-cntr .ot-addtl-venbox{display:none}#onetrust-pc-sdk .ot-vlst-cntr{margin-bottom:0;width:100%}#onetrust-pc-sdk .ot-vensec-title{font-size:.813em;vertical-align:middle;display:inline-block}#onetrust-pc-sdk .category-vendors-list-handler,#onetrust-pc-sdk .category-vendors-list-handler+a{margin-left:0;margin-top:10px}#onetrust-pc-sdk #ot-selall-vencntr.line-through label::after,#onetrust-pc-sdk #ot-selall-adtlvencntr.line-through label::after,#onetrust-pc-sdk #ot-selall-licntr.line-through label::after,#onetrust-pc-sdk #ot-selall-hostcntr.line-through label::after,#onetrust-pc-sdk #ot-selall-gnvencntr.line-through label::after{height:auto;border-left:0;transform:none;-o-transform:none;-ms-transform:none;-webkit-transform:none;left:5px;top:9px}#onetrust-pc-sdk #ot-category-title{float:left;padding-bottom:10px;font-size:1em;width:100%}#onetrust-pc-sdk .ot-cat-grp{margin-top:10px}#onetrust-pc-sdk .ot-cat-item{line-height:1.1;margin-top:10px;display:inline-block;width:100%}#onetrust-pc-sdk .ot-btn-container{text-align:right}#onetrust-pc-sdk .ot-btn-container button{display:inline-block;font-size:.75em;letter-spacing:.08em;margin-top:19px}#onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon{position:absolute;top:10px;right:0;z-index:1;padding:0;background-color:rgba(0,0,0,0);border:none}#onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon svg{display:block;height:10px;width:10px}#onetrust-pc-sdk #clear-filters-handler{margin-top:20px;margin-bottom:10px;float:right;max-width:200px;text-decoration:none;color:#3860be;font-size:.9em;font-weight:bold;background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0);padding:1px}#onetrust-pc-sdk #clear-filters-handler:hover{color:#2285f7}#onetrust-pc-sdk #clear-filters-handler:focus{outline:#000 solid 1px}#onetrust-pc-sdk .ot-enbl-chr h4~.ot-tgl,#onetrust-pc-sdk .ot-enbl-chr h4~.ot-always-active{right:45px}#onetrust-pc-sdk .ot-enbl-chr h4~.ot-tgl+.ot-tgl{right:120px}#onetrust-pc-sdk .ot-enbl-chr .ot-pli-hdr.ot-leg-border-color span:first-child{width:90px}#onetrust-pc-sdk .ot-enbl-chr li.ot-subgrp>h5+.ot-tgl-cntr{padding-right:25px}#onetrust-pc-sdk .ot-plus-minus{width:20px;height:20px;font-size:1.5em;position:relative;display:inline-block;margin-right:5px;top:3px}#onetrust-pc-sdk .ot-plus-minus span{position:absolute;background:#27455c;border-radius:1px}#onetrust-pc-sdk .ot-plus-minus span:first-of-type{top:25%;bottom:25%;width:10%;left:45%}#onetrust-pc-sdk .ot-plus-minus span:last-of-type{left:25%;right:25%;height:10%;top:45%}#onetrust-pc-sdk button[aria-expanded=true]~.ot-acc-hdr .ot-arw,#onetrust-pc-sdk button[aria-expanded=true]~.ot-acc-hdr .ot-plus-minus span:first-of-type,#onetrust-pc-sdk button[aria-expanded=true]~.ot-acc-hdr .ot-plus-minus span:last-of-type{transform:rotate(90deg)}#onetrust-pc-sdk button[aria-expanded=true]~.ot-acc-hdr .ot-plus-minus span:last-of-type{left:50%;right:50%}#onetrust-pc-sdk #ot-selall-vencntr label,#onetrust-pc-sdk #ot-selall-adtlvencntr label,#onetrust-pc-sdk #ot-selall-hostcntr label,#onetrust-pc-sdk #ot-selall-licntr label{position:relative;display:inline-block;width:20px;height:20px}#onetrust-pc-sdk .ot-host-item .ot-plus-minus,#onetrust-pc-sdk .ot-ven-item .ot-plus-minus{float:left;margin-right:8px;top:10px}#onetrust-pc-sdk .ot-ven-item ul{list-style:none inside;font-size:100%;margin:0}#onetrust-pc-sdk .ot-ven-item ul li{margin:0 !important;padding:0;border:none !important}#onetrust-pc-sdk .ot-pli-hdr{color:#77808e;overflow:hidden;padding-top:7.5px;padding-bottom:7.5px;width:calc(100% - 2px);border-top-left-radius:3px;border-top-right-radius:3px}#onetrust-pc-sdk .ot-pli-hdr span:first-child{top:50%;transform:translateY(50%);max-width:90px}#onetrust-pc-sdk .ot-pli-hdr span:last-child{padding-right:10px;max-width:95px;text-align:center}#onetrust-pc-sdk .ot-li-title{float:right;font-size:.813em}#onetrust-pc-sdk .ot-pli-hdr.ot-leg-border-color{background-color:#f4f4f4;border:1px solid #d8d8d8}#onetrust-pc-sdk .ot-pli-hdr.ot-leg-border-color span:first-child{text-align:left;width:70px}#onetrust-pc-sdk li.ot-subgrp>h5,#onetrust-pc-sdk .ot-cat-header{width:calc(100% - 130px)}#onetrust-pc-sdk li.ot-subgrp>h5+.ot-tgl-cntr{padding-left:13px}#onetrust-pc-sdk .ot-acc-grpcntr .ot-acc-grpdesc{margin-bottom:5px}#onetrust-pc-sdk .ot-acc-grpcntr .ot-subgrp-cntr{border-top:1px solid #d8d8d8}#onetrust-pc-sdk .ot-acc-grpcntr .ot-vlst-cntr+.ot-subgrp-cntr{border-top:none}#onetrust-pc-sdk .ot-acc-hdr .ot-arw-cntr+.ot-tgl-cntr,#onetrust-pc-sdk .ot-acc-txt h4+.ot-tgl-cntr{padding-left:13px}#onetrust-pc-sdk .ot-pli-hdr~.ot-cat-item .ot-subgrp>h5,#onetrust-pc-sdk .ot-pli-hdr~.ot-cat-item .ot-cat-header{width:calc(100% - 145px)}#onetrust-pc-sdk .ot-pli-hdr~.ot-cat-item h5+.ot-tgl-cntr,#onetrust-pc-sdk .ot-pli-hdr~.ot-cat-item .ot-cat-header+.ot-tgl{padding-left:28px}#onetrust-pc-sdk .ot-sel-all-hdr,#onetrust-pc-sdk .ot-sel-all-chkbox{display:inline-block;width:100%;position:relative}#onetrust-pc-sdk .ot-sel-all-chkbox{z-index:1}#onetrust-pc-sdk .ot-sel-all{margin:0;position:relative;padding-right:23px;float:right}#onetrust-pc-sdk .ot-consent-hdr,#onetrust-pc-sdk .ot-li-hdr{float:right;font-size:.812em;line-height:normal;text-align:center;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk .ot-li-hdr{max-width:100px;padding-right:10px}#onetrust-pc-sdk .ot-consent-hdr{max-width:55px}#onetrust-pc-sdk #ot-selall-licntr{display:block;width:21px;height:auto;float:right;position:relative;right:80px}#onetrust-pc-sdk #ot-selall-licntr label{position:absolute}#onetrust-pc-sdk .ot-ven-ctgl{margin-left:66px}#onetrust-pc-sdk .ot-ven-litgl+.ot-arw-cntr{margin-left:81px}#onetrust-pc-sdk .ot-enbl-chr .ot-host-cnt .ot-tgl-cntr{width:auto}#onetrust-pc-sdk #ot-lst-cnt:not(.ot-host-cnt) .ot-tgl-cntr{width:auto;top:auto;height:20px}#onetrust-pc-sdk #ot-lst-cnt .ot-chkbox{position:relative;display:inline-block;width:20px;height:20px}#onetrust-pc-sdk #ot-lst-cnt .ot-chkbox label{position:absolute;padding:0;width:20px;height:20px}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info-cntr{border:1px solid #d8d8d8;padding:.75rem 2rem;padding-bottom:0;width:auto;margin-top:.5rem}#onetrust-pc-sdk .ot-acc-grpdesc+.ot-leg-btn-container{padding-left:20px;padding-right:20px;width:calc(100% - 40px);margin-bottom:5px}#onetrust-pc-sdk .ot-subgrp .ot-leg-btn-container{margin-bottom:5px}#onetrust-pc-sdk #ot-ven-lst .ot-leg-btn-container{margin-top:10px}#onetrust-pc-sdk .ot-leg-btn-container{display:inline-block;width:100%;margin-bottom:10px}#onetrust-pc-sdk .ot-leg-btn-container button{height:auto;padding:6.5px 8px;margin-bottom:0;letter-spacing:0;font-size:.75em;line-height:normal}#onetrust-pc-sdk .ot-leg-btn-container svg{display:none;height:14px;width:14px;padding-right:5px;vertical-align:sub}#onetrust-pc-sdk .ot-active-leg-btn{cursor:default;pointer-events:none}#onetrust-pc-sdk .ot-active-leg-btn svg{display:inline-block}#onetrust-pc-sdk .ot-remove-objection-handler{text-decoration:underline;padding:0;font-size:.75em;font-weight:600;line-height:1;padding-left:10px}#onetrust-pc-sdk .ot-obj-leg-btn-handler span{font-weight:bold;text-align:center;font-size:inherit;line-height:1.5}#onetrust-pc-sdk.ot-close-btn-link #close-pc-btn-handler{border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em;background:none;right:15px;top:15px;width:auto;font-weight:normal}#onetrust-pc-sdk .ot-pgph-link{font-size:.813em !important;margin-top:5px;position:relative}#onetrust-pc-sdk .ot-pgph-link.ot-pgph-link-subgroup{margin-bottom:1rem}#onetrust-pc-sdk .ot-pgph-contr{margin:0 2.5rem}#onetrust-pc-sdk .ot-pgph-title{font-size:1.18rem;margin-bottom:2rem}#onetrust-pc-sdk .ot-pgph-desc{font-size:1rem;font-weight:400;margin-bottom:2rem;line-height:1.5rem}#onetrust-pc-sdk .ot-pgph-desc:not(:last-child):after{content:"";width:96%;display:block;margin:0 auto;padding-bottom:2rem;border-bottom:1px solid #e9e9e9}#onetrust-pc-sdk .ot-cat-header{float:left;font-weight:600;font-size:.875em;line-height:1.5;max-width:90%;vertical-align:middle}#onetrust-pc-sdk .ot-vnd-item>button:focus{outline:#000 solid 2px}#onetrust-pc-sdk .ot-vnd-item>button{position:absolute;cursor:pointer;width:100%;height:100%;margin:0;top:0;left:0;z-index:1;max-width:none;border:none}#onetrust-pc-sdk .ot-vnd-item>button[aria-expanded=false]~.ot-acc-txt{margin-top:0;max-height:0;opacity:0;overflow:hidden;width:100%;transition:.25s ease-out;display:none}#onetrust-pc-sdk .ot-vnd-item>button[aria-expanded=true]~.ot-acc-txt{transition:.1s ease-in;margin-top:10px;width:100%;overflow:auto;display:block}#onetrust-pc-sdk .ot-vnd-item>button[aria-expanded=true]~.ot-acc-grpcntr{width:auto;margin-top:0px;padding-bottom:10px}#onetrust-pc-sdk .ot-accordion-layout.ot-cat-item{position:relative;border-radius:2px;margin:0;padding:0;border:1px solid #d8d8d8;border-top:none;width:calc(100% - 2px);float:left}#onetrust-pc-sdk .ot-accordion-layout.ot-cat-item:first-of-type{margin-top:10px;border-top:1px solid #d8d8d8}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-grpdesc{padding-left:20px;padding-right:20px;width:calc(100% - 40px);font-size:.812em;margin-bottom:10px;margin-top:15px}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-grpdesc>ul{padding-top:10px}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-grpdesc>ul li{padding-top:0;line-height:1.5;padding-bottom:10px}#onetrust-pc-sdk .ot-accordion-layout div+.ot-acc-grpdesc{margin-top:5px}#onetrust-pc-sdk .ot-accordion-layout .ot-vlst-cntr:first-child{margin-top:10px}#onetrust-pc-sdk .ot-accordion-layout .ot-vlst-cntr:last-child,#onetrust-pc-sdk .ot-accordion-layout .ot-hlst-cntr:last-child{margin-bottom:5px}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-hdr{padding-top:11.5px;padding-bottom:11.5px;padding-left:20px;padding-right:20px;width:calc(100% - 40px);display:inline-block}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-txt{width:100%;padding:0}#onetrust-pc-sdk .ot-accordion-layout .ot-subgrp-cntr{padding-left:20px;padding-right:15px;padding-bottom:0;width:calc(100% - 35px)}#onetrust-pc-sdk .ot-accordion-layout .ot-subgrp{padding-right:5px}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-grpcntr{z-index:1;position:relative}#onetrust-pc-sdk .ot-accordion-layout .ot-cat-header+.ot-arw-cntr{position:absolute;top:50%;transform:translateY(-50%);right:20px;margin-top:-2px}#onetrust-pc-sdk .ot-accordion-layout .ot-cat-header+.ot-arw-cntr .ot-arw{width:15px;height:20px;margin-left:5px;color:dimgray}#onetrust-pc-sdk .ot-accordion-layout .ot-cat-header{float:none;color:#2e3644;margin:0;display:inline-block;height:auto;word-wrap:break-word;min-height:inherit}#onetrust-pc-sdk .ot-accordion-layout .ot-vlst-cntr,#onetrust-pc-sdk .ot-accordion-layout .ot-hlst-cntr{padding-left:20px;width:calc(100% - 20px);display:inline-block;margin-top:0;padding-bottom:2px}#onetrust-pc-sdk .ot-accordion-layout .ot-acc-hdr{position:relative;min-height:25px}#onetrust-pc-sdk .ot-accordion-layout h4~.ot-tgl,#onetrust-pc-sdk .ot-accordion-layout h4~.ot-always-active{position:absolute;top:50%;transform:translateY(-50%);right:20px}#onetrust-pc-sdk .ot-accordion-layout h4~.ot-tgl+.ot-tgl{right:95px}#onetrust-pc-sdk .ot-accordion-layout .category-vendors-list-handler,#onetrust-pc-sdk .ot-accordion-layout .category-vendors-list-handler+a{margin-top:5px}#onetrust-pc-sdk #ot-lst-cnt{margin-top:1rem;max-height:calc(100% - 96px)}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info-cntr{border:1px solid #d8d8d8;padding:.75rem 2rem;padding-bottom:0;width:auto;margin-top:.5rem}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info{margin-bottom:1rem;padding-left:.75rem;padding-right:.75rem;display:flex;flex-direction:column}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info[data-vnd-info-key*=DPOEmail]{border-top:1px solid #d8d8d8;padding-top:1rem}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info[data-vnd-info-key*=DPOLink]{border-bottom:1px solid #d8d8d8;padding-bottom:1rem}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info .ot-vnd-lbl{font-weight:bold;font-size:.85em;margin-bottom:.5rem}#onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info .ot-vnd-cnt{margin-left:.5rem;font-weight:500;font-size:.85rem}#onetrust-pc-sdk .ot-vs-list,#onetrust-pc-sdk .ot-vnd-serv{width:auto;padding:1rem 1.25rem;padding-bottom:0}#onetrust-pc-sdk .ot-vs-list .ot-vnd-serv-hdr-cntr,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-serv-hdr-cntr{padding-bottom:.75rem;border-bottom:1px solid #d8d8d8}#onetrust-pc-sdk .ot-vs-list .ot-vnd-serv-hdr-cntr .ot-vnd-serv-hdr,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-serv-hdr-cntr .ot-vnd-serv-hdr{font-weight:600;font-size:.95em;line-height:2;margin-left:.5rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item{border:none;margin:0;padding:0}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item button,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item button{outline:none;border-bottom:1px solid #d8d8d8}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item button[aria-expanded=true],#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item button[aria-expanded=true]{border-bottom:none}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item:first-child,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item:first-child{margin-top:.25rem;border-top:unset}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item:last-child,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item:last-child{margin-bottom:.5rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item:last-child button,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item:last-child button{border-bottom:none}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info-cntr,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info-cntr{border:1px solid #d8d8d8;padding:.75rem 1.75rem;padding-bottom:0;width:auto;margin-top:.5rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info{margin-bottom:1rem;padding-left:.75rem;padding-right:.75rem;display:flex;flex-direction:column}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info[data-vnd-info-key*=DPOEmail],#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info[data-vnd-info-key*=DPOEmail]{border-top:1px solid #d8d8d8;padding-top:1rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info[data-vnd-info-key*=DPOLink],#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info[data-vnd-info-key*=DPOLink]{border-bottom:1px solid #d8d8d8;padding-bottom:1rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info .ot-vnd-lbl,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info .ot-vnd-lbl{font-weight:bold;font-size:.85em;margin-bottom:.5rem}#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info .ot-vnd-cnt,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info .ot-vnd-cnt{margin-left:.5rem;font-weight:500;font-size:.85rem}#onetrust-pc-sdk .ot-vs-list.ot-vnd-subgrp-cnt,#onetrust-pc-sdk .ot-vnd-serv.ot-vnd-subgrp-cnt{padding-left:40px}#onetrust-pc-sdk .ot-vs-list.ot-vnd-subgrp-cnt .ot-vnd-serv-hdr-cntr .ot-vnd-serv-hdr,#onetrust-pc-sdk .ot-vnd-serv.ot-vnd-subgrp-cnt .ot-vnd-serv-hdr-cntr .ot-vnd-serv-hdr{font-size:.8em}#onetrust-pc-sdk .ot-vs-list.ot-vnd-subgrp-cnt .ot-cat-header,#onetrust-pc-sdk .ot-vnd-serv.ot-vnd-subgrp-cnt .ot-cat-header{font-size:.8em}#onetrust-pc-sdk .ot-subgrp-cntr .ot-vnd-serv{margin-bottom:1rem;padding:1rem .95rem}#onetrust-pc-sdk .ot-subgrp-cntr .ot-vnd-serv .ot-vnd-serv-hdr-cntr{padding-bottom:.75rem;border-bottom:1px solid #d8d8d8}#onetrust-pc-sdk .ot-subgrp-cntr .ot-vnd-serv .ot-vnd-serv-hdr-cntr .ot-vnd-serv-hdr{font-weight:700;font-size:.8em;line-height:20px;margin-left:.82rem}#onetrust-pc-sdk .ot-subgrp-cntr .ot-cat-header{font-weight:700;font-size:.8em;line-height:20px}#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-vnd-serv .ot-vnd-lst-cont .ot-accordion-layout .ot-acc-hdr div.ot-chkbox{margin-left:.82rem}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr{padding:.7rem 0;margin:0;display:flex;width:100%;align-items:center;justify-content:space-between}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr div:first-child,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr div:first-child,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr div:first-child,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr div:first-child,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr div:first-child,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr div:first-child,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr div:first-child{margin-left:.5rem}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr div:last-child,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr div:last-child,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr div:last-child,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr div:last-child,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr div:last-child,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr div:last-child,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr div:last-child{margin-right:.5rem;margin-left:.5rem}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-always-active,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-always-active{position:relative;right:unset;top:unset;transform:unset}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-plus-minus,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-plus-minus{top:0}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-arw-cntr,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-arw-cntr{float:none;top:unset;right:unset;transform:unset;margin-top:-2px;position:relative}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-cat-header,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-cat-header{flex:1;margin:0 .5rem}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-tgl,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-tgl{position:relative;transform:none;right:0;top:0;float:none}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-chkbox{position:relative;margin:0 .5rem}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox label,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-chkbox label{padding:0}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox label::before,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-chkbox label::before{position:relative}#onetrust-pc-sdk .ot-vs-config .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk ul.ot-subgrps .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk #ot-pc-lst .ot-vs-list .ot-vnd-item .ot-acc-hdr .ot-chkbox input,#onetrust-pc-sdk .ot-accordion-layout.ot-checkbox-consent .ot-acc-hdr .ot-chkbox input{position:absolute;cursor:pointer;width:100%;height:100%;opacity:0;margin:0;top:0;left:0;z-index:1}#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps li.ot-subgrp .ot-acc-hdr h5.ot-cat-header,#onetrust-pc-sdk .ot-subgrp-cntr ul.ot-subgrps li.ot-subgrp .ot-acc-hdr h4.ot-cat-header{margin:0}#onetrust-pc-sdk .ot-vs-config .ot-subgrp-cntr ul.ot-subgrps li.ot-subgrp h5{top:0;line-height:20px}#onetrust-pc-sdk .ot-vs-list{display:flex;flex-direction:column;padding:0;margin:.5rem 4px}#onetrust-pc-sdk .ot-vs-selc-all{display:flex;padding:0;float:unset;align-items:center;justify-content:flex-start}#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf{justify-content:flex-end}#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf.ot-caret-conf .ot-sel-all-chkbox{margin-right:48px}#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf .ot-sel-all-chkbox{margin:0;padding:0;margin-right:14px;justify-content:flex-end}#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf #ot-selall-vencntr.ot-chkbox,#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf #ot-selall-vencntr.ot-tgl{display:inline-block;right:unset;width:auto;height:auto;float:none}#onetrust-pc-sdk .ot-vs-selc-all.ot-toggle-conf #ot-selall-vencntr label{width:45px;height:25px}#onetrust-pc-sdk .ot-vs-selc-all .ot-sel-all-chkbox{margin-right:11px;margin-left:.75rem;display:flex;align-items:center}#onetrust-pc-sdk .ot-vs-selc-all .sel-all-hdr{margin:0 1.25rem;font-size:.812em;line-height:normal;text-align:center;word-break:break-word;word-wrap:break-word}#onetrust-pc-sdk .ot-vnd-list-cnt #ot-selall-vencntr.ot-chkbox{float:unset;right:0}#onetrust-pc-sdk[dir=rtl] #ot-back-arw,#onetrust-pc-sdk[dir=rtl] input~.ot-acc-hdr .ot-arw{transform:rotate(180deg);-o-transform:rotate(180deg);-ms-transform:rotate(180deg);-webkit-transform:rotate(180deg)}#onetrust-pc-sdk[dir=rtl] input:checked~.ot-acc-hdr .ot-arw{transform:rotate(270deg);-o-transform:rotate(270deg);-ms-transform:rotate(270deg);-webkit-transform:rotate(270deg)}#onetrust-pc-sdk[dir=rtl] .ot-chkbox label::after{transform:rotate(45deg);-webkit-transform:rotate(45deg);-o-transform:rotate(45deg);-ms-transform:rotate(45deg);border-left:0;border-right:3px solid}#onetrust-pc-sdk[dir=rtl] .ot-search-cntr>svg{right:0}@media only screen and (max-width: 600px){#onetrust-pc-sdk.otPcCenter{left:0;min-width:100%;height:100%;top:0;border-radius:0}#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk.ot-ftr-stacked .ot-btn-container{margin:1px 3px 0 10px;padding-right:10px;width:calc(100% - 23px)}#onetrust-pc-sdk .ot-btn-container button{max-width:none;letter-spacing:.01em}#onetrust-pc-sdk #close-pc-btn-handler{top:10px;right:17px}#onetrust-pc-sdk p{font-size:.7em}#onetrust-pc-sdk #ot-pc-hdr{margin:10px 10px 0 5px;width:calc(100% - 15px)}#onetrust-pc-sdk .vendor-search-handler{font-size:1em}#onetrust-pc-sdk #ot-back-arw{margin-left:12px}#onetrust-pc-sdk #ot-lst-cnt{margin:0;padding:0 5px 0 10px;min-width:95%}#onetrust-pc-sdk .switch+p{max-width:80%}#onetrust-pc-sdk .ot-ftr-stacked button{width:100%}#onetrust-pc-sdk #ot-fltr-cnt{max-width:320px;width:90%;border-top-right-radius:0;border-bottom-right-radius:0;margin:0;margin-left:15px;left:auto;right:40px;top:85px}#onetrust-pc-sdk .ot-fltr-opt{margin-left:25px;margin-bottom:10px}#onetrust-pc-sdk .ot-pc-refuse-all-handler{margin-bottom:0}#onetrust-pc-sdk #ot-fltr-cnt{right:40px}}@media only screen and (max-width: 476px){#onetrust-pc-sdk .ot-fltr-cntr,#onetrust-pc-sdk #ot-fltr-cnt{right:10px}#onetrust-pc-sdk #ot-anchor{right:25px}#onetrust-pc-sdk button{width:100%}#onetrust-pc-sdk:not(.ot-addtl-vendors) #ot-pc-lst:not(.ot-enbl-chr) .ot-sel-all{padding-right:9px}#onetrust-pc-sdk:not(.ot-addtl-vendors) #ot-pc-lst:not(.ot-enbl-chr) .ot-tgl-cntr{right:0}}@media only screen and (max-width: 896px)and (max-height: 425px)and (orientation: landscape){#onetrust-pc-sdk.otPcCenter{left:0;top:0;min-width:100%;height:100%;border-radius:0}#onetrust-pc-sdk .ot-pc-header{height:auto;min-height:20px}#onetrust-pc-sdk .ot-pc-header .ot-pc-logo{max-height:30px}#onetrust-pc-sdk .ot-pc-footer{max-height:60px;overflow-y:auto}#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk #ot-pc-lst{bottom:70px}#onetrust-pc-sdk.ot-ftr-stacked #ot-pc-content{bottom:70px}#onetrust-pc-sdk #ot-anchor{left:initial;right:50px}#onetrust-pc-sdk #ot-lst-title{margin-top:12px}#onetrust-pc-sdk #ot-lst-title *{font-size:inherit}#onetrust-pc-sdk #ot-pc-hdr input{margin-right:0;padding-right:45px}#onetrust-pc-sdk .switch+p{max-width:85%}#onetrust-pc-sdk #ot-sel-blk{position:static}#onetrust-pc-sdk #ot-pc-lst{overflow:auto}#onetrust-pc-sdk #ot-lst-cnt{max-height:none;overflow:initial}#onetrust-pc-sdk #ot-lst-cnt.no-results{height:auto}#onetrust-pc-sdk input{font-size:1em !important}#onetrust-pc-sdk p{font-size:.6em}#onetrust-pc-sdk #ot-fltr-modal{width:100%;top:0}#onetrust-pc-sdk ul li p,#onetrust-pc-sdk .category-vendors-list-handler,#onetrust-pc-sdk .category-vendors-list-handler+a,#onetrust-pc-sdk .category-host-list-handler{font-size:.6em}#onetrust-pc-sdk.ot-shw-fltr #ot-anchor{display:none !important}#onetrust-pc-sdk.ot-shw-fltr #ot-pc-lst{height:100% !important;overflow:hidden;top:0px}#onetrust-pc-sdk.ot-shw-fltr #ot-fltr-cnt{margin:0;height:100%;max-height:none;padding:10px;top:0;width:calc(100% - 20px);position:absolute;right:0;left:0;max-width:none}#onetrust-pc-sdk.ot-shw-fltr .ot-fltr-scrlcnt{max-height:calc(100% - 65px)}}
+                      #onetrust-consent-sdk #onetrust-pc-sdk,
+                          #onetrust-consent-sdk #ot-search-cntr,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-switch.ot-toggle,
+                          #onetrust-consent-sdk #onetrust-pc-sdk ot-grp-hdr1 .checkbox,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-title:after
+                          ,#onetrust-consent-sdk #onetrust-pc-sdk #ot-sel-blk,
+                                  #onetrust-consent-sdk #onetrust-pc-sdk #ot-fltr-cnt,
+                                  #onetrust-consent-sdk #onetrust-pc-sdk #ot-anchor {
+                              background-color: #FFFFFF;
+                          }
+
+                      #onetrust-consent-sdk #onetrust-pc-sdk h3,
+                          #onetrust-consent-sdk #onetrust-pc-sdk h4,
+                          #onetrust-consent-sdk #onetrust-pc-sdk h5,
+                          #onetrust-consent-sdk #onetrust-pc-sdk h6,
+                          #onetrust-consent-sdk #onetrust-pc-sdk p,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-ven-lst .ot-ven-opts p,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-desc,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-title,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-li-title,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-sel-all-hdr span,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-host-lst .ot-host-info,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-fltr-modal #modal-header,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-checkbox label span,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-lst #ot-sel-blk p,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-lst #ot-lst-title h3,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-lst .back-btn-handler p,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-lst .ot-ven-name,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-lst #ot-ven-lst .consent-category,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-inactive-leg-btn,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-label-status,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-chkbox label span,
+                          #onetrust-consent-sdk #onetrust-pc-sdk #clear-filters-handler,
+                          #onetrust-consent-sdk #onetrust-pc-sdk .ot-optout-signal
+                          {
+                              color: #2b273c;
+                          }
+                       #onetrust-consent-sdk #onetrust-pc-sdk .privacy-notice-link,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .ot-pgph-link,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler + a,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .category-host-list-handler,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .ot-ven-link,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .ot-ven-legclaim-link,
+                              #onetrust-consent-sdk #onetrust-pc-sdk #ot-host-lst .ot-host-name a,
+                              #onetrust-consent-sdk #onetrust-pc-sdk #ot-host-lst .ot-acc-hdr .ot-host-expand,
+                              #onetrust-consent-sdk #onetrust-pc-sdk #ot-host-lst .ot-host-info a,
+                              #onetrust-consent-sdk #onetrust-pc-sdk #ot-pc-content #ot-pc-desc .ot-link-btn,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info a,
+                              #onetrust-consent-sdk #onetrust-pc-sdk #ot-lst-cnt .ot-vnd-info a
+                              {
+                                  color: #00838f;
+                              }
+                      #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler:hover { text-decoration: underline;}
+
+                       #onetrust-consent-sdk #onetrust-pc-sdk #ot-host-lst .ot-host-info,
+                              #onetrust-consent-sdk #onetrust-pc-sdk .ot-acc-txt .ot-ven-dets
+                                      {
+                                          background-color: #F8F8F8;
+                                      }
+                  #onetrust-consent-sdk #onetrust-pc-sdk
+                      button:not(#clear-filters-handler):not(.ot-close-icon):not(#filter-btn-handler):not(.ot-remove-objection-handler):not(.ot-obj-leg-btn-handler):not([aria-expanded]):not(.ot-link-btn),
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-active-leg-btn {
+                          background-color: #E00707;border-color: #E00707;
+                          color: #FFFFFF;
+                      }
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-active-menu {
+                          border-color: #E00707;
+                      }
+
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-remove-objection-handler{
+                          background-color: transparent;
+                          border: 1px solid transparent;
+                      }
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-inactive-leg-btn {
+                          background-color: #FFFFFF;
+                          color: #4D4D4D; border-color: #4D4D4D;
+                      }
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-tgl input:focus + .ot-switch, .ot-switch .ot-switch-nob, .ot-switch .ot-switch-nob:before,
+                      #onetrust-pc-sdk .ot-checkbox input[type="checkbox"]:focus + label::before,
+                      #onetrust-pc-sdk .ot-chkbox input[type="checkbox"]:focus + label::before {
+                          outline-color: #000000;
+                          outline-width: 1px;
+                      }
+                      #onetrust-pc-sdk .ot-host-item > button:focus, #onetrust-pc-sdk .ot-ven-item > button:focus {
+                          border: 1px solid #000000;
+                      }
+                      #onetrust-consent-sdk #onetrust-pc-sdk *:focus,
+                      #onetrust-consent-sdk #onetrust-pc-sdk .ot-vlst-cntr > a:focus {
+                         outline: 1px solid #000000;
+                      }#onetrust-pc-sdk .ot-vlst-cntr .ot-ext-lnk,  #onetrust-pc-sdk .ot-ven-hdr .ot-ext-lnk{
+                              background-image: url('https://cdn.cookielaw.org/logos/static/ot_external_link.svg');
+                          }
+
+          #onetrust-pc-sdk {
+              font-family: Open Sans,Helvetica Neue,Helvetica,Arial,sans-serif !important;
+              text-decoration: none !important;
+          }
+
+          .ot-pc-header {
+              height: 0 !important;
+              border-bottom: none !important;
+              padding: 0 !important;
+          }
+
+          .ot-pc-logo {
+              display: none !important;
+          }
+
+          #ot-category-title {
+              display: none !important;
+          }
+
+          #ot-pc-title {
+              font-size: 20px !important;
+              line-height: 26px !important;
+              font-weight: 700 !important;
+              margin-bottom: 8px !important;
+              margin-top: 32px !important;
+          }
+
+          #ot-pc-desc {
+              margin-bottom: 0 !important;
+          }
+
+          #ot-pc-content {
+              position: static !important;
+              margin-left: 32px !important;
+              margin-top: 0 !important;
+              overflow: auto !important;
+              height: calc(100% - 118px) !important;
+          }
+
+          #ot-pc-desc {
+              font-size: 16px !important;
+              line-height: 22px !important;
+          }
+
+          #accept-recommended-btn-handler {
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 40px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+              margin-top: 24px !important;
+              margin-bottom: 0 !important;
+              display: block !important;
+          }
+
+          .save-preference-btn-handler {
+              color: #2b273c !important;
+              background: transparent !important;
+              border: 1px solid #bbbac0 !important;
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 50px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+              letter-spacing: inherit !important;
+              margin-right: 20px !important;
+          }
+
+          .ot-pc-refuse-all-handler {
+              color: #2b273c !important;
+              background: transparent !important;
+              border: 1px solid #bbbac0 !important;
+              user-select: none !important;
+              padding: 0 16px !important;
+              height: 50px !important;
+              border-radius: 4px !important;
+              font-weight: 600 !important;
+              font-size: 16px !important;
+              line-height: 22px !important;
+              letter-spacing: inherit !important;
+              margin-left: 20px !important;
+          }
+
+          .privacy-notice-link {
+              display: none !important;
+              margin-left: 0 !important;
+          }
+
+          .ot-cat-grp {
+              margin-bottom: 24px !important;
+          }
+
+          .ot-cat-item {
+              border-top: solid 1px #EEEEEF !important;
+              padding-top: 24px !important;
+              margin-top: 24px !important;
+          }
+
+          .ot-always-active {
+              font-size: 16px !important;
+              font-weight: 700 !important;
+              color: #2b273c !important;
+              float: none !important;
+          }
+
+          .ot-always-active::before {
+              content: "\00a0 ";
+          }
+
+          .ot-cat-header {
+              font-size: 16px !important;
+              font-weight: 700 !important;
+              line-height: 22px !important;
+              width: auto !important;
+          }
+
+          .ot-category-desc {
+              font-size: 14px !important;
+          }
+
+          .ot-pc-footer .ot-btn-container {
+              text-align: left !important;
+              display: flex; !important;
+              justify-content: center; !important;
+              align-items: center; !important;
+              padding: 0 !important;
+          }.ot-sdk-cookie-policy{font-family:inherit;font-size:16px}.ot-sdk-cookie-policy.otRelFont{font-size:1rem}.ot-sdk-cookie-policy h3,.ot-sdk-cookie-policy h4,.ot-sdk-cookie-policy h6,.ot-sdk-cookie-policy p,.ot-sdk-cookie-policy li,.ot-sdk-cookie-policy a,.ot-sdk-cookie-policy th,.ot-sdk-cookie-policy #cookie-policy-description,.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group,.ot-sdk-cookie-policy #cookie-policy-title{color:dimgray}.ot-sdk-cookie-policy #cookie-policy-description{margin-bottom:1em}.ot-sdk-cookie-policy h4{font-size:1.2em}.ot-sdk-cookie-policy h6{font-size:1em;margin-top:2em}.ot-sdk-cookie-policy th{min-width:75px}.ot-sdk-cookie-policy a,.ot-sdk-cookie-policy a:hover{background:#fff}.ot-sdk-cookie-policy thead{background-color:#f6f6f4;font-weight:bold}.ot-sdk-cookie-policy .ot-mobile-border{display:none}.ot-sdk-cookie-policy section{margin-bottom:2em}.ot-sdk-cookie-policy table{border-collapse:inherit}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy{font-family:inherit;font-size:1rem}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy p,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-title{color:dimgray}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description{margin-bottom:1em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup{margin-left:1.5em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group-desc,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-table-header,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy span,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td{font-size:.9em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td span,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td a{font-size:inherit}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group{font-size:1em;margin-bottom:.6em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-title{margin-bottom:1.2em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy>section{margin-bottom:1em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th{min-width:75px}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a:hover{background:#fff}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead{background-color:#f6f6f4;font-weight:bold}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-mobile-border{display:none}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy section{margin-bottom:2em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup ul li{list-style:disc;margin-left:1.5em}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup ul li h4{display:inline-block}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table{border-collapse:inherit;margin:auto;border:1px solid #d7d7d7;border-radius:5px;border-spacing:initial;width:100%;overflow:hidden}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table th,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table td{border-bottom:1px solid #d7d7d7;border-right:1px solid #d7d7d7}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td{border-bottom:0px}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr th:last-child,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr td:last-child{border-right:0px}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-host,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-cookies-type{width:25%}.ot-sdk-cookie-policy[dir=rtl]{text-align:left}#ot-sdk-cookie-policy h3{font-size:1.5em}@media only screen and (max-width: 530px){.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) table,.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) thead,.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tbody,.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) th,.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td,.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr{display:block}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) thead tr{position:absolute;top:-9999px;left:-9999px}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr{margin:0 0 1em 0}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr:nth-child(odd),.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr:nth-child(odd) a{background:#f6f6f4}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td{border:none;border-bottom:1px solid #eee;position:relative;padding-left:50%}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td:before{position:absolute;height:100%;left:6px;width:40%;padding-right:10px}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) .ot-mobile-border{display:inline-block;background-color:#e4e4e4;position:absolute;height:100%;top:0;left:45%;width:2px}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td:before{content:attr(data-label);font-weight:bold}.ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) li{word-break:break-word;word-wrap:break-word}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table{overflow:hidden}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table td{border:none;border-bottom:1px solid #d7d7d7}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tr{display:block}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-host,#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-cookies-type{width:auto}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tr{margin:0 0 1em 0}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td:before{height:100%;width:40%;padding-right:10px}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td:before{content:attr(data-label);font-weight:bold}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li{word-break:break-word;word-wrap:break-word}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead tr{position:absolute;top:-9999px;left:-9999px;z-index:-9999}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td{border-bottom:1px solid #d7d7d7;border-right:0px}#ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td:last-child{border-bottom:0px}}
+
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h5,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h6,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy p,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy span,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td,
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description {
+                                  color: #696969;
+                              }
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th {
+                                  color: #696969;
+                              }
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group {
+                                  color: #696969;
+                              }
+
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-title {
+                                      color: #696969;
+                                  }
+
+
+                              #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table th {
+                                      background-color: #F8F8F8;
+                                  }
+
+                      .ot-floating-button__front{background-image:url('https://cdn.cookielaw.org/logos/static/ot_persistent_cookie_icon.png')}
+                  @keyframes slide-down-custom {
+                      0% {
+                          bottom: 857px !important;
+                      }
+                      100% {
+                          bottom: 0px;
+                      }
+                  }
+                  @-webkit-keyframes slide-down-custom {
+                      0% {
+                          bottom: 857px !important;
+                      }
+                      100% {
+                          bottom: 0px;
+                      }
+                  }
+                  @-moz-keyframes slide-down-custom {
+                      0% {
+                          bottom: 857px !important;
+                      }
+                      100% {
+                          bottom: 0px;
+                      }
+                  }
+    </style>
+  </head>
+  <body>
+    onetrust cookie banner
+    <div id="onetrust-consent-sdk">
+      <div class="onetrust-pc-dark-filter ot-hide ot-fade-in"></div>
+      <div
+        id="onetrust-banner-sdk"
+        class="otFlat bottom vertical-align-content ot-buttons-fw"
+        tabindex="0"
+        role="region"
+        aria-label="Cookie banner"
+        style="bottom: 0px"
+      >
+        <div
+          role="alertdialog"
+          aria-describedby="onetrust-policy-text"
+          aria-label="We use cookies to deliver example's services"
+        >
+          <div class="ot-sdk-container">
+            <div class="ot-sdk-row">
+              <div
+                id="onetrust-group-container"
+                class="ot-sdk-eight ot-sdk-columns"
+              >
+                <div class="banner_logo"></div>
+                <div id="onetrust-policy">
+                  <h2 id="onetrust-policy-title">
+                    We use cookies to deliver example's services
+                  </h2>
+                  <div id="onetrust-policy-text">
+                    We and our partners use cookies to enhance and personalise
+                    your experience. "Allow all cookies," "Accept only essential
+                    cookies", or select "Manage cookies" to choose which types
+                    of cookies are used. example does not use cookies to target
+                    advertising in Europe. You can learn more about cookies at
+                    example or adjust your cookie preferences anytime through the
+                    Privacy Policy.
+                    <a
+                      class="ot-cookie-policy-link"
+                      href="https://www.example.com/tos/privacy_policy#cookies"
+                      aria-label="More information about your privacy, opens in a new tab"
+                      rel="noopener"
+                      target="_blank"
+                      >More information</a
+                    >
+                  </div>
+                </div>
+              </div>
+              <div
+                id="onetrust-button-group-parent"
+                class="ot-sdk-three ot-sdk-columns has-reject-all-button"
+              >
+                <div id="onetrust-button-group">
+                  <button id="onetrust-pc-btn-handler">Manage cookies</button>
+                  <button id="onetrust-reject-all-handler">
+                    Accept only essential cookies
+                  </button>
+                  <button id="onetrust-accept-btn-handler">
+                    Allow all cookies
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Close Button -->
+          <div id="onetrust-close-btn-container"></div>
+          <!-- Close Button END-->
+        </div>
+      </div>
+      <div
+        id="onetrust-pc-sdk"
+        class="otPcCenter ot-hide ot-fade-in"
+        lang="en"
+        aria-label="Preference center"
+        role="region"
+      >
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-describedby="ot-pc-desc"
+          style="height: 100%"
+          aria-label="Cookie preferences"
+        >
+          <!-- Close Button -->
+          <div class="ot-pc-header">
+            <!-- Logo Tag -->
+            <div class="ot-pc-logo" role="img" aria-label="Company Logo">
+              <img
+                alt="Company Logo"
+                src="none"
+              />
+            </div>
+          </div>
+          <!-- Close Button -->
+          <div id="ot-pc-content" class="ot-pc-scrollbar">
+            <div class="ot-optout-signal ot-hide">
+              <div class="ot-optout-icon">
+                <svg xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    class="ot-floating-button__svg-fill"
+                    d="M14.588 0l.445.328c1.807 1.303 3.961 2.533 6.461 3.688 2.015.93 4.576 1.746 7.682 2.446 0 14.178-4.73 24.133-14.19 29.864l-.398.236C4.863 30.87 0 20.837 0 6.462c3.107-.7 5.668-1.516 7.682-2.446 2.709-1.251 5.01-2.59 6.906-4.016zm5.87 13.88a.75.75 0 00-.974.159l-5.475 6.625-3.005-2.997-.077-.067a.75.75 0 00-.983 1.13l4.172 4.16 6.525-7.895.06-.083a.75.75 0 00-.16-.973z"
+                    fill="#FFF"
+                    fill-rule="evenodd"
+                  ></path>
+                </svg>
+              </div>
+              <span>Your Opt Out Preference Signal is Honored</span>
+            </div>
+            <h2 id="ot-pc-title">Cookie preferences</h2>
+            <div id="ot-pc-desc">
+              We use cookies to enhance and personalise your experience. example
+              does not use cookies to target advertising in Europe. <br /><a
+                href="https://terms.example.com/privacy/en_us/20200101_en_us/#Cookies"
+                class="privacy-notice-link"
+                rel="noopener"
+                target="_blank"
+                aria-label="More information about your privacy, opens in a new tab"
+                >More information</a
+              >
+            </div>
+            <button id="accept-recommended-btn-handler">Allow all</button>
+            <section class="ot-sdk-row ot-cat-grp">
+              <h3 id="ot-category-title" aria-hidden="true"></h3>
+              <div
+                class="ot-cat-item ot-always-active-group ot-vs-config"
+                data-optanongroupid="C0001"
+              >
+                <!-- Group name -->
+                <h4 class="ot-cat-header" id="ot-header-id-C0001">
+                  Essential cookies
+                </h4>
+                <div id="ot-status-id-C0001" class="ot-always-active">
+                  (required)
+                </div>
+                <!-- Group description -->
+                <p class="ot-category-desc" id="ot-desc-id-C0001">
+                  These cookies are necessary for the website to function. They
+                  are usually only set in response to requests made by you, such
+                  as setting your privacy preferences, logging in, or filling in
+                  forms.
+                </p>
+                <div class="ot-hlst-cntr">
+                  <button
+                    class="ot-link-btn category-host-list-handler"
+                    aria-label="Cookie Details button opens Cookie List menu"
+                    data-parent-id="C0001"
+                  >
+                    Cookies Details‎
+                  </button>
+                </div>
+              </div>
+              <div class="ot-cat-item ot-vs-config" data-optanongroupid="C0002">
+                <!-- Group name -->
+                <h4 class="ot-cat-header" id="ot-header-id-C0002">
+                  Analytics cookies
+                </h4>
+                <div class="ot-tgl">
+                  <input
+                    type="checkbox"
+                    name="ot-group-id-C0002"
+                    id="ot-group-id-C0002"
+                    role="switch"
+                    class="category-switch-handler"
+                    data-optanongroupid="C0002"
+                    aria-labelledby="ot-header-id-C0002"
+                  />
+                  <label class="ot-switch" for="ot-group-id-C0002"
+                    ><span
+                      class="ot-switch-nob"
+                      aria-checked="false"
+                      role="switch"
+                      aria-label="Analytics cookies"
+                    ></span>
+                    <span class="ot-label-txt">Analytics cookies</span></label
+                  >
+                </div>
+                <!-- Group description -->
+                <p class="ot-category-desc" id="ot-desc-id-C0002">
+                  Analytics cookies allow us to understand how visitors use our
+                  site and measure and optimize the site's performance.
+                </p>
+                <div class="ot-hlst-cntr">
+                  <button
+                    class="ot-link-btn category-host-list-handler"
+                    aria-label="Cookie Details button opens Cookie List menu"
+                    data-parent-id="C0002"
+                  >
+                    Cookies Details‎
+                  </button>
+                </div>
+              </div>
+              <div class="ot-cat-item ot-vs-config" data-optanongroupid="C0003">
+                <!-- Group name -->
+                <h4 class="ot-cat-header" id="ot-header-id-C0003">
+                  Functional cookies
+                </h4>
+                <div class="ot-tgl">
+                  <input
+                    type="checkbox"
+                    name="ot-group-id-C0003"
+                    id="ot-group-id-C0003"
+                    role="switch"
+                    class="category-switch-handler"
+                    data-optanongroupid="C0003"
+                    aria-labelledby="ot-header-id-C0003"
+                  />
+                  <label class="ot-switch" for="ot-group-id-C0003"
+                    ><span
+                      class="ot-switch-nob"
+                      aria-checked="false"
+                      role="switch"
+                      aria-label="Functional cookies"
+                    ></span>
+                    <span class="ot-label-txt">Functional cookies</span></label
+                  >
+                </div>
+                <!-- Group description -->
+                <p class="ot-category-desc" id="ot-desc-id-C0003">
+                  Functional cookies enable us to provide enhanced functionality
+                  and personalisation, for example, by remembering that you
+                  prefer vegetarian food when conducting searches for
+                  restaurants.
+                </p>
+                <div class="ot-hlst-cntr">
+                  <button
+                    class="ot-link-btn category-host-list-handler"
+                    aria-label="Cookie Details button opens Cookie List menu"
+                    data-parent-id="C0003"
+                  >
+                    Cookies Details‎
+                  </button>
+                </div>
+              </div>
+              <!-- Groups sections starts --><!-- Group section ends --><!-- Accordion Group section starts --><!-- Accordion Group section ends -->
+            </section>
+          </div>
+          <section id="ot-pc-lst" class="ot-hide ot-hosts-ui ot-pc-scrollbar">
+            <div id="ot-pc-hdr">
+              <div id="ot-lst-title">
+                <button class="ot-link-btn back-btn-handler" aria-label="Back">
+                  <svg
+                    id="ot-back-arw"
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    x="0px"
+                    y="0px"
+                    viewBox="0 0 444.531 444.531"
+                    xml:space="preserve"
+                  >
+                    <title>Back Button</title>
+                    <g>
+                      <path
+                        fill="#656565"
+                        d="M213.13,222.409L351.88,83.653c7.05-7.043,10.567-15.657,10.567-25.841c0-10.183-3.518-18.793-10.567-25.835
+                        l-21.409-21.416C323.432,3.521,314.817,0,304.637,0s-18.791,3.521-25.841,10.561L92.649,196.425
+                        c-7.044,7.043-10.566,15.656-10.566,25.841s3.521,18.791,10.566,25.837l186.146,185.864c7.05,7.043,15.66,10.564,25.841,10.564
+                        s18.795-3.521,25.834-10.564l21.409-21.412c7.05-7.039,10.567-15.604,10.567-25.697c0-10.085-3.518-18.746-10.567-25.978
+                        L213.13,222.409z"
+                      ></path>
+                    </g>
+                  </svg>
+                </button>
+                <h3>Cookie List</h3>
+              </div>
+              <div class="ot-lst-subhdr">
+                <div class="ot-search-cntr">
+                  <p role="status" class="ot-scrn-rdr"></p>
+                  <input
+                    id="vendor-search-handler"
+                    type="text"
+                    name="vendor-search-handler"
+                    placeholder="Search…"
+                    aria-label="Cookie list search"
+                  />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    x="0px"
+                    y="0px"
+                    viewBox="0 -30 110 110"
+                    aria-hidden="true"
+                  >
+                    <title>Search Icon</title>
+                    <path
+                      fill="#2e3644"
+                      d="M55.146,51.887L41.588,37.786c3.486-4.144,5.396-9.358,5.396-14.786c0-12.682-10.318-23-23-23s-23,10.318-23,23
+                s10.318,23,23,23c4.761,0,9.298-1.436,13.177-4.162l13.661,14.208c0.571,0.593,1.339,0.92,2.162,0.92
+                c0.779,0,1.518-0.297,2.079-0.837C56.255,54.982,56.293,53.08,55.146,51.887z M23.984,6c9.374,0,17,7.626,17,17s-7.626,17-17,17
+                s-17-7.626-17-17S14.61,6,23.984,6z"
+                    ></path>
+                  </svg>
+                </div>
+                <div class="ot-fltr-cntr">
+                  <button
+                    id="filter-btn-handler"
+                    aria-label="Filter"
+                    aria-haspopup="true"
+                  >
+                    <svg
+                      role="presentation"
+                      aria-hidden="true"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      x="0px"
+                      y="0px"
+                      viewBox="0 0 402.577 402.577"
+                      xml:space="preserve"
+                    >
+                      <title>Filter Icon</title>
+                      <g>
+                        <path
+                          fill="#fff"
+                          d="M400.858,11.427c-3.241-7.421-8.85-11.132-16.854-11.136H18.564c-7.993,0-13.61,3.715-16.846,11.136
+          c-3.234,7.801-1.903,14.467,3.999,19.985l140.757,140.753v138.755c0,4.955,1.809,9.232,5.424,12.854l73.085,73.083
+          c3.429,3.614,7.71,5.428,12.851,5.428c2.282,0,4.66-0.479,7.135-1.43c7.426-3.238,11.14-8.851,11.14-16.845V172.166L396.861,31.413
+          C402.765,25.895,404.093,19.231,400.858,11.427z"
+                        ></path>
+                      </g>
+                    </svg>
+                  </button>
+                </div>
+                <div id="ot-anchor"></div>
+                <section id="ot-fltr-modal">
+                  <div id="ot-fltr-cnt">
+                    <button id="clear-filters-handler">Clear</button>
+                    <div class="ot-fltr-scrlcnt ot-pc-scrollbar">
+                      <div class="ot-fltr-opts">
+                        <div class="ot-fltr-opt">
+                          <div class="ot-chkbox">
+                            <input
+                              id="chkbox-id"
+                              type="checkbox"
+                              class="category-filter-handler"
+                            />
+                            <label for="chkbox-id"
+                              ><span class="ot-label-txt"
+                                >checkbox label</span
+                              ></label
+                            >
+                            <span class="ot-label-status">label</span>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="ot-fltr-btns">
+                        <button id="filter-apply-handler">Apply</button>
+                        <button id="filter-cancel-handler">Cancel</button>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+              </div>
+            </div>
+            <section id="ot-lst-cnt" class="ot-host-cnt ot-pc-scrollbar">
+              <div id="ot-sel-blk">
+                <div class="ot-sel-all">
+                  <div class="ot-sel-all-hdr">
+                    <span class="ot-consent-hdr">Consent</span>
+                    <span class="ot-li-hdr">Leg.Interest</span>
+                  </div>
+                  <div class="ot-sel-all-chkbox">
+                    <div class="ot-chkbox" id="ot-selall-hostcntr">
+                      <input
+                        id="select-all-hosts-groups-handler"
+                        type="checkbox"
+                      />
+                      <label for="select-all-hosts-groups-handler"
+                        ><span class="ot-label-txt">checkbox label</span></label
+                      >
+                      <span class="ot-label-status">label</span>
+                    </div>
+                    <div class="ot-chkbox" id="ot-selall-vencntr">
+                      <input
+                        id="select-all-vendor-groups-handler"
+                        type="checkbox"
+                      />
+                      <label for="select-all-vendor-groups-handler"
+                        ><span class="ot-label-txt">checkbox label</span></label
+                      >
+                      <span class="ot-label-status">label</span>
+                    </div>
+                    <div class="ot-chkbox" id="ot-selall-licntr">
+                      <input
+                        id="select-all-vendor-leg-handler"
+                        type="checkbox"
+                      />
+                      <label for="select-all-vendor-leg-handler"
+                        ><span class="ot-label-txt">checkbox label</span></label
+                      >
+                      <span class="ot-label-status">label</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="ot-sdk-row">
+                <div class="ot-sdk-column"><ul id="ot-host-lst"></ul></div>
+              </div>
+            </section>
+          </section>
+          <div class="ot-pc-footer ot-pc-scrollbar">
+            <div class="ot-btn-container">
+              <button class="ot-pc-refuse-all-handler">
+                Accept only essential cookies
+              </button>
+              <button
+                class="save-preference-btn-handler onetrust-close-btn-handler"
+              >
+                Save preferences
+              </button>
+            </div>
+            <!-- Footer logo -->
+            <div class="ot-pc-footer-logo">
+              <a
+                href="https://www.onetrust.com/products/cookie-consent/"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Powered by OneTrust Opens in a new Tab"
+                ><img
+                  alt="Powered by Onetrust"
+                  src="https://cdn.cookielaw.org/logos/static/powered_by_logo.svg"
+                  title="Powered by OneTrust Opens in a new Tab"
+              /></a>
+            </div>
+          </div>
+          <!-- Cookie subgroup container --><!-- Vendor list link --><!-- Cookie lost link --><!-- Toggle HTML element --><!-- Checkbox HTML --><!-- plus minus--><!-- Arrow SVG element --><!-- Accordion basic element --><span
+            class="ot-scrn-rdr"
+            aria-atomic="true"
+            aria-live="polite"
+          ></span
+          ><!-- Vendor Service container and item template -->
+        </div>
+        <iframe
+          class="ot-text-resize"
+          sandbox="allow-same-origin"
+          title="onetrust-text-resize"
+          style="position: absolute; top: -50000px; width: 100em"
+          aria-hidden="true"
+        ></iframe>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tracker/test/fixtures/cookies-quantcast.html
+++ b/tracker/test/fixtures/cookies-quantcast.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Plausible Playwright tests</title>
+  </head>
+
+  <body>
+    quantcast fixture
+    <div class="qc-cmp2-container" id="qc-cmp2-container" data-nosnippet="">
+      <div class="qc-cmp2-main" id="qc-cmp2-main" data-nosnippet="">
+        <div height="857" class="qc-cmp-cleanslate css-1svdtbq">
+          <div
+            id="qc-cmp2-ui"
+            role="dialog"
+            aria-label="Privacy"
+            aria-modal="true"
+            tabindex="0"
+            class="css-w9wzt7"
+          >
+            <div class="qc-cmp2-summary-section">
+              <div class="qc-cmp2-consent-info">
+                <div class="qc-cmp2-publisher-logo-container">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      padding: 5px 0px;
+                      width: 100%;
+                      margin-top: 10px;
+                      justify-content: space-between;
+                    "
+                  >
+                    <figure style="width: 100%; text-align: center">
+                      <div
+                        height="89"
+                        width="300"
+                        class="logo-container css-4pd0y0"
+                      >
+                        <img
+                          alt="Publisher Logo"
+                          src="https://info.quantcast.com/rs/516-DGM-318/images/Quantcast_Logo_DkBlue.svg?version=0&amp;qc-size=300,89"
+                        />
+                      </div>
+                      <span role="heading" aria-level="2" class="span-heading"
+                        >We value your privacy</span
+                      >
+                    </figure>
+                  </div>
+                  <div class="qc-cmp2-summary-info qc-cmp2-logo-displayed">
+                    <div class="">
+                      We and our
+                      <button
+                        mode="link"
+                        class="qc-cmp2-link-inline css-1sjf9qp"
+                        size="large"
+                      >
+                        partners
+                      </button>
+                      store and/or access information on a device, such as
+                      cookies and process personal data, such as unique
+                      identifiers and standard information sent by a device for
+                      personalised advertising and content, advertising and
+                      content measurement, audience research and services
+                      development. With your permission we and our partners may
+                      use precise geolocation data and identification through
+                      device scanning. You may click to consent to our and our
+                      11 partners’ processing as described above. Alternatively
+                      you may click to refuse to consent or access more detailed
+                      information and change your preferences before consenting.
+                      Please note that some processing of your personal data may
+                      not require your consent, but you have a right to object
+                      to such processing. Your preferences will apply to this
+                      website only and will be stored in IABGPP_HDR_GppString
+                      cookie for 13 months. You can change your preferences or
+                      withdraw your consent at any time by returning to this
+                      site and clicking the "Privacy" button at the bottom of
+                      the webpage.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="qc-cmp2-footer qc-cmp2-footer-overlay qc-cmp2-footer-scrolled"
+            >
+              <div class="qc-cmp2-summary-buttons">
+                <button
+                  mode="secondary"
+                  id="more-options-btn"
+                  size="large"
+                  class="css-1hy2vtq"
+                >
+                  <span>MORE OPTIONS</span></button
+                ><button
+                  mode="primary"
+                  id="accept-btn"
+                  size="large"
+                  class="css-47sehv"
+                >
+                  <span>AGREE</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -795,30 +795,35 @@ test.describe('installed plausible esm variant', () => {
   })
 })
 
-test.describe('cookie banners', () => {
-  for (const { url, cookieBannerTitle, expectedcookiesConsentResult } of [
+test.describe('opts in on cookie banners', () => {
+  for (const { url, expectedcookiesConsentResult } of [
     {
-      url: 'https://www.yelp.ie/dublin',
-      cookieBannerTitle: 'We use cookies to deliver',
+      url: `${LOCAL_SERVER_ADDR}/cookies-onetrust.html`,
       expectedcookiesConsentResult: {
         cmp: 'Onetrust',
         handled: true
       }
+    },
+    {
+      url: `${LOCAL_SERVER_ADDR}/cookies-iubenda.html`,
+      expectedcookiesConsentResult: {
+        cmp: 'iubenda',
+        handled: true
+      }
     }
   ]) {
-    test(`accepts cookies on ${url} (${expectedcookiesConsentResult.cmp})`, async ({
+    test(`accepts cookies of cmp ${expectedcookiesConsentResult.cmp}`, async ({
       page
     }) => {
       const response = await page.goto(url)
       const responseHeaders = response?.headers() ?? {}
-      await expect(page.getByText(cookieBannerTitle)).toBeVisible()
 
       const result = await executeVerifyV2(page, {
         ...DEFAULT_VERIFICATION_OPTIONS,
         timeoutMs: 2000,
         responseHeaders
       })
-      await expect(page.getByText(cookieBannerTitle)).not.toBeVisible()
+
       expect(result.data).toEqual(
         expect.objectContaining({
           cookiesConsentResult: expectedcookiesConsentResult

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -796,23 +796,37 @@ test.describe('installed plausible esm variant', () => {
 })
 
 test.describe('opts in on cookie banners', () => {
-  for (const { url, expectedcookiesConsentResult } of [
+  for (const { url, expectedCookiesConsentResult } of [
     {
       url: `${LOCAL_SERVER_ADDR}/cookies-onetrust.html`,
-      expectedcookiesConsentResult: {
+      expectedCookiesConsentResult: {
         cmp: 'Onetrust',
         handled: true
       }
     },
     {
       url: `${LOCAL_SERVER_ADDR}/cookies-iubenda.html`,
-      expectedcookiesConsentResult: {
+      expectedCookiesConsentResult: {
         cmp: 'iubenda',
+        handled: true
+      }
+    },
+    {
+      url: `${LOCAL_SERVER_ADDR}/cookies-cookiebot.html`,
+      expectedCookiesConsentResult: {
+        cmp: 'cookiebot',
+        handled: true
+      }
+    },
+    {
+      url: `${LOCAL_SERVER_ADDR}/cookies-quantcast.html`,
+      expectedCookiesConsentResult: {
+        cmp: 'quantcast',
         handled: true
       }
     }
   ]) {
-    test(`accepts cookies of cmp ${expectedcookiesConsentResult.cmp}`, async ({
+    test(`accepts cookies of cmp ${expectedCookiesConsentResult.cmp}`, async ({
       page
     }) => {
       const response = await page.goto(url)
@@ -826,7 +840,7 @@ test.describe('opts in on cookie banners', () => {
 
       expect(result.data).toEqual(
         expect.objectContaining({
-          cookiesConsentResult: expectedcookiesConsentResult
+          cookiesConsentResult: expectedCookiesConsentResult
         })
       )
     })

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -65,7 +65,13 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -126,7 +132,13 @@ test.describe('installed plausible web variant', () => {
           responseStatus: undefined,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -183,7 +195,13 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 400,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -225,7 +243,13 @@ test.describe('installed plausible web variant', () => {
           responseStatus: undefined,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -288,7 +312,13 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -407,7 +437,13 @@ test.describe('installed plausible web variant', () => {
           requestUrl: undefined,
           responseStatus: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -468,7 +504,13 @@ test.describe('installed plausible web variant', () => {
           requestUrl: undefined,
           responseStatus: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -533,7 +575,13 @@ test.describe('installed plausible web variant', () => {
           },
           responseStatus: 202
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -592,7 +640,13 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -651,7 +705,13 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -710,7 +770,13 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: 500,
           error: undefined
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
@@ -760,8 +826,76 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: undefined,
           error: { message: 'Failed to fetch' }
         },
-        cookieBannerLikely: false
+        cookiesConsentResult: {
+          handled: false,
+          error: {
+            engineLifecycle: 'started',
+            message: 'Time allocated for cookie consent engine exceeded'
+          }
+        }
       }
     })
   })
+})
+
+test.describe('cookie banners', () => {
+  for (const { url, cookieBannerTitle, expectedcookiesConsentResult } of [
+    // {
+    //   url: 'https://visitestonia.com/en',
+    //   expectedcookiesConsentResult: { cmp: 'cookiebot' }
+    // } // this site uses cookiebot but consent-o-matic is not able to accept the cookies
+    // {
+    //   url: 'https://www.vepsalainen.com/en/ee/',
+    //   cookieBannerTitle: 'We use cookies to better your user experience',
+    //   expectedcookiesConsentResult: {
+    //     handled: true,
+    //     cmp: 'cookiebot',
+    //     clicks: expect.any(Number)
+    //   }
+    // },
+    // {
+    //   url: 'https://www.swedbank.se/en',
+    //   cookieBannerTitle: 'Our cookies, your',
+    //   expectedcookiesConsentResult: {
+    //     cmp: 'auto_NO_swedbank.se_63w',
+    //     handled: true
+    //   }
+    // },
+    // {
+    //   url: 'https://www.mohito.com/ee/et/',
+    //   cookieBannerTitle: 'Luba küpsised',
+    //   expectedcookiesConsentResult: {
+    //     cmp: 'consent-o-matic',
+    //     handled: true
+    //   }
+    // },
+    {
+      url: 'https://www.yelp.ie/dublin',
+      cookieBannerTitle: 'We use cookies to deliver',
+      expectedcookiesConsentResult: {
+        cmp: 'Onetrust',
+        handled: true
+      }
+    }
+  ]) {
+    test(`accepts cookies on ${url} (${expectedcookiesConsentResult.cmp})`, async ({
+      page
+    }) => {
+      const response = await page.goto(url)
+      const responseHeaders = response?.headers() ?? {}
+      await expect(page.getByText(cookieBannerTitle)).toBeVisible()
+
+      const result = await executeVerifyV2(page, {
+        ...DEFAULT_VERIFICATION_OPTIONS,
+        timeoutMs: 2000,
+        responseHeaders
+      })
+      await expect(page.getByText(cookieBannerTitle)).not.toBeVisible()
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          cookiesConsentResult: expectedcookiesConsentResult
+        })
+      )
+    })
+  }
 })

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -14,6 +14,11 @@ const DEFAULT_VERIFICATION_OPTIONS = {
   timeoutBetweenAttemptsMs: 500
 }
 
+const incompleteCookiesConsentResult = {
+  engineLifecycle: expect.stringMatching(/started|initialized/),
+  handled: null
+}
+
 test.describe('installed plausible web variant', () => {
   test('using provided snippet', async ({ page }, { testId }) => {
     await mockManyRequests({
@@ -65,13 +70,7 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -132,13 +131,7 @@ test.describe('installed plausible web variant', () => {
           responseStatus: undefined,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -195,13 +188,7 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 400,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -243,13 +230,7 @@ test.describe('installed plausible web variant', () => {
           responseStatus: undefined,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -312,13 +293,7 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -437,13 +412,7 @@ test.describe('installed plausible web variant', () => {
           requestUrl: undefined,
           responseStatus: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -504,13 +473,7 @@ test.describe('installed plausible web variant', () => {
           requestUrl: undefined,
           responseStatus: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -576,11 +539,8 @@ test.describe('installed plausible web variant', () => {
           responseStatus: 202
         },
         cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
+          handled: null,
+          engineLifecycle: 'started'
         }
       }
     })
@@ -640,13 +600,7 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: 202,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -706,11 +660,8 @@ test.describe('installed plausible esm variant', () => {
           error: undefined
         },
         cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
+          handled: null,
+          engineLifecycle: 'started'
         }
       }
     })
@@ -770,13 +721,7 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: 500,
           error: undefined
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -826,13 +771,7 @@ test.describe('installed plausible esm variant', () => {
           responseStatus: undefined,
           error: { message: 'Failed to fetch' }
         },
-        cookiesConsentResult: {
-          handled: false,
-          error: {
-            engineLifecycle: 'started',
-            message: 'Time allocated for cookie consent engine exceeded'
-          }
-        }
+        cookiesConsentResult: incompleteCookiesConsentResult
       }
     })
   })
@@ -840,35 +779,6 @@ test.describe('installed plausible esm variant', () => {
 
 test.describe('cookie banners', () => {
   for (const { url, cookieBannerTitle, expectedcookiesConsentResult } of [
-    // {
-    //   url: 'https://visitestonia.com/en',
-    //   expectedcookiesConsentResult: { cmp: 'cookiebot' }
-    // } // this site uses cookiebot but consent-o-matic is not able to accept the cookies
-    // {
-    //   url: 'https://www.vepsalainen.com/en/ee/',
-    //   cookieBannerTitle: 'We use cookies to better your user experience',
-    //   expectedcookiesConsentResult: {
-    //     handled: true,
-    //     cmp: 'cookiebot',
-    //     clicks: expect.any(Number)
-    //   }
-    // },
-    // {
-    //   url: 'https://www.swedbank.se/en',
-    //   cookieBannerTitle: 'Our cookies, your',
-    //   expectedcookiesConsentResult: {
-    //     cmp: 'auto_NO_swedbank.se_63w',
-    //     handled: true
-    //   }
-    // },
-    // {
-    //   url: 'https://www.mohito.com/ee/et/',
-    //   cookieBannerTitle: 'Luba küpsised',
-    //   expectedcookiesConsentResult: {
-    //     cmp: 'consent-o-matic',
-    //     handled: true
-    //   }
-    // },
     {
       url: 'https://www.yelp.ie/dublin',
       cookieBannerTitle: 'We use cookies to deliver',

--- a/tracker/test/support/types.ts
+++ b/tracker/test/support/types.ts
@@ -24,6 +24,24 @@ export type VerifyV2Args = {
   cspHostToCheck: string
 }
 
+type ConsentResult =
+  // consented to cookies of cmp
+  | { handled: true; cmp: string }
+  // did not detect cmps, exhausted detection retries
+  | {
+      handled: true
+    }
+  // failed init or consent process
+  | {
+      handled: false
+      error: unknown
+    }
+  // none of the above, most likely didn't get to finish
+  | {
+      handled: null
+      engineLifecycle: string
+    }
+
 export type VerifyV2Result = {
   data:
     | {
@@ -34,19 +52,7 @@ export type VerifyV2Result = {
         plausibleVariant?: string
         disallowedByCsp: boolean
         cookieBannerLikely: boolean
-        cookiesConsentResult:
-          | {
-              handled: true
-              // this is undefined if no cmp is detected and detection retries are exhausted
-              cmp?: string
-            }
-          | {
-            handled: false,
-            error: {
-              message: string
-              engineLifecycle?: string
-            }
-          }
+        cookiesConsentResult: ConsentResult
         testEvent: {
           /**
            * window.plausible (track) callback

--- a/tracker/test/support/types.ts
+++ b/tracker/test/support/types.ts
@@ -5,8 +5,10 @@ export type Options = {
   formSubmissions: boolean
   captureOnLocalhost: boolean
   autoCapturePageviews: boolean
-  customProperties: Record<string, any> | ((eventName: string) => Record<string, any>)
-  transformRequest: (payload: unknown) => unknown,
+  customProperties:
+    | Record<string, any>
+    | ((eventName: string) => Record<string, any>)
+  transformRequest: (payload: unknown) => unknown
   logging: boolean
 }
 
@@ -32,6 +34,19 @@ export type VerifyV2Result = {
         plausibleVariant?: string
         disallowedByCsp: boolean
         cookieBannerLikely: boolean
+        cookiesConsentResult:
+          | {
+              handled: true
+              // this is undefined if no cmp is detected and detection retries are exhausted
+              cmp?: string
+            }
+          | {
+            handled: false,
+            error: {
+              message: string
+              engineLifecycle?: string
+            }
+          }
         testEvent: {
           /**
            * window.plausible (track) callback


### PR DESCRIPTION
### Changes

Makes use of https://www.npmjs.com/package/@duckduckgo/autoconsent to accept cookies during installation verification process. 

I picked this approach in favor of hand-rolling a cookie consenter because I don't think we'll be able to maintain a hand-rolled solution at a good-enough level as consent management platforms (CMPs) wax and wane in popularity and our user base becomes more international.

The autoconsent library and rules to detect CMPs are bundled into the verifier script. This increases its size: the compiled verifier-v2.js file is now ~840kb (up from ~3kb on master) , of which 800kb are rulesets for 100s of different cookie banner setups. Since the extra size takes longer to deliver to Browserless.io, I think we should trim it down. 

Edit: It's now trimmed down to be ~100kb.

Todos
- [x] Fix unexpected CI-only test failure with "installed plausible web variant › there are more than maxAttempts JS navigations"
- [x] Expose in Verification diagnostics
- [x] Remove cookieBannerLikely related diagnostics case
- [x] Replace test on real pages with a couple of tests on fake pages
- [x] Stop waiting for cookie consent if plausible function test successful
- [x] Trim rules to recognize and accept cookies of the following CMPs
  - Cookiebot
  - Quantcast
  - Iubenda
  - Usercentrics (button-based)
  - didomi.io
  - oil.js <-- a likely defunct CMP that's compiled in
  - optanon
  - quantcast2 
  - springer <--  a likely defunct CMP that's compiled in
  - wordpressgdpr <-- a likely defunct CMP that's compiled in
  

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
