### PR TITLE
Skip reading engagements when not necessary

### DIFF
--- a/extra/lib/plausible/stats/funnel.ex
+++ b/extra/lib/plausible/stats/funnel.ex
@@ -28,6 +28,10 @@ defmodule Plausible.Stats.Funnel do
   end
 
   def funnel(_site, query, %Funnel{} = funnel) do
+    funnel_goals = Enum.map(funnel.steps, & &1.goal)
+
+    query = %{query | preloaded_goals: %{all: funnel_goals}}
+
     funnel_data =
       query
       |> Base.base_event_query()

--- a/lib/plausible/stats/sql/where_builder.ex
+++ b/lib/plausible/stats/sql/where_builder.ex
@@ -54,13 +54,9 @@ defmodule Plausible.Stats.SQL.WhereBuilder do
       not scroll_goal_involved?(query)
   end
 
-  defp scroll_goal_involved?(%{preloaded_goals: %{matching_toplevel_filters: goals}} = query) do
-    Enum.any?(goals, fn goal -> Plausible.Goal.type(goal) == :scroll end) and
-      (Enum.any?(query.filters, fn
-         [_, "event:goal", _] -> true
-         _ -> false
-       end) or
-         "event:goal" in query.dimensions)
+  defp scroll_goal_involved?(%{preloaded_goals: %{all: goals}} = query) do
+    Enum.any?(goals, fn goal -> Plausible.Goal.type(goal) == :scroll end) or
+      "event:goal" in query.dimensions
   end
 
   defp scroll_goal_involved?(_query), do: false


### PR DESCRIPTION
Adds `WHERE name != 'engagement'` all events_v2 queries that don't need engagement data. That is queries without `time_on_page` or `scroll_depth` metrics, or scroll goals included in dimensions/filters. 

Since the `name` field is included in the events_v2 sort key, engagement events cluster together in storage, allowing ClickHouse to efficiently skip granules that contain only engagement rows when they are not needed.

I don't like that the most natural place for this was in the `where_builder.ex` module. But I didn't find a much better place for this either. Naturally I'd like it to be in the `QueryOptimizer` given the name of that module. But it only operates on the `Query` struct and I didn't want to add another field to that struct.

IMO the query pipeline is overdue for a refactoring where the `Query` struct is stripped down to represent user intent and site context. And all hints about SQL generation, which tables to query, JOIN types, and optimizations like this would be added to an intermediate `ExecutionPlan` struct. But this is a separate topic from the optimization itself.