### PR TITLE
Fix: time series trimming

### DIFF
--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -31,7 +31,8 @@ defmodule Plausible.Stats.Filters.QueryParser do
       if now do
         {now, DateTime.shift_zone!(now, site.timezone) |> DateTime.to_date()}
       else
-        {DateTime.utc_now(:second), today(site)}
+        now = Plausible.Stats.Query.Test.get_fixed_now()
+        {now, today(now, site)}
       end
 
     with :ok <- JSONSchema.validate(schema_type, params),
@@ -289,7 +290,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
-  defp today(site), do: DateTime.now!(site.timezone) |> DateTime.to_date()
+  defp today(now, site), do: now |> DateTime.shift_zone!(site.timezone) |> DateTime.to_date()
 
   defp parse_dimensions(dimensions) when is_list(dimensions) do
     parse_list(

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -11,7 +11,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
   alias Plausible.Stats.{Filters, Interval, Query, DateTimeRange}
 
   def from(site, params, debug_metadata, now \\ nil) do
-    now = now || DateTime.utc_now(:second)
+    now = now || Plausible.Stats.Query.Test.get_fixed_now()
 
     query =
       Query

--- a/lib/plausible/stats/query/test.ex
+++ b/lib/plausible/stats/query/test.ex
@@ -1,0 +1,15 @@
+defmodule Plausible.Stats.Query.Test do
+  @moduledoc """
+  Module used in tests to 'set' the current time.
+  """
+
+  @now_key :__now
+
+  def fix_now(now) do
+    Process.put(@now_key, now)
+  end
+
+  def get_fixed_now() do
+    Process.get(@now_key) || DateTime.utc_now(:second)
+  end
+end

--- a/lib/plausible/stats/timeseries.ex
+++ b/lib/plausible/stats/timeseries.ex
@@ -7,7 +7,7 @@ defmodule Plausible.Stats.Timeseries do
 
   use Plausible
   use Plausible.ClickhouseRepo
-  alias Plausible.Stats.{Comparisons, Query, QueryRunner, Metrics, Time}
+  alias Plausible.Stats.{Comparisons, Query, QueryRunner, Metrics, Time, QueryOptimizer}
 
   @time_dimension %{
     "month" => "time:month",
@@ -26,6 +26,7 @@ defmodule Plausible.Stats.Timeseries do
         order_by: [{time_dimension(query), :asc}],
         remove_unavailable_revenue_metrics: true
       )
+      |> QueryOptimizer.optimize()
 
     comparison_query =
       if(query.include.comparisons,

--- a/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_comparisons_test.exs
@@ -185,12 +185,13 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryComparisonsTest do
       build(:pageview, timestamp: ~N[2022-07-01 00:00:00])
     ])
 
+    Plausible.Stats.Query.Test.fix_now(~U[2022-07-01 14:00:00Z])
+
     conn =
       post(conn, "/api/v2/query-internal-test", %{
         "site_id" => site.domain,
         "metrics" => ["visitors"],
         "date_range" => "91d",
-        "date" => "2022-07-01",
         "dimensions" => ["time:day"],
         "include" => %{
           "time_labels" => true,


### PR DESCRIPTION
https://github.com/plausible/analytics/pull/5699 accidentally broke time series trimming on main graph

It tried to remove a seemingly redundant Query.optimize call, but this was implicitly needed for time labels functionality. :facepalm: 

Introduces tooling lifted from https://github.com/plausible/analytics/pull/5680 to test this so it doesn't regress anymore.