### PR TITLE
fix responsive layout for invitation reject button

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -549,6 +549,7 @@ defmodule PlausibleWeb.Live.Sites do
               href="#"
               theme="bright"
               data-method="post"
+              class="w-full sm:w-auto mr-2 sm:text-sm"
               data-csrf={Plug.CSRFProtection.get_csrf_token()}
               x-bind:data-to="selectedInvitation && ('/sites/invitations/' + selectedInvitation.invitation.invitation_id + '/reject')"
             >


### PR DESCRIPTION
### Changes

Add a styling class to the invitation reject button to enhance its layout and responsiveness for mobile view.

<img width="486" height="926" alt="image" src="https://github.com/user-attachments/assets/b3b64eee-c578-424d-8d7d-b46ccc6b96fa" />


Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests

- [x] This PR does not require tests




