### PR TITLE
Retry on HTTP2 `:unprocessed` error in `Persistor.Remote`

### DIFF
--- a/lib/plausible/ingestion/persistor/remote.ex
+++ b/lib/plausible/ingestion/persistor/remote.ex
@@ -56,6 +56,10 @@ defmodule Plausible.Ingestion.Persistor.Remote do
     true
   end
 
+  defp handle_transient_error(_request, %Req.HTTPError{protocol: :http2, reason: :unprocessed}) do
+    true
+  end
+
   defp handle_transient_error(_reqeust, _response), do: false
 
   defp encode_payload(event, session_attrs) do


### PR DESCRIPTION
### Changes

It seldom happened during testing but it's safe to retry per https://hexdocs.pm/mint/Mint.HTTP2.html#module-closed-connection

