### PR TITLE
CRM: Expose 2FA user status & allow CS to force disable it

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/user/components/overview.ex
+++ b/extra/lib/plausible_web/live/customer_support/user/components/overview.ex
@@ -102,15 +102,9 @@ defmodule PlausibleWeb.CustomerSupport.User.Components.Overview do
   def handle_event("force-disable-2fa", _params, socket) do
     user = socket.assigns.user
 
-    case TOTP.force_disable(user) do
-      {:ok, updated_user} ->
-        send(self(), {:success, "2FA has been force disabled for this user"})
-        {:noreply, assign(socket, user: updated_user)}
-
-      {:error, reason} ->
-        send(self(), {:error, "Failed to disable 2FA: #{reason}"})
-        {:noreply, socket}
-    end
+    {:ok, updated_user} = TOTP.force_disable(user)
+    send(self(), {:success, "2FA has been force disabled for this user"})
+    {:noreply, assign(socket, user: updated_user)}
   end
 
   def handle_event("save-user", %{"user" => params}, socket) do

--- a/test/plausible_web/live/customer_support/users_test.exs
+++ b/test/plausible_web/live/customer_support/users_test.exs
@@ -112,5 +112,50 @@ defmodule PlausibleWeb.Live.CustomerSupport.UsersTest do
         refute html =~ k3.key_prefix
       end
     end
+
+    describe "2FA management" do
+      setup [:create_user, :log_in, :create_site]
+
+      setup %{user: user} do
+        patch_env(:super_admin_user_ids, [user.id])
+      end
+
+      test "shows 2FA disabled status when user has no 2FA", %{conn: conn, user: user} do
+        {:ok, _lv, html} = live(conn, open_user(user.id))
+
+        assert text(html) =~ "Two-Factor Authentication: Disabled"
+        refute text(html) =~ "Force Disable 2FA"
+      end
+
+      test "shows 2FA enabled status and disable button when user has 2FA", %{
+        conn: conn,
+        user: user
+      } do
+        {:ok, user, _} = Plausible.Auth.TOTP.initiate(user)
+        {:ok, user, _} = Plausible.Auth.TOTP.enable(user, :skip_verify)
+
+        {:ok, _lv, html} = live(conn, open_user(user.id))
+
+        assert text(html) =~ "Two-Factor Authentication: Enabled"
+        assert text(html) =~ "Force Disable 2FA"
+      end
+
+      test "force disables 2FA when button is clicked", %{conn: conn, user: user} do
+        {:ok, user, _} = Plausible.Auth.TOTP.initiate(user)
+        {:ok, user, _} = Plausible.Auth.TOTP.enable(user, :skip_verify)
+
+        {:ok, lv, _html} = live(conn, open_user(user.id))
+
+        lv |> element("[phx-click='force-disable-2fa']") |> render_click()
+
+        html = render(lv)
+        assert text(html) =~ "2FA has been force disabled"
+        assert text(html) =~ "Two-Factor Authentication: Disabled"
+        refute text(html) =~ "Force Disable 2FA"
+
+        updated_user = Plausible.Repo.reload(user)
+        refute Plausible.Auth.TOTP.enabled?(updated_user)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Changes

<img width="1362" height="262" alt="image" src="https://github.com/user-attachments/assets/ce6746c1-12f1-4109-8907-1d4dc4b216c7" />

<img width="1453" height="706" alt="image" src="https://github.com/user-attachments/assets/7b140b00-fd01-4f30-a9bf-028256d3e082" />

cc @metmarkosaric 

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
