### PR TITLE
[Tracker] Use ResizeObserver instead of polling for document height

### DIFF
--- a/.github/workflows/tracker-script-update.yml
+++ b/.github/workflows/tracker-script-update.yml
@@ -116,7 +116,6 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'tracker-release: none') ) }}
 
         run: |
-          echo "PR labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
           echo "::error::PR changes tracker script but does not have a 'tracker release:' label. Please add one."
           exit 1
 

--- a/.github/workflows/tracker-script-update.yml
+++ b/.github/workflows/tracker-script-update.yml
@@ -30,13 +30,15 @@ jobs:
 
       - name: Install jq and clickhouse-local
         run: |
-          sudo apt-get install apt-transport-https ca-certificates dirmngr
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
-          echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
-              /etc/apt/sources.list.d/clickhouse.list
+          sudo apt-get install -y apt-transport-https ca-certificates dirmngr
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/clickhouse-archive-keyring.gpg \
+            --keyserver hkps://keyserver.ubuntu.com \
+            --recv-keys 8919F6BD2B48D754
+          echo "deb [signed-by=/usr/share/keyrings/clickhouse-archive-keyring.gpg] https://packages.clickhouse.com/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/clickhouse.list
           sudo apt-get update
-
-          sudo apt-get install jq clickhouse-server -y
+          sudo apt-get install -y jq clickhouse-server
 
       - name: Compare and increment tracker_script_version
         id: increment

--- a/.github/workflows/tracker-script-update.yml
+++ b/.github/workflows/tracker-script-update.yml
@@ -30,11 +30,8 @@ jobs:
 
       - name: Install jq and clickhouse-local
         run: |
-          sudo apt-get install -y apt-transport-https ca-certificates dirmngr
-          sudo gpg --no-default-keyring \
-            --keyring /usr/share/keyrings/clickhouse-archive-keyring.gpg \
-            --keyserver hkps://keyserver.ubuntu.com \
-            --recv-keys 8919F6BD2B48D754
+          curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' \
+            | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/clickhouse-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/clickhouse-archive-keyring.gpg] https://packages.clickhouse.com/deb stable main" \
             | sudo tee /etc/apt/sources.list.d/clickhouse.list
           sudo apt-get update

--- a/.github/workflows/tracker-script-update.yml
+++ b/.github/workflows/tracker-script-update.yml
@@ -116,6 +116,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'tracker-release: none') ) }}
 
         run: |
+          echo "PR labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
           echo "::error::PR changes tracker script but does not have a 'tracker release:' label. Please add one."
           exit 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Allow querying `views_per_visit` with a time dimension in Stats API
 - Add `bounce_rate` to page-filtered Top Stats even when imports are included, but render a metric warning about imported data not included in `bounce_rate` tooltip.
-- Add `time_on_page` to page-filtered Top Stats even when imports are included, unless legacy time on page is in view. 
+- Add `time_on_page` to page-filtered Top Stats even when imports are included, unless legacy time on page is in view.
 - Adds team_id to query debug metadata (saved in system.query_log log_comment column)
 - Add "Unknown" option to Countries shield, for when the country code is unrecognized
 - Add "Last 24 Hours" to dashboard time range picker and Stats API v2
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 - Keybind hints are hidden on smaller screens
 - Site index is sortable alphanumerically and by traffic
+- Use ResizeObserver instead of polling in tracker for scroll depth. Removes forced reflows caused by the tracker script.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Moved graph interval picker, export button, imported data toggle and notices out of the graph and into a new options menu in the top bar
 - Standardised and improved segment and filter modals styling
 - Changed graph tooltip positioning logic: it now aligns to the top of the chart, to the right of the hovered data point
+- Use ResizeObserver instead of polling in tracker for scroll depth. Removes forced reflows caused by the tracker script.
 
 ### Fixed
 

--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.5] - 2026-05-05
+
+- Use ResizeObserver over polling for getting scroll metrics
+
 ## [0.4.4] - 2025-10-31
 
 - Convert all TypeScript definition comments from `//` style to JSDoc `/** */` style for better IDE integration and TypeScript tooling support

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 33,
+  "tracker_script_version": 34,
   "type": "module",
   "scripts": {
     "lint": "eslint",

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -151,23 +151,11 @@ export function init() {
   currentDocumentHeight = getDocumentHeight()
   maxScrollDepthPx = getCurrentScrollDepthPx()
 
-  window.addEventListener('load', function () {
+  new ResizeObserver(function () {
     currentDocumentHeight = getDocumentHeight()
-
-    // Update the document height again after every 200ms during the
-    // next 3 seconds. This makes sure dynamically loaded content is
-    // also accounted for.
-    var count = 0
-    var interval = setInterval(function () {
-      currentDocumentHeight = getDocumentHeight()
-      if (++count === 15) {
-        clearInterval(interval)
-      }
-    }, 200)
-  })
+  }).observe(document.documentElement)
 
   document.addEventListener('scroll', function () {
-    currentDocumentHeight = getDocumentHeight()
     var currentScrollDepthPx = getCurrentScrollDepthPx()
 
     if (currentScrollDepthPx > maxScrollDepthPx) {

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -137,10 +137,8 @@ function getDocumentHeight() {
 }
 
 function getCurrentScrollDepthPx() {
-  var body = document.body || {}
-  var el = document.documentElement || {}
-  var viewportHeight = window.innerHeight || el.clientHeight || 0
-  var scrollTop = window.scrollY || el.scrollTop || body.scrollTop || 0
+  var viewportHeight = window.innerHeight
+  var scrollTop = window.scrollY
 
   return currentDocumentHeight <= viewportHeight
     ? currentDocumentHeight

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -137,6 +137,16 @@ function getDocumentHeight() {
 }
 
 function getCurrentScrollDepthPx() {
+  if (COMPILE_COMPAT) {
+    var el = document.documentElement || {}
+    var body = document.body || {}
+    var viewportHeight = window.innerHeight || el.clientHeight || 0
+    var scrollTop = window.scrollY || window.pageYOffset || el.scrollTop || body.scrollTop || 0
+    return currentDocumentHeight <= viewportHeight
+      ? currentDocumentHeight
+      : scrollTop + viewportHeight
+  }
+
   var viewportHeight = window.innerHeight
   var scrollTop = window.scrollY
 
@@ -149,9 +159,20 @@ export function init() {
   currentDocumentHeight = getDocumentHeight()
   maxScrollDepthPx = getCurrentScrollDepthPx()
 
-  new ResizeObserver(function () {
-    currentDocumentHeight = getDocumentHeight()
-  }).observe(document.documentElement)
+  if (COMPILE_COMPAT) {
+    window.addEventListener('load', function () {
+      currentDocumentHeight = getDocumentHeight()
+      var count = 0
+      var interval = setInterval(function () {
+        currentDocumentHeight = getDocumentHeight()
+        if (++count === 15) clearInterval(interval)
+      }, 200)
+    })
+  } else {
+    new ResizeObserver(function () {
+      currentDocumentHeight = getDocumentHeight()
+    }).observe(document.documentElement)
+  }
 
   document.addEventListener('scroll', function () {
     var currentScrollDepthPx = getCurrentScrollDepthPx()

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -142,7 +142,12 @@ function getCurrentScrollDepthPx() {
     var el = document.documentElement || {}
     var body = document.body || {}
     viewportHeight = window.innerHeight || el.clientHeight || 0
-    scrollTop = window.scrollY || window.pageYOffset || el.scrollTop || body.scrollTop || 0
+    scrollTop =
+      window.scrollY ||
+      window.pageYOffset ||
+      el.scrollTop ||
+      body.scrollTop ||
+      0
   } else {
     viewportHeight = window.innerHeight
     scrollTop = window.scrollY

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -137,19 +137,16 @@ function getDocumentHeight() {
 }
 
 function getCurrentScrollDepthPx() {
+  var viewportHeight, scrollTop
   if (COMPILE_COMPAT) {
     var el = document.documentElement || {}
     var body = document.body || {}
-    var viewportHeight = window.innerHeight || el.clientHeight || 0
-    var scrollTop = window.scrollY || window.pageYOffset || el.scrollTop || body.scrollTop || 0
-    return currentDocumentHeight <= viewportHeight
-      ? currentDocumentHeight
-      : scrollTop + viewportHeight
+    viewportHeight = window.innerHeight || el.clientHeight || 0
+    scrollTop = window.scrollY || window.pageYOffset || el.scrollTop || body.scrollTop || 0
+  } else {
+    viewportHeight = window.innerHeight
+    scrollTop = window.scrollY
   }
-
-  var viewportHeight = window.innerHeight
-  var scrollTop = window.scrollY
-
   return currentDocumentHeight <= viewportHeight
     ? currentDocumentHeight
     : scrollTop + viewportHeight

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -16,7 +16,9 @@ function init(overrides) {
 
   initConfig(options)
 
-  initEngagementTracking()
+  if (!COMPILE_COMPAT) {
+    initEngagementTracking()
+  }
 
   if (!COMPILE_MANUAL || (COMPILE_CONFIG && config.autoCapturePageviews)) {
     initAutocapture(track)

--- a/tracker/src/plausible.js
+++ b/tracker/src/plausible.js
@@ -16,9 +16,7 @@ function init(overrides) {
 
   initConfig(options)
 
-  if (!COMPILE_COMPAT) {
-    initEngagementTracking()
-  }
+  initEngagementTracking()
 
   if (!COMPILE_MANUAL || (COMPILE_CONFIG && config.autoCapturePageviews)) {
     initAutocapture(track)


### PR DESCRIPTION
### Changes

Replaces document height polling with `ResizeObserver` to avoid forced reflows.

Fixes https://github.com/plausible/analytics/issues/5727

`ResizeObserver` is a fairly modern API. Should be OK for the main script since overall it doesn't have worse support than fetch-with-keepalive. The only gap I was able to find is Edge versions less than 79 do not support `ResizeObserver` while fetch support goes back longer on Edge. So we will lose pre-2020 Edge versions but they have negligible usage worldwide. It would be good to have some kind of feature matrix for tracker script and check against caniuse data when we update it.

Instead of keeping the old code as fallback for `compat` code, I've disabled engagement tracking completely in `compat` mode. Without fetch-with-keepalive engagement data isn't reliable anyways. But it should probably be checked with sites that actually use the `compat` mode.

Disabling engagements in `compat` mode also allowed me to remove some fallbacks in `getCurrentScrollDepthPx` function which are not relevant in modern browsers (window.scrollY and window.innerHeight are way better supported than fetch and ResizeObserver, the fallbacks were only relevant for IE).

- [x] All existing tests pass
- [x] Add changelog entry
- [ ] Post-merge: release NPM tracker. Include this improvement as well: https://github.com/plausible/analytics/pull/6158
- [x] This change does not need a documentation update
- [x] This PR does not change the UI

### Verification

On a local page with plausible installed, I profiled a scripted journey where page is loaded and scrolled after waiting a half a second. The old code produced 27 document reflows, with this PR there were 3 reflows. None of the remaining 3 were triggered by our script, they were all internal chrome events.
