### PR TITLE
Add hover state for location bars

### DIFF
--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -54,7 +54,7 @@ function Countries({ query, site, onClick, afterFetchData }) {
         search: (search) => search
       }}
       renderIcon={renderIcon}
-      color="bg-orange-50"
+      color="bg-orange-50 group-hover:bg-orange-100"
     />
   )
 }
@@ -93,7 +93,7 @@ function Regions({ query, site, onClick, afterFetchData }) {
       metrics={chooseMetrics()}
       detailsLinkProps={{ path: regionsRoute.path, search: (search) => search }}
       renderIcon={renderIcon}
-      color="bg-orange-50"
+      color="bg-orange-50 group-hover:bg-orange-100"
     />
   )
 }
@@ -131,7 +131,7 @@ function Cities({ query, site, afterFetchData }) {
       metrics={chooseMetrics()}
       detailsLinkProps={{ path: citiesRoute.path, search: (search) => search }}
       renderIcon={renderIcon}
-      color="bg-orange-50"
+      color="bg-orange-50 group-hover:bg-orange-100"
     />
   )
 }


### PR DESCRIPTION
### Changes

- As part of https://github.com/plausible/analytics/pull/5890, hover states were added to all bars on the dashboard, but the countries/regions/cities bars were missed.

### Tests
- [x] This PR does not require tests

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
