### PR TITLE
Fix broken v1 filters redirect for pages containing special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - To make internal stats API requests for password-protected shared links, shared link auth cookie must be set in the requests
-- Fix issue with site guests in Editor role and team members in Editor role not being able to change the domain of site
+- Fixed issue with site guests in Editor role and team members in Editor role not being able to change the domain of site
+- Fixed direct dashboard links that use legacy dashboard filters containing URL encoded special characters (e.g. character `ê` in the legacy filter `?page=%C3%AA`)
 
 ## v3.1.0 - 2025-11-13
 

--- a/assets/js/dashboard/util/url-search-params.test.ts
+++ b/assets/js/dashboard/util/url-search-params.test.ts
@@ -242,21 +242,25 @@ describe(`${getRedirectTarget.name}`, () => {
     ).toBeNull()
   })
 
-  it('returns updated URL for page=... style filters (v1), and running the updated value through the function again returns null (no redirect loop)', () => {
-    const pathname = '/'
-    const search = '?page=/docs'
-    const expectedUpdatedSearch = '?f=is,page,/docs&r=v1'
-    expect(
-      getRedirectTarget({
-        pathname,
-        search
-      } as Location)
-    ).toEqual(`${pathname}${expectedUpdatedSearch}`)
-    expect(
-      getRedirectTarget({
-        pathname,
-        search: expectedUpdatedSearch
-      } as Location)
-    ).toBeNull()
-  })
+  it.each([
+    ['?page=/docs', '?f=is,page,/docs&r=v1'],
+    ['?page=%C3%AA&embed=true', '?f=is,page,%C3%AA&embed=true&r=v1']
+  ])(
+    'returns updated URL v1 style filter %s, and running the updated value through the function again returns null (no redirect loop)',
+    (searchString, expectedSearchString) => {
+      const pathname = '/'
+      expect(
+        getRedirectTarget({
+          pathname,
+          search: searchString
+        } as Location)
+      ).toEqual(`${pathname}${expectedSearchString}`)
+      expect(
+        getRedirectTarget({
+          pathname,
+          search: expectedSearchString
+        } as Location)
+      ).toBeNull()
+    }
+  )
 })

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -241,18 +241,17 @@ export function getRedirectTarget(windowLocation: Location): null | string {
   }
 
   const isV2 = v2.isV2(searchParams)
+  const isV1 = v1.isV1(searchParams)
+
   if (isV2) {
     return `${windowLocation.pathname}${stringifySearch({ ...v2.parseSearch(windowLocation.search), [REDIRECTED_SEARCH_PARAM_NAME]: 'v2' })}`
   }
 
-  const searchRecord = v2.parseSearch(windowLocation.search)
-  const isV1 = v1.isV1(searchRecord)
-
-  if (!isV1) {
-    return null
+  if (isV1) {
+    return `${windowLocation.pathname}${stringifySearch({ ...v1.parseSearch(windowLocation.search), [REDIRECTED_SEARCH_PARAM_NAME]: 'v1' })}`
   }
 
-  return `${windowLocation.pathname}${stringifySearch({ ...v1.parseSearchRecord(searchRecord), [REDIRECTED_SEARCH_PARAM_NAME]: 'v1' })}`
+  return null
 }
 
 /** Called once before React app mounts. If legacy url search params are present, does a redirect to new format. */


### PR DESCRIPTION
### Changes

- Fixed direct dashboard links that use legacy dashboard filters containing URL encoded special characters (e.g. character `ê` in the legacy filter `?page=%C3%AA`)

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
