### PR TITLE
Script v2: Show "Plausible not detected" errors with installation type specific recommendations

### DIFF
--- a/lib/plausible/installation_support/verification/diagnostics.ex
+++ b/lib/plausible/installation_support/verification/diagnostics.ex
@@ -218,7 +218,8 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
         _expected_domain,
         url
       )
-      when is_binary(url) and page_response_status not in [200, nil] and plausible_is_on_window != true and
+      when is_binary(url) and page_response_status not in [200, nil] and
+             plausible_is_on_window != true and
              plausible_is_initialized != true do
     attempted_url = shorten_url(url)
 
@@ -228,16 +229,15 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   end
 
   def interpret(
-    %__MODULE__{
-      selected_installation_type: selected_installation_type,
-      plausible_is_on_window: false,
-      service_error: nil,
-    },
-    _expected_domain,
-    _url
-  ),
-  do: error_plausible_not_found(selected_installation_type)
-
+        %__MODULE__{
+          selected_installation_type: selected_installation_type,
+          plausible_is_on_window: false,
+          service_error: nil
+        },
+        _expected_domain,
+        _url
+      ),
+      do: error_plausible_not_found(selected_installation_type)
 
   def interpret(%__MODULE__{} = diagnostics, _expected_domain, url) do
     Sentry.capture_message("Unhandled case for site verification (v2)",

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -6,21 +6,23 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
 
   describe "interpreting diagnostics" do
     for status <- [200, 202] do
-      test "success with response status #{status}" do
+      test "returns success if test event response status is #{status} and domain is as expected" do
         expected_domain = "example.com"
         url_to_verify = "https://#{expected_domain}"
 
-        diagnostics = %Diagnostics{
-          plausible_is_on_window: true,
-          plausible_is_initialized: true,
-          test_event: %{
-            "normalizedBody" => %{
-              "domain" => "example.com"
+        diagnostics =
+          randomized_diagnostics(
+            plausible_is_on_window: true,
+            plausible_is_initialized: true,
+            test_event: %{
+              "normalizedBody" => %{
+                "domain" => "example.com"
+              },
+              "responseStatus" => unquote(status)
             },
-            "responseStatus" => unquote(status)
-          },
-          service_error: nil
-        }
+            service_error: nil,
+            diagnostics_are_from_cache_bust: nil
+          )
 
         assert Diagnostics.interpret(diagnostics, expected_domain, url_to_verify) == %Result{
                  ok?: true
@@ -28,22 +30,23 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       end
     end
 
-    test "error when it 'succeeds', but only after cache bust" do
+    test "returns error when it 'succeeds', but only after cache bust" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: true,
-        plausible_is_initialized: true,
-        test_event: %{
-          "normalizedBody" => %{
-            "domain" => "example.com"
+      diagnostics =
+        randomized_diagnostics(
+          plausible_is_on_window: true,
+          plausible_is_initialized: true,
+          test_event: %{
+            "normalizedBody" => %{
+              "domain" => "example.com"
+            },
+            "responseStatus" => 200
           },
-          "responseStatus" => 200
-        },
-        diagnostics_are_from_cache_bust: true,
-        service_error: nil
-      }
+          diagnostics_are_from_cache_bust: true,
+          service_error: nil
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -58,48 +61,62 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "error when test event domain doesn't match expected domain" do
-      expected_domain = "example.com"
-      url_to_verify = "https://#{expected_domain}"
+    for {installation_type, expected_recommendation} <- [
+          {"wordpress",
+           "Please check that you've installed the WordPress plugin correctly, or verify your installation manually"},
+          {"gtm",
+           "Please check that you've entered the ID in the GTM template correctly, or verify your installation manually"},
+          {"npm",
+           "Please check that you've initialized Plausible with the correct domain, or verify your installation manually"},
+          {"manual",
+           "Please check that the snippet on your site matches the installation instructions exactly, or verify your installation manually"}
+        ] do
+      test "returns error when test event domain doesn't match the expected domain, with recommendation for installation type: #{installation_type}" do
+        expected_domain = "example.com"
+        url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: true,
-        plausible_is_initialized: true,
-        test_event: %{
-          "normalizedBody" => %{
-            "domain" => "wrong-domain.com"
-          },
-          "responseStatus" => 200
-        },
-        service_error: nil
-      }
+        diagnostics =
+          randomized_diagnostics(
+            selected_installation_type: unquote(installation_type),
+            plausible_is_on_window: true,
+            plausible_is_initialized: true,
+            test_event: %{
+              "normalizedBody" => %{
+                "domain" => "wrong-domain.com"
+              },
+              "responseStatus" => 200
+            },
+            service_error: nil
+          )
 
-      assert_matches %Result{
-                       ok?: false,
-                       errors: [^any(:string, ~r/.*not for this site.*/)],
-                       recommendations: [
-                         %{
-                           text: ^any(:string, ~r/.*snippet.*/),
-                           url:
-                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
-                         }
-                       ]
-                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+        assert_matches %Result{
+                         ok?: false,
+                         errors: ["Plausible test event is not for this site"],
+                         recommendations: [
+                           %{
+                             text: unquote(expected_recommendation),
+                             url:
+                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                           }
+                         ]
+                       } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+      end
     end
 
-    test "error when proxy network error occurs" do
+    test "returns error when proxy network error occurs" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: true,
-        plausible_is_initialized: true,
-        test_event: %{
-          "requestUrl" => "https://proxy.example.com/event",
-          "responseStatus" => 500
-        },
-        service_error: nil
-      }
+      diagnostics =
+        randomized_diagnostics(
+          plausible_is_on_window: true,
+          plausible_is_initialized: true,
+          test_event: %{
+            "requestUrl" => "https://proxy.example.com/event",
+            "responseStatus" => 500
+          },
+          service_error: nil
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -113,19 +130,20 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "error when plausible network error occurs" do
+    test "returns error when Plausible network error occurs" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: true,
-        plausible_is_initialized: true,
-        test_event: %{
-          "requestUrl" => PlausibleWeb.Endpoint.url() <> "/api/event",
-          "responseStatus" => 500
-        },
-        service_error: nil
-      }
+      diagnostics =
+        randomized_diagnostics(
+          plausible_is_on_window: true,
+          plausible_is_initialized: true,
+          test_event: %{
+            "requestUrl" => PlausibleWeb.Endpoint.url() <> "/api/event",
+            "responseStatus" => 500
+          },
+          service_error: nil
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -140,14 +158,16 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "error when disallowed by CSP" do
+    test "returns error when Plausible domain is disallowed by CSP" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        disallowed_by_csp: true,
-        service_error: nil
-      }
+      diagnostics =
+        randomized_diagnostics(
+          disallowed_by_csp: true,
+          test_event: nil,
+          service_error: nil
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -163,15 +183,16 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
     end
 
     for error_code <- [:domain_not_found, :invalid_url] do
-      test "error when DNS check fails (#{error_code})" do
+      test "returns error when DNS check fails (with error code: #{error_code})" do
         expected_domain = "example.com"
         url_to_verify = "https://#{expected_domain}"
 
-        diagnostics = %Diagnostics{
-          plausible_is_on_window: nil,
-          plausible_is_initialized: nil,
-          service_error: unquote(error_code)
-        }
+        diagnostics =
+          randomized_diagnostics(
+            plausible_is_on_window: nil,
+            plausible_is_initialized: nil,
+            service_error: unquote(error_code)
+          )
 
         assert_matches %Result{
                          ok?: false,
@@ -190,15 +211,16 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       end
     end
 
-    test "error when Browserless encounters a network error during verification" do
+    test "returns error when there's a network error during verification, offers custom URL input" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}?plausible_verification=123123123"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: nil,
-        plausible_is_initialized: nil,
-        service_error: "net::ERR_CONNECTION_CLOSED at https://example.com"
-      }
+      diagnostics =
+        randomized_diagnostics(
+          plausible_is_on_window: nil,
+          plausible_is_initialized: nil,
+          service_error: "net::ERR_CONNECTION_CLOSED at https://example.com"
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -219,15 +241,19 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "error when plausible not installed and page.goto(url) response is not 200" do
+    test "returns error when Plausible not installed and website response status is not 200, offers custom URL input" do
       expected_domain = "example.com"
       url_to_verify = "https://#{expected_domain}?plausible_verification=123123123"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: false,
-        plausible_is_initialized: nil,
-        response_status: 403
-      }
+      diagnostics =
+        randomized_diagnostics(
+          disallowed_by_csp: false,
+          plausible_is_on_window: false,
+          plausible_is_initialized: false,
+          test_event: %{"error" => "Timed out"},
+          response_status: 403,
+          service_error: nil
+        )
 
       assert_matches %Result{
                        ok?: false,
@@ -252,28 +278,153 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                      } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
     end
 
-    test "unknown error when no specific case matches" do
-      expected_domain = "example.com"
-      url_to_verify = "https://#{expected_domain}"
+    for {installation_type, expected_recommendation} <- [
+          {"wordpress",
+           "Please make sure you've enabled the plugin, or verify your installation manually"},
+          {"gtm",
+           "Please make sure you've configured the GTM template correctly, or verify your installation manually"},
+          {"npm",
+           "Please make sure you've initialized Plausible on your site, or verify your installation manually"},
+          {"manual",
+           "Please make sure you've copied snippet to the head of your site, or verify your installation manually"}
+        ] do
+      test "returns error \"We couldn't detect Plausible on your site\" when plausible_is_on_window is false (with best guess recommendation for installation type: #{installation_type})" do
+        expected_domain = "example.com"
+        url_to_verify = "https://#{expected_domain}"
 
-      diagnostics = %Diagnostics{
-        plausible_is_on_window: false,
-        plausible_is_initialized: false,
-        response_status: 200,
-        service_error: nil
-      }
+        diagnostics =
+          randomized_diagnostics(
+            response_status: 200,
+            disallowed_by_csp: false,
+            plausible_is_on_window: false,
+            service_error: nil,
+            test_event: %{"error" => "Timed out"},
+            selected_installation_type: unquote(installation_type)
+          )
 
-      assert_matches %Result{
-                       ok?: false,
-                       errors: [^any(:string, ~r/.*integration is not working.*/)],
-                       recommendations: [
-                         %{
-                           text: ^any(:string, ~r/.*manually check.*/),
-                           url:
-                             "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
-                         }
-                       ]
-                     } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+        assert_matches %Result{
+                         ok?: false,
+                         errors: ["We couldn't detect Plausible on your site"],
+                         recommendations: [
+                           %{
+                             text: unquote(expected_recommendation),
+                             url:
+                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                           }
+                         ]
+                       } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+      end
+
+      test "falls back to error \"We couldn't detect Plausible on your site\" when no other case matches (with best guess recommendation for installation type: #{installation_type}), sends diagnostics to Sentry" do
+        expected_domain = "example.com"
+        url_to_verify = "https://#{expected_domain}"
+
+        diagnostics =
+          randomized_diagnostics(
+            selected_installation_type: unquote(installation_type),
+            disallowed_by_csp: nil,
+            response_status: nil,
+            disallowed_by_csp: nil,
+            service_error: nil,
+            test_event: nil
+          )
+
+        assert_matches %Result{
+                         ok?: false,
+                         errors: ["We couldn't detect Plausible on your site"],
+                         recommendations: [
+                           %{
+                             text: unquote(expected_recommendation),
+                             url:
+                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                           }
+                         ]
+                       } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
+      end
     end
+  end
+
+  # creates a randomized diagnostics struct, and overwrites only the fields defined in opts
+  defp randomized_diagnostics(opts) do
+    selected_installation_type =
+      Keyword.get(
+        opts,
+        :selected_installation_type,
+        Enum.random(["npm", "gtm", "wordpress", "manual", nil])
+      )
+
+    disallowed_by_csp = Keyword.get(opts, :disallowed_by_csp, Enum.random([true, false, nil]))
+
+    plausible_is_on_window =
+      Keyword.get(opts, :plausible_is_on_window, Enum.random([true, false, nil]))
+
+    plausible_is_initialized =
+      Keyword.get(opts, :plausible_is_initialized, Enum.random([true, false, nil]))
+
+    plausible_version =
+      Keyword.get(opts, :plausible_version, Enum.random([Enum.random(1..100), nil]))
+
+    plausible_variant =
+      Keyword.get(opts, :plausible_variant, Enum.random(["npm", "web", "random string", nil]))
+
+    diagnostics_are_from_cache_bust =
+      Keyword.get(opts, :diagnostics_are_from_cache_bust, Enum.random([true, false, nil]))
+
+    test_event =
+      Keyword.get(
+        opts,
+        :test_event,
+        Enum.random([
+          %{
+            "normalizedBody" => %{"domain" => Enum.random(["example.com", nil])},
+            "responseStatus" => Enum.random([200, 202, 403, 404, 500, nil]),
+            "requestUrl" => Enum.random(["https://example.com/api/event", "https://plausible.io/api/event", nil])
+          },
+          nil
+        ])
+      )
+
+    cookies_consent_result =
+      Keyword.get(
+        opts,
+        :cookies_consent_result,
+        Enum.random([
+          %{"handled" => nil, "cmp" => "cookiebot"},
+          %{"handled" => false, "error" => %{"message" => "Unknown error"}},
+          %{"handled" => nil, "engineLifecycle" => "not-started"},
+          nil
+        ])
+      )
+
+    response_status =
+      Keyword.get(opts, :response_status, Enum.random([200, 202, 403, 404, 500, nil]))
+
+    service_error =
+      Keyword.get(
+        opts,
+        :service_error,
+        Enum.random([
+          "net::ERR_CONNECTION_CLOSED at https://example.com",
+          :domain_not_found,
+          :invalid_url,
+          nil
+        ])
+      )
+
+    attempts = Keyword.get(opts, :attempts, Enum.random([1, 2, 3, nil]))
+    %Diagnostics{
+      selected_installation_type: selected_installation_type,
+      disallowed_by_csp: disallowed_by_csp,
+      plausible_is_on_window: plausible_is_on_window,
+      plausible_is_initialized: plausible_is_initialized,
+      plausible_version: plausible_version,
+      plausible_variant: plausible_variant,
+      diagnostics_are_from_cache_bust: diagnostics_are_from_cache_bust,
+      test_event: test_event,
+      cookies_consent_result: cookies_consent_result,
+      response_status: response_status,
+      service_error: service_error,
+      attempts: attempts
+    }
   end
 end

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -226,14 +226,12 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                        ok?: false,
                        data: %{offer_custom_url_input: true},
                        errors: [
-                         ^any(
-                           :string,
-                           ~r/.*couldn't verify your website at https:\/\/#{expected_domain}$/
-                         )
+                         "We couldn't verify your website at https://example.com"
                        ],
                        recommendations: [
                          %{
-                           text: ^any(:string, ~r/.*verify your integration manually.*/),
+                           text:
+                             "Accessing the website resulted in a network error. Please verify your installation manually",
                            url:
                              "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                          }
@@ -259,18 +257,12 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                        ok?: false,
                        data: %{offer_custom_url_input: true},
                        errors: [
-                         ^any(
-                           :string,
-                           ~r/.*couldn't verify your website at https:\/\/#{expected_domain}.*/
-                         )
+                         "We couldn't verify your website at https://example.com"
                        ],
                        recommendations: [
                          %{
                            text:
-                             ^any(
-                               :string,
-                               ~r/403 error.*firewall.*authentication.*CDN.*verify your integration manually/
-                             ),
+                             "Accessing the website resulted in an unexpected status code 403. Please check for anything that might be blocking us from reaching your site, like a firewall, authentication requirements, or CDN rules. If you'd prefer, you can skip this and verify your installation manually",
                            url:
                              "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                          }

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -378,7 +378,12 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
           %{
             "normalizedBody" => %{"domain" => Enum.random(["example.com", nil])},
             "responseStatus" => Enum.random([200, 202, 403, 404, 500, nil]),
-            "requestUrl" => Enum.random(["https://example.com/api/event", "https://plausible.io/api/event", nil])
+            "requestUrl" =>
+              Enum.random([
+                "https://example.com/api/event",
+                "https://plausible.io/api/event",
+                nil
+              ])
           },
           nil
         ])
@@ -412,6 +417,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       )
 
     attempts = Keyword.get(opts, :attempts, Enum.random([1, 2, 3, nil]))
+
     %Diagnostics{
       selected_installation_type: selected_installation_type,
       disallowed_by_csp: disallowed_by_csp,

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -11,7 +11,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
         url_to_verify = "https://#{expected_domain}"
 
         diagnostics =
-          randomized_diagnostics(
+          %Diagnostics{
             plausible_is_on_window: true,
             plausible_is_initialized: true,
             test_event: %{
@@ -22,7 +22,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
             },
             service_error: nil,
             diagnostics_are_from_cache_bust: nil
-          )
+          }
 
         assert Diagnostics.interpret(diagnostics, expected_domain, url_to_verify) == %Result{
                  ok?: true
@@ -35,7 +35,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           plausible_is_on_window: true,
           plausible_is_initialized: true,
           test_event: %{
@@ -46,7 +46,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
           },
           diagnostics_are_from_cache_bust: true,
           service_error: nil
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -76,7 +76,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
         url_to_verify = "https://#{expected_domain}"
 
         diagnostics =
-          randomized_diagnostics(
+          %Diagnostics{
             selected_installation_type: unquote(installation_type),
             plausible_is_on_window: true,
             plausible_is_initialized: true,
@@ -87,7 +87,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
               "responseStatus" => 200
             },
             service_error: nil
-          )
+          }
 
         assert_matches %Result{
                          ok?: false,
@@ -108,7 +108,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           plausible_is_on_window: true,
           plausible_is_initialized: true,
           test_event: %{
@@ -116,7 +116,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
             "responseStatus" => 500
           },
           service_error: nil
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -135,7 +135,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           plausible_is_on_window: true,
           plausible_is_initialized: true,
           test_event: %{
@@ -143,7 +143,7 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
             "responseStatus" => 500
           },
           service_error: nil
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -163,11 +163,11 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           disallowed_by_csp: true,
           test_event: nil,
           service_error: nil
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -188,11 +188,11 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
         url_to_verify = "https://#{expected_domain}"
 
         diagnostics =
-          randomized_diagnostics(
+          %Diagnostics{
             plausible_is_on_window: nil,
             plausible_is_initialized: nil,
             service_error: unquote(error_code)
-          )
+          }
 
         assert_matches %Result{
                          ok?: false,
@@ -216,11 +216,11 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}?plausible_verification=123123123"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           plausible_is_on_window: nil,
           plausible_is_initialized: nil,
           service_error: "net::ERR_CONNECTION_CLOSED at https://example.com"
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -244,14 +244,14 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
       url_to_verify = "https://#{expected_domain}?plausible_verification=123123123"
 
       diagnostics =
-        randomized_diagnostics(
+        %Diagnostics{
           disallowed_by_csp: false,
           plausible_is_on_window: false,
           plausible_is_initialized: false,
           test_event: %{"error" => "Timed out"},
           response_status: 403,
           service_error: nil
-        )
+        }
 
       assert_matches %Result{
                        ok?: false,
@@ -285,14 +285,14 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
         url_to_verify = "https://#{expected_domain}"
 
         diagnostics =
-          randomized_diagnostics(
+          %Diagnostics{
             response_status: 200,
             disallowed_by_csp: false,
             plausible_is_on_window: false,
             service_error: nil,
             test_event: %{"error" => "Timed out"},
             selected_installation_type: unquote(installation_type)
-          )
+          }
 
         assert_matches %Result{
                          ok?: false,
@@ -312,14 +312,13 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
         url_to_verify = "https://#{expected_domain}"
 
         diagnostics =
-          randomized_diagnostics(
+          %Diagnostics{
             selected_installation_type: unquote(installation_type),
             disallowed_by_csp: nil,
             response_status: nil,
-            disallowed_by_csp: nil,
             service_error: nil,
             test_event: nil
-          )
+          }
 
         assert_matches %Result{
                          ok?: false,
@@ -334,95 +333,5 @@ defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
                        } = Diagnostics.interpret(diagnostics, expected_domain, url_to_verify)
       end
     end
-  end
-
-  # creates a randomized diagnostics struct, and overwrites only the fields defined in opts
-  defp randomized_diagnostics(opts) do
-    selected_installation_type =
-      Keyword.get(
-        opts,
-        :selected_installation_type,
-        Enum.random(["npm", "gtm", "wordpress", "manual", nil])
-      )
-
-    disallowed_by_csp = Keyword.get(opts, :disallowed_by_csp, Enum.random([true, false, nil]))
-
-    plausible_is_on_window =
-      Keyword.get(opts, :plausible_is_on_window, Enum.random([true, false, nil]))
-
-    plausible_is_initialized =
-      Keyword.get(opts, :plausible_is_initialized, Enum.random([true, false, nil]))
-
-    plausible_version =
-      Keyword.get(opts, :plausible_version, Enum.random([Enum.random(1..100), nil]))
-
-    plausible_variant =
-      Keyword.get(opts, :plausible_variant, Enum.random(["npm", "web", "random string", nil]))
-
-    diagnostics_are_from_cache_bust =
-      Keyword.get(opts, :diagnostics_are_from_cache_bust, Enum.random([true, false, nil]))
-
-    test_event =
-      Keyword.get(
-        opts,
-        :test_event,
-        Enum.random([
-          %{
-            "normalizedBody" => %{"domain" => Enum.random(["example.com", nil])},
-            "responseStatus" => Enum.random([200, 202, 403, 404, 500, nil]),
-            "requestUrl" =>
-              Enum.random([
-                "https://example.com/api/event",
-                "https://plausible.io/api/event",
-                nil
-              ])
-          },
-          nil
-        ])
-      )
-
-    cookies_consent_result =
-      Keyword.get(
-        opts,
-        :cookies_consent_result,
-        Enum.random([
-          %{"handled" => nil, "cmp" => "cookiebot"},
-          %{"handled" => false, "error" => %{"message" => "Unknown error"}},
-          %{"handled" => nil, "engineLifecycle" => "not-started"},
-          nil
-        ])
-      )
-
-    response_status =
-      Keyword.get(opts, :response_status, Enum.random([200, 202, 403, 404, 500, nil]))
-
-    service_error =
-      Keyword.get(
-        opts,
-        :service_error,
-        Enum.random([
-          "net::ERR_CONNECTION_CLOSED at https://example.com",
-          :domain_not_found,
-          :invalid_url,
-          nil
-        ])
-      )
-
-    attempts = Keyword.get(opts, :attempts, Enum.random([1, 2, 3, nil]))
-
-    %Diagnostics{
-      selected_installation_type: selected_installation_type,
-      disallowed_by_csp: disallowed_by_csp,
-      plausible_is_on_window: plausible_is_on_window,
-      plausible_is_initialized: plausible_is_initialized,
-      plausible_version: plausible_version,
-      plausible_variant: plausible_variant,
-      diagnostics_are_from_cache_bust: diagnostics_are_from_cache_bust,
-      test_event: test_event,
-      cookies_consent_result: cookies_consent_result,
-      response_status: response_status,
-      service_error: service_error,
-      attempts: attempts
-    }
   end
 end

--- a/tracker/test/support/types.ts
+++ b/tracker/test/support/types.ts
@@ -51,7 +51,6 @@ export type VerifyV2Result = {
         plausibleVersion: number
         plausibleVariant?: string
         disallowedByCsp: boolean
-        cookieBannerLikely: boolean
         cookiesConsentResult: ConsentResult
         testEvent: {
           /**


### PR DESCRIPTION
### Changes
The problems this PR attempts to solve are
1) weird message and recommendation in the case of unknown error 
2) too many unknown errors logged in sentry

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
