### PR TITLE
Script v2: Make sure undefined callbackResult (ignored event) is visible in logs

### DIFF
--- a/tracker/installation_support/verifier-v2.js
+++ b/tracker/installation_support/verifier-v2.js
@@ -67,7 +67,8 @@ async function verifyPlausibleInstallation(options) {
     plausibleVersion,
     plausibleVariant,
     testEvent: {
-      ...testEvent,
+      ...testEvent, // callbackResult
+      testPlausibleFunctionError,
       requestUrl: interceptedTestEvent?.request?.url,
       normalizedBody: interceptedTestEvent?.request?.normalizedBody,
       responseStatus: interceptedTestEvent?.response?.status,
@@ -243,7 +244,9 @@ async function testPlausibleFunction({ timeoutMs, debug }) {
         window.plausible('verification-agent-test', {
           callback: (testEventCallbackResult) => {
             resolve({
-              testEvent: { callbackResult: testEventCallbackResult }
+              testEvent: {
+                callbackResult: testEventCallbackResult ?? 'undefined or null'
+              }
             })
           }
         })

--- a/tracker/test/installation_support/verifier-v2.spec.ts
+++ b/tracker/test/installation_support/verifier-v2.spec.ts
@@ -70,7 +70,8 @@ test.describe('installed plausible web variant', () => {
             version
           },
           responseStatus: 202,
-          error: undefined
+          error: undefined,
+          testPlausibleFunctionError: undefined
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }
@@ -132,7 +133,8 @@ test.describe('installed plausible web variant', () => {
             version
           },
           responseStatus: undefined,
-          error: undefined
+          error: undefined,
+          testPlausibleFunctionError: 'Test Plausible function timeout exceeded'
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }
@@ -190,7 +192,8 @@ test.describe('installed plausible web variant', () => {
             version
           },
           responseStatus: 400,
-          error: undefined
+          error: undefined,
+          testPlausibleFunctionError: undefined
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }
@@ -229,11 +232,12 @@ test.describe('installed plausible web variant', () => {
         plausibleVersion: version,
         plausibleVariant: 'web',
         testEvent: {
-          callbackResult: undefined,
+          callbackResult: 'undefined or null',
           requestUrl: undefined,
           normalizedBody: undefined,
           responseStatus: undefined,
-          error: undefined
+          error: undefined,
+          testPlausibleFunctionError: undefined
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }
@@ -441,7 +445,8 @@ test.describe('installed plausible web variant', () => {
           error: undefined,
           normalizedBody: undefined,
           requestUrl: undefined,
-          responseStatus: undefined
+          responseStatus: undefined,
+          testPlausibleFunctionError: 'Test Plausible function timeout exceeded'
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }
@@ -503,7 +508,8 @@ test.describe('installed plausible web variant', () => {
           error: undefined,
           normalizedBody: undefined,
           requestUrl: undefined,
-          responseStatus: undefined
+          responseStatus: undefined,
+          testPlausibleFunctionError: 'Test Plausible function timeout exceeded'
         },
         cookiesConsentResult: incompleteCookiesConsentResult
       }


### PR DESCRIPTION
### Changes

Verifier logs indicate an unhandled case where `testEvent` is an empty map when it shouldn't be. `undefined` is a valid `callbackResult` for the tracker script if the event is ignored. Since `JSON.stringify({callbackResult: undefined})
-> {}`, this remap may help us investigate further.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
