### PR TITLE
Make `Sites.list_guests_query` ordering deterministic to avoid flaky tests

### DIFF
--- a/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
+++ b/extra/lib/plausible_web/controllers/api/external_sites_controller.ex
@@ -35,7 +35,7 @@ defmodule PlausibleWeb.Api.ExternalSitesController do
 
     with {:ok, site_id} <- expect_param_key(params, "site_id"),
          {:ok, site} <- find_site(user, team, site_id, [:owner, :admin, :editor, :viewer]) do
-      opts = [cursor_fields: [inserted_at: :desc, id: :desc], limit: 100, maximum_limit: 1000]
+      opts = [cursor_fields: [sort_index: :asc], limit: 100, maximum_limit: 1000]
       page = site |> Sites.list_guests_query() |> paginate(params, opts)
 
       json(conn, %{

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -247,6 +247,7 @@ defmodule Plausible.Sites do
     from(g in subquery(guests),
       select: %{
         id: g.id,
+        sort_index: g.sort_index,
         inserted_at: g.inserted_at,
         email: g.email,
         role: g.role,


### PR DESCRIPTION
The tests are currently wreaking havoc on our CI. This PR should fix it

