### PR TITLE
Improve logging on failed browserless requests

### DIFF
--- a/extra/lib/plausible/installation_support/checks/detection.ex
+++ b/extra/lib/plausible/installation_support/checks/detection.ex
@@ -121,9 +121,11 @@ defmodule Plausible.InstallationSupport.Checks.Detection do
     end
   end
 
-  defp handle_browserless_response(state, _body, status) do
+  defp handle_browserless_response(state, body, status) do
     error = "Unhandled browserless response with status: #{status}"
-    Logger.warning(warning_message(error, state))
+
+    warning_message("#{error}; body: #{inspect(body)}", state)
+    |> Logger.warning()
 
     put_diagnostics(state, service_error: error)
   end

--- a/extra/lib/plausible/installation_support/checks/installation_v2.ex
+++ b/extra/lib/plausible/installation_support/checks/installation_v2.ex
@@ -146,9 +146,11 @@ defmodule Plausible.InstallationSupport.Checks.InstallationV2 do
     end
   end
 
-  defp handle_browserless_response(state, _body, status) do
+  defp handle_browserless_response(state, body, status) do
     error = "Unhandled browserless response with status: #{status}"
-    Logger.warning(warning_message(error, state))
+
+    warning_message("#{error}; body: #{inspect(body)}", state)
+    |> Logger.warning()
 
     put_diagnostics(state, service_error: error)
   end


### PR DESCRIPTION
### Changes

Whenever there's an unexpected browserless response (without the key `completed` in the payload), we'll also log the request body.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
