### PR TITLE
Fix filter modal overflow bug

### DIFF
--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -178,7 +178,7 @@ class FilterModal extends React.Component {
 
   render() {
     return (
-      <Modal maxWidth="460px" onClose={this.closeModal}>
+      <Modal maxWidth="460px" allowScroll={true} onClose={this.closeModal}>
         <div className="flex items-center justify-between gap-3">
           <h1 className="text-base md:text-lg font-bold dark:text-gray-100">
             Filter by {formatFilterGroup(this.props.modalType)}

--- a/assets/js/dashboard/stats/modals/modal.js
+++ b/assets/js/dashboard/stats/modals/modal.js
@@ -56,6 +56,12 @@ class Modal extends React.Component {
     return styleObject
   }
 
+  getOverflowClass() {
+    return this.props.allowScroll === true
+      ? 'overflow-y-auto'
+      : 'overflow-hidden'
+  }
+
   render() {
     return createPortal(
       <>
@@ -68,10 +74,10 @@ class Modal extends React.Component {
         />
         <div className="modal is-open" onClick={this.props.onClick}>
           <div className="modal__overlay">
-            <div className="[--gap:1rem] sm:[--gap:2rem] md:[--gap:4rem] flex h-full w-full items-center md:items-start justify-center p-[var(--gap)] box-border">
+            <div className="[--gap:1rem] sm:[--gap:2rem] md:[--gap:3.2rem] flex h-full w-full items-center md:items-start justify-center p-[var(--gap)] box-border">
               <div
                 ref={this.node}
-                className="max-h-[calc(100dvh_-_var(--gap)*2)] min-h-[66vh] md:min-h-120 w-full flex flex-col bg-white p-3 md:px-6 md:py-4 overflow-hidden box-border transition-[height] duration-200 ease-in shadow-2xl rounded-lg dark:bg-gray-900 focus:outline-hidden"
+                className={`max-h-[calc(100dvh_-_var(--gap)*2)] min-h-[66vh] md:min-h-120 w-full flex flex-col bg-white p-3 md:px-6 md:py-4 ${this.getOverflowClass()} box-border transition-[height] duration-200 ease-in shadow-2xl rounded-lg dark:bg-gray-900 focus:outline-hidden`}
                 style={this.getStyle()}
                 // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                 tabIndex={0}


### PR DESCRIPTION
### Changes

- When the filter modal height exceeds the viewport height, it was impossible to scroll. Added an `allowScroll` prop to the modal component to optionally allow scrolling. In the breakdown modal we don't want to allow it, because only the inner table is scrollable.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
