### PR TITLE
Prevent billing notice tests from failing within an hour to midnight

### DIFF
--- a/test/plausible_web/components/billing/notice_test.exs
+++ b/test/plausible_web/components/billing/notice_test.exs
@@ -214,7 +214,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
 
       assert rendered =~ "Upgrade required due to sustained higher traffic"
       assert rendered =~ "To ensure uninterrupted access to your stats"
-      refute rendered =~ "within the next"
+      refute rendered =~ "within the"
       assert rendered =~ "Upgrade"
       assert rendered =~ "Learn more"
     end
@@ -237,7 +237,7 @@ defmodule PlausibleWeb.Components.Billing.NoticeTest do
         )
 
       assert rendered =~ "Upgrade required due to sustained higher traffic"
-      assert rendered =~ "within the next"
+      assert rendered =~ "within the"
       assert rendered =~ "hours"
       refute rendered =~ "days"
     end


### PR DESCRIPTION
### Changes

Addresses failing tests like https://github.com/plausible/analytics/actions/runs/23220632505/job/67492187700?pr=6171


