### PR TITLE
Change header dropdown copy to sentence case

### DIFF
--- a/lib/plausible/teams.ex
+++ b/lib/plausible/teams.ex
@@ -14,7 +14,7 @@ defmodule Plausible.Teams do
   @accept_traffic_until_free ~D[2135-01-01]
 
   @spec default_name() :: String.t()
-  def default_name(), do: "My Personal Sites"
+  def default_name(), do: "My personal sites"
 
   @spec name(nil | Teams.Team.t()) :: String.t()
   def name(nil), do: default_name()

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -24,7 +24,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
         %Teams.Team{} ->
           team_name_form =
             current_team
-            |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s Team"})
+            |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s team"})
             |> Repo.update!()
             |> Teams.Team.name_changeset(%{})
             |> to_form()
@@ -90,7 +90,7 @@ defmodule PlausibleWeb.Live.TeamSetup do
           >
             <.input
               type="text"
-              placeholder={"#{@current_user.name}'s Team"}
+              placeholder={"#{@current_user.name}'s team"}
               autofocus={not @locked?}
               field={f[:name]}
               label="Name"

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -81,13 +81,13 @@
                     />
                     <.dropdown_divider />
                     <.dropdown_item href={Routes.settings_path(@conn, :index)}>
-                      Account Settings
+                      Account settings
                     </.dropdown_item>
 
                     <div :if={@my_team && @my_team.id == @current_team.id}>
                       <.dropdown_item class="flex" href={Routes.team_setup_path(@conn, :setup)}>
                         <span data-test="create-a-team-cta" class="flex-1">
-                          Create a Team
+                          Create a team
                         </span>
                       </.dropdown_item>
                       <.dropdown_divider />
@@ -99,7 +99,7 @@
                         href={Routes.settings_path(@conn, :team_general)}
                       >
                         <span class="flex-1">
-                          Team Settings
+                          Team settings
                         </span>
                       </.dropdown_item>
                       <.dropdown_divider />
@@ -109,7 +109,7 @@
                       new_tab
                       href="https://plausible.io/docs"
                     >
-                      Help Center
+                      Help center
                     </.dropdown_item>
                     <.dropdown_item
                       :if={ee?()}
@@ -117,7 +117,7 @@
                       new_tab
                       href="https://plausible.io/contact"
                     >
-                      Contact Support
+                      Contact support
                     </.dropdown_item>
                     <.dropdown_item
                       :if={ee?()}
@@ -125,7 +125,7 @@
                       new_tab
                       href={feedback_link(@conn.assigns[:current_user])}
                     >
-                      Feature Requests
+                      Feature requests
                     </.dropdown_item>
                     <.dropdown_item
                       :if={ce?()}
@@ -133,9 +133,9 @@
                       new_tab
                       href="https://github.com/plausible/analytics"
                     >
-                      Github Repo
+                      Github repo
                     </.dropdown_item>
-                    <.dropdown_item href="/logout">Log Out</.dropdown_item>
+                    <.dropdown_item href="/logout">Log out</.dropdown_item>
                   </:menu>
                 </.dropdown>
               </li>

--- a/test/plausible/teams_test.exs
+++ b/test/plausible/teams_test.exs
@@ -11,14 +11,14 @@ defmodule Plausible.TeamsTest do
 
   describe "name/1" do
     test "returns default name when there's no team" do
-      assert Teams.name(nil) == "My Personal Sites"
+      assert Teams.name(nil) == "My personal sites"
     end
 
     test "returns default name when team setup is not completed yet" do
       user = new_user(team: [setup_complete: false, name: "Foo"])
       team = team_of(user)
 
-      assert Teams.name(team) == "My Personal Sites"
+      assert Teams.name(team) == "My personal sites"
     end
 
     test "returns team name for a setup team" do
@@ -30,14 +30,14 @@ defmodule Plausible.TeamsTest do
   end
 
   describe "get_or_create/1" do
-    test "creates 'My Personal Sites' if user is a member of no teams" do
+    test "creates 'My personal sites' if user is a member of no teams" do
       today = Date.utc_today()
       user = new_user()
       user_id = user.id
 
       assert {:ok, team} = Teams.get_or_create(user)
 
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
       assert Date.compare(team.trial_expiry_date, today) == :gt
 
       assert [
@@ -70,7 +70,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}
@@ -98,7 +98,7 @@ defmodule Plausible.TeamsTest do
                |> Enum.sort_by(& &1.id)
     end
 
-    test "creates 'My Personal Sites' if user is a guest on another team" do
+    test "creates 'My personal sites' if user is a guest on another team" do
       user = new_user()
       user_id = user.id
       site = new_site()
@@ -108,7 +108,7 @@ defmodule Plausible.TeamsTest do
       assert {:ok, team} = Teams.get_or_create(user)
 
       assert team.id != existing_team.id
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
 
       assert [%{user_id: ^user_id, role: :owner, is_autocreated: true}] =
                team
@@ -116,7 +116,7 @@ defmodule Plausible.TeamsTest do
                |> Map.fetch!(:team_memberships)
     end
 
-    test "creates 'My Personal Sites' if user is a non-owner member on existing teams" do
+    test "creates 'My personal sites' if user is a non-owner member on existing teams" do
       user = new_user()
       user_id = user.id
       site1 = new_site()
@@ -207,7 +207,7 @@ defmodule Plausible.TeamsTest do
       assert {:error, :no_team} = Teams.get_by_owner(user)
     end
 
-    test "returns existing 'My Personal Sites' if user already owns one" do
+    test "returns existing 'My personal sites' if user already owns one" do
       user = new_user(trial_expiry_date: ~D[2020-04-01])
       user_id = user.id
       existing_team = team_of(user)
@@ -216,7 +216,7 @@ defmodule Plausible.TeamsTest do
 
       assert team.id == existing_team.id
       assert Date.compare(team.trial_expiry_date, ~D[2020-04-01])
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
 
       assert [
                %{user_id: ^user_id, role: :owner, is_autocreated: true}

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -84,7 +84,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                    },
                    %{
                      "id" => personal_team.identifier,
-                     "name" => "My Personal Sites",
+                     "name" => "My personal sites",
                      "api_available" => false
                    }
                  ],
@@ -113,7 +113,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
                  "teams" => [
                    %{
                      "id" => personal_team.identifier,
-                     "name" => "My Personal Sites",
+                     "name" => "My personal sites",
                      "api_available" => true
                    }
                  ],

--- a/test/plausible_web/controllers/help_scout_controller_test.exs
+++ b/test/plausible_web/controllers/help_scout_controller_test.exs
@@ -163,7 +163,7 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
         assert html = html_response(conn, 200)
         assert html =~ Routes.customer_support_user_path(PlausibleWeb.Endpoint, :show, user.id)
         assert html =~ "Some user notes"
-        assert html =~ "My Personal Sites"
+        assert html =~ "My personal sites"
         assert html =~ "HS Integration Test Team"
       end
 
@@ -193,7 +193,7 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
 
         assert html = html_response(conn, 200)
         refute html =~ "HS Integration Test Team"
-        refute html =~ "My Personal Sites"
+        refute html =~ "My personal sites"
         assert html =~ "Some user notes"
       end
 
@@ -223,7 +223,7 @@ defmodule PlausibleWeb.HelpScoutControllerTest do
 
         assert html = html_response(conn, 200)
         assert html =~ "HS Integration Test Team"
-        refute html =~ "My Personal Sites"
+        refute html =~ "My personal sites"
         assert html =~ "Some user notes"
       end
 

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -1358,7 +1358,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
   ]
 
   on_ee do
-    describe "Account Settings - SSO user" do
+    describe "Account settings - SSO user" do
       setup [:create_user, :create_site, :create_team, :setup_sso, :provision_sso_user, :log_in]
 
       test "shows only expected menu items", %{conn: conn} do
@@ -1409,7 +1409,7 @@ defmodule PlausibleWeb.SettingsControllerTest do
     end
   end
 
-  describe "Team Settings" do
+  describe "Team settings" do
     setup [:create_user, :log_in]
 
     test "when no team is assigned & the user doesn't have a subscription, limited account menu is present",
@@ -2003,14 +2003,14 @@ defmodule PlausibleWeb.SettingsControllerTest do
   describe "account dropdown menu (_header.html)" do
     setup [:create_user, :log_in]
 
-    test "renders the 'Create a Team' option", %{conn: conn, user: user} do
+    test "renders the 'Create a team' option", %{conn: conn, user: user} do
       subscribe_to_growth_plan(user)
       conn = get(conn, Routes.settings_path(conn, :preferences))
       html = html_response(conn, 200)
-      assert text_of_element(html, ~s/[data-test="create-a-team-cta"]/) == "Create a Team"
+      assert text_of_element(html, ~s/[data-test="create-a-team-cta"]/) == "Create a team"
     end
 
-    test "does not render the 'Create a Team' option if a team is already set up", %{
+    test "does not render the 'Create a team' option if a team is already set up", %{
       conn: conn,
       user: user
     } do

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -14,7 +14,7 @@ defmodule PlausibleWeb.Live.SitesTest do
       {:ok, _lv, html} = live(conn, "/sites")
 
       text = text(html)
-      assert text =~ "My Personal Sites"
+      assert text =~ "My personal sites"
       assert text =~ "You don't have any sites yet"
       refute text =~ "You currently have no personal sites"
       refute text =~ "Go to your team"
@@ -31,7 +31,7 @@ defmodule PlausibleWeb.Live.SitesTest do
       {:ok, _lv, html} = live(conn, "/sites")
       text = text(html)
 
-      assert text =~ "My Personal Sites"
+      assert text =~ "My personal sites"
       refute text =~ "You don't have any sites yet"
       assert text =~ "You currently have no personal sites"
       assert text =~ "Go to your team"
@@ -68,10 +68,10 @@ defmodule PlausibleWeb.Live.SitesTest do
       {:ok, _lv, html} = live(conn, "/sites")
 
       assert text_of_element(html, "#invitation-#{invitation1.invitation_id}") =~
-               "G.I. Joe has invited you to join the \"My Personal Sites\" as viewer member."
+               "G.I. Joe has invited you to join the \"My personal sites\" as viewer member."
 
       assert text_of_element(html, "#invitation-#{invitation2.invitation_id}") =~
-               "G.I. Jane has invited you to join the \"My Personal Sites\" as editor member."
+               "G.I. Jane has invited you to join the \"My personal sites\" as editor member."
 
       assert element_exists?(
                html,

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -31,24 +31,24 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
     setup [:create_user, :log_in, :create_team]
 
     test "renames the team on first render", %{conn: conn, team: team} do
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
       {:ok, _lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "Jane Smith's Team"
+               "Jane Smith's team"
 
-      assert Repo.reload!(team).name == "Jane Smith's Team"
+      assert Repo.reload!(team).name == "Jane Smith's team"
     end
 
     test "renames even if team already has non-default name", %{conn: conn, team: team} do
-      assert team.name == "My Personal Sites"
+      assert team.name == "My personal sites"
       Repo.update!(Teams.Team.name_changeset(team, %{name: "Foo"}))
       {:ok, _lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "Jane Smith's Team"
+               "Jane Smith's team"
 
-      assert Repo.reload!(team).name == "Jane Smith's Team"
+      assert Repo.reload!(team).name == "Jane Smith's team"
     end
 
     test "renders form", %{conn: conn} do
@@ -67,7 +67,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       _ = render(lv)
     end
 
-    test "setting team name to 'My Personal Sites' is reserved", %{
+    test "setting team name to 'My personal sites' is reserved", %{
       conn: conn,
       team: team,
       user: user
@@ -75,11 +75,11 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       {:ok, lv, html} = live(conn, @url)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
-               "#{user.name}'s Team"
+               "#{user.name}'s team"
 
       type_into_input(lv, "team[name]", "Team Name 1")
       _ = render(lv)
-      type_into_input(lv, "team[name]", "My Personal Sites")
+      type_into_input(lv, "team[name]", "My personal sites")
       _ = render(lv)
       assert Repo.reload!(team).name == "Team Name 1"
     end


### PR DESCRIPTION
### Changes
- The list items in the dropdown of the top navigation was in title case and has been updated to be sentence case – to be consistent with the rest of the app.

### Tests
- [x] Automated tests have been updated

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI (copy change only)
