### PR TITLE
Improve the notice component visually

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -6,22 +6,22 @@ defmodule PlausibleWeb.Components.Generic do
 
   @notice_themes %{
     gray: %{
-      bg: "bg-gray-100 dark:bg-gray-700/50",
-      icon: "text-gray-400",
-      title_text: "text-sm text-gray-800 dark:text-gray-300",
-      body_text: "text-sm text-gray-700 dark:text-gray-400 leading-5"
+      bg: "bg-gray-150 dark:bg-gray-700/50",
+      icon: "text-gray-600 dark:text-gray-300",
+      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      body_text: "text-sm text-gray-600 dark:text-gray-300 leading-5"
     },
     yellow: %{
-      bg: "bg-yellow-50 dark:bg-yellow-100",
-      icon: "text-yellow-400",
-      title_text: "text-sm text-yellow-800 dark:text-yellow-900",
-      body_text: "text-sm text-yellow-700 dark:text-yellow-800 leading-5"
+      bg: "bg-yellow-100/60 dark:bg-yellow-900/40",
+      icon: "text-yellow-500",
+      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
     },
     red: %{
-      bg: "bg-red-100",
-      icon: "text-red-700",
-      title_text: "text-sm text-red-800 dark:text-red-900",
-      body_text: "text-sm text-red-700 dark:text-red-800"
+      bg: "bg-red-100 dark:bg-red-900/50",
+      icon: "text-red-600",
+      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
     }
   }
 
@@ -161,7 +161,7 @@ defmodule PlausibleWeb.Components.Generic do
 
     ~H"""
     <div id={@dismissable_id} class={[@dismissable_id && "hidden"]}>
-      <div class={["rounded-md p-4 relative", @theme.bg, @class]} {@rest}>
+      <div class={["rounded-md p-5 relative", @theme.bg, @class]} {@rest}>
         <button
           :if={@dismissable_id}
           class={"absolute right-0 top-0 m-2 #{@theme.title_text}"}
@@ -169,7 +169,7 @@ defmodule PlausibleWeb.Components.Generic do
         >
           <Heroicons.x_mark class="h-4 w-4 hover:stroke-2" />
         </button>
-        <div class="flex">
+        <div class="flex gap-x-3">
           <div :if={@title} class="flex-shrink-0">
             <svg
               class={"h-5 w-5 #{@theme.icon}"}
@@ -184,8 +184,8 @@ defmodule PlausibleWeb.Components.Generic do
               />
             </svg>
           </div>
-          <div class={["w-full", @title && "ml-3"]}>
-            <h3 :if={@title} class={"font-medium #{@theme.title_text} mb-2"}>
+          <div class="w-full flex flex-col gap-y-1.5">
+            <h3 :if={@title} class={"font-medium #{@theme.title_text}"}>
               {@title}
             </h3>
             <div class={"#{@theme.body_text}"}>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -61,8 +61,8 @@ defmodule PlausibleWeb.LayoutView do
         %{key: "Funnels", value: "funnels", icon: :funnel}
       end,
       %{key: "Custom properties", value: "properties", icon: :document_text},
-      %{key: "Integrations", value: "integrations", icon: :arrow_path_rounded_square},
-      %{key: "Imports & exports", value: "imports-exports", icon: :arrows_up_down},
+      %{key: "Integrations", value: "integrations", icon: :puzzle_piece},
+      %{key: "Imports & exports", value: "imports-exports", icon: :arrow_down_tray},
       %{
         key: "Shields",
         icon: :shield_exclamation,


### PR DESCRIPTION
### Changes

- Adjust text and background color for light and dark mode
- Adjust spacing
- Swap two icons in site settings sidebar (unrelated to notice component)

**Notice component before:**
<img width="1736" height="268" alt="CleanShot 2025-09-23 at 17 02 16@2x" src="https://github.com/user-attachments/assets/56167828-e0f0-4304-bb82-840875d2fe05" />
<img width="1716" height="266" alt="CleanShot 2025-09-23 at 17 02 32@2x" src="https://github.com/user-attachments/assets/ea2638f8-3775-49d2-887a-ef05500a386c" />
<img width="1718" height="264" alt="CleanShot 2025-09-23 at 17 02 47@2x" src="https://github.com/user-attachments/assets/6c607e32-accd-4076-b01a-51ec59bb3fe7" />
<img width="1736" height="264" alt="CleanShot 2025-09-23 at 17 03 40@2x" src="https://github.com/user-attachments/assets/de8cd351-f44b-4dd1-adee-b5b9b4371a19" />
<img width="1716" height="258" alt="CleanShot 2025-09-23 at 17 03 27@2x" src="https://github.com/user-attachments/assets/c5bd89e2-1900-4e83-908c-3ca1067715c1" />
<img width="1718" height="254" alt="CleanShot 2025-09-23 at 17 03 11@2x" src="https://github.com/user-attachments/assets/2d9a9ff3-e922-48fd-b0c7-e3f133c1bc29" />

**Notice component  after:**
<img width="1730" height="280" alt="CleanShot 2025-09-23 at 17 01 52@2x" src="https://github.com/user-attachments/assets/783e8634-9b98-45a8-a95f-92ced7a56387" />
<img width="1714" height="278" alt="CleanShot 2025-09-23 at 17 01 30@2x" src="https://github.com/user-attachments/assets/8469312c-76be-47c3-9af6-4497ae7f5ba7" />
<img width="1716" height="278" alt="CleanShot 2025-09-23 at 17 01 07@2x" src="https://github.com/user-attachments/assets/708f256f-b057-4692-a1c3-cdd99a62804e" />
<img width="1726" height="274" alt="CleanShot 2025-09-23 at 16 59 19@2x" src="https://github.com/user-attachments/assets/172b43be-787d-4ac8-81d1-047bb67617f7" />
<img width="1698" height="258" alt="CleanShot 2025-09-23 at 16 58 41@2x" src="https://github.com/user-attachments/assets/d3de4cc5-9f89-4c41-93a4-2902e0f56ca2" />
<img width="1740" height="274" alt="CleanShot 2025-09-23 at 16 59 37@2x" src="https://github.com/user-attachments/assets/deb4c4b9-bfc6-4445-9b5c-fd81c8f0996b" />


| **Icons before:** | **Icons after:** |
|---------|---------|
| <img width="622" height="328" alt="CleanShot 2025-09-23 at 17 22 15@2x" src="https://github.com/user-attachments/assets/f73e5399-69f1-4f99-9b1b-4ab8e3b3f806" /> | <img width="620" height="306" alt="CleanShot 2025-09-23 at 17 22 28@2x" src="https://github.com/user-attachments/assets/5cd09dde-87f4-4b6d-8766-2ce4619399cb" /> |

### Tests
- [x] This PR does not require tests

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode