### PR TITLE
Declare favicon external resource properly

### DIFF
--- a/lib/plausible_web/plugs/favicon.ex
+++ b/lib/plausible_web/plugs/favicon.ex
@@ -31,6 +31,7 @@ defmodule PlausibleWeb.Favicon do
 
   @placeholder_icon_location "priv/link_favicon.svg"
   @placeholder_icon File.read!(@placeholder_icon_location)
+  @external_resource @placeholder_icon_location
   @custom_icons %{
     "Brave" => "search.brave.com",
     "Sogou" => "sogou.com",


### PR DESCRIPTION
### Changes
Declares the favicon as an external resource. 
This ensures that if the favicon file changes, the module is recompiled. 
Without this, we'd need to run `mix clean` when switching between branches where the favicon has changed for the change to take effect.

**Previously:**
- checkout master
- `mix clean`
- `mix test/plausible_web/plugs/favicon_test.exs` ✅ 
- checkout `branch-that-changes-favicon`
- `mix test/plausible_web/plugs/favicon_test.exs` ⛔ 

Had to run `mix clean` after checkout `branch-that-changes-favicon` to get the test to pass


**After this PR:**
- checkout master
- `mix clean`
- `mix test/plausible_web/plugs/favicon_test.exs` ✅ 
- checkout `branch-that-changes-favicon`
- `mix test/plausible_web/plugs/favicon_test.exs` ✅ 

No need to run `mix clean` after checkout

