### PR TITLE
Add usage progress bar for plan limits

### DIFF
--- a/test/plausible_web/components/billing/billing_test.exs
+++ b/test/plausible_web/components/billing/billing_test.exs
@@ -119,4 +119,95 @@ defmodule PlausibleWeb.Components.BillingTest do
     """
     |> rendered_to_string()
   end
+
+  describe "usage_progress_row/1" do
+    test "renders progress bar with green color at 0% usage" do
+      html = render_progress_row(0, 10_000)
+
+      assert html =~ "0"
+      assert html =~ "10,000"
+      assert html =~ "width: 0"
+      assert html =~ "bg-green-500 dark:bg-green-600"
+    end
+
+    test "renders progress bar with green color at 50% usage" do
+      html = render_progress_row(5_000, 10_000)
+
+      assert html =~ "5,000"
+      assert html =~ "10,000"
+      assert html =~ "width: 50.0%"
+      assert html =~ "bg-green-500 dark:bg-green-600"
+    end
+
+    test "renders progress bar with green color at 90% usage" do
+      html = render_progress_row(9_000, 10_000)
+
+      assert html =~ "9,000"
+      assert html =~ "10,000"
+      assert html =~ "width: 90.0%"
+      assert html =~ "bg-green-500 dark:bg-green-600"
+    end
+
+    test "renders progress bar with gradient at 95% usage" do
+      html = render_progress_row(9_500, 10_000)
+
+      assert html =~ "9,500"
+      assert html =~ "10,000"
+      assert html =~ "width: 95.0%"
+      assert html =~ "bg-gradient-to-r from-green-500 via-yellow-500 via-[80%] to-orange-500"
+    end
+
+    test "renders progress bar with red gradient at 100% usage" do
+      html = render_progress_row(10_000, 10_000)
+
+      assert html =~ "10,000"
+      assert html =~ "width: 100.0%"
+      assert html =~ "bg-gradient-to-r from-green-500 via-orange-500 via-[80%] to-red-500"
+    end
+
+    test "caps percentage at 100% when usage exceeds limit" do
+      html = render_progress_row(15_000, 10_000)
+
+      assert html =~ "15,000"
+      assert html =~ "10,000"
+      assert html =~ "width: 100.0%"
+      assert html =~ "bg-gradient-to-r from-green-500 via-orange-500 via-[80%] to-red-500"
+    end
+
+    test "handles unlimited limit" do
+      html = render_progress_row(5_000, :unlimited)
+
+      assert html =~ "5,000"
+      assert html =~ "Unlimited"
+      assert html =~ "width: 0%"
+      assert html =~ "bg-green-500 dark:bg-green-600"
+    end
+
+    test "handles zero limit" do
+      html = render_progress_row(0, 0)
+
+      assert html =~ "0"
+      assert html =~ "width: 0%"
+      assert html =~ "bg-gray-200 dark:bg-gray-700"
+    end
+
+    test "includes title in output" do
+      html = render_progress_row(100, 1000, "Test title")
+
+      assert html =~ "Test title"
+    end
+  end
+
+  defp render_progress_row(usage, limit, title \\ "Pageviews") do
+    assigns = %{title: title, usage: usage, limit: limit}
+
+    ~H"""
+    <PlausibleWeb.Components.Billing.usage_progress_row
+      title={@title}
+      usage={@usage}
+      limit={@limit}
+    />
+    """
+    |> rendered_to_string()
+  end
 end


### PR DESCRIPTION
### Changes

- As part of improving the subscription settings page, this commit adds a progress bar for displaying how far a usage limit has been reached. This component not yet being displayed in the UI.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
