### PR TITLE
Avoid slowdowns in tests due to code server waits

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,8 +23,12 @@ end
 
 default_exclude = [:slow, :minio, :migrations]
 
-# avoid slowdowns contacting the code server https://github.com/sasa1977/con_cache/pull/79
-:code.ensure_loaded(ConCache.Lock.Resource)
+# avoid slowdowns contacting the code server
+for {app, _, _} <- Application.loaded_applications() do
+  if modules = Application.spec(app, :modules) do
+    Code.ensure_all_loaded(modules)
+  end
+end
 
 if Mix.env() == :ce_test do
   IO.puts("Test mode: Community Edition")


### PR DESCRIPTION
This is supposed to be taken care of
by https://github.com/elixir-lang/elixir/commit/d05731194e0c9ef6fa00dedd1803f1e03623b976 but not quite it seems.

The first test with a fairly involved exunit template (ConnCase) is usually 700ms vs 60ms whichever comes second. (48-core Threadripper, but similar results on macs AFAIU). This makes --trace / --slowest flags produce misleading results.

h/t @zoldar