### PR TITLE
Make visualisations depend on centrally determined theme

### DIFF
--- a/assets/js/dashboard/extra/funnel.js
+++ b/assets/js/dashboard/extra/funnel.js
@@ -12,6 +12,35 @@ import * as api from '../api'
 import LazyLoader from '../components/lazy-loader'
 import { useQueryContext } from '../query-context'
 import { useSiteContext } from '../site-context'
+import { UIMode, useTheme } from '../theme-context'
+
+const getPalette = (theme) => {
+  if (theme.mode === UIMode.dark) {
+    return {
+      dataLabelBackground: 'rgb(9, 9, 11)',
+      dataLabelTextColor: 'rgb(244, 244, 245)',
+      visitorsBackground: 'rgb(99, 102, 241)',
+      dropoffBackground: 'rgb(63, 63, 70)',
+      dropoffStripes: 'rgb(9, 9, 11)',
+      stepNameLegendColor: 'rgb(228, 228, 231)',
+      visitorsLegendClass: 'bg-indigo-500',
+      dropoffLegendClass: 'bg-gray-600',
+      smallBarClass: 'bg-indigo-500'
+    }
+  } else {
+    return {
+      dataLabelBackground: 'rgb(39, 39, 42)',
+      dataLabelTextColor: 'rgb(244, 244, 245)',
+      visitorsBackground: 'rgb(99, 102, 241)',
+      dropoffBackground: 'rgb(224, 231, 255)',
+      dropoffStripes: 'rgb(255, 255, 255)',
+      stepNameLegendColor: 'rgb(24, 24, 27)',
+      visitorsLegendClass: 'bg-indigo-500',
+      dropoffLegendClass: 'bg-indigo-100',
+      smallBarClass: 'bg-indigo-300'
+    }
+  }
+}
 
 export default function Funnel({ funnelName, tabs }) {
   const site = useSiteContext()
@@ -21,6 +50,7 @@ export default function Funnel({ funnelName, tabs }) {
   const [error, setError] = useState(undefined)
   const [funnel, setFunnel] = useState(null)
   const [isSmallScreen, setSmallScreen] = useState(false)
+  const theme = useTheme()
   const chartRef = useRef(null)
   const canvasRef = useRef(null)
 
@@ -50,10 +80,10 @@ export default function Funnel({ funnelName, tabs }) {
 
   useEffect(() => {
     if (canvasRef.current && funnel && visible && !isSmallScreen) {
-      initialiseChart()
+      initialiseChart(getPalette(theme))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [funnel, visible])
+  }, [funnel, visible, theme])
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(max-width: 768px)')
@@ -89,38 +119,6 @@ export default function Funnel({ funnelName, tabs }) {
       window.removeEventListener('mousemove', repositionFunnelTooltip)
     }
   }, [])
-
-  const isDarkMode = () => {
-    return document.querySelector('html').classList.contains('dark') || false
-  }
-
-  const getPalette = () => {
-    if (isDarkMode()) {
-      return {
-        dataLabelBackground: 'rgb(9, 9, 11)',
-        dataLabelTextColor: 'rgb(244, 244, 245)',
-        visitorsBackground: 'rgb(99, 102, 241)',
-        dropoffBackground: 'rgb(63, 63, 70)',
-        dropoffStripes: 'rgb(9, 9, 11)',
-        stepNameLegendColor: 'rgb(228, 228, 231)',
-        visitorsLegendClass: 'bg-indigo-500',
-        dropoffLegendClass: 'bg-gray-600',
-        smallBarClass: 'bg-indigo-500'
-      }
-    } else {
-      return {
-        dataLabelBackground: 'rgb(39, 39, 42)',
-        dataLabelTextColor: 'rgb(244, 244, 245)',
-        visitorsBackground: 'rgb(99, 102, 241)',
-        dropoffBackground: 'rgb(224, 231, 255)',
-        dropoffStripes: 'rgb(255, 255, 255)',
-        stepNameLegendColor: 'rgb(24, 24, 27)',
-        visitorsLegendClass: 'bg-indigo-500',
-        dropoffLegendClass: 'bg-indigo-100',
-        smallBarClass: 'bg-indigo-300'
-      }
-    }
-  }
 
   const formatDataLabel = (visitors, ctx) => {
     if (ctx.dataset.label === 'Visitors') {
@@ -160,12 +158,10 @@ export default function Funnel({ funnelName, tabs }) {
     }
   }
 
-  const initialiseChart = () => {
+  const initialiseChart = (palette) => {
     if (chartRef.current) {
       chartRef.current.destroy()
     }
-
-    const palette = getPalette()
 
     const createDiagonalPattern = (color1, color2) => {
       // create a 10x10 px canvas for the pattern's base shape
@@ -334,7 +330,7 @@ export default function Funnel({ funnelName, tabs }) {
     }
   }
 
-  const renderInner = () => {
+  const renderInner = (theme) => {
     if (loading) {
       return (
         <div className="mx-auto loading pt-44">
@@ -354,15 +350,16 @@ export default function Funnel({ funnelName, tabs }) {
             {funnel.steps.length}-step funnel • {conversionRate}% conversion
             rate
           </p>
-          {isSmallScreen && <div className="mt-4">{renderBars(funnel)}</div>}
+          {isSmallScreen && (
+            <div className="mt-4">{renderBars(funnel, theme)}</div>
+          )}
         </div>
       )
     }
   }
 
-  const renderBar = (step) => {
-    const palette = getPalette()
-
+  const renderBar = (step, theme) => {
+    const palette = getPalette(theme)
     return (
       <>
         <div className="flex items-center justify-between my-1 text-sm">
@@ -389,7 +386,7 @@ export default function Funnel({ funnelName, tabs }) {
     )
   }
 
-  const renderBars = (funnel) => {
+  const renderBars = (funnel, theme) => {
     return (
       <>
         <div className="flex items-center justify-between mt-3 mb-2 text-xs font-bold tracking-wide text-gray-500 dark:text-gray-400">
@@ -398,7 +395,9 @@ export default function Funnel({ funnelName, tabs }) {
             <span className="inline-block w-20">Visitors</span>
           </span>
         </div>
-        <FlipMove>{funnel.steps.map(renderBar)}</FlipMove>
+        <FlipMove>
+          {funnel.steps.map((step) => renderBar(step, theme))}
+        </FlipMove>
       </>
     )
   }
@@ -406,7 +405,7 @@ export default function Funnel({ funnelName, tabs }) {
   return (
     <div style={{ minHeight: '400px' }}>
       <LazyLoader onVisible={() => setVisible(true)}>
-        {renderInner()}
+        {renderInner(theme)}
       </LazyLoader>
       {!isSmallScreen && (
         <canvas className="" id="funnel" ref={canvasRef}></canvas>

--- a/assets/js/dashboard/stats/graph/graph-tooltip.js
+++ b/assets/js/dashboard/stats/graph/graph-tooltip.js
@@ -4,11 +4,7 @@ import dateFormatter from './date-formatter'
 import { METRIC_LABELS, hasMultipleYears } from './graph-util'
 import { MetricFormatterShort } from '../reports/metric-formatter'
 import { ChangeArrow } from '../reports/change-arrow'
-
-// Function to detect if dark mode is active
-const isDarkMode = () => {
-  return document.documentElement.classList.contains('dark')
-}
+import { UIMode } from '../../theme-context'
 
 const renderBucketLabel = function (
   query,
@@ -104,7 +100,7 @@ const buildTooltipData = function (query, graphData, metric, tooltipModel) {
 
 let tooltipRoot
 
-export default function GraphTooltip(graphData, metric, query) {
+export default function GraphTooltip(graphData, metric, query, theme) {
   return (context) => {
     const tooltipModel = context.tooltip
     const offset = document
@@ -122,7 +118,7 @@ export default function GraphTooltip(graphData, metric, query) {
       tooltipRoot = createRoot(tooltipEl)
     }
 
-    const bgClass = isDarkMode() ? 'bg-gray-950' : 'bg-gray-800'
+    const bgClass = theme.mode === UIMode.dark ? 'bg-gray-950' : 'bg-gray-800'
     tooltipEl.className = `absolute text-sm font-normal py-3 px-4 pointer-events-none rounded-md z-[100] min-w-[180px] ${bgClass}`
 
     if (tooltipEl && offset && window.innerWidth < 768) {

--- a/assets/js/dashboard/stats/graph/line-graph.js
+++ b/assets/js/dashboard/stats/graph/line-graph.js
@@ -9,6 +9,7 @@ import FadeIn from '../../fade-in'
 import classNames from 'classnames'
 import { hasConversionGoalFilter } from '../../util/filters'
 import { MetricFormatterShort } from '../reports/metric-formatter'
+import { UIMode, useTheme } from '../../theme-context'
 
 const calculateMaximumY = function (dataset) {
   const yAxisValues = dataset
@@ -40,7 +41,7 @@ class LineGraph extends React.Component {
   }
 
   regenerateChart() {
-    const { graphData, query } = this.props
+    const { graphData, query, theme } = this.props
     const metric = this.getGraphMetric()
     const graphEl = document.getElementById('main-graph-canvas')
     this.ctx = graphEl.getContext('2d')
@@ -67,7 +68,7 @@ class LineGraph extends React.Component {
             mode: 'index',
             intersect: false,
             position: 'average',
-            external: GraphTooltip(graphData, metric, query)
+            external: GraphTooltip(graphData, metric, query, theme)
           }
         },
         responsive: true,
@@ -84,14 +85,16 @@ class LineGraph extends React.Component {
             suggestedMax: calculateMaximumY(dataSet),
             ticks: {
               callback: MetricFormatterShort[metric],
-              color: this.props.darkTheme ? 'rgb(161, 161, 170)' : undefined
+              color:
+                theme.mode === UIMode.dark ? 'rgb(161, 161, 170)' : undefined
             },
             grid: {
               zeroLineColor: 'transparent',
               drawBorder: false,
-              color: this.props.darkTheme
-                ? 'rgba(39, 39, 42, 0.75)'
-                : 'rgb(236, 236, 238)'
+              color:
+                theme.mode === UIMode.dark
+                  ? 'rgba(39, 39, 42, 0.75)'
+                  : 'rgb(236, 236, 238)'
             }
           },
           yComparison: {
@@ -147,7 +150,8 @@ class LineGraph extends React.Component {
                   shouldShowYear
                 })(this.getLabelForValue(val))
               },
-              color: this.props.darkTheme ? 'rgb(161, 161, 170)' : undefined
+              color:
+                theme.mode === UIMode.dark ? 'rgb(161, 161, 170)' : undefined
             }
           }
         },
@@ -183,12 +187,12 @@ class LineGraph extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { graphData, darkTheme } = this.props
+    const { graphData, theme } = this.props
     const tooltip = document.getElementById('chartjs-tooltip-main')
 
     if (
       graphData !== prevProps.graphData ||
-      darkTheme !== prevProps.darkTheme
+      theme.mode !== prevProps.theme.mode
     ) {
       if (graphData) {
         if (this.chart) {
@@ -271,5 +275,8 @@ class LineGraph extends React.Component {
 export default function LineGraphWrapped(props) {
   const { query } = useQueryContext()
   const navigate = useAppNavigate()
-  return <LineGraph {...props} navigate={navigate} query={query} />
+  const theme = useTheme()
+  return (
+    <LineGraph {...props} navigate={navigate} query={query} theme={theme} />
+  )
 }

--- a/assets/js/dashboard/stats/graph/visitor-graph.js
+++ b/assets/js/dashboard/stats/graph/visitor-graph.js
@@ -34,8 +34,6 @@ export default function VisitorGraph({ updateImportedDataInView }) {
   const site = useSiteContext()
 
   const isRealtime = query.period === 'realtime'
-  const isDarkTheme =
-    document.querySelector('html').classList.contains('dark') || false
 
   const topStatsBoundary = useRef(null)
 
@@ -209,7 +207,6 @@ export default function VisitorGraph({ updateImportedDataInView }) {
               ...graphData,
               interval: getCurrentInterval(site, query)
             }}
-            darkTheme={isDarkTheme}
           />
         </div>
       </FadeIn>


### PR DESCRIPTION
### Changes
Makes visualisations depend on centrally determined theme. 

Before this PR:
If the app theme is set to follow system theme and the system theme changes, then some visualisations are not aware of the change and keep using stale theme colors. This is cleared up only with a refresh.

After this PR:
If the app theme is set to follow system theme and the system theme changes, then visualisations update themselves automatically. No refresh needed.

### Tests
- [x] This PR does not require tests: manually tested

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode

Left: this preview env, right: staging

https://github.com/user-attachments/assets/93a74315-e496-43b2-a557-9def245dd071


