### PR TITLE
Fix e2e test flakiness by waiting for element to appear

### DIFF
--- a/e2e/tests/dashboard/top-stats.spec.ts
+++ b/e2e/tests/dashboard/top-stats.spec.ts
@@ -248,9 +248,8 @@ test('different graph time intervals are available', async ({
   const intervalOptions = page.getByTestId('graph-interval')
   await expect(intervalButton).toHaveText('Days')
   await intervalButton.click()
+  await expect(intervalOptions).toHaveCount(2)
   const intervalOptions28Days = await intervalOptions.allTextContents()
-
-  console.info('Interval Options 28 dyas', intervalOptions28Days)
 
   expect(intervalOptions28Days.indexOf('Days') > -1).toBeTruthy()
   expect(intervalOptions28Days.indexOf('Weeks') > -1).toBeTruthy()


### PR DESCRIPTION
### Changes

A particular e2e test started failing pretty consistently on CI. It turned out there was a check missing, forcing wait for element to appear before fetching its text contents. This change fixes that.

