### PR TITLE
Migration: Add user preferences per team table

### DIFF
--- a/priv/repo/migrations/20251110084943_team_user_preferences.exs
+++ b/priv/repo/migrations/20251110084943_team_user_preferences.exs
@@ -1,0 +1,14 @@
+defmodule Plausible.Repo.Migrations.TeamUserPreferences do
+  use Ecto.Migration
+
+  def change do
+    create table(:team_user_preferences) do
+      add :consolidated_view_cta_dismissed, :boolean, default: false
+      add :team_id, references(:teams, on_delete: :delete_all), null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      timestamps()
+    end
+
+    create unique_index(:team_user_preferences, [:user_id, :team_id])
+  end
+end


### PR DESCRIPTION
Migration extracted from #5866 5866

Superseded by https://github.com/plausible/analytics/pull/5881