### PR TITLE
Adjust percentage hover effect to only show when hovering rows

### DIFF
--- a/assets/js/dashboard/stats/devices/index.js
+++ b/assets/js/dashboard/stats/devices/index.js
@@ -438,7 +438,7 @@ export default function Devices() {
   }
 
   return (
-    <div className="group/report overflow-x-hidden">
+    <div className="overflow-x-hidden">
       <div className="flex justify-between w-full">
         <div className="flex gap-x-1">
           <h3 className="font-bold dark:text-gray-100">Devices</h3>

--- a/assets/js/dashboard/stats/locations/index.js
+++ b/assets/js/dashboard/stats/locations/index.js
@@ -253,7 +253,7 @@ class Locations extends React.Component {
 
   render() {
     return (
-      <div className="group/report overflow-x-hidden">
+      <div className="overflow-x-hidden">
         <div className="w-full flex justify-between">
           <div className="flex gap-x-1">
             <h3 className="font-bold dark:text-gray-100">

--- a/assets/js/dashboard/stats/pages/index.js
+++ b/assets/js/dashboard/stats/pages/index.js
@@ -193,7 +193,7 @@ export default function Pages() {
   }
 
   return (
-    <div className="group/report overflow-x-hidden">
+    <div className="overflow-x-hidden">
       {/* Header Container */}
       <div className="w-full flex justify-between">
         <div className="flex gap-x-1">

--- a/assets/js/dashboard/stats/reports/list.tsx
+++ b/assets/js/dashboard/stats/reports/list.tsx
@@ -234,7 +234,10 @@ export default function ListReport<
         <div className="h-full flex flex-col">
           <div style={{ height: ROW_HEIGHT }}>{renderReportHeader()}</div>
 
-          <div style={{ minHeight: DATA_CONTAINER_HEIGHT }}>
+          <div
+            className="group/report"
+            style={{ minHeight: DATA_CONTAINER_HEIGHT }}
+          >
             <FlipMove className="grow">
               {state.list.slice(0, MAX_ITEMS).map(renderRow)}
             </FlipMove>

--- a/assets/js/dashboard/stats/sources/source-list.js
+++ b/assets/js/dashboard/stats/sources/source-list.js
@@ -247,7 +247,7 @@ export default function SourceList() {
   }
 
   return (
-    <div className="group/report overflow-x-hidden">
+    <div className="overflow-x-hidden">
       {/* Header Container */}
       <div className="w-full flex justify-between">
         <div className="flex gap-x-1">


### PR DESCRIPTION
### Changes

- To avoid triggering the percentages when hovering over the tabs, the hover effect is now only applied when hovering the rows themselves.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
