### PR TITLE
Fix Safari bug where `+ Add another step` button wasn't hidden properly

### DIFF
--- a/extra/lib/plausible_web/live/funnel_settings/form.ex
+++ b/extra/lib/plausible_web/live/funnel_settings/form.ex
@@ -117,12 +117,12 @@ defmodule PlausibleWeb.Live.FunnelSettings.Form do
                 </div>
               </div>
 
-              <div class="mt-6">
+              <div class="flex flex-col gap-y-4 mt-6">
                 <.add_step_button :if={
                   length(@step_ids) < Funnel.max_steps() and
                     map_size(@selections_made) < length(@goals)
                 } />
-                <p id="funnel-eval" class="text-gray-500 dark:text-gray-400 text-sm my-2">
+                <p id="funnel-eval" class="text-gray-800 dark:text-gray-200 text-sm">
                   <%= if @evaluation_result do %>
                     Last month conversion rate: <strong><%= List.last(@evaluation_result.steps).conversion_rate %></strong>%
                   <% end %>


### PR DESCRIPTION
### Changes

- Fix the following Safari bug:
<img width="527" height="467" alt="image" src="https://github.com/user-attachments/assets/127c7fdf-f88c-4af6-adda-8e1da99e07e9" />

To repro: In Safari, ensure you have exactly 2 goals, then create a funnel where you add two goals. The `+ Add another step` should disappear (as there are no more goals to add), but the top is still slightly visible.


### Tests
- [x] This PR does not require tests

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
