### PR TITLE
Don't cache app and dependency specific dialyzer PLTs on CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -147,7 +147,7 @@ jobs:
           path: |
             deps
             _build
-            priv/plts
+            priv/plts/core
           key: static-${{ env.MIX_ENV }}-${{ env.CACHE_VERSION }}-${{ github.head_ref || github.ref }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             static-${{ env.MIX_ENV }}-${{ env.CACHE_VERSION }}-${{ github.head_ref || github.ref }}-

--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,8 @@ plausible-report.xml
 *.code-workspace
 .vscode
 
-# Dializer
-/priv/plts/*.plt
-/priv/plts/*.plt.hash
+# Dialyzer
+/priv/plts
 
 .env
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Plausible.MixProject do
         ]
       ],
       dialyzer: [
-        plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
+        plt_core_path: "priv/plts/core",
+        plt_local_path: "priv/plts/local",
         plt_add_apps: [:mix, :ex_unit]
       ]
     ]


### PR DESCRIPTION
### Changes

This change reduces risk of dialyzer going wonky due to stale PLTs, which [happened in the past](https://github.com/plausible/analytics/pull/4920#issuecomment-2550394046). The PLTs for app and dependencies are kept separate from core PLTs. While core PLTs are kept in the CI cache, the app and dep PLTs are kept outside of it.


