### PR TITLE
Set `protocols` in persistor pool config instead of deprecated `protocol`

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -281,7 +281,7 @@ defmodule Plausible.Application do
         persistor_url,
         Config.Reader.merge(
           default,
-          protocol: :http2,
+          protocols: [:http2],
           count: count,
           conn_opts: [transport_opts: [timeout: timeout_ms]]
         )


### PR DESCRIPTION
`protocol` is deprecated and `protocols` should be used instead, according to [finch changelog ](https://github.com/sneako/finch/blob/f857ad514411f8ae7383bb431827769612493434/CHANGELOG.md?plain=1#L69). While deprecation seems to be still graceful (proper pool module is selected), the `protocols` is then kept and `[:http1]` which is wrong and might have some other unexpected side effects.

