### PR TITLE
Fine tune sampling logic: filter estimate multiplier and cap filter exponent

### DIFF
--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -97,7 +97,9 @@ defmodule Plausible.Stats.Sampling do
     estimate_by_filters(duration_adjusted_traffic, query.filters)
   end
 
-  @filter_traffic_multiplier 1 / 20.0
+  @filter_traffic_multiplier 1 / 4.0
+  @max_filters 2
+
   defp estimate_by_filters(estimation, filters),
-    do: estimation * @filter_traffic_multiplier ** length(filters)
+    do: estimation * @filter_traffic_multiplier ** min(length(filters), @max_filters)
 end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -46,10 +46,20 @@ defmodule Plausible.Stats.SamplingTest do
         assert fractional_sample_rate(@threshold * 50, query(30, filters: [])) == 0.02
 
         assert fractional_sample_rate(@threshold * 50, query(30, filters: [@filter])) ==
-                 0.40
+                 0.08
 
         assert fractional_sample_rate(
                  @threshold * 50,
+                 query(30, filters: [@filter, @filter])
+               ) == 0.32
+
+        assert fractional_sample_rate(
+                 @threshold * 50,
+                 query(30, filters: [@filter, @filter, @filter])
+               ) == 0.32
+
+        assert fractional_sample_rate(
+                 @threshold * 10,
                  query(30, filters: [@filter, @filter])
                ) == :no_sampling
       end


### PR DESCRIPTION
### Changes

This change reduces the risk of dropping sampling when querying very large quantities of data due to too aggressive relaxation of sampling threshold when applying filters. The cap on the exponent ensures there's a clear upper boundary. The multiplier got adjusted as well so that sampling is not reduced as sharply with a second (and further) filter.

### Tests
- [x] Automated tests have been added

