### PR TITLE
Fix SamplingCache read concurrency

### DIFF
--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -151,7 +151,7 @@ defmodule Plausible.Application do
             adapter_opts: [
               n_lock_partitions: 1,
               ttl_check_interval: false,
-              read_concurrency: true
+              ets_options: [read_concurrency: true]
             ],
             warmers: [
               refresh_all:


### PR DESCRIPTION
### Changes

Passes `read_concurrency: true` to the underlying ETS table. It's not passed at the moment.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
