### PR TITLE
Refactor free billing features logic

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/team/components/billing.ex
+++ b/extra/lib/plausible_web/live/customer_support/team/components/billing.ex
@@ -190,7 +190,7 @@ defmodule PlausibleWeb.CustomerSupport.Team.Components.Billing do
                 Plausible.Billing.Feature.list()
                 |> Enum.sort_by(fn item -> if item.name() == :stats_api, do: 0, else: 1 end)
             }
-            :if={not mod.free?()}
+            :if={mod not in Teams.Billing.free_features()}
             x-on:change="featureChangeCallback(event)"
             type="checkbox"
             value={mod in (f.source.changes[:features] || f.source.data.features || [])}

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -590,7 +590,7 @@ defmodule Plausible.Billing.QuotaTest do
       subscribe_to_plan(user, "free_10k")
       team = team_of(user)
 
-      assert [Goals, Props, StatsAPI, SharedLinks] ==
+      assert [Props, StatsAPI, SharedLinks, Goals] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -613,7 +613,8 @@ defmodule Plausible.Billing.QuotaTest do
         assert [
                  Plausible.Billing.Feature.StatsAPI,
                  Plausible.Billing.Feature.Funnels,
-                 Plausible.Billing.Feature.SharedLinks
+                 Plausible.Billing.Feature.SharedLinks,
+                 Plausible.Billing.Feature.Goals
                ] ==
                  Plausible.Teams.Billing.allowed_features_for(team)
       end
@@ -662,7 +663,7 @@ defmodule Plausible.Billing.QuotaTest do
 
       team = team_of(user)
 
-      assert [Plausible.Billing.Feature.StatsAPI] ==
+      assert [Plausible.Billing.Feature.StatsAPI, Plausible.Billing.Feature.Goals] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end
 
@@ -677,7 +678,8 @@ defmodule Plausible.Billing.QuotaTest do
 
       assert [
                Plausible.Billing.Feature.StatsAPI,
-               Plausible.Billing.Feature.SitesAPI
+               Plausible.Billing.Feature.SitesAPI,
+               Plausible.Billing.Feature.Goals
              ] ==
                Plausible.Teams.Billing.allowed_features_for(team)
     end


### PR DESCRIPTION
### Changes

This PR refactors free features logic so that there's one authoritative place where free features are listed. `Feature.free?()` was removed in favor of `Billing.allowed_features_for` always returning free features and a dedicated `Billing.free_features` function.

References https://github.com/plausible/analytics/pull/3740#discussion_r1473320113

### Tests
- [x] Automated tests have been added

