### PR TITLE
Remove `OrderedObject` wrappings from `QueryResult`

### DIFF
--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -40,21 +40,20 @@ defmodule Plausible.Stats.QueryResult do
     struct!(
       __MODULE__,
       results: results,
-      meta: meta(runner) |> Enum.sort_by(&elem(&1, 0)) |> Jason.OrderedObject.new(),
-      query:
-        Jason.OrderedObject.new(
-          site_id: site.domain,
-          metrics: query.metrics,
-          date_range: [
-            to_iso8601(query.utc_time_range.first, query.timezone),
-            to_iso8601(query.utc_time_range.last, query.timezone)
-          ],
-          filters: query.filters,
-          dimensions: query.dimensions,
-          order_by: query.order_by |> Enum.map(&Tuple.to_list/1),
-          include: include(query) |> Map.filter(fn {_key, val} -> val end),
-          pagination: query.pagination
-        )
+      meta: meta(runner),
+      query: %{
+        site_id: site.domain,
+        metrics: query.metrics,
+        date_range: [
+          to_iso8601(query.utc_time_range.first, query.timezone),
+          to_iso8601(query.utc_time_range.last, query.timezone)
+        ],
+        filters: query.filters,
+        dimensions: query.dimensions,
+        order_by: query.order_by |> Enum.map(&Tuple.to_list/1),
+        include: include(query) |> Map.filter(fn {_key, val} -> val end),
+        pagination: query.pagination
+      }
     )
   end
 
@@ -212,7 +211,6 @@ end
 
 defimpl Jason.Encoder, for: Plausible.Stats.QueryResult do
   def encode(%Plausible.Stats.QueryResult{results: results, meta: meta, query: query}, opts) do
-    Jason.OrderedObject.new(results: results, meta: meta, query: query)
-    |> Jason.Encoder.encode(opts)
+    Jason.Encoder.encode(%{results: results, meta: meta, query: query}, opts)
   end
 end

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -373,7 +373,7 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   @imported_query_unsupported_warning "Imported stats are not included in the results because query parameters are not supported. For more information, see: https://plausible.io/docs/stats-api#filtering-imported-stats"
 
-  defp maybe_add_warning(payload, %Jason.OrderedObject{} = meta) do
+  defp maybe_add_warning(payload, meta) do
     case meta[:imports_skip_reason] do
       :unsupported_query -> Map.put(payload, :warning, @imported_query_unsupported_warning)
       _ -> payload

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -216,7 +216,7 @@ defmodule PlausibleWeb.Api.StatsController do
     })
   end
 
-  defp with_imported_switch_info(%Jason.OrderedObject{} = meta) do
+  defp with_imported_switch_info(meta) do
     case {meta[:imports_included], meta[:imports_skip_reason]} do
       {true, nil} ->
         %{visible: true, togglable: true, tooltip_msg: "Click to exclude imported data"}

--- a/test/plausible/stats/query/query_result_test.exs
+++ b/test/plausible/stats/query/query_result_test.exs
@@ -1,6 +1,6 @@
 defmodule Plausible.Stats.Query.QueryResultTest do
   use Plausible.DataCase, async: true
-  alias Plausible.Stats.{Query, QueryRunner, QueryResult, QueryOptimizer}
+  alias Plausible.Stats.{Query, QueryRunner}
 
   setup do
     user = insert(:user)
@@ -37,61 +37,5 @@ defmodule Plausible.Stats.Query.QueryResultTest do
                      }
                    )
                  end
-  end
-
-  test "serializing query to JSON keeps keys ordered", %{site: site} do
-    query =
-      Query.parse_and_build!(
-        site,
-        %{
-          "site_id" => site.domain,
-          "metrics" => ["pageviews"],
-          "date_range" => ["2024-01-01", "2024-02-01"],
-          "include" => %{"imports" => true}
-        }
-      )
-
-    query = QueryOptimizer.optimize(query)
-
-    query_result_json =
-      %QueryRunner{site: site, results: [], main_query: query}
-      |> QueryResult.from()
-      |> Jason.encode!(pretty: true)
-      |> String.replace(site.domain, "dummy.site")
-
-    assert query_result_json == """
-           {
-             "results": [],
-             "meta": {
-               "imports_included": false,
-               "imports_skip_reason": "no_imported_data"
-             },
-             "query": {
-               "site_id": "dummy.site",
-               "metrics": [
-                 "pageviews"
-               ],
-               "date_range": [
-                 "2024-01-01T00:00:00Z",
-                 "2024-02-01T23:59:59Z"
-               ],
-               "filters": [],
-               "dimensions": [],
-               "order_by": [
-                 [
-                   "pageviews",
-                   "desc"
-                 ]
-               ],
-               "include": {
-                 "imports": true
-               },
-               "pagination": {
-                 "offset": 0,
-                 "limit": 10000
-               }
-             }
-           }\
-           """
   end
 end

--- a/test/plausible_web/live/components/dashboard/report_list_test.exs
+++ b/test/plausible_web/live/components/dashboard/report_list_test.exs
@@ -43,8 +43,8 @@ defmodule PlausibleWeb.Components.Dashboard.ReportListTest do
           %{metrics: [70, 40.0], dimensions: ["/b"]},
           %{metrics: [30, 20.0], dimensions: ["/c"]}
         ],
-        meta: Jason.OrderedObject.new(metric_labels: ["Conversions", "CR"]),
-        query: Jason.OrderedObject.new(metrics: [:visitors, :conversion_rate])
+        meta: %{metric_labels: ["Conversions", "CR"]},
+        query: %{metrics: [:visitors, :conversion_rate]}
       })
 
     assigns = Keyword.put(assigns, :query_result, successful_async_result)


### PR DESCRIPTION
### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
