### PR TITLE
Use embed-friendly secure headers for HelpScout integration endpoints

### DIFF
--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -40,6 +40,17 @@ defmodule PlausibleWeb.Router do
     plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
   end
 
+  on_ee do
+    pipeline :helpscout do
+      plug :accepts, ["html"]
+      plug :fetch_session
+      plug PlausibleWeb.Plugs.SecureEmbedHeaders
+      plug PlausibleWeb.Plugs.NoRobots
+      plug PlausibleWeb.AuthPlug
+      plug :put_root_layout, html: {PlausibleWeb.LayoutView, :app}
+    end
+  end
+
   pipeline :csrf do
     plug :protect_from_forgery
   end
@@ -503,6 +514,14 @@ defmodule PlausibleWeb.Router do
       get "/logout", AuthController, :logout
       get "/team/select", AuthController, :select_team
     end
+
+    scope "/", PlausibleWeb do
+      pipe_through [:helpscout, :csrf]
+
+      get "/helpscout/callback", HelpScoutController, :callback
+      get "/helpscout/show", HelpScoutController, :show
+      get "/helpscout/search", HelpScoutController, :search
+    end
   end
 
   scope "/", PlausibleWeb do
@@ -516,12 +535,6 @@ defmodule PlausibleWeb.Router do
     delete "/me", AuthController, :delete_me
 
     get "/auth/google/callback", AuthController, :google_auth_callback
-
-    on_ee do
-      get "/helpscout/callback", HelpScoutController, :callback
-      get "/helpscout/show", HelpScoutController, :show
-      get "/helpscout/search", HelpScoutController, :search
-    end
 
     get "/", PageController, :index
 

--- a/test/plausible_web/controllers/help_scout_controller_test.exs
+++ b/test/plausible_web/controllers/help_scout_controller_test.exs
@@ -50,6 +50,8 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
             "/helpscout/callback?conversation-id=123&customer-id=500&X-HelpScout-Signature=#{signature}"
           )
 
+        assert [] = Plug.Conn.get_resp_header(conn, "content-security-policy")
+
         assert html_response(conn, 200) =~
                  Routes.customer_support_user_path(PlausibleWeb.Endpoint, :show, user.id)
       end


### PR DESCRIPTION
### Changes

Addresses in issue with integration embed failing to load in HS dashboard.

### Tests
- [x] Automated tests have been added

