### PR TITLE
Fix: Trim comparisons for year/month

### DIFF
--- a/lib/plausible/stats/query_optimizer.ex
+++ b/lib/plausible/stats/query_optimizer.ex
@@ -246,10 +246,6 @@ defmodule Plausible.Stats.QueryOptimizer do
 
   defp trim_relative_date_range(query), do: query
 
-  defp should_trim_date_range?(%Query{include: %{comparisons: comparison_opts}})
-       when is_map(comparison_opts),
-       do: false
-
   defp should_trim_date_range?(%Query{input_date_range: "month"} = query) do
     today = query.now |> DateTime.shift_zone!(query.timezone) |> DateTime.to_date()
     date_range = Query.date_range(query)
@@ -274,7 +270,7 @@ defmodule Plausible.Stats.QueryOptimizer do
     today = query.now |> DateTime.shift_zone!(query.timezone) |> DateTime.to_date()
     date_range = Query.date_range(query)
 
-    date_range.first == today and date_range.last == today
+    is_nil(query.include.comparisons) and date_range.first == today and date_range.last == today
   end
 
   defp should_trim_date_range?(_query), do: false

--- a/test/plausible/stats/query_optimizer_test.exs
+++ b/test/plausible/stats/query_optimizer_test.exs
@@ -252,7 +252,7 @@ defmodule Plausible.Stats.QueryOptimizerTest do
       assert result.utc_time_range == original_range
     end
 
-    test "does not trim when comparisons are set" do
+    test "does not trim day when comparisons are set" do
       now = DateTime.new!(~D[2024-01-15], ~T[12:00:00], "UTC")
       original_range = DateTimeRange.new!(~D[2024-01-01], ~D[2024-01-31], "UTC")
 
@@ -270,6 +270,26 @@ defmodule Plausible.Stats.QueryOptimizerTest do
         })
 
       assert result.utc_time_range == original_range
+    end
+
+    test "trims month when comparisons are set" do
+      now = DateTime.new!(~D[2024-01-15], ~T[12:00:00], "UTC")
+
+      result =
+        perform(%{
+          utc_time_range: DateTimeRange.new!(~D[2024-01-01], ~D[2024-01-31], "UTC"),
+          input_date_range: "month",
+          now: now,
+          timezone: "UTC",
+          include:
+            Map.merge(
+              QueryParser.default_include(),
+              %{comparisons: %{mode: "previous_period"}, trim_relative_date_range: true}
+            )
+        })
+
+      assert result.utc_time_range.first == ~U[2024-01-01 00:00:00Z]
+      assert result.utc_time_range.last == ~U[2024-01-15 23:59:59Z]
     end
 
     test "does not trim when flag is false" do

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -169,31 +169,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
     assert actual_comparison_last_date == expected_comparison_last_date
   end
 
-  test "regression: does not trim when trim_relative_date_range is true", %{
-    conn: conn,
-    site: site
-  } do
-    conn =
-      post(conn, "/api/v2/query-internal-test", %{
-        "site_id" => site.domain,
-        "metrics" => ["visitors"],
-        "date_range" => "month",
-        "date" => "2021-01-15",
-        "dimensions" => ["time:day"],
-        "include" => %{
-          "trim_relative_date_range" => true,
-          "comparisons" => %{
-            "mode" => "previous_period"
-          }
-        }
-      })
-
-    assert json_response(conn, 200)["query"]["date_range"] == [
-             "2021-01-01T00:00:00+00:00",
-             "2021-01-31T23:59:59+00:00"
-           ]
-  end
-
   test "timeseries last 91d period in year_over_year comparison", %{
     conn: conn,
     site: site


### PR DESCRIPTION
### Changes

`year` and `month` periods worked differently from what I expected: they always compare with the last N months/years compared to the running year/month. This resulted in empty graphs.

<details>
  <summary><strong>Screenshots before/after: Month to date comparison graph</strong></summary>

Before:
<img width="1007" height="580" alt="image" src="https://github.com/user-attachments/assets/484e84d0-4e41-432f-9e16-44fc64abb956" />

After:
<img width="1109" height="626" alt="image" src="https://github.com/user-attachments/assets/15168012-c98e-44c2-80c9-8a5d99e5064a" />
</details>


<details>
  <summary><strong>Screenshots before/after: Year to date comparison graph</strong></summary>

Before:
<img width="1012" height="571" alt="image" src="https://github.com/user-attachments/assets/0562c4ce-e41d-4f95-a193-13c51fc64b3e" />

After:
<img width="1110" height="627" alt="image" src="https://github.com/user-attachments/assets/e4b82ddb-5efa-4120-b2cd-6e6068108147" />

</details>

Ref: https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/8450025970#__recording_9035003250