### PR TITLE
CE: Fix v2 onboarding, review installation, and domain change flows

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -495,7 +495,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
   end
 
   defp get_or_create_config(site, params, user) do
-    if scriptv2?(site, user) do
+    if PlausibleWeb.Tracker.scriptv2?(site, user) do
       case PlausibleWeb.Tracker.get_or_create_tracker_script_configuration(site, params) do
         {:ok, tracker_script_configuration} ->
           {:ok, tracker_script_configuration}
@@ -509,7 +509,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
   end
 
   defp update_config(site, params, user) do
-    if scriptv2?(site, user) do
+    if PlausibleWeb.Tracker.scriptv2?(site, user) do
       case PlausibleWeb.Tracker.update_script_configuration(site, params, :installation) do
         {:ok, tracker_script_configuration} ->
           {:ok, tracker_script_configuration}
@@ -528,7 +528,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
   defp get_site_response(site, user) do
     serializable_properties =
-      if(scriptv2?(site, user),
+      if(PlausibleWeb.Tracker.scriptv2?(site, user),
         do: [:domain, :timezone, :tracker_script_configuration],
         else: [:domain, :timezone]
       )
@@ -537,9 +537,5 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
     |> Map.take(serializable_properties)
     # remap to `custom_properties`
     |> Map.put(:custom_properties, site.allowed_event_props || [])
-  end
-
-  defp scriptv2?(site, user) do
-    FunWithFlags.enabled?(:scriptv2, for: site) or FunWithFlags.enabled?(:scriptv2, for: user)
   end
 end

--- a/lib/plausible_web/controllers/site_controller.ex
+++ b/lib/plausible_web/controllers/site_controller.ex
@@ -748,7 +748,7 @@ defmodule PlausibleWeb.SiteController do
   end
 
   def change_domain(conn, _params) do
-    if FunWithFlags.enabled?(:scriptv2, for: conn.assigns.site) do
+    if PlausibleWeb.Tracker.scriptv2?(conn.assigns.site) do
       redirect(conn,
         to: Routes.site_path(conn, :change_domain_v2, conn.assigns.site.domain)
       )

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -2,12 +2,16 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
   @moduledoc """
   LiveView for the change domain v2 flow.
   """
+  use Plausible
   use PlausibleWeb, :live_view
 
   alias PlausibleWeb.Router.Helpers, as: Routes
   alias PlausibleWeb.Live.ChangeDomainV2.Form
-  alias Plausible.InstallationSupport.{Detection, Result}
   alias Phoenix.LiveView.AsyncResult
+
+  on_ee do
+    alias Plausible.InstallationSupport.{Detection, Result}
+  end
 
   def mount(
         %{"domain" => domain},
@@ -28,19 +32,25 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
      )}
   end
 
-  def handle_params(_params, _url, socket) do
-    socket =
-      if socket.assigns.live_action == :success and connected?(socket) do
-        site_domain = socket.assigns.site.domain
+  on_ee do
+    def handle_params(_params, _url, socket) do
+      socket =
+        if socket.assigns.live_action == :success and connected?(socket) do
+          site_domain = socket.assigns.site.domain
 
-        assign_async(socket, :detection_result, fn ->
-          run_detection(site_domain)
-        end)
-      else
-        socket
-      end
+          assign_async(socket, :detection_result, fn ->
+            run_detection(site_domain)
+          end)
+        else
+          socket
+        end
 
-    {:noreply, socket}
+      {:noreply, socket}
+    end
+  else
+    def handle_params(_params, _url, socket) do
+      {:noreply, socket}
+    end
   end
 
   def render(%{live_action: :change_domain_v2} = assigns) do
@@ -90,62 +100,109 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
           ← Back to Site Settings
         </.styled_link>
       </:footer>
+      <%= on_ee do %>
+        <.async_result :let={detection_result} assign={@detection_result}>
+          <:loading>
+            <div class="flex items-center">
+              <.spinner class="w-4 h-4 mr-2" />
+              <span class="text-sm text-gray-600 dark:text-gray-400">
+                Checking your new domain...
+              </span>
+            </div>
+          </:loading>
 
-      <.async_result :let={detection_result} assign={@detection_result}>
-        <:loading>
-          <div class="flex items-center">
-            <.spinner class="w-4 h-4 mr-2" />
-            <span class="text-sm text-gray-600 dark:text-gray-400">Checking your new domain...</span>
-          </div>
-        </:loading>
+          <:failed>
+            <.generic_notice />
+          </:failed>
 
-        <:failed>
-          <.generic_notice />
-        </:failed>
-
-        <.success_notice :if={detection_result} detection_result={detection_result} />
-      </.async_result>
+          <.success_notice :if={detection_result} detection_result={detection_result} />
+        </.async_result>
+      <% else %>
+        <.ce_generic_notice />
+      <% end %>
     </.focus_box>
     """
   end
 
-  defp success_notice(assigns) do
-    case assigns.detection_result do
-      %{v1_detected: true, wordpress_plugin: true} -> wordpress_plugin_notice(assigns)
-      %{v1_detected: true, wordpress_plugin: false} -> generic_notice(assigns)
-      %{v1_detected: false, npm: true} -> generic_notice(assigns)
-      _ -> ~H""
+  on_ee do
+    defp success_notice(assigns) do
+      case assigns.detection_result do
+        %{v1_detected: true, wordpress_plugin: true} -> wordpress_plugin_notice(assigns)
+        %{v1_detected: true, wordpress_plugin: false} -> generic_notice(assigns)
+        %{v1_detected: false, npm: true} -> generic_notice(assigns)
+        _ -> ~H""
+      end
     end
-  end
 
-  defp wordpress_plugin_notice(assigns) do
-    ~H"""
-    <.notice class="mt-4" title="Additional Steps Required">
-      To guarantee continuous tracking, you <i>must</i>
-      also update the site <code>domain</code>
-      in your Plausible Wordpress Plugin settings within 72 hours
-      to match the updated domain. See
-      <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
-        documentation
-      </.styled_link>
-      for details.
-    </.notice>
-    """
-  end
+    defp wordpress_plugin_notice(assigns) do
+      ~H"""
+      <.notice class="mt-4" title="Additional Steps Required">
+        To guarantee continuous tracking, you <i>must</i>
+        also update the site <code>domain</code>
+        in your Plausible Wordpress Plugin settings within 72 hours
+        to match the updated domain. See
+        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+          documentation
+        </.styled_link>
+        for details.
+      </.notice>
+      """
+    end
 
-  defp generic_notice(assigns) do
-    ~H"""
-    <.notice class="mt-4" title="Additional Steps Required">
-      To guarantee continuous tracking, you <i>must</i>
-      also update the site <code>domain</code>
-      of your Plausible Installation within 72 hours
-      to match the updated domain. See
-      <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
-        documentation
-      </.styled_link>
-      for details.
-    </.notice>
-    """
+    defp generic_notice(assigns) do
+      ~H"""
+      <.notice class="mt-4" title="Additional Steps Required">
+        To guarantee continuous tracking, you <i>must</i>
+        also update the site <code>domain</code>
+        of your Plausible Installation within 72 hours
+        to match the updated domain. See
+        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+          documentation
+        </.styled_link>
+        for details.
+      </.notice>
+      """
+    end
+
+    defp run_detection(domain) do
+      detection_result =
+        Detection.Checks.run(nil, domain,
+          detect_v1?: true,
+          report_to: nil,
+          async?: false,
+          slowdown: 0
+        )
+        |> Detection.Checks.interpret_diagnostics()
+
+      case detection_result do
+        %Result{
+          ok?: true,
+          data: data
+        } ->
+          {:ok, %{detection_result: data}}
+
+        %Result{ok?: false, errors: errors} ->
+          {:error, List.first(errors, :unknown_reason)}
+      end
+    end
+  else
+    defp ce_generic_notice(assigns) do
+      ~H"""
+      <.notice class="mt-4" title="Additional steps may be required">
+        If you're using our legacy script (i.e. your Plausible snippet includes the
+        <code>data-domain</code>
+        attribute), OR if you've installed Plausible using
+        our NPM package, you <i>must</i>
+        also update the site <code>domain</code>
+        of
+        your Plausible Installation within 72 hours to match the updated domain. See
+        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+          documentation
+        </.styled_link>
+        for details.
+      </.notice>
+      """
+    end
   end
 
   def handle_info({:domain_changed, updated_site}, socket) do
@@ -155,27 +212,5 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
      socket
      |> assign(site: updated_site)
      |> push_patch(to: Routes.site_path(socket, :success, updated_site.domain))}
-  end
-
-  defp run_detection(domain) do
-    detection_result =
-      Detection.Checks.run(nil, domain,
-        detect_v1?: true,
-        report_to: nil,
-        async?: false,
-        slowdown: 0
-      )
-      |> Detection.Checks.interpret_diagnostics()
-
-    case detection_result do
-      %Result{
-        ok?: true,
-        data: data
-      } ->
-        {:ok, %{detection_result: data}}
-
-      %Result{ok?: false, errors: errors} ->
-        {:error, List.first(errors, :unknown_reason)}
-    end
   end
 end

--- a/lib/plausible_web/live/change_domain_v2.ex
+++ b/lib/plausible_web/live/change_domain_v2.ex
@@ -13,6 +13,10 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
     alias Plausible.InstallationSupport.{Detection, Result}
   end
 
+  @change_domain_docs_link "https://plausible.io/docs/change-domain-name/"
+
+  def change_domain_docs_link(), do: @change_domain_docs_link
+
   def mount(
         %{"domain" => domain},
         _session,
@@ -141,7 +145,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
         also update the site <code>domain</code>
         in your Plausible Wordpress Plugin settings within 72 hours
         to match the updated domain. See
-        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+        <.styled_link new_tab href={@change_domain_docs_link}>
           documentation
         </.styled_link>
         for details.
@@ -156,7 +160,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
         also update the site <code>domain</code>
         of your Plausible Installation within 72 hours
         to match the updated domain. See
-        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+        <.styled_link new_tab href={@change_domain_docs_link}>
           documentation
         </.styled_link>
         for details.
@@ -187,8 +191,10 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
     end
   else
     defp ce_generic_notice(assigns) do
+      assigns = assign(assigns, docs_link: @change_domain_docs_link)
+
       ~H"""
-      <.notice class="mt-4" title="Additional steps may be required">
+      <.notice data-test-id="ce-generic-notice" class="mt-4" title="Additional steps may be required">
         If you're using our legacy script (i.e. your Plausible snippet includes the
         <code>data-domain</code>
         attribute), OR if you've installed Plausible using
@@ -196,7 +202,7 @@ defmodule PlausibleWeb.Live.ChangeDomainV2 do
         also update the site <code>domain</code>
         of
         your Plausible Installation within 72 hours to match the updated domain. See
-        <.styled_link new_tab href="https://plausible.io/docs/change-domain-name/">
+        <.styled_link new_tab href={@docs_link}>
           documentation
         </.styled_link>
         for details.

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -40,7 +40,7 @@ defmodule PlausibleWeb.Live.Installation do
         :viewer
       ])
 
-    if FunWithFlags.enabled?(:scriptv2, for: site) do
+    if PlausibleWeb.Tracker.scriptv2?(site) do
       {:ok,
        redirect(socket,
          to: Routes.site_path(socket, :installation_v2, site.domain, flow: params["flow"])

--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
             >
               <Icons.wordpress_icon /> WordPress
             </.tab>
-            <.tab patch={"?type=gtm&flow=#{@flow}"} selected={@installation_type.result == "gtm"}>
+            <.tab :if={ee?()} patch={"?type=gtm&flow=#{@flow}"} selected={@installation_type.result == "gtm"}>
               <Icons.tag_manager_icon /> Tag Manager
             </.tab>
             <.tab patch={"?type=npm&flow=#{@flow}"} selected={@installation_type.result == "npm"}>
@@ -146,7 +146,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
               recommended_installation_type={recommended_installation_type}
             />
             <Instructions.gtm_instructions
-              :if={@installation_type.result == "gtm"}
+              :if={ee?() and @installation_type.result == "gtm"}
               recommended_installation_type={recommended_installation_type}
               tracker_script_configuration_form={@tracker_script_configuration_form.result}
             />
@@ -198,12 +198,12 @@ defmodule PlausibleWeb.Live.InstallationV2 do
       if assigns[:selected] do
         assign(assigns,
           class:
-            "bg-white dark:bg-gray-800 rounded-md px-3.5 py-2.5 text-sm font-medium flex items-center"
+            "bg-white dark:bg-gray-800 rounded-md px-3.5 py-2.5 text-sm font-medium flex items-center flex-1 justify-center whitespace-nowrap"
         )
       else
         assign(assigns,
           class:
-            "bg-gray-100 dark:bg-gray-700 rounded-md px-3.5 py-2.5 text-sm font-medium flex items-center cursor-pointer"
+            "bg-gray-100 dark:bg-gray-700 rounded-md px-3.5 py-2.5 text-sm font-medium flex items-center cursor-pointer flex-1 justify-center whitespace-nowrap"
         )
       end
 

--- a/lib/plausible_web/live/installationv2.ex
+++ b/lib/plausible_web/live/installationv2.ex
@@ -2,13 +2,24 @@ defmodule PlausibleWeb.Live.InstallationV2 do
   @moduledoc """
   User assistance module around Plausible installation instructions/onboarding
   """
+
+  use Plausible
+  use PlausibleWeb, :live_view
+
+  require Logger
+
   alias PlausibleWeb.Flows
   alias Phoenix.LiveView.AsyncResult
-  alias Plausible.InstallationSupport.{Detection, Result}
   alias PlausibleWeb.Live.InstallationV2.Icons
   alias PlausibleWeb.Live.InstallationV2.Instructions
-  use PlausibleWeb, :live_view
-  require Logger
+
+  on_ee do
+    alias Plausible.InstallationSupport.{Detection, Result}
+
+    @installation_methods ["manual", "wordpress", "gtm", "npm"]
+  else
+    @installation_methods ["manual", "wordpress", "npm"]
+  end
 
   def mount(
         %{"domain" => domain} = params,
@@ -27,19 +38,49 @@ defmodule PlausibleWeb.Live.InstallationV2 do
     flow = params["flow"] || Flows.provisioning()
 
     socket =
-      if connected?(socket) do
-        assign_async(
-          socket,
-          [
-            :recommended_installation_type,
-            :installation_type,
-            :tracker_script_configuration_form,
-            :v1_detected
-          ],
-          fn -> initialize_installation_data(flow, site, params) end
-        )
+      on_ee do
+        if connected?(socket) do
+          assign_async(
+            socket,
+            [
+              :recommended_installation_type,
+              :installation_type,
+              :tracker_script_configuration_form,
+              :v1_detected
+            ],
+            fn -> initialize_installation_data(flow, site, params) end
+          )
+        else
+          assign_loading_states(socket)
+        end
       else
-        assign_loading_states(socket)
+        # On Community Edition, there's no v1 detection, nor pre-installation
+        # site scan - we just default the pre-selected tab to "manual".
+
+        # Although it's functionally unnecessary, we stick to using `%AsyncResult{}`
+        # for these assigns to minimize branching out the CE code and maintain only
+        # a single `render` function.
+
+        {:ok, installation_data} = initialize_installation_data(flow, site, params)
+
+        assign(socket,
+          recommended_installation_type: %AsyncResult{
+            result: installation_data.recommended_installation_type,
+            ok?: true
+          },
+          installation_type: %AsyncResult{
+            result: installation_data.installation_type,
+            ok?: true
+          },
+          tracker_script_configuration_form: %AsyncResult{
+            result: installation_data.tracker_script_configuration_form,
+            ok?: true
+          },
+          v1_detected: %AsyncResult{
+            result: installation_data.v1_detected,
+            ok?: true
+          }
+        )
       end
 
     {:ok,
@@ -51,7 +92,8 @@ defmodule PlausibleWeb.Live.InstallationV2 do
 
   def handle_params(params, _url, socket) do
     socket =
-      if socket.assigns.recommended_installation_type.result do
+      if connected?(socket) && socket.assigns.recommended_installation_type.result &&
+           params["type"] in @installation_methods do
         assign(socket,
           installation_type: %AsyncResult{result: params["type"]}
         )
@@ -94,40 +136,23 @@ defmodule PlausibleWeb.Live.InstallationV2 do
             >
               <Icons.wordpress_icon /> WordPress
             </.tab>
-            <.tab :if={ee?()} patch={"?type=gtm&flow=#{@flow}"} selected={@installation_type.result == "gtm"}>
-              <Icons.tag_manager_icon /> Tag Manager
-            </.tab>
+            <%= on_ee do %>
+              <.tab patch={"?type=gtm&flow=#{@flow}"} selected={@installation_type.result == "gtm"}>
+                <Icons.tag_manager_icon /> Tag Manager
+              </.tab>
+            <% end %>
             <.tab patch={"?type=npm&flow=#{@flow}"} selected={@installation_type.result == "npm"}>
               <Icons.npm_icon /> NPM
             </.tab>
           </div>
 
-          <div :if={
-            @v1_detected.result == true and @recommended_installation_type.result == "manual" and
-              @installation_type.result == "manual"
-          }>
-            <.notice class="mt-4" theme={:yellow}>
-              Your website is running an outdated version of the tracking script. Please
-              <.styled_link new_tab href="https://plausible.io/docs/script-update-guide">
-                update
-              </.styled_link>
-              your tracking script before continuing
-            </.notice>
-          </div>
-
-          <div :if={
-            @v1_detected.result == true and @recommended_installation_type.result == "gtm" and
-              @installation_type.result == "gtm"
-          }>
-            <.notice class="mt-4" theme={:yellow}>
-              Your website might be using an outdated version of our Google Tag Manager template.
-              If so,
-              <.styled_link new_tab href="https://plausible.io/docs/script-update-guide#gtm">
-                update
-              </.styled_link>
-              your Google Tag Manager template before continuing
-            </.notice>
-          </div>
+          <%= on_ee do %>
+            <.outdated_script_notice
+              :if={@v1_detected.result == true}
+              recommended_installation_type={@recommended_installation_type}
+              installation_type={@installation_type}
+            />
+          <% end %>
 
           <.form for={@tracker_script_configuration_form.result} phx-submit="submit" class="mt-4">
             <.input
@@ -145,11 +170,13 @@ defmodule PlausibleWeb.Live.InstallationV2 do
               flow={@flow}
               recommended_installation_type={recommended_installation_type}
             />
-            <Instructions.gtm_instructions
-              :if={ee?() and @installation_type.result == "gtm"}
-              recommended_installation_type={recommended_installation_type}
-              tracker_script_configuration_form={@tracker_script_configuration_form.result}
-            />
+            <%= on_ee do %>
+              <Instructions.gtm_instructions
+                :if={@installation_type.result == "gtm"}
+                recommended_installation_type={recommended_installation_type}
+                tracker_script_configuration_form={@tracker_script_configuration_form.result}
+              />
+            <% end %>
             <Instructions.npm_instructions :if={@installation_type.result == "npm"} />
 
             <.button type="submit" class="w-full mt-8">
@@ -157,6 +184,16 @@ defmodule PlausibleWeb.Live.InstallationV2 do
             </.button>
           </.form>
         </.async_result>
+        <:footer :if={ce?() and @installation_type.result == "manual"}>
+          <.focus_list>
+            <:item>
+              Still using the legacy snippet with the data-domain attribute? See
+              <.styled_link href="https://plausible.io/docs/script-update-guide.md">
+                migration guide
+              </.styled_link>
+            </:item>
+          </.focus_list>
+        </:footer>
       </.focus_box>
     </div>
     """
@@ -167,25 +204,71 @@ defmodule PlausibleWeb.Live.InstallationV2 do
   defp verify_cta("gtm"), do: "Verify Tag Manager installation"
   defp verify_cta("npm"), do: "Verify NPM installation"
 
-  defp get_recommended_installation_type(flow, site) do
-    detection_result =
-      Detection.Checks.run(nil, site.domain,
-        detect_v1?: flow == Flows.review(),
-        report_to: nil,
-        slowdown: 0,
-        async?: false
+  on_ee do
+    defp detect_recommended_installation_type(flow, site) do
+      detection_result =
+        Detection.Checks.run(nil, site.domain,
+          detect_v1?: flow == Flows.review(),
+          report_to: nil,
+          slowdown: 0,
+          async?: false
+        )
+        |> Detection.Checks.interpret_diagnostics()
+
+      case detection_result do
+        %Result{
+          ok?: true,
+          data: %{suggested_technology: suggested_technology, v1_detected: v1_detected}
+        } ->
+          {suggested_technology, v1_detected}
+
+        _ ->
+          {"manual", false}
+      end
+    end
+
+    defp outdated_script_notice(assigns) do
+      ~H"""
+      <div :if={
+        @recommended_installation_type.result == "manual" and
+          @installation_type.result == "manual"
+      }>
+        <.notice class="mt-4" theme={:yellow}>
+          Your website is running an outdated version of the tracking script. Please
+          <.styled_link new_tab href="https://plausible.io/docs/script-update-guide">
+            update
+          </.styled_link>
+          your tracking script before continuing
+        </.notice>
+      </div>
+
+      <div :if={
+        @recommended_installation_type.result == "gtm" and
+          @installation_type.result == "gtm"
+      }>
+        <.notice class="mt-4" theme={:yellow}>
+          Your website might be using an outdated version of our Google Tag Manager template.
+          If so,
+          <.styled_link new_tab href="https://plausible.io/docs/script-update-guide#gtm">
+            update
+          </.styled_link>
+          your Google Tag Manager template before continuing
+        </.notice>
+      </div>
+      """
+    end
+
+    defp assign_loading_states(socket) do
+      assign(socket,
+        recommended_installation_type: AsyncResult.loading(),
+        v1_detected: AsyncResult.loading(),
+        installation_type: AsyncResult.loading(),
+        tracker_script_configuration_form: AsyncResult.loading()
       )
-      |> Detection.Checks.interpret_diagnostics()
-
-    case detection_result do
-      %Result{
-        ok?: true,
-        data: %{suggested_technology: suggested_technology, v1_detected: v1_detected}
-      } ->
-        {suggested_technology, v1_detected}
-
-      _ ->
-        {"manual", false}
+    end
+  else
+    defp detect_recommended_installation_type(_flow, _site) do
+      {"manual", false}
     end
   end
 
@@ -232,7 +315,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
 
   defp initialize_installation_data(flow, site, params) do
     {recommended_installation_type, v1_detected} =
-      get_recommended_installation_type(flow, site)
+      detect_recommended_installation_type(flow, site)
 
     tracker_script_configuration =
       PlausibleWeb.Tracker.get_or_create_tracker_script_configuration!(site, %{
@@ -245,7 +328,7 @@ defmodule PlausibleWeb.Live.InstallationV2 do
 
     selected_installation_type =
       cond do
-        params["type"] in ["manual", "wordpress", "gtm", "npm"] ->
+        params["type"] in @installation_methods ->
           params["type"]
 
         flow == Flows.review() and
@@ -269,14 +352,5 @@ defmodule PlausibleWeb.Live.InstallationV2 do
            )
          )
      }}
-  end
-
-  defp assign_loading_states(socket) do
-    assign(socket,
-      recommended_installation_type: AsyncResult.loading(),
-      v1_detected: AsyncResult.loading(),
-      installation_type: AsyncResult.loading(),
-      tracker_script_configuration_form: AsyncResult.loading()
-    )
   end
 end

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -152,22 +152,19 @@ defmodule PlausibleWeb.Live.Verification do
       installation_type = socket.assigns.installation_type
 
       {:ok, pid} =
-        if(
-          FunWithFlags.enabled?(:scriptv2, for: socket.assigns.site) or
-            FunWithFlags.enabled?(:scriptv2, for: socket.assigns.current_user),
-          do:
-            Verification.Checks.run(socket.assigns.url_to_verify, domain, installation_type,
-              report_to: report_to,
-              slowdown: socket.assigns.slowdown
-            ),
-          else:
-            LegacyVerification.Checks.run(
-              "https://#{socket.assigns.domain}",
-              domain,
-              report_to: report_to,
-              slowdown: socket.assigns.slowdown
-            )
-        )
+        if PlausibleWeb.Tracker.scriptv2?(socket.assigns.site, socket.assigns.current_user) do
+          Verification.Checks.run(socket.assigns.url_to_verify, domain, installation_type,
+            report_to: report_to,
+            slowdown: socket.assigns.slowdown
+          )
+        else
+          LegacyVerification.Checks.run(
+            "https://#{socket.assigns.domain}",
+            domain,
+            report_to: report_to,
+            slowdown: socket.assigns.slowdown
+          )
+        end
 
       {:noreply, assign(socket, checks_pid: pid, attempts: socket.assigns.attempts + 1)}
     end
@@ -190,7 +187,7 @@ defmodule PlausibleWeb.Live.Verification do
 
   def handle_info({:all_checks_done, %State{} = state}, socket) do
     interpretation =
-      if(FunWithFlags.enabled?(:scriptv2, for: socket.assigns.site),
+      if(PlausibleWeb.Tracker.scriptv2?(socket.assigns.site),
         do: Verification.Checks.interpret_diagnostics(state),
         else: LegacyVerification.Checks.interpret_diagnostics(state)
       )

--- a/lib/plausible_web/tracker.ex
+++ b/lib/plausible_web/tracker.ex
@@ -14,6 +14,10 @@ defmodule PlausibleWeb.Tracker do
   @plausible_main_script File.read!(path)
   @external_resource "priv/tracker/js/plausible-web.js"
 
+  def scriptv2?(site, user \\ nil) do
+    FunWithFlags.enabled?(:scriptv2, for: site) or FunWithFlags.enabled?(:scriptv2, for: user)
+  end
+
   @spec get_plausible_main_script(String.t(), Keyword.t()) :: String.t() | nil
   def get_plausible_main_script(id, cache_opts \\ []) do
     on_ee do

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -66,10 +66,13 @@ user2 = new_user(name: "Mary Jane", email: "user2@plausible.test", password: "pl
 site2 = new_site(domain: "computer.example.com", owner: user2)
 invite_guest(site2, user, inviter: user2, role: :viewer)
 
-solo_user = new_user(name: "Solo User", email: "solo@plausible.test", password: "plausible")
-new_site(domain: "mysolosite.com", owner: solo_user)
-{:ok, solo_team} = Plausible.Teams.get_or_create(solo_user)
-Plausible.Billing.DevSubscriptions.create(solo_team.id, "910413")
+on_ee do
+  solo_user = new_user(name: "Solo User", email: "solo@plausible.test", password: "plausible")
+  new_site(domain: "mysolosite.com", owner: solo_user)
+  {:ok, solo_team} = Plausible.Teams.get_or_create(solo_user)
+
+  Plausible.Billing.DevSubscriptions.create(solo_team.id, "910413")
+end
 
 Plausible.Factory.insert_list(29, :ip_rule, site: site)
 Plausible.Factory.insert(:country_rule, site: site, country_code: "PL")

--- a/test/plausible_web/live/change_domain_v2_test.exs
+++ b/test/plausible_web/live/change_domain_v2_test.exs
@@ -2,19 +2,21 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
   use PlausibleWeb.ConnCase, async: false
   use Plausible
 
-  @moduletag :ee_only
+  import Phoenix.LiveViewTest
+  import Plausible.TestUtils
+  import ExUnit.CaptureLog
+  import Plausible.Test.Support.HTML
 
   on_ee do
-    import Phoenix.LiveViewTest
-    import Plausible.TestUtils
-    import ExUnit.CaptureLog
     import Mox
+  end
 
-    alias Plausible.Repo
+  alias Plausible.Repo
 
-    describe "ChangeDomainV2 LiveView" do
-      setup [:create_user, :log_in, :create_site]
+  describe "ChangeDomainV2 LiveView" do
+    setup [:create_user, :log_in, :create_site]
 
+    on_ee do
       setup do
         # mock all domains resolve
         Plausible.DnsLookup.Mock
@@ -24,86 +26,264 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
 
         :ok
       end
+    end
 
-      test "mounts and renders form", %{conn: conn, site: site} do
-        {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
+    test "mounts and renders form", %{conn: conn, site: site} do
+      {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
 
-        assert html =~ "Change your website domain"
-      end
+      assert html =~ "Change your website domain"
+    end
 
-      test "form submission when no change is made", %{conn: conn, site: site} do
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+    test "form submission when no change is made", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
 
-        html =
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: site.domain}})
+      html =
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: site.domain}})
 
-        assert html =~ "New domain must be different than the current one"
-      end
+      assert html =~ "New domain must be different than the current one"
+    end
 
-      test "form submission to an existing domain", %{conn: conn, site: site} do
-        another_site = insert(:site)
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+    test "form submission to an existing domain", %{conn: conn, site: site} do
+      another_site = insert(:site)
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
 
-        html =
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: another_site.domain}})
+      html =
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: another_site.domain}})
 
-        assert html =~ "This domain cannot be registered"
+      assert html =~ "This domain cannot be registered"
 
-        site = Repo.reload!(site)
-        assert site.domain != another_site.domain
-        assert is_nil(site.domain_changed_from)
-      end
+      site = Repo.reload!(site)
+      assert site.domain != another_site.domain
+      assert is_nil(site.domain_changed_from)
+    end
 
-      test "form submission to a domain in transition period", %{conn: conn, site: site} do
-        _another_site = insert(:site, domain_changed_from: "foo.example.com")
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+    test "form submission to a domain in transition period", %{conn: conn, site: site} do
+      _another_site = insert(:site, domain_changed_from: "foo.example.com")
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
 
-        html =
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: "foo.example.com"}})
+      html =
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: "foo.example.com"}})
 
-        assert html =~ "This domain cannot be registered"
+      assert html =~ "This domain cannot be registered"
 
-        site = Repo.reload!(site)
-        assert site.domain != "foo.example.com"
-        assert is_nil(site.domain_changed_from)
-      end
+      site = Repo.reload!(site)
+      assert site.domain != "foo.example.com"
+      assert is_nil(site.domain_changed_from)
+    end
 
-      test "successful form submission updates database", %{conn: conn, site: site} do
+    test "successful form submission updates database", %{conn: conn, site: site} do
+      on_ee do
         stub_detection_result(%{
           "v1Detected" => false,
           "gtmLikely" => false,
           "wordpressLikely" => false,
           "wordpressPlugin" => false
         })
-
-        original_domain = site.domain
-        new_domain = "new-example.com"
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: new_domain}})
-
-        site = Repo.reload!(site)
-        assert site.domain == new_domain
-        assert site.domain_changed_from == original_domain
       end
 
-      test "successful form submission navigates to success page", %{conn: conn, site: site} do
+      original_domain = site.domain
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      site = Repo.reload!(site)
+      assert site.domain == new_domain
+      assert site.domain_changed_from == original_domain
+    end
+
+    test "successful form submission navigates to success page", %{conn: conn, site: site} do
+      on_ee do
         stub_detection_result(%{
           "v1Detected" => false,
           "gtmLikely" => false,
           "wordpressLikely" => false,
           "wordpressPlugin" => false
         })
+      end
 
-        original_domain = site.domain
+      original_domain = site.domain
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      assert html =~ "Domain Changed Successfully"
+      assert html =~ original_domain
+      assert html =~ new_domain
+    end
+
+    test "form validation shows error for empty domain", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      html =
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: ""}})
+
+      assert html =~ "can&#39;t be blank"
+    end
+
+    test "form validation shows error for invalid domain format", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      html =
+        lv
+        |> element("form")
+        |> render_submit(%{site: %{domain: "invalid domain with spaces"}})
+
+      assert html =~ "only letters, numbers, slashes and period allowed"
+    end
+
+    test "renders back to settings link with correct path", %{conn: conn, site: site} do
+      {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      expected_link = Routes.site_path(conn, :settings_general, site.domain)
+      assert html =~ expected_link
+    end
+
+    @tag :ee_only
+    test "success page shows WordPress plugin notice when detected", %{conn: conn, site: site} do
+      stub_detection_result(%{
+        "v1Detected" => true,
+        "gtmLikely" => false,
+        "wordpressLikely" => true,
+        "wordpressPlugin" => true
+      })
+
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      assert html =~ "<i>must</i>"
+      assert html =~ "also update the site"
+      assert html =~ "Plausible Wordpress Plugin settings"
+      assert html =~ "within 72 hours"
+
+      assert element_exists?(
+               html,
+               "a[href='#{PlausibleWeb.Live.ChangeDomainV2.change_domain_docs_link()}']"
+             )
+    end
+
+    @tag :ee_only
+    test "success page shows generic v1 notice when detected but not WordPress", %{
+      conn: conn,
+      site: site
+    } do
+      stub_detection_result(%{
+        "v1Detected" => true,
+        "gtmLikely" => false,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      assert html =~ "<i>must</i>"
+      assert html =~ "also update the site"
+      assert html =~ "Plausible Installation"
+      assert html =~ "within 72 hours"
+      refute html =~ "Wordpress Plugin"
+
+      assert element_exists?(
+               html,
+               "a[href='#{PlausibleWeb.Live.ChangeDomainV2.change_domain_docs_link()}']"
+             )
+    end
+
+    @tag :ee_only
+    test "success page shows no notice when no v1 tracking detected", %{conn: conn, site: site} do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => false,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      refute html =~ "Additional Steps Required"
+      refute html =~ "<i>must</i>"
+      refute html =~ "also update the site"
+
+      refute element_exists?(
+               html,
+               "a[href='#{PlausibleWeb.Live.ChangeDomainV2.change_domain_docs_link()}']"
+             )
+    end
+
+    @tag :ee_only
+    test "success page shows generic npm notice when detected", %{conn: conn, site: site} do
+      stub_detection_result(%{
+        "v1Detected" => false,
+        "gtmLikely" => false,
+        "npm" => true,
+        "wordpressLikely" => false,
+        "wordpressPlugin" => false
+      })
+
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      assert html =~ "<i>must</i>"
+      assert html =~ "also update the site"
+      assert html =~ "Plausible Installation"
+      assert html =~ "within 72 hours"
+
+      assert element_exists?(
+               html,
+               "a[href='#{PlausibleWeb.Live.ChangeDomainV2.change_domain_docs_link()}']"
+             )
+    end
+
+    @tag :ee_only
+    test "success page handles detection error gracefully", %{conn: conn, site: site} do
+      stub_detection_error()
+
+      capture_log(fn ->
         new_domain = "new-example.com"
         {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
 
@@ -114,179 +294,55 @@ defmodule PlausibleWeb.Live.ChangeDomainV2Test do
         assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
 
         html = render_async(lv, 500)
-        assert html =~ "Domain Changed Successfully"
-        assert html =~ original_domain
-        assert html =~ new_domain
-      end
-
-      test "form validation shows error for empty domain", %{conn: conn, site: site} do
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        html =
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: ""}})
-
-        assert html =~ "can&#39;t be blank"
-      end
-
-      test "form validation shows error for invalid domain format", %{conn: conn, site: site} do
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        html =
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: "invalid domain with spaces"}})
-
-        assert html =~ "only letters, numbers, slashes and period allowed"
-      end
-
-      test "renders back to settings link with correct path", %{conn: conn, site: site} do
-        {:ok, _lv, html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        expected_link = Routes.site_path(conn, :settings_general, site.domain)
-        assert html =~ expected_link
-      end
-
-      test "success page shows WordPress plugin notice when detected", %{conn: conn, site: site} do
-        stub_detection_result(%{
-          "v1Detected" => true,
-          "gtmLikely" => false,
-          "wordpressLikely" => true,
-          "wordpressPlugin" => true
-        })
-
-        new_domain = "new-example.com"
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: new_domain}})
-
-        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-        html = render_async(lv, 500)
-        assert html =~ "<i>must</i>"
-        assert html =~ "also update the site"
-        assert html =~ "Plausible Wordpress Plugin settings"
-        assert html =~ "within 72 hours"
-      end
-
-      test "success page shows generic v1 notice when detected but not WordPress", %{
-        conn: conn,
-        site: site
-      } do
-        stub_detection_result(%{
-          "v1Detected" => true,
-          "gtmLikely" => false,
-          "wordpressLikely" => false,
-          "wordpressPlugin" => false
-        })
-
-        new_domain = "new-example.com"
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: new_domain}})
-
-        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-        html = render_async(lv, 500)
+        assert html =~ "Additional Steps Required"
         assert html =~ "<i>must</i>"
         assert html =~ "also update the site"
         assert html =~ "Plausible Installation"
-        assert html =~ "within 72 hours"
-        refute html =~ "Wordpress Plugin"
-      end
-
-      test "success page shows no notice when no v1 tracking detected", %{conn: conn, site: site} do
-        stub_detection_result(%{
-          "v1Detected" => false,
-          "gtmLikely" => false,
-          "wordpressLikely" => false,
-          "wordpressPlugin" => false
-        })
-
-        new_domain = "new-example.com"
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: new_domain}})
-
-        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-        html = render_async(lv, 500)
-        refute html =~ "Additional Steps Required"
-        refute html =~ "<i>must</i>"
-        refute html =~ "also update the site"
-      end
-
-      test "success page shows generic npm notice when detected", %{conn: conn, site: site} do
-        stub_detection_result(%{
-          "v1Detected" => false,
-          "gtmLikely" => false,
-          "npm" => true,
-          "wordpressLikely" => false,
-          "wordpressPlugin" => false
-        })
-
-        new_domain = "new-example.com"
-        {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-        lv
-        |> element("form")
-        |> render_submit(%{site: %{domain: new_domain}})
-
-        assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-        html = render_async(lv, 500)
-        assert html =~ "<i>must</i>"
-        assert html =~ "also update the site"
-        assert html =~ "Plausible Installation"
-        assert html =~ "within 72 hours"
-      end
-
-      test "success page handles detection error gracefully", %{conn: conn, site: site} do
-        stub_detection_error()
-
-        capture_log(fn ->
-          new_domain = "new-example.com"
-          {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
-
-          lv
-          |> element("form")
-          |> render_submit(%{site: %{domain: new_domain}})
-
-          assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
-
-          html = render_async(lv, 500)
-          assert html =~ "Additional Steps Required"
-          assert html =~ "<i>must</i>"
-          assert html =~ "also update the site"
-          assert html =~ "Plausible Installation"
-        end)
-      end
-    end
-
-    defp stub_detection_result(js_data) do
-      Req.Test.stub(:global, fn conn ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
       end)
     end
 
-    defp stub_detection_error do
-      Req.Test.stub(:global, fn conn ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(
-          200,
-          Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
-        )
-      end)
+    @tag :ce_only
+    test "success page shows generic v1 notice for CE", %{
+      conn: conn,
+      site: site
+    } do
+      new_domain = "new-example.com"
+      {:ok, lv, _html} = live(conn, "/#{site.domain}/change-domain-v2")
+
+      lv
+      |> element("form")
+      |> render_submit(%{site: %{domain: new_domain}})
+
+      assert_patch(lv, "/#{new_domain}/change-domain-v2/success")
+
+      html = render_async(lv, 500)
+      notice = text_of_element(html, "div[data-test-id='ce-generic-notice']")
+
+      assert notice =~ "Additional steps may be required"
+
+      assert element_exists?(
+               html,
+               "a[href='#{PlausibleWeb.Live.ChangeDomainV2.change_domain_docs_link()}']"
+             )
     end
+  end
+
+  defp stub_detection_result(js_data) do
+    Req.Test.stub(:global, fn conn ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
+    end)
+  end
+
+  defp stub_detection_error do
+    Req.Test.stub(:global, fn conn ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        200,
+        Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
+      )
+    end)
   end
 end

--- a/test/plausible_web/live/installationv2_test.exs
+++ b/test/plausible_web/live/installationv2_test.exs
@@ -2,209 +2,262 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
   use PlausibleWeb.ConnCase, async: true
   use Plausible
 
-  @moduletag :ee_only
+  import Phoenix.LiveViewTest
+  import Plausible.Test.Support.HTML
+  import Plausible.Teams.Test
+  import Mox
 
-  on_ee do
-    import Phoenix.LiveViewTest
-    import Plausible.Test.Support.HTML
-    import Plausible.Teams.Test
-    import Mox
+  alias Plausible.Site.TrackerScriptConfiguration
 
-    alias Plausible.Site.TrackerScriptConfiguration
+  @migration_guide_link "https://plausible.io/docs/script-update-guide.md"
 
-    setup [:create_user, :log_in, :create_site]
+  setup [:create_user, :log_in, :create_site]
 
-    setup %{site: site} do
-      FunWithFlags.enable(:scriptv2, for_actor: site)
-      :ok
+  setup %{site: site} do
+    FunWithFlags.enable(:scriptv2, for_actor: site)
+    :ok
+  end
+
+  describe "GET /:domain/installationv2" do
+    @tag :ee_only
+    test "renders loading installation screen on EE", %{conn: conn, site: site} do
+      resp = get(conn, "/#{site.domain}/installationv2") |> html_response(200)
+
+      assert resp =~ "animate-spin"
     end
 
-    describe "GET /:domain/installationv2" do
-      test "static installation screen renders with spinner", %{conn: conn, site: site} do
-        resp = get(conn, "/#{site.domain}/installationv2") |> html_response(200)
+    @tag :ce_only
+    test "no loading spinner, no GTM tab on CE", %{conn: conn, site: site} do
+      resp = get(conn, "/#{site.domain}/installationv2") |> html_response(200)
 
-        assert resp =~ "animate-spin"
-      end
+      tabs_text = text_of_element(resp, "a[data-phx-link='patch']")
+
+      assert length(String.split(tabs_text)) == 3
+
+      assert tabs_text =~ "Script"
+      assert tabs_text =~ "WordPress"
+      assert tabs_text =~ "NPM"
+
+      refute resp =~ "animate-spin"
+    end
+  end
+
+  describe "LiveView" do
+    @tag :ee_only
+    test "detects installation type when mounted", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
+
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert text(html) =~ "Verify WordPress installation"
     end
 
-    describe "LiveView" do
-      test "detects installation type when mounted", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
+    @tag :ee_only
+    test "When ?type=wordpress URL parameter is supplied, detected type is unused", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_manual()
 
-        {lv, _} = get_lv(conn, site)
+      {lv, _} = get_lv(conn, site, "?type=wordpress")
 
-        html = render_async(lv, 500)
-        assert text(html) =~ "Verify WordPress installation"
-      end
+      html = render_async(lv, 500)
+      assert text(html) =~ "Verify WordPress installation"
+    end
 
-      test "When ?type=wordpress URL parameter is supplied, detected type is unused", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
+    @tag :ee_only
+    test "When ?type=gtm URL parameter is supplied, detected type is unused", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
 
-        {lv, _} = get_lv(conn, site, "?type=wordpress")
+      {lv, _} = get_lv(conn, site, "?type=gtm")
 
-        html = render_async(lv, 500)
-        assert text(html) =~ "Verify WordPress installation"
-      end
+      html = render_async(lv, 500)
+      assert text(html) =~ "Verify Tag Manager installation"
+    end
 
-      test "When ?type=gtm URL parameter is supplied, detected type is unused", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
+    @tag :ee_only
+    test "When ?type=npm URL parameter is supplied, detected type is unused", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
 
-        {lv, _} = get_lv(conn, site, "?type=gtm")
+      {lv, _} = get_lv(conn, site, "?type=npm")
 
-        html = render_async(lv, 500)
-        assert text(html) =~ "Verify Tag Manager installation"
-      end
+      html = render_async(lv, 500)
+      assert text(html) =~ "Verify NPM installation"
+    end
 
-      test "When ?type=npm URL parameter is supplied, detected type is unused", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
+    @tag :ee_only
+    test "When ?type=manual URL parameter is supplied, detected type is unused", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
 
-        {lv, _} = get_lv(conn, site, "?type=npm")
+      {lv, _} = get_lv(conn, site, "?type=manual")
 
-        html = render_async(lv, 500)
-        assert text(html) =~ "Verify NPM installation"
-      end
+      html = render_async(lv, 500)
+      assert text(html) =~ "Verify Script installation"
+    end
 
-      test "When ?type=manual URL parameter is supplied, detected type is unused", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
+    @tag :ee_only
+    test "allows switching between installation tabs (EE)", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_manual()
 
-        {lv, _} = get_lv(conn, site, "?type=manual")
+      {lv, _html} = get_lv(conn, site, "?type=manual")
 
-        html = render_async(lv, 500)
-        assert text(html) =~ "Verify Script installation"
-      end
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
 
-      test "allows switching between installation tabs", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual")
+      lv
+      |> element("a[href*=\"type=wordpress\"]")
+      |> render_click()
 
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
+      html = render(lv)
+      assert html =~ "Verify WordPress installation"
 
-        lv
-        |> element("a[href*=\"type=wordpress\"]")
-        |> render_click()
+      lv
+      |> element("a[href*=\"type=gtm\"]")
+      |> render_click()
 
-        html = render(lv)
-        assert html =~ "Verify WordPress installation"
+      html = render(lv)
+      assert html =~ "Verify Tag Manager installation"
 
-        lv
-        |> element("a[href*=\"type=gtm\"]")
-        |> render_click()
+      lv
+      |> element("a[href*=\"type=npm\"]")
+      |> render_click()
 
-        html = render(lv)
-        assert html =~ "Verify Tag Manager installation"
+      html = render(lv)
+      assert html =~ "Verify NPM installation"
+    end
 
-        lv
-        |> element("a[href*=\"type=npm\"]")
-        |> render_click()
+    @tag :ce_only
+    test "allows switching between installation tabs (CE)", %{conn: conn, site: site} do
+      {lv, _html} = get_lv(conn, site)
 
-        html = render(lv)
-        assert html =~ "Verify NPM installation"
-      end
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
 
-      test "manual installations has script snippet with expected ID", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+      lv
+      |> element("a[href*=\"type=wordpress\"]")
+      |> render_click()
 
-        assert eventually(fn ->
-                 html = render(lv)
-                 {html =~ "Verify Script installation", html}
-               end)
+      html = render(lv)
+      assert html =~ "Verify WordPress installation"
+    end
 
-        html = render(lv)
-        config = Plausible.Repo.get_by!(TrackerScriptConfiguration, site_id: site.id)
-        assert html =~ "Privacy-friendly analytics by Plausible"
-        assert html =~ "/js/#{config.id}.js"
-        assert html =~ "async"
-      end
-
-      test "manual installation shows optional measurements", %{conn: conn, site: site} do
+    test "manual installations has script snippet with expected ID", %{conn: conn, site: site} do
+      on_ee do
         stub_dns_lookup_a_records(site.domain)
         stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-        assert html =~ "Optional measurements"
-        assert html =~ "Outbound links"
-        assert html =~ "File downloads"
-        assert html =~ "Form submissions"
       end
 
-      test "manual installation shows advanced options in disclosure", %{conn: conn, site: site} do
+      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+      assert eventually(fn ->
+               html = render(lv)
+               {html =~ "Verify Script installation", html}
+             end)
+
+      html = render(lv)
+      config = Plausible.Repo.get_by!(TrackerScriptConfiguration, site_id: site.id)
+      assert html =~ "Privacy-friendly analytics by Plausible"
+      assert html =~ "/js/#{config.id}.js"
+      assert html =~ "async"
+    end
+
+    test "manual installation shows optional measurements", %{conn: conn, site: site} do
+      on_ee do
         stub_dns_lookup_a_records(site.domain)
         stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-        assert html =~ "Advanced options"
-        assert html =~ "Manual tagging"
-        assert html =~ "404 error pages"
-        assert html =~ "Hashed page paths"
-        assert html =~ "Custom properties"
-        assert html =~ "Ecommerce revenue"
       end
 
-      test "toggling optional measurements updates tracker configuration", %{
-        conn: conn,
-        site: site
-      } do
+      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+      assert html =~ "Optional measurements"
+      assert html =~ "Outbound links"
+      assert html =~ "File downloads"
+      assert html =~ "Form submissions"
+    end
+
+    test "manual installation shows advanced options in disclosure", %{conn: conn, site: site} do
+      on_ee do
         stub_dns_lookup_a_records(site.domain)
         stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-
-        config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
-        assert config.outbound_links == true
-        assert config.file_downloads == true
-        assert config.form_submissions == true
-
-        lv
-        |> element("form[phx-submit='submit']")
-        |> render_submit(%{
-          "tracker_script_configuration" => %{
-            "installation_type" => "manual",
-            "outbound_links" => "false",
-            "file_downloads" => "true",
-            "form_submissions" => "true"
-          }
-        })
-
-        updated_config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
-        assert updated_config.outbound_links == false
-        assert updated_config.file_downloads == true
-        assert updated_config.form_submissions == true
       end
 
+      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+      assert html =~ "Advanced options"
+      assert html =~ "Manual tagging"
+      assert html =~ "404 error pages"
+      assert html =~ "Hashed page paths"
+      assert html =~ "Custom properties"
+      assert html =~ "Ecommerce revenue"
+    end
+
+    test "toggling optional measurements updates tracker configuration", %{
+      conn: conn,
+      site: site
+    } do
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+      end
+
+      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+
+      config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
+      assert config.outbound_links == true
+      assert config.file_downloads == true
+      assert config.form_submissions == true
+
+      lv
+      |> element("form[phx-submit='submit']")
+      |> render_submit(%{
+        "tracker_script_configuration" => %{
+          "installation_type" => "manual",
+          "outbound_links" => "false",
+          "file_downloads" => "true",
+          "form_submissions" => "true"
+        }
+      })
+
+      updated_config = TrackerScriptConfiguration |> Plausible.Repo.get_by!(site_id: site.id)
+      assert updated_config.outbound_links == false
+      assert updated_config.file_downloads == true
+      assert updated_config.form_submissions == true
+    end
+
+    on_ee do
       for {type, expected_text} <- [
             {"manual", "Verify Script installation"},
             {"wordpress", "Verify WordPress installation"},
             {"gtm", "Verify Tag Manager installation"},
             {"npm", "Verify NPM installation"}
           ] do
-        test "submitting form with #{type} redirects to verification", %{conn: conn, site: site} do
+        test "submitting form with #{type} redirects to verification (EE)", %{
+          conn: conn,
+          site: site
+        } do
           stub_dns_lookup_a_records(site.domain)
           stub_detection_manual()
           {lv, _html} = get_lv(conn, site, "?type=#{unquote(type)}")
@@ -229,298 +282,360 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
           )
         end
       end
-
-      test "404 goal gets created regardless of user options", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-
-        # Test with all options disabled
-        lv
-        |> element("form[phx-submit='submit']")
-        |> render_submit(%{
-          "tracker_script_configuration" => %{
-            "installation_type" => "manual",
-            "outbound_links" => "false",
-            "file_downloads" => "false",
-            "form_submissions" => "false"
-          }
-        })
-
-        # 404 goal should still be created
-        goals = Plausible.Goals.for_site(site)
-        assert Enum.any?(goals, &(&1.event_name == "404"))
-      end
-
-      test "submitting form with review flow redirects to verification with flow param", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-        {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-
-        lv
-        |> element("form[phx-submit='submit']")
-        |> render_submit(%{
-          "tracker_script_configuration" => %{
-            "installation_type" => "manual",
-            "outbound_links" => "true",
-            "file_downloads" => "true",
-            "form_submissions" => "true"
-          }
-        })
-
-        assert_redirect(lv, Routes.site_path(conn, :verification, site.domain, flow: "review"))
-      end
-
-      test "detected WordPress installation shows special message", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
-
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert text(html) =~ "We've detected your website is using WordPress"
-      end
-
-      test "detected GTM installation shows special message", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_gtm()
-
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Tag Manager installation"
-        assert text(html) =~ "We've detected your website is using Google Tag Manager"
-      end
-
-      test "detected NPM installation shows npm tab", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-
-        stub_detection_result(%{
-          "v1Detected" => false,
-          "gtmLikely" => false,
-          "npm" => true,
-          "wordpressLikely" => false,
-          "wordpressPlugin" => false
-        })
-
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify NPM installation"
-      end
-
-      test "shows v1 detection warning for manual installation", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual_with_v1()
-
-        {lv, _} = get_lv(conn, site, "?type=manual")
-
-        html = render_async(lv, 500)
-        assert text(html) =~ "Your website is running an outdated version of the tracking script"
-      end
-
-      test "does not show v1 detection warning for non-manual installation", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress_with_v1()
-
-        {lv, _} = get_lv(conn, site, "?type=wordpress")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify WordPress installation"
-        refute text(html) =~ "Your website is running an outdated version of the tracking script"
-      end
-
-      test "falls back to manual installation when detection fails at dns check level", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain, [])
-
-        ExUnit.CaptureLog.capture_log(fn ->
-          {lv, _} = get_lv(conn, site)
-
-          assert eventually(fn ->
-                   html = render(lv)
-                   # Should default to manual installation when detection returns {:error, _}
-                   {html =~ "Verify Script installation", html}
-                 end)
-        end)
-      end
-
-      test "falls back to manual installation when dns succeeds but detection fails", %{
-        conn: conn,
-        site: site
-      } do
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_error()
-
-        ExUnit.CaptureLog.capture_log(fn ->
-          {lv, _} = get_lv(conn, site)
-
-          html = render_async(lv, 500)
-          # Should default to manual installation when detection returns {:error, _}
-          assert html =~ "Verify Script installation"
-        end)
-      end
     end
 
-    describe "Authorization" do
-      test "requires site access permissions", %{conn: conn} do
-        other_user = insert(:user)
-        other_site = new_site(owner: other_user)
+    test "submitting the form redirects to verification (CE)", %{conn: conn, site: site} do
+      {lv, _html} = get_lv(conn, site)
 
-        assert_raise Ecto.NoResultsError, fn ->
-          get_lv(conn, other_site)
-        end
-      end
+      lv
+      |> element("form[phx-submit='submit']")
+      |> render_submit(%{
+        "tracker_script_configuration" => %{
+          "installation_type" => "manual",
+          "outbound_links" => "true",
+          "file_downloads" => "true",
+          "form_submissions" => "true"
+        }
+      })
 
-      test "allows viewer access to installation page", %{conn: conn, user: user} do
-        site = new_site()
-        add_guest(site, user: user, role: :viewer)
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-      end
-
-      test "allows editor access to installation page", %{conn: conn, user: user} do
-        site = new_site()
-        add_guest(site, user: user, role: :editor)
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_manual()
-
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
-      end
+      assert_redirect(
+        lv,
+        Routes.site_path(conn, :verification, site.domain, flow: "provisioning")
+      )
     end
 
-    describe "URL Parameter Handling" do
-      test "falls back to manual installation when invalid installation type parameter supplied",
-           %{
-             conn: conn,
-             site: site
-           } do
+    test "404 goal gets created regardless of user options", %{conn: conn, site: site} do
+      on_ee do
         stub_dns_lookup_a_records(site.domain)
         stub_detection_manual()
-
-        {lv, _} = get_lv(conn, site, "?type=invalid")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
       end
 
-      test "falls back to provisioning flow when invalid flow parameter supplied", %{
-        conn: conn,
-        site: site
-      } do
+      {lv, _html} = get_lv(conn, site, "?type=manual")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+
+      # Test with all options disabled
+      lv
+      |> element("form[phx-submit='submit']")
+      |> render_submit(%{
+        "tracker_script_configuration" => %{
+          "installation_type" => "manual",
+          "outbound_links" => "false",
+          "file_downloads" => "false",
+          "form_submissions" => "false"
+        }
+      })
+
+      # 404 goal should still be created
+      goals = Plausible.Goals.for_site(site)
+      assert Enum.any?(goals, &(&1.event_name == "404"))
+    end
+
+    test "submitting form with review flow redirects to verification with flow param", %{
+      conn: conn,
+      site: site
+    } do
+      on_ee do
         stub_dns_lookup_a_records(site.domain)
         stub_detection_manual()
-
-        {lv, _} = get_lv(conn, site, "?flow=invalid")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Script installation"
       end
+
+      {lv, _html} = get_lv(conn, site, "?type=manual&flow=review")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+
+      lv
+      |> element("form[phx-submit='submit']")
+      |> render_submit(%{
+        "tracker_script_configuration" => %{
+          "installation_type" => "manual",
+          "outbound_links" => "true",
+          "file_downloads" => "true",
+          "form_submissions" => "true"
+        }
+      })
+
+      assert_redirect(lv, Routes.site_path(conn, :verification, site.domain, flow: "review"))
     end
 
-    describe "Detection Result Combinations" do
-      test "When GTM + Wordpress detected, GTM takes precedence", %{conn: conn, site: site} do
-        stub_dns_lookup_a_records(site.domain)
+    @tag :ee_only
+    test "detected WordPress installation shows special message", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
 
-        stub_detection_result(%{
-          "v1Detected" => false,
-          "gtmLikely" => true,
-          "wordpressLikely" => true,
-          "wordpressPlugin" => false
-        })
+      {lv, _} = get_lv(conn, site)
 
-        {lv, _} = get_lv(conn, site)
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify Tag Manager installation"
-      end
+      html = render_async(lv, 500)
+      assert text(html) =~ "We've detected your website is using WordPress"
     end
 
-    describe "Legacy Installations" do
-      test "uses detected type in review flow when installation_type is nil", %{
-        conn: conn,
-        site: site
-      } do
-        _config =
-          PlausibleWeb.Tracker.get_or_create_tracker_script_configuration!(site, %{
-            installation_type: nil,
-            outbound_links: true,
-            file_downloads: false,
-            form_submissions: true
-          })
+    @tag :ee_only
+    test "detected GTM installation shows special message", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_gtm()
 
-        stub_dns_lookup_a_records(site.domain)
-        stub_detection_wordpress()
+      {lv, _} = get_lv(conn, site)
 
-        {lv, _} = get_lv(conn, site, "?flow=review")
-
-        html = render_async(lv, 500)
-        assert html =~ "Verify WordPress installation"
-      end
+      html = render_async(lv, 500)
+      assert html =~ "Verify Tag Manager installation"
+      assert text(html) =~ "We've detected your website is using Google Tag Manager"
     end
 
-    defp stub_detection_manual do
+    @tag :ee_only
+    test "detected NPM installation shows npm tab", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => false,
-        "npm" => false,
+        "npm" => true,
         "wordpressLikely" => false,
         "wordpressPlugin" => false
       })
+
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify NPM installation"
     end
 
-    defp stub_detection_wordpress do
-      stub_detection_result(%{
-        "v1Detected" => false,
-        "gtmLikely" => false,
-        "npm" => false,
-        "wordpressLikely" => true,
-        "wordpressPlugin" => false
-      })
+    @tag :ee_only
+    test "shows v1 detection warning and migration guide link for manual installation", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_manual_with_v1()
+
+      {lv, _} = get_lv(conn, site, "?type=manual")
+
+      html = render_async(lv, 500)
+      assert text(html) =~ "Your website is running an outdated version of the tracking script"
+      assert element_exists?(html, "a[href='#{@migration_guide_link}']")
     end
 
-    defp stub_detection_gtm do
+    @tag :ce_only
+    test "shows v1 migration guide link for manual instructions", %{conn: conn, site: site} do
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert text(html) =~ "Still using the legacy snippet"
+      assert element_exists?(html, "a[href='#{@migration_guide_link}']")
+    end
+
+    test "does not render link to migrate guide on WordPress installation tab", %{
+      conn: conn,
+      site: site
+    } do
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_wordpress_with_v1()
+      end
+
+      {lv, _} = get_lv(conn, site, "?type=wordpress")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify WordPress installation"
+      refute element_exists?(html, "a[href='#{@migration_guide_link}']")
+    end
+
+    @tag :ee_only
+    test "falls back to manual installation when detection fails at dns check level", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain, [])
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        {lv, _} = get_lv(conn, site)
+
+        assert eventually(fn ->
+                 html = render(lv)
+                 # Should default to manual installation when detection returns {:error, _}
+                 {html =~ "Verify Script installation", html}
+               end)
+      end)
+    end
+
+    @tag :ee_only
+    test "falls back to manual installation when dns succeeds but detection fails", %{
+      conn: conn,
+      site: site
+    } do
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_error()
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        {lv, _} = get_lv(conn, site)
+
+        html = render_async(lv, 500)
+        # Should default to manual installation when detection returns {:error, _}
+        assert html =~ "Verify Script installation"
+      end)
+    end
+  end
+
+  describe "Authorization" do
+    test "requires site access permissions", %{conn: conn} do
+      other_user = insert(:user)
+      other_site = new_site(owner: other_user)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        get_lv(conn, other_site)
+      end
+    end
+
+    test "allows viewer access to installation page", %{conn: conn, user: user} do
+      site = new_site()
+      add_guest(site, user: user, role: :viewer)
+
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+      end
+
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+    end
+
+    test "allows editor access to installation page", %{conn: conn, user: user} do
+      site = new_site()
+      add_guest(site, user: user, role: :editor)
+
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+      end
+
+      {lv, _} = get_lv(conn, site)
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+    end
+  end
+
+  describe "URL Parameter Handling" do
+    test "falls back to manual installation when invalid installation type parameter supplied",
+         %{
+           conn: conn,
+           site: site
+         } do
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+      end
+
+      {lv, _} = get_lv(conn, site, "?type=invalid")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+    end
+
+    test "falls back to provisioning flow when invalid flow parameter supplied", %{
+      conn: conn,
+      site: site
+    } do
+      on_ee do
+        stub_dns_lookup_a_records(site.domain)
+        stub_detection_manual()
+      end
+
+      {lv, _} = get_lv(conn, site, "?flow=invalid")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify Script installation"
+    end
+  end
+
+  describe "Detection Result Combinations" do
+    @describetag :ee_only
+
+    test "When GTM + Wordpress detected, GTM takes precedence", %{conn: conn, site: site} do
+      stub_dns_lookup_a_records(site.domain)
+
       stub_detection_result(%{
         "v1Detected" => false,
         "gtmLikely" => true,
-        "npm" => false,
-        "wordpressLikely" => false,
+        "wordpressLikely" => true,
         "wordpressPlugin" => false
       })
-    end
 
-    defp stub_detection_manual_with_v1 do
-      stub_detection_result(%{
-        "v1Detected" => true,
-        "gtmLikely" => false,
-        "npm" => false,
-        "wordpressLikely" => false,
-        "wordpressPlugin" => false
-      })
-    end
+      {lv, _} = get_lv(conn, site)
 
+      html = render_async(lv, 500)
+      assert html =~ "Verify Tag Manager installation"
+    end
+  end
+
+  describe "Legacy Installations" do
+    @tag :ee_only
+    test "uses detected type in review flow when installation_type is nil", %{
+      conn: conn,
+      site: site
+    } do
+      _config =
+        PlausibleWeb.Tracker.get_or_create_tracker_script_configuration!(site, %{
+          installation_type: nil,
+          outbound_links: true,
+          file_downloads: false,
+          form_submissions: true
+        })
+
+      stub_dns_lookup_a_records(site.domain)
+      stub_detection_wordpress()
+
+      {lv, _} = get_lv(conn, site, "?flow=review")
+
+      html = render_async(lv, 500)
+      assert html =~ "Verify WordPress installation"
+    end
+  end
+
+  defp stub_detection_manual do
+    stub_detection_result(%{
+      "v1Detected" => false,
+      "gtmLikely" => false,
+      "npm" => false,
+      "wordpressLikely" => false,
+      "wordpressPlugin" => false
+    })
+  end
+
+  defp stub_detection_wordpress do
+    stub_detection_result(%{
+      "v1Detected" => false,
+      "gtmLikely" => false,
+      "npm" => false,
+      "wordpressLikely" => true,
+      "wordpressPlugin" => false
+    })
+  end
+
+  defp stub_detection_gtm do
+    stub_detection_result(%{
+      "v1Detected" => false,
+      "gtmLikely" => true,
+      "npm" => false,
+      "wordpressLikely" => false,
+      "wordpressPlugin" => false
+    })
+  end
+
+  defp stub_detection_manual_with_v1 do
+    stub_detection_result(%{
+      "v1Detected" => true,
+      "gtmLikely" => false,
+      "npm" => false,
+      "wordpressLikely" => false,
+      "wordpressPlugin" => false
+    })
+  end
+
+  on_ee do
     defp stub_detection_wordpress_with_v1 do
       stub_detection_result(%{
         "v1Detected" => true,
@@ -530,39 +645,39 @@ defmodule PlausibleWeb.Live.InstallationV2Test do
         "wordpressPlugin" => false
       })
     end
+  end
 
-    defp stub_detection_result(js_data) do
-      Req.Test.stub(:global, fn conn ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
-      end)
-    end
+  defp stub_detection_result(js_data) do
+    Req.Test.stub(:global, fn conn ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, Jason.encode!(%{"data" => Map.put(js_data, "completed", true)}))
+    end)
+  end
 
-    defp stub_detection_error do
-      Req.Test.stub(:global, fn conn ->
-        conn
-        |> put_resp_content_type("application/json")
-        |> send_resp(
-          200,
-          Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
-        )
-      end)
-    end
+  defp stub_detection_error do
+    Req.Test.stub(:global, fn conn ->
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        200,
+        Jason.encode!(%{"data" => %{"error" => %{"message" => "Simulated browser error"}}})
+      )
+    end)
+  end
 
-    defp get_lv(conn, site, qs \\ nil) do
-      {:ok, lv, html} = live(conn, "/#{site.domain}/installationv2#{qs}")
+  defp get_lv(conn, site, qs \\ nil) do
+    {:ok, lv, html} = live(conn, "/#{site.domain}/installationv2#{qs}")
 
-      {lv, html}
-    end
+    {lv, html}
+  end
 
-    defp stub_dns_lookup_a_records(domain, a_records \\ [{192, 168, 1, 1}]) do
-      lookup_domain = to_charlist(domain)
+  defp stub_dns_lookup_a_records(domain, a_records \\ [{192, 168, 1, 1}]) do
+    lookup_domain = to_charlist(domain)
 
-      Plausible.DnsLookup.Mock
-      |> expect(:lookup, fn ^lookup_domain, _type, _record, _opts, _timeout ->
-        a_records
-      end)
-    end
+    Plausible.DnsLookup.Mock
+    |> expect(:lookup, fn ^lookup_domain, _type, _record, _opts, _timeout ->
+      a_records
+    end)
   end
 end


### PR DESCRIPTION
### Changes

This PR improves the UX on Community Edition, where there's no Browserless service available to carry out pre-installation scans or verification checks.

- [x] Turn off the pre-installation scan /  v1 script detection on CE. Make sure there's no loading spinner showing up and the user lands straight to the installation (or domain change) screen. 
- [x] Get rid of the "Tag Manager" tab on the InstallationV2 screen. There are no existing instructions for v2 script installation on GTM without the new template, and adding those instructions is out of scope for now.
- [x] In the Review Installation flow, add a link in the footer (only CE; only manual installation) linking to the v1 -> v2 migration guide:
<img width="1027" height="765" alt="image" src="https://github.com/user-attachments/assets/12457c8f-4798-4439-a159-ff6d95f861d5" />

- [x] In the Domain Change flow, change the copy of the yellow warning message (about maybe having to take additional action to change the site domain of the installation) and display it always on CE: 
<img width="1414" height="763" alt="image" src="https://github.com/user-attachments/assets/da92da3f-b874-430f-9b82-120b90deef2e" />

- [x] Tests: enable existing `:ee_only` tests for CE and add new ones explicit to CE where necessary
- [ ] Update changelog about script v2

### Tests
- [x] Automated tests have been added

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
