### PR TITLE
Increase tab and details button hit area

### DIFF
--- a/assets/js/dashboard/components/tabs.tsx
+++ b/assets/js/dashboard/components/tabs.tsx
@@ -59,7 +59,10 @@ export const TabButton = ({
     })}
   >
     <button
-      className={classNames('group/tab relative flex rounded-sm before:absolute before:inset-[-16px_-6px] before:content-[" "]', className)}
+      className={classNames(
+        'group/tab relative flex rounded-sm before:absolute before:inset-[-16px_-6px] before:content-[" "]',
+        className
+      )}
       onClick={onClick}
     >
       <TabButtonText active={active}>{children}</TabButtonText>

--- a/assets/js/dashboard/stats/more-link.js
+++ b/assets/js/dashboard/stats/more-link.js
@@ -30,7 +30,7 @@ export default function MoreLink({ linkProps, state }) {
   }, [])
 
   const baseClassName =
-    'flex mt-px text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors duration-150'
+    'relative flex mt-px text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors duration-150 before:absolute before:inset-[-8px] before:content-[" "]'
   const icon = detailsIcon()
 
   if (state === MoreLinkState.HIDDEN) {


### PR DESCRIPTION
### Changes

- Expand the clickable area using an invisible `::before pseudo-element` without affecting visuals.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
