### PR TITLE
Add centralized Icons component with custom SVG icons

### DIFF
--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -4,6 +4,8 @@ defmodule PlausibleWeb.Components.Generic do
   """
   use Phoenix.Component, global_prefixes: ~w(x-)
 
+  import PlausibleWeb.Components.Icons
+
   @notice_themes %{
     gray: %{
       bg: "bg-gray-100 dark:bg-gray-800",
@@ -404,7 +406,7 @@ defmodule PlausibleWeb.Components.Generic do
         {@rest}
       >
         {render_slot(@inner_block)}
-        <Heroicons.arrow_top_right_on_square class={["stroke-2", @icon_class]} />
+        <.external_link_icon class={[@icon_class]} />
       </.link>
       """
     else
@@ -760,14 +762,26 @@ defmodule PlausibleWeb.Components.Generic do
     """
   end
 
-  attr(:rest, :global, include: ~w(fill stroke stroke-width))
+  attr(:rest, :global, include: ~w(fill stroke stroke-width class))
   attr(:name, :atom, required: true)
   attr(:outline, :boolean, default: true)
   attr(:solid, :boolean, default: false)
   attr(:mini, :boolean, default: false)
 
   def dynamic_icon(assigns) do
-    apply(Heroicons, assigns.name, [assigns])
+    case assigns.name do
+      :tag ->
+        PlausibleWeb.Components.Icons.tag_icon(%{class: assigns.rest[:class]})
+
+      :subscription ->
+        PlausibleWeb.Components.Icons.subscription_icon(%{class: assigns.rest[:class]})
+
+      :api_keys ->
+        PlausibleWeb.Components.Icons.key_icon(%{class: assigns.rest[:class]})
+
+      icon_name ->
+        apply(Heroicons, icon_name, [assigns])
+    end
   end
 
   attr(:width, :integer, default: 100)

--- a/lib/plausible_web/components/icons.ex
+++ b/lib/plausible_web/components/icons.ex
@@ -1,0 +1,91 @@
+defmodule PlausibleWeb.Components.Icons do
+  @moduledoc """
+  Reusable icon components
+  """
+  use Phoenix.Component
+
+  attr :class, :any, default: []
+
+  def external_link_icon(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      class={@class}
+    >
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        d="M9 5H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-4M12 12l9-9-.303.303M14 3h7v7"
+      />
+    </svg>
+    """
+  end
+
+  attr :class, :any, default: []
+
+  def tag_icon(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class={@class}>
+      <circle fill="currentColor" cx="7.25" cy="7.25" r="1.25" />
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        d="M4 3h5.172a2 2 0 0 1 1.414.586l5.536 5.536a3 3 0 0 1 0 4.243l-2.757 2.757a3 3 0 0 1-4.243 0l-5.536-5.536A2 2 0 0 1 3 9.172V4a1 1 0 0 1 1-1Z"
+      />
+    </svg>
+    """
+  end
+
+  attr :class, :any, default: []
+
+  def subscription_icon(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class={@class}>
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        d="m21.667 4.333-.72 4a9.669 9.669 0 0 0-18.61 3.399m-.004 7.934.72-4a9.67 9.67 0 0 0 18.61-3.4"
+      />
+      <path
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        d="M14.333 8.333h-3.166a1.835 1.835 0 0 0-1.834 1.827c0 1.013.82 1.84 1.834 1.84h1.666c1.012 0 1.834.827 1.834 1.827 0 1.013-.822 1.84-1.834 1.84H9.667M12 7v1.333M12 17v-1.333"
+      />
+    </svg>
+    """
+  end
+
+  attr :class, :any, default: []
+
+  def key_icon(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class={@class}>
+      <g
+        fill="currentColor"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        transform="translate(.25 .25)"
+      >
+        <circle cx="8" cy="16" r="1" />
+        <path
+          fill="none"
+          d="M17 2 9.856 9.144A6.5 6.5 0 1 0 15 15.5a6.47 6.47 0 0 0-.366-2.134L17 11V8h3l2-2V2h-5Z"
+        />
+      </g>
+    </svg>
+    """
+  end
+end

--- a/lib/plausible_web/live/goal_settings/list.ex
+++ b/lib/plausible_web/live/goal_settings/list.ex
@@ -7,6 +7,8 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
   alias PlausibleWeb.Live.Components.Modal
   alias PlausibleWeb.Components.PrimaDropdown
 
+  import PlausibleWeb.Components.Icons
+
   attr(:goals, :list, required: true)
   attr(:domain, :string, required: true)
   attr(:filter_text, :string)
@@ -286,21 +288,7 @@ defmodule PlausibleWeb.Live.GoalSettings.List do
             </div>
           </div>
         </:tooltip_content>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          class="size-3.5 mt-px flex-shrink-0"
-        >
-          <circle fill="currentColor" cx="7.25" cy="7.25" r="1.25" />
-          <path
-            fill="none"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 3h5.172a2 2 0 0 1 1.414.586l5.536 5.536a3 3 0 0 1 0 4.243l-2.757 2.757a3 3 0 0 1-4.243 0l-5.536-5.536A2 2 0 0 1 3 9.172V4a1 1 0 0 1 1-1Z"
-          />
-        </svg>
+        <.tag_icon class="size-3.5 mt-px flex-shrink-0" />
       </.tooltip>
     </div>
     """

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -68,7 +68,7 @@ defmodule PlausibleWeb.LayoutView do
           %{key: "Funnels", value: "funnels", icon: :funnel}
         end
       end,
-      %{key: "Custom properties", value: "properties", icon: :document_text},
+      %{key: "Custom properties", value: "properties", icon: :tag},
       if regular_site? do
         %{key: "Integrations", value: "integrations", icon: :puzzle_piece}
       end,
@@ -108,13 +108,13 @@ defmodule PlausibleWeb.LayoutView do
           %{key: "Preferences", value: "preferences", icon: :cog_6_tooth},
           %{key: "Security", value: "security", icon: :lock_closed},
           if(ee?() and not Teams.setup?(current_team),
-            do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
+            do: %{key: "Subscription", value: "billing/subscription", icon: :subscription}
           ),
           if(ee?() and not Teams.setup?(current_team) and subscription?,
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(not Teams.setup?(current_team),
-            do: %{key: "API keys", value: "api-keys", icon: :key}
+            do: %{key: "API keys", value: "api-keys", icon: :api_keys}
           ),
           if(Plausible.Users.type(conn.assigns.current_user) == :standard,
             do: %{key: "Danger zone", value: "danger-zone", icon: :exclamation_triangle}
@@ -130,13 +130,13 @@ defmodule PlausibleWeb.LayoutView do
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
           if(ee?() and current_team_role in [:owner, :billing],
-            do: %{key: "Subscription", value: "billing/subscription", icon: :circle_stack}
+            do: %{key: "Subscription", value: "billing/subscription", icon: :subscription}
           ),
           if(ee?() and current_team_role in [:owner, :billing] and subscription?,
             do: %{key: "Invoices", value: "billing/invoices", icon: :banknotes}
           ),
           if(current_team_role in [:owner, :billing, :admin, :editor],
-            do: %{key: "API keys", value: "api-keys", icon: :key}
+            do: %{key: "API keys", value: "api-keys", icon: :api_keys}
           ),
           if(
             ee?() and current_team_role == :owner and


### PR DESCRIPTION
### Changes

In some places we deviate from the Heroicons library and use our own custom icons for aesthetic purposes. This commit centralizes these custom icons in a single component and updates the sidebar menu and goal settings to use them.

- Create PlausibleWeb.Components.Icons module with reusable icon components
- Replace Heroicons external link icon with custom design
- Add custom icons for Custom Properties (tag), Subscription, and API Keys
- Update sidebar menu and goal settings to use centralized icons

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode