### PR TITLE
Fix Sentry error in filter suggestions

### DIFF
--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -1427,13 +1427,20 @@ defmodule PlausibleWeb.Api.StatsController do
 
   def filter_suggestions(conn, params) do
     site = conn.assigns[:site]
+    search_query = params["q"]
 
-    query = Query.from(site, params, debug_metadata(conn))
+    if is_nil(search_query) do
+      conn
+      |> put_status(:bad_request)
+      |> json(%{"error" => "Search parameter 'q' is required"})
+    else
+      query = Query.from(site, params, debug_metadata(conn))
 
-    json(
-      conn,
-      Stats.filter_suggestions(site, query, params["filter_name"], params["q"])
-    )
+      json(
+        conn,
+        Stats.filter_suggestions(site, query, params["filter_name"], search_query)
+      )
+    end
   end
 
   def custom_prop_value_filter_suggestions(conn, %{"prop_key" => prop_key} = params) do

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -4,7 +4,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
   describe "GET /api/stats/:domain/suggestions/:filter_name" do
     setup [:create_user, :log_in, :create_site]
 
-    test "returns suggestions for pages without a query", %{conn: conn, site: site} do
+    test "returns suggestions for pages with empty query", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, timestamp: ~N[2019-01-01 23:00:00], pathname: "/"),
         build(:pageview, timestamp: ~N[2019-01-01 23:00:00], pathname: "/register"),
@@ -12,7 +12,8 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview, timestamp: ~N[2019-01-01 23:00:01], pathname: "/irrelevant")
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/suggestions/page?period=month&date=2019-01-01")
+      conn =
+        get(conn, "/api/stats/#{site.domain}/suggestions/page?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [
                %{"label" => "/", "value" => "/"},
@@ -83,7 +84,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/source?period=month&date=2019-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/source?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [
                %{"label" => "Direct / None", "value" => "Direct / None"},
@@ -103,7 +104,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/channel?period=month&date=2019-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/channel?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [
                %{"label" => "Organic Search", "value" => "Organic Search"},
@@ -197,7 +198,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         )
 
       assert json_response(conn, 400) == %{
-               "error" => "Query parameter 'q' is required"
+               "error" => "Search parameter 'q' is required"
              }
     end
 
@@ -211,7 +212,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/screen?period=month&date=2019-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/screen?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [%{"value" => "Desktop", "label" => "Desktop"}]
     end
@@ -226,7 +227,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/browser?period=month&date=2019-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/browser?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [%{"label" => "Chrome", "value" => "Chrome"}]
     end
@@ -245,7 +246,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/browser_version?period=month&date=2019-01-01&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/browser_version?period=month&date=2019-01-01&filters=#{filters}&q="
         )
 
       assert json_response(conn, 200) == [%{"value" => "78.0", "label" => "78.0"}]
@@ -256,7 +257,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
         build(:pageview, timestamp: ~N[2019-01-01 00:00:00], operating_system: "Mac")
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/suggestions/os?period=month&date=2019-01-01")
+      conn = get(conn, "/api/stats/#{site.domain}/suggestions/os?period=month&date=2019-01-01&q=")
 
       assert json_response(conn, 200) == [%{"value" => "Mac", "label" => "Mac"}]
     end
@@ -275,7 +276,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/os_version?period=month&date=2019-01-01&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/os_version?period=month&date=2019-01-01&filters=#{filters}&q="
         )
 
       assert json_response(conn, 200) == [%{"label" => "10.15", "value" => "10.15"}]
@@ -407,7 +408,10 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/referrer?period=month&date=2019-01-01")
+        get(
+          conn,
+          "/api/stats/#{site.domain}/suggestions/referrer?period=month&date=2019-01-01&q="
+        )
 
       assert json_response(conn, 200) == [
                %{"value" => "10words.com/page1", "label" => "10words.com/page1"}
@@ -453,7 +457,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&q=")
 
       assert json_response(conn, 200) == [
                %{"label" => "author", "value" => "author"},
@@ -538,7 +542,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&filters=#{filters}"
+          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&filters=#{filters}&q="
         )
 
       assert json_response(conn, 200) == [
@@ -572,7 +576,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&q=")
 
       assert json_response(conn, 200) == [
                %{"label" => "author", "value" => "author"}
@@ -603,7 +607,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       ])
 
       conn =
-        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01")
+        get(conn, "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&q=")
 
       suggestions = json_response(conn, 200)
       assert %{"label" => "author", "value" => "author"} in suggestions
@@ -1141,7 +1145,7 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       key_conn =
         get(
           conn,
-          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&with_imported=true"
+          "/api/stats/#{site.domain}/suggestions/prop_key?period=day&date=2022-01-01&with_imported=true&q="
         )
 
       assert json_response(key_conn, 200) == [%{"label" => "url", "value" => "url"}]

--- a/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/suggestions_test.exs
@@ -181,6 +181,26 @@ defmodule PlausibleWeb.Api.StatsController.SuggestionsTest do
       assert json_response(conn, 200) == []
     end
 
+    test "returns 400 for nil query parameter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          timestamp: ~N[2019-01-01 23:00:01],
+          pathname: "/",
+          country_code: "US"
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/suggestions/country?period=month&date=2019-01-01"
+        )
+
+      assert json_response(conn, 400) == %{
+               "error" => "Query parameter 'q' is required"
+             }
+    end
+
     test "returns suggestions for screen sizes", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview,


### PR DESCRIPTION
https://sentry.plausible.io/organizations/plausible/issues/47/?environment=prod&project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+downcase&referrer=issue-stream&statsPeriod=14d&stream_index=0
https://sentry.plausible.io/organizations/plausible/issues/46/?environment=prod&project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+downcase&referrer=issue-stream&statsPeriod=14d&stream_index=1
https://sentry.plausible.io/organizations/plausible/issues/1081/?environment=prod&project=2&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+downcase&referrer=issue-stream&statsPeriod=14d&stream_index=2

Not sure why we're getting requests to this endpoint with missing `q` parameter. Solving this by validating the existence of it and return 400 in case it's missing. A more defensive approach would be to default to empty string when missing and still return results, but I don't see why the frontend would send a request with missing `q` param.