### PR TITLE
Fix search input placeholder visibility when input has value

### DIFF
--- a/assets/css/loader.css
+++ b/assets/css/loader.css
@@ -5,8 +5,8 @@
 }
 
 .loading.sm {
-  width: 25px;
-  height: 25px;
+  width: 20px;
+  height: 20px;
 }
 
 .loading div {
@@ -25,8 +25,8 @@
 }
 
 .loading.sm div {
-  width: 25px;
-  height: 25px;
+  width: 20px;
+  height: 20px;
 }
 
 @keyframes spin {

--- a/assets/js/dashboard/components/search-input.tsx
+++ b/assets/js/dashboard/components/search-input.tsx
@@ -22,6 +22,7 @@ export const SearchInput = ({
   placeholderUnfocusedOnlyDesktop?: string
 }) => {
   const [isFocused, setIsFocused] = useState(false)
+  const [hasValue, setHasValue] = useState(false)
 
   const onSearchInputChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
@@ -30,6 +31,15 @@ export const SearchInput = ({
     [onSearch]
   )
   const debouncedOnSearchInputChange = useDebounce(onSearchInputChange)
+
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      const value = event.target.value
+      setHasValue(value.length > 0)
+      debouncedOnSearchInputChange(event)
+    },
+    [debouncedOnSearchInputChange]
+  )
 
   const blurSearchBox = useCallback(() => {
     searchRef.current?.blur()
@@ -67,14 +77,18 @@ export const SearchInput = ({
           type="text"
           placeholder=" "
           className="peer w-full text-sm dark:text-gray-100 block border-gray-300 dark:border-gray-750 rounded-md dark:bg-gray-750 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
-          onChange={debouncedOnSearchInputChange}
+          onChange={handleInputChange}
         />
-        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 peer-[:not(:placeholder-shown)]:hidden md:peer-[:not(:focus)]:hidden">
-          {placeholderFocusedOrMobile}
-        </span>
-        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 peer-[:not(:placeholder-shown)]:hidden hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
-          {placeholderUnfocusedOnlyDesktop}
-        </span>
+        {!hasValue && (
+          <>
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 md:peer-[:not(:focus)]:hidden">
+              {placeholderFocusedOrMobile}
+            </span>
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
+              {placeholderUnfocusedOnlyDesktop}
+            </span>
+          </>
+        )}
       </div>
     </>
   )

--- a/assets/js/dashboard/stats/modals/breakdown-table.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-table.tsx
@@ -50,7 +50,6 @@ export const BreakdownTable = <TListItem extends { name: string }>({
           <h1 className="shrink-0 mb-0.5 text-base md:text-lg font-bold dark:text-gray-100">
             {title}
           </h1>
-          {!isPending && isFetching && <SmallLoadingSpinner />}
           {!!onSearch && (
             <SearchInput
               searchRef={searchRef}
@@ -62,6 +61,7 @@ export const BreakdownTable = <TListItem extends { name: string }>({
               }
             />
           )}
+          {!isPending && isFetching && <SmallLoadingSpinner />}
         </div>
         <button
           type="button"


### PR DESCRIPTION
### Changes

In a [previous commit](https://github.com/plausible/analytics/pull/5979), the search input placeholder was updated to only show `Search` rather than `Press / to search` on mobile. This introduced a bug where placeholders remained visible when the input contained a value but wasn't focused. Replacing CSS-only placeholder hiding with React state-based approach.

- Add `hasValue` state to track input content
- Update `onChange` handler to immediately set `hasValue` while keeping `onSearch` callback debounced
- Conditionally render placeholder spans only when `!hasValue`

<img width="1062" height="317" alt="CleanShot 2026-01-07 at 12 40 22@2x" src="https://github.com/user-attachments/assets/6e26f546-1840-429b-b3b2-c4bab5e68148" />

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not affect dark mode
