### PR TITLE
Improve account, team, and site settings areas visually

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
       colors: {
         yellow: colors.amber, // We started using `yellow` in v2 but it was renamed to `amber` in v3 https://tailwindcss.com/docs/upgrade-guide#removed-color-aliases
         gray: colors.slate,
+        'gray-150': 'rgb(234, 238, 244)',
         'gray-950': 'rgb(13, 18, 30)',
         'gray-850': 'rgb(26, 32, 44)',
         'gray-825': 'rgb(37, 47, 63)'

--- a/extra/lib/plausible_web/live/sso_management.ex
+++ b/extra/lib/plausible_web/live/sso_management.ex
@@ -34,7 +34,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
         <a id="sso-config">Single Sign-On</a>
       </:title>
       <:subtitle>
-        Configure and manage Single Sign-On for your team
+        Configure and manage Single Sign-On for your team.
       </:subtitle>
 
       <.init_view :if={@mode == :init} current_team={@current_team} />
@@ -244,7 +244,7 @@ defmodule PlausibleWeb.Live.SSOManagement do
         <a id="sso-manage-config">Single Sign-On</a>
       </:title>
       <:subtitle>
-        Configure and manage Single Sign-On for your team
+        Configure and manage Single Sign-On for your team.
       </:subtitle>
 
       <div class="flex-col space-y-6">

--- a/lib/plausible_web/components/billing/billing.ex
+++ b/lib/plausible_web/components/billing/billing.ex
@@ -330,7 +330,11 @@ defmodule PlausibleWeb.Components.Billing do
 
   def upgrade_link(assigns) do
     ~H"""
-    <.button_link id="upgrade-link-2" href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}>
+    <.button_link
+      id="upgrade-link-2"
+      href={Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan)}
+      mt?={false}
+    >
       Upgrade
     </.button_link>
     """

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -6,10 +6,10 @@ defmodule PlausibleWeb.Components.Generic do
 
   @notice_themes %{
     gray: %{
-      bg: "bg-white dark:bg-gray-800",
+      bg: "bg-gray-100 dark:bg-gray-700/50",
       icon: "text-gray-400",
-      title_text: "text-gray-800 dark:text-gray-400",
-      body_text: "text-gray-700 dark:text-gray-500 leading-5"
+      title_text: "text-sm text-gray-800 dark:text-gray-300",
+      body_text: "text-sm text-gray-700 dark:text-gray-400 leading-5"
     },
     yellow: %{
       bg: "bg-yellow-50 dark:bg-yellow-100",
@@ -138,7 +138,7 @@ defmodule PlausibleWeb.Components.Generic do
     ~H"""
     <a href={"https://plausible.io/docs/#{@slug}"} rel="noopener noreferrer" target="_blank">
       <Heroicons.information_circle class={[
-        "text-gray-500 dark:text-indigo-500 w-6 h-6 stroke-2 hover:text-indigo-500 dark:hover:text-indigo-300",
+        "text-gray-400 dark:text-indigo-500 w-5 h-5 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors duration-150",
         @class
       ]} />
     </a>
@@ -217,7 +217,7 @@ defmodule PlausibleWeb.Components.Generic do
       new_tab={@new_tab}
       href={@href}
       method={@method}
-      class={"text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 " <> @class}
+      class={"text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-400 transition-colors duration-150 " <> @class}
       {@rest}
     >
       {render_slot(@inner_block)}
@@ -444,7 +444,7 @@ defmodule PlausibleWeb.Components.Generic do
   attr :docs, :string, default: nil
   slot :inner_block, required: true
   slot :title, required: true
-  slot :subtitle, required: true
+  slot :subtitle, required: false
   attr :feature_mod, :atom, default: nil
   attr :feature_toggle?, :boolean, default: false
   attr :current_role, :atom, default: nil
@@ -461,7 +461,7 @@ defmodule PlausibleWeb.Components.Generic do
 
           <.docs_info :if={@docs} slug={@docs} class="absolute top-4 right-4" />
         </.title>
-        <div class="text-sm mt-px text-gray-500 dark:text-gray-400 leading-5">
+        <div :if={@subtitle != []} class="text-sm mt-px text-gray-500 dark:text-gray-400 leading-5">
           {render_slot(@subtitle)}
         </div>
         <PlausibleWeb.Components.Site.Feature.toggle
@@ -479,12 +479,12 @@ defmodule PlausibleWeb.Components.Generic do
             current_role={@current_role}
             current_team={@current_team}
           >
-            <div class="py-4 px-6">
+            <div class="p-6">
               {render_slot(@inner_block)}
             </div>
           </PlausibleWeb.Components.Billing.feature_gate>
         <% else %>
-          <div class="py-4 px-6">
+          <div class="p-6">
             {render_slot(@inner_block)}
           </div>
         <% end %>
@@ -753,7 +753,7 @@ defmodule PlausibleWeb.Components.Generic do
       if assigns[:invisible] do
         "invisible"
       else
-        "px-6 first:pl-0 last:pr-0 py-3 text-left text-sm font-medium"
+        "px-6 first:pl-0 last:pr-0 py-3 text-left text-sm font-semibold"
       end
 
     assigns = assign(assigns, class: class)
@@ -771,7 +771,7 @@ defmodule PlausibleWeb.Components.Generic do
 
   def toggle_submit(assigns) do
     ~H"""
-    <div class="mt-4 mb-2 flex items-center">
+    <div class="my-2 flex items-center">
       <button
         type="submit"
         class={[
@@ -813,7 +813,7 @@ defmodule PlausibleWeb.Components.Generic do
       <.unstyled_link href={@href} {@rest}>
         <.dynamic_icon
           name={@icon}
-          class="w-5 h-5 text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300"
+          class="size-5 text-indigo-700 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300"
         />
       </.unstyled_link>
       """
@@ -822,7 +822,7 @@ defmodule PlausibleWeb.Components.Generic do
       <button {@rest}>
         <.dynamic_icon
           name={@icon}
-          class="w-5 h-5 text-indigo-800 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300"
+          class="size-5 text-indigo-700 hover:text-indigo-500 dark:text-indigo-500 dark:hover:text-indigo-300"
         />
       </button>
       """
@@ -839,7 +839,7 @@ defmodule PlausibleWeb.Components.Generic do
       <.unstyled_link href={@href} {@rest}>
         <.dynamic_icon
           name={@icon}
-          class="w-5 h-5 text-red-800 hover:text-red-500 dark:text-red-500 dark:hover:text-red-400"
+          class="size-5 text-red-700 hover:text-red-500 dark:text-red-500 dark:hover:text-red-400"
         />
       </.unstyled_link>
       """
@@ -848,7 +848,7 @@ defmodule PlausibleWeb.Components.Generic do
       <button {@rest}>
         <.dynamic_icon
           name={@icon}
-          class="w-5 h-5 text-red-800 hover:text-red-500 dark:text-red-500 dark:hover:text-red-400"
+          class="size-5 text-red-700 hover:text-red-500 dark:text-red-500 dark:hover:text-red-400"
         />
       </button>
       """
@@ -963,4 +963,14 @@ defmodule PlausibleWeb.Components.Generic do
     </div>
     """
   end
+
+  def settings_badge(%{type: :new} = assigns) do
+    ~H"""
+    <span class="inline-block ml-2 bg-indigo-100 text-indigo-600 text-xs font-semibold py-1 px-2 rounded-md">
+      NEW 🔥
+    </span>
+    """
+  end
+
+  def settings_badge(assigns), do: ~H""
 end

--- a/lib/plausible_web/components/layout.ex
+++ b/lib/plausible_web/components/layout.ex
@@ -59,15 +59,17 @@ defmodule PlausibleWeb.Components.Layout do
 
   def settings_sidebar(assigns) do
     ~H"""
-    <.settings_top_tab
-      :for={%{key: key, value: value, icon: icon} = opts <- @options}
-      selected_fn={@selected_fn}
-      prefix={@prefix}
-      icon={icon}
-      text={key}
-      badge={opts[:badge]}
-      value={value}
-    />
+    <div class="flex flex-col gap-0.5 -ml-2">
+      <.settings_top_tab
+        :for={%{key: key, value: value, icon: icon} = opts <- @options}
+        selected_fn={@selected_fn}
+        prefix={@prefix}
+        icon={icon}
+        text={key}
+        badge={opts[:badge]}
+        value={value}
+      />
+    </div>
     """
   end
 
@@ -126,19 +128,19 @@ defmodule PlausibleWeb.Components.Layout do
       class={[
         "text-sm flex items-center px-2 py-2 leading-5 font-medium rounded-md outline-none focus:outline-none transition ease-in-out duration-150",
         @current_tab? &&
-          "text-gray-900 dark:text-gray-100 bg-gray-100 font-semibold dark:bg-gray-900 hover:text-gray-900 focus:bg-gray-200 dark:focus:bg-gray-800",
+          "text-gray-900 dark:text-gray-100 bg-gray-150 font-semibold dark:bg-gray-700/50 hover:text-gray-900 focus:bg-gray-200 dark:focus:bg-gray-800",
         @value && not @current_tab? &&
-          "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 focus:text-gray-900 focus:bg-gray-50 dark:focus:text-gray-100 dark:focus:bg-gray-800",
-        !@value && "text-gray-600 dark:text-gray-400"
+          "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 focus:text-gray-900 focus:bg-gray-50 dark:focus:text-gray-100 dark:focus:bg-gray-800",
+        !@value && "text-gray-600 dark:text-gray-300"
       ]}
     >
       <PlausibleWeb.Components.Generic.dynamic_icon
         :if={not @submenu? && @icon}
         name={@icon}
-        class={["h-4 w-4 mr-2", @current_tab? && "stroke-2"]}
+        class="size-5 mr-2"
       />
       {@text}
-      <.settings_badge type={@badge} />
+      <PlausibleWeb.Components.Generic.settings_badge type={@badge} />
       <Heroicons.chevron_down
         :if={is_nil(@value)}
         class="h-3 w-3 ml-2 text-gray-400 dark:text-gray-500"
@@ -146,16 +148,6 @@ defmodule PlausibleWeb.Components.Layout do
     </a>
     """
   end
-
-  defp settings_badge(%{type: :new} = assigns) do
-    ~H"""
-    <span class="inline-block ml-2 bg-indigo-700 text-gray-100 text-xs p-1 rounded">
-      NEW
-    </span>
-    """
-  end
-
-  defp settings_badge(assigns), do: ~H""
 
   defp theme_preference(%{theme: theme}) when not is_nil(theme), do: theme
 

--- a/lib/plausible_web/components/site/feature.ex
+++ b/lib/plausible_web/components/site/feature.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Components.Site.Feature do
       |> assign(:disabled?, assigns.feature_mod.check_availability(assigns.site.team) !== :ok)
 
     ~H"""
-    <div>
+    <div class="mt-4">
       <.form
         action={target(@site, @feature_mod.toggle_field(), @conn, !@current_setting)}
         method="put"
@@ -26,7 +26,7 @@ defmodule PlausibleWeb.Components.Site.Feature do
         class={@class}
       >
         <.toggle_submit set_to={@current_setting} disabled?={@disabled?}>
-          Show {@feature_mod.display_name()} in the Dashboard
+          Show {String.downcase(@feature_mod.display_name())} in the dashboard
         </.toggle_submit>
       </.form>
 

--- a/lib/plausible_web/components/team/notice.ex
+++ b/lib/plausible_web/components/team/notice.ex
@@ -43,7 +43,7 @@ defmodule PlausibleWeb.Team.Notice do
   def team_members_notice(assigns) do
     ~H"""
     <aside class="mt-4 mb-4">
-      <.notice theme={:gray} class="rounded border border-gray-300 text-sm mt-4">
+      <.notice theme={:gray} class="mt-4">
         <p>
           Team members automatically have access to this site.
           <.styled_link href={Routes.settings_path(PlausibleWeb.Endpoint, :team_general)}>

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -146,10 +146,10 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <div class="mt-6 w-full md:flex">
           <a
             href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
-            class="hidden md:flex md:w-1/6 h-max md:mt-2 text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-bold gap-1 items-center"
+            class="hidden md:flex md:w-1/6 h-max md:mt-2 text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-semibold gap-1 items-center"
           >
             <span>←</span>
-            <p>Back to Settings</p>
+            <p>Back to settings</p>
           </a>
           <div class="md:w-4/6">
             <h1 class="mx-auto max-w-4xl text-center text-2xl font-bold tracking-tight lg:text-3xl">
@@ -165,9 +165,9 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         <div class="md:hidden mt-6 max-w-md mx-auto">
           <a
             href={Routes.settings_path(PlausibleWeb.Endpoint, :subscription)}
-            class="text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-bold"
+            class="text-indigo-600 hover:text-indigo-700 dark:text-indigo-500 dark:hover:text-indigo-600 text-sm font-semibold"
           >
-            ← Back to Settings
+            ← Back to settings
           </a>
         </div>
         <div class="mt-10 flex flex-col gap-8 lg:flex-row items-center lg:items-baseline">

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -74,8 +74,8 @@ defmodule PlausibleWeb.Live.Components.Form do
 
   def input(%{type: "select"} = assigns) do
     ~H"""
-    <div class={@mt? && "mt-2"}>
-      <.label for={@id} class="mb-2">{@label}</.label>
+    <div class={@mt? && "mt-4"}>
+      <.label for={@id} class="mb-1.5">{@label}</.label>
 
       <p :if={@help_text} class="text-gray-500 dark:text-gray-400 mb-2 text-sm">
         {@help_text}
@@ -122,8 +122,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   def input(%{type: "radio"} = assigns) do
     ~H"""
     <div class={[
-      "flex flex-inline items-center justify-start gap-x-3",
-      @mt? && "mt-2"
+      "flex flex-inline items-center justify-start gap-x-3"
     ]}>
       <input
         type="radio"
@@ -151,8 +150,8 @@ defmodule PlausibleWeb.Live.Components.Form do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div class={@mt? && "mt-2"}>
-      <.label class="mb-2" for={@id}>{@label}</.label>
+    <div class={@mt? && "mt-4"}>
+      <.label class="mb-1.5" for={@id}>{@label}</.label>
       <textarea
         id={@id}
         rows={@rest[:rows] || "6"}
@@ -177,8 +176,8 @@ defmodule PlausibleWeb.Live.Components.Form do
     assigns = assign(assigns, :errors, errors)
 
     ~H"""
-    <div class={@mt? && "mt-2"}>
-      <.label :if={@label != nil and @label != ""} for={@id} class="mb-2">
+    <div class={@mt? && "mt-4"}>
+      <.label :if={@label != nil and @label != ""} for={@id} class="mb-1.5">
         {@label}
       </.label>
       <p :if={@help_text} class="text-gray-500 dark:text-gray-400 mb-2 text-sm">

--- a/lib/plausible_web/live/components/team.ex
+++ b/lib/plausible_web/live/components/team.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Live.Components.Team do
   def member(assigns) do
     ~H"""
     <div
-      class="mt-4"
+      class="mt-6"
       id={"member-row-#{:erlang.phash2(@user.email)}"}
       data-test-kind={if @role == :guest, do: "guest", else: "member"}
       data-role-changed={
@@ -29,21 +29,24 @@ defmodule PlausibleWeb.Live.Components.Team do
       }
     >
       <div class="flex items-center gap-x-5">
-        <img src={User.profile_img_url(@user)} class="w-7 rounded-full bg-gray-300" />
-        <span class="text-sm">
-          {@user.name}
-          <span
-            :if={@label}
-            class="ml-1 dark:bg-indigo-600 dark:text-gray-200 bg-gray-100 text-gray-500 text-xs px-1 rounded"
-          >
-            {@label}
+        <img src={User.profile_img_url(@user)} class="w-8 rounded-full bg-gray-300" />
+        <div class="flex flex-col">
+          <span class="text-sm font-medium">
+            {@user.name}
+            <span
+              :if={@label}
+              class="ml-1 dark:bg-indigo-600 dark:text-gray-200 bg-gray-150 text-gray-500 text-xs px-1 py-0.5 rounded-md"
+            >
+              {@label}
+            </span>
           </span>
-
-          <br /><span class="text-gray-500 text-xs">{@user.email}</span>
-        </span>
+          <span class="text-gray-500 text-xs">
+            {@user.email}
+          </span>
+        </div>
         <div class="flex-1 text-right">
           <.dropdown id={"role-dropdown-#{@user.email}"}>
-            <:button class="role bg-transparent text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700 focus-visible:outline-gray-100 whitespace-nowrap truncate inline-flex items-center gap-x-2 font-medium rounded-md px-3.5 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:bg-gray-400 dark:disabled:text-white dark:disabled:text-gray-400 dark:disabled:bg-gray-700">
+            <:button class="role bg-transparent text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 focus-visible:outline-gray-100 whitespace-nowrap truncate inline-flex items-center gap-x-2 font-medium rounded-md px-3.5 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:bg-gray-400 dark:disabled:text-white dark:disabled:text-gray-400 dark:disabled:bg-gray-700">
               <span :if={@disabled} class="text-gray-400">
                 {@role |> to_string() |> String.capitalize()}
               </span>

--- a/lib/plausible_web/live/imports_exports_settings.ex
+++ b/lib/plausible_web/live/imports_exports_settings.ex
@@ -72,22 +72,24 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       {@import_warning}
     </.notice>
 
-    <div class="mt-4 flex justify-end gap-x-4">
+    <div class="flex gap-x-4">
       <.button_link
         theme="bright"
         href={Plausible.Google.API.import_authorize_url(@site.id)}
         disabled={@import_in_progress? or @at_maximum?}
+        mt?={false}
       >
         Import from
         <img
           src="/images/icon/google_analytics_logo.svg"
           alt="Google Analytics import"
-          class="h-6 w-12"
+          class="h-6 w-12 -my-1"
         />
       </.button_link>
       <.button_link
         disabled={@import_in_progress? or @at_maximum?}
         href={"/#{URI.encode_www_form(@site.domain)}/settings/import"}
+        mt?={false}
       >
         Import from CSV
       </.button_link>
@@ -97,7 +99,7 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
       There are no imports yet for this site.
     </p>
 
-    <div class="mt-8">
+    <div class="mt-6">
       <.table :if={not Enum.empty?(@site_imports)} rows={@site_imports}>
         <:thead>
           <.th>Import</.th>
@@ -111,22 +113,22 @@ defmodule PlausibleWeb.Live.ImportsExportsSettings do
         <:tbody :let={entry}>
           <.td max_width="max-w-40">
             <div class="flex items-center gap-x-2 truncate">
-              <div class="w-6" title={notice_message(entry.tooltip)}>
+              <div class="w-5" title={notice_message(entry.tooltip)}>
                 <Heroicons.clock
                   :if={entry.live_status == SiteImport.pending()}
-                  class="block h-6 w-6 text-indigo-600 dark:text-green-600"
+                  class="block size-5 text-indigo-600 dark:text-green-600"
                 />
                 <.spinner
                   :if={entry.live_status == SiteImport.importing()}
-                  class="block h-6 w-6 text-indigo-600 dark:text-green-600"
+                  class="block size-5 text-indigo-600 dark:text-green-600"
                 />
                 <Heroicons.check
                   :if={entry.live_status == SiteImport.completed()}
-                  class="block h-6 w-6 text-indigo-600 dark:text-green-600"
+                  class="block size-5 text-indigo-600 dark:text-green-600"
                 />
                 <Heroicons.exclamation_triangle
                   :if={entry.live_status == SiteImport.failed()}
-                  class="block h-6 w-6 text-red-700 dark:text-red-500"
+                  class="block size-5 text-red-700 dark:text-red-500"
                 />
               </div>
               <div

--- a/lib/plausible_web/live/plugins/api/settings.ex
+++ b/lib/plausible_web/live/plugins/api/settings.ex
@@ -51,7 +51,7 @@ defmodule PlausibleWeb.Live.Plugins.API.Settings do
       <div>
         <.filter_bar filtering_enabled?={false}>
           <.button phx-click="create-token" mt?={false}>
-            Create Plugin Token
+            Create plugin token
           </.button>
         </.filter_bar>
 

--- a/lib/plausible_web/live/shields/country_rules.ex
+++ b/lib/plausible_web/live/shields/country_rules.ex
@@ -30,8 +30,8 @@ defmodule PlausibleWeb.Live.Shields.CountryRules do
     <div>
       <.settings_tiles>
         <.tile docs="excluding">
-          <:title>Country Block List</:title>
-          <:subtitle>Reject incoming traffic from specific countries</:subtitle>
+          <:title>Country block list</:title>
+          <:subtitle>Reject incoming traffic from specific countries.</:subtitle>
           <.filter_bar
             :if={@country_rules_count < Shields.maximum_country_rules()}
             filtering_enabled?={false}
@@ -42,7 +42,7 @@ defmodule PlausibleWeb.Live.Shields.CountryRules do
               x-on:click={Modal.JS.open("country-rule-form-modal")}
               mt?={false}
             >
-              Add Country
+              Add country
             </.button>
           </.filter_bar>
 
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Live.Shields.CountryRules do
           </.notice>
 
           <p :if={Enum.empty?(@country_rules)} class="mt-12 mb-8 text-center text-sm">
-            No Country Rules configured for this site.
+            No country rules configured for this site.
           </p>
 
           <.table :if={not Enum.empty?(@country_rules)} rows={@country_rules}>

--- a/lib/plausible_web/live/shields/hostname_rules.ex
+++ b/lib/plausible_web/live/shields/hostname_rules.ex
@@ -33,8 +33,8 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
     <div>
       <.settings_tiles>
         <.tile docs="excluding#exclude-visits-by-hostname">
-          <:title>Hostnames Allow List</:title>
-          <:subtitle>Accept incoming traffic only from familiar hostnames</:subtitle>
+          <:title>Hostnames allow list</:title>
+          <:subtitle>Accept incoming traffic only from familiar hostnames.</:subtitle>
           <.filter_bar
             :if={@hostname_rules_count < Shields.maximum_hostname_rules()}
             filtering_enabled?={false}
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
               x-on:click={Modal.JS.open("hostname-rule-form-modal")}
               mt?={false}
             >
-              Add Hostname
+              Add hostname
             </.button>
           </.filter_bar>
 
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.Shields.HostnameRules do
           </.notice>
 
           <p :if={Enum.empty?(@hostname_rules)} class="mt-12 mb-8 text-center text-sm">
-            No Hostname Rules configured for this site.
+            No hostname rules configured for this site.
             <strong>
               Traffic from all hostnames is currently accepted.
             </strong>

--- a/lib/plausible_web/live/shields/ip_rules.ex
+++ b/lib/plausible_web/live/shields/ip_rules.ex
@@ -31,8 +31,8 @@ defmodule PlausibleWeb.Live.Shields.IPRules do
     <div>
       <.settings_tiles>
         <.tile docs="excluding">
-          <:title>IP Block List</:title>
-          <:subtitle>Reject incoming traffic from specific IP addresses</:subtitle>
+          <:title>IP block list</:title>
+          <:subtitle>Reject incoming traffic from specific IP addresses.</:subtitle>
           <.filter_bar :if={@ip_rules_count < Shields.maximum_ip_rules()} filtering_enabled?={false}>
             <.button
               id="add-ip-rule"
@@ -40,7 +40,7 @@ defmodule PlausibleWeb.Live.Shields.IPRules do
               x-on:click={Modal.JS.open("ip-rule-form-modal")}
               mt?={false}
             >
-              Add IP Address
+              Add IP address
             </.button>
           </.filter_bar>
 
@@ -56,12 +56,12 @@ defmodule PlausibleWeb.Live.Shields.IPRules do
           </.notice>
 
           <p :if={Enum.empty?(@ip_rules)} class="mt-12 mb-8 text-center text-sm">
-            No IP Rules configured for this site.
+            No IP rules configured for this site.
           </p>
 
           <.table :if={not Enum.empty?(@ip_rules)} rows={@ip_rules}>
             <:thead>
-              <.th>IP Address</.th>
+              <.th>IP address</.th>
               <.th hide_on_mobile>Status</.th>
               <.th hide_on_mobile>Description</.th>
               <.th invisible>Actions</.th>

--- a/lib/plausible_web/live/shields/page_rules.ex
+++ b/lib/plausible_web/live/shields/page_rules.ex
@@ -33,8 +33,8 @@ defmodule PlausibleWeb.Live.Shields.PageRules do
     <div>
       <.settings_tiles>
         <.tile docs="top-pages#block-traffic-from-specific-pages-or-sections">
-          <:title>Pages Block List</:title>
-          <:subtitle>Reject incoming traffic for specific pages</:subtitle>
+          <:title>Pages block list</:title>
+          <:subtitle>Reject incoming traffic for specific pages.</:subtitle>
           <.filter_bar
             :if={@page_rules_count < Shields.maximum_page_rules()}
             filtering_enabled?={false}
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.Live.Shields.PageRules do
               x-on:click={Modal.JS.open("page-rule-form-modal")}
               mt?={false}
             >
-              Add Page
+              Add page
             </.button>
           </.filter_bar>
 
@@ -61,7 +61,7 @@ defmodule PlausibleWeb.Live.Shields.PageRules do
           </.notice>
 
           <p :if={Enum.empty?(@page_rules)} class="mt-12 mb-8 text-center text-sm">
-            No Page Rules configured for this site.
+            No page rules configured for this site.
           </p>
 
           <.table :if={not Enum.empty?(@page_rules)} rows={@page_rules}>

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -332,15 +332,15 @@ defmodule PlausibleWeb.Live.TeamManagement do
   end
 
   defp entry_label(%Layout.Entry{role: :guest, type: :membership}, _), do: nil
-  defp entry_label(%Layout.Entry{type: :invitation_pending}, _), do: "Invitation Pending"
-  defp entry_label(%Layout.Entry{type: :invitation_sent}, _), do: "Invitation Sent"
+  defp entry_label(%Layout.Entry{type: :invitation_pending}, _), do: "Invitation pending"
+  defp entry_label(%Layout.Entry{type: :invitation_sent}, _), do: "Invitation sent"
 
   defp entry_label(%Layout.Entry{meta: %{user: %{id: id, type: :sso}}}, %{id: id}),
     do: "You (SSO)"
 
   defp entry_label(%Layout.Entry{meta: %{user: %{id: id}}}, %{id: id}), do: "You"
-  defp entry_label(%Layout.Entry{meta: %{user: %{type: :sso}}}, _), do: "SSO Member"
-  defp entry_label(_, _), do: "Team Member"
+  defp entry_label(%Layout.Entry{meta: %{user: %{type: :sso}}}, _), do: "SSO"
+  defp entry_label(_, _), do: nil
 
   def at_limit?(layout, limit) do
     not Plausible.Billing.Quota.below_limit?(

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -100,7 +100,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
           </.form>
 
           <.label class="mb-2">
-            Team Members
+            Team members
           </.label>
           {live_render(@socket, PlausibleWeb.Live.TeamManagement,
             id: "team-management-setup",

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -1,10 +1,10 @@
 <%= render_layout "app.html", assigns do %>
   <% options = account_settings_sidebar(@conn) %>
   <div class="container pt-6">
-    <.styled_link class="text-indigo-600 font-bold text-sm" href="/sites">
-      ← Back to Sites
+    <.styled_link class="font-semibold text-sm" href="/sites">
+      ← Back to sites
     </.styled_link>
-    <div class="pb-5 border-b border-gray-200 dark:border-gray-500">
+    <div class="pb-5 border-b border-gray-200 dark:border-gray-700">
       <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate">
         Settings
       </h2>
@@ -19,23 +19,30 @@
           href_base="/settings/"
         />
 
-        <div class="hidden lg:block py-4 top-0 sticky">
-          <h3 class="uppercase text-sm text-indigo-600 font-semibold">Account Settings</h3>
-          <p class="text-xs dark:text-gray-400 truncate">{@current_user.email}</p>
-          <Layout.settings_sidebar
-            selected_fn={&is_current_tab(@conn, &1)}
-            options={options["Account Settings"]}
-          />
-
-          <div :if={Plausible.Teams.setup?(@current_team)}>
-            <h3 class="uppercase text-sm text-indigo-600 font-semibold mt-6">Team Settings</h3>
-            <p class="text-xs dark:text-gray-400 truncate mb-4">
-              {Plausible.Teams.name(@current_team)}
-            </p>
-
+        <div class="hidden lg:flex flex-col gap-8 py-4 top-0 sticky">
+          <div class="flex flex-col gap-4">
+            <div>
+              <h3 class="text-gray-900 dark:text-gray-100 font-bold">Account</h3>
+              <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
+                {@current_user.email}
+              </p>
+            </div>
             <Layout.settings_sidebar
               selected_fn={&is_current_tab(@conn, &1)}
-              options={options["Team Settings"]}
+              options={options["Account"]}
+            />
+          </div>
+
+          <div :if={Plausible.Teams.setup?(@current_team)} class="flex flex-col gap-4">
+            <div>
+              <h3 class="text-gray-900 dark:text-gray-100 font-bold">Team</h3>
+              <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
+                {Plausible.Teams.name(@current_team)}
+              </p>
+            </div>
+            <Layout.settings_sidebar
+              selected_fn={&is_current_tab(@conn, &1)}
+              options={options["Team"]}
             />
           </div>
         </div>

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -2,12 +2,12 @@
   <% options = site_settings_sidebar(@conn) %>
   <div class="container pt-6">
     <.styled_link
-      class="text-indigo-600 font-bold text-sm"
+      class="text-indigo-600 font-semibold text-sm"
       href={"/#{URI.encode_www_form(@site.domain)}"}
     >
-      ← Back to Stats
+      ← Back to stats
     </.styled_link>
-    <div class="pb-5 border-b border-gray-200 dark:border-gray-500">
+    <div class="pb-5 border-b border-gray-200 dark:border-gray-700">
       <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate">
         Settings for {@site.domain}
       </h2>

--- a/lib/plausible_web/templates/settings/api_keys.html.heex
+++ b/lib/plausible_web/templates/settings/api_keys.html.heex
@@ -6,10 +6,10 @@
     feature_mod={Plausible.Billing.Feature.StatsAPI}
   >
     <:title>
-      <a id="api-keys">API Keys</a>
+      <a id="api-keys">API keys</a>
     </:title>
     <:subtitle>
-      Manage your API keys
+      Create and manage access.
     </:subtitle>
 
     <.filter_bar filtering_enabled?={false}>

--- a/lib/plausible_web/templates/settings/danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/danger_zone.html.heex
@@ -1,16 +1,16 @@
-<.notice title="Danger Zone" theme={:red}>
+<.notice title="Danger zone" theme={:red}>
   Destructive actions below can result in irrecoverable data loss. Be careful.
 </.notice>
 
 <.settings_tiles>
   <.tile docs="delete-account">
-    <:title>Delete Account</:title>
-    <:subtitle>Deleting your account removes all sites and stats you've collected</:subtitle>
+    <:title>Delete account</:title>
+    <:subtitle>Permanently deletes your sites and all collected stats.</:subtitle>
 
     <%= cond do %>
       <% length(@solely_owned_teams) > 0 -> %>
-        <.notice theme={:gray} title="Cannot delete account at this time">
-          You are the sole owner of one or more teams. If you want to delete your account, please either add another owner or delete each of the following teams:
+        <.notice theme={:gray} title="You can't delete your account yet">
+          You're the sole owner of one or more teams. To delete your account, either add another owner or delete each of the following team(s):
           <ul class="w-full py-4">
             <li :for={team <- @solely_owned_teams} class="pt-1">
               <.styled_link href={
@@ -22,8 +22,8 @@
           </ul>
         </.notice>
       <% Plausible.Billing.Subscription.Status.active?(@my_team && @my_team.subscription) -> %>
-        <.notice theme={:gray} title="Cannot delete account at this time">
-          Your account cannot be deleted because you have an active subscription. If you want to delete your account, please cancel your subscription first.
+        <.notice theme={:gray} title="You can't delete your account yet">
+          You have an active subscription. To delete your account, cancel your subscription first.
         </.notice>
       <% true -> %>
         <.button_link
@@ -31,8 +31,9 @@
           href="/me"
           method="delete"
           theme="danger"
+          mt?={false}
         >
-          Delete My Account
+          Delete my account
         </.button_link>
     <% end %>
   </.tile>

--- a/lib/plausible_web/templates/settings/invoices.html.heex
+++ b/lib/plausible_web/templates/settings/invoices.html.heex
@@ -4,13 +4,13 @@
       <a id="invoices">Invoices</a>
     </:title>
     <:subtitle>
-      Download your invoices
+      Download your invoices.
     </:subtitle>
     <%= case @invoices do %>
       <% {:error, :no_invoices} -> %>
         <p class="mt-12 mb-8 text-center text-sm">
           <span>
-            Your invoice will be created once you upgrade to a subscription
+            Your invoice will be created once you upgrade to a subscription.
           </span>
         </p>
       <% {:error, :request_failed} -> %>
@@ -44,7 +44,7 @@
             <tr :if={length(invoice_list) > 12}>
               <td colspan="3" class="text-center pt-8 pb-4">
                 <.button_link href={} theme="bright" x-on:click="showAll = true" x-show="!showAll">
-                  Show More
+                  Show more
                 </.button_link>
               </td>
             </tr>

--- a/lib/plausible_web/templates/settings/preferences.html.heex
+++ b/lib/plausible_web/templates/settings/preferences.html.heex
@@ -1,44 +1,35 @@
 <.settings_tiles>
   <.tile :if={Plausible.Users.type(@current_user) == :standard}>
     <:title>
-      <a id="update-name">Your Name</a>
+      <a id="update-name">Your name</a>
     </:title>
-    <:subtitle>
-      Change the name associated with your account
-    </:subtitle>
     <.form
       :let={f}
       action={Routes.settings_path(@conn, :update_name)}
       for={@name_changeset}
       method="post"
     >
-      <.input type="text" field={f[:name]} label="Name" width="w-1/2" />
+      <.input type="text" field={f[:name]} label="Name" width="w-1/2" mt?={false} />
 
       <.button type="submit">
-        Change Name
+        Change name
       </.button>
     </.form>
   </.tile>
 
   <.tile :if={Plausible.Users.type(@current_user) == :sso}>
     <:title>
-      <a id="view-name">Your Name</a>
+      <a id="view-name">Your name</a>
     </:title>
-    <:subtitle>
-      The name associated with your account
-    </:subtitle>
     <.form :let={f} for={@name_changeset}>
-      <.input type="text" field={f[:name]} disabled={true} label="Name" width="w-1/2" />
+      <.input type="text" field={f[:name]} disabled={true} label="Name" width="w-1/2" mt?={false} />
     </.form>
   </.tile>
 
   <.tile docs="dashboard-appearance">
     <:title>
-      <a id="update-theme">Dashboard Appearance</a>
+      <a id="update-theme">Appearance</a>
     </:title>
-    <:subtitle>
-      Set your visual preferences
-    </:subtitle>
     <.form
       :let={f}
       action={Routes.settings_path(@conn, :update_theme)}
@@ -51,10 +42,11 @@
         options={Plausible.Themes.options()}
         label="Theme"
         width="w-1/2"
+        mt?={false}
       />
 
       <.button type="submit">
-        Change Theme
+        Change theme
       </.button>
     </.form>
   </.tile>

--- a/lib/plausible_web/templates/settings/security.html.heex
+++ b/lib/plausible_web/templates/settings/security.html.heex
@@ -1,10 +1,10 @@
 <.settings_tiles>
   <.tile :if={Plausible.Users.type(@current_user) == :standard} docs="change-email">
     <:title>
-      <a id="update-email">Email Address</a>
+      <a id="update-email">Email address</a>
     </:title>
     <:subtitle>
-      Change the address associated with your account
+      Change the address associated with your account.
     </:subtitle>
     <.form
       :let={f}
@@ -16,35 +16,37 @@
         type="text"
         name="user[current_email]"
         value={f.data.email}
-        label="Current Email"
+        label="Current email"
         width="w-1/2"
+        mt?={false}
         disabled
       />
 
-      <.input type="email" field={f[:email]} label="New E-mail" width="w-1/2" />
+      <.input type="email" field={f[:email]} label="New email" width="w-1/2" />
 
-      <.input type="password" field={f[:password]} label="Account Password" width="w-1/2" />
+      <.input type="password" field={f[:password]} label="Confirm with password" width="w-1/2" />
 
       <.button type="submit">
-        Change Email
+        Change email
       </.button>
     </.form>
   </.tile>
 
   <.tile :if={Plausible.Users.type(@current_user) == :sso}>
     <:title>
-      <a id="view-email">Email Address</a>
+      <a id="view-email">Email address</a>
     </:title>
     <:subtitle>
-      Address associated with your account
+      Address associated with your account.
     </:subtitle>
     <.form :let={f} for={@email_changeset}>
       <.input
         type="text"
         name="user[current_email]"
         value={f.data.email}
-        label="Current Email"
+        label="Current email"
         width="w-1/2"
+        mt?={false}
         disabled
       />
     </.form>
@@ -55,7 +57,7 @@
       <a id="update-password">Password</a>
     </:title>
     <:subtitle>
-      Change your password
+      Change your password.
     </:subtitle>
     <.form
       :let={f}
@@ -67,15 +69,16 @@
         type="password"
         max_one_error
         field={f[:old_password]}
-        label="Old Password"
+        label="Old password"
         width="w-1/2"
+        mt?={false}
       />
 
       <.input
         type="password"
         max_one_error
         field={f[:password]}
-        label="New Password"
+        label="New password"
         width="w-1/2"
       />
 
@@ -84,7 +87,7 @@
         max_one_error
         autocomplete="new-password"
         field={f[:password_confirmation]}
-        label="Confirm New Password"
+        label="Confirm new password"
         width="w-1/2"
       />
 
@@ -100,7 +103,7 @@
       </div>
 
       <.button type="submit">
-        Change Password
+        Change password
       </.button>
     </.form>
   </.tile>
@@ -110,7 +113,7 @@
       <a id="update-2fa">Two-Factor Authentication (2FA)</a>
     </:title>
     <:subtitle>
-      Two-Factor Authentication protects your account by adding an extra security step when you log in
+      Protect your account by adding an extra security step when you log in.
     </:subtitle>
 
     <div x-data="{disable2FAOpen: false, regenerate2FAOpen: false}">
@@ -237,10 +240,10 @@
 
   <.tile docs="login-management">
     <:title>
-      <a id="user-sessions">Login Management</a>
+      <a id="user-sessions">Login management</a>
     </:title>
     <:subtitle>
-      Log out of your account on other devices. Note that logged-in sessions automatically expire after 14 days of inactivity
+      Log out other devices. Inactive sessions auto-expire after 14 days.
     </:subtitle>
 
     <.table rows={@user_sessions}>

--- a/lib/plausible_web/templates/settings/subscription.html.heex
+++ b/lib/plausible_web/templates/settings/subscription.html.heex
@@ -4,24 +4,21 @@
       <a id="subscription">Subscription</a>
     </:title>
     <:subtitle>
-      Manage your plan
+      Manage your plan.
     </:subtitle>
-    <div class="w-full inline-flex gap-x-4 justify-end items-center mt-4 mb-4">
+    <div :if={@subscription} class="w-full inline-flex gap-x-4 justify-end items-center mt-4 mb-4">
       <span
-        :if={@subscription && Plausible.Billing.Plans.business_tier?(@subscription)}
+        :if={Plausible.Billing.Plans.business_tier?(@subscription)}
         class={[
           "w-max px-2.5 py-0.5 rounded-md text-sm font-bold leading-5 text-indigo-600 bg-blue-100 dark:text-yellow-200 dark:border dark:bg-inherit dark:border-yellow-200"
         ]}
       >
         Business
       </span>
-      <span
-        :if={@subscription}
-        class={[
-          "w-max px-2.5 py-0.5 rounded-md text-sm font-bold leading-5",
-          subscription_colors(@subscription.status)
-        ]}
-      >
+      <span class={[
+        "w-max px-2.5 py-0.5 rounded-md text-sm font-bold leading-5",
+        subscription_colors(@subscription.status)
+      ]}>
         {present_subscription_status(@subscription.status)}
       </span>
     </div>

--- a/lib/plausible_web/templates/settings/team_danger_zone.html.heex
+++ b/lib/plausible_web/templates/settings/team_danger_zone.html.heex
@@ -1,11 +1,11 @@
-<.notice title="Danger Zone" theme={:red}>
+<.notice title="Danger zone" theme={:red}>
   Destructive actions below can result in irrecoverable data loss. Be careful.
 </.notice>
 
 <.settings_tiles>
   <.tile docs="delete-team">
-    <:title>Delete Team</:title>
-    <:subtitle>Deleting the team removes all associated sites and collected stats</:subtitle>
+    <:title>Delete team</:title>
+    <:subtitle>Remove all associated sites and collected stats.</:subtitle>
 
     <%= if Plausible.Billing.Subscription.Status.active?(@current_team && @current_team.subscription) do %>
       <.notice theme={:gray} title="Cannot delete the team at this time">
@@ -17,6 +17,7 @@
         href={Routes.settings_path(@conn, :delete_team)}
         method="delete"
         theme="danger"
+        mt?={false}
       >
         Delete "{Plausible.Teams.name(@current_team)}"
       </.button_link>

--- a/lib/plausible_web/templates/settings/team_general.html.heex
+++ b/lib/plausible_web/templates/settings/team_general.html.heex
@@ -1,10 +1,10 @@
 <.settings_tiles>
   <.tile docs="users-roles">
     <:title>
-      <a id="update-name#changing-the-name-of-a-team">Team Information</a>
+      <a id="update-name#changing-the-name-of-a-team">Team name</a>
     </:title>
     <:subtitle>
-      Change the name of your team
+      Change the name of your team.
     </:subtitle>
     <.form
       :let={f}
@@ -18,10 +18,11 @@
         field={f[:name]}
         label="Name"
         width="w-1/2"
+        mt?={false}
       />
 
       <.button type="submit" disabled={@current_team_role not in [:owner, :admin]}>
-        Change Name
+        Change name
       </.button>
     </.form>
   </.tile>
@@ -32,10 +33,10 @@
     feature_mod={Plausible.Billing.Feature.Teams}
   >
     <:title>
-      <a id="team-members">Team Members</a>
+      <a id="team-members">Team members</a>
     </:title>
     <:subtitle>
-      Add or remove team members and adjust their roles
+      Add or remove team members and adjust their roles.
     </:subtitle>
     {live_render(@conn, PlausibleWeb.Live.TeamManagement,
       id: "team-setup",
@@ -43,15 +44,16 @@
     )}
   </.tile>
   <.tile docs="users-roles#leaving-team">
-    <:title>Leave Team</:title>
-    <:subtitle>Leaving the team removes you from this team as a member.</:subtitle>
+    <:title>Leave team</:title>
+    <:subtitle>Remove yourself from this team as a member.</:subtitle>
     <.button_link
       data-confirm="Are you sure you want to leave this team?"
       href={Routes.settings_path(@conn, :leave_team)}
       method="post"
       theme="danger"
+      mt?={false}
     >
-      Leave Team
+      Leave team
     </.button_link>
   </.tile>
 </.settings_tiles>

--- a/lib/plausible_web/templates/site/settings_danger_zone.html.heex
+++ b/lib/plausible_web/templates/site/settings_danger_zone.html.heex
@@ -1,14 +1,15 @@
-<.notice title="Danger Zone" theme={:red}>
+<.notice title="Danger zone" theme={:red}>
   Destructive actions below can result in irrecoverable data loss. Be careful.
 </.notice>
 
 <.settings_tiles>
   <.tile>
-    <:title>Transfer Site Ownership</:title>
-    <:subtitle>Transfer ownership of the site to a different account</:subtitle>
+    <:title>Transfer site ownership</:title>
+    <:subtitle>Transfer ownership of the site to a different account.</:subtitle>
     <.button_link
       href={Routes.membership_path(@conn, :transfer_ownership_form, @site.domain)}
       theme="danger"
+      mt?={false}
     >
       Transfer {@site.domain} ownership
     </.button_link>
@@ -26,26 +27,28 @@
   </.tile>
 
   <.tile>
-    <:title>Reset Stats</:title>
-    <:subtitle>Reset all stats but keep the site configuration intact</:subtitle>
+    <:title>Reset stats</:title>
+    <:subtitle>Reset all stats but keep the site configuration intact.</:subtitle>
     <.button_link
       href={Routes.site_path(@conn, :reset_stats, @site.domain)}
       method="delete"
       data-confirm="Resetting the stats cannot be reversed. Are you sure?"
       theme="danger"
+      mt?={false}
     >
       Reset {@site.domain} stats
     </.button_link>
   </.tile>
 
   <.tile>
-    <:title>Delete Site</:title>
-    <:subtitle>Permanently remove all stats and the site configuration too</:subtitle>
+    <:title>Delete site</:title>
+    <:subtitle>Permanently delete all stats and site settings.</:subtitle>
     <.button_link
       href={Routes.site_path(@conn, :delete_site, @site.domain)}
       theme="danger"
       method="delete"
       data-confirm="Deleting the site data cannot be reversed. Are you sure?"
+      mt?={false}
     >
       Delete {@site.domain}
     </.button_link>

--- a/lib/plausible_web/templates/site/settings_email_reports.html.heex
+++ b/lib/plausible_web/templates/site/settings_email_reports.html.heex
@@ -6,10 +6,10 @@
       enable_route: :enable_weekly_report,
       remove_route: :remove_weekly_report_recipient,
       add_route: :add_weekly_report_recipient,
-      heading: "Weekly Email Reports",
-      subtitle: "Send weekly analytics reports to as many addresses as you wish",
+      heading: "Weekly email reports",
+      subtitle: "Send weekly analytics reports to as many addresses as you wish.",
       toggle: "Send a weekly email report every Monday",
-      add_label: "Add Weekly Report Recipient"
+      add_label: "Add weekly report recipient"
     },
     monthly: %{
       report: @monthly_report,
@@ -17,10 +17,10 @@
       enable_route: :enable_monthly_report,
       remove_route: :remove_monthly_report_recipient,
       add_route: :add_monthly_report_recipient,
-      heading: "Monthly Email Reports",
-      subtitle: "Send monthly analytics reports to as many addresses as you wish",
+      heading: "Monthly email reports",
+      subtitle: "Send monthly analytics reports to as many addresses as you wish.",
       toggle: "Send a monthly email report on 1st of the month",
-      add_label: "Add Monthly Report Recipient"
+      add_label: "Add monthly report recipient"
     }
   ] %>
 
@@ -48,11 +48,7 @@
     </.form>
 
     <div :if={meta.report} class="mt-4">
-      <.table
-        :if={Enum.count(meta.report.recipients) > 0}
-        width="w-1/2"
-        rows={meta.report.recipients}
-      >
+      <.table :if={Enum.count(meta.report.recipients) > 0} rows={meta.report.recipients}>
         <:thead>
           <.th>
             Recipients
@@ -101,7 +97,7 @@
             mt?={false}
           />
           <.button type="submit" mt?={false}>
-            Add Recipient
+            Add recipient
           </.button>
         </div>
       </.form>
@@ -111,16 +107,16 @@
   <% change_notifications = [
     spike: %{
       notification: @spike_notification,
-      heading: "Traffic Spike Notifications",
-      subtitle: "Get notified when your site has unusually high number of current visitors",
+      heading: "Traffic spike notifications",
+      subtitle: "Get notified when your site has unusually high number of current visitors.",
       threshold_text: "Current visitors threshold",
       toggle: "Send notifications of traffic spikes"
     },
     drop: %{
       notification: @drop_notification,
-      heading: "Traffic Drop Notifications",
+      heading: "Traffic drop notifications",
       subtitle:
-        "Get notified when your site has unusually low number of visitors within 12 hours",
+        "Get notified when your site has unusually low number of visitors within 12 hours.",
       threshold_text: "12 hours visitor threshold",
       toggle: "Send notifications of traffic drops"
     }
@@ -163,17 +159,13 @@
           label={meta.threshold_text}
         />
         <.button type="submit" mt?={false}>
-          Save Threshold
+          Save threshold
         </.button>
       </div>
     </.form>
 
-    <div class="mt-4">
-      <.table
-        :if={meta.notification && Enum.count(meta.notification.recipients) > 0}
-        width="w-1/2"
-        rows={meta.notification.recipients}
-      >
+    <div :if={meta.notification && Enum.count(meta.notification.recipients) > 0} class="mt-4">
+      <.table rows={meta.notification.recipients}>
         <:thead>
           <.th>
             Recipients
@@ -231,7 +223,7 @@
             required
           />
           <.button type="submit" mt?={false}>
-            Add Recipient
+            Add recipient
           </.button>
         </div>
       </.form>

--- a/lib/plausible_web/templates/site/settings_funnels.html.heex
+++ b/lib/plausible_web/templates/site/settings_funnels.html.heex
@@ -12,7 +12,7 @@
       Funnels
     </:title>
     <:subtitle>
-      Compose Goals into Funnels
+      Compose goals into funnels
     </:subtitle>
 
     {live_render(@conn, PlausibleWeb.Live.FunnelSettings,

--- a/lib/plausible_web/templates/site/settings_general.html.heex
+++ b/lib/plausible_web/templates/site/settings_general.html.heex
@@ -1,21 +1,21 @@
 <.settings_tiles>
   <.tile docs="change-domain-name">
     <:title>
-      Site Domain
+      Site domain
     </:title>
     <:subtitle>
       Moving your site to a different domain? We got you!
     </:subtitle>
-    <.input name="domain" label="Domain" value={@site.domain} disabled width="w-1/2" />
+    <.input name="domain" label="Domain" value={@site.domain} disabled width="w-1/2" mt?={false} />
 
     <.button_link href={Routes.site_path(@conn, :change_domain, @site.domain)}>
-      Change Domain
+      Change domain
     </.button_link>
   </.tile>
 
   <.tile docs="general">
-    <:title>Site Timezone</:title>
-    <:subtitle>Update your reporting timezone</:subtitle>
+    <:title>Site timezone</:title>
+    <:subtitle>Update your reporting timezone.</:subtitle>
     <.form :let={f} for={@changeset} action={"/#{URI.encode_www_form(@site.domain)}/settings"}>
       <.input
         field={f[:timezone]}
@@ -23,6 +23,7 @@
         type="select"
         options={Plausible.Timezones.options()}
         width="w-1/2"
+        mt?={false}
       />
       <.button type="submit">
         Save timezone
@@ -30,17 +31,17 @@
     </.form>
   </.tile>
   <.tile docs="plausible-script">
-    <:title>Site Installation</:title>
+    <:title>Site installation</:title>
     <:subtitle>
       Control what data is collected and verify your installation.
     </:subtitle>
     <.button_link
-      class="mt-4"
       href={
         Routes.site_path(@conn, :installation, @site.domain, flow: PlausibleWeb.Flows.review())
       }
+      mt?={false}
     >
-      Review Installation
+      Review installation
     </.button_link>
   </.tile>
 </.settings_tiles>

--- a/lib/plausible_web/templates/site/settings_goals.html.heex
+++ b/lib/plausible_web/templates/site/settings_goals.html.heex
@@ -16,7 +16,7 @@
       <p :if={ee?()}>
         You can also
         <.styled_link href={Routes.site_path(@conn, :settings_funnels, @site.domain)}>
-          compose Goals into Funnels
+          compose goals into funnels.
         </.styled_link>
       </p>
     </:subtitle>

--- a/lib/plausible_web/templates/site/settings_imports_exports.html.heex
+++ b/lib/plausible_web/templates/site/settings_imports_exports.html.heex
@@ -1,7 +1,7 @@
 <.settings_tiles docs="google-analytics-import">
   <.tile>
     <:title>
-      Import Data
+      Import data
     </:title>
     <:subtitle>
       Import existing data from external sources.
@@ -16,10 +16,10 @@
 
   <.tile>
     <:title>
-      Export Data
+      Export data
     </:title>
     <:subtitle>
-      Export all your data into CSV format
+      Export all your data into CSV format.
     </:subtitle>
 
     {live_render(@conn, PlausibleWeb.Live.CSVExport,

--- a/lib/plausible_web/templates/site/settings_integrations.html.heex
+++ b/lib/plausible_web/templates/site/settings_integrations.html.heex
@@ -3,7 +3,7 @@
 <.settings_tiles>
   <.tile docs="google-search-console-integration">
     <:title>
-      Google Search Console Integration
+      Google Search Console integration
     </:title>
     <:subtitle>
       <p>
@@ -18,6 +18,7 @@
           value={@site.google_auth.email}
           disabled="disabled"
           width="w-1/2"
+          mt?={false}
         />
 
         <.button_link
@@ -25,7 +26,7 @@
           href={Routes.site_path(@conn, :delete_google_auth, @site.domain)}
           method="delete"
         >
-          Unlink Google Account
+          Unlink Google account
         </.button_link>
 
         <%= case @search_console_domains do %>
@@ -142,7 +143,7 @@
       </p>
     </:subtitle>
 
-    <div class="mt-4 text-sm">
+    <div class="text-sm">
       Plausible Looker Studio Connector adds powerful reporting features that help turn Plausible
       into an even better replacement for Google Analytics.
       <.styled_link href="https://plausible.io/docs/looker-studio" new_tab={true}>
@@ -153,10 +154,10 @@
 
   <.tile :if={@has_plugins_tokens? || @conn.query_params["new_token"]}>
     <:title>
-      Plugin Tokens
+      Plugin tokens
     </:title>
     <:subtitle>
-      Control Plugin Access
+      Control plugin access.
     </:subtitle>
 
     {live_render(@conn, PlausibleWeb.Live.Plugins.API.Settings,

--- a/lib/plausible_web/templates/site/settings_people.html.heex
+++ b/lib/plausible_web/templates/site/settings_people.html.heex
@@ -20,7 +20,7 @@
         mt?={false}
         href={Routes.membership_path(@conn, :invite_member_form, @site.domain)}
       >
-        Invite New Guest
+        Invite new guest
       </.button_link>
     </.filter_bar>
 
@@ -29,7 +29,7 @@
     } />
 
     <div class="flow-root">
-      <ul class="divide-y divide-gray-200 dark:divide-gray-400">
+      <ul class="divide-y divide-gray-200 dark:divide-gray-600">
         <%= for membership <- @memberships do %>
           <li class="py-4" id={"membership-#{membership.user.id}"}>
             <div class="flex items-center space-x-4">
@@ -78,7 +78,7 @@
                       method="put"
                       disabled={@site_role not in [:owner, :admin] or membership.role == "editor"}
                     >
-                      <div>Guest Editor</div>
+                      <div>Guest editor</div>
                       <div class="text-gray-500 dark:text-gray-400 text-xs/5">
                         View stats and edit site settings
                       </div>
@@ -96,7 +96,7 @@
                       method="put"
                       disabled={@site_role not in [:owner, :admin] or membership.role == "viewer"}
                     >
-                      <div>Guest Viewer</div>
+                      <div>Guest viewer</div>
                       <div class="text-gray-500 dark:text-gray-400 text-xs/5">
                         View stats only
                       </div>
@@ -129,7 +129,7 @@
 
   <.tile :if={Enum.count(@invitations) > 0}>
     <:title>Pending invitations</:title>
-    <:subtitle>Waiting for new members to accept their invitations</:subtitle>
+    <:subtitle>Waiting for new members to accept their invitations.</:subtitle>
 
     <.table
       rows={@invitations}

--- a/lib/plausible_web/templates/site/settings_visibility.html.heex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.heex
@@ -1,10 +1,10 @@
 <.settings_tiles>
   <.tile docs="visibility">
     <:title>
-      Public Dashboard
+      Public dashboard
     </:title>
     <:subtitle>
-      Share your stats publicly or keep them private
+      Share your stats publicly or keep them private.
     </:subtitle>
 
     <.form
@@ -36,7 +36,7 @@
     conn={@conn}
   >
     <:title>
-      Shared Links
+      Shared links
     </:title>
     <:subtitle>
       You can share your stats privately by generating a shared link. The links are impossible to guess and you can add password protection for extra security.
@@ -96,7 +96,7 @@
     conn={@conn}
   >
     <:title>
-      Embed Dashboard
+      Embed dashboard
     </:title>
     <:subtitle>
       You can use shared links to embed your stats in any other webpage using an <code>iframe</code>. Copy & paste a shared link into the form below to generate the embed code.
@@ -105,16 +105,17 @@
     <.input
       name="embed-link"
       id="embed-link"
-      label="Enter Shared Link (only public shared links without password can be embedded)"
+      label="Enter shared link (only public shared links without password can be embedded)"
       value=""
       width="w-1/2"
+      mt?={false}
     />
 
     <.input
       type="select"
       name="theme"
       id="theme"
-      label="Select Theme"
+      label="Select theme"
       options={["Light", "Dark", "System"]}
       value="Light"
       width="w-1/2"
@@ -123,18 +124,18 @@
     <.input
       name="background"
       id="background"
-      label="Custom Background Colour (optional). Try using `transparent` background to blend the dashboard with your site."
+      label="Custom background color (optional). Try using `transparent` background to blend the dashboard with your site."
       value=""
       placeholder="e.g. #F9FAFB"
       width="w-1/2"
     />
 
     <.input name="base-url" type="hidden" id="base-url" value={plausible_url()} />
-    <.button id="generate-embed" class="mt-4">
-      Generate Embed Code
+    <.button id="generate-embed" mt?={false}>
+      Generate embed code
     </.button>
 
-    <.label for="embed-code">Embed Code</.label>
+    <.label for="embed-code" class="mt-4">Embed code</.label>
 
     <div class="relative mt-1">
       <textarea

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -60,22 +60,22 @@ defmodule PlausibleWeb.LayoutView do
       on_ee do
         %{key: "Funnels", value: "funnels", icon: :funnel}
       end,
-      %{key: "Custom Properties", value: "properties", icon: :document_text},
+      %{key: "Custom properties", value: "properties", icon: :document_text},
       %{key: "Integrations", value: "integrations", icon: :arrow_path_rounded_square},
-      %{key: "Imports & Exports", value: "imports-exports", icon: :arrows_up_down},
+      %{key: "Imports & exports", value: "imports-exports", icon: :arrows_up_down},
       %{
         key: "Shields",
         icon: :shield_exclamation,
         value: [
-          %{key: "IP Addresses", value: "shields/ip_addresses"},
+          %{key: "IP addresses", value: "shields/ip_addresses"},
           %{key: "Countries", value: "shields/countries"},
           %{key: "Pages", value: "shields/pages"},
           %{key: "Hostnames", value: "shields/hostnames"}
         ]
       },
-      %{key: "Email Reports", value: "email-reports", icon: :envelope},
+      %{key: "Email reports", value: "email-reports", icon: :envelope},
       if conn.assigns[:site_role] in [:owner, :admin] do
-        %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
+        %{key: "Danger zone", value: "danger-zone", icon: :exclamation_triangle}
       end
     ]
     |> Enum.reject(&is_nil/1)
@@ -89,7 +89,7 @@ defmodule PlausibleWeb.LayoutView do
     subscription? = !!(conn.assigns[:current_team] && conn.assigns.current_team.subscription)
 
     options = %{
-      "Account Settings" =>
+      "Account" =>
         [
           %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
           %{key: "Security", value: "security", icon: :lock_closed},
@@ -100,10 +100,10 @@ defmodule PlausibleWeb.LayoutView do
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(not Teams.setup?(current_team),
-            do: %{key: "API Keys", value: "api-keys", icon: :key}
+            do: %{key: "API keys", value: "api-keys", icon: :key}
           ),
           if(Plausible.Users.type(conn.assigns.current_user) == :standard,
-            do: %{key: "Danger Zone", value: "danger-zone", icon: :exclamation_triangle}
+            do: %{key: "Danger zone", value: "danger-zone", icon: :exclamation_triangle}
           )
         ]
         |> Enum.reject(&is_nil/1)
@@ -112,7 +112,7 @@ defmodule PlausibleWeb.LayoutView do
     if Teams.setup?(current_team) do
       Map.put(
         options,
-        "Team Settings",
+        "Team",
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
           if(current_team_role in [:owner, :billing],
@@ -122,7 +122,7 @@ defmodule PlausibleWeb.LayoutView do
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(current_team_role in [:owner, :billing, :admin, :editor],
-            do: %{key: "API Keys", value: "api-keys", icon: :key}
+            do: %{key: "API keys", value: "api-keys", icon: :key}
           ),
           if(
             ee?() and current_team_role == :owner and
@@ -141,12 +141,11 @@ defmodule PlausibleWeb.LayoutView do
             do: %{
               key: "Single Sign-On",
               value: "sso/info",
-              icon: :cloud,
-              badge: :new
+              icon: :cloud
             }
           ),
           if(current_team_role == :owner,
-            do: %{key: "Danger Zone", value: "team/delete", icon: :exclamation_triangle}
+            do: %{key: "Danger zone", value: "team/delete", icon: :exclamation_triangle}
           )
         ]
         |> Enum.reject(&is_nil/1)

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1310,8 +1310,10 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
       assert html = html_response(conn, 200)
 
-      refute html =~ "Your account cannot be deleted because you have an active subscription"
-      assert html =~ "Delete My Account"
+      refute html =~
+               "You have an active subscription. To delete your account, cancel your subscription first."
+
+      assert html =~ "Delete my account"
     end
 
     test "with active subscription", %{conn: conn, user: user} do
@@ -1320,8 +1322,10 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
       assert html = html_response(conn, 200)
 
-      assert html =~ "Your account cannot be deleted because you have an active subscription"
-      refute html =~ "Delete My Account"
+      assert html =~
+               "You have an active subscription. To delete your account, cancel your subscription first."
+
+      refute html =~ "Delete my account"
     end
 
     test "with a setup team", %{conn: conn, user: user} do
@@ -1336,8 +1340,8 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
       assert html = html_response(conn, 200)
 
-      assert html =~ "You are the sole owner of one or more teams"
-      refute html =~ "Delete My Account"
+      assert html =~ "You're the sole owner of one or more teams"
+      refute html =~ "Delete my account"
     end
   end
 
@@ -1348,19 +1352,19 @@ defmodule PlausibleWeb.SettingsControllerTest do
       test "does not allow to update name in preferences", %{conn: conn} do
         conn = get(conn, Routes.settings_path(conn, :preferences))
         assert html = html_response(conn, 200)
-        refute html =~ "Change Name"
+        refute html =~ "Change name"
       end
 
       test "does not allow to update email in security settings", %{conn: conn} do
         conn = get(conn, Routes.settings_path(conn, :security))
         assert html = html_response(conn, 200)
-        refute html =~ "Change Email"
+        refute html =~ "Change email"
       end
 
       test "does not allow to change password in security settings", %{conn: conn} do
         conn = get(conn, Routes.settings_path(conn, :security))
         assert html = html_response(conn, 200)
-        refute html =~ "Change Password"
+        refute html =~ "Change password"
       end
 
       test "does not allow to disable 2FA in security settings", %{conn: conn, user: user} do
@@ -1386,7 +1390,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
     test "does not render team settings, when no team assigned", %{conn: conn} do
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      refute html =~ "Team Settings"
+      refute html =~ "Team"
     end
 
     test "does not render invoices when no subscription present (no team assigned)", %{conn: conn} do
@@ -1437,7 +1441,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       conn = set_current_team(conn, team)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      assert html =~ "Team Settings"
+      assert html =~ ~r/Team.*#{Regex.escape(team.name)}/s
       assert html =~ team.name
     end
 
@@ -1445,7 +1449,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       {:ok, team} = Plausible.Teams.get_or_create(user)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      refute html =~ "Team Settings"
+      refute html =~ ~r/Team.*#{Regex.escape(team.name)}/s
       refute html =~ team.name
     end
 
@@ -1455,7 +1459,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
       conn = set_current_team(conn, team)
       conn = get(conn, Routes.settings_path(conn, :team_general))
       html = html_response(conn, 200)
-      assert html =~ "Team Information"
+      assert html =~ "Team name"
       assert html =~ "Change the name of your team"
       assert text_of_attr(html, "input#team_name", "value") == team.name
     end
@@ -1465,13 +1469,13 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
       conn =
         post(conn, Routes.settings_path(conn, :update_team_name), %{
-          "team" => %{"name" => "New Name"}
+          "team" => %{"name" => "New name"}
         })
 
       assert redirected_to(conn, 302) ==
                Routes.settings_path(conn, :team_general) <> "#update-name"
 
-      assert Repo.reload!(team).name == "New Name"
+      assert Repo.reload!(team).name == "New name"
     end
 
     test "POST /settings/team/general/name - changeset error", %{conn: conn, user: user} do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -505,9 +505,9 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn = get(conn, "/#{site.domain}/settings/general")
       resp = html_response(conn, 200)
 
-      assert resp =~ "Site Timezone"
-      assert resp =~ "Site Domain"
-      assert resp =~ "Site Installation"
+      assert resp =~ "Site timezone"
+      assert resp =~ "Site domain"
+      assert resp =~ "Site installation"
     end
 
     @tag :ee_only
@@ -530,16 +530,16 @@ defmodule PlausibleWeb.SiteControllerTest do
                {"Visibility", "/#{site.domain}/settings/visibility"},
                {"Goals", "/#{site.domain}/settings/goals"},
                {"Funnels", "/#{site.domain}/settings/funnels"},
-               {"Custom Properties", "/#{site.domain}/settings/properties"},
+               {"Custom properties", "/#{site.domain}/settings/properties"},
                {"Integrations", "/#{site.domain}/settings/integrations"},
-               {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
+               {"Imports & exports", "/#{site.domain}/settings/imports-exports"},
                {"Shields", ""},
-               {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
+               {"IP addresses", "/#{site.domain}/settings/shields/ip_addresses"},
                {"Countries", "/#{site.domain}/settings/shields/countries"},
                {"Pages", "/#{site.domain}/settings/shields/pages"},
                {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
-               {"Email Reports", "/#{site.domain}/settings/email-reports"},
-               {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
+               {"Email reports", "/#{site.domain}/settings/email-reports"},
+               {"Danger zone", "/#{site.domain}/settings/danger-zone"}
              ]
     end
 
@@ -562,16 +562,16 @@ defmodule PlausibleWeb.SiteControllerTest do
                {"People", "/#{site.domain}/settings/people"},
                {"Visibility", "/#{site.domain}/settings/visibility"},
                {"Goals", "/#{site.domain}/settings/goals"},
-               {"Custom Properties", "/#{site.domain}/settings/properties"},
+               {"Custom properties", "/#{site.domain}/settings/properties"},
                {"Integrations", "/#{site.domain}/settings/integrations"},
-               {"Imports & Exports", "/#{site.domain}/settings/imports-exports"},
+               {"Imports & exports", "/#{site.domain}/settings/imports-exports"},
                {"Shields", ""},
-               {"IP Addresses", "/#{site.domain}/settings/shields/ip_addresses"},
+               {"IP addresses", "/#{site.domain}/settings/shields/ip_addresses"},
                {"Countries", "/#{site.domain}/settings/shields/countries"},
                {"Pages", "/#{site.domain}/settings/shields/pages"},
                {"Hostnames", "/#{site.domain}/settings/shields/hostnames"},
-               {"Email Reports", "/#{site.domain}/settings/email-reports"},
-               {"Danger Zone", "/#{site.domain}/settings/danger-zone"}
+               {"Email reports", "/#{site.domain}/settings/email-reports"},
+               {"Danger zone", "/#{site.domain}/settings/danger-zone"}
              ]
     end
 
@@ -905,9 +905,9 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert text_of_attr(resp, ~s|a[href]|, "href") =~
                "https://accounts.google.com/o/oauth2/"
 
-      assert resp =~ "Import Data"
+      assert resp =~ "Import data"
       assert resp =~ "There are no imports yet"
-      assert resp =~ "Export Data"
+      assert resp =~ "Export data"
     end
 
     test "renders imports in import list", %{conn: conn, site: site} do
@@ -1870,8 +1870,8 @@ defmodule PlausibleWeb.SiteControllerTest do
       conn = get(conn, Routes.site_path(conn, :settings_general, site.domain))
       resp = html_response(conn, 200)
 
-      assert resp =~ "Site Domain"
-      assert resp =~ "Change Domain"
+      assert resp =~ "Site domain"
+      assert resp =~ "Change domain"
       assert resp =~ Routes.site_path(conn, :change_domain, site.domain)
     end
 
@@ -1980,7 +1980,7 @@ defmodule PlausibleWeb.SiteControllerTest do
     test "no change team section appears when <1 team", %{conn: conn, site: site} do
       conn = get(conn, Routes.site_path(conn, :settings_danger_zone, site.domain))
       html = html_response(conn, 200)
-      assert html =~ "Danger Zone"
+      assert html =~ "Danger zone"
       assert html =~ "Delete #{site.domain}"
       refute html =~ "Change #{site.domain} team"
     end
@@ -1990,7 +1990,7 @@ defmodule PlausibleWeb.SiteControllerTest do
 
       conn = get(conn, Routes.site_path(conn, :settings_danger_zone, site.domain))
       html = html_response(conn, 200)
-      assert html =~ "Danger Zone"
+      assert html =~ "Danger zone"
       assert html =~ "Delete #{site.domain}"
       assert html =~ "Change #{site.domain} team"
     end

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -69,7 +69,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
         {:ok, _lv, doc} = get_liveview(conn)
 
         assert doc =~ "Upgrade your trial"
-        assert doc =~ "Back to Settings"
+        assert doc =~ "Back to settings"
         assert doc =~ "You have used"
         assert doc =~ "<b>0</b>"
         assert doc =~ "billable pageviews in the last 30 days"

--- a/test/plausible_web/live/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings_test.exs
@@ -29,7 +29,7 @@ defmodule PlausibleWeb.Live.FunnelSettingsTest do
         conn = get(conn, "/#{site.domain}/settings/funnels")
 
         resp = html_response(conn, 200)
-        assert resp =~ "Compose Goals into Funnels"
+        assert resp =~ "Compose goals into funnels"
         assert resp =~ "From blog to signup"
         assert resp =~ "From signup to blog"
         refute resp =~ "Your account does not have access"

--- a/test/plausible_web/live/goal_settings_test.exs
+++ b/test/plausible_web/live/goal_settings_test.exs
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Live.GoalSettingsTest do
 
       resp = html_response(conn, 200)
       assert resp =~ "Define actions that you want your users to take"
-      assert resp =~ "compose Goals into Funnels"
+      assert resp =~ "compose goals into funnels"
       assert resp =~ "/#{URI.encode_www_form(site.domain)}/settings/funnels"
       assert element_exists?(resp, ~s|a[href="https://plausible.io/docs/goal-conversions"]|)
 

--- a/test/plausible_web/live/plugins_api_tokens_test.exs
+++ b/test/plausible_web/live/plugins_api_tokens_test.exs
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       conn = get(conn, "/#{site.domain}/settings/integrations?new_token=test")
       resp = html_response(conn, 200)
 
-      assert resp =~ "Plugin Tokens"
+      assert resp =~ "Plugin tokens"
     end
 
     test "does display the Plugins API section when there are tokens already created", %{
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Live.PluginsAPISettingsTest do
       conn = get(conn, "/#{site.domain}/settings/integrations")
       resp = html_response(conn, 200)
 
-      assert resp =~ "Plugin Tokens"
+      assert resp =~ "Plugin tokens"
     end
 
     test "lists tokens with revoke actions", %{conn: conn, site: site} do

--- a/test/plausible_web/live/shields/countries_test.exs
+++ b/test/plausible_web/live/shields/countries_test.exs
@@ -13,8 +13,8 @@ defmodule PlausibleWeb.Live.Shields.CountriesTest do
       conn = get(conn, "/#{site.domain}/settings/shields/countries")
       resp = html_response(conn, 200)
 
-      assert resp =~ "No Country Rules configured for this site"
-      assert resp =~ "Country Block List"
+      assert resp =~ "No country rules configured for this site"
+      assert resp =~ "Country block list"
     end
 
     test "lists country rules with remove actions", %{conn: conn, site: site} do

--- a/test/plausible_web/live/shields/hostnames_test.exs
+++ b/test/plausible_web/live/shields/hostnames_test.exs
@@ -13,8 +13,8 @@ defmodule PlausibleWeb.Live.Shields.HostnamesTest do
       conn = get(conn, "/#{site.domain}/settings/shields/hostnames")
       resp = html_response(conn, 200)
 
-      assert resp =~ "No Hostname Rules configured for this site"
-      assert resp =~ "Hostnames Allow List"
+      assert resp =~ "No hostname rules configured for this site"
+      assert resp =~ "Hostnames allow list"
       assert resp =~ "Traffic from all hostnames is currently accepted."
     end
 

--- a/test/plausible_web/live/shields/ip_addresses_test.exs
+++ b/test/plausible_web/live/shields/ip_addresses_test.exs
@@ -13,8 +13,8 @@ defmodule PlausibleWeb.Live.Shields.IPAddressesTest do
       conn = get(conn, "/#{site.domain}/settings/shields/ip_addresses")
       resp = html_response(conn, 200)
 
-      assert resp =~ "No IP Rules configured for this site"
-      assert resp =~ "IP Block List"
+      assert resp =~ "No IP rules configured for this site"
+      assert resp =~ "IP block list"
     end
 
     test "lists ip rules with remove actions", %{conn: conn, site: site} do

--- a/test/plausible_web/live/shields/pages_test.exs
+++ b/test/plausible_web/live/shields/pages_test.exs
@@ -13,8 +13,8 @@ defmodule PlausibleWeb.Live.Shields.PagesTest do
       conn = get(conn, "/#{site.domain}/settings/shields/pages")
       resp = html_response(conn, 200)
 
-      assert resp =~ "No Page Rules configured for this site"
-      assert resp =~ "Pages Block List"
+      assert resp =~ "No page rules configured for this site"
+      assert resp =~ "Pages block list"
     end
 
     test "lists page rules with remove actions", %{conn: conn, site: site} do

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -96,7 +96,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
         assert text_of_element(html, "#{member_el()}:nth-of-type(1)") =~ "You (SSO)"
 
         assert text_of_element(html, "#{member_el()}:nth-of-type(2) button") == "Viewer"
-        assert text_of_element(html, "#{member_el()}:nth-of-type(2)") =~ "SSO Member"
+        assert text_of_element(html, "#{member_el()}:nth-of-type(2)") =~ "SSO"
 
         change_role(lv, 2, "owner")
         html = render(lv)
@@ -123,7 +123,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       member_row1 = find(html, "#{member_el()}:nth-of-type(1)") |> text()
       assert member_row1 =~ "new@example.com"
       assert member_row1 =~ "Invited User"
-      assert member_row1 =~ "Invitation Sent"
+      assert member_row1 =~ "Invitation sent"
 
       member_row2 = find(html, "#{member_el()}:nth-of-type(2)") |> text()
       assert member_row2 =~ "#{user.name}"
@@ -236,10 +236,10 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       guest_member = find(html, "#{guest_el()}:first-of-type") |> text()
 
-      assert pending =~ "Invitation Pending"
-      assert sent =~ "Invitation Sent"
-      assert owner =~ "You"
-      assert admin =~ "Team Member"
+      assert pending =~ "Invitation pending"
+      assert sent =~ "Invitation sent"
+      assert owner =~ "Owner"
+      assert admin != ""
       assert guest_member =~ "Guest"
 
       remove_member(lv, 1)
@@ -253,9 +253,8 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       html = render(lv) |> text()
 
-      refute html =~ "Invitation Pending"
-      refute html =~ "Invitation Sent"
-      refute html =~ "Team Member"
+      refute html =~ "Invitation pending"
+      refute html =~ "Invitation sent"
       refute html =~ "Guest"
 
       html = render(lv)
@@ -306,9 +305,9 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       guest_member = find(html, "#{guest_el()}:first-of-type") |> text()
 
-      assert sent =~ "Invitation Sent"
-      assert owner =~ "You"
-      assert admin =~ "Team Member"
+      assert sent =~ "Invitation sent"
+      assert owner =~ "Owner"
+      assert admin != ""
       assert guest_member =~ "Guest"
 
       remove_member(lv, 1)
@@ -320,8 +319,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       html = render(lv) |> text()
 
-      refute html =~ "Invitation Sent"
-      refute html =~ "Team Member"
+      refute html =~ "Invitation sent"
       refute html =~ "Guest"
 
       html = render(lv)

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -117,7 +117,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       member_row1 = find(html, "#{member_el()}:nth-of-type(1)") |> text()
       assert member_row1 =~ "new@example.com"
       assert member_row1 =~ "Invited User"
-      assert member_row1 =~ "Invitation Pending"
+      assert member_row1 =~ "Invitation pending"
 
       member_row2 = find(html, "#{member_el()}:nth-of-type(2)") |> text()
       assert member_row2 =~ "#{user.name}"
@@ -298,10 +298,10 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       guest_member = find(html, "#{guest_el()}:first-of-type") |> text()
 
-      assert pending =~ "Invitation Pending"
-      assert sent =~ "Invitation Sent"
+      assert pending =~ "Invitation pending"
+      assert sent =~ "Invitation sent"
       assert owner =~ "You"
-      assert admin =~ "Team Member"
+      assert admin != ""
       assert guest_member =~ "Guest"
 
       remove_member(lv, 1)
@@ -315,9 +315,9 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       html = render(lv) |> text()
 
-      refute html =~ "Invitation Pending"
-      refute html =~ "Invitation Sent"
-      refute html =~ "Team Member"
+      refute html =~ "Invitation pending"
+      refute html =~ "Invitation sent"
+      refute html =~ "Team member"
       refute html =~ "Guest"
 
       save_layout(lv)
@@ -351,7 +351,6 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       html = render(lv)
 
-      assert find(html, "#{member_el()}:nth-of-type(1)") |> text() =~ "Team Member"
       assert find(html, "#{member_el()}:nth-of-type(2)") |> text() =~ "You"
 
       save_layout(lv)


### PR DESCRIPTION
### Changes

- Improve the spacing and typography of the settings sidebars
- Improve the spacing between form components
- Change UI copy from Title Case to Sentence case for a more natural reading flow
- Improve subtitle and label copy

**Before:**
<img width="2936" height="1568" alt="CleanShot 2025-09-19 at 16 40 17@2x" src="https://github.com/user-attachments/assets/dc00b989-80f0-4344-beae-25b4bc032935" />

**After:**
<img width="1470" height="802" alt="CleanShot 2025-09-19 at 16 39 39@2x" src="https://github.com/user-attachments/assets/a817ded8-1241-4a9d-8dc6-9d08db694401" />

### Tests
- [x] Automated tests have been updated

### Dark mode
- [x] The UI has been tested both in dark and light mode
