### PR TITLE
CRM: enable team search by identifier via `team:{UUID}`

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/components/layout.ex
+++ b/extra/lib/plausible_web/live/customer_support/components/layout.ex
@@ -67,7 +67,7 @@ defmodule PlausibleWeb.CustomerSupport.Components.Layout do
           </p>
           <strong>team:</strong>input<br />
           <p class="font-sans pl-2 mb-1">
-            Search for teams exclusively. Input will be checked against user's name and e-mail.
+            Search for teams exclusively. Input will be checked against user/team name, e-mail or team identifier. Identifier must be provided complete, as is.
           </p>
 
           <strong>team:</strong>input <strong>+sub</strong>

--- a/extra/lib/plausible_web/live/customer_support/components/search.ex
+++ b/extra/lib/plausible_web/live/customer_support/components/search.ex
@@ -103,6 +103,15 @@ defmodule PlausibleWeb.CustomerSupport.Components.Search do
         opts
       end
 
+    opts =
+      case Ecto.UUID.cast(input) do
+        {:ok, _uuid} ->
+          Keyword.merge(opts, uuid_provided?: true)
+
+        _ ->
+          opts
+      end
+
     {[Resource.Team], input, opts}
   end
 


### PR DESCRIPTION
### Changes

<img width="846" height="604" alt="image" src="https://github.com/user-attachments/assets/0cce4883-5b4c-4537-86f8-5538a0eb0901" />

<img width="1266" height="750" alt="image" src="https://github.com/user-attachments/assets/9eb9fc49-57d8-47a7-96da-d7535530b09a" />



### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
