### PR TITLE
Don't multiply average revenue metric by sampling rate in the query

### DIFF
--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -272,8 +272,7 @@ defmodule Plausible.Stats.SQL.Expression do
       wrap_alias(
         [e],
         %{
-          average_revenue:
-            fragment("toDecimal64(avg(?), 3)", e.revenue_reporting_amount)
+          average_revenue: fragment("toDecimal64(avg(?), 3)", e.revenue_reporting_amount)
         }
       )
     end


### PR DESCRIPTION
### Changes

Average calculation should not be corrected by sampling rate as this leads to invalid results for large datasets.

