### PR TITLE
Fix flaky tests

### DIFF
--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -372,8 +372,8 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
                    true
                  }
                end,
-               200,
-               20
+               50,
+               50
              )
     end
 
@@ -393,8 +393,8 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
                    true
                  }
                end,
-               200,
-               20
+               50,
+               50
              )
     end
   end

--- a/test/plausible_web/live/funnel_settings_test.exs
+++ b/test/plausible_web/live/funnel_settings_test.exs
@@ -1,5 +1,5 @@
 defmodule PlausibleWeb.Live.FunnelSettingsTest do
-  use PlausibleWeb.ConnCase, async: true
+  use PlausibleWeb.ConnCase, async: false
   @moduletag :ee_only
 
   on_ee do


### PR DESCRIPTION
The suggest function sleeps for 500ms, so we need sufficient retries to handle
both the task execution time and LiveView message processing under low
resources. With this I couldn't reproduce anymore in repetead runs.

In the other case, funnel saved message may arrive after the test is
done and this is when Funnels are listed again.