### PR TITLE
Explicitly enable Nagle's algorithm for persistor HTTP client

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -284,7 +284,7 @@ defmodule Plausible.Application do
           default,
           protocols: [:http2],
           count: count,
-          conn_opts: [transport_opts: [timeout: timeout_ms]]
+          conn_opts: [transport_opts: [timeout: timeout_ms, nodelay: false]]
         )
       )
     else


### PR DESCRIPTION
### Changes

This change optimizes the client for traffic pattern of sending _large_ number of small payloads between two hosts.
