### PR TITLE
Improve monthly usage breakdown component

### DIFF
--- a/lib/plausible_web/components/billing/billing.ex
+++ b/lib/plausible_web/components/billing/billing.ex
@@ -129,7 +129,12 @@ defmodule PlausibleWeb.Components.Billing do
           {PlausibleWeb.TextHelpers.format_date_range(@usage.date_range)}
           <span :if={@period in [:current_cycle, :last_30_days]}>{cycle_label(@period)}</span>
         </p>
-        <.usage_progress_bar :if={@limit != :unlimited} id={"total_pageviews_#{@period}"} usage={@usage.total} limit={@limit} />
+        <.usage_progress_bar
+          :if={@limit != :unlimited}
+          id={"total_pageviews_#{@period}"}
+          usage={@usage.total}
+          limit={@limit}
+        />
       </div>
       <button
         class="flex justify-between items-center flex-wrap w-full text-left"

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -396,16 +396,18 @@ defmodule PlausibleWeb.SettingsControllerTest do
 
       assert_usage = fn doc ->
         refute element_exists?(doc, "#total_pageviews_current_cycle")
-        assert element_exists?(doc, "#total_pageviews_last_30_days")
         assert text_of_element(doc, "#pageviews_last_30_days") =~ "Pageviews 1"
         assert text_of_element(doc, "#custom_events_last_30_days") =~ "Custom events 2"
       end
 
       # for a trial user
-      conn
-      |> get(Routes.settings_path(conn, :subscription))
-      |> html_response(200)
-      |> assert_usage.()
+      trial_html =
+        conn
+        |> get(Routes.settings_path(conn, :subscription))
+        |> html_response(200)
+
+      assert_usage.(trial_html)
+      refute element_exists?(trial_html, "#total_pageviews_last_30_days")
 
       subscribe_to_plan(user, @v4_plan_id,
         status: :deleted,


### PR DESCRIPTION
### Changes
- Remove progress bar when pageview limit is unlimited.
- Change default state to be collapsed when more than 1 site is present
- Remove "/ Unlimited" from usage breakdown when pageview limit is unlimited.

### Tests
- [x] Automated tests have been updated

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
