### PR TITLE
Add metric for decode duration in remote persistor client

### DIFF
--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -277,6 +277,15 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         measurement: :duration
       ),
       distribution(
+        metric_prefix ++ [:persistor, :remote, :decode, :duration, :millisecond],
+        event_name: Persistor.Remote.telemetry_decode_duration(),
+        reporter_options: [
+          buckets: [1, 10, 25, 50, 75, 100, 250, 350, 500, 750, 1_000, 5_000, 10_000, 30_000]
+        ],
+        unit: {:native, :millisecond},
+        measurement: :duration
+      ),
+      distribution(
         metric_prefix ++ [:persistor, :remote, :request, :duration, :millisecond],
         event_name: Persistor.TelemetryHandler.request_event(),
         reporter_options: [


### PR DESCRIPTION
### Changes

Additional measurement to understand discrepancy between remote_register_session ingest step duration and remote request total duration which is a lot shorter in some cases even though it's basically all the remote_register_session does in practice.


