### PR TITLE
Crm consolidated views followup

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
+++ b/extra/lib/plausible_web/live/customer_support/team/components/consolidated_views.ex
@@ -29,7 +29,6 @@ defmodule PlausibleWeb.CustomerSupport.Team.Components.ConsolidatedViews do
             <.th>Domain</.th>
             <.th>Timezone</.th>
             <.th invisible>Dashboard</.th>
-            <.th invisible>Settings</.th>
             <.th invisible>Delete</.th>
           </:thead>
 
@@ -42,21 +41,6 @@ defmodule PlausibleWeb.CustomerSupport.Team.Components.ConsolidatedViews do
                 href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, consolidated_view.domain, [])}
               >
                 Dashboard
-              </.styled_link>
-            </.td>
-            <.td>
-              <.styled_link
-                new_tab={true}
-                href={
-                  Routes.site_path(
-                    PlausibleWeb.Endpoint,
-                    :settings_general,
-                    consolidated_view.domain,
-                    []
-                  )
-                }
-              >
-                Settings
               </.styled_link>
             </.td>
             <.td>

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -218,7 +218,6 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
 
         assert table_text =~ team.identifier
         assert table_text =~ "Dashboard"
-        assert table_text =~ "Settings"
 
         assert element_exists?(html, @delete_consolidated_view_button)
       end


### PR DESCRIPTION
### Changes

This PR addresses the review comments left on https://github.com/plausible/analytics/pull/5761. Also, removes the settings link for consolidated views in CS, as settings are currently not functional and would trigger unnecessary Sentry errors.