### PR TITLE
removing extra space in the link

### DIFF
--- a/lib/plausible_web/templates/email/trial_ending_tomorrow.html.heex
+++ b/lib/plausible_web/templates/email/trial_ending_tomorrow.html.heex
@@ -9,5 +9,6 @@ Over the last 30 days, your account has used {PlausibleWeb.AuthView.delimit_inte
   This exceeds our standard plans. Please reply to this email and we’ll prepare a custom plan for your volume.
 <% else %>
   Based on your usage, the {@suggested_volume} pageviews/month plan would be the right fit.<br /><br />
-  You can <a href={PlausibleWeb.Router.Helpers.billing_url(PlausibleWeb.Endpoint, :choose_plan) <> "?__team=#{@team.identifier}"}>upgrade your account</a> at any time to continue without interruption.
+  You can <a href={choose_plan_url(@team)}>upgrade your account</a>
+  at any time to continue without interruption.
 <% end %>

--- a/lib/plausible_web/templates/email/trial_one_week_reminder.html.heex
+++ b/lib/plausible_web/templates/email/trial_one_week_reminder.html.heex
@@ -1,4 +1,5 @@
 Your Plausible trial ends in a week.<br /><br />
 If Plausible has become part of how you check traffic and measure results, you can continue without interruption by choosing a subscription plan.<br /><br />
 Everything you've set up will remain exactly as it is. No migration. No changes needed.<br /><br />
-You can <a href={PlausibleWeb.Router.Helpers.billing_url(PlausibleWeb.Endpoint, :choose_plan) <> "?__team=#{@team.identifier}"}>upgrade your account</a> at any time.
+You can <a href={choose_plan_url(@team)}>upgrade your account</a>
+at any time.

--- a/lib/plausible_web/templates/email/yearly_expiration_notification.html.heex
+++ b/lib/plausible_web/templates/email/yearly_expiration_notification.html.heex
@@ -1,8 +1,5 @@
 Time flies! This is a reminder that your annual subscription for {Plausible.product_name()} will expire on {@next_bill_date}.
-<br /><br /> You need to
-<a href={PlausibleWeb.Router.Helpers.billing_url(PlausibleWeb.Endpoint, :choose_plan) <> "?__team=#{@team.identifier}"}>
-  renew your subscription
-</a>
+<br /><br />You need to <a href={choose_plan_url(@team)}>renew your subscription</a>
 if you want to continue using Plausible to count your website stats in a privacy-friendly way.
 <br /><br />
 If you don't want to continue your subscription, there's no action required. You will lose access to your dashboard on {@next_bill_date} and we'll stop accepting stats on {@accept_traffic_until}.

--- a/lib/plausible_web/views/email_view.ex
+++ b/lib/plausible_web/views/email_view.ex
@@ -6,6 +6,11 @@ defmodule PlausibleWeb.EmailView do
     PlausibleWeb.Endpoint.url()
   end
 
+  def choose_plan_url(team) do
+    PlausibleWeb.Router.Helpers.billing_url(PlausibleWeb.Endpoint, :choose_plan) <>
+      "?__team=#{team.identifier}"
+  end
+
   def greet_recipient(%{user: %{name: name}}) when is_binary(name) do
     "Hey #{String.split(name) |> List.first()},"
   end


### PR DESCRIPTION
I noticed that this link in the actual email has an extra space so hope this will remove it?

<img width="1168" height="116" alt="screenshot-2026-04-01 at 14 45 38@2x" src="https://github.com/user-attachments/assets/e3331a71-4727-48e3-ae21-cc74bb65255d" />
