### PR TITLE
Prevent Mobile Safari from auto-zooming text inputs and textareas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Fixed issue with all non-interactive events being counted as interactive
 - Fixed countries map countries staying highlighted on Chrome
 - Fixed comparison tooltip in the top pages report missing date labels
+- Prevent Mobile Safari from auto-zooming when focusing text inputs and textareas sized below 16px
 
 ## v3.2.0 - 2026-01-16
 

--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -220,7 +220,7 @@ export default function PlausibleCombobox({
   }, [isEmpty, singleOption, autoFocus])
 
   const searchBoxClass =
-    'border-none py-1 px-0 w-full inline-block rounded-md focus:outline-hidden focus:ring-0 text-base sm:text-sm'
+    'border-none py-1 px-0 w-full inline-block rounded-md focus:outline-hidden focus:ring-0 text-base'
 
   const containerClass = classNames('relative w-full', {
     [className]: !!className,

--- a/assets/js/dashboard/components/combobox.js
+++ b/assets/js/dashboard/components/combobox.js
@@ -220,7 +220,7 @@ export default function PlausibleCombobox({
   }, [isEmpty, singleOption, autoFocus])
 
   const searchBoxClass =
-    'border-none py-1 px-0 w-full inline-block rounded-md focus:outline-hidden focus:ring-0 text-sm'
+    'border-none py-1 px-0 w-full inline-block rounded-md focus:outline-hidden focus:ring-0 text-base sm:text-sm'
 
   const containerClass = classNames('relative w-full', {
     [className]: !!className,

--- a/assets/js/dashboard/components/search-input.tsx
+++ b/assets/js/dashboard/components/search-input.tsx
@@ -77,15 +77,15 @@ export const SearchInput = ({
           ref={searchRef}
           type="text"
           placeholder=" "
-          className="peer w-full text-base sm:text-sm dark:text-gray-100 block border-gray-300 dark:border-gray-750 rounded-md dark:bg-gray-750 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+          className="peer w-full text-base dark:text-gray-100 block border-gray-300 dark:border-gray-750 rounded-md dark:bg-gray-750 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
           onChange={handleInputChange}
         />
         {!hasValue && (
           <>
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base sm:text-sm text-gray-400 dark:text-gray-400 md:peer-[:not(:focus)]:hidden">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base text-gray-400 dark:text-gray-400 md:peer-[:not(:focus)]:hidden">
               {placeholderFocusedOrMobile}
             </span>
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base sm:text-sm text-gray-400 dark:text-gray-400 hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base text-gray-400 dark:text-gray-400 hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
               {placeholderUnfocusedOnlyDesktop}
             </span>
           </>

--- a/assets/js/dashboard/components/search-input.tsx
+++ b/assets/js/dashboard/components/search-input.tsx
@@ -77,15 +77,15 @@ export const SearchInput = ({
           ref={searchRef}
           type="text"
           placeholder=" "
-          className="peer w-full text-sm dark:text-gray-100 block border-gray-300 dark:border-gray-750 rounded-md dark:bg-gray-750 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+          className="peer w-full text-base sm:text-sm dark:text-gray-100 block border-gray-300 dark:border-gray-750 rounded-md dark:bg-gray-750 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
           onChange={handleInputChange}
         />
         {!hasValue && (
           <>
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 md:peer-[:not(:focus)]:hidden">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base sm:text-sm text-gray-400 dark:text-gray-400 md:peer-[:not(:focus)]:hidden">
               {placeholderFocusedOrMobile}
             </span>
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-gray-400 hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base sm:text-sm text-gray-400 dark:text-gray-400 hidden md:peer-[:not(:focus)]:block peer-focus:hidden">
               {placeholderUnfocusedOnlyDesktop}
             </span>
           </>

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -334,7 +334,7 @@ const SegmentNameInput = ({
         onChange={(e) => onChange(e.target.value)}
         placeholder={namePlaceholder}
         id="name"
-        className="block px-3.5 py-2.5 w-full text-sm dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-750 dark:bg-gray-750 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+        className="block px-3.5 py-2.5 w-full text-base sm:text-sm dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-750 dark:bg-gray-750 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
       />
     </>
   )

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -334,7 +334,7 @@ const SegmentNameInput = ({
         onChange={(e) => onChange(e.target.value)}
         placeholder={namePlaceholder}
         id="name"
-        className="block px-3.5 py-2.5 w-full text-base sm:text-sm dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-750 dark:bg-gray-750 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+        className="block px-3.5 py-2.5 w-full text-base dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-750 dark:bg-gray-750 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
       />
     </>
   )

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -1189,7 +1189,7 @@ defmodule PlausibleWeb.Components.Generic do
               type="text"
               name="filter-text"
               id="filter-text"
-              class="w-full max-w-80 pl-8 pr-3.5 py-2.5 text-sm dark:bg-gray-750 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-750 rounded-md dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+              class="w-full max-w-80 pl-8 pr-3.5 py-2.5 text-base sm:text-sm dark:bg-gray-750 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-750 rounded-md dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
               placeholder="Press / to search"
               x-ref="filter_text"
               phx-debounce={200}

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -1189,7 +1189,7 @@ defmodule PlausibleWeb.Components.Generic do
               type="text"
               name="filter-text"
               id="filter-text"
-              class="w-full max-w-80 pl-8 pr-3.5 py-2.5 text-base sm:text-sm dark:bg-gray-750 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-750 rounded-md dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+              class="w-full max-w-80 pl-8 pr-3.5 py-2.5 text-base dark:bg-gray-750 dark:text-gray-300 focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-750 rounded-md dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
               placeholder="Press / to search"
               x-ref="filter_text"
               phx-debounce={200}

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -108,7 +108,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
             phx-debounce={200}
             value={@display_value}
             class={[
-              "text-sm [&.phx-change-loading+svg.spinner]:block border-none py-1.5 px-1.5 w-full inline-block rounded-md focus:outline-hidden focus:ring-0",
+              "text-base sm:text-sm [&.phx-change-loading+svg.spinner]:block border-none py-1.5 px-1.5 w-full inline-block rounded-md focus:outline-hidden focus:ring-0",
               @input_class
             ]}
             style="background-color: inherit;"

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -108,7 +108,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
             phx-debounce={200}
             value={@display_value}
             class={[
-              "text-base sm:text-sm [&.phx-change-loading+svg.spinner]:block border-none py-1.5 px-1.5 w-full inline-block rounded-md focus:outline-hidden focus:ring-0",
+              "text-base [&.phx-change-loading+svg.spinner]:block border-none py-1.5 px-1.5 w-full inline-block rounded-md focus:outline-hidden focus:ring-0",
               @input_class
             ]}
             style="background-color: inherit;"

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   <.input name="my-input" errors={["oh no!"]} />
   """
 
-  @default_input_class "text-base sm:text-sm text-gray-900 dark:text-white dark:bg-gray-750 block pl-3.5 py-2.5 border-gray-300 dark:border-gray-800 transition-all duration-150 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500 rounded-md disabled:bg-gray-100 disabled:dark:bg-gray-800 disabled:border-gray-200 disabled:dark:border-gray-800 disabled:text-gray-900/40 disabled:dark:text-white/30 disabled:cursor-not-allowed"
+  @default_input_class "text-base text-gray-900 dark:text-white dark:bg-gray-750 block pl-3.5 py-2.5 border-gray-300 dark:border-gray-800 transition-all duration-150 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500 rounded-md disabled:bg-gray-100 disabled:dark:bg-gray-800 disabled:border-gray-200 disabled:dark:border-gray-800 disabled:text-gray-900/40 disabled:dark:text-white/30 disabled:cursor-not-allowed"
 
   attr(:id, :any, default: nil)
   attr(:name, :any)
@@ -162,7 +162,7 @@ defmodule PlausibleWeb.Live.Components.Form do
         id={@id}
         rows={@rest[:rows] || "6"}
         name={@name}
-        class="block w-full textarea border-1 border-gray-300 rounded-md p-4 text-base sm:text-sm text-gray-700 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300"
+        class="block w-full textarea border-1 border-gray-300 rounded-md p-4 text-base text-gray-700 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300"
         {@rest}
       >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
       <.error :for={msg <- @errors}>{msg}</.error>

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -18,7 +18,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   <.input name="my-input" errors={["oh no!"]} />
   """
 
-  @default_input_class "text-sm text-gray-900 dark:text-white dark:bg-gray-750 block pl-3.5 py-2.5 border-gray-300 dark:border-gray-800 transition-all duration-150 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500 rounded-md disabled:bg-gray-100 disabled:dark:bg-gray-800 disabled:border-gray-200 disabled:dark:border-gray-800 disabled:text-gray-900/40 disabled:dark:text-white/30 disabled:cursor-not-allowed"
+  @default_input_class "text-base sm:text-sm text-gray-900 dark:text-white dark:bg-gray-750 block pl-3.5 py-2.5 border-gray-300 dark:border-gray-800 transition-all duration-150 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500 rounded-md disabled:bg-gray-100 disabled:dark:bg-gray-800 disabled:border-gray-200 disabled:dark:border-gray-800 disabled:text-gray-900/40 disabled:dark:text-white/30 disabled:cursor-not-allowed"
 
   attr(:id, :any, default: nil)
   attr(:name, :any)
@@ -162,7 +162,7 @@ defmodule PlausibleWeb.Live.Components.Form do
         id={@id}
         rows={@rest[:rows] || "6"}
         name={@name}
-        class="block w-full textarea border-1 border-gray-300 rounded-md p-4 text-sm text-gray-700 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300"
+        class="block w-full textarea border-1 border-gray-300 rounded-md p-4 text-base sm:text-sm text-gray-700 dark:border-gray-500 dark:bg-gray-900 dark:text-gray-300"
         {@rest}
       >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
       <.error :for={msg <- @errors}>{msg}</.error>

--- a/lib/plausible_web/live/installation/instructions.ex
+++ b/lib/plausible_web/live/installation/instructions.ex
@@ -241,7 +241,7 @@ defmodule PlausibleWeb.Live.Installation.Instructions do
     <div class="relative">
       <textarea
         id="snippet"
-        class={"w-full border-1 border-gray-300 rounded-md p-4 text-base sm:text-sm text-gray-700 dark:border-gray-750 dark:bg-gray-750 dark:text-gray-300 #{if !@resizable, do: "resize-none"}"}
+        class={"w-full border-1 border-gray-300 rounded-md p-4 text-base text-gray-700 dark:border-gray-750 dark:bg-gray-750 dark:text-gray-300 #{if !@resizable, do: "resize-none"}"}
         rows={@rows}
         readonly
       ><%= @text %></textarea>

--- a/lib/plausible_web/live/installation/instructions.ex
+++ b/lib/plausible_web/live/installation/instructions.ex
@@ -241,7 +241,7 @@ defmodule PlausibleWeb.Live.Installation.Instructions do
     <div class="relative">
       <textarea
         id="snippet"
-        class={"w-full border-1 border-gray-300 rounded-md p-4 text-sm text-gray-700 dark:border-gray-750 dark:bg-gray-750 dark:text-gray-300 #{if !@resizable, do: "resize-none"}"}
+        class={"w-full border-1 border-gray-300 rounded-md p-4 text-base sm:text-sm text-gray-700 dark:border-gray-750 dark:bg-gray-750 dark:text-gray-300 #{if !@resizable, do: "resize-none"}"}
         rows={@rows}
         readonly
       ><%= @text %></textarea>

--- a/lib/plausible_web/templates/site/settings_visibility.html.heex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.heex
@@ -91,7 +91,7 @@
         rows="6"
         readonly="readonly"
         onclick="this.select()"
-        class="block w-full border-gray-300 dark:border-gray-750 resize-none text-base sm:text-sm shadow-xs focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:bg-gray-750 dark:text-gray-300"
+        class="block w-full border-gray-300 dark:border-gray-750 resize-none text-base shadow-xs focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:bg-gray-750 dark:text-gray-300"
       ></textarea>
       <a
         onclick="var textarea = document.getElementById('embed-code'); textarea.focus(); textarea.select(); document.execCommand('copy');"

--- a/lib/plausible_web/templates/site/settings_visibility.html.heex
+++ b/lib/plausible_web/templates/site/settings_visibility.html.heex
@@ -91,7 +91,7 @@
         rows="6"
         readonly="readonly"
         onclick="this.select()"
-        class="block w-full border-gray-300 dark:border-gray-750 resize-none text-sm shadow-xs focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:bg-gray-750 dark:text-gray-300"
+        class="block w-full border-gray-300 dark:border-gray-750 resize-none text-base sm:text-sm shadow-xs focus:ring-indigo-500 focus:border-indigo-500 rounded-md dark:bg-gray-750 dark:text-gray-300"
       ></textarea>
       <a
         onclick="var textarea = document.getElementById('embed-code'); textarea.focus(); textarea.select(); document.execCommand('copy');"


### PR DESCRIPTION
## Summary
- keep real text inputs and textareas at 16px so Mobile Safari does not auto-zoom them on focus
- apply the fix to the shared Phoenix form input component and the custom dashboard search/combobox fields that were still using smaller text sizing
- add a changelog entry for the bugfix

## Testing
- `git diff --check`
- automated tests not run in this environment
- `mix` is not installed in this environment
- frontend dependencies are not installed in `assets/node_modules`
- dark mode was not visually verified in this environment

## Risk & Rollback
- low risk, this only changes typography sizing for actual text entry fields
- rollback is a straightforward revert of this branch

## Linked Issues
- Closes #6235