### PR TITLE
Remove background color from demo CTA

### DIFF
--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -56,29 +56,27 @@
   </div>
   <div id="modal_root"></div>
   <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
-    <div class="bg-gray-50 dark:bg-gray-850">
-      <div class="py-12 lg:py-16 lg:flex lg:items-center lg:justify-between">
-        <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 leading-9 sm:text-4xl sm:leading-10 dark:text-gray-100">
-          Want these stats for your website? <br />
-          <span class="text-indigo-600">Start your free trial today.</span>
-        </h2>
-        <div class="flex mt-8 lg:shrink-0 lg:mt-0">
-          <div class="inline-flex shadow-sm rounded-md">
-            <a
-              href="/register"
-              class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
-            >
-              Get started
-            </a>
-          </div>
-          <div class="inline-flex ml-3 shadow-xs rounded-md">
-            <a
-              href="/"
-              class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-indigo-600 bg-white border border-transparent leading-6 rounded-md dark:text-gray-100 dark:bg-gray-800 hover:text-indigo-500 dark:hover:text-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
-            >
-              Learn more
-            </a>
-          </div>
+    <div class="py-12 lg:py-16 lg:flex lg:items-center lg:justify-between">
+      <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 leading-9 sm:text-4xl sm:leading-10 dark:text-gray-100">
+        Want these stats for your website? <br />
+        <span class="text-indigo-600">Start your free trial today.</span>
+      </h2>
+      <div class="flex mt-8 lg:shrink-0 lg:mt-0">
+        <div class="inline-flex shadow-sm rounded-md">
+          <a
+            href="/register"
+            class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
+          >
+            Get started
+          </a>
+        </div>
+        <div class="inline-flex ml-3 shadow-xs rounded-md">
+          <a
+            href="/"
+            class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-indigo-600 bg-white border border-transparent leading-6 rounded-md dark:text-gray-100 dark:bg-gray-800 hover:text-indigo-500 dark:hover:text-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
+          >
+            Learn more
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Changes

The background color of the demo call-to-action was missed during the dark-mode refresh:

<img width="2480" height="628" alt="CleanShot 2025-11-25 at 20 11 45@2x" src="https://github.com/user-attachments/assets/8e81e47c-aa98-4620-af5f-9fbadb6055d3" />


The CTA should just follow the page's background color and therefore doesn't need a background color at all.


### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode