### PR TITLE
Avoid crashing telemetry handler for persistor on recv Finch errors

### DIFF
--- a/lib/plausible/ingestion/persistor/telemetry_handler.ex
+++ b/lib/plausible/ingestion/persistor/telemetry_handler.ex
@@ -131,10 +131,12 @@ defmodule Plausible.Ingestion.Persistor.TelemetryHandler do
   def handle_event(
         @finch_receive_event,
         %{duration: duration},
-        %{request: request, status: status} = meta,
+        %{request: request} = meta,
         config
       ) do
     if request.host == config.remote_host do
+      status = meta[:status] || 0
+
       :telemetry.execute(
         @persistor_receive_event,
         %{duration: duration},


### PR DESCRIPTION
### Changes

Fixes telemetry handler for persistor requests crashing due to Finch telemetry event lacking one of the meta fields for certain recv errors.


