### PR TITLE
Do not access `location` during import of tracker module

### DIFF
--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -9,7 +9,7 @@ import { sendRequest } from './networking'
 var listeningOnEngagement = false
 
 var currentEngagementIgnored
-var currentEngagementURL = location.href
+var currentEngagementURL
 var currentEngagementProps = {}
 var currentEngagementMaxScrollDepth = -1
 


### PR DESCRIPTION
### Changes

After making this change, I am able to use server-side generation of a Vue-based website using vite-ssg and the node package, with a static import of the analytics code so it gets inlined and packed into the main JS bundle.

#### Initialize currentEngagementURL to undefined, not `location.href`

For use in a server-side rendered environment, it is important we don't access browser variables before `init` or `track` are called, that might not exist in Node/Bun/etc.

There isn't much reason to set this variable to location.href prior to `postPageviewTrack` being called, as we won't use it until engagements are registered, in which case, we will have set the URL from the payload.

This is the current error when importing (but not running) the code in Node:

```
Welcome to Node.js v25.4.0.
Type ".help" for more information.
> import('@plausible-analytics/tracker/plausible.js')
Promise {
  <pending>,
  Symbol(async_id_symbol): 103,
  Symbol(trigger_async_id_symbol): 6
}
> Uncaught ReferenceError: location is not defined
```

After this change, the import is successful:

```
Welcome to Node.js v25.4.0.
Type ".help" for more information.
> await import('@plausible-analytics/tracker')
[Module: null prototype] {
  DEFAULT_FILE_TYPES: [
    'pdf', 'xlsx', 'docx', 'txt',
...
    'wma', 'dmg'
  ],
  init: [Function: init],
  track: [Function: track]
}
```

### Tests
- [X] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

I didn't update the tracker changelog- this seems like something done at release time, when I read the tracker-specific docs.

### Documentation
- [X] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
