### PR TITLE
Add Consolidated Views tab to /cs

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/team.ex
+++ b/extra/lib/plausible_web/live/customer_support/team.ex
@@ -11,6 +11,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
     Overview,
     Members,
     Sites,
+    ConsolidatedViews,
     Billing,
     SSO,
     Audit
@@ -139,6 +140,9 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
         <.tab to="sites" tab={@tab}>
           Sites ({number_format(@usage.sites)}/{number_format(@limits.sites)})
         </.tab>
+        <.tab to="consolidated_views" tab={@tab}>
+          Consolidated Views
+        </.tab>
         <.tab :if={has_sso_integration?(@team)} to="sso" tab={@tab}>SSO</.tab>
         <.tab to="billing" tab={@tab}>Billing</.tab>
         <.tab to="audit" tab={@tab}>Audit</.tab>
@@ -208,6 +212,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.Team do
   defp tab_component("overview"), do: Overview
   defp tab_component("members"), do: Members
   defp tab_component("sites"), do: Sites
+  defp tab_component("consolidated_views"), do: ConsolidatedViews
   defp tab_component("billing"), do: Billing
   defp tab_component("sso"), do: SSO
   defp tab_component("audit"), do: Audit

--- a/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
+++ b/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
@@ -1,0 +1,95 @@
+defmodule PlausibleWeb.CustomerSupport.Team.Components.ConsolidatedViews do
+  @moduledoc """
+  [Experimental - new feature]
+
+  Lists ConsolidatedViews of a team and allows creating one if none exist. Current
+  limitation is one consolidated view per team, which always includes all sites of
+  this team.
+  """
+  use PlausibleWeb, :live_component
+  import PlausibleWeb.CustomerSupport.Live
+
+  def update(%{team: team}, socket) do
+    cvs =
+      case Plausible.ConsolidatedView.get(team) do
+        nil -> []
+        cv -> [cv]
+      end
+
+    {:ok, assign(socket, team: team, consolidated_views: cvs)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="mt-2 mb-4">
+      <%= if Enum.empty?(@consolidated_views) do %>
+        <div class="mx-auto flex flex-col items-center">
+          <p>This team does not have a consolidated view yet.</p>
+          <.button class="mx-auto" phx-click="create-consolidated-view" phx-target={@myself}>
+            Create one
+          </.button>
+        </div>
+      <% else %>
+        <.table rows={@consolidated_views}>
+          <:thead>
+            <.th>Domain</.th>
+            <.th>Timezone</.th>
+            <.th invisible>Dashboard</.th>
+            <.th invisible>Settings</.th>
+            <.th invisible>Delete</.th>
+          </:thead>
+
+          <:tbody :let={consolidated_view}>
+            <.td>{consolidated_view.domain}</.td>
+            <.td>{consolidated_view.timezone}</.td>
+            <.td>
+              <.styled_link
+                new_tab={true}
+                href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, consolidated_view.domain, [])}
+              >
+                Dashboard
+              </.styled_link>
+            </.td>
+            <.td>
+              <.styled_link
+                new_tab={true}
+                href={
+                  Routes.site_path(
+                    PlausibleWeb.Endpoint,
+                    :settings_general,
+                    consolidated_view.domain,
+                    []
+                  )
+                }
+              >
+                Settings
+              </.styled_link>
+            </.td>
+            <.td>
+              <.delete_button phx-click="delete-consolidated-view" phx-target={@myself} />
+            </.td>
+          </:tbody>
+        </.table>
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("create-consolidated-view", _, socket) do
+    case Plausible.ConsolidatedView.enable(socket.assigns.team) do
+      {:ok, cv} ->
+        success("Consolidated view created")
+        {:noreply, assign(socket, consolidated_views: [cv])}
+
+      {:error, _} ->
+        failure("Could not create consolidated View")
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("delete-consolidated-view", _, socket) do
+    Plausible.ConsolidatedView.disable(socket.assigns.team)
+    success("Deleted consolidated view")
+    {:noreply, assign(socket, consolidated_views: [])}
+  end
+end

--- a/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
+++ b/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
@@ -21,7 +21,7 @@ defmodule PlausibleWeb.CustomerSupport.Team.Components.ConsolidatedViews do
 
   def render(assigns) do
     ~H"""
-    <div class="mt-2 mb-4">
+    <div data-test-id="consolidated-views-tab-content" class="mt-2 mb-4">
       <%= if Enum.empty?(@consolidated_views) do %>
         <div class="mx-auto flex flex-col items-center">
           <p>This team does not have a consolidated view yet.</p>


### PR DESCRIPTION
### Changes

Adds a new tab in the CS to manage consolidated views.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
