### PR TITLE
Allow underscores in site domain names

### DIFF
--- a/lib/plausible/site.ex
+++ b/lib/plausible/site.ex
@@ -208,8 +208,8 @@ defmodule Plausible.Site do
   end
 
   defp validate_domain_format(changeset) do
-    validate_format(changeset, :domain, ~r/^[-\.\\\/:\p{L}\d]*$/u,
-      message: "only letters, numbers, slashes and period allowed"
+    validate_format(changeset, :domain, ~r/^[-\.\\\/_:\p{L}\d]*$/u,
+      message: "only letters, numbers, slashes, underscores and period allowed"
     )
   end
 

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -463,7 +463,21 @@ defmodule PlausibleWeb.SiteControllerTest do
           }
         })
 
-      assert html_response(conn, 200) =~ "only letters, numbers, slashes and period allowed"
+      assert html_response(conn, 200) =~
+               "only letters, numbers, slashes, underscores and period allowed"
+    end
+
+    test "underscores are allowed in the domain", %{conn: conn} do
+      conn =
+        post(conn, "/sites", %{
+          "site" => %{
+            "timezone" => "Europe/London",
+            "domain" => "example.com/some_blog_site"
+          }
+        })
+
+      assert redirected_to(conn) ==
+               "/example.com%2Fsome_blog_site/installation?site_created=true&flow="
     end
 
     test "renders form again when it is a duplicate domain", %{conn: conn} do

--- a/test/plausible_web/live/change_domain_test.exs
+++ b/test/plausible_web/live/change_domain_test.exs
@@ -161,7 +161,7 @@ defmodule PlausibleWeb.Live.ChangeDomainTest do
         |> element("form")
         |> render_submit(%{site: %{domain: "invalid domain with spaces"}})
 
-      assert html =~ "only letters, numbers, slashes and period allowed"
+      assert html =~ "only letters, numbers, slashes, underscores and period allowed"
     end
 
     test "renders back to settings link with correct path", %{conn: conn, site: site} do


### PR DESCRIPTION
### Changes

Allows using underscores in site domain names. As those names can also include slash delimited url paths, underscores are entirely valid (even if discouraged, at least in the past).

### Tests
- [x] Automated tests have been added

