### PR TITLE
Add top goal conversions to weekly/monthly e-mail digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Ability to leave team via Team Settings > Leave Team
 - Properties are now included in full site exports done via Site Settings > Imports & Exports
 - Google Search Console integration settings: properties can be dynamically sought
+- Weekly/monthly e-mail reports now contain top goal conversions
 
 ### Removed
 

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -25,7 +25,8 @@ defmodule Plausible.Stats.EmailReport do
         site,
         :internal,
         %{
-          "site_id" => "#{site.id}",
+          # site_id parameter is required, but it doesn't matter what we pass here since the query is executed against a specific site later on
+          "site_id" => site.domain,
           # metrics will be overridden in the pipeline that follows, and the build interface forces us to pass something
           "metrics" => ["visitors"],
           "date_range" => period,
@@ -86,7 +87,8 @@ defmodule Plausible.Stats.EmailReport do
         site,
         :internal,
         %{
-          "site_id" => "#{site.id}",
+          # site_id parameter is required, but it doesn't matter what we pass here since the query is executed against a specific site later on
+          "site_id" => site.domain,
           "metrics" => ["visitors"],
           "dimensions" => ["event:goal"],
           "date_range" => period_str,

--- a/lib/plausible/stats/email_report.ex
+++ b/lib/plausible/stats/email_report.ex
@@ -79,7 +79,6 @@ defmodule Plausible.Stats.EmailReport do
   end
 
   defp put_top_5_goals(stats, site, query) do
-    date_str = Date.to_iso8601(query.now)
     period_str = if query.period == "month", do: "month", else: "7d"
 
     {:ok, q} =
@@ -92,7 +91,6 @@ defmodule Plausible.Stats.EmailReport do
           "metrics" => ["visitors"],
           "dimensions" => ["event:goal"],
           "date_range" => period_str,
-          "date" => date_str,
           "pagination" => %{"limit" => 5}
         },
         %{}

--- a/lib/plausible_web/mjml/templates/stats_report.mjml.eex
+++ b/lib/plausible_web/mjml/templates/stats_report.mjml.eex
@@ -179,6 +179,37 @@
       </mj-group>
     </mj-section>
 
+    <%= if @stats.goals && length(@stats.goals) > 0 do %>
+    <mj-section padding="0">
+      <mj-column>
+        <mj-divider />
+      </mj-column>
+    </mj-section>
+
+    <mj-section>
+      <mj-group>
+        <mj-column>
+          <mj-text font-weight="bold">Goal</mj-text>
+
+          <%= for goal <- @stats.goals do %>
+            <mj-text css-class="goal-name">
+              <%= goal[:goal] %>
+            </mj-text>
+          <% end %>
+        </mj-column>
+        <mj-column>
+          <mj-text font-weight="bold" align="right">Conversions</mj-text>
+
+          <%= for goal <- @stats.goals do %>
+            <mj-text align="right" css-class="goal-conversions">
+              <%= PlausibleWeb.StatsView.large_number_format(goal[:visitors]) %>
+            </mj-text>
+          <% end %>
+        </mj-column>
+      </mj-group>
+    </mj-section>
+    <% end %>
+
     <%= if @login_link do %>
       <mj-section>
         <mj-column>

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -213,7 +213,7 @@ defmodule Plausible.Workers.SendEmailReportTest do
 
     test "includes goal conversions when goals exist" do
       now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-      site = new_site(domain: "test-site.com", inserted_at: Timex.shift(now, days: -8))
+      site = new_site(domain: "test-site.com", inserted_at: NaiveDateTime.shift(now, day: -8))
       insert(:weekly_report, site: site, recipients: ["user@email.com"])
 
       _goal1 = insert(:goal, site: site, event_name: "Signup")
@@ -223,31 +223,31 @@ defmodule Plausible.Workers.SendEmailReportTest do
       populate_stats(site, [
         build(:pageview,
           user_id: 123,
-          timestamp: Timex.shift(now, days: -7)
+          timestamp: NaiveDateTime.shift(now, day: -7)
         ),
         build(:pageview,
           user_id: 124,
-          timestamp: Timex.shift(now, days: -6)
+          timestamp: NaiveDateTime.shift(now, day: -6)
         ),
         build(:event,
           user_id: 123,
           name: "Signup",
-          timestamp: Timex.shift(now, days: -7)
+          timestamp: NaiveDateTime.shift(now, day: -7)
         ),
         build(:event,
           user_id: 124,
           name: "Signup",
-          timestamp: Timex.shift(now, days: -6)
+          timestamp: NaiveDateTime.shift(now, day: -6)
         ),
         build(:event,
           user_id: 125,
           name: "Purchase",
-          timestamp: Timex.shift(now, days: -5)
+          timestamp: NaiveDateTime.shift(now, day: -5)
         ),
         build(:pageview,
           user_id: 126,
           pathname: "/thank-you",
-          timestamp: Timex.shift(now, days: -4)
+          timestamp: NaiveDateTime.shift(now, day: -4)
         )
       ])
 

--- a/test/workers/send_email_report_test.exs
+++ b/test/workers/send_email_report_test.exs
@@ -210,6 +210,60 @@ defmodule Plausible.Workers.SendEmailReportTest do
       assert text(bounce_rate_change_container) == "0%"
       assert text_of_attr(bounce_rate_change_container, "style") =~ @green
     end
+
+    test "includes goal conversions when goals exist" do
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      site = new_site(domain: "test-site.com", inserted_at: Timex.shift(now, days: -8))
+      insert(:weekly_report, site: site, recipients: ["user@email.com"])
+
+      _goal1 = insert(:goal, site: site, event_name: "Signup")
+      _goal2 = insert(:goal, site: site, event_name: "Purchase")
+      _goal3 = insert(:goal, site: site, page_path: "/thank-you")
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          timestamp: Timex.shift(now, days: -7)
+        ),
+        build(:pageview,
+          user_id: 124,
+          timestamp: Timex.shift(now, days: -6)
+        ),
+        build(:event,
+          user_id: 123,
+          name: "Signup",
+          timestamp: Timex.shift(now, days: -7)
+        ),
+        build(:event,
+          user_id: 124,
+          name: "Signup",
+          timestamp: Timex.shift(now, days: -6)
+        ),
+        build(:event,
+          user_id: 125,
+          name: "Purchase",
+          timestamp: Timex.shift(now, days: -5)
+        ),
+        build(:pageview,
+          user_id: 126,
+          pathname: "/thank-you",
+          timestamp: Timex.shift(now, days: -4)
+        )
+      ])
+
+      perform_job(SendEmailReport, %{"site_id" => site.id, "interval" => "weekly"})
+
+      assert_delivered_email_matches(%{
+        to: [nil: "user@email.com"],
+        html_body: html_body
+      })
+
+      goal_names = find(html_body, ".goal-name") |> Enum.map(&text/1)
+      goal_conversions = find(html_body, ".goal-conversions") |> Enum.map(&text/1)
+
+      assert goal_names == ["Signup", "Purchase", "Visit /thank-you"]
+      assert goal_conversions == ["2", "1", "1"]
+    end
   end
 
   describe "monthly_reports" do


### PR DESCRIPTION
### Changes

Includes top goal conversions (unique visitors) in weekly/monthly e-mail report

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
