### PR TITLE
Fix comparison line color in dark mode regression

### DIFF
--- a/assets/js/dashboard/stats/graph/graph-util.js
+++ b/assets/js/dashboard/stats/graph/graph-util.js
@@ -31,9 +31,9 @@ const buildComparisonDataset = function (comparisonPlot) {
   return [
     {
       data: plottable(comparisonPlot),
-      borderColor: 'rgb(199, 210, 254)',
-      pointBackgroundColor: 'rgb(199, 210, 254)',
-      pointHoverBackgroundColor: 'rgb(199, 210, 254)',
+      borderColor: 'rgba(99, 102, 241, 0.3)',
+      pointBackgroundColor: 'rgba(99, 102, 241, 0.2)',
+      pointHoverBackgroundColor: 'rgba(99, 102, 241, 0.5)',
       yAxisID: 'yComparison'
     }
   ]


### PR DESCRIPTION
### Changes

- There was a regression in [this commit](https://github.com/plausible/analytics/pull/5962) that replaced the transparent rgba values with opaque rgb values for the comparison line in the main graph. This resulted in the line being very light in dark mode. This commit updates the value to use transparency again so that it works for both light and dark mode.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode