### PR TITLE
Fix funnel tooltip not showing on hover

### DIFF
--- a/assets/js/dashboard/extra/funnel-tooltip.js
+++ b/assets/js/dashboard/extra/funnel-tooltip.js
@@ -8,11 +8,13 @@ export default function FunnelTooltip(palette, funnel) {
     if (!tooltipEl) {
       tooltipEl = document.createElement('div')
       tooltipEl.id = 'chartjs-tooltip-funnel'
-      tooltipEl.className = 'chartjs-tooltip'
       tooltipEl.style.display = 'none'
       tooltipEl.style.opacity = 0
       document.body.appendChild(tooltipEl)
     }
+
+    tooltipEl.className =
+      'absolute text-sm font-normal py-3 px-4 pointer-events-none rounded-md z-[100] bg-[rgb(25_30_56)]'
 
     if (tooltipEl && offset) {
       tooltipEl.style.opacity = 1


### PR DESCRIPTION
### Changes
- The `.chartjs-tooltip` CSS rule was removed when `chartjs.css` was deleted in 91363a2 (Improve dark mode), which meant it wasn't showing on hover. The fix applies Tailwind utility classes directly on the tooltip element.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
