### PR TITLE
Fix wrapping in .tooltip

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -543,7 +543,8 @@ defmodule PlausibleWeb.Components.Generic do
       "-translate-y-full",
       "z-[1000]",
       "sm:max-w-72",
-      "whitespace-nowrap"
+      "whitespace-normal",
+      "break-words"
     ]
 
     tooltip_position_classes =


### PR DESCRIPTION
### Changes

Tries to fix issue from Tailwind 4 upgrade that makes tooltips overflow. Apparently in the new version "whitespace-nowrap" is stronger than it used to be.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
