### PR TITLE
Increase detection call timeout

### DIFF
--- a/extra/lib/plausible/installation_support/checks/detection.ex
+++ b/extra/lib/plausible/installation_support/checks/detection.ex
@@ -54,10 +54,10 @@ defmodule Plausible.InstallationSupport.Checks.Detection do
   """
 
   # We define a timeout for the browserless endpoint call to avoid waiting too long for a response
-  @endpoint_timeout_ms 2_000
+  @endpoint_timeout_ms 3_000
 
   # This timeout determines how long we wait for window.plausible to be initialized on the page, used for detecting whether v1 installed
-  @plausible_window_check_timeout_ms 1_500
+  @plausible_window_check_timeout_ms 2_000
 
   # To support browserless API being unavailable or overloaded, we retry the endpoint call if it doesn't return a successful response
   @max_retries 1

--- a/extra/lib/plausible/installation_support/checks/detection.ex
+++ b/extra/lib/plausible/installation_support/checks/detection.ex
@@ -57,7 +57,7 @@ defmodule Plausible.InstallationSupport.Checks.Detection do
   @endpoint_timeout_ms 3_000
 
   # This timeout determines how long we wait for window.plausible to be initialized on the page, used for detecting whether v1 installed
-  @plausible_window_check_timeout_ms 2_000
+  @plausible_window_check_timeout_ms 1_500
 
   # To support browserless API being unavailable or overloaded, we retry the endpoint call if it doesn't return a successful response
   @max_retries 1


### PR DESCRIPTION
### Changes

Increases detection call timeout. The idea is to prefer to get a timeout from the inner function that's run on the site, rather than destroy the whole function context. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
