### PR TITLE
Add tooltip to info icon in settings

### DIFF
--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -288,7 +288,7 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
       </PlausibleWeb.Components.Billing.paddle_button>
     <% end %>
     <div :if={@exceeded_plan_limits != [] && @disabled_message} class="flex flex-col items-center">
-      <.tooltip>
+      <.tooltip testid="plan-tooltip">
         <div class="h-0 text-sm">
           <div class="flex items-center text-red-700 dark:text-red-500 justify-center">
             {@disabled_message}

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -136,12 +136,16 @@ defmodule PlausibleWeb.Components.Generic do
 
   def docs_info(assigns) do
     ~H"""
-    <a href={"https://plausible.io/docs/#{@slug}"} rel="noopener noreferrer" target="_blank">
-      <Heroicons.information_circle class={[
-        "text-gray-400 dark:text-indigo-500 w-5 h-5 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors duration-150",
-        @class
-      ]} />
-    </a>
+    <div class={@class}>
+      <.tooltip enabled?={true} centered?={true}>
+        <:tooltip_content>
+          <span>Learn more</span>
+        </:tooltip_content>
+        <a href={"https://plausible.io/docs/#{@slug}"} rel="noopener noreferrer" target="_blank">
+          <Heroicons.information_circle class="text-gray-400 dark:text-indigo-500 size-5 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors duration-150" />
+        </a>
+      </.tooltip>
+    </div>
     """
   end
 
@@ -495,6 +499,8 @@ defmodule PlausibleWeb.Components.Generic do
 
   attr(:sticky?, :boolean, default: true)
   attr(:enabled?, :boolean, default: true)
+  attr(:centered?, :boolean, default: false)
+  attr(:testid, :string, default: nil)
   slot(:inner_block, required: true)
   slot(:tooltip_content, required: true)
 
@@ -504,7 +510,29 @@ defmodule PlausibleWeb.Components.Generic do
 
     show_inner = if assigns[:sticky?], do: "hovered || sticky", else: "hovered"
 
-    assigns = assign(assigns, wrapper_data: wrapper_data, show_inner: show_inner)
+    base_classes = [
+      "absolute",
+      "pb-2",
+      "top-0",
+      "-translate-y-full",
+      "z-[1000]",
+      "sm:max-w-72",
+      "whitespace-nowrap"
+    ]
+
+    tooltip_position_classes =
+      if assigns.centered? do
+        base_classes ++ ["left-1/2", "-translate-x-1/2"]
+      else
+        base_classes
+      end
+
+    assigns =
+      assign(assigns,
+        wrapper_data: wrapper_data,
+        show_inner: show_inner,
+        tooltip_position_classes: tooltip_position_classes
+      )
 
     if assigns.enabled? do
       ~H"""
@@ -517,7 +545,8 @@ defmodule PlausibleWeb.Components.Generic do
         <div
           x-cloak
           x-show={@show_inner}
-          class={["tooltip-content absolute pb-2 top-0 -translate-y-full z-[1000] sm:w-72"]}
+          class={@tooltip_position_classes}
+          data-testid={@testid}
           x-transition:enter="transition ease-out duration-200"
           x-transition:enter-start="opacity-0"
           x-transition:enter-end="opacity-100"
@@ -525,7 +554,7 @@ defmodule PlausibleWeb.Components.Generic do
           x-transition:leave-start="opacity-100"
           x-transition:leave-end="opacity-0"
         >
-          <div class="bg-gray-900 text-white rounded p-4 text-sm font-medium">
+          <div class="bg-gray-900 text-white rounded px-2.5 py-1.5 text-xs font-medium">
             {render_slot(@tooltip_content)}
           </div>
         </div>

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -29,7 +29,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     @slider_value "#slider-value"
 
     @starter_plan_box "#starter-plan-box"
-    @starter_plan_tooltip "#starter-plan-box .tooltip-content"
+    @starter_plan_tooltip "#starter-plan-box [data-testid='plan-tooltip']"
     @starter_price_tag_amount "#starter-price-tag-amount"
     @starter_price_tag_interval "#starter-price-tag-interval"
     @starter_discount_price_tag_amount "#starter-discount-price-tag-amount"
@@ -39,7 +39,7 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
     @starter_checkout_button "#starter-checkout"
 
     @growth_plan_box "#growth-plan-box"
-    @growth_plan_tooltip "#growth-plan-box .tooltip-content"
+    @growth_plan_tooltip "#growth-plan-box [data-testid='plan-tooltip']"
     @growth_price_tag_amount "#growth-price-tag-amount"
     @growth_price_tag_interval "#growth-price-tag-interval"
     @growth_discount_price_tag_amount "#growth-discount-price-tag-amount"


### PR DESCRIPTION
### Changes

- Add "Learn more" tooltip to the info icon that is used repeatedly in settings to link to docs, for extra affordance.
- Add centered? attribute to tooltip component.
- Replace the tooltip-content class with testid attribute, as it was only used for testing purposes.

<img width="532" height="286" alt="CleanShot 2025-09-22 at 13 47 49@2x" src="https://github.com/user-attachments/assets/97fdd86b-d707-41db-be99-986813e3da9c" />

### Tests
- [x] Automated tests have been added

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
