### PR TITLE
Stop trying to compile detector and verifier on CE

### DIFF
--- a/tracker/compiler/variants.json
+++ b/tracker/compiler/variants.json
@@ -32,12 +32,14 @@
       "npm_package": "esm"
     },
     {
+      "ee_only": true,
       "name": "detector.js",
       "entry_point": "installation_support/detector.js",
       "output_path": "priv/tracker/installation_support/detector.js",
       "globals": {}
     },
     {
+      "ee_only": true,
       "name": "verifier.js",
       "entry_point": "installation_support/verifier.js",
       "output_path": "priv/tracker/installation_support/verifier.js",


### PR DESCRIPTION
### Changes

Attempting to build the CE docker image without this PR throws because the installation_support output directory is missing for CE. 
Compiling the detector and verifier scripts isn't needed for CE, so this PR stops them from being built.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
