### PR TITLE
Use dictionary lookup to fetch rollup site IDs

### DIFF
--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -47,10 +47,9 @@ defmodule Plausible.Stats.Filters.QueryParser do
          {:ok, pagination} <- parse_pagination(Map.get(params, "pagination", %{})),
          {preloaded_goals, revenue_warning, revenue_currencies} <-
            preload_goals_and_revenue(site, metrics, filters, dimensions),
-         rollup_site_ids = get_rollup_site_ids(site),
          query = %{
            now: now,
-           rollup_site_ids: rollup_site_ids,
+           rollup_team_id: if(site.rollup, do: site.team_id),
            input_date_range: Map.get(params, "date_range"),
            metrics: metrics,
            filters: filters,
@@ -76,12 +75,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
       {:ok, query}
     end
   end
-
-  def get_rollup_site_ids(%Plausible.Site{rollup: true} = site) do
-    Plausible.Teams.owned_sites_ids(site.team)
-  end
-
-  def get_rollup_site_ids(_site), do: nil
 
   def parse_date_range_pair(site, [from, to]) when is_binary(from) and is_binary(to) do
     with {:ok, date_range} <- date_range_from_date_strings(site, from, to) do

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -28,7 +28,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_parsed_filters(params)
       |> resolve_segments(site)
       |> preload_goals_and_revenue(site)
-      |> put_rollup_site_ids(site)
+      |> put_rollup(site)
       |> put_order_by(params)
       |> put_include(site, params)
       |> Query.put_comparison_utc_time_range()
@@ -42,12 +42,11 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     query
   end
 
-  defp put_rollup_site_ids(query, %Plausible.Site{rollup: true} = site) do
-    site_ids = Plausible.Teams.owned_sites_ids(site.team)
-    struct!(query, rollup_site_ids: site_ids)
+  defp put_rollup(query, %Plausible.Site{rollup: true, team_id: team_id}) do
+    struct!(query, rollup_team_id: team_id)
   end
 
-  defp put_rollup_site_ids(query, _site), do: query
+  defp put_rollup(query, _site), do: query
 
   defp resolve_segments(query, site) do
     with {:ok, preloaded_segments} <-

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Stats.Query do
             revenue_warning: nil,
             remove_unavailable_revenue_metrics: false,
             site_id: nil,
-            rollup_site_ids: nil,
+            rollup_team_id: nil,
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
             time_on_page_data: %{},

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -43,13 +43,15 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
   defp filter_site_time_range(
          :events,
-         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
-       ) do
+         %Plausible.Stats.Query{rollup_team_id: rollup_team_id} = query
+       )
+       when not is_nil(rollup_team_id) do
     {first_datetime, last_datetime} = utc_boundaries(query)
 
     dynamic(
       [e],
-      e.site_id in ^site_ids and e.timestamp >= ^first_datetime and
+      fragment("? in dictGet('team_sites_dict', 'site_ids', ?)", e.site_id, ^rollup_team_id) and
+        e.timestamp >= ^first_datetime and
         e.timestamp <= ^last_datetime
     )
   end
@@ -66,13 +68,14 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
   defp filter_site_time_range(
          :sessions,
-         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
-       ) do
+         %Plausible.Stats.Query{rollup_team_id: rollup_team_id} = query
+       )
+       when not is_nil(rollup_team_id) do
     {first_datetime, last_datetime} = utc_boundaries(query)
 
     dynamic(
       [s],
-      s.site_id in ^site_ids and
+      fragment("? in dictGet('team_sites_dict', 'site_ids', ?)", s.site_id, ^rollup_team_id) and
         s.start >= ^NaiveDateTime.add(first_datetime, -7, :day) and
         s.timestamp >= ^first_datetime and
         s.start <= ^last_datetime

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -78,7 +78,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         :preloaded_goals,
         :revenue_warning,
         :revenue_currencies,
-        :rollup_site_ids
+        :rollup_team_id
       ])
 
     assert result == expected_result


### PR DESCRIPTION
The exact way of dictionary provisioning and maintenance is TBD.

This solves two severe performance bottlenecks with previous implementation: building queries that are likely to hit raw payload and AST depth limits.

We can run this on prod by providing some dictionary ad-hoc first.

