### PR TITLE
Put params in URL for GET Paddle API request instead of body

### DIFF
--- a/lib/plausible/billing/paddle_api.ex
+++ b/lib/plausible/billing/paddle_api.ex
@@ -122,7 +122,13 @@ defmodule Plausible.Billing.PaddleApi do
   def fetch_prices([_ | _] = product_ids, customer_ip) do
     params = %{product_ids: Enum.join(product_ids, ","), customer_ip: customer_ip}
 
-    case HTTPClient.impl().get(prices_url(), @headers, params) do
+    prices_final_url =
+      prices_url()
+      |> URI.parse()
+      |> Map.replace(:query, URI.encode_query(params))
+      |> URI.to_string()
+
+    case HTTPClient.impl().get(prices_final_url, @headers, nil) do
       {:ok, %{body: %{"success" => true, "response" => %{"products" => products}}}} ->
         products =
           Enum.into(products, %{}, fn %{

--- a/test/plausible/billing/paddle_api_test.exs
+++ b/test/plausible/billing/paddle_api_test.exs
@@ -11,9 +11,11 @@ defmodule Plausible.Billing.PaddleApiTest do
       expect(
         Plausible.HTTPClient.Mock,
         :get,
-        fn "https://checkout.paddle.com/api/2.0/prices",
+        fn "https://checkout.paddle.com/api/2.0/prices" <> query,
            [{"content-type", "application/json"}, {"accept", "application/json"}],
-           %{product_ids: "19878,20127,20657,20658"} ->
+           _ ->
+          assert query =~ "product_ids=#{URI.encode_www_form("19878,20127,20657,20658")}"
+
           {:ok,
            %Finch.Response{
              status: 200,

--- a/test/plausible_web/controllers/api/paddle_controller_test.exs
+++ b/test/plausible_web/controllers/api/paddle_controller_test.exs
@@ -102,9 +102,9 @@ defmodule PlausibleWeb.Api.PaddleControllerTest do
       expect(
         Plausible.HTTPClient.Mock,
         :get,
-        fn "https://checkout.paddle.com/api/2.0/prices",
-           _,
-           %{customer_ip: _customer_ip, product_ids: "857097"} ->
+        fn "https://checkout.paddle.com/api/2.0/prices" <> query, _, _ ->
+          assert query =~ "product_ids=857097"
+
           send(test, :paddle_queried)
 
           {:ok,


### PR DESCRIPTION
### Changes

Address a caching related issue with Paddle API

### Tests
- [x] Automated tests have been added
