### PR TITLE
Broadcast consolidated view cache updates across the cluster

### DIFF
--- a/lib/plausible/cache.ex
+++ b/lib/plausible/cache.ex
@@ -64,6 +64,19 @@ defmodule Plausible.Cache do
       alias Plausible.Cache.Adapter
       require Logger
 
+      @spec broadcast_put(any(), Keyword.t()) :: :ok
+      def broadcast_put(key, value, opts \\ []) do
+        cache_name = Keyword.get(opts, :cache_name, name())
+        multicall_timeout = Keyword.get(opts, :multicall_timeout, :timer.seconds(5))
+
+        {:ok, _} =
+          Task.start(fn ->
+            :rpc.multicall(Adapter, :put, [cache_name, key, value, opts], multicall_timeout)
+          end)
+
+        :ok
+      end
+
       @spec get(any(), Keyword.t()) :: any() | nil
       def get(key, opts \\ []) when is_list(opts) do
         cache_name = Keyword.get(opts, :cache_name, name())

--- a/test/plausible/cache_test.exs
+++ b/test/plausible/cache_test.exs
@@ -115,6 +115,15 @@ defmodule Plausible.CacheTest do
       assert :changed == ExampleCache.get("item1", cache_name: test, force?: true)
       assert :item2 == ExampleCache.get("item2", cache_name: test, force?: true)
     end
+
+    test "broadcast_put puts into local cache", %{test: test} do
+      {:ok, _} = start_test_cache(test)
+      :ok = ExampleCache.broadcast_put("item1", :item1, cache_name: test)
+
+      assert eventually(fn ->
+               {ExampleCache.get("item1", cache_name: test, force?: true) == :item1, :ok}
+             end)
+    end
   end
 
   describe "warming the cache" do

--- a/test/plausible/consolidated_view_test.exs
+++ b/test/plausible/consolidated_view_test.exs
@@ -51,6 +51,15 @@ defmodule Plausible.ConsolidatedViewTest do
         assert view.native_stats_start_at == min
         assert view.stats_start_date == NaiveDateTime.to_date(min)
       end
+
+      test "enable/1 updates cache", %{team: team} do
+        site = new_site(team: team)
+        {:ok, _} = ConsolidatedView.enable(team)
+
+        assert eventually(fn ->
+                 {ConsolidatedView.Cache.get(team.identifier) == [site.id], :ok}
+               end)
+      end
     end
 
     describe "disable/1" do


### PR DESCRIPTION
### Changes

This PR ensures enabling consolidated view for a team, attempts to perform cluster-aware partial cache update, instead of relying on periodic refresh cycles exclusively. 

This is UX improvement - because the dashboard is making multiple queries, each of which may end up on different application node (with inconsistent cache state) and thus leading up to a situation in which some of the stats are not immediately available upon enabling the consolidation.

This is lazy "best effort". We are not interested in resolving any internal networking issues, for example when some of the nodes fail to respond due to cluster corruption, be it temporary or permanent. The RPC timeout is gracious 5 seconds by default and the RPC call itself is run in a "fire & forget" manner.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
