### PR TITLE
Adjust persistor metrics buckets and remove decode measurement

### DIFF
--- a/lib/plausible/ingestion/persistor/remote.ex
+++ b/lib/plausible/ingestion/persistor/remote.ex
@@ -94,21 +94,16 @@ defmodule Plausible.Ingestion.Persistor.Remote do
   end
 
   defp decode_payload(payload) do
-    Plausible.PromEx.Plugins.PlausibleMetrics.measure_duration(
-      telemetry_decode_duration(),
-      fn ->
-        case Base.decode64(payload, padding: false) do
-          {:ok, data} ->
-            event_data = :erlang.binary_to_term(data)
-            event = struct(Plausible.ClickhouseEventV2, event_data)
+    case Base.decode64(payload, padding: false) do
+      {:ok, data} ->
+        event_data = :erlang.binary_to_term(data)
+        event = struct(Plausible.ClickhouseEventV2, event_data)
 
-            {:ok, event}
+        {:ok, event}
 
-          _ ->
-            {:error, :invalid_web_encoding}
-        end
-      end
-    )
+      _ ->
+        {:error, :invalid_web_encoding}
+    end
   catch
     _, _ ->
       {:error, :invalid_payload}

--- a/lib/plausible/telemetry/plausible_metrics.ex
+++ b/lib/plausible/telemetry/plausible_metrics.ex
@@ -85,7 +85,24 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
           metric_prefix ++ [:remote_ingest, :events, :pipeline, :steps],
           event_name: Ingestion.Persistor.EmbeddedWithRelay.telemetry_pipeline_step_duration(),
           reporter_options: [
-            buckets: [10, 50, 100, 250, 350, 500, 1000, 5000, 10_000, 100_000, 500_000]
+            buckets: [
+              10,
+              50,
+              100,
+              250,
+              350,
+              500,
+              1000,
+              5000,
+              7_000,
+              10_000,
+              15_000,
+              20_000,
+              35_000,
+              50_000,
+              100_000,
+              500_000
+            ]
           ],
           unit: {:native, :microsecond},
           measurement: :duration,
@@ -271,16 +288,7 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         metric_prefix ++ [:persistor, :remote, :request, :total_duration, :millisecond],
         event_name: Persistor.Remote.telemetry_request_duration(),
         reporter_options: [
-          buckets: [1, 10, 25, 50, 75, 100, 250, 350, 500, 750, 1_000, 5_000, 10_000, 30_000]
-        ],
-        unit: {:native, :millisecond},
-        measurement: :duration
-      ),
-      distribution(
-        metric_prefix ++ [:persistor, :remote, :decode, :duration, :millisecond],
-        event_name: Persistor.Remote.telemetry_decode_duration(),
-        reporter_options: [
-          buckets: [1, 10, 25, 50, 75, 100, 250, 350, 500, 750, 1_000, 5_000, 10_000, 30_000]
+          buckets: [1, 3, 5, 7, 10, 13, 15, 20, 25, 50, 75, 100, 500, 1_000, 10_000, 30_000]
         ],
         unit: {:native, :millisecond},
         measurement: :duration
@@ -289,7 +297,7 @@ defmodule Plausible.PromEx.Plugins.PlausibleMetrics do
         metric_prefix ++ [:persistor, :remote, :request, :duration, :millisecond],
         event_name: Persistor.TelemetryHandler.request_event(),
         reporter_options: [
-          buckets: [1, 10, 25, 50, 75, 100, 250, 350, 500, 750, 1_000, 5_000, 10_000, 30_000]
+          buckets: [1, 3, 5, 7, 10, 13, 15, 20, 25, 50, 75, 100, 500, 1_000, 10_000, 30_000]
         ],
         unit: {:native, :millisecond},
         measurement: :duration,


### PR DESCRIPTION
### Changes

Current bucket settings are still skewing the measurements pretty significantly. 
