### PR TITLE
Adjust secure headers for shared links to avoid breaking embeds

### DIFF
--- a/lib/plausible_web/plugs/secure_embed_headers.ex
+++ b/lib/plausible_web/plugs/secure_embed_headers.ex
@@ -1,0 +1,22 @@
+defmodule PlausibleWeb.Plugs.SecureEmbedHeaders do
+  @moduledoc """
+  Sets secure headers tailored for embedded content.
+  """
+
+  import Plug.Conn
+
+  def init(_opts) do
+    []
+  end
+
+  def call(conn, _opts) do
+    merge_resp_headers(
+      conn,
+      [
+        {"referrer-policy", "strict-origin-when-cross-origin"},
+        {"x-content-type-options", "nosniff"},
+        {"x-permitted-cross-domain-policies", "none"}
+      ]
+    )
+  end
+end

--- a/lib/plausible_web/plugs/secure_embed_headers.ex
+++ b/lib/plausible_web/plugs/secure_embed_headers.ex
@@ -1,4 +1,4 @@
-defmodule PlausibleWeb.Plugs.SecureHeaders do
+defmodule PlausibleWeb.Plugs.SecureEmbedHeaders do
   @moduledoc """
   Sets secure headers tailored for embedded content.
   """

--- a/lib/plausible_web/plugs/secure_headers.ex
+++ b/lib/plausible_web/plugs/secure_headers.ex
@@ -1,4 +1,4 @@
-defmodule PlausibleWeb.Plugs.SecureEmbedHeaders do
+defmodule PlausibleWeb.Plugs.SecureHeaders do
   @moduledoc """
   Sets secure headers tailored for embedded content.
   """

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_live_flash
-    plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.SecureHeaders
     plug PlausibleWeb.Plugs.NoRobots
     on_ee(do: nil, else: plug(PlausibleWeb.FirstLaunchPlug, redirect_to: "/register"))
     plug PlausibleWeb.AuthPlug
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Router do
 
   pipeline :shared_link do
     plug :accepts, ["html"]
-    plug PlausibleWeb.Plugs.SecureEmbedHeaders
+    plug PlausibleWeb.Plugs.SecureHeaders
     plug PlausibleWeb.Plugs.NoRobots
     plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Router do
 
   pipeline :shared_link do
     plug :accepts, ["html"]
-    plug :put_secure_browser_headers
+    plug PlausibleWeb.Plugs.SecureEmbedHeaders
     plug PlausibleWeb.Plugs.NoRobots
     plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -8,7 +8,7 @@ defmodule PlausibleWeb.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_live_flash
-    plug PlausibleWeb.Plugs.SecureHeaders
+    plug :put_secure_browser_headers
     plug PlausibleWeb.Plugs.NoRobots
     on_ee(do: nil, else: plug(PlausibleWeb.FirstLaunchPlug, redirect_to: "/register"))
     plug PlausibleWeb.AuthPlug
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Router do
 
   pipeline :shared_link do
     plug :accepts, ["html"]
-    plug PlausibleWeb.Plugs.SecureHeaders
+    plug PlausibleWeb.Plugs.SecureEmbedHeaders
     plug PlausibleWeb.Plugs.NoRobots
     plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
   end


### PR DESCRIPTION
### Changes

Recent Phoenix update introduced `content-security-policy` header which breaks embedding. This PR replaces default secure headers with a custom version with CSP removed, just for shared links. We might revise it further in the future following something like https://help.docebo.com/hc/en-us/articles/15539609538194-Configuring-your-site-content-security-policy-for-embedded-learning