### PR TITLE
Add migration adding `teams.policy` to CE

### DIFF
--- a/priv/repo/migrations/20251103150703_add_teams_policy_to_ce.exs
+++ b/priv/repo/migrations/20251103150703_add_teams_policy_to_ce.exs
@@ -1,0 +1,13 @@
+defmodule Plausible.Repo.Migrations.AddTeamsPolicyToCe do
+  use Ecto.Migration
+
+  import Plausible.MigrationUtils
+
+  def change do
+    if community_edition?() do
+      alter table(:teams) do
+        add :policy, :jsonb, null: false, default: "{}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Changes

Prerequisite to already approved https://github.com/plausible/analytics/pull/5855. The migration is a no-op for EE.

