### PR TITLE
Fix 2FA disable dialog

### DIFF
--- a/lib/plausible_web/components/two_factor.ex
+++ b/lib/plausible_web/components/two_factor.ex
@@ -130,10 +130,10 @@ defmodule PlausibleWeb.Components.TwoFactor do
           x-transition:leave="transition ease-in duration-200"
           x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
           x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-          class="inline-block align-bottom bg-white dark:bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+          class="relative inline-block align-bottom bg-white dark:bg-gray-900 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
         >
           <.form :let={f} for={@form_data} action={@form_target} onsubmit={@onsubmit}>
-            <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div class="bg-white dark:bg-gray-850 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
               <div class="hidden sm:block absolute top-0 right-0 pt-4 pr-4">
                 <a
                   href="#"


### PR DESCRIPTION
### Changes

Fixes the issue with 2FA disable modal backdrop covering the modal and making it un-usable. Fix inspired from `PlausibleWeb.Live.Sites.invitation_dialog/1`. In the future, we should unify the two to a single reusable component. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
