### PR TITLE
Explicitly declare color scheme availability and preference

### DIFF
--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -12,6 +12,7 @@
       <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
       <meta name="websocket-url" content={websocket_url()} />
     <% end %>
+    <meta name="color-scheme" content="light dark" />
     <meta name="robots" content={@conn.private.robots} />
 
     <PlausibleWeb.Components.Layout.favicon conn={@conn} />


### PR DESCRIPTION
### Changes

Declares color scheme preference explicitly. Fixes an issue where embedded dashboard has opaque background in transparent mode.

