### PR TITLE
POC: Rollup view

### DIFF
--- a/assets/js/dashboard/util/url.ts
+++ b/assets/js/dashboard/util/url.ts
@@ -10,9 +10,13 @@ export function apiPath(
 export function externalLinkForPage(
   domain: PlausibleSite['domain'],
   page: string
-): string {
-  const domainURL = new URL(`https://${domain}`)
-  return `https://${domainURL.host}${page}`
+): string | null {
+  try {
+    const domainURL = new URL(`https://${domain}`)
+    return `https://${domainURL.host}${page}`
+  } catch (_error) {
+    return null
+  }
 }
 
 export function isValidHttpUrl(input: string): boolean {

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -73,7 +73,7 @@ defmodule Plausible.Site do
       native_stats_start_at: ~N[2018-01-01 00:00:00],
       stats_start_date: ~D[2018-01-01],
       rollup: true,
-      domain: "rollup:#{team.id}",
+      domain: "rollup:#{team.identifier}",
       team: team,
       team_id: team.id
     }

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -74,7 +74,8 @@ defmodule Plausible.Site do
       stats_start_date: ~D[2018-01-01],
       rollup: true,
       domain: "rollup:#{team.id}",
-      team: team
+      team: team,
+      team_id: team.id
     }
   end
 

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -62,7 +62,20 @@ defmodule Plausible.Site do
 
     has_many :completed_imports, Plausible.Imported.SiteImport, where: [status: :completed]
 
+    field :rollup, :boolean, virtual: true, default: false
+
     timestamps()
+  end
+
+  def rollup(team) do
+    %Plausible.Site{
+      id: 0,
+      native_stats_start_at: ~N[2018-01-01 00:00:00],
+      stats_start_date: ~D[2018-01-01],
+      rollup: true,
+      domain: "rollup:#{team.id}",
+      team: team
+    }
   end
 
   def new_for_team(team, params) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -47,8 +47,10 @@ defmodule Plausible.Stats.Filters.QueryParser do
          {:ok, pagination} <- parse_pagination(Map.get(params, "pagination", %{})),
          {preloaded_goals, revenue_warning, revenue_currencies} <-
            preload_goals_and_revenue(site, metrics, filters, dimensions),
+         rollup_site_ids = get_rollup_site_ids(site),
          query = %{
            now: now,
+           rollup_site_ids: rollup_site_ids,
            input_date_range: Map.get(params, "date_range"),
            metrics: metrics,
            filters: filters,
@@ -74,6 +76,12 @@ defmodule Plausible.Stats.Filters.QueryParser do
       {:ok, query}
     end
   end
+
+  def get_rollup_site_ids(%Plausible.Site{rollup: true} = site) do
+    Plausible.Teams.owned_sites_ids(site.team)
+  end
+
+  def get_rollup_site_ids(_site), do: nil
 
   def parse_date_range_pair(site, [from, to]) when is_binary(from) and is_binary(to) do
     with {:ok, date_range} <- date_range_from_date_strings(site, from, to) do

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -28,6 +28,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_parsed_filters(params)
       |> resolve_segments(site)
       |> preload_goals_and_revenue(site)
+      |> put_rollup_site_ids(site)
       |> put_order_by(params)
       |> put_include(site, params)
       |> Query.put_comparison_utc_time_range()
@@ -40,6 +41,13 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
     query
   end
+
+  defp put_rollup_site_ids(query, %Plausible.Site{rollup: true} = site) do
+    site_ids = Plausible.Teams.owned_sites_ids(site.team)
+    struct!(query, rollup_site_ids: site_ids)
+  end
+
+  defp put_rollup_site_ids(query, _site), do: query
 
   defp resolve_segments(query, site) do
     with {:ok, preloaded_segments} <-

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -26,6 +26,7 @@ defmodule Plausible.Stats.Query do
             revenue_warning: nil,
             remove_unavailable_revenue_metrics: false,
             site_id: nil,
+            rollup_site_ids: nil,
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
             time_on_page_data: %{},

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -41,6 +41,19 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
     end
   end
 
+  defp filter_site_time_range(
+         :events,
+         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
+       ) do
+    {first_datetime, last_datetime} = utc_boundaries(query)
+
+    dynamic(
+      [e],
+      e.site_id in ^site_ids and e.timestamp >= ^first_datetime and
+        e.timestamp <= ^last_datetime
+    )
+  end
+
   defp filter_site_time_range(:events, query) do
     {first_datetime, last_datetime} = utc_boundaries(query)
 
@@ -48,6 +61,21 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
       [e],
       e.site_id == ^query.site_id and e.timestamp >= ^first_datetime and
         e.timestamp <= ^last_datetime
+    )
+  end
+
+  defp filter_site_time_range(
+         :sessions,
+         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
+       ) do
+    {first_datetime, last_datetime} = utc_boundaries(query)
+
+    dynamic(
+      [s],
+      s.site_id in ^site_ids and
+        s.start >= ^NaiveDateTime.add(first_datetime, -7, :day) and
+        s.timestamp >= ^first_datetime and
+        s.start <= ^last_datetime
     )
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -97,6 +97,30 @@ defmodule PlausibleWeb.StatsController do
     end
   end
 
+  def rollup(conn, params) do
+    team_id = String.to_integer(params["team_id"])
+    team = Plausible.Teams.get!(team_id)
+    site = Plausible.Site.rollup(team)
+
+    render(conn, "stats.html",
+      site: site,
+      site_role: :super_admin,
+      has_goals: false,
+      revenue_goals: [],
+      funnels: [],
+      has_props: false,
+      stats_start_date: ~D[2025-01-01],
+      native_stats_start_date: ~D[2025-01-01],
+      title: "HELLO WORLD",
+      demo: false,
+      flags: get_flags(nil, nil),
+      is_dbip: is_dbip(),
+      segments: [],
+      load_dashboard_js: true,
+      hide_footer?: true
+    )
+  end
+
   on_ee do
     defp list_funnels(site) do
       Plausible.Funnels.list(site)

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -97,30 +97,6 @@ defmodule PlausibleWeb.StatsController do
     end
   end
 
-  def rollup(conn, params) do
-    team_id = String.to_integer(params["team_id"])
-    team = Plausible.Teams.get!(team_id)
-    site = Plausible.Site.rollup(team)
-
-    render(conn, "stats.html",
-      site: site,
-      site_role: :super_admin,
-      has_goals: false,
-      revenue_goals: [],
-      funnels: [],
-      has_props: false,
-      stats_start_date: ~D[2025-01-01],
-      native_stats_start_date: ~D[2025-01-01],
-      title: "HELLO WORLD",
-      demo: false,
-      flags: get_flags(nil, nil),
-      is_dbip: is_dbip(),
-      segments: [],
-      load_dashboard_js: true,
-      hide_footer?: true
-    )
-  end
-
   on_ee do
     defp list_funnels(site) do
       Plausible.Funnels.list(site)

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -175,10 +175,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   defp find_site(nil, _api_key), do: {:error, :missing_site_id}
 
-  defp find_site("rollup:" <> team_id, api_key) do
+  defp find_site("rollup:" <> team_identifier, api_key) do
     with true <- Plausible.Auth.is_super_admin?(api_key.user),
-         {team_id, ""} <- Integer.parse(team_id),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_id) do
+         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
       {:ok, Plausible.Site.rollup(team)}
     else
       _ -> {:error, :invalid_api_key}

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   defp verify_by_scope(conn, api_key, "stats:read:" <> _ = scope) do
     with :ok <- check_scope(api_key, scope),
-         {:ok, site} <- find_site(conn.params["site_id"]),
+         {:ok, site} <- find_site(conn.params["site_id"], api_key),
          :ok <- verify_site_access(api_key, site) do
       Plausible.OpenTelemetry.add_site_attributes(site)
       site = Plausible.Repo.preload(site, :completed_imports)
@@ -173,9 +173,19 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
     end
   end
 
-  defp find_site(nil), do: {:error, :missing_site_id}
+  defp find_site(nil, _api_key), do: {:error, :missing_site_id}
 
-  defp find_site(site_id) do
+  defp find_site("rollup:" <> team_id, api_key) do
+    with true <- Plausible.Auth.is_super_admin?(api_key.user),
+         {team_id, ""} <- Integer.parse(team_id),
+         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_id) do
+      {:ok, Plausible.Site.rollup(team)}
+    else
+      _ -> {:error, :invalid_api_key}
+    end
+  end
+
+  defp find_site(site_id, _api_key) do
     domain_based_search =
       from s in Plausible.Site, where: s.domain == ^site_id or s.domain_changed_from == ^site_id
 

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -172,6 +172,16 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
+  defp get_site_with_role(conn, current_user, "rollup:" <> team_id) do
+    with true <- Plausible.Auth.is_super_admin?(current_user),
+         {team_id, ""} <- Integer.parse(team_id),
+         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_id) do
+      {:ok, %{site: Plausible.Site.rollup(team), role: nil, member_type: nil}}
+    else
+      _ -> error_not_found(conn)
+    end
+  end
+
   defp get_site_with_role(conn, current_user, domain) do
     site = Repo.get_by(Plausible.Site, domain: domain)
 

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -172,10 +172,9 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
-  defp get_site_with_role(conn, current_user, "rollup:" <> team_id) do
+  defp get_site_with_role(conn, current_user, "rollup:" <> team_identifier) do
     with true <- Plausible.Auth.is_super_admin?(current_user),
-         {team_id, ""} <- Integer.parse(team_id),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_id) do
+         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
       {:ok, %{site: Plausible.Site.rollup(team), role: nil, member_type: nil}}
     else
       _ -> error_not_found(conn)

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -77,7 +77,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         :input_date_range,
         :preloaded_goals,
         :revenue_warning,
-        :revenue_currencies
+        :revenue_currencies,
+        :rollup_site_ids
       ])
 
     assert result == expected_result


### PR DESCRIPTION
### Changes

This PR is a proof of concept that aims to uncover possible issues/limitations querying clickhouse for rollup sites. It does not touch any database fields yet, but allows viewing the dashboard of multiple sites at once. To be reverted as soon as we get the necessary insights.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
