### PR TITLE
Fix regression in shared link settings form

### DIFF
--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -75,7 +75,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div class={@mt? && "mt-4"}>
-      <.label for={@id} class="mb-1.5">{@label}</.label>
+      <.label for={@id} class={if @help_text, do: "mb-0.5", else: "mb-1.5"}>{@label}</.label>
 
       <p :if={@help_text} class="text-gray-500 dark:text-gray-400 mb-2 text-sm">
         {@help_text}
@@ -177,7 +177,11 @@ defmodule PlausibleWeb.Live.Components.Form do
 
     ~H"""
     <div class={@mt? && "mt-4"}>
-      <.label :if={@label != nil and @label != ""} for={@id} class="mb-1.5">
+      <.label
+        :if={@label != nil and @label != ""}
+        for={@id}
+        class={if @help_text, do: "mb-0.5", else: "mb-1.5"}
+      >
         {@label}
       </.label>
       <p :if={@help_text} class="text-gray-500 dark:text-gray-400 mb-2 text-sm">

--- a/lib/plausible_web/live/shared_link_settings/form.ex
+++ b/lib/plausible_web/live/shared_link_settings/form.ex
@@ -58,10 +58,10 @@ defmodule PlausibleWeb.Live.SharedLinkSettings.Form do
       <.input
         field={f[:password]}
         label="Password (optional)"
+        help_text="Store the password securely, as it can't be viewed again."
         type="password"
         autocomplete="new-password"
       />
-
       <.button type="submit" class="w-full">
         Create shared link
       </.button>


### PR DESCRIPTION
### Changes

- As the form was moved to a modal, the help text has been removed unintentionally. This adds it back.

### Tests
- [x] This PR does not require tests

### Dark mode
- [x] The UI has been tested both in dark and light mode