### PR TITLE
Exploration: don't reload already selected steps

### DIFF
--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -50,6 +50,10 @@ function ExplorationColumn({
   )
 
   useEffect(() => {
+    if (selected) {
+      return
+    }
+
     if (steps === null) {
       setFilter('')
       setResults([])


### PR DESCRIPTION
Even with the UI being a temporary prototype, having all the already selected steps reload on subsequent step selection is unnecessary.