### PR TITLE
Add border to tab component

### DIFF
--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -446,7 +446,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
   def tabs(assigns) do
     ~H"""
     <div class="text-sm mt-6 font-medium dark:text-gray-100">Goal trigger</div>
-    <div class="my-2 text-sm w-full flex gap-1 overflow-hidden">
+    <div class="my-2 p-1 text-sm w-full flex gap-1 overflow-hidden rounded-lg border border-gray-300 dark:border-gray-700">
       <.tab
         id="event-tab"
         tab_value="custom_events"
@@ -485,7 +485,7 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
     ~H"""
     <a
       class={[
-        "flex-1 text-center py-2.5 rounded-md font-medium hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors duration-150",
+        "flex-1 text-center py-2 px-3 rounded-md font-medium hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors duration-150",
         "cursor-pointer",
         @selected? && "bg-gray-150 dark:bg-gray-700 text-gray-800 dark:text-white",
         !@selected? && "dark:text-gray-200 text-gray-600 hover:text-gray-800 dark:hover:text-white"

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -121,7 +121,7 @@ defmodule PlausibleWeb.Live.Installation do
             </div>
           </:loading>
 
-          <div class="grid grid-cols-2 sm:flex sm:flex-row gap-1 rounded-md">
+          <div class="grid grid-cols-2 sm:flex sm:flex-row gap-1 rounded-lg p-1 border border-gray-300 dark:border-gray-700">
             <.tab
               patch={"?type=manual&flow=#{@flow}"}
               selected={@installation_type.result == "manual"}
@@ -272,7 +272,7 @@ defmodule PlausibleWeb.Live.Installation do
 
   defp tab(assigns) do
     base_classes =
-      "rounded-md px-3.5 py-2.5 text-sm font-medium flex items-center flex-1 justify-center whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors duration-150"
+      "rounded-md px-3 py-2 text-sm font-medium flex items-center flex-1 justify-center whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-750 transition-colors duration-150"
 
     selected_class =
       if assigns[:selected] do


### PR DESCRIPTION
### Changes

- Update tab component visually for extra affordance


**Before:**

| <img width="1472" height="640" alt="CleanShot 2025-10-29 at 09 20 11@2x" src="https://github.com/user-attachments/assets/d36eef88-8a37-4df5-94be-8ad128d4923c" /> | <img width="1480" height="534" alt="CleanShot 2025-10-29 at 09 24 20@2x" src="https://github.com/user-attachments/assets/275948b9-9cf8-4eb0-8f2b-f8088c1101f3" /> |
|---------|---------|

**After:**

| <img width="1404" height="618" alt="CleanShot 2025-10-29 at 09 19 48@2x" src="https://github.com/user-attachments/assets/943b5cbe-66c5-492b-9bb3-89902ed55ea3" /> | <img width="1588" height="554" alt="CleanShot 2025-10-29 at 09 25 05@2x" src="https://github.com/user-attachments/assets/7938f928-5923-442e-b162-418fa4a18e04" /> |
|---------|---------|

### Dark mode
- [x] The UI has been tested both in dark and light mode