### PR TITLE
Fix test suites that are async and shouldn't be

### DIFF
--- a/test/plausible_web/controllers/api/external_sites_controller_sites_crud_api_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_sites_crud_api_test.exs
@@ -5,7 +5,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerSitesCrudApiTest do
   The overlapped tests from that suite can be deleted once the feature flag is enabled globally.
   """
   use Plausible
-  use PlausibleWeb.ConnCase, async: false
+  use PlausibleWeb.ConnCase
   use Plausible.Repo
   use Plausible.Teams.Test
   use Bamboo.Test

--- a/test/plausible_web/live/installationv2_test.exs
+++ b/test/plausible_web/live/installationv2_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Live.InstallationV2Test do
-  use PlausibleWeb.ConnCase, async: true
+  use PlausibleWeb.ConnCase
   use Plausible
   use Plausible.Test.Support.DNS
 

--- a/test/plausible_web/live/verification_v2_test.exs
+++ b/test/plausible_web/live/verification_v2_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Live.VerificationV2Test do
-  use PlausibleWeb.ConnCase, async: true
+  use PlausibleWeb.ConnCase
 
   use Plausible.Test.Support.DNS
 
@@ -293,7 +293,6 @@ defmodule PlausibleWeb.Live.VerificationV2Test do
 
   defp get_lv(conn, site, qs \\ nil) do
     {:ok, lv, html} = conn |> no_slowdown() |> live("/#{site.domain}/verification#{qs}")
-
     {lv, html}
   end
 


### PR DESCRIPTION
### Changes

Fixes tests that are async and shouldn't be due to using feature flags. 