### PR TITLE
Don't log `no_session_for_engagement` errors coming from persistor

### DIFF
--- a/lib/plausible/ingestion/persistor/remote.ex
+++ b/lib/plausible/ingestion/persistor/remote.ex
@@ -38,6 +38,9 @@ defmodule Plausible.Ingestion.Persistor.Remote do
             {:error, :persist_decode_error}
         end
 
+      {:ok, %{body: "no_session_for_engagement"}} ->
+        {:error, :no_session_for_engagement}
+
       {:ok, %{body: error}} ->
         log_error(site_id, current_user_id, previous_user_id, error)
         {:error, decode_error(error)}

--- a/test/plausible/ingestion/persistor_test.exs
+++ b/test/plausible/ingestion/persistor_test.exs
@@ -147,16 +147,14 @@ defmodule Plausible.Ingestion.PersistorTest do
 
     Bypass.expect_once(bypass, "POST", "/event", fn conn ->
       conn
-      |> Plug.Conn.resp(500, "no_session_for_engagement")
+      |> Plug.Conn.resp(422, "no_session_for_engagement")
     end)
 
-    assert capture_log(fn ->
-             assert {:error, :no_session_for_engagement} =
-                      Persistor.persist_event(ingest_event, nil,
-                        backend: Persistor.Remote,
-                        url: bypass_url(bypass)
-                      )
-           end) =~ "no_session_for_engagement"
+    assert {:error, :no_session_for_engagement} =
+             Persistor.persist_event(ingest_event, nil,
+               backend: Persistor.Remote,
+               url: bypass_url(bypass)
+             )
   end
 
   test "remote persistor failing due to lock timeout" do


### PR DESCRIPTION
### Changes

"no_session_for_engagement" is an error that is expected to happen under normal circumstances. This PR stops explicitly logging it. The respective test got also updated to reflect that persistor returns this error with 422 HTTP code and not 500.

### Tests
- [x] Automated tests have been updated
