### PR TITLE
Reduce calls triggered by /api/plugins/v1/capabilities

### DIFF
--- a/lib/plausible/plugins/api/capabilities.ex
+++ b/lib/plausible/plugins/api/capabilities.ex
@@ -14,12 +14,12 @@ defmodule Plausible.Plugins.API.Capabilities do
     features =
       if site do
         site = Plausible.Repo.preload(site, :team)
+        allowed_features = Plausible.Teams.Billing.allowed_features_for(site.team)
 
         Feature.list()
         |> Enum.map(fn mod ->
-          result = mod.check_availability(site.team)
           feature = mod |> Module.split() |> List.last()
-          {feature, result == :ok}
+          {feature, mod in allowed_features}
         end)
       else
         Enum.map(Feature.list_short_names(), &{&1, false})


### PR DESCRIPTION
I noticed some super slow queries to that endpoint, which queried about 20x subscriptions and enterprise_plans
This reduces the amount of calls necessary.
