### PR TITLE
Implement directing percentage of traffic to a given persistor backend

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -148,6 +148,11 @@ persistor_backend =
     "remote" -> Plausible.Ingestion.Persistor.Remote
   end
 
+persistor_backend_percent_enabled =
+  config_dir
+  |> get_var_from_path_or_env("PERSISTOR_BACKEND_PERCENT_ENABLED", "0")
+  |> Integer.parse()
+
 persistor_url =
   get_var_from_path_or_env(config_dir, "PERSISTOR_URL", "http://localhost:8001/event")
 
@@ -663,7 +668,9 @@ config :plausible, Plausible.ImportDeletionRepo,
   transport_opts: ch_transport_opts,
   pool_size: 1
 
-config :plausible, Plausible.Ingestion.Persistor, backend: persistor_backend
+config :plausible, Plausible.Ingestion.Persistor,
+  backend: persistor_backend,
+  backend_percent_enabled: persistor_backend_percent_enabled
 
 config :plausible, Plausible.Ingestion.Persistor.Remote,
   url: persistor_url,


### PR DESCRIPTION
### Changes

Adds ability to declare a percentage of traffic which should be directed towards the configured persistor backend with a fallback to embedded implementation.