### PR TITLE
Hide save as segment button on public, shared and embedded dashboards if user not logged in

### DIFF
--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -186,6 +186,15 @@ export function resolveFilters(
   })
 }
 
+export const canSeeSaveAsSegmentAction = ({
+  user
+}: {
+  user: UserContextValue
+}) =>
+  user.loggedIn &&
+  (ROLES_WITH_MAYBE_SITE_SEGMENTS.includes(user.role) ||
+    ROLES_WITH_PERSONAL_SEGMENTS.includes(user.role))
+
 export function canExpandSegment({
   segment,
   user

--- a/assets/js/dashboard/nav-menu/filters-bar.tsx
+++ b/assets/js/dashboard/nav-menu/filters-bar.tsx
@@ -6,9 +6,13 @@ import { useDashboardStateContext } from '../dashboard-state-context'
 import { AppNavigationLink } from '../navigation/use-app-navigate'
 import { Popover, Transition } from '@headlessui/react'
 import { popover, BlurMenuButtonOnEscape } from '../components/popover'
-import { isSegmentFilter } from '../filtering/segments'
+import {
+  canSeeSaveAsSegmentAction,
+  isSegmentFilter
+} from '../filtering/segments'
 import { useRoutelessModalsContext } from '../navigation/routeless-modals-context'
 import { DashboardState } from '../dashboard-state'
+import { useUserContext } from '../user-context'
 
 // Component structure is
 // `..[ filter (x) ]..[ filter (x) ]..[ three dot menu ]..`
@@ -121,14 +125,16 @@ export const FiltersBar = ({ accessors }: FiltersBarProps) => {
   const pillsRef = useRef<HTMLDivElement>(null)
   const [visibility, setVisibility] = useState<null | VisibilityState>(null)
   const { dashboardState, expandedSegment } = useDashboardStateContext()
+  const user = useUserContext()
 
   const showingClearAll = canShowClearAllAction({
     filters: dashboardState.filters
   })
-  const showingSaveAsSegment = canShowSaveAsSegmentAction({
-    filters: dashboardState.filters,
-    isEditingSegment: !!expandedSegment
-  })
+  const showingSaveAsSegment =
+    canShowSaveAsSegmentAction({
+      filters: dashboardState.filters,
+      isEditingSegment: !!expandedSegment
+    }) && canSeeSaveAsSegmentAction({ user })
 
   const actionsInSeeMoreMenu = [
     showingSaveAsSegment && ('save as segment' as const),


### PR DESCRIPTION
### Changes
Hides save as segment button on public, shared and embedded dashboards if user not logged in

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
