### PR TITLE
Add :segment_id field to shared_links schema

### DIFF
--- a/priv/repo/migrations/20251201154500_add_limited_to_segment_to_shared_links.exs
+++ b/priv/repo/migrations/20251201154500_add_limited_to_segment_to_shared_links.exs
@@ -5,6 +5,7 @@ defmodule Plausible.Repo.Migrations.AddLimitedToSegmentToSharedLinks do
     alter table(:shared_links) do
       add :segment_id, references(:segments, on_delete: :delete_all)
     end
+
     create index(:shared_links, [:segment_id])
   end
 end


### PR DESCRIPTION
### Changes

Adds field to shared_links schema that allows limiting that shared link to this particular segment only.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
