### PR TITLE
Handle team policy update on empty default struct gracefully

### DIFF
--- a/extra/lib/plausible/auth/sso.ex
+++ b/extra/lib/plausible/auth/sso.ex
@@ -120,13 +120,11 @@ defmodule Plausible.Auth.SSO do
           {:ok, Teams.Team.t()} | {:error, Ecto.Changeset.t()}
   def update_policy(team, attrs \\ []) do
     params = Map.new(attrs)
-    policy = %{team.policy | id: Ecto.UUID.generate()}
-    policy_changeset = Teams.Policy.update_changeset(policy, params)
 
     changeset =
       team
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_embed(:policy, policy_changeset)
+      |> Ecto.Changeset.cast(%{policy: params}, [])
+      |> Ecto.Changeset.cast_embed(:policy, with: &Teams.Policy.update_changeset/2)
 
     case Repo.update_with_audit(changeset, "sso_policy_updated", %{team_id: team.id}) do
       {:ok, integration} -> {:ok, integration}
@@ -144,11 +142,13 @@ defmodule Plausible.Auth.SSO do
              | :no_sso_user}
   def set_force_sso(team, mode) do
     with :ok <- check_force_sso(team, mode) do
-      policy_changeset = Teams.Policy.force_sso_changeset(team.policy, mode)
+      params = %{policy: %{force_sso: mode}}
 
       team
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_embed(:policy, policy_changeset)
+      |> Ecto.Changeset.cast(params, [])
+      |> Ecto.Changeset.cast_embed(:policy,
+        with: &Teams.Policy.force_sso_changeset(&1, &2.force_sso)
+      )
       |> Repo.update_with_audit("sso_force_mode_changed", %{team_id: team.id})
     end
   end

--- a/lib/plausible/teams/policy.ex
+++ b/lib/plausible/teams/policy.ex
@@ -28,6 +28,7 @@ defmodule Plausible.Teams.Policy do
              only: [:force_sso, :sso_default_role, :sso_session_timeout_minutes]}
   end
 
+  @primary_key false
   embedded_schema do
     # SSO options apply to all team's integrations, should there
     # ever be more than one allowed at once.


### PR DESCRIPTION
### Changes

Update on default embedded schema without populated ID turned out to fail. This change ensures team policy updates work against empty default policy (with `{}` in jsonb column underneath).

### Tests
- [x] Automated tests have been added

