### PR TITLE
Improve site dropdown ui

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -284,7 +284,7 @@ defmodule PlausibleWeb.Components.Generic do
   attr(:rest, :global, include: ~w(method))
   slot(:inner_block, required: true)
 
-  @base_class "block rounded-lg text-sm/6 text-gray-900 ui-disabled:text-gray-500 dark:text-gray-100 dark:ui-disabled:text-gray-400 px-3.5 py-1.5"
+  @base_class "block rounded-md text-sm/6 text-gray-900 ui-disabled:text-gray-500 dark:text-gray-100 dark:ui-disabled:text-gray-400 px-3 py-1.5"
   @clickable_class "hover:bg-gray-100 dark:hover:bg-gray-700"
   def dropdown_item(assigns) do
     assigns =

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -69,7 +69,7 @@ defmodule PlausibleWeb.Live.Sites do
             data-test-id="team-settings-link"
             href={Routes.settings_path(@socket, :team_general)}
           >
-            <Heroicons.cog_6_tooth class="hidden group-hover:inline size-4 dark:text-gray-100 text-gray-900" />
+            <Heroicons.cog_6_tooth class="hidden group-hover:inline size-5 dark:text-gray-100 text-gray-900" />
           </.unstyled_link>
         </h2>
       </div>
@@ -191,7 +191,7 @@ defmodule PlausibleWeb.Live.Sites do
           <img
             src={"/favicon/sources/#{@site.domain}"}
             onerror="this.onerror=null; this.src='/favicon/sources/placeholder';"
-            class="w-4 h-4 flex-shrink-0 mt-px"
+            class="size-[1.15rem] flex-shrink-0"
           />
           <div class="flex-1 truncate -mt-px">
             <h3 class="text-gray-900 font-medium text-lg truncate dark:text-gray-100">
@@ -258,17 +258,17 @@ defmodule PlausibleWeb.Live.Sites do
   def ellipsis_menu(assigns) do
     ~H"""
     <.dropdown>
-      <:button class="size-10 rounded-md hover:cursor-pointer text-gray-400 dark:text-gray-600 hover:text-black dark:hover:text-indigo-400">
-        <Heroicons.ellipsis_vertical class="absolute top-3 right-3 size-4" />
+      <:button class="size-10 rounded-md hover:cursor-pointer text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
+        <Heroicons.ellipsis_vertical class="absolute top-3 right-3 size-5 transition-colors duration-150" />
       </:button>
       <:menu class="!mt-0 mr-4 min-w-40">
         <!-- adjust position because click area is much bigger than icon. Default positioning from click area looks weird -->
         <.dropdown_item
           :if={List.first(@site.memberships).role != :viewer}
           href={"/#{URI.encode_www_form(@site.domain)}/settings/general"}
-          class="!flex items-center gap-x-2"
+          class="group/item !flex items-center gap-x-2"
         >
-          <Heroicons.cog_6_tooth class="size-4" />
+          <Heroicons.cog_6_tooth class="size-5 text-gray-600 dark:text-gray-400 group-hover/item:text-gray-900 dark:group-hover/item:text-gray-100 transition-colors duration-150" />
           <span>Settings</span>
         </.dropdown_item>
 
@@ -284,25 +284,29 @@ defmodule PlausibleWeb.Live.Sites do
             |> JS.push("pin-toggle")
           }
           phx-value-domain={@site.domain}
-          class="!flex items-center gap-x-2"
+          class="group/item !flex items-center gap-x-2"
         >
           <.icon_pin
             :if={@site.pinned_at}
-            class="size-4 text-red-400 stroke-red-500 dark:text-yellow-600 dark:stroke-yellow-700"
+            filled={true}
+            class="size-[1.15rem] text-indigo-600 dark:text-indigo-500 group-hover/item:text-indigo-700 dark:group-hover/item:text-indigo-400 transition-colors duration-150"
           />
-          <span :if={@site.pinned_at}>Unpin Site</span>
+          <span :if={@site.pinned_at}>Unpin site</span>
 
-          <.icon_pin :if={!@site.pinned_at} class="size-4" />
-          <span :if={!@site.pinned_at}>Pin Site</span>
+          <.icon_pin
+            :if={!@site.pinned_at}
+            class="size-5 text-gray-600 dark:text-gray-400 group-hover/item:text-gray-900 dark:group-hover/item:text-gray-100 transition-colors duration-150"
+          />
+          <span :if={!@site.pinned_at}>Pin site</span>
         </.dropdown_item>
         <.dropdown_item
           :if={Application.get_env(:plausible, :environment) == "dev"}
           href={Routes.site_path(PlausibleWeb.Endpoint, :delete_site, @site.domain)}
           method="delete"
-          class="!flex items-center gap-x-2"
+          class="group/item !flex items-center gap-x-2"
         >
-          <Heroicons.trash class="size-4 text-red-500" />
-          <span class="text-red-500">[DEV ONLY] Quick Delete</span>
+          <Heroicons.trash class="size-5 text-red-500" />
+          <span class="text-red-500">[DEV ONLY] Quick delete</span>
         </.dropdown_item>
       </:menu>
     </.dropdown>
@@ -310,18 +314,21 @@ defmodule PlausibleWeb.Live.Sites do
   end
 
   attr(:rest, :global)
+  attr(:filled, :boolean, default: false)
 
   def icon_pin(assigns) do
     ~H"""
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      fill="currentColor"
-      viewBox="0 0 16 16"
+      viewBox="0 0 24 24"
+      fill={if @filled, do: "currentColor", else: "none"}
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.5"
       {@rest}
     >
-      <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
+      <path d="m4 20 4.5-4.5-.196.196M14.314 21.005l-5.657-5.657L3 9.69l1.228-1.228a3 3 0 0 1 3.579-.501l.58.322 7.34-5.664 5.658 5.657-5.665 7.34.323.581a3 3 0 0 1-.501 3.578l-1.228 1.229Z" />
     </svg>
     """
   end

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -310,7 +310,7 @@ defmodule PlausibleWeb.Live.SitesTest do
       assert text_of_element(
                html,
                ~s/li[data-domain="#{site.domain}"] a[phx-value-domain]/
-             ) == "Pin Site"
+             ) == "Pin site"
     end
 
     test "site state changes when pin toggled", %{conn: conn, user: user} do
@@ -327,7 +327,7 @@ defmodule PlausibleWeb.Live.SitesTest do
 
       assert html =~ "Site pinned"
 
-      assert text_of_element(html, button_selector) == "Unpin Site"
+      assert text_of_element(html, button_selector) == "Unpin site"
 
       html =
         lv
@@ -336,7 +336,7 @@ defmodule PlausibleWeb.Live.SitesTest do
 
       assert html =~ "Site unpinned"
 
-      assert text_of_element(html, button_selector) == "Pin Site"
+      assert text_of_element(html, button_selector) == "Pin site"
     end
 
     test "shows error when pins limit hit", %{conn: conn, user: user} do


### PR DESCRIPTION
### Changes

- Adjust icon sizes and colors to be consistent with the icons in settings
- Improve the pin icon to be consistent in look and feel with the Heroicons
- Changed pinned icon color from red to indigo

**Before:**
<table>
  <tr>
    <td>
      <img alt="CleanShot 2025-09-22 at 15 17 15@2x" src="https://github.com/user-attachments/assets/c2d9bc4d-8588-43a1-94dc-0a6a35f6fa59" width="100%" />
    </td>
    <td>
      <img alt="CleanShot 2025-09-22 at 15 17 26@2x" src="https://github.com/user-attachments/assets/77fe7ece-aae7-4bce-9609-3efd1aaba49f" width="100%" />
    </td>
  </tr>
</table>

**After:**
<table>
  <tr>
    <td>
      <img alt="CleanShot 2025-09-22 at 15 16 34@2x" src="https://github.com/user-attachments/assets/526a6bf2-4d71-4859-8fb6-b096febfbda8" width="100%" />
    </td>
    <td>
      <img alt="CleanShot 2025-09-22 at 15 16 55@2x" src="https://github.com/user-attachments/assets/edd9fc7a-218b-4ae9-bee2-978fdfe11c78" width="100%" />
    </td>
  </tr>
</table>


### Tests
- [x] This PR does not require tests

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode