### PR TITLE
Configure promex metrics sent by `Persistor.EmbeddedWithRelay`

### DIFF
--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -76,6 +76,16 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
           tags: [:step]
         ),
         distribution(
+          metric_prefix ++ [:remote_ingest, :events, :pipeline, :steps],
+          event_name: Ingestion.Persistor.EmbeddedWithRelay.telemetry_pipeline_step_duration(),
+          reporter_options: [
+            buckets: [10, 50, 100, 250, 350, 500, 1000, 5000, 10_000, 100_000, 500_000]
+          ],
+          unit: {:native, :microsecond},
+          measurement: :duration,
+          tags: [:step]
+        ),
+        distribution(
           metric_prefix ++ [:sessions, :cache, :register, :lock],
           event_name: Plausible.Session.CacheStore.lock_telemetry_event(),
           reporter_options: [
@@ -91,6 +101,15 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         counter(
           metric_prefix ++ [:ingest, :events, :dropped, :total],
           event_name: Ingestion.Event.telemetry_event_dropped(),
+          tags: [:reason]
+        ),
+        counter(
+          metric_prefix ++ [:remote_ingest, :events, :buffered, :total],
+          event_name: Ingestion.Persistor.EmbeddedWithRelay.telemetry_event_buffered()
+        ),
+        counter(
+          metric_prefix ++ [:remote_ingest, :events, :dropped, :total],
+          event_name: Ingestion.Persistor.EmbeddedWithRelay.telemetry_event_dropped(),
           tags: [:reason]
         ),
         counter(


### PR DESCRIPTION
### Changes

Expose newly introduced metrics for relayed persistor setup.


