### PR TITLE
Filter out  driver disconnect error messages

### DIFF
--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -32,6 +32,16 @@ defmodule Plausible.SentryFilter do
     %{event | fingerprint: ["mint_transport", reason]}
   end
 
+  def before_send(
+        %{source: :logger, message: %{formatted: "Ch.Connection (#PID<" <> rest}} = event
+      ) do
+    if String.ends_with?(rest, ")) disconnected: ** (Mint.HTTPError) the connection is closed") do
+      false
+    else
+      event
+    end
+  end
+
   def before_send(%{extra: %{request: %Plausible.Ingestion.Request{}}} = event) do
     %{event | fingerprint: ["ingestion_request"]}
   end


### PR DESCRIPTION
They are pure noise as the driver is setup to automatically reconnect since https://github.com/plausible/ch/pull/292.

Meant to filter out log entries like:

```
Ch.Connection (#PID<0.5405.0> ("db_conn_12")) disconnected: ** (Mint.HTTPError) the connection is closed 
```
