### PR TITLE
Consolidated views: remove broken external page links

### DIFF
--- a/assets/js/dashboard/site-context.tsx
+++ b/assets/js/dashboard/site-context.tsx
@@ -29,7 +29,7 @@ export function parseSiteFromDataset(dataset: DOMStringMap): PlausibleSite {
 // Update this object when new feature flags are added to the frontend.
 type FeatureFlags = Record<never, boolean>
 
-const siteContextDefaultValue = {
+export const siteContextDefaultValue = {
   domain: '',
   /** offset in seconds from UTC at site load time, @example 7200 */
   offset: 0,

--- a/assets/js/dashboard/stats/behaviours/goal-conversions.js
+++ b/assets/js/dashboard/stats/behaviours/goal-conversions.js
@@ -51,7 +51,7 @@ function SpecialPropBreakdown({ prop, afterFetchData }) {
 
   function getExternalLinkUrlFactory() {
     if (prop === 'path') {
-      return (listItem) => url.externalLinkForPage(site.domain, listItem.name)
+      return (listItem) => url.externalLinkForPage(site, listItem.name)
     } else if (prop === 'search_query') {
       return null // WP Search Queries should not become external links
     } else {

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -20,7 +20,7 @@ function EntryPages({ afterFetchData }) {
   }
 
   function getExternalLinkUrl(page) {
-    return url.externalLinkForPage(site.domain, page.name)
+    return url.externalLinkForPage(site, page.name)
   }
 
   function getFilterInfo(listItem) {
@@ -66,7 +66,7 @@ function ExitPages({ afterFetchData }) {
   }
 
   function getExternalLinkUrl(page) {
-    return url.externalLinkForPage(site.domain, page.name)
+    return url.externalLinkForPage(site, page.name)
   }
 
   function getFilterInfo(listItem) {
@@ -112,7 +112,7 @@ function TopPages({ afterFetchData }) {
   }
 
   function getExternalLinkUrl(page) {
-    return url.externalLinkForPage(site.domain, page.name)
+    return url.externalLinkForPage(site, page.name)
   }
 
   function getFilterInfo(listItem) {

--- a/assets/js/dashboard/util/url.test.ts
+++ b/assets/js/dashboard/util/url.test.ts
@@ -1,4 +1,5 @@
 import { apiPath, externalLinkForPage, isValidHttpUrl, trimURL } from './url'
+import { siteContextDefaultValue } from '../site-context'
 
 describe('apiPath', () => {
   it.each([
@@ -32,10 +33,19 @@ describe('externalLinkForPage', () => {
   ])(
     'when domain is %s and page is %s, it should return %s',
     (domain, page, expected) => {
-      const result = externalLinkForPage(domain, page)
+      const site = { ...siteContextDefaultValue, domain: domain }
+      const result = externalLinkForPage(site, page)
       expect(result).toBe(expected)
     }
   )
+
+  it('returns null for consolidated view', () => {
+    const consolidatedView = {
+      ...siteContextDefaultValue,
+      isConsolidatedView: true
+    }
+    expect(externalLinkForPage(consolidatedView, '/some-page')).toBe(null)
+  })
 })
 
 describe('isValidHttpUrl', () => {

--- a/assets/js/dashboard/util/url.ts
+++ b/assets/js/dashboard/util/url.ts
@@ -8,11 +8,15 @@ export function apiPath(
 }
 
 export function externalLinkForPage(
-  domain: PlausibleSite['domain'],
+  site: PlausibleSite,
   page: string
 ): string | null {
+  if (site.isConsolidatedView) {
+    return null
+  }
+
   try {
-    const domainURL = new URL(`https://${domain}`)
+    const domainURL = new URL(`https://${site.domain}`)
     return `https://${domainURL.host}${page}`
   } catch (_error) {
     return null


### PR DESCRIPTION
### Changes

Our dashboard constructs external URLs to link to pages on the site itself and renders these as icons when list items are hovered:

<img width="553" height="155" alt="image" src="https://github.com/user-attachments/assets/310957bb-4441-4dfa-a95c-c44faf5ce97a" />

For consolidated views, these are currently broken, because a consolidated view is not an actual domain to link to. This PR fixes that by adding a conditional in the `url.externalLinkForPage` utility.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
