### PR TITLE
Send shared link auth as a query param in the new query endpoint

### DIFF
--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -113,7 +113,12 @@ function getSharedLinkSearchParams(): Record<string, string> {
 }
 
 export async function stats(site: PlausibleSite, statsQuery: StatsQuery) {
-  const response = await fetch(url.apiPath(site, '/query'), {
+  const sharedLinkParams = getSharedLinkSearchParams()
+  const queryString = sharedLinkParams.auth
+    ? new URLSearchParams(sharedLinkParams).toString()
+    : ''
+  const path = url.apiPath(site, '/query')
+  const response = await fetch(queryString ? `${path}?${queryString}` : path, {
     method: 'POST',
     signal: abortController.signal,
     headers: {


### PR DESCRIPTION
### Changes

Fixes a bug that emerged from https://github.com/plausible/analytics/pull/6035. Currently, the top stats request fails with status 404 because the `auth` parameter is missing. As a hotfix, this PR makes the behaviour the same with the GET endpoint and appends `auth` as a query parameter.