### PR TITLE
Fix migration for CE 3.0.1 to current

### DIFF
--- a/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
+++ b/lib/plausible/data_migration/backfill_tracker_script_configuration.ex
@@ -74,18 +74,14 @@ defmodule Plausible.DataMigration.BackfillTrackerScriptConfiguration do
     installation_meta = site.installation_meta
 
     installation_type =
-      if(installation_meta,
-        do:
-          Map.get(installation_meta, "installation_type", false) ||
-            installation_meta.installation_type,
-        else: nil
-      )
+      if installation_meta do
+        Map.get(installation_meta, "installation_type")
+      end
 
     script_config =
-      if(installation_meta,
-        do: Map.get(installation_meta, "script_config", false) || installation_meta.script_config,
-        else: %{}
-      )
+      if installation_meta do
+        Map.get(installation_meta, "script_config", %{})
+      end
 
     %{
       id: Nanoid.generate(),


### PR DESCRIPTION
### Changes

In the process of figuring out the new CE release, I discovered that the migration `BackfillTrackerScriptConfiguration` failed on an entry in the database created with CE version 3.0.1. This fixes it.

### Tests
- [x] Tested manually by 
  - booting a fresh 3.0.1 CE
  - creating a website
  - locally building a new CE image from this branch
  - replacing the 3.0.1 image with new CE image in CE compose file

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
