### PR TITLE
Stop docs info icon hovering over account menu

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -489,7 +489,7 @@ defmodule PlausibleWeb.Components.Generic do
         <.title>
           {render_slot(@title)}
 
-          <.docs_info :if={@docs} slug={@docs} class="absolute top-4 right-4" />
+          <.docs_info :if={@docs} slug={@docs} class="absolute top-4 right-4 z-1" />
         </.title>
         <div :if={@subtitle != []} class="text-sm mt-px text-gray-500 dark:text-gray-400 leading-5">
           {render_slot(@subtitle)}


### PR DESCRIPTION
### Changes

Stops docs info icon from hovering over account menu.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
