### PR TITLE
Prevent "freeze" of modal during close and open and fix history handling

### DIFF
--- a/assets/js/liveview/dashboard_root.js
+++ b/assets/js/liveview/dashboard_root.js
@@ -15,7 +15,11 @@ const MODAL_ROUTES = {
   '/utm_medium': '#utm-mediums-breakdown-details-modal'
 }
 
-function routeModal(path) {
+function routeModal(uri) {
+  // Domain is dropped from URL prefix, because that's what react-dom-router
+  // expects.
+  const path = '/' + uri.pathname.split('/').slice(2).join('/')
+
   const modalId = MODAL_ROUTES[path]
 
   if (modalId) {
@@ -33,17 +37,23 @@ export default buildHook({
     this.portalTargets = Array.from(portals, (p) => p.dataset.phxPortal)
     this.url = window.location.href
 
+    this.addListener('phx:navigate', window, (info) => {
+      if (info.detail?.patch && info.detail?.pop) {
+        const uri = new URL(
+          (info.detail.href.startsWith('http') ? '' : 'https://example.com') +
+            info.detail.href
+        )
+        routeModal(uri)
+      }
+    })
+
     this.addListener('click', document.body, (e) => {
       const link = e.target.closest('[data-phx-link]')
       const type = link && (link.dataset.type || null)
 
       if (type === 'dashboard-link') {
         const uri = new URL(link.href)
-        // Domain is dropped from URL prefix, because that's what react-dom-router
-        // expects.
-        const path = '/' + uri.pathname.split('/').slice(2).join('/')
-
-        routeModal(path)
+        routeModal(uri)
       }
     })
   }

--- a/lib/plausible_web/live/components/dashboard/base.ex
+++ b/lib/plausible_web/live/components/dashboard/base.ex
@@ -75,7 +75,7 @@ defmodule PlausibleWeb.Components.Dashboard.Base do
         </div>
       </div>
     </div>
-    <Modal.modal id={@id} on_close={@on_close} auto_close={false} show={@show}>
+    <Modal.modal id={@id} on_close={@on_close} show={@show}>
       <Modal.modal_overlay
         transition_enter={{"ease-out duration-300", "opacity-0", "opacity-100"}}
         transition_leave={{"ease-in duration-200", "opacity-100", "opacity-0"}}

--- a/lib/plausible_web/live/dashboard.ex
+++ b/lib/plausible_web/live/dashboard.ex
@@ -7,6 +7,7 @@ defmodule PlausibleWeb.Live.Dashboard do
 
   alias Plausible.Repo
   alias Plausible.Stats.Dashboard
+  alias Plausible.Stats.Dashboard.Utils
   alias Plausible.Teams
 
   @spec enabled?(Plausible.Site.t() | nil) :: boolean()
@@ -193,6 +194,13 @@ defmodule PlausibleWeb.Live.Dashboard do
     """
   end
 
+  def handle_event("close_modal", _params, socket) do
+    close_url = Utils.dashboard_route(socket.assigns.site, socket.assigns.params)
+    socket = push_patch(socket, to: close_url)
+
+    {:noreply, socket}
+  end
+
   @modals %{
     ["pages"] => "pages-breakdown-details-modal",
     ["entry-pages"] => "entry-pages-breakdown-details-modal",
@@ -203,7 +211,7 @@ defmodule PlausibleWeb.Live.Dashboard do
   }
 
   defp maybe_close_modal(socket, old_path) do
-    if length(old_path) == 1 and socket.assigns.path == [] and Map.has_key?(@modals, old_path) do
+    if socket.assigns.path == [] and Map.has_key?(@modals, old_path) do
       Prima.Modal.push_close(socket, @modals[old_path])
     else
       socket

--- a/lib/plausible_web/live/dashboard/details_modal.ex
+++ b/lib/plausible_web/live/dashboard/details_modal.ex
@@ -17,8 +17,6 @@ defmodule PlausibleWeb.Live.Dashboard.DetailsModal do
   @pagination %{limit: 50, offset: 0}
 
   def update(assigns, socket) do
-    close_url = Utils.dashboard_route(assigns.site, assigns.params)
-
     socket =
       assign(socket,
         title: assigns.title,
@@ -28,8 +26,7 @@ defmodule PlausibleWeb.Live.Dashboard.DetailsModal do
         site: assigns.site,
         params: assigns.params,
         open?: assigns.open?,
-        connected?: assigns.connected?,
-        close_url: close_url
+        connected?: assigns.connected?
       )
       |> load_stats()
 
@@ -41,7 +38,7 @@ defmodule PlausibleWeb.Live.Dashboard.DetailsModal do
     <div>
       <.modal
         id={"#{@key}-breakdown-details-modal"}
-        on_close={JS.patch(@close_url)}
+        on_close={JS.push("close_modal")}
         show={@open?}
         ready={@connected?}
       >


### PR DESCRIPTION
### Changes

This PR changes two things:

- It removes blocking/freezing behavior when opening and closing modals. I've made another round of manual testing with this. I'm assuming the simulated latency of 400ms is enough of a lower threshold for maintaining acceptable experience (given 2g in Firefox network throttling settings implies ~300ms). It turns out, it's not as bad, provided one keeps in mind that the possible failure modes are:
  - closing and opening the same modal in quick succession may cause the subsequent opening get canceled out by closing event. After URL update settles, next open attempt succeeds
  - closing one modal and opening a different modal in quick succession might result in lack of URL update - it will remain on root ("/") path. In practice this only matters when doing a full page refresh, and, truth be told, I don't see this being a huge pain. The modal can still be closed cleanly and subsequent navigation and open/close cycles of modals work correctly. Also, once has to be _very_ fast to manage to do that even at 400ms. So I think, except for professional Starcraft players with cpms in the hundreds, it should be an acceptable experience.
- It fixes navigation handling for modals when navigating via popstate (browser forward/backward) - now modal is opened and closed in accordance to the updated URL - that was missing

There's still some inconsistency in applying page navigation loading state and popstate navigation does not (always/sometimes) trigger the loading state either, but that's most likely something we can address with further revisions of loading logic.
