### PR TITLE
Persist consolidated views as sites

### DIFF
--- a/extra/lib/plausible/customer_support/resource/site.ex
+++ b/extra/lib/plausible/customer_support/resource/site.ex
@@ -16,6 +16,7 @@ defmodule Plausible.CustomerSupport.Resource.Site do
 
     q =
       from s in Plausible.Site,
+        where: not s.consolidated,
         inner_join: t in assoc(s, :team),
         inner_join: o in assoc(t, :owners),
         order_by: [
@@ -34,6 +35,7 @@ defmodule Plausible.CustomerSupport.Resource.Site do
       from s in Plausible.Site,
         inner_join: t in assoc(s, :team),
         inner_join: o in assoc(t, :owners),
+        where: not s.consolidated,
         where:
           ilike(s.domain, ^"%#{input}%") or ilike(t.name, ^"%#{input}%") or
             ilike(o.name, ^"%#{input}%") or ilike(o.email, ^"%#{input}%"),

--- a/extra/lib/plausible/help_scout.ex
+++ b/extra/lib/plausible/help_scout.ex
@@ -174,6 +174,7 @@ defmodule Plausible.HelpScout do
       from(s in Plausible.Site,
         inner_join: t in assoc(s, :team),
         inner_join: tm in assoc(t, :team_memberships),
+        where: not s.consolidated,
         where: tm.user_id == parent_as(:user).id and tm.role == :owner,
         where: ilike(s.domain, ^search_term) or ilike(s.domain_changed_from, ^search_term),
         select: 1
@@ -296,6 +297,7 @@ defmodule Plausible.HelpScout do
       left_join: t in assoc(tm, :team),
       left_join: s in assoc(t, :sites),
       as: :sites,
+      where: is_nil(s) or not s.consolidated,
       group_by: u.id,
       order_by: [desc: count(s.id)]
     )

--- a/extra/lib/plausible_web/live/customer_support/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/team.ex
@@ -11,6 +11,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
     Overview,
     Members,
     Sites,
+    ConsolidatedViews,
     Billing,
     SSO,
     Audit
@@ -139,6 +140,9 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
         <.tab to="sites" tab={@tab}>
           Sites ({number_format(@usage.sites)}/{number_format(@limits.sites)})
         </.tab>
+        <.tab to="consolidated_views" tab={@tab}>
+          Consolidated Views
+        </.tab>
         <.tab :if={has_sso_integration?(@team)} to="sso" tab={@tab}>SSO</.tab>
         <.tab to="billing" tab={@tab}>Billing</.tab>
         <.tab to="audit" tab={@tab}>Audit</.tab>
@@ -208,6 +212,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
   defp tab_component("overview"), do: Overview
   defp tab_component("members"), do: Members
   defp tab_component("sites"), do: Sites
+  defp tab_component("consolidated_views"), do: ConsolidatedViews
   defp tab_component("billing"), do: Billing
   defp tab_component("sso"), do: SSO
   defp tab_component("audit"), do: Audit

--- a/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
+++ b/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
@@ -1,0 +1,99 @@
+defmodule PlausibleWeb.CustomerSupport.Team.Components.ConsolidatedViews do
+  @moduledoc """
+  [Experimental - new feature]
+
+  Lists ConsolidatedViews of a team and allows creating one if none exist. Current
+  limitation is one consolidated view per team, which always includes all sites of
+  this team.
+  """
+  use PlausibleWeb, :live_component
+  import PlausibleWeb.CustomerSupport.Live
+
+  def update(%{team: team}, socket) do
+    cvs =
+      case Plausible.ConsolidatedView.get_for_team(team) do
+        nil -> []
+        cv -> [cv]
+      end
+
+    {:ok, assign(socket, team: team, consolidated_views: cvs)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="mt-2 mb-4">
+      <%= if Enum.empty?(@consolidated_views) do %>
+        <div class="mx-auto flex flex-col items-center">
+          <p>This team does not have a consolidated view yet.</p>
+          <.button class="mx-auto" phx-click="create-consolidated-view" phx-target={@myself}>
+            Create one
+          </.button>
+        </div>
+      <% else %>
+        <.table rows={@consolidated_views}>
+          <:thead>
+            <.th>Domain</.th>
+            <.th>Timezone</.th>
+            <.th invisible>Dashboard</.th>
+            <.th invisible>Settings</.th>
+            <.th invisible>Delete</.th>
+          </:thead>
+
+          <:tbody :let={consolidated_view}>
+            <.td>{consolidated_view.domain}</.td>
+            <.td>{consolidated_view.timezone}</.td>
+            <.td>
+              <.styled_link
+                new_tab={true}
+                href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, consolidated_view.domain, [])}
+              >
+                Dashboard
+              </.styled_link>
+            </.td>
+            <.td>
+              <.styled_link
+                new_tab={true}
+                href={
+                  Routes.site_path(
+                    PlausibleWeb.Endpoint,
+                    :settings_general,
+                    consolidated_view.domain,
+                    []
+                  )
+                }
+              >
+                Settings
+              </.styled_link>
+            </.td>
+            <.td>
+              <.delete_button
+                phx-click="delete-consolidated-view"
+                phx-value-id={consolidated_view.id}
+                phx-target={@myself}
+              />
+            </.td>
+          </:tbody>
+        </.table>
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("create-consolidated-view", _, socket) do
+    case Plausible.ConsolidatedView.create_for_team(socket.assigns.team) do
+      {:ok, cv} ->
+        success("Consolidated view created")
+        {:noreply, assign(socket, consolidated_views: [cv])}
+
+      {:error, _} ->
+        failure("Could not create consolidated View")
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("delete-consolidated-view", %{"id" => id}, socket) do
+    Plausible.Repo.get!(Plausible.Site, id) |> Plausible.Repo.delete()
+    success("Deleted consolidated view")
+    {:noreply, assign(socket, consolidated_views: [])}
+  end
+end

--- a/lib/plausible/consolidated_view.ex
+++ b/lib/plausible/consolidated_view.ex
@@ -1,4 +1,13 @@
 defmodule Plausible.ConsolidatedView do
+  def create_for_team(%Plausible.Teams.Team{} = team) do
+    Plausible.Site.new_consolidated_for_team(team)
+    |> Plausible.Repo.insert()
+  end
+
+  def get_for_team(%Plausible.Teams.Team{} = team) do
+    Plausible.Repo.get_by(Plausible.Site, domain: "cv-#{team.identifier}")
+  end
+
   def get_site_ids(%Plausible.Site{consolidated: true} = site) do
     Plausible.Cache.Adapter.get(:site_ids, site.id, fn ->
       Plausible.Teams.owned_sites_ids(site.team)

--- a/lib/plausible/consolidated_view.ex
+++ b/lib/plausible/consolidated_view.ex
@@ -1,0 +1,9 @@
+defmodule Plausible.ConsolidatedView do
+  def get_site_ids(%Plausible.Site{consolidated: true} = site) do
+    Plausible.Cache.Adapter.get(:site_ids, site.id, fn ->
+      Plausible.Teams.owned_sites_ids(site.team)
+    end)
+  end
+
+  def get_site_ids(%Plausible.Site{consolidated: false}), do: nil
+end

--- a/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
+++ b/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
@@ -44,7 +44,12 @@ defmodule Plausible.DataMigration.BackfillTrackerScriptConfiguration do
   def process_batch(offset, now) do
     sites =
       Repo.all(
-        from(s in Plausible.Site, order_by: [asc: :id], limit: @batch_size, offset: ^offset)
+        from(s in "sites",
+          order_by: [asc: :id],
+          limit: @batch_size,
+          offset: ^offset,
+          select: %{id: s.id, installation_meta: s.installation_meta}
+        )
       )
 
     if length(sites) > 0 do

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -12,6 +12,7 @@ defmodule Plausible.Site do
   @derive {Jason.Encoder, only: [:domain, :timezone]}
   schema "sites" do
     field :domain, :string
+    field :consolidated, :boolean, default: false
     field :timezone, :string, default: "Etc/UTC"
     field :public, :boolean
     field :stats_start_date, :date
@@ -67,16 +68,8 @@ defmodule Plausible.Site do
     timestamps()
   end
 
-  def rollup(team) do
-    %Plausible.Site{
-      id: 0,
-      native_stats_start_at: ~N[2018-01-01 00:00:00],
-      stats_start_date: ~D[2018-01-01],
-      rollup: true,
-      domain: "rollup:#{team.identifier}",
-      team: team,
-      team_id: team.id
-    }
+  def new_consolidated_for_team(team) do
+    new_for_team(team, %{consolidated: true, domain: "cv-#{team.identifier}"})
   end
 
   def new_for_team(team, params) do
@@ -99,7 +92,7 @@ defmodule Plausible.Site do
 
   def changeset(site, attrs \\ %{}) do
     site
-    |> cast(attrs, [:domain, :timezone, :legacy_time_on_page_cutoff])
+    |> cast(attrs, [:domain, :consolidated, :timezone, :legacy_time_on_page_cutoff])
     |> clean_domain()
     |> validate_required([:domain, :timezone])
     |> validate_timezone()

--- a/lib/plausible/site/cache.ex
+++ b/lib/plausible/site/cache.ex
@@ -41,12 +41,14 @@ defmodule Plausible.Site.Cache do
 
   @impl true
   def count_all() do
-    Plausible.Repo.aggregate(Site, :count)
+    from(s in Site, where: not s.consolidated)
+    |> Plausible.Repo.aggregate(:count)
   end
 
   @impl true
   def base_db_query() do
     from s in Site,
+      where: not s.consolidated,
       left_join: rg in assoc(s, :revenue_goals),
       inner_join: team in assoc(s, :team),
       select: {

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -222,6 +222,7 @@ defmodule Plausible.Sites do
         left_join: gm in assoc(tm, :guest_memberships),
         as: :guest_memberships,
         where: tm.user_id == ^user.id,
+        where: not s.consolidated,
         order_by: [desc: s.id]
       )
 

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -47,10 +47,10 @@ defmodule Plausible.Stats.Filters.QueryParser do
          {:ok, pagination} <- parse_pagination(Map.get(params, "pagination", %{})),
          {preloaded_goals, revenue_warning, revenue_currencies} <-
            preload_goals_and_revenue(site, metrics, filters, dimensions),
-         rollup_site_ids = get_rollup_site_ids(site),
+         consolidated_site_ids = Plausible.ConsolidatedView.get_site_ids(site),
          query = %{
            now: now,
-           rollup_site_ids: rollup_site_ids,
+           consolidated_site_ids: consolidated_site_ids,
            input_date_range: Map.get(params, "date_range"),
            metrics: metrics,
            filters: filters,
@@ -76,14 +76,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
       {:ok, query}
     end
   end
-
-  def get_rollup_site_ids(%Plausible.Site{rollup: true} = site) do
-    Plausible.Cache.Adapter.get(:site_ids, site.team_id, fn ->
-      Plausible.Teams.owned_sites_ids(site.team)
-    end)
-  end
-
-  def get_rollup_site_ids(_site), do: nil
 
   def parse_date_range_pair(site, [from, to]) when is_binary(from) and is_binary(to) do
     with {:ok, date_range} <- date_range_from_date_strings(site, from, to) do

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Stats.Query do
             revenue_warning: nil,
             remove_unavailable_revenue_metrics: false,
             site_id: nil,
-            rollup_site_ids: nil,
+            consolidated_site_ids: nil,
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
             time_on_page_data: %{},

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -43,7 +43,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
   defp filter_site_time_range(
          :events,
-         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
+         %Plausible.Stats.Query{consolidated_site_ids: [_ | _] = site_ids} = query
        ) do
     {first_datetime, last_datetime} = utc_boundaries(query)
 
@@ -67,7 +67,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
 
   defp filter_site_time_range(
          :sessions,
-         %Plausible.Stats.Query{rollup_site_ids: [_ | _] = site_ids} = query
+         %Plausible.Stats.Query{consolidated_site_ids: [_ | _] = site_ids} = query
        ) do
     {first_datetime, last_datetime} = utc_boundaries(query)
 

--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -89,7 +89,11 @@ defmodule Plausible.Teams do
   def owned_sites(nil, _), do: []
 
   def owned_sites(team, limit) do
-    query = from(s in Plausible.Site, where: s.team_id == ^team.id, order_by: [asc: s.domain])
+    query =
+      from(s in Plausible.Site,
+        where: s.team_id == ^team.id and not s.consolidated,
+        order_by: [asc: s.domain]
+      )
 
     if limit do
       query
@@ -108,7 +112,7 @@ defmodule Plausible.Teams do
   def owned_sites_ids(team) do
     Repo.all(
       from(s in Plausible.Site,
-        where: s.team_id == ^team.id,
+        where: s.team_id == ^team.id and not s.consolidated,
         select: s.id,
         order_by: [desc: s.id]
       )
@@ -121,7 +125,7 @@ defmodule Plausible.Teams do
   def owned_sites_count(team) do
     Repo.aggregate(
       from(s in Plausible.Site,
-        where: s.team_id == ^team.id
+        where: s.team_id == ^team.id and not s.consolidated
       ),
       :count
     )

--- a/lib/plausible/teams/sites.ex
+++ b/lib/plausible/teams/sites.ex
@@ -50,6 +50,7 @@ defmodule Plausible.Teams.Sites do
       inner_join: s in Plausible.Site,
       on: u.site_id == s.id,
       as: :site,
+      where: not s.consolidated,
       left_join: up in Site.UserPreference,
       on: up.site_id == s.id and up.user_id == ^user.id,
       select: %{
@@ -98,6 +99,7 @@ defmodule Plausible.Teams.Sites do
       inner_join: s in Plausible.Site,
       on: u.site_id == s.id,
       as: :site,
+      where: not s.consolidated,
       left_join: up in Site.UserPreference,
       on: up.site_id == s.id and up.user_id == ^user.id,
       left_join: ti in Teams.Invitation,

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -60,7 +60,7 @@ defmodule PlausibleWeb.StatsController do
     can_see_stats? = not Teams.locked?(site.team) or site_role == :super_admin
     demo = site.domain == "plausible.io"
     dogfood_page_path = if demo, do: "/#{site.domain}", else: "/:dashboard"
-    skip_to_dashboard? = conn.params["skip_to_dashboard"] == "true"
+    skip_to_dashboard? = conn.params["skip_to_dashboard"] == "true" or site.consolidated
 
     {:ok, segments} = Plausible.Segments.get_all_for_site(site, site_role)
 

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   defp verify_by_scope(conn, api_key, "stats:read:" <> _ = scope) do
     with :ok <- check_scope(api_key, scope),
-         {:ok, site} <- find_site(conn.params["site_id"], api_key),
+         {:ok, site} <- find_site(conn.params["site_id"]),
          :ok <- verify_site_access(api_key, site) do
       Plausible.OpenTelemetry.add_site_attributes(site)
       site = Plausible.Repo.preload(site, :completed_imports)
@@ -173,18 +173,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
     end
   end
 
-  defp find_site(nil, _api_key), do: {:error, :missing_site_id}
+  defp find_site(nil), do: {:error, :missing_site_id}
 
-  defp find_site("rollup:" <> team_identifier, api_key) do
-    with true <- Plausible.Auth.is_super_admin?(api_key.user),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
-      {:ok, Plausible.Site.rollup(team)}
-    else
-      _ -> {:error, :invalid_api_key}
-    end
-  end
-
-  defp find_site(site_id, _api_key) do
+  defp find_site(site_id) do
     domain_based_search =
       from s in Plausible.Site, where: s.domain == ^site_id or s.domain_changed_from == ^site_id
 

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -172,15 +172,6 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
-  defp get_site_with_role(conn, current_user, "rollup:" <> team_identifier) do
-    with true <- Plausible.Auth.is_super_admin?(current_user),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
-      {:ok, %{site: Plausible.Site.rollup(team), role: nil, member_type: nil}}
-    else
-      _ -> error_not_found(conn)
-    end
-  end
-
   defp get_site_with_role(conn, current_user, domain) do
     site = Repo.get_by(Plausible.Site, domain: domain)
 

--- a/priv/repo/migrations/20250916154337_add_consolidated_field_to_sites.exs
+++ b/priv/repo/migrations/20250916154337_add_consolidated_field_to_sites.exs
@@ -1,0 +1,9 @@
+defmodule Plausible.Repo.Migrations.AddConsolidatedFieldToSites do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sites) do
+      add :consolidated, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -78,7 +78,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         :preloaded_goals,
         :revenue_warning,
         :revenue_currencies,
-        :rollup_site_ids
+        :consolidated_site_ids
       ])
 
     assert result == expected_result


### PR DESCRIPTION
### Changes

Removes virtual rollup sites and replaces them with persisted sites with a boolean `consolidated` field.

Todos:

- [ ] introduce a general site listing/counting query function or macro to call `where: not s.consolidated` in a single place
- [ ] tests
- [ ] extract migration

### Tests
- [ ] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
