### PR TITLE
Do not crash dashboard when externalLinkForPage fails

### DIFF
--- a/assets/js/dashboard/util/url.ts
+++ b/assets/js/dashboard/util/url.ts
@@ -10,9 +10,13 @@ export function apiPath(
 export function externalLinkForPage(
   domain: PlausibleSite['domain'],
   page: string
-): string {
-  const domainURL = new URL(`https://${domain}`)
-  return `https://${domainURL.host}${page}`
+): string | null {
+  try {
+    const domainURL = new URL(`https://${domain}`)
+    return `https://${domainURL.host}${page}`
+  } catch (_error) {
+    return null
+  }
 }
 
 export function isValidHttpUrl(input: string): boolean {


### PR DESCRIPTION
### Changes

Extracts a small change from https://github.com/plausible/analytics/pull/5719. We don't want to crash the dashboard if external URL construction fails. Merging it separately to be able to revert #5719 later.