### PR TITLE
Stats: Rebuild session smearing for timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to this project will be documented in this file.
 - Make clicking Compare / Disable Comparison in period picker menu close the menu
 - Do not log page views for hidden pages (prerendered pages and new tabs), until pages are viewed
 - Password-authenticated shared links now carry over dashboard params properly
+- Realtime and hourly graphs of visit duration, views per visit no longer overcount due to long-lasting sessions, instead showing each visit
+  when they occurred.
+- Fixed realtime and hourly graphs of visits overcounting
 
 ## v3.0.0 - 2025-04-11
 

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -28,7 +28,8 @@ defmodule Plausible.Stats.Query do
             site_id: nil,
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
-            time_on_page_data: %{}
+            time_on_page_data: %{},
+            sql_join_type: :left
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy, Comparisons}

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -29,7 +29,8 @@ defmodule Plausible.Stats.Query do
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
             time_on_page_data: %{},
-            sql_join_type: :left
+            sql_join_type: :left,
+            smear_session_metrics: false
 
   require OpenTelemetry.Tracer, as: Tracer
   alias Plausible.Stats.{DateTimeRange, Filters, Imported, Legacy, Comparisons}

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -15,15 +15,13 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   require Plausible.Stats.SQL.Expression
 
   def build(query, site) do
-    {event_query, sessions_query} = QueryOptimizer.split(query)
-
-    event_q = build_events_query(site, event_query)
-    sessions_q = build_sessions_query(site, sessions_query)
-
-    join_query_results(
-      {event_q, event_query},
-      {sessions_q, sessions_query}
-    )
+    query
+    |> QueryOptimizer.split()
+    |> Enum.map(fn {table_type, table_query} ->
+      q = build_table_query(table_type, site, table_query)
+      {table_type, table_query, q}
+    end)
+    |> join_query_results(query)
     |> paginate(query.pagination)
     |> select_total_rows(query.include.total_rows)
   end
@@ -32,9 +30,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     Enum.reduce(query.order_by || [], q, &build_order_by(&2, query, &1))
   end
 
-  defp build_events_query(_site, %Query{metrics: []}), do: nil
-
-  defp build_events_query(site, events_query) do
+  defp build_table_query(:events, site, events_query) do
     q =
       from(
         e in "events_v2",
@@ -52,6 +48,25 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     |> merge_imported(site, events_query)
     |> SQL.SpecialMetrics.add(site, events_query)
     |> TimeOnPage.merge_legacy_time_on_page(events_query)
+  end
+
+  defp build_table_query(:sessions, site, sessions_query) do
+    q =
+      from(
+        e in "sessions_v2",
+        where: ^SQL.WhereBuilder.build(:sessions, sessions_query),
+        select: ^select_session_metrics(sessions_query)
+      )
+
+    on_ee do
+      q = Plausible.Stats.Sampling.add_query_hint(q, sessions_query)
+    end
+
+    q
+    |> join_events_if_needed(sessions_query)
+    |> build_group_by(:sessions, sessions_query)
+    |> merge_imported(site, sessions_query)
+    |> SQL.SpecialMetrics.add(site, sessions_query)
   end
 
   defp join_sessions_if_needed(q, query) do
@@ -77,27 +92,6 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     else
       q
     end
-  end
-
-  defp build_sessions_query(_site, %Query{metrics: []}), do: nil
-
-  defp build_sessions_query(site, sessions_query) do
-    q =
-      from(
-        e in "sessions_v2",
-        where: ^SQL.WhereBuilder.build(:sessions, sessions_query),
-        select: ^select_session_metrics(sessions_query)
-      )
-
-    on_ee do
-      q = Plausible.Stats.Sampling.add_query_hint(q, sessions_query)
-    end
-
-    q
-    |> join_events_if_needed(sessions_query)
-    |> build_group_by(:sessions, sessions_query)
-    |> merge_imported(site, sessions_query)
-    |> SQL.SpecialMetrics.add(site, sessions_query)
   end
 
   def join_events_if_needed(q, query) do
@@ -173,24 +167,25 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     )
   end
 
-  defp join_query_results({nil, _}, {nil, _}), do: nil
+  defp join_query_results([nil], _main_query), do: nil
 
-  defp join_query_results({events_q, events_query}, {nil, _}),
-    do: events_q |> build_order_by(events_query)
+  # Only one table is being queried - skip joining!
+  defp join_query_results([{_table_type, _query, q}], main_query),
+    do: q |> build_order_by(main_query)
 
-  defp join_query_results({nil, events_query}, {sessions_q, _}),
-    do: sessions_q |> build_order_by(events_query)
-
-  defp join_query_results({events_q, events_query}, {sessions_q, sessions_query}) do
+  defp join_query_results(
+         [{:events, events_query, events_q}, {:sessions, sessions_query, sessions_q}],
+         main_query
+       ) do
     {join_type, events_q_fields, sessions_q_fields} =
       TableDecider.join_options(events_query, sessions_query)
 
     join(subquery(events_q), join_type, [e], s in subquery(sessions_q),
-      on: ^build_group_by_join(events_query)
+      on: ^build_group_by_join(main_query)
     )
     |> select_join_fields(events_query, events_q_fields, e)
     |> select_join_fields(sessions_query, sessions_q_fields, s)
-    |> build_order_by(events_query)
+    |> build_order_by(main_query)
   end
 
   # NOTE: Old queries do their own pagination

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -22,6 +22,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
       {table_type, table_query, q}
     end)
     |> join_query_results(query)
+    |> build_order_by(query)
     |> paginate(query.pagination)
     |> select_total_rows(query.include.total_rows)
   end
@@ -170,8 +171,7 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
   defp join_query_results([nil], _main_query), do: nil
 
   # Only one table is being queried - skip joining!
-  defp join_query_results([{_table_type, _query, q}], main_query),
-    do: q |> build_order_by(main_query)
+  defp join_query_results([{_table_type, _query, q}], _main_query), do: q
 
   defp join_query_results(
          [{:events, events_query, events_q}, {:sessions, sessions_query, sessions_q}],
@@ -185,7 +185,6 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     )
     |> select_join_fields(events_query, events_q_fields, e)
     |> select_join_fields(sessions_query, sessions_q_fields, s)
-    |> build_order_by(main_query)
   end
 
   # NOTE: Old queries do their own pagination

--- a/lib/plausible/stats/sql/query_builder.ex
+++ b/lib/plausible/stats/sql/query_builder.ex
@@ -168,8 +168,6 @@ defmodule Plausible.Stats.SQL.QueryBuilder do
     )
   end
 
-  defp join_query_results([nil], _main_query), do: nil
-
   # Only one table is being queried - skip joining!
   defp join_query_results([{_table_type, _query, q}], _main_query), do: q
 

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -97,6 +97,8 @@ defmodule Plausible.Stats.TableDecider do
   defp metric_partitioner(%Query{legacy_breakdown: true}, :pageviews), do: :either
   defp metric_partitioner(%Query{legacy_breakdown: true}, :events), do: :either
 
+  # :TRICKY: For time:minute dimension we prefer sessions over events as there
+  # might be minutes where no events occurred but the session was active.
   defp metric_partitioner(query, metric) when metric in [:visitors, :visits] do
     if "time:minute" in query.dimensions, do: :session, else: :either
   end

--- a/lib/plausible/stats/table_decider.ex
+++ b/lib/plausible/stats/table_decider.ex
@@ -54,39 +54,6 @@ defmodule Plausible.Stats.TableDecider do
     end
   end
 
-  @doc """
-  Returns a three-element tuple with instructions on how to join two Ecto
-  queries. The arguments (`events_query` and `sessions_query`) are `%Query{}`
-  structs that have been split by TableDecider already.
-
-  Normally we can always LEFT JOIN sessions to events, selecting `dimensions`
-  only from the events subquery. That's because:
-
-  1) session dimensions (e.g. entry_page) cannot be queried alongside event
-     metrics/dimensions, or
-
-  2) session dimensions (e.g. operating_system) are also available in the
-     events table.
-
-  The only exception is using the "time:minute" dimension where the sessions
-  subquery might return more rows than the events one. That's because we're
-  counting sessions in all time buckets they were active in.
-  """
-  def join_options(events_query, sessions_query) do
-    events_q_select_fields = events_query.metrics ++ events_query.dimensions
-    sessions_q_select_fields = sessions_query.metrics -- [:sample_percent]
-
-    if "time:minute" in events_query.dimensions do
-      {
-        :full,
-        events_q_select_fields -- ["time:minute"],
-        sessions_q_select_fields ++ ["time:minute"]
-      }
-    else
-      {:left, events_q_select_fields, sessions_q_select_fields}
-    end
-  end
-
   @type table_type() :: :events | :sessions
   @type metric() :: String.t()
 

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -343,4 +343,14 @@ defmodule Plausible.Stats.QueryOptimizerTest do
       assert result.utc_time_range.last == nyc_mar_15_end
     end
   end
+
+  describe "set_sql_join_type" do
+    test "updates sql_join_type to :full if time:minute dimension is present" do
+      assert perform(%{dimensions: ["time:minute"]}).sql_join_type == :full
+    end
+
+    test "keeps default sql_join_type otherwise" do
+      assert perform(%{dimensions: ["time:hour"]}).sql_join_type == :left
+    end
+  end
 end

--- a/test/plausible/stats/table_decider_test.exs
+++ b/test/plausible/stats/table_decider_test.exs
@@ -164,6 +164,29 @@ defmodule Plausible.Stats.TableDeciderTest do
                sessions: [:visitors]
              ]
     end
+
+    test "smearable metrics" do
+      assert partition_metrics(
+               [:visitors, :visits, :visit_duration, :pageviews],
+               make_query([], ["time:minute"])
+             ) == [
+               events: [:pageviews],
+               sessions: [:visit_duration],
+               sessions_smeared: [:visitors, :visits]
+             ]
+
+      assert partition_metrics([:visitors], make_query([], ["time:hour"])) == [
+               sessions_smeared: [:visitors]
+             ]
+
+      assert partition_metrics([:visitors], make_query([], ["time:day"])) == [
+               sessions: [:visitors]
+             ]
+
+      assert partition_metrics([:visitors], make_query([], [])) == [
+               sessions: [:visitors]
+             ]
+    end
   end
 
   describe "validate_no_metrics_dimensions_conflict" do

--- a/test/plausible/stats/table_decider_test.exs
+++ b/test/plausible/stats/table_decider_test.exs
@@ -28,127 +28,141 @@ defmodule Plausible.Stats.TableDeciderTest do
     test "with no metrics or filters" do
       query = make_query([])
 
-      assert partition_metrics([], query) == {[], [], []}
+      assert partition_metrics([], query) == []
     end
 
     test "session-only metrics accordingly" do
       query = make_query([])
 
-      assert partition_metrics([:bounce_rate, :views_per_visit], query) ==
-               {[], [:bounce_rate, :views_per_visit], []}
+      assert partition_metrics([:bounce_rate, :views_per_visit], query) == [
+               sessions: [:bounce_rate, :views_per_visit]
+             ]
     end
 
     test "event-only metrics accordingly" do
       query = make_query([])
 
-      assert partition_metrics([:total_revenue, :visitors], query) ==
-               {[:total_revenue, :visitors], [], []}
+      assert partition_metrics([:total_revenue, :visitors], query) == [
+               events: [:total_revenue, :visitors]
+             ]
     end
 
     test "filters from both, event-only metrics" do
       query = make_query(["event:name", "visit:source"])
 
-      assert partition_metrics([:total_revenue], query) == {[:total_revenue], [], []}
+      assert partition_metrics([:total_revenue], query) == [events: [:total_revenue]]
     end
 
     test "filters from both, session-only metrics" do
       query = make_query(["event:name", "visit:source"])
 
-      assert partition_metrics([:bounce_rate], query) == {[], [:bounce_rate], []}
+      assert partition_metrics([:bounce_rate], query) == [sessions: [:bounce_rate]]
     end
 
     test "session filters but no session metrics" do
       query = make_query(["visit:source"])
 
-      assert partition_metrics([:total_revenue], query) == {[:total_revenue], [], []}
+      assert partition_metrics([:total_revenue], query) == [events: [:total_revenue]]
     end
 
     test "sample_percent is added to both types of metrics" do
       query = make_query([])
 
-      assert partition_metrics([:total_revenue, :sample_percent], query) ==
-               {[:total_revenue, :sample_percent], [], []}
+      assert partition_metrics([:total_revenue, :sample_percent], query) == [
+               events: [:total_revenue, :sample_percent]
+             ]
 
-      assert partition_metrics([:bounce_rate, :sample_percent], query) ==
-               {[], [:bounce_rate, :sample_percent], []}
+      assert partition_metrics([:bounce_rate, :sample_percent], query) == [
+               sessions: [:bounce_rate, :sample_percent]
+             ]
 
-      assert partition_metrics([:total_revenue, :bounce_rate, :sample_percent], query) ==
-               {[:total_revenue, :sample_percent], [:bounce_rate, :sample_percent], []}
+      assert partition_metrics([:total_revenue, :bounce_rate, :sample_percent], query) == [
+               events: [:total_revenue, :sample_percent],
+               sessions: [:bounce_rate, :sample_percent]
+             ]
     end
 
-    test "other metrics put in its own result" do
+    test "other metrics get ignored" do
       query = make_query([])
 
-      assert partition_metrics([:percentage, :total_visitors], query) ==
-               {[], [:percentage], [:total_visitors]}
+      assert partition_metrics([:percentage, :total_visitors], query) == [sessions: [:percentage]]
     end
 
     test "metrics that can be calculated on either when event-only metrics" do
       query = make_query([])
 
-      assert partition_metrics([:total_revenue, :visitors], query) ==
-               {[:total_revenue, :visitors], [], []}
+      assert partition_metrics([:total_revenue, :visitors], query) == [
+               events: [:total_revenue, :visitors]
+             ]
 
-      assert partition_metrics([:pageviews, :visits], query) == {[:pageviews, :visits], [], []}
+      assert partition_metrics([:pageviews, :visits], query) == [events: [:pageviews, :visits]]
     end
 
     test "metrics that can be calculated on either when session-only metrics" do
       query = make_query([])
 
-      assert partition_metrics([:bounce_rate, :visitors], query) ==
-               {[], [:bounce_rate, :visitors], []}
+      assert partition_metrics([:bounce_rate, :visitors], query) == [
+               sessions: [:bounce_rate, :visitors]
+             ]
 
-      assert partition_metrics([:visit_duration, :visits], query) ==
-               {[], [:visit_duration, :visits], []}
+      assert partition_metrics([:visit_duration, :visits], query) == [
+               sessions: [:visit_duration, :visits]
+             ]
     end
 
     test "metrics that can be calculated on either are biased to events" do
       query = make_query([])
 
-      assert partition_metrics([:bounce_rate, :total_revenue, :visitors], query) ==
-               {[:total_revenue, :visitors], [:bounce_rate], []}
+      assert partition_metrics([:bounce_rate, :total_revenue, :visitors], query) == [
+               events: [:total_revenue, :visitors],
+               sessions: [:bounce_rate]
+             ]
     end
 
     test "sample_percent is handled with either metrics" do
       query = make_query([])
 
-      assert partition_metrics([:visitors, :sample_percent], query) ==
-               {[], [:visitors, :sample_percent], []}
+      assert partition_metrics([:visitors, :sample_percent], query) == [
+               sessions: [:visitors, :sample_percent]
+             ]
     end
 
     test "metric can be calculated on either, but filtering on events" do
       query = make_query(["event:name"])
 
-      assert partition_metrics([:visitors], query) == {[:visitors], [], []}
+      assert partition_metrics([:visitors], query) == [events: [:visitors]]
     end
 
     test "metric can be calculated on either, but filtering on events and sessions" do
       query = make_query(["event:name", "visit:exit_page"])
 
-      assert partition_metrics([:visitors], query) == {[], [:visitors], []}
+      assert partition_metrics([:visitors], query) == [sessions: [:visitors]]
     end
 
     test "metric can be calculated on either, filtering on either" do
       query = make_query(["visit:source"])
 
-      assert partition_metrics([:visitors], query) == {[], [:visitors], []}
+      assert partition_metrics([:visitors], query) == [sessions: [:visitors]]
     end
 
     test "metric can be calculated on either, filtering on sessions" do
       query = make_query(["visit:exit_page"])
 
-      assert partition_metrics([:visitors], query) == {[], [:visitors], []}
+      assert partition_metrics([:visitors], query) == [sessions: [:visitors]]
     end
 
     test "query dimensions lean metric" do
-      assert partition_metrics([:visitors], make_query([], ["event:name"])) ==
-               {[:visitors], [], []}
+      assert partition_metrics([:visitors], make_query([], ["event:name"])) == [
+               events: [:visitors]
+             ]
 
-      assert partition_metrics([:visitors], make_query([], ["visit:source"])) ==
-               {[], [:visitors], []}
+      assert partition_metrics([:visitors], make_query([], ["visit:source"])) == [
+               sessions: [:visitors]
+             ]
 
-      assert partition_metrics([:visitors], make_query([], ["visit:exit_page"])) ==
-               {[], [:visitors], []}
+      assert partition_metrics([:visitors], make_query([], ["visit:exit_page"])) == [
+               sessions: [:visitors]
+             ]
     end
   end
 


### PR DESCRIPTION
When graphing timeseries, **Session smearing** refers to counting sessions in _each_ of the time buckets a session was active in instead of only when it ended. This works well for visitors/visit graphs, but for visit duration metric it was causing severe over-counting under each value.

<img width="1002" height="457" alt="image" src="https://github.com/user-attachments/assets/ed681dad-7063-4a00-9353-32506040663a" />

This PR:
1. Refactors session smearing to only work for visits/visitors metrics and no longer with visit_duration
2. Fixes a bug with visits metric when smearing

To facilitate this, internals of the query building are revamped to allow joining more than 1 event query with 1 session query. Some business logic was also moved to QueryOptimizer.

Basecamp ref: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/8546432041#__recording_9025673227