### PR TITLE
Consolidated lifecycle

### DIFF
--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -20,6 +20,10 @@ defmodule Plausible.Site.Removal do
       Teams.Invitations.prune_guest_invitations(site.team)
 
       on_ee do
+        if not Plausible.ConsolidatedView.has_sites_to_consolidate?(site.team) do
+          Plausible.ConsolidatedView.disable(site.team)
+        end
+
         Plausible.Billing.SiteLocker.update_for(site.team, send_email?: false)
       end
 

--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -20,7 +20,8 @@ defmodule Plausible.Site.Removal do
       Teams.Invitations.prune_guest_invitations(site.team)
 
       on_ee do
-        if not Plausible.ConsolidatedView.has_sites_to_consolidate?(site.team) do
+        if Plausible.ConsolidatedView.enabled?(site.team) and
+             not Plausible.ConsolidatedView.has_sites_to_consolidate?(site.team) do
           Plausible.ConsolidatedView.disable(site.team)
         end
 

--- a/lib/plausible/site/removal.ex
+++ b/lib/plausible/site/removal.ex
@@ -20,7 +20,7 @@ defmodule Plausible.Site.Removal do
       Teams.Invitations.prune_guest_invitations(site.team)
 
       on_ee do
-        if Plausible.ConsolidatedView.enabled?(site.team) and
+        if Plausible.Sites.regular?(site) and Plausible.ConsolidatedView.enabled?(site.team) and
              not Plausible.ConsolidatedView.has_sites_to_consolidate?(site.team) do
           Plausible.ConsolidatedView.disable(site.team)
         end

--- a/test/plausible/consolidated_view_test.exs
+++ b/test/plausible/consolidated_view_test.exs
@@ -7,13 +7,13 @@ defmodule Plausible.ConsolidatedViewTest do
     alias Plausible.ConsolidatedView
     import Plausible.Teams.Test
 
-    describe "enable/1" do
+    describe "enable/1 and enabled?/1" do
       setup [:create_user, :create_team]
 
       test "creates and persists a new consolidated site instance", %{team: team} do
         new_site(team: team)
         assert {:ok, %Plausible.Site{consolidated: true}} = ConsolidatedView.enable(team)
-        assert ConsolidatedView.get(team)
+        assert ConsolidatedView.enabled?(team)
       end
 
       test "is idempotent", %{team: team} do
@@ -30,6 +30,7 @@ defmodule Plausible.ConsolidatedViewTest do
 
       test "returns {:error, :no_sites} when the team does not have any sites", %{team: team} do
         assert {:error, :no_sites} = ConsolidatedView.enable(team)
+        refute ConsolidatedView.enabled?(team)
       end
 
       @tag :skip

--- a/test/plausible/site/site_removal_test.exs
+++ b/test/plausible/site/site_removal_test.exs
@@ -39,18 +39,49 @@ defmodule Plausible.Site.SiteRemovalTest do
     refute Repo.reload(team_invitation)
   end
 
-  @tag :ee_only
-  test "site deletion updates team dashboard lock state" do
-    owner = new_user(team: [locked: true])
-    site = new_site(owner: owner)
-    team = site.team
+  on_ee do
+    test "site deletion updates team dashboard lock state" do
+      owner = new_user(team: [locked: true])
+      site = new_site(owner: owner)
+      team = site.team
 
-    assert team.locked
+      assert team.locked
 
-    assert {:ok, context} = Removal.run(site)
-    assert context.delete_all == {1, nil}
-    refute Sites.get_by_domain(site.domain)
+      assert {:ok, context} = Removal.run(site)
+      assert context.delete_all == {1, nil}
+      refute Sites.get_by_domain(site.domain)
 
-    refute Repo.reload(team).locked
+      refute Repo.reload(team).locked
+    end
+
+    test "site deletion disables consolidated view if need be" do
+      owner = new_user()
+      site = new_site(owner: owner)
+      team = team_of(owner)
+
+      {:ok, _} = Plausible.ConsolidatedView.enable(team)
+      assert Plausible.ConsolidatedView.enabled?(team)
+
+      assert {:ok, _} = Removal.run(site)
+
+      refute Plausible.ConsolidatedView.enabled?(team)
+    end
+
+    test "site deletion keeps consolidated view if there's still regular sites" do
+      owner = new_user()
+      site = new_site(owner: owner)
+
+      # another site
+      new_site(owner: owner)
+
+      team = team_of(owner)
+
+      {:ok, _} = Plausible.ConsolidatedView.enable(team)
+      assert Plausible.ConsolidatedView.enabled?(team)
+
+      assert {:ok, _} = Removal.run(site)
+
+      assert Plausible.ConsolidatedView.enabled?(team)
+    end
   end
 end


### PR DESCRIPTION
### Changes

With this change, regular site removal disables consolidated view, if there's no sites to consolidate any more.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
