### PR TITLE
Call `page.goto` in e2e test with `waitUntil: commit` better offline support

### DIFF
--- a/e2e/tests/dashboard/behaviours.spec.ts
+++ b/e2e/tests/dashboard/behaviours.spec.ts
@@ -104,7 +104,7 @@ test('goals breakdown', async ({ page, request }) => {
     scrollPercentage: 75
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const goalsTabButton = tabButton(report, 'Goals')
 
@@ -186,7 +186,9 @@ test('goals breakdown', async ({ page, request }) => {
   })
 
   await test.step('listing goals without revenue', async () => {
-    await page.goto('/' + domain + '?f=has_not_done,goal,purchase')
+    await page.goto('/' + domain + '?f=has_not_done,goal,purchase', {
+      waitUntil: 'commit'
+    })
 
     await goalsTabButton.scrollIntoViewIfNeeded()
     await expect(goalsTabButton).toHaveAttribute('data-active', 'true')
@@ -286,7 +288,7 @@ test('props breakdown', async ({ page, request }) => {
 
   await addAllCustomProps({ page, domain })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const propsTabButton = tabButton(report, 'Properties')
 
@@ -427,7 +429,7 @@ test('funnels', async ({ page, request }) => {
     })
   }
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const funnelsTabButton = tabButton(report, 'Funnels')
 

--- a/e2e/tests/dashboard/breakdowns.spec.ts
+++ b/e2e/tests/dashboard/breakdowns.spec.ts
@@ -48,7 +48,7 @@ test('sources breakdown', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const report = page.getByTestId('report-sources')
 
@@ -409,7 +409,7 @@ test('pages breakdown', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const report = page.getByTestId('report-pages')
 
@@ -523,7 +523,7 @@ test('pages breakdown modal', async ({ page, request }) => {
     events: pageEvents
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const report = page.getByTestId('report-pages')
 
@@ -683,7 +683,9 @@ test('pages breakdown with a pageview goal filter applied', async ({
   const report = page.getByTestId('report-pages')
 
   await test.step('custom goal filter applied', async () => {
-    await page.goto('/' + domain + '?f=is,goal,create_site')
+    await page.goto('/' + domain + '?f=is,goal,create_site', {
+      waitUntil: 'commit'
+    })
 
     const pagesTabButton = tabButton(report, 'Conversion pages')
     await pagesTabButton.scrollIntoViewIfNeeded()
@@ -718,7 +720,9 @@ test('pages breakdown with a pageview goal filter applied', async ({
   })
 
   await test.step('revenue goal filter applied', async () => {
-    await page.goto('/' + domain + '?f=is,goal,purchase')
+    await page.goto('/' + domain + '?f=is,goal,purchase', {
+      waitUntil: 'commit'
+    })
 
     const pagesTabButton = tabButton(report, 'Conversion pages')
     await pagesTabButton.scrollIntoViewIfNeeded()
@@ -789,7 +793,7 @@ test('locations breakdown', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const report = page.getByTestId('report-locations')
 
@@ -950,7 +954,7 @@ test('devices breakdown', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const report = page.getByTestId('report-devices')
 

--- a/e2e/tests/dashboard/filtering.spec.ts
+++ b/e2e/tests/dashboard/filtering.spec.ts
@@ -30,7 +30,7 @@ test.describe('page filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const pageFilterRow = filterRow(page, 'page')
     const pageInput = page.getByPlaceholder('Select a Page')
@@ -84,7 +84,7 @@ test.describe('page filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const pageFilterRow = filterRow(page, 'page')
     const pageInput = page.getByPlaceholder('Select a Page')
@@ -199,7 +199,7 @@ test.describe('page filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const entryPageFilterRow = filterRow(page, 'entry_page')
     const entryPageInput = page.getByPlaceholder('Select an Entry Page')
@@ -236,7 +236,7 @@ test.describe('page filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const exitPageFilterRow = filterRow(page, 'exit_page')
     const exitPageInput = page.getByPlaceholder('Select an Exit Page')
@@ -273,7 +273,7 @@ test.describe('hostname filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const hostnameFilterRow = filterRow(page, 'hostname')
     const hostnameInput = page.getByPlaceholder('Select a Hostname')
@@ -310,7 +310,7 @@ test.describe('acquisition filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     await test.step('filtering by source', async () => {
       const sourceFilterRow = filterRow(page, 'source')
@@ -415,7 +415,7 @@ test.describe('acquisition filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     await test.step('filtering by UTM medium', async () => {
       const utmMediumFilterRow = filterRow(page, 'utm_medium')
@@ -574,7 +574,7 @@ test.describe('location filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     await test.step('filtering by country', async () => {
       const countryFilterRow = filterRow(page, 'country')
@@ -658,7 +658,7 @@ test.describe('screen size filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const screenSizeFilterRow = filterRow(page, 'screen')
     const screenSizeInput = page.getByPlaceholder('Select a Screen size')
@@ -698,7 +698,7 @@ test.describe('browser filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     await test.step('filtering by browser type', async () => {
       const browserFilterRow = filterRow(page, 'browser')
@@ -769,7 +769,7 @@ test.describe('operating system filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     await test.step('filtering by operating system type', async () => {
       const operatingSystemFilterRow = filterRow(page, 'os')
@@ -840,7 +840,7 @@ test.describe('goal filtering tests', () => {
     await addPageviewGoal({ page, domain, pathname: '/page1' })
     await addPageviewGoal({ page, domain, pathname: '/page2' })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const goalFilterRow = filterRow(page, 'goal')
     const goalInput = goalFilterRow.getByPlaceholder('Select a Goal')
@@ -915,7 +915,7 @@ test.describe('property filtering tests', () => {
       ]
     })
 
-    await page.goto('/' + domain)
+    await page.goto('/' + domain, { waitUntil: 'commit' })
 
     const propFilterRow = filterRow(page, 'props')
     const propNameInput = propFilterRow.getByPlaceholder('Property')

--- a/e2e/tests/dashboard/general.spec.ts
+++ b/e2e/tests/dashboard/general.spec.ts
@@ -11,7 +11,7 @@ test('dashboard renders for logged in user', async ({ page, request }) => {
   const { domain } = await setupSite({ page, request })
   await populateStats({ request, domain, events: [{ name: 'pageview' }] })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page).toHaveTitle(/Plausible/)
 
@@ -24,7 +24,7 @@ test('dashboard renders for anonymous viewer', async ({ page, request }) => {
   await populateStats({ request, domain, events: [{ name: 'pageview' }] })
   await logout(page)
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page).toHaveTitle(/Plausible/)
 
@@ -44,7 +44,7 @@ test('dashboard renders via shared link', async ({ page, request }) => {
   await logout(page)
 
   await test.step('public link', async () => {
-    await page.goto(link)
+    await page.goto(link, { waitUntil: 'commit' })
 
     await expect(page.getByRole('button', { name: domain })).toBeVisible()
 
@@ -52,7 +52,7 @@ test('dashboard renders via shared link', async ({ page, request }) => {
   })
 
   await test.step('password protected link', async () => {
-    await page.goto(passwordLink)
+    await page.goto(passwordLink, { waitUntil: 'commit' })
 
     await page.locator('input#password').fill('secret')
 
@@ -81,7 +81,7 @@ test('dashboard renders with imported data', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await test.step('with imported data included', async () => {
     await expect(page.locator('#visitors')).toHaveText('4')
@@ -109,11 +109,11 @@ test('tab selection user preferences are preserved across reloads', async ({
   const { domain } = await setupSite({ page, request })
   await populateStats({ request, domain, events: [{ name: 'pageview' }] })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await page.getByRole('button', { name: 'Entry pages' }).click()
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   let currentTab = await page.evaluate(
     (domain) => localStorage.getItem('pageTab__' + domain),
@@ -124,7 +124,7 @@ test('tab selection user preferences are preserved across reloads', async ({
 
   await page.getByRole('button', { name: 'Exit pages' }).click()
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   currentTab = await page.evaluate(
     (domain) => localStorage.getItem('pageTab__' + domain),
@@ -142,7 +142,7 @@ test('back navigation closes the modal', async ({ page, request, baseURL }) => {
     events: [{ name: 'pageview' }]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await page.getByRole('button', { name: 'Filter' }).click()
 

--- a/e2e/tests/dashboard/segments.spec.ts
+++ b/e2e/tests/dashboard/segments.spec.ts
@@ -83,7 +83,7 @@ const createPersonalSegment = async (page: Page, name: string) => {
 test('saving a segment', async ({ page, request }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await test.step('creating personal segment using defaults', async () => {
     await addSourceFilter(page, 'Facebook')
@@ -220,7 +220,7 @@ test('creating a segment from a combination of segment and a filter is not allow
 }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await addSourceFilter(page, 'Google')
   await createPersonalSegment(page, 'Traffic from Google')
@@ -249,7 +249,7 @@ test('creating a segment from a combination of segment and a filter is not allow
 test('editing an existing segment', async ({ page, request }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await addSourceFilter(page, 'Google')
   await createPersonalSegment(page, 'Traffic from Google')
@@ -294,7 +294,7 @@ test('editing an existing segment', async ({ page, request }) => {
 test('saving edited segment as new', async ({ page, request }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await addSourceFilter(page, 'Google')
   await createPersonalSegment(page, 'Traffic from Google')
@@ -348,7 +348,7 @@ test('saving edited segment as new', async ({ page, request }) => {
 test('deleting segment', async ({ page, request }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await addSourceFilter(page, 'Google')
   await createPersonalSegment(page, 'Traffic from Google')
@@ -377,7 +377,7 @@ test('deleting segment', async ({ page, request }) => {
 test('closing edited segment without saving', async ({ page, request }) => {
   const { domain } = await setupSiteAndStats({ page, request })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await addSourceFilter(page, 'Google')
   await createPersonalSegment(page, 'Traffic from Google')

--- a/e2e/tests/dashboard/team-setup.spec.ts
+++ b/e2e/tests/dashboard/team-setup.spec.ts
@@ -7,7 +7,7 @@ test('submitting team name via Enter key does not crash', async ({
   request
 }) => {
   await setupSite({ page, request })
-  await page.goto('/team/setup')
+  await page.goto('/team/setup', { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 

--- a/e2e/tests/dashboard/top-stats.spec.ts
+++ b/e2e/tests/dashboard/top-stats.spec.ts
@@ -40,7 +40,7 @@ test('site switcher allows switching between different sites', async ({
     events: [{ name: 'pageview' }]
   })
 
-  await page.goto('/' + domain1)
+  await page.goto('/' + domain1, { waitUntil: 'commit' })
 
   const switcherButton = page.getByTestId('site-switcher-current-site')
 
@@ -93,7 +93,7 @@ test('current visitors counter shows number of active visitors', async ({
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page.getByText('4 current visitors')).toBeVisible()
 })
@@ -131,7 +131,7 @@ test('top stats show relevant metrics', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page).toHaveTitle(/Plausible/)
 
@@ -200,7 +200,7 @@ test('different time ranges are supported', async ({ page, request }) => {
 
   await populateStats({ request, domain, events })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
   await expect(page.getByRole('button', { name: domain })).toBeVisible()
 
   await expect(page.getByTestId('current-query-period')).toHaveText(
@@ -238,7 +238,7 @@ test('different graph time intervals are available', async ({
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page.getByTestId('current-query-period')).toHaveText(
     'Last 28 days'
@@ -301,7 +301,7 @@ test('navigating dates previous next time periods', async ({
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const currentQueryPeriod = page.getByTestId('current-query-period')
   const queryPeriodPicker = page.getByTestId('query-period-picker')
@@ -375,7 +375,7 @@ test('selecting a custom date range', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   const currentQueryPeriod = page.getByTestId('current-query-period')
   const queryPeriodPicker = page.getByTestId('query-period-picker')
@@ -411,7 +411,7 @@ test('comparing stats over time is supported', async ({ page, request }) => {
     ]
   })
 
-  await page.goto('/' + domain)
+  await page.goto('/' + domain, { waitUntil: 'commit' })
 
   await expect(page.getByTestId('current-query-period')).toHaveText(
     'Last 28 days'

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -67,7 +67,7 @@ export async function register({
   request: APIRequestContext
   user: User
 }) {
-  await page.goto('/register')
+  await page.goto('/register', { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 
@@ -113,7 +113,7 @@ export async function register({
 }
 
 export async function login({ page, user }: { page: Page; user: User }) {
-  await page.goto('/login')
+  await page.goto('/login', { waitUntil: 'commit' })
 
   await expect(page.getByRole('button', { name: 'Log in' })).toBeVisible()
 
@@ -125,7 +125,7 @@ export async function login({ page, user }: { page: Page; user: User }) {
 }
 
 export async function logout(page: Page) {
-  await page.goto('/logout')
+  await page.goto('/logout', { waitUntil: 'commit' })
 
   await expect(
     page.getByRole('heading', { name: 'Welcome to Plausible!' })
@@ -139,7 +139,7 @@ export async function addSite({
   page: Page
   domain: string
 }) {
-  await page.goto('/sites/new')
+  await page.goto('/sites/new', { waitUntil: 'commit' })
 
   await expect(
     page.getByRole('button', { name: 'Install Plausible' })
@@ -162,7 +162,7 @@ export async function makeSitePublic({
   page: Page
   domain: string
 }) {
-  await page.goto(`/${domain}/settings/visibility`)
+  await page.goto(`/${domain}/settings/visibility`, { waitUntil: 'commit' })
 
   await page
     .getByRole('form', { name: 'Make stats publicly available' })
@@ -186,7 +186,7 @@ export async function createSharedLink({
   const modal = page.locator('#shared-links-form-modal')
   const table = page.locator('#shared-links-table')
 
-  await page.goto(`/${domain}/settings/visibility`)
+  await page.goto(`/${domain}/settings/visibility`, { waitUntil: 'commit' })
 
   await page.getByRole('button', { name: 'Add shared link' }).click()
 
@@ -247,7 +247,7 @@ export async function addCustomGoal({
   currency?: string
   clickManually?: boolean
 }) {
-  await page.goto(`/${domain}/settings/goals`)
+  await page.goto(`/${domain}/settings/goals`, { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 
@@ -310,7 +310,7 @@ export async function addPageviewGoal({
   pathname: string
   displayName?: string
 }) {
-  await page.goto(`/${domain}/settings/goals`)
+  await page.goto(`/${domain}/settings/goals`, { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 
@@ -354,7 +354,7 @@ export async function addScrollDepthGoal({
   displayName?: string
   scrollPercentage?: number
 }) {
-  await page.goto(`/${domain}/settings/goals`)
+  await page.goto(`/${domain}/settings/goals`, { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 
@@ -401,7 +401,7 @@ export async function addCustomProp({
   domain: string
   name: string
 }) {
-  await page.goto(`/${domain}/settings/properties`)
+  await page.goto(`/${domain}/settings/properties`, { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 
@@ -433,7 +433,7 @@ export async function addAllCustomProps({
   page: Page
   domain: string
 }) {
-  await page.goto(`/${domain}/settings/properties`)
+  await page.goto(`/${domain}/settings/properties`, { waitUntil: 'commit' })
 
   await expectLiveViewConnected(page)
 


### PR DESCRIPTION
Currently, when running E2E tests without internet connection, each `page.goto` call takes several seconds, close to 10. This in turn makes basically all tests fail. With `waitUntil` option set to `commit`, we wait only until the page HTML _starts_ loading. The default option value is `load`, which waits until all resources load. In practice however, given the tests are written according to guidelines (using playwright actions like `click()`, checking for visibility of expected elements with `toBeVisible()` etc.), we do not have to wait until the page's resources are fully loaded. The most likely reason for the slowdown are attempts to load gravatar images, which eventually time out.

After the change, the tests complete when offline, although they are still noticeably slower (~23 seconds vs ~38 seconds). Yet still, being able to run them offline at all is still in improvement.

Another benefit is that with the option added, even when the tests are run online, they execute faster (~18 seconds vs ~23 seconds).

Refs https://www.checklyhq.com/blog/why-page-goto-is-slowing-down-your-playwright-test/

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [x] Automated tests have been added
