### PR TITLE
Fix visitors being invisible in OS report on mobile

### DIFF
--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -191,7 +191,7 @@ function OperatingSystems({ afterFetchData }) {
       metrics.createVisitors({ meta: { plot: true } }),
       !hasConversionGoalFilter(query) &&
         metrics.createPercentage({
-          meta: { showOnHover: true, hiddenOnMobile: true }
+          meta: { showOnHover: true }
         }),
       hasConversionGoalFilter(query) && metrics.createConversionRate()
     ].filter((metric) => !!metric)


### PR DESCRIPTION
### Changes

- The `hiddenOnMobile` classes were a remnant from when the percentages were displayed only for this report, and were conflicting with the new styling.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
