### PR TITLE
Stop queries for cancelled requests

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -628,7 +628,8 @@ config :plausible, Plausible.ClickhouseRepo,
   transport_opts: ch_transport_opts,
   settings: [
     readonly: 1,
-    join_algorithm: "direct,parallel_hash,hash"
+    join_algorithm: "direct,parallel_hash,hash",
+    cancel_http_readonly_queries_on_client_close: 1
   ]
 
 config :plausible, Plausible.IngestRepo,


### PR DESCRIPTION
### Changes

Stops CH queries for cancelled requests. Saves some resources that would go to waste otherwise.

### Tests
- [x] Manually tested

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
