### PR TITLE
Remove virtual rollups in favour of persisted consolidated sites

### DIFF
--- a/extra/lib/plausible/consolidated_view.ex
+++ b/extra/lib/plausible/consolidated_view.ex
@@ -35,7 +35,7 @@ defmodule Plausible.ConsolidatedView do
     :ok
   end
 
-  @spec site_ids(Team.t()) :: [pos_integer()] | {:error, :not_found}
+  @spec site_ids(Team.t()) :: {:ok, [pos_integer()]} | {:error, :not_found}
   def site_ids(%Team{} = team) do
     case get(team) do
       nil -> {:error, :not_found}

--- a/extra/lib/plausible/consolidated_view.ex
+++ b/extra/lib/plausible/consolidated_view.ex
@@ -43,6 +43,7 @@ defmodule Plausible.ConsolidatedView do
     end
   end
 
+  @spec native_stats_start_at(Team.t()) :: NaiveDateTime.t() | nil
   def native_stats_start_at(%Team{} = team) do
     q =
       from(sr in Site.regular(),

--- a/extra/lib/plausible/consolidated_view.ex
+++ b/extra/lib/plausible/consolidated_view.ex
@@ -71,8 +71,11 @@ defmodule Plausible.ConsolidatedView do
   defp do_enable(%Team{} = team) do
     case get(team) do
       nil ->
+        native_stats_start_at = native_stats_start_at(team)
+
         team
         |> Site.new_for_team(%{consolidated: true, domain: make_id(team)})
+        |> Site.set_native_stats_start_at(native_stats_start_at)
         |> Repo.insert()
 
       consolidated_view ->

--- a/extra/lib/plausible/consolidated_view.ex
+++ b/extra/lib/plausible/consolidated_view.ex
@@ -20,7 +20,7 @@ defmodule Plausible.ConsolidatedView do
     from s in q, where: s.consolidated == true
   end
 
-  @spec enable(Team.t()) :: {:ok, Site.t()} | {:error, :no_sites | :upgrade_required}
+  @spec enable(Team.t()) :: {:ok, Site.t()} | {:error, :no_sites}
   def enable(%Team{} = team) do
     with :ok <- ensure_eligible(team), do: do_enable(team)
   end
@@ -90,10 +90,10 @@ defmodule Plausible.ConsolidatedView do
   # TODO: Only active trials and business subscriptions should be eligible.
   # This function should also call a new underlying feature module.
   defp ensure_eligible(%Team{} = team) do
-    cond do
-      always(false) -> {:error, :upgrade_required}
-      Plausible.Teams.owned_sites_count(team) == 0 -> {:error, :no_sites}
-      true -> :ok
+    if Plausible.Teams.owned_sites_count(team) == 0 do
+      {:error, :no_sites}
+    else
+      :ok
     end
   end
 end

--- a/extra/lib/plausible/consolidated_view.ex
+++ b/extra/lib/plausible/consolidated_view.ex
@@ -43,6 +43,17 @@ defmodule Plausible.ConsolidatedView do
     end
   end
 
+  def native_stats_start_at(%Team{} = team) do
+    q =
+      from(sr in Site.regular(),
+        group_by: sr.team_id,
+        where: sr.team_id == ^team.id,
+        select: min(sr.native_stats_start_at)
+      )
+
+    Repo.one(q)
+  end
+
   @spec get(Team.t() | String.t()) :: Site.t() | nil
   def get(team_or_id)
 

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -58,12 +58,6 @@ defmodule Plausible.Application do
           n_lock_partitions: 1,
           ets_options: [read_concurrency: true, write_concurrency: true]
         ),
-        Plausible.Cache.Adapter.child_specs(:site_ids, :cache_site_ids,
-          ttl_check_interval: :timer.seconds(10),
-          global_ttl: :timer.minutes(30),
-          n_lock_partitions: 1,
-          ets_options: [read_concurrency: true, write_concurrency: true]
-        ),
         {Plausible.Session.Transfer,
          base_path: Application.get_env(:plausible, :session_transfer_dir)},
         warmed_cache(Plausible.Site.Cache,

--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -65,25 +65,11 @@ defmodule Plausible.Site do
 
     has_many :completed_imports, Plausible.Imported.SiteImport, where: [status: :completed]
 
-    field :rollup, :boolean, virtual: true, default: false
-
     timestamps()
   end
 
   def regular(q \\ __MODULE__) do
     from s in q, where: not s.consolidated
-  end
-
-  def rollup(team) do
-    %Plausible.Site{
-      id: 0,
-      native_stats_start_at: ~N[2018-01-01 00:00:00],
-      stats_start_date: ~D[2018-01-01],
-      rollup: true,
-      domain: "rollup:#{team.identifier}",
-      team: team,
-      team_id: team.id
-    }
   end
 
   def new_for_team(team, params) do

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -352,6 +352,21 @@ defmodule Plausible.Sites do
     date
   end
 
+  def stats_start_date(%Site{consolidated: true} = site) do
+    native_stats_start_at = Plausible.ConsolidatedView.native_stats_start_at(site.team)
+
+    if native_stats_start_at do
+      start_date = NaiveDateTime.to_date(native_stats_start_at)
+
+      site
+      |> Site.set_native_stats_start_at(native_stats_start_at)
+      |> Site.set_stats_start_date(start_date)
+      |> Repo.update!()
+
+      start_date
+    end
+  end
+
   def stats_start_date(%Site{} = site) do
     start_date =
       [

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -352,18 +352,20 @@ defmodule Plausible.Sites do
     date
   end
 
-  def stats_start_date(%Site{consolidated: true} = site) do
-    native_stats_start_at = Plausible.ConsolidatedView.native_stats_start_at(site.team)
+  on_ee do
+    def stats_start_date(%Site{consolidated: true} = site) do
+      native_stats_start_at = Plausible.ConsolidatedView.native_stats_start_at(site.team)
 
-    if native_stats_start_at do
-      start_date = NaiveDateTime.to_date(native_stats_start_at)
+      if native_stats_start_at do
+        start_date = NaiveDateTime.to_date(native_stats_start_at)
 
-      site
-      |> Site.set_native_stats_start_at(native_stats_start_at)
-      |> Site.set_stats_start_date(start_date)
-      |> Repo.update!()
+        site
+        |> Site.set_native_stats_start_at(native_stats_start_at)
+        |> Site.set_stats_start_date(start_date)
+        |> Repo.update!()
 
-      start_date
+        start_date
+      end
     end
   end
 

--- a/lib/plausible/stats/clickhouse.ex
+++ b/lib/plausible/stats/clickhouse.ex
@@ -84,6 +84,10 @@ defmodule Plausible.Stats.Clickhouse do
   end
 
   def has_pageviews?(site) do
+    # This function is currently only used in installation verification
+    # which is not accessible for consolidated views.
+    true = Plausible.Sites.regular?(site)
+
     ClickhouseRepo.exists?(
       from(e in "events_v2",
         where:

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -77,13 +77,17 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
-  def get_consolidated_site_ids(%Plausible.Site{} = site) do
-    if Plausible.Sites.consolidated?(site) do
-      {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
-      site_ids
-    else
-      nil
+  on_ee do
+    def get_consolidated_site_ids(%Plausible.Site{} = site) do
+      if Plausible.Sites.consolidated?(site) do
+        {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
+        site_ids
+      else
+        nil
+      end
     end
+  else
+    def get_consolidated_site_ids(_site), do: nil
   end
 
   def parse_date_range_pair(site, [from, to]) when is_binary(from) and is_binary(to) do

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -82,8 +82,6 @@ defmodule Plausible.Stats.Filters.QueryParser do
       if Plausible.Sites.consolidated?(site) do
         {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
         site_ids
-      else
-        nil
       end
     end
   else

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -80,8 +80,7 @@ defmodule Plausible.Stats.Filters.QueryParser do
   on_ee do
     def get_consolidated_site_ids(%Plausible.Site{} = site) do
       if Plausible.Sites.consolidated?(site) do
-        {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
-        site_ids
+        Plausible.ConsolidatedView.Cache.get(site.team.identifier)
       end
     end
   else

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -79,7 +79,8 @@ defmodule Plausible.Stats.Filters.QueryParser do
 
   def get_consolidated_site_ids(%Plausible.Site{} = site) do
     if Plausible.Sites.consolidated?(site) do
-      Plausible.ConsolidatedView.site_ids(site.team)
+      {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
+      site_ids
     else
       nil
     end

--- a/lib/plausible/stats/filters/query_parser.ex
+++ b/lib/plausible/stats/filters/query_parser.ex
@@ -47,10 +47,10 @@ defmodule Plausible.Stats.Filters.QueryParser do
          {:ok, pagination} <- parse_pagination(Map.get(params, "pagination", %{})),
          {preloaded_goals, revenue_warning, revenue_currencies} <-
            preload_goals_and_revenue(site, metrics, filters, dimensions),
-         rollup_site_ids = get_rollup_site_ids(site),
+         consolidated_site_ids = get_consolidated_site_ids(site),
          query = %{
            now: now,
-           rollup_site_ids: rollup_site_ids,
+           consolidated_site_ids: consolidated_site_ids,
            input_date_range: Map.get(params, "date_range"),
            metrics: metrics,
            filters: filters,
@@ -77,13 +77,13 @@ defmodule Plausible.Stats.Filters.QueryParser do
     end
   end
 
-  def get_rollup_site_ids(%Plausible.Site{rollup: true} = site) do
-    Plausible.Cache.Adapter.get(:site_ids, site.team_id, fn ->
-      Plausible.Teams.owned_sites_ids(site.team)
-    end)
+  def get_consolidated_site_ids(%Plausible.Site{} = site) do
+    if Plausible.Sites.consolidated?(site) do
+      Plausible.ConsolidatedView.site_ids(site.team)
+    else
+      nil
+    end
   end
-
-  def get_rollup_site_ids(_site), do: nil
 
   def parse_date_range_pair(site, [from, to]) when is_binary(from) and is_binary(to) do
     with {:ok, date_range} <- date_range_from_date_strings(site, from, to) do

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -45,7 +45,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
   on_ee do
     defp put_consolidated_site_ids(query, %Plausible.Site{} = site) do
       if Plausible.Sites.consolidated?(site) do
-        {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
+        site_ids = Plausible.ConsolidatedView.Cache.get(site.team.identifier)
         struct!(query, consolidated_site_ids: site_ids)
       else
         query

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -42,13 +42,17 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     query
   end
 
-  defp put_consolidated_site_ids(query, %Plausible.Site{} = site) do
-    if Plausible.Sites.consolidated?(site) do
-      {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
-      struct!(query, consolidated_site_ids: site_ids)
-    else
-      query
+  on_ee do
+    defp put_consolidated_site_ids(query, %Plausible.Site{} = site) do
+      if Plausible.Sites.consolidated?(site) do
+        {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
+        struct!(query, consolidated_site_ids: site_ids)
+      else
+        query
+      end
     end
+  else
+    defp put_consolidated_site_ids(query, _site), do: query
   end
 
   defp resolve_segments(query, site) do

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -44,7 +44,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
 
   defp put_consolidated_site_ids(query, %Plausible.Site{} = site) do
     if Plausible.Sites.consolidated?(site) do
-      site_ids = Plausible.ConsolidatedView.site_ids(site.team)
+      {:ok, site_ids} = Plausible.ConsolidatedView.site_ids(site.team)
       struct!(query, consolidated_site_ids: site_ids)
     else
       query

--- a/lib/plausible/stats/legacy/legacy_query_builder.ex
+++ b/lib/plausible/stats/legacy/legacy_query_builder.ex
@@ -28,7 +28,7 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
       |> put_parsed_filters(params)
       |> resolve_segments(site)
       |> preload_goals_and_revenue(site)
-      |> put_rollup_site_ids(site)
+      |> put_consolidated_site_ids(site)
       |> put_order_by(params)
       |> put_include(site, params)
       |> Query.put_comparison_utc_time_range()
@@ -42,16 +42,14 @@ defmodule Plausible.Stats.Legacy.QueryBuilder do
     query
   end
 
-  defp put_rollup_site_ids(query, %Plausible.Site{rollup: true} = site) do
-    site_ids =
-      Plausible.Cache.Adapter.get(:site_ids, site.team_id, fn ->
-        Plausible.Teams.owned_sites_ids(site.team)
-      end)
-
-    struct!(query, rollup_site_ids: site_ids)
+  defp put_consolidated_site_ids(query, %Plausible.Site{} = site) do
+    if Plausible.Sites.consolidated?(site) do
+      site_ids = Plausible.ConsolidatedView.site_ids(site.team)
+      struct!(query, consolidated_site_ids: site_ids)
+    else
+      query
+    end
   end
-
-  defp put_rollup_site_ids(query, _site), do: query
 
   defp resolve_segments(query, site) do
     with {:ok, preloaded_segments} <-

--- a/lib/plausible/stats/query.ex
+++ b/lib/plausible/stats/query.ex
@@ -26,7 +26,7 @@ defmodule Plausible.Stats.Query do
             revenue_warning: nil,
             remove_unavailable_revenue_metrics: false,
             site_id: nil,
-            rollup_site_ids: nil,
+            consolidated_site_ids: nil,
             site_native_stats_start_at: nil,
             # Contains information to determine how to combine legacy and new time on page metrics
             time_on_page_data: %{},

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -48,7 +48,7 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
   defp filter_site_id(query) do
     case query.consolidated_site_ids do
       nil -> dynamic([x], x.site_id == ^query.site_id)
-      ids -> dynamic([x], fragment("? in ?", x.site_id, ^ids))
+      [_ | _] = ids -> dynamic([x], fragment("? in ?", x.site_id, ^ids))
     end
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -60,7 +60,9 @@ defmodule PlausibleWeb.StatsController do
     can_see_stats? = not Teams.locked?(site.team) or site_role == :super_admin
     demo = site.domain == "plausible.io"
     dogfood_page_path = if demo, do: "/#{site.domain}", else: "/:dashboard"
-    skip_to_dashboard? = conn.params["skip_to_dashboard"] == "true"
+
+    skip_to_dashboard? =
+      conn.params["skip_to_dashboard"] == "true" or Plausible.Sites.consolidated?(site)
 
     {:ok, segments} = Plausible.Segments.get_all_for_site(site, site_role)
 

--- a/lib/plausible_web/live/verification.ex
+++ b/lib/plausible_web/live/verification.ex
@@ -32,6 +32,8 @@ defmodule PlausibleWeb.Live.Verification do
         ]
       )
 
+    true = Plausible.Sites.regular?(site)
+
     private = Map.get(socket.private.connect_info, :private, %{})
 
     super_admin? = Plausible.Auth.is_super_admin?(current_user)

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -177,7 +177,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   defp find_site(site_id) do
     domain_based_search =
-      from s in Plausible.Site.regular(),
+      from s in Plausible.Site,
         where: s.domain == ^site_id or s.domain_changed_from == ^site_id
 
     case Repo.one(domain_based_search) do

--- a/lib/plausible_web/plugs/authorize_public_api.ex
+++ b/lib/plausible_web/plugs/authorize_public_api.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
 
   defp verify_by_scope(conn, api_key, "stats:read:" <> _ = scope) do
     with :ok <- check_scope(api_key, scope),
-         {:ok, site} <- find_site(conn.params["site_id"], api_key),
+         {:ok, site} <- find_site(conn.params["site_id"]),
          :ok <- verify_site_access(api_key, site) do
       Plausible.OpenTelemetry.add_site_attributes(site)
       site = Plausible.Repo.preload(site, :completed_imports)
@@ -173,18 +173,9 @@ defmodule PlausibleWeb.Plugs.AuthorizePublicAPI do
     end
   end
 
-  defp find_site(nil, _api_key), do: {:error, :missing_site_id}
+  defp find_site(nil), do: {:error, :missing_site_id}
 
-  defp find_site("rollup:" <> team_identifier, api_key) do
-    with true <- Plausible.Auth.is_super_admin?(api_key.user),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
-      {:ok, Plausible.Site.rollup(team)}
-    else
-      _ -> {:error, :invalid_api_key}
-    end
-  end
-
-  defp find_site(site_id, _api_key) do
+  defp find_site(site_id) do
     domain_based_search =
       from s in Plausible.Site.regular(),
         where: s.domain == ^site_id or s.domain_changed_from == ^site_id

--- a/lib/plausible_web/plugs/authorize_site_access.ex
+++ b/lib/plausible_web/plugs/authorize_site_access.ex
@@ -172,15 +172,6 @@ defmodule PlausibleWeb.Plugs.AuthorizeSiteAccess do
     end
   end
 
-  defp get_site_with_role(conn, current_user, "rollup:" <> team_identifier) do
-    with true <- Plausible.Auth.is_super_admin?(current_user),
-         %Plausible.Teams.Team{} = team <- Plausible.Teams.get(team_identifier) do
-      {:ok, %{site: Plausible.Site.rollup(team), role: nil, member_type: nil}}
-    else
-      _ -> error_not_found(conn)
-    end
-  end
-
   defp get_site_with_role(conn, current_user, domain) do
     site = Repo.get_by(Plausible.Site, domain: domain)
 

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2717,8 +2717,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
 
     test "is set to a list of site_ids when site is consolidated", %{site: site} do
-      Plausible.ConsolidatedView.enable(site.team)
-      cv = Plausible.ConsolidatedView.get(site.team) |> Plausible.Repo.preload(:team)
+      cv = new_consolidated_view(site.team)
 
       params = %{
         "site_id" => site.domain,

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -78,7 +78,7 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
         :preloaded_goals,
         :revenue_warning,
         :revenue_currencies,
-        :rollup_site_ids
+        :consolidated_site_ids
       ])
 
     assert result == expected_result

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2705,6 +2705,8 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
   end
 
   describe "query.consolidated_site_ids" do
+    @describetag :ee_only
+
     test "is set to nil when site is regular", %{site: site} do
       params = %{
         "site_id" => site.domain,

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2703,4 +2703,33 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
       )
     end
   end
+
+  describe "query.consolidated_site_ids" do
+    test "is set to nil when site is regular", %{site: site} do
+      params = %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors"],
+        "date_range" => "all"
+      }
+
+      {:ok, %{consolidated_site_ids: nil}} = parse(site, :public, params)
+      {:ok, %{consolidated_site_ids: nil}} = parse(site, :internal, params)
+    end
+
+    test "is set to a list of site_ids when site is consolidated", %{site: site} do
+      Plausible.ConsolidatedView.enable(site.team)
+      cv = Plausible.ConsolidatedView.get(site.team) |> Plausible.Repo.preload(:team)
+
+      params = %{
+        "site_id" => site.domain,
+        "metrics" => ["visitors"],
+        "date_range" => "all"
+      }
+
+      site_id = site.id
+
+      assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :public, params)
+      assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :internal, params)
+    end
+  end
 end

--- a/test/plausible/stats/query_parser_test.exs
+++ b/test/plausible/stats/query_parser_test.exs
@@ -2704,33 +2704,33 @@ defmodule Plausible.Stats.Filters.QueryParserTest do
     end
   end
 
-  describe "query.consolidated_site_ids" do
-    @describetag :ee_only
+  on_ee do
+    describe "query.consolidated_site_ids" do
+      test "is set to nil when site is regular", %{site: site} do
+        params = %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors"],
+          "date_range" => "all"
+        }
 
-    test "is set to nil when site is regular", %{site: site} do
-      params = %{
-        "site_id" => site.domain,
-        "metrics" => ["visitors"],
-        "date_range" => "all"
-      }
+        {:ok, %{consolidated_site_ids: nil}} = parse(site, :public, params)
+        {:ok, %{consolidated_site_ids: nil}} = parse(site, :internal, params)
+      end
 
-      {:ok, %{consolidated_site_ids: nil}} = parse(site, :public, params)
-      {:ok, %{consolidated_site_ids: nil}} = parse(site, :internal, params)
-    end
+      test "is set to a list of site_ids when site is consolidated", %{site: site} do
+        cv = new_consolidated_view(site.team)
 
-    test "is set to a list of site_ids when site is consolidated", %{site: site} do
-      cv = new_consolidated_view(site.team)
+        params = %{
+          "site_id" => site.domain,
+          "metrics" => ["visitors"],
+          "date_range" => "all"
+        }
 
-      params = %{
-        "site_id" => site.domain,
-        "metrics" => ["visitors"],
-        "date_range" => "all"
-      }
+        site_id = site.id
 
-      site_id = site.id
-
-      assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :public, params)
-      assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :internal, params)
+        assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :public, params)
+        assert {:ok, %{consolidated_site_ids: [^site_id]}} = parse(cv, :internal, params)
+      end
     end
   end
 end

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -486,6 +486,8 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   describe "query.consolidated_site_ids" do
+    @describetag :ee_only
+
     test "is set to nil when site is regular", %{site: site} do
       assert %{consolidated_site_ids: nil} = Query.from(site, %{"period" => "day"})
     end

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -491,8 +491,7 @@ defmodule Plausible.Stats.QueryTest do
     end
 
     test "is set to a list of site_ids when site is consolidated", %{site: site} do
-      Plausible.ConsolidatedView.enable(site.team)
-      cv = Plausible.ConsolidatedView.get(site.team) |> Plausible.Repo.preload(:team)
+      cv = new_consolidated_view(site.team)
 
       site_id = site.id
       assert %{consolidated_site_ids: [^site_id]} = Query.from(cv, %{"period" => "day"})

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -485,18 +485,18 @@ defmodule Plausible.Stats.QueryTest do
     end
   end
 
-  describe "query.consolidated_site_ids" do
-    @describetag :ee_only
+  on_ee do
+    describe "query.consolidated_site_ids" do
+      test "is set to nil when site is regular", %{site: site} do
+        assert %{consolidated_site_ids: nil} = Query.from(site, %{"period" => "day"})
+      end
 
-    test "is set to nil when site is regular", %{site: site} do
-      assert %{consolidated_site_ids: nil} = Query.from(site, %{"period" => "day"})
-    end
+      test "is set to a list of site_ids when site is consolidated", %{site: site} do
+        cv = new_consolidated_view(site.team)
 
-    test "is set to a list of site_ids when site is consolidated", %{site: site} do
-      cv = new_consolidated_view(site.team)
-
-      site_id = site.id
-      assert %{consolidated_site_ids: [^site_id]} = Query.from(cv, %{"period" => "day"})
+        site_id = site.id
+        assert %{consolidated_site_ids: [^site_id]} = Query.from(cv, %{"period" => "day"})
+      end
     end
   end
 end

--- a/test/plausible/stats/query_test.exs
+++ b/test/plausible/stats/query_test.exs
@@ -484,4 +484,18 @@ defmodule Plausible.Stats.QueryTest do
                })
     end
   end
+
+  describe "query.consolidated_site_ids" do
+    test "is set to nil when site is regular", %{site: site} do
+      assert %{consolidated_site_ids: nil} = Query.from(site, %{"period" => "day"})
+    end
+
+    test "is set to a list of site_ids when site is consolidated", %{site: site} do
+      Plausible.ConsolidatedView.enable(site.team)
+      cv = Plausible.ConsolidatedView.get(site.team) |> Plausible.Repo.preload(:team)
+
+      site_id = site.id
+      assert %{consolidated_site_ids: [^site_id]} = Query.from(cv, %{"period" => "day"})
+    end
+  end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -1,33 +1,34 @@
 defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
   use PlausibleWeb.ConnCase
-  use Plausible.Teams.Test
 
-  @moduletag :ee_only
+  on_ee do
+    use Plausible.Teams.Test
 
-  setup [:create_user, :create_team, :create_site, :create_api_key, :use_api_key]
+    setup [:create_user, :create_team, :create_site, :create_api_key, :use_api_key]
 
-  test "simple aggregate query across all consolidated site_ids", %{
-    team: team,
-    site: site,
-    conn: conn
-  } do
-    another_site = new_site(team: team)
-    cv = new_consolidated_view(team)
+    test "simple aggregate query across all consolidated site_ids", %{
+      team: team,
+      site: site,
+      conn: conn
+    } do
+      another_site = new_site(team: team)
+      cv = new_consolidated_view(team)
 
-    cv
-    |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2020-01-01 12:00:00]})
-    |> Plausible.Repo.update!()
+      cv
+      |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2020-01-01 12:00:00]})
+      |> Plausible.Repo.update!()
 
-    populate_stats(site, [build(:pageview)])
-    populate_stats(another_site, [build(:pageview)])
+      populate_stats(site, [build(:pageview)])
+      populate_stats(another_site, [build(:pageview)])
 
-    conn =
-      post(conn, "/api/v2/query", %{
-        "site_id" => cv.domain,
-        "date_range" => "all",
-        "metrics" => ["visitors"]
-      })
+      conn =
+        post(conn, "/api/v2/query", %{
+          "site_id" => cv.domain,
+          "date_range" => "all",
+          "metrics" => ["visitors"]
+        })
 
-    assert %{"results" => [%{"metrics" => [2]}]} = json_response(conn, 200)
+      assert %{"results" => [%{"metrics" => [2]}]} = json_response(conn, 200)
+    end
   end
 end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -14,6 +14,10 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
     another_site = new_site(team: team)
     cv = new_consolidated_view(team)
 
+    cv
+    |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2020-01-01 12:00:00]})
+    |> Plausible.Repo.update!()
+
     populate_stats(site, [build(:pageview)])
     populate_stats(another_site, [build(:pageview)])
 

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -10,7 +10,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
     conn: conn
   } do
     another_site = new_site(team: team)
-    {:ok, cv} = Plausible.ConsolidatedView.enable(team)
+    cv = new_consolidated_view(team)
 
     populate_stats(site, [build(:pageview)])
     populate_stats(another_site, [build(:pageview)])

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -1,0 +1,27 @@
+defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
+  use PlausibleWeb.ConnCase
+  use Plausible.Teams.Test
+
+  setup [:create_user, :create_team, :create_site, :create_api_key, :use_api_key]
+
+  test "simple aggregate query across all consolidated site_ids", %{
+    team: team,
+    site: site,
+    conn: conn
+  } do
+    another_site = new_site(team: team)
+    {:ok, cv} = Plausible.ConsolidatedView.enable(team)
+
+    populate_stats(site, [build(:pageview)])
+    populate_stats(another_site, [build(:pageview)])
+
+    conn =
+      post(conn, "/api/v2/query", %{
+        "site_id" => cv.domain,
+        "date_range" => "all",
+        "metrics" => ["visitors"]
+      })
+
+    assert %{"results" => [%{"metrics" => [2]}]} = json_response(conn, 200)
+  end
+end

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
   use PlausibleWeb.ConnCase
   use Plausible.Teams.Test
 
+  @moduletag :ee_only
+
   setup [:create_user, :create_team, :create_site, :create_api_key, :use_api_key]
 
   test "simple aggregate query across all consolidated site_ids", %{

--- a/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/query_consolidated_view_test.exs
@@ -14,10 +14,6 @@ defmodule PlausibleWeb.Api.ExternalStatsController.QueryConsolidatedViewTest do
       another_site = new_site(team: team)
       cv = new_consolidated_view(team)
 
-      cv
-      |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2020-01-01 12:00:00]})
-      |> Plausible.Repo.update!()
-
       populate_stats(site, [build(:pageview)])
       populate_stats(another_site, [build(:pageview)])
 

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -2143,6 +2143,56 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
                }
              ]
     end
+
+    test "returns pages across all sites on a consolidated view", %{conn: conn, site: site} do
+      another_site = new_site(team: site.team)
+      cv = new_consolidated_view(site.team)
+
+      populate_stats(site, [
+        build(:pageview, pathname: "/a1", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      populate_stats(another_site, [
+        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{cv.domain}/pages?period=day&date=2021-01-01&detailed=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "bounce_rate" => 100,
+                 "name" => "/b1",
+                 "pageviews" => 3,
+                 "time_on_page" => nil,
+                 "visitors" => 3,
+                 "scroll_depth" => nil
+               },
+               %{
+                 "bounce_rate" => 100,
+                 "name" => "/a2",
+                 "pageviews" => 2,
+                 "time_on_page" => nil,
+                 "visitors" => 2,
+                 "scroll_depth" => nil
+               },
+               %{
+                 "bounce_rate" => 100,
+                 "name" => "/a1",
+                 "pageviews" => 1,
+                 "time_on_page" => nil,
+                 "visitors" => 1,
+                 "scroll_depth" => nil
+               }
+             ]
+    end
   end
 
   describe "GET /api/stats/:domain/entry-pages" do

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -2149,10 +2149,6 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
         another_site = new_site(team: site.team)
         cv = new_consolidated_view(site.team)
 
-        cv
-        |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2021-01-01 00:00:00]})
-        |> Plausible.Repo.update()
-
         populate_stats(site, [
           build(:pageview, pathname: "/a1", timestamp: ~N[2021-01-01 00:00:00]),
           build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00]),

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -2149,6 +2149,10 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
       another_site = new_site(team: site.team)
       cv = new_consolidated_view(site.team)
 
+      cv
+      |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2021-01-01 00:00:00]})
+      |> Plausible.Repo.update()
+
       populate_stats(site, [
         build(:pageview, pathname: "/a1", timestamp: ~N[2021-01-01 00:00:00]),
         build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00]),

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -2144,6 +2144,7 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
+    @tag :ee_only
     test "returns pages across all sites on a consolidated view", %{conn: conn, site: site} do
       another_site = new_site(team: site.team)
       cv = new_consolidated_view(site.team)

--- a/test/plausible_web/controllers/api/stats_controller/pages_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_test.exs
@@ -2144,59 +2144,60 @@ defmodule PlausibleWeb.Api.StatsController.PagesTest do
              ]
     end
 
-    @tag :ee_only
-    test "returns pages across all sites on a consolidated view", %{conn: conn, site: site} do
-      another_site = new_site(team: site.team)
-      cv = new_consolidated_view(site.team)
+    on_ee do
+      test "returns pages across all sites on a consolidated view", %{conn: conn, site: site} do
+        another_site = new_site(team: site.team)
+        cv = new_consolidated_view(site.team)
 
-      cv
-      |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2021-01-01 00:00:00]})
-      |> Plausible.Repo.update()
+        cv
+        |> Ecto.Changeset.change(%{native_stats_start_at: ~N[2021-01-01 00:00:00]})
+        |> Plausible.Repo.update()
 
-      populate_stats(site, [
-        build(:pageview, pathname: "/a1", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00])
-      ])
+        populate_stats(site, [
+          build(:pageview, pathname: "/a1", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, pathname: "/a2", timestamp: ~N[2021-01-01 00:00:00])
+        ])
 
-      populate_stats(another_site, [
-        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
-        build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00])
-      ])
+        populate_stats(another_site, [
+          build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00]),
+          build(:pageview, pathname: "/b1", timestamp: ~N[2021-01-01 00:00:00])
+        ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{cv.domain}/pages?period=day&date=2021-01-01&detailed=true"
-        )
+        conn =
+          get(
+            conn,
+            "/api/stats/#{cv.domain}/pages?period=day&date=2021-01-01&detailed=true"
+          )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "bounce_rate" => 100,
-                 "name" => "/b1",
-                 "pageviews" => 3,
-                 "time_on_page" => nil,
-                 "visitors" => 3,
-                 "scroll_depth" => nil
-               },
-               %{
-                 "bounce_rate" => 100,
-                 "name" => "/a2",
-                 "pageviews" => 2,
-                 "time_on_page" => nil,
-                 "visitors" => 2,
-                 "scroll_depth" => nil
-               },
-               %{
-                 "bounce_rate" => 100,
-                 "name" => "/a1",
-                 "pageviews" => 1,
-                 "time_on_page" => nil,
-                 "visitors" => 1,
-                 "scroll_depth" => nil
-               }
-             ]
+        assert json_response(conn, 200)["results"] == [
+                 %{
+                   "bounce_rate" => 100,
+                   "name" => "/b1",
+                   "pageviews" => 3,
+                   "time_on_page" => nil,
+                   "visitors" => 3,
+                   "scroll_depth" => nil
+                 },
+                 %{
+                   "bounce_rate" => 100,
+                   "name" => "/a2",
+                   "pageviews" => 2,
+                   "time_on_page" => nil,
+                   "visitors" => 2,
+                   "scroll_depth" => nil
+                 },
+                 %{
+                   "bounce_rate" => 100,
+                   "name" => "/a1",
+                   "pageviews" => 1,
+                   "time_on_page" => nil,
+                   "visitors" => 1,
+                   "scroll_depth" => nil
+                 }
+               ]
+      end
     end
   end
 

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -149,52 +149,52 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
-    @tag :ee_only
-    test "first view of a consolidated dashboard sets stats_start_date and native_stats_start_at according to native_stats_start_at of the earliest team site",
-         %{
-           conn: conn,
-           site: site,
-           user: user
-         } do
-      team = team_of(user)
-      now = NaiveDateTime.utc_now(:second)
-      ten_days_ago = NaiveDateTime.add(now, -10, :day)
-      twenty_days_ago = NaiveDateTime.add(now, -20, :day)
+    on_ee do
+      test "first view of a consolidated dashboard sets stats_start_date and native_stats_start_at according to native_stats_start_at of the earliest team site",
+           %{
+             conn: conn,
+             site: site,
+             user: user
+           } do
+        team = team_of(user)
+        now = NaiveDateTime.utc_now(:second)
+        ten_days_ago = NaiveDateTime.add(now, -10, :day)
+        twenty_days_ago = NaiveDateTime.add(now, -20, :day)
 
-      site
-      |> Plausible.Site.set_native_stats_start_at(ten_days_ago)
-      |> Plausible.Repo.update!()
+        site
+        |> Plausible.Site.set_native_stats_start_at(ten_days_ago)
+        |> Plausible.Repo.update!()
 
-      new_site(team: team, native_stats_start_at: twenty_days_ago)
-      cv = new_consolidated_view(team)
+        new_site(team: team, native_stats_start_at: twenty_days_ago)
+        cv = new_consolidated_view(team)
 
-      conn = get(conn, "/" <> cv.domain)
-      resp = html_response(conn, 200)
+        conn = get(conn, "/" <> cv.domain)
+        resp = html_response(conn, 200)
 
-      assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
-      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
-      assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
-      assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
+        assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
+        assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+        assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
+        assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
 
-      cv = Plausible.Repo.reload(cv)
-      assert cv.stats_start_date == NaiveDateTime.to_date(twenty_days_ago)
-      assert cv.native_stats_start_at == twenty_days_ago
-    end
+        cv = Plausible.Repo.reload(cv)
+        assert cv.stats_start_date == NaiveDateTime.to_date(twenty_days_ago)
+        assert cv.native_stats_start_at == twenty_days_ago
+      end
 
-    @tag :ee_only
-    test "does not redirect consolidated views to verification", %{
-      conn: conn,
-      user: user
-    } do
-      cv = user |> team_of() |> new_consolidated_view()
+      test "does not redirect consolidated views to verification", %{
+        conn: conn,
+        user: user
+      } do
+        cv = user |> team_of() |> new_consolidated_view()
 
-      conn = get(conn, "/" <> cv.domain)
-      resp = html_response(conn, 200)
+        conn = get(conn, "/" <> cv.domain)
+        resp = html_response(conn, 200)
 
-      assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
-      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
-      assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
-      assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
+        assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
+        assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+        assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
+        assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
+      end
     end
 
     @tag :ee_only

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -149,6 +149,21 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
+    test "does not redirect consolidated views to verification", %{
+      conn: conn,
+      user: user
+    } do
+      cv = user |> team_of() |> new_consolidated_view()
+
+      conn = get(conn, "/" <> cv.domain)
+      resp = html_response(conn, 200)
+
+      assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+      assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
+      assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
+    end
+
     @tag :ee_only
     test "header, stats are shown; footer is not shown", %{conn: conn, site: site, user: user} do
       populate_stats(site, [build(:pageview)])

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -150,6 +150,38 @@ defmodule PlausibleWeb.StatsControllerTest do
     end
 
     @tag :ee_only
+    test "first view of a consolidated dashboard sets stats_start_date and native_stats_start_at according to native_stats_start_at of the earliest team site",
+         %{
+           conn: conn,
+           site: site,
+           user: user
+         } do
+      team = team_of(user)
+      now = NaiveDateTime.utc_now(:second)
+      ten_days_ago = NaiveDateTime.add(now, -10, :day)
+      twenty_days_ago = NaiveDateTime.add(now, -20, :day)
+
+      site
+      |> Plausible.Site.set_native_stats_start_at(ten_days_ago)
+      |> Plausible.Repo.update!()
+
+      new_site(team: team, native_stats_start_at: twenty_days_ago)
+      cv = new_consolidated_view(team)
+
+      conn = get(conn, "/" <> cv.domain)
+      resp = html_response(conn, 200)
+
+      assert text_of_attr(resp, @react_container, "data-domain") == cv.domain
+      assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
+      assert text_of_attr(resp, @react_container, "data-current-user-role") == "owner"
+      assert text_of_attr(resp, @react_container, "data-current-user-id") == "#{user.id}"
+
+      cv = Plausible.Repo.reload(cv)
+      assert cv.stats_start_date == NaiveDateTime.to_date(twenty_days_ago)
+      assert cv.native_stats_start_at == twenty_days_ago
+    end
+
+    @tag :ee_only
     test "does not redirect consolidated views to verification", %{
       conn: conn,
       user: user

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -149,6 +149,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
+    @tag :ee_only
     test "does not redirect consolidated views to verification", %{
       conn: conn,
       user: user

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -28,10 +28,6 @@ defmodule Plausible.Teams.Test do
       {:ok, site} = Plausible.ConsolidatedView.enable(team)
       site
     end
-  else
-    # Keeping the function available on CE so that ee_only tests can be
-    # excluded by tags without having to wrap them into on_ee blocks.
-    def new_consolidated_view(_), do: {:error, :ee_only}
   end
 
   def new_site(args \\ []) do

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -28,6 +28,10 @@ defmodule Plausible.Teams.Test do
       {:ok, site} = Plausible.ConsolidatedView.enable(team)
       site
     end
+  else
+    # Keeping the function available on CE so that ee_only tests can be
+    # excluded by tags without having to wrap them into on_ee blocks.
+    def new_consolidated_view(_), do: {:error, :ee_only}
   end
 
   def new_site(args \\ []) do

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -23,6 +23,10 @@ defmodule Plausible.Teams.Test do
     Plug.Conn.put_session(conn, :current_team_id, team.identifier)
   end
 
+  def new_consolidated_view(team) do
+    new_site(team: team, domain: team.identifier, consolidated: true)
+  end
+
   def new_site(args \\ []) do
     args =
       cond do

--- a/test/support/teams/test.ex
+++ b/test/support/teams/test.ex
@@ -23,8 +23,11 @@ defmodule Plausible.Teams.Test do
     Plug.Conn.put_session(conn, :current_team_id, team.identifier)
   end
 
-  def new_consolidated_view(team) do
-    new_site(team: team, domain: team.identifier, consolidated: true)
+  on_ee do
+    def new_consolidated_view(team) do
+      {:ok, site} = Plausible.ConsolidatedView.enable(team)
+      site
+    end
   end
 
   def new_site(args \\ []) do


### PR DESCRIPTION
### Changes

Get rid of the current virtual rollups and replace them with consolidated views. Note that there's no functionality for creating any consolidated views yet, other than calling `Plausible.ConsolidatedView.enable(team)` manually from `iex -S mix`. The next PR will make it possible to create consolidated views from the CRM.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
