### PR TITLE
Improving the CSV error message 

### DIFF
--- a/lib/plausible_web/live/csv_import.ex
+++ b/lib/plausible_web/live/csv_import.ex
@@ -142,7 +142,7 @@ defmodule PlausibleWeb.Live.CSVImport do
     <% else %>
       <.notice title="Dates Conflict" theme={:red} class="mt-4">
         The dates <.dates range={@original} />
-        overlap with dates we've already imported and cannot be used for new imports.
+        overlap with existing site data and cannot be used for a new import.
       </.notice>
     <% end %>
     """


### PR DESCRIPTION
Improving the CSV error message to clarify that the import overlaps with other data already in Plausible and not only other imported data 