### PR TITLE
grace period end in hours + remove unused fn

### DIFF
--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -398,12 +398,12 @@ defmodule PlausibleWeb.Components.Billing.Notice do
   end
 
   def usage_notification(%{type: :grace_period_active, team: team} = assigns) do
-    days_left = Plausible.Teams.GracePeriod.days_left(team)
-
     deadline_text =
-      case days_left do
-        1 -> "within the next day"
-        n -> "within the next #{n} days"
+      case Plausible.Teams.GracePeriod.expires_in(team) do
+        {0, :hours} -> "within the hour"
+        {1, :hours} -> "within the next hour"
+        {n, :hours} -> "within the next #{n} hours"
+        {n, :days} -> "within the next #{n} days"
       end
 
     assigns = assign(assigns, :deadline_text, deadline_text)

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -6,7 +6,6 @@
   <Notice.active_grace_period
     :if={Plausible.Teams.GracePeriod.active?(@current_team)}
     enterprise?={Plausible.Teams.Billing.enterprise_configured?(@current_team)}
-    grace_period_end={grace_period_end(@current_team)}
   />
 
   <Notice.dashboard_locked :if={Plausible.Teams.GracePeriod.expired?(@current_team)} />

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -248,16 +248,6 @@ defmodule PlausibleWeb.LayoutView do
     end
   end
 
-  def grace_period_end(%{grace_period: %{end_date: %Date{} = date}}) do
-    case Date.diff(date, Date.utc_today()) do
-      0 -> "today"
-      1 -> "tomorrow"
-      n -> "within #{n} days"
-    end
-  end
-
-  def grace_period_end(_user), do: "in the following days"
-
   @doc "http://blog.plataformatec.com.br/2018/05/nested-layouts-with-phoenix/"
   def render_layout(layout, assigns, do: content) do
     render(layout, Map.put(assigns, :inner_layout, content))

--- a/test/plausible/teams/grace_period_test.exs
+++ b/test/plausible/teams/grace_period_test.exs
@@ -112,4 +112,79 @@ defmodule Plausible.Teams.GracePeriodTest do
     refute Plausible.Teams.GracePeriod.active?(team)
     refute Plausible.Teams.GracePeriod.expired?(team)
   end
+
+  describe "expires_in/1" do
+    test "returns nil for no team" do
+      assert Plausible.Teams.GracePeriod.expires_in(nil) == nil
+    end
+
+    test "returns nil for team without grace period" do
+      team = new_user() |> team_of()
+      refute team.grace_period
+      assert Plausible.Teams.GracePeriod.expires_in(team) == nil
+    end
+
+    test "returns nil for team with a manual_lock grace period" do
+      team =
+        new_user(trial_expiry_date: Date.utc_today())
+        |> team_of()
+        |> Plausible.Teams.GracePeriod.start_manual_lock_changeset()
+        |> Ecto.Changeset.apply_changes()
+
+      assert team.grace_period.manual_lock
+      assert Plausible.Teams.GracePeriod.expires_in(team) == nil
+    end
+
+    test "returns diff in days when at least 48 hours left" do
+      now = ~N[2021-01-01 00:00:00]
+
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: ~D[2021-01-03],
+        is_over: false
+      }
+
+      team = new_user(team: [grace_period: grace_period]) |> team_of()
+
+      assert Plausible.Teams.GracePeriod.expires_in(team, now) == {:days, 2}
+    end
+
+    test "returns diff in hours when less than 48 hours left" do
+      now = ~N[2021-01-01 00:00:01]
+
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: ~D[2021-01-03],
+        is_over: false
+      }
+
+      team = new_user(team: [grace_period: grace_period]) |> team_of()
+
+      assert Plausible.Teams.GracePeriod.expires_in(team, now) == {:hours, 47}
+    end
+
+    test "returns {:hours, 0} when less than an hour left" do
+      now = ~N[2021-01-01 23:00:01]
+
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: ~D[2021-01-02],
+        is_over: false
+      }
+
+      team = new_user(team: [grace_period: grace_period]) |> team_of()
+
+      assert Plausible.Teams.GracePeriod.expires_in(team, now) == {:hours, 0}
+    end
+
+    test "returns {:hours, 0} when end date in already in the past" do
+      now = ~N[2021-01-01 10:00:00]
+
+      grace_period = %Plausible.Teams.GracePeriod{
+        end_date: ~D[2021-01-01],
+        is_over: false
+      }
+
+      team = new_user(team: [grace_period: grace_period]) |> team_of()
+
+      assert Plausible.Teams.GracePeriod.expires_in(team, now) == {:hours, 0}
+    end
+  end
 end


### PR DESCRIPTION
### Changes

Suggestion to display the "grace period ends in" message in hours when less than 48 hours left. Also removes the unused `grace_period_end` function.

Targets the https://github.com/plausible/analytics/pull/6056 branch.