### PR TITLE
Handle case of empty metrics during prom_ex scraping

### DIFF
--- a/lib/plausible/prom_ex/striped_peep.ex
+++ b/lib/plausible/prom_ex/striped_peep.ex
@@ -7,7 +7,7 @@ defmodule Plausible.PromEx.StripedPeep do
 
   @impl true
   def scrape(name) do
-    Peep.get_all_metrics(name)
+    (Peep.get_all_metrics(name) || [])
     |> Peep.Prometheus.export()
     |> IO.iodata_to_binary()
   end


### PR DESCRIPTION
This surfaces only in a corner case where there are no metrics to export over the period between scrapes, which is very rare.

Manifests as:

```
Request: GET /metrics
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Enumerable not implemented for type Atom. This protocol is implemented for the following type(s): Ch.Stream, DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Floki.HTMLTree, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, LazyHTML, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Req.Response.Async, Scrivener.Page, Stream, Timex.Interval

Got value:

    nil

        (elixir 1.18.3) lib/enum.ex:1: Enumerable.impl_for!/1
        (elixir 1.18.3) lib/enum.ex:166: Enumerable.reduce/3
        (elixir 1.18.3) lib/enum.ex:4515: Enum.map/2
        (plausible 0.0.1) lib/plausible/prom_ex/striped_peep.ex:11: Plausible.PromEx.StripedPeep.scrape/1
        (prom_ex 1.11.0) lib/prom_ex/plug.ex:58: PromEx.Plug.call/2
        (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint.plug_builder_call/2
        (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint."call (overridable 3)"/2
        (plausible 0.0.1) lib/plausible_web/endpoint.ex:1: PlausibleWeb.Endpoint.call/2
```