### PR TITLE
Add deadline reminder for ownership transfer request

### DIFF
--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has requested to transfer the ownership of {@site.domain} site on {Plausible.product_name()} to you. Please accept the request within 48 hours. 
+{@inviter.email} has requested to transfer the ownership of {@site.domain} site on {Plausible.product_name()} to you. Please accept the request within 48 hours.
 <%= if @new_owner_account do %>
   <a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a>
   to view and respond to the invitation.


### PR DESCRIPTION
Added a reminder for the new owner to accept the ownership transfer request within 48 hours. This will help us reduce a bit of support volume too.

### Changes

It's a simple copy change for more context.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
