### PR TITLE
Make sure imported data switch appears on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Fixed unhandled tracker-related exceptions on link clicks within svgs
 - Remove Subscription and Invoices menu from CE
 - Fix email sending error "Mua.SMTPError" 503 Bad sequence of commands
+- Make button to include / exclude imported data visible on Safari
 
 ## v3.0.0 - 2025-04-11
 

--- a/assets/js/dashboard/stats/graph/with-imported-switch.tsx
+++ b/assets/js/dashboard/stats/graph/with-imported-switch.tsx
@@ -15,7 +15,7 @@ export default function WithImportedSwitch({
   const { query } = useQueryContext()
   const importsSwitchedOn = query.with_imported
 
-  const iconClass = classNames({
+  const iconClass = classNames('size-4', {
     'dark:text-gray-300 text-gray-700': importsSwitchedOn,
     'dark:text-gray-500 text-gray-400': !importsSwitchedOn
   })
@@ -23,7 +23,7 @@ export default function WithImportedSwitch({
   return (
     <Tooltip
       info={<div className="font-normal truncate">{tooltipMessage}</div>}
-      className="w-4 h-4"
+      className="size-4"
     >
       <AppNavigationLink
         search={


### PR DESCRIPTION
### Changes

Imported data switch stopped appearing on Safari due to missing width & height for the svg tag. This fixes it.
<img width="300" height="138" alt="Screenshot 2025-11-04 at 21 10 52" src="https://github.com/user-attachments/assets/2d9a0fa7-5436-4420-b717-1fb8525cf68f" />

### Tests
- [x] Manually tested

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
