### PR TITLE
APIv2: Make site_id not required when calling `Query.build` with internal schema

### DIFF
--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -352,7 +352,6 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "date_range" => "month",
           "metrics" => ["pageviews"]
         },

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -135,7 +135,6 @@ defmodule Plausible.Segments.Segment do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "metrics" => ["visitors"],
           "date_range" => "7d",
           "filters" => filters

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -29,6 +29,13 @@ defmodule Plausible.Stats.Filters.QueryParser do
   def parse(site, schema_type, params, now \\ nil) when is_map(params) do
     now = now || Plausible.Stats.Query.Test.get_fixed_now()
     date = now |> DateTime.shift_zone!(site.timezone) |> DateTime.to_date()
+    # Ensure site_id is always present in params. This is required by the JSON schema
+    # but we already know site at this point. Simplifies :internal schema query building
+    params =
+      if(schema_type == :internal,
+        do: Map.merge(%{"site_id" => site.domain}, params),
+        else: params
+      )
 
     with :ok <- JSONSchema.validate(schema_type, params),
          {:ok, date, now} <- parse_date(site, Map.get(params, "date"), date, now),

--- a/lib/plausible/stats/goal_suggestions.ex
+++ b/lib/plausible/stats/goal_suggestions.ex
@@ -45,7 +45,6 @@ defmodule Plausible.Stats.GoalSuggestions do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "date_range" => [Date.to_iso8601(from_date), Date.to_iso8601(to_date)],
           "metrics" => ["pageviews"],
           "include" => %{"imports" => true}

--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -558,7 +558,6 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "date_range" => "all",
           "metrics" => ["pageviews"],
           "include" => %{"imports" => true}

--- a/lib/plausible_web/live/shields/hostname_rules.ex
+++ b/lib/plausible_web/live/shields/hostname_rules.ex
@@ -232,7 +232,6 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "date_range" => "all",
           "metrics" => ["pageviews"]
         },

--- a/lib/plausible_web/live/shields/page_rules.ex
+++ b/lib/plausible_web/live/shields/page_rules.ex
@@ -225,7 +225,6 @@ defmodule PlausibleWeb.Live.Shields.PageRules do
         site,
         :internal,
         %{
-          "site_id" => site.domain,
           "date_range" => "all",
           "metrics" => ["pageviews"],
           "filters" => [["is_not", "event:page", Enum.map(page_rules, & &1.page_path)]]

--- a/lib/workers/traffic_change_notifier.ex
+++ b/lib/workers/traffic_change_notifier.ex
@@ -118,28 +118,26 @@ defmodule Plausible.Workers.TrafficChangeNotifier do
     Plausible.Mailer.send(template)
   end
 
+  @pagination %{"limit" => 3}
+
   defp get_traffic_spike_stats(site) do
     %{}
     |> put_sources(site)
     |> put_pages(site)
   end
 
-  @base_query_params %{
-    "metrics" => ["visitors"],
-    "pagination" => %{"limit" => 3},
-    "date_range" => "realtime"
-  }
-
   defp put_sources(stats, site) do
     {:ok, query} =
       Query.build(
         site,
         :internal,
-        Map.merge(@base_query_params, %{
-          "site_id" => site.domain,
+        %{
+          "date_range" => "realtime",
+          "metrics" => ["visitors"],
           "dimensions" => ["visit:source"],
-          "filters" => [["is_not", "visit:source", ["Direct / None"]]]
-        }),
+          "filters" => [["is_not", "visit:source", ["Direct / None"]]],
+          "pagination" => @pagination
+        },
         %{}
       )
 
@@ -153,10 +151,12 @@ defmodule Plausible.Workers.TrafficChangeNotifier do
       Query.build(
         site,
         :internal,
-        Map.merge(@base_query_params, %{
-          "site_id" => site.domain,
-          "dimensions" => ["event:page"]
-        }),
+        %{
+          "date_range" => "realtime",
+          "metrics" => ["visitors"],
+          "dimensions" => ["event:page"],
+          "pagination" => @pagination
+        },
         %{}
       )
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -128,6 +128,24 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     |> check_error(site, "#: Required properties site_id, metrics, date_range were not present.")
   end
 
+  test "site_id is not required in internal schema", %{site: site} do
+    %{"metrics" => ["visitors"], "date_range" => "all"}
+    |> check_success(
+      site,
+      %{
+        metrics: [:visitors],
+        utc_time_range: @date_range_day,
+        filters: [],
+        dimensions: [],
+        order_by: nil,
+        timezone: site.timezone,
+        include: @default_include,
+        pagination: %{limit: 10_000, offset: 0}
+      },
+      :internal
+    )
+  end
+
   describe "metrics validation" do
     test "valid metrics passed", %{site: site} do
       %{"site_id" => site.domain, "metrics" => ["visitors", "events"], "date_range" => "all"}


### PR DESCRIPTION
Feedback from https://3.basecamp.com/5308029/buckets/26383192/messages/9035043082#__recording_9050481657 indicated this causes some confusion. Let's add an exception so it's not required in this scenario.