### PR TITLE
Extend active session smearing to current time on time:minute graphs

### DIFF
--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -33,7 +33,7 @@ defmodule Plausible.Stats.SQL.Expression do
         """
         timeSlots(
           toTimeZone(greatest(?, ?), ?),
-          toUInt32(timeDiff(greatest(?, ?), least(?, ?))),
+          toUInt32(timeDiff(greatest(?, ?), least(if(timeDiff(?, ?) < 1800, ?, ?), ?))),
           toUInt32(?)
         )
         """,
@@ -42,6 +42,9 @@ defmodule Plausible.Stats.SQL.Expression do
         ^unquote(query).timezone,
         s.start,
         ^unquote(first),
+        s.timestamp,
+        ^unquote(query).now,
+        ^unquote(query).now,
         s.timestamp,
         ^unquote(last),
         ^unquote(period_in_seconds)

--- a/test/plausible/stats/query/query_test.exs
+++ b/test/plausible/stats/query/query_test.exs
@@ -126,6 +126,31 @@ defmodule Plausible.Stats.QueryTest do
     end
   end
 
+  describe "active session smearing on time:minute graphs" do
+    test "active sessions (last event within 30 min) are smeared through current time, not just last event",
+         %{site: site} do
+      now = ~U[2024-01-01 12:00:00Z]
+
+      populate_stats(site, [
+        # Visitor had an event 5 minutes ago - session is still active (within 30 min timeout)
+        build(:pageview, user_id: @user_id, timestamp: ~N[2024-01-01 11:55:00])
+      ])
+
+      {:ok, query} =
+        QueryBuilder.build(site, %ParsedQueryParams{
+          metrics: [:visitors],
+          input_date_range: :realtime_30m,
+          dimensions: ["time:minute"],
+          now: now
+        })
+
+      %Stats.QueryResult{results: results} = Stats.query(site, query)
+
+      # The current minute (12:00) should show the visitor since their session is still active
+      assert %{dimensions: ["2024-01-01 12:00:00"], metrics: [1]} in results
+    end
+  end
+
   describe "session smearing respects query date range boundaries" do
     test "time:hour does not include buckets from outside the query range",
          %{site: site} do


### PR DESCRIPTION
Sessions with a last event within the 30-minute session timeout window are now smeared through query.now rather than stopping at s.timestamp, eliminating the artificial visitor drop at the trailing edge of realtime/30m minute-interval graphs.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
