### PR TITLE
Add more varied load test profile, refactor instructions to use k6 Docker image

### DIFF
--- a/test/load/.gitignore
+++ b/test/load/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!script.js
+!README.md

--- a/test/load/README.md
+++ b/test/load/README.md
@@ -1,100 +1,127 @@
 # Load testing
 
-This folder contains a [`k6s`](https://grafana.com/docs/k6) load testing script.
-Open the script, set input constants (environment under test, site domains, auth cookie, API token), then run the script using 
+This folder contains a [`k6`](https://grafana.com/docs/k6) load testing script.
+
+## Running the load test
+
+Open the script, set input constants (environment under test, site domains), then run it:
 
 ```sh
-$ docker run --rm -i grafana/k6 run - <script.js
+$ docker run --name k6-test -i --rm grafana/k6 run -e AUTH_COOKIE="_plausible_staging=..." -e STATS_API_TOKEN="..." - < ./script.js
 ```
 
-To reconfigure the load profile, edit the exported `options` constant. 
+To get a machine readable JSON summary, run it using the command:
+
+```sh
+$ docker run --name k6-test -i grafana/k6 run -e AUTH_COOKIE="_plausible_staging=..." -e STATS_API_TOKEN="..." -e JSON_SUMMARY=true - < ./script.js; docker cp k6-test:/tmp/summary.json ./summary.json; docker rm k6-test
+```
+
+## Changing the load profile
+
+To reconfigure the load profile, edit the exported `options` constant.
+
+## Example output
 
 The output looks like this:
+
 ```
-  █ THRESHOLDS 
+  █ THRESHOLDS
 
     http_req_duration{endpoint: "/api/event", domain: "dummy.site/heavy"}
-    ✗ 'p(95)<500' p(95)=5.32s
+    ✗ 'p(95)<1500' p(95)=7.38s
 
     http_req_duration{endpoint: "/api/event", domain: "dummy.site/light"}
-    ✗ 'p(95)<500' p(95)=5.32s
+    ✗ 'p(95)<1500' p(95)=7.56s
+
+    http_req_duration{endpoint: "/api/health"}
+    ✓ 'p(95)<300' p(95)=0s
 
     http_req_duration{endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy"}
-    ✗ 'p(95)<500' p(95)=5.55s
+    ✗ 'p(95)<3000' p(95)=5.53s
 
     http_req_duration{endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light"}
-    ✗ 'p(95)<500' p(95)=4.96s
+    ✗ 'p(95)<1500' p(95)=1.61s
 
     http_req_duration{endpoint: "/api/system/health/ready"}
-    ✗ 'p(95)<500' p(95)=3.99s
+    ✓ 'p(95)<500' p(95)=226.96ms
 
     http_req_duration{endpoint: "/api/v2/query", domain: "dummy.site/heavy"}
-    ✗ 'p(95)<500' p(95)=5.66s
+    ✗ 'p(95)<5000' p(95)=7.2s
 
     http_req_duration{endpoint: "/api/v2/query", domain: "dummy.site/light"}
-    ✗ 'p(95)<500' p(95)=5.98s
+    ✓ 'p(95)<2500' p(95)=1.58s
 
     http_req_failed{endpoint: "/api/event", domain: "dummy.site/heavy"}
-    ✓ 'rate<0.01' rate=0.00%
+    ✗ 'rate<0.01' rate=21.95%
 
     http_req_failed{endpoint: "/api/event", domain: "dummy.site/light"}
-    ✓ 'rate<0.01' rate=0.00%
+    ✗ 'rate<0.01' rate=19.60%
+
+    http_req_failed{endpoint: "/api/health"}
+    ✗ 'rate<0.01' rate=100.00%
 
     http_req_failed{endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy"}
-    ✓ 'rate<0.01' rate=0.00%
+    ✗ 'rate<0.01' rate=14.28%
 
     http_req_failed{endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light"}
-    ✓ 'rate<0.01' rate=0.00%
+    ✗ 'rate<0.01' rate=16.66%
 
     http_req_failed{endpoint: "/api/system/health/ready"}
     ✓ 'rate<0.01' rate=0.00%
 
     http_req_failed{endpoint: "/api/v2/query", domain: "dummy.site/heavy"}
-    ✗ 'rate<0.01' rate=3.27%
+    ✗ 'rate<0.01' rate=33.33%
 
     http_req_failed{endpoint: "/api/v2/query", domain: "dummy.site/light"}
-    ✗ 'rate<0.01' rate=3.27%
+    ✓ 'rate<0.01' rate=0.00%
 
 
-  █ TOTAL RESULTS 
+  █ TOTAL RESULTS
 
-    checks_total.......: 9069   430.116267/s
-    checks_succeeded...: 98.47% 8931 out of 9069
-    checks_failed......: 1.52%  138 out of 9069
+    checks_total.......: 1132   36.498981/s
+    checks_succeeded...: 86.92% 984 out of 1132
+    checks_failed......: 13.07% 148 out of 1132
 
     ✗ request is successful
-      ↳  98% — ✓ 261 / ✗ 4
-    ✓ is accepted
+      ↳  81% — ✓ 13 / ✗ 3
+    ✗ is accepted
+      ↳  78% — ✓ 432 / ✗ 120
     ✗ is buffered
-      ↳  96% — ✓ 4268 / ✗ 134
+      ↳  96% — ✓ 534 / ✗ 18
+    ✗ request is successful (200)
+      ↳  83% — ✓ 5 / ✗ 1
+    ✗ request is rate limited (429)
+      ↳  0% — ✓ 0 / ✗ 6
 
     HTTP
-    http_req_duration...............................................................: avg=1.27s    min=45.76ms  med=332.65ms max=13.95s p(90)=4.49s p(95)=5.32s
-      { endpoint: "/api/event", domain: "dummy.site/heavy" }.................: avg=1.25s    min=45.76ms  med=330.37ms max=9.8s   p(90)=4.48s p(95)=5.32s
-      { endpoint: "/api/event", domain: "dummy.site/light" }.................: avg=1.23s    min=54.57ms  med=327.16ms max=9.44s  p(90)=4.16s p(95)=5.32s
-      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy" }...: avg=1.78s    min=235.45ms med=494.39ms max=13.95s p(90)=5.36s p(95)=5.55s
-      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light" }...: avg=1.47s    min=199.07ms med=464.42ms max=7.86s  p(90)=4.25s p(95)=4.96s
-      { endpoint: "/api/system/health/ready" }......................................: avg=819.57ms min=86.45ms  med=146.18ms max=4.61s  p(90)=3.21s p(95)=3.99s
-      { endpoint: "/api/v2/query", domain: "dummy.site/heavy" }..............: avg=1.84s    min=114.13ms med=579.62ms max=11.42s p(90)=5.04s p(95)=5.66s
-      { endpoint: "/api/v2/query", domain: "dummy.site/light" }..............: avg=1.89s    min=99.36ms  med=581.55ms max=10.53s p(90)=5.4s  p(95)=5.98s
-      { expected_response:true }....................................................: avg=1.28s    min=45.76ms  med=332.76ms max=13.95s p(90)=4.49s p(95)=5.32s
-    http_req_failed.................................................................: 0.08%  4 out of 4667
-      { endpoint: "/api/event", domain: "dummy.site/heavy" }.................: 0.00%  0 out of 4001
-      { endpoint: "/api/event", domain: "dummy.site/light" }.................: 0.00%  0 out of 401
-      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy" }...: 0.00%  0 out of 61
-      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light" }...: 0.00%  0 out of 61
-      { endpoint: "/api/system/health/ready" }......................................: 0.00%  0 out of 21
-      { endpoint: "/api/v2/query", domain: "dummy.site/heavy" }..............: 3.27%  2 out of 61
-      { endpoint: "/api/v2/query", domain: "dummy.site/light" }..............: 3.27%  2 out of 61
-    http_reqs.......................................................................: 4667   221.342223/s
+    http_req_duration........................................................: avg=1.38s    min=0s       med=1.06s    max=7.78s    p(90)=1.88s    p(95)=7.38s
+      { endpoint: "/api/event", domain: "dummy.site/heavy" }.................: avg=1.37s    min=0s       med=1.05s    max=7.77s    p(90)=1.86s    p(95)=7.38s
+      { endpoint: "/api/event", domain: "dummy.site/light" }.................: avg=1.54s    min=0s       med=1.41s    max=7.78s    p(90)=1.91s    p(95)=7.56s
+      { endpoint: "/api/health" }............................................: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
+      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy" }...: avg=1.71s    min=279.43ms med=912.92ms max=7.07s    p(90)=3.99s    p(95)=5.53s
+      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light" }...: avg=738.31ms min=282.4ms  med=437.64ms max=1.77s    p(90)=1.45s    p(95)=1.61s
+      { endpoint: "/api/system/health/ready" }...............................: avg=209.82ms min=190.77ms med=209.82ms max=228.87ms p(90)=225.06ms p(95)=226.96ms
+      { endpoint: "/api/v2/query", domain: "dummy.site/heavy" }..............: avg=3.86s    min=1.8s     med=1.99s    max=7.78s    p(90)=6.62s    p(95)=7.2s
+      { endpoint: "/api/v2/query", domain: "dummy.site/light" }..............: avg=1s       min=371ms    med=989.72ms max=1.65s    p(90)=1.52s    p(95)=1.58s
+      { expected_response:true }.............................................: avg=1.12s    min=111.27ms med=1.19s    max=2.15s    p(90)=1.8s     p(95)=1.86s
+    http_req_failed..........................................................: 21.60%  124 out of 574
+      { endpoint: "/api/event", domain: "dummy.site/heavy" }.................: 21.95%  110 out of 501
+      { endpoint: "/api/event", domain: "dummy.site/light" }.................: 19.60%  10 out of 51
+      { endpoint: "/api/health" }............................................: 100.00% 1 out of 1
+      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/heavy" }...: 14.28%  1 out of 7
+      { endpoint: "/api/stats/:domain/pages", domain: "dummy.site/light" }...: 16.66%  1 out of 6
+      { endpoint: "/api/system/health/ready" }...............................: 0.00%   0 out of 2
+      { endpoint: "/api/v2/query", domain: "dummy.site/heavy" }..............: 33.33%  1 out of 3
+      { endpoint: "/api/v2/query", domain: "dummy.site/light" }..............: 0.00%   0 out of 3
+    http_reqs................................................................: 574     18.507434/s
 
     EXECUTION
-    iteration_duration..............................................................: avg=1.3s     min=46.2ms   med=361.51ms max=14.04s p(90)=4.52s p(95)=5.4s 
-    iterations......................................................................: 4667   221.342223/s
-    vus.............................................................................: 144    min=139       max=362 
-    vus_max.........................................................................: 1310   min=1310      max=1310
+    iteration_duration.......................................................: avg=6.67s    min=332.62ms med=1.92s    max=30.01s   p(90)=30s      p(95)=30s
+    iterations...............................................................: 574     18.507434/s
+    vus......................................................................: 48      min=0          max=420
+    vus_max..................................................................: 8000    min=6005       max=8000
 
     NETWORK
-    data_received...................................................................: 5.5 MB 262 kB/s
-    data_sent.......................................................................: 3.6 MB 172 kB/s
+    data_received............................................................: 1.7 MB  54 kB/s
+    data_sent................................................................: 1.0 MB  33 kB/s
 ```

--- a/test/load/script.js
+++ b/test/load/script.js
@@ -8,10 +8,6 @@ const baseURL = "http://localhost:8000";
 const domainHeavy = "dummy.site/heavy";
 /** Domain of a site registered in the env */
 const domainLight = "dummy.site/light";
-/** Valid auth cookie of a user with access to the domains above in the env */
-const internalApiCookie = "_plausible_dev=...";
-/** Valid Stats API token of a user with access to the domains above in the env */
-const externalApiToken = "...";
 
 const endpoints = {
   track: {
@@ -46,24 +42,34 @@ const endpoints = {
       "is buffered": (res) => res.headers["X-Plausible-Dropped"] != 1,
     },
   },
-  internalApi: {
+  internalApiPages: {
     method: "GET",
     name: "/api/stats/:domain/pages",
     getUrl: ({ domain }) =>
       `${baseURL}/api/stats/${encodeURIComponent(domain)}/pages?period=all&date=${new Date().toISOString().split("T")[0]}&filters=%5B%5D`,
-    getParams: () => ({ headers: { Cookie: internalApiCookie } }),
+    getParams: () => ({ headers: { Cookie: __ENV.AUTH_COOKIE } }),
     checks: {
       "request is successful": (res) => res.status === 200,
     },
   },
-  externalApi: {
+  externalApiQuery: {
     method: "POST",
     name: "/api/v2/query",
     getUrl: () => `${baseURL}/api/v2/query`,
     getBody: ({ domain }) => {
       const { site_id, metrics, date_range, ...rest } = {
         site_id: domain,
-        metrics: ["visitors"],
+        // increase complexity / load with harder queries
+        metrics: ["visitors", "percentage"],
+        filters: [
+          [
+            "or",
+            [
+              ["contains", "event:page", ["1"]],
+              ["not", ["contains", "event:page", ["5", "6", "7", "8", "9"]]],
+            ],
+          ],
+        ],
         date_range: "all",
       };
 
@@ -71,7 +77,7 @@ const endpoints = {
     },
     getParams: () => ({
       headers: {
-        Authorization: `Bearer ${externalApiToken}`,
+        Authorization: `Bearer ${__ENV.STATS_API_TOKEN}`,
         "Content-Type": "application/json",
       },
     }),
@@ -80,10 +86,19 @@ const endpoints = {
       "request is rate limited (429)": (res) => res.status === 429,
     },
   },
-  health: {
+  healthReadiness: {
     method: "GET",
     name: "/api/system/health/ready",
     getUrl: () => `${baseURL}/api/system/health/ready`,
+    getParams: () => ({}),
+    checks: {
+      "request is successful": (res) => res.status === 200,
+    },
+  },
+  healthLiveness: {
+    method: "GET",
+    name: "/api/health",
+    getUrl: () => `${baseURL}/api/health`,
     getParams: () => ({}),
     checks: {
       "request is successful": (res) => res.status === 200,
@@ -110,89 +125,155 @@ export const trackHeavy = () =>
   makeRequest(endpoints.track, { domain: domainHeavy });
 export const trackLight = () =>
   makeRequest(endpoints.track, { domain: domainLight });
-export const healthCheck = () => makeRequest(endpoints.health);
+
+export const readinessCheck = () => makeRequest(endpoints.healthReadiness);
+export const livenessCheck = () => makeRequest(endpoints.healthLiveness);
+
 export const pagesHeavy = () =>
-  makeRequest(endpoints.internalApi, { domain: domainHeavy });
+  makeRequest(endpoints.internalApiPages, { domain: domainHeavy });
 export const pagesLight = () =>
-  makeRequest(endpoints.internalApi, { domain: domainLight });
+  makeRequest(endpoints.internalApiPages, { domain: domainLight });
+
 export const queryHeavy = () =>
-  makeRequest(endpoints.externalApi, { domain: domainHeavy });
+  makeRequest(endpoints.externalApiQuery, { domain: domainHeavy });
 export const queryLight = () =>
-  makeRequest(endpoints.externalApi, { domain: domainLight });
+  makeRequest(endpoints.externalApiQuery, { domain: domainLight });
 
 const scenarioOptions = {
   executor: "constant-arrival-rate",
   timeUnit: "1s",
-  duration: "20s",
+  duration: "120s",
 };
 
+// configuring thresholds changes what stats are shown in the summary at the end
 const selectors = [
-  `endpoint: "${endpoints.health.name}"`,
-  `endpoint: "${endpoints.track.name}", domain: "${domainHeavy}"`,
-  `endpoint: "${endpoints.track.name}", domain: "${domainLight}"`,
-  `endpoint: "${endpoints.internalApi.name}", domain: "${domainHeavy}"`,
-  `endpoint: "${endpoints.internalApi.name}", domain: "${domainLight}"`,
-  `endpoint: "${endpoints.externalApi.name}", domain: "${domainHeavy}"`,
-  `endpoint: "${endpoints.externalApi.name}", domain: "${domainLight}"`,
+  [
+    `endpoint: "${endpoints.healthLiveness.name}"`,
+    [
+      ["http_req_duration", ["p(95)<300"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.healthReadiness.name}"`,
+    [
+      ["http_req_duration", ["p(95)<500"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.track.name}", domain: "${domainHeavy}"`,
+    [
+      ["http_req_duration", ["p(95)<1500"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.track.name}", domain: "${domainLight}"`,
+    [
+      ["http_req_duration", ["p(95)<1500"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.internalApiPages.name}", domain: "${domainHeavy}"`,
+    [
+      ["http_req_duration", ["p(95)<3000"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.internalApiPages.name}", domain: "${domainLight}"`,
+    [
+      ["http_req_duration", ["p(95)<1500"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.externalApiQuery.name}", domain: "${domainHeavy}"`,
+    [
+      ["http_req_duration", ["p(95)<5000"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
+  [
+    `endpoint: "${endpoints.externalApiQuery.name}", domain: "${domainLight}"`,
+    [
+      ["http_req_duration", ["p(95)<2500"]],
+      ["http_req_failed", ["rate<0.01"]],
+    ],
+  ],
 ];
 
 export const options = {
+  // to disable specific requests, comment out those scenarios
   scenarios: {
+    [livenessCheck.name]: {
+      ...scenarioOptions,
+      rate: 1,
+      preAllocatedVUs: 100,
+      exec: livenessCheck.name,
+    },
+    [readinessCheck.name]: {
+      ...scenarioOptions,
+      rate: 1,
+      preAllocatedVUs: 100,
+      exec: readinessCheck.name,
+    },
     [trackHeavy.name]: {
       ...scenarioOptions,
       rate: 500,
-      preAllocatedVUs: 2000,
+      preAllocatedVUs: 6000,
       exec: trackHeavy.name,
     },
     [trackLight.name]: {
       ...scenarioOptions,
       rate: 50,
-      preAllocatedVUs: 200,
+      preAllocatedVUs: 600,
       exec: trackLight.name,
-    },
-    [healthCheck.name]: {
-      ...scenarioOptions,
-      rate: 1,
-      preAllocatedVUs: 10,
-      exec: healthCheck.name,
     },
     [pagesHeavy.name]: {
       ...scenarioOptions,
       rate: 6,
-      preAllocatedVUs: 50,
+      preAllocatedVUs: 400,
       exec: pagesHeavy.name,
     },
     [pagesLight.name]: {
       ...scenarioOptions,
       rate: 6,
-      preAllocatedVUs: 50,
+      preAllocatedVUs: 400,
       exec: pagesLight.name,
     },
     [queryHeavy.name]: {
       ...scenarioOptions,
-      rate: 6,
-      preAllocatedVUs: 50,
+      rate: 3,
+      preAllocatedVUs: 200,
       exec: queryHeavy.name,
     },
     [queryLight.name]: {
       ...scenarioOptions,
-      rate: 6,
-      preAllocatedVUs: 50,
+      rate: 3,
+      preAllocatedVUs: 200,
       exec: queryLight.name,
     },
   },
   thresholds: {
     ...Object.fromEntries(
-      selectors.map((selector) => [
-        `http_req_duration{${selector}}`,
-        ["p(95)<500"],
-      ]),
-    ),
-    ...Object.fromEntries(
-      selectors.map((selector) => [
-        `http_req_failed{${selector}}`,
-        ["rate<0.01"],
-      ]),
+      selectors.flatMap(([selector, thresholds]) =>
+        thresholds.map(([metricName, thresholdValues]) => [
+          `${metricName}{${selector}}`,
+          thresholdValues,
+        ]),
+      ),
     ),
   },
 };
+
+export function handleSummary(data) {
+  if (__ENV.JSON_SUMMARY) {
+    return {
+      "/tmp/summary.json": JSON.stringify(data),
+    };
+  }
+  return undefined; // built-in text summary
+}


### PR DESCRIPTION
### Changes

Adds more varied load test profile: 

- two sites are tracking events (one at 10x the rate of the other)
- both sites are requesting a dashboard report (at the same rate)
- both sites are requesting a custom stats query (at the same rate)

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
